### PR TITLE
fix #105. Removed duplicate definition of table reset.

### DIFF
--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Aug 26 19:31:44 PDT 2011
+ * Date: Sat Aug 27 20:02:35 MDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -166,10 +166,6 @@ input[type="search"]::-webkit-search-decoration {
 textarea {
   overflow: auto;
   vertical-align: top;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
 }
 /* Preboot.less
  * Variables and mixins to pre-ignite any new web development project

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -19,7 +19,6 @@ button,input[type="button"],input[type="reset"],input[type="submit"]{cursor:poin
 input[type="search"]{-webkit-appearance:textfield;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;}
 input[type="search"]::-webkit-search-decoration{-webkit-appearance:none;}
 textarea{overflow:auto;vertical-align:top;}
-table{border-collapse:collapse;border-spacing:0;}
 .clearfix{zoom:1;}.clearfix:before,.clearfix:after{display:table;content:"";}
 .clearfix:after{clear:both;}
 .center-block{display:block;margin:0 auto;}

--- a/lib/reset.less
+++ b/lib/reset.less
@@ -134,13 +134,3 @@ textarea {
   overflow: auto; // Remove vertical scrollbar in IE6-9
   vertical-align: top; // Readability and alignment cross-browser
 }
-
-// Tables
-// -------------------------
-// Source: http://github.com/necolas/normalize.css
-
-// Remove spacing between table cells
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}


### PR DESCRIPTION
Fix for issue #105. Table reset styles were listed twice in /lib/reset.less.
