### PR TITLE
color-stop() not supported in mozilla gradients

### DIFF
--- a/lib/preboot.less
+++ b/lib/preboot.less
@@ -254,7 +254,7 @@
     background-repeat: no-repeat;
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
     background-image: -webkit-linear-gradient(@startColor, color-stop(@colorStop, @midColor), @endColor);
-    background-image: -moz-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
+    background-image: -moz-linear-gradient(@startColor, @midColor @colorStop*100%, @endColor);
     background-image: -ms-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
     background-image: -o-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
     background-image: linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);


### PR DESCRIPTION
Mozilla gradients simply use color [ percentage | length ] instead of a color-stop() function

https://developer.mozilla.org/en/CSS/-moz-linear-gradient
