### PR TITLE
Fix for padding issue with .topbar > .container-fluid

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -96,6 +96,11 @@ div.topbar {
     }
   }
 
+  // Fluid Container
+  .container-fluid {
+    padding: 0 20px;
+  }
+
   // Navigation
   ul {
     display: block;


### PR DESCRIPTION
If you use `.topbar > .container-fluid` the `.container-fluid` inherits the `padding: 20px;` when it just needs `padding: 0 20px;`
