### PR TITLE
.sidebar and .content in fluid layouts don't need to be divs

### DIFF
--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -67,11 +67,11 @@ div.container {
 div.container-fluid {
   padding: 0 20px;
   .clearfix();
-  div.sidebar {
+  .sidebar {
     float: left;
     width: 220px;
   }
-  div.content {
+  .content {
     min-width: 700px;
     max-width: 1180px;
     margin-left: 240px;


### PR DESCRIPTION
There's no reason to force the use of divs in this classes.
