### PR TITLE
Fixed syntax error in patterns.less

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -460,7 +460,7 @@
     border: 1px solid #ddd;
     border: 1px solid rgba(0,0,0,.15);
     .border-radius(3px);
-    .box-shadow(0 1px 2px rgba(0,0,0,.05);
+    .box-shadow(0 1px 2px rgba(0,0,0,.05));
     li {
       display: inline;
       a {


### PR DESCRIPTION
There was a brace missing in patterns.less that prevented bootstrap from compiling on the dotlesscss compiler (a .NET port of less).
