### PR TITLE
Serif font stack defaults to sans-serif font

### DIFF
--- a/lib/preboot.less
+++ b/lib/preboot.less
@@ -105,7 +105,7 @@
     line-height: @lineHeight;
   }
   .serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Georgia", Times New Roman, Times, sans-serif;
+    font-family: "Georgia", Times New Roman, Times, serif;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;


### PR DESCRIPTION
# font > .serif() will default to a sans-serif font.
