### PR TITLE
First cut of selector optimization (issue #100)

### DIFF
--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sat Aug 27 20:43:25 PDT 2011
+ * Date: Sat Aug 27 21:50:03 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -1092,22 +1092,22 @@ table {
   border-collapse: separate;
   font-size: 13px;
 }
-table th, table td {
+th, td {
   padding: 10px 10px 9px;
   line-height: 13.5px;
   text-align: left;
   vertical-align: middle;
   border-bottom: 1px solid #ddd;
 }
-table th {
+th {
   padding-top: 9px;
   font-weight: bold;
   border-bottom-width: 2px;
 }
-.zebra-striped tbody tr:nth-child(odd) td {
+.zebra-striped tr:nth-child(odd) td {
   background-color: #f9f9f9;
 }
-.zebra-striped tbody tr:hover td {
+.zebra-striped tr:hover td {
   background-color: #f5f5f5;
 }
 .zebra-striped .header {
@@ -1122,13 +1122,6 @@ table th {
   border-color: #000 transparent;
   visibility: hidden;
 }
-.zebra-striped .headerSortUp, .zebra-striped .headerSortDown {
-  background-color: rgba(141, 192, 219, 0.25);
-  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
-  -webkit-border-radius: 3px 3px 0 0;
-  -moz-border-radius: 3px 3px 0 0;
-  border-radius: 3px 3px 0 0;
-}
 .zebra-striped .header:hover:after {
   visibility: visible;
 }
@@ -1140,11 +1133,20 @@ table th {
   opacity: 0.6;
 }
 .zebra-striped .headerSortUp:after {
+  visibility: visible;
+}
+.headerSortUp, .headerSortDown {
+  background-color: rgba(141, 192, 219, 0.25);
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+  -webkit-border-radius: 3px 3px 0 0;
+  -moz-border-radius: 3px 3px 0 0;
+  border-radius: 3px 3px 0 0;
+}
+.headerSortUp:after {
   border-bottom: none;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 4px solid #000;
-  visibility: visible;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
@@ -1157,42 +1159,42 @@ table .blue {
   color: #049cdb;
   border-bottom-color: #049cdb;
 }
-table .headerSortUp.blue, table .headerSortDown.blue {
-  background-color: #ade6fe;
-}
 table .green {
   color: #46a546;
   border-bottom-color: #46a546;
-}
-table .headerSortUp.green, table .headerSortDown.green {
-  background-color: #cdeacd;
 }
 table .red {
   color: #9d261d;
   border-bottom-color: #9d261d;
 }
-table .headerSortUp.red, table .headerSortDown.red {
-  background-color: #f4c8c5;
-}
 table .yellow {
   color: #ffc40d;
   border-bottom-color: #ffc40d;
-}
-table .headerSortUp.yellow, table .headerSortDown.yellow {
-  background-color: #fff6d9;
 }
 table .orange {
   color: #f89406;
   border-bottom-color: #f89406;
 }
-table .headerSortUp.orange, table .headerSortDown.orange {
-  background-color: #fee9cc;
-}
 table .purple {
   color: #7a43b6;
   border-bottom-color: #7a43b6;
 }
-table .headerSortUp.purple, table .headerSortDown.purple {
+.headerSortUp.blue, .headerSortDown.blue {
+  background-color: #ade6fe;
+}
+.headerSortUp.green, .headerSortDown.green {
+  background-color: #cdeacd;
+}
+.headerSortUp.red, .headerSortDown.red {
+  background-color: #f4c8c5;
+}
+.headerSortUp.yellow, .headerSortDown.yellow {
+  background-color: #fff6d9;
+}
+.headerSortUp.orange, .headerSortDown.orange {
+  background-color: #fee9cc;
+}
+.headerSortUp.purple, .headerSortDown.purple {
   background-color: #e2d5f0;
 }
 /* Patterns.less

--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Aug 26 19:31:44 PDT 2011
+ * Date: Sat Aug 27 19:39:10 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -1224,7 +1224,7 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   color: #bfbfbf;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
-.topbar a:hover, .topbar ul li.active a {
+.topbar a:hover, .topbar li.active a {
   background-color: #333;
   background-color: rgba(255, 255, 255, 0.05);
   color: #ffffff;
@@ -1252,7 +1252,7 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   -moz-opacity: 1;
   opacity: 1;
 }
-.topbar form input {
+.topbar input {
   background-color: #444;
   background-color: rgba(255, 255, 255, 0.3);
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -1274,18 +1274,18 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   -moz-transition: none;
   transition: none;
 }
-.topbar form input:-moz-placeholder {
+.topbar input:-moz-placeholder {
   color: #e6e6e6;
 }
-.topbar form input::-webkit-input-placeholder {
+.topbar input::-webkit-input-placeholder {
   color: #e6e6e6;
 }
-.topbar form input:hover {
+.topbar input:hover {
   background-color: #bfbfbf;
   background-color: rgba(255, 255, 255, 0.5);
   color: #fff;
 }
-.topbar form input:focus, .topbar form input.focused {
+.topbar input:focus, .topbar input.focused {
   outline: none;
   background-color: #fff;
   color: #404040;
@@ -1307,79 +1307,13 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   margin-left: 10px;
   margin-right: 0;
 }
-.topbar ul li {
-  display: block;
-  float: left;
-  font-size: 13px;
-}
-.topbar ul li a {
-  display: block;
-  float: none;
-  padding: 10px 10px 11px;
-  line-height: 19px;
-  text-decoration: none;
-}
-.topbar ul li a:hover {
-  color: #fff;
-  text-decoration: none;
-}
-.topbar ul li.active a {
-  background-color: #222;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-.topbar ul.primary-nav li ul {
+.topbar ul.primary-nav ul {
   left: 0;
 }
-.topbar ul.secondary-nav li ul {
+.topbar ul.secondary-nav ul {
   right: 0;
 }
-.topbar ul li.menu {
-  position: relative;
-}
-.topbar ul li.menu a.menu:after {
-  width: 0px;
-  height: 0px;
-  display: inline-block;
-  content: "&darr;";
-  text-indent: -99999px;
-  vertical-align: top;
-  margin-top: 8px;
-  margin-left: 4px;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 4px solid #fff;
-  filter: alpha(opacity=50);
-  -khtml-opacity: 0.5;
-  -moz-opacity: 0.5;
-  opacity: 0.5;
-}
-.topbar ul li.menu.open a.menu, .topbar ul li.menu.open a:hover {
-  background-color: #444;
-  background-color: rgba(255, 255, 255, 0.1);
-  *background-color: #444;
-  /* IE6-7 */
-
-  color: #fff;
-}
-.topbar ul li.menu.open ul {
-  display: block;
-}
-.topbar ul li.menu.open ul li a {
-  background-color: transparent;
-  font-weight: normal;
-}
-.topbar ul li.menu.open ul li a:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  *background-color: #444;
-  /* IE6-7 */
-
-  color: #fff;
-}
-.topbar ul li.menu.open ul li.active a {
-  background-color: rgba(255, 255, 255, 0.1);
-  font-weight: bold;
-}
-.topbar ul li ul {
+.topbar ul ul {
   background-color: #333;
   float: left;
   display: none;
@@ -1401,14 +1335,7 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   -moz-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
-.topbar ul li ul li {
-  float: none;
-  clear: both;
-  display: block;
-  background: none;
-  font-size: 12px;
-}
-.topbar ul li ul li a {
+.topbar ul ul a {
   display: block;
   padding: 6px 15px;
   clear: both;
@@ -1416,20 +1343,12 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   line-height: 19px;
   color: #bbb;
 }
-.topbar ul li ul li a:hover {
+.topbar ul ul a:hover {
   background-color: #333;
   background-color: rgba(255, 255, 255, 0.25);
   color: #fff;
 }
-.topbar ul li ul li.divider {
-  height: 1px;
-  overflow: hidden;
-  background: #222;
-  background: rgba(0, 0, 0, 0.2);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  margin: 5px 0;
-}
-.topbar ul li ul li span {
+.topbar ul ul span {
   clear: both;
   display: block;
   background: rgba(0, 0, 0, 0.2);
@@ -1437,6 +1356,87 @@ table .headerSortUp.purple, table .headerSortDown.purple {
   cursor: default;
   color: #808080;
   border-top: 1px solid rgba(0, 0, 0, 0.2);
+}
+.topbar li {
+  display: block;
+  float: left;
+  font-size: 13px;
+}
+.topbar li a {
+  display: block;
+  float: none;
+  padding: 10px 10px 11px;
+  line-height: 19px;
+  text-decoration: none;
+}
+.topbar li a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+.topbar li.active a {
+  background-color: #222;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.topbar li li {
+  float: none;
+  clear: both;
+  display: block;
+  background: none;
+  font-size: 12px;
+}
+.topbar li li.divider {
+  height: 1px;
+  overflow: hidden;
+  background: #222;
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 5px 0;
+}
+.topbar li.menu {
+  position: relative;
+}
+.topbar li.menu.open a.menu, .topbar li.menu.open a:hover {
+  background-color: #444;
+  background-color: rgba(255, 255, 255, 0.1);
+  *background-color: #444;
+  /* IE6-7 */
+
+  color: #fff;
+}
+.topbar li.menu.open ul {
+  display: block;
+}
+.topbar li.menu.open li a {
+  background-color: transparent;
+  font-weight: normal;
+}
+.topbar li.menu.open li a:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  *background-color: #444;
+  /* IE6-7 */
+
+  color: #fff;
+}
+.topbar li.menu.open li.active a {
+  background-color: rgba(255, 255, 255, 0.1);
+  font-weight: bold;
+}
+.topbar a.menu:after {
+  width: 0px;
+  height: 0px;
+  display: inline-block;
+  content: "&darr;";
+  text-indent: -99999px;
+  vertical-align: top;
+  margin-top: 8px;
+  margin-left: 4px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #fff;
+  filter: alpha(opacity=50);
+  -khtml-opacity: 0.5;
+  -moz-opacity: 0.5;
+  opacity: 0.5;
 }
 .hero-unit {
   background-color: #f5f5f5;
@@ -1632,9 +1632,6 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 .alert-message.block-message p {
   margin-right: 30px;
 }
-.alert-message.block-message .alert-actions {
-  margin-top: 5px;
-}
 .alert-message.block-message.error, .alert-message.block-message.success, .alert-message.block-message.info {
   color: #404040;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
@@ -1650,6 +1647,9 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 .alert-message.block-message.info {
   background-color: #ddf4fb;
   border-color: #c6edf9;
+}
+.alert-message .alert-actions {
+  margin-top: 5px;
 }
 .tabs, .pills {
   margin: 0 0 20px;
@@ -1670,7 +1670,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 .tabs li, .pills li {
   display: inline;
 }
-.tabs li a, .pills li a {
+.tabs a, .pills a {
   float: left;
   width: auto;
 }
@@ -1678,7 +1678,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   width: 100%;
   border-bottom: 1px solid #bfbfbf;
 }
-.tabs li a {
+.tabs a {
   margin-bottom: -1px;
   margin-right: 2px;
   padding: 0 15px;
@@ -1687,7 +1687,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-border-radius: 3px 3px 0 0;
   border-radius: 3px 3px 0 0;
 }
-.tabs li a:hover {
+.tabs a:hover {
   background-color: #e6e6e6;
   border-bottom: 1px solid #bfbfbf;
 }
@@ -1698,7 +1698,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   border-bottom: 0;
   color: #808080;
 }
-.pills li a {
+.pills a {
   margin: 5px 3px 5px 0;
   padding: 0 15px;
   text-shadow: 0 1px 1px #fff;
@@ -1707,7 +1707,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-border-radius: 15px;
   border-radius: 15px;
 }
-.pills li a:hover {
+.pills a:hover {
   background: #0050a3;
   color: #fff;
   text-decoration: none;
@@ -1734,10 +1734,10 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
-.pagination ul li {
+.pagination li {
   display: inline;
 }
-.pagination ul li a {
+.pagination li a {
   float: left;
   padding: 0 14px;
   line-height: 34px;
@@ -1749,14 +1749,14 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 
   text-decoration: none;
 }
-.pagination ul li a:hover, .pagination ul li.active a {
+.pagination li a:hover, .pagination li.active a {
   background-color: #c7eefe;
 }
-.pagination ul li.disabled a, .pagination ul li.disabled a:hover {
+.pagination li.disabled a, .pagination li.disabled a:hover {
   background-color: transparent;
   color: #bfbfbf;
 }
-.pagination ul li.next a {
+.pagination li.next a {
   border: 0;
 }
 .well {
@@ -1805,11 +1805,11 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-background-clip: padding-box;
   background-clip: padding-box;
 }
-.modal .modal-header {
+.modal-header {
   border-bottom: 1px solid #eee;
   padding: 5px 20px;
 }
-.modal .modal-header .close {
+.modal-header .close {
   position: absolute;
   right: 10px;
   top: 10px;
@@ -1817,10 +1817,10 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   line-height: 10px;
   font-size: 18px;
 }
-.modal .modal-body {
+.modal-body {
   padding: 20px;
 }
-.modal .modal-footer {
+.modal-footer {
   background-color: #f5f5f5;
   padding: 14px 20px 15px;
   border-top: 1px solid #ddd;
@@ -1834,14 +1834,14 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   margin-bottom: 18px;
   margin-bottom: 0;
 }
-.modal .modal-footer:before, .modal .modal-footer:after {
+.modal-footer:before, .modal-footer:after {
   display: table;
   content: "";
 }
-.modal .modal-footer:after {
+.modal-footer:after {
   clear: both;
 }
-.modal .modal-footer .btn {
+.modal-footer .btn {
   float: right;
   margin-left: 10px;
 }
@@ -1889,7 +1889,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   border-bottom: 5px solid transparent;
   border-right: 5px solid #000000;
 }
-.twipsy .twipsy-inner {
+.twipsy-inner {
   padding: 3px 8px;
   background-color: #000;
   color: white;
@@ -1900,7 +1900,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
-.twipsy .twipsy-arrow {
+.twipsy-arrow {
   position: absolute;
   width: 0;
   height: 0;
@@ -1985,6 +1985,6 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-background-clip: padding-box;
   background-clip: padding-box;
 }
-.popover .content p, .popover .content ul, .popover .content ol {
+.popover p, .popover ul, .popover ol {
   margin-bottom: 0;
 }

--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sat Aug 27 19:39:10 PDT 2011
+ * Date: Sat Aug 27 20:35:25 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -727,7 +727,7 @@ fieldset {
   margin-bottom: 18px;
   padding-top: 18px;
 }
-fieldset legend {
+legend {
   display: block;
   margin-left: 150px;
   font-size: 20px;
@@ -831,7 +831,7 @@ form div.error {
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
-form div.error > label, form div.error span.help-inline, form div.error span.help-block {
+form div.error > label, form div.error .help-inline, form div.error .help-block {
   color: #9d261d;
 }
 form div.error input[type=text], form div.error input[type=password], form div.error textarea {
@@ -846,7 +846,7 @@ form div.error input[type=text]:focus, form div.error input[type=password]:focus
   -moz-box-shadow: 0 0 6px rgba(171, 41, 32, 0.5);
   box-shadow: 0 0 6px rgba(171, 41, 32, 0.5);
 }
-form div.error .input-prepend span.add-on, form div.error .input-append span.add-on {
+form div.error .add-on {
   background: #f4c8c5;
   border-color: #c87872;
   color: #b9554d;
@@ -907,13 +907,13 @@ input[readonly]:focus, textarea[readonly]:focus, input.disabled {
   -moz-border-radius: 0 0 3px 3px;
   border-radius: 0 0 3px 3px;
 }
-.actions .secondary-action {
+.secondary-action {
   float: right;
 }
-.actions .secondary-action a {
+.secondary-action a {
   line-height: 30px;
 }
-.actions .secondary-action a:hover {
+.secondary-action a:hover {
   text-decoration: underline;
 }
 .help-inline, .help-block {
@@ -1007,29 +1007,31 @@ input[readonly]:focus, textarea[readonly]:focus, input.disabled {
   padding: 0;
   width: 100%;
 }
+.inputs-list li:first-child {
+  padding-top: 5px;
+}
 .inputs-list li label {
+  line-height: 18px;
+}
+.inputs-list label {
   display: block;
   float: none;
   width: auto;
   padding: 0;
-  line-height: 18px;
   text-align: left;
   white-space: normal;
 }
-.inputs-list li label strong {
+.inputs-list label strong {
   color: #808080;
 }
-.inputs-list li label small {
+.inputs-list label small {
   font-size: 12px;
   font-weight: normal;
 }
-.inputs-list li ul.inputs-list {
+.inputs-list ul.inputs-list {
   margin-left: 25px;
   margin-bottom: 10px;
   padding-top: 0;
-}
-.inputs-list li:first-child {
-  padding-top: 5px;
 }
 .inputs-list input[type=radio], .inputs-list input[type=checkbox] {
   margin-bottom: 0;
@@ -1055,7 +1057,7 @@ input[readonly]:focus, textarea[readonly]:focus, input.disabled {
 .form-stacked .clearfix {
   margin-bottom: 9px;
 }
-.form-stacked .clearfix div.input {
+.form-stacked div.input {
   margin-left: 0;
 }
 .form-stacked .inputs-list {
@@ -1064,7 +1066,7 @@ input[readonly]:focus, textarea[readonly]:focus, input.disabled {
 .form-stacked .inputs-list li {
   padding-top: 0;
 }
-.form-stacked .inputs-list li label {
+.form-stacked .inputs-list label {
   font-weight: normal;
   padding-top: 0;
 }

--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sat Aug 27 20:35:25 PDT 2011
+ * Date: Sat Aug 27 20:43:25 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -280,108 +280,108 @@ table {
 .row:after {
   clear: both;
 }
-.row .span1,
-.row .span2,
-.row .span3,
-.row .span4,
-.row .span5,
-.row .span6,
-.row .span7,
-.row .span8,
-.row .span9,
-.row .span10,
-.row .span11,
-.row .span12,
-.row .span13,
-.row .span14,
-.row .span15,
-.row .span16 {
+.span1,
+.span2,
+.span3,
+.span4,
+.span5,
+.span6,
+.span7,
+.span8,
+.span9,
+.span10,
+.span11,
+.span12,
+.span13,
+.span14,
+.span15,
+.span16 {
   display: inline;
   float: left;
   margin-left: 20px;
 }
-.row .span1 {
+.span1 {
   width: 40px;
 }
-.row .span2 {
+.span2 {
   width: 100px;
 }
-.row .span3 {
+.span3 {
   width: 160px;
 }
-.row .span4 {
+.span4 {
   width: 220px;
 }
-.row .span5 {
+.span5 {
   width: 280px;
 }
-.row .span6 {
+.span6 {
   width: 340px;
 }
-.row .span7 {
+.span7 {
   width: 400px;
 }
-.row .span8 {
+.span8 {
   width: 460px;
 }
-.row .span9 {
+.span9 {
   width: 520px;
 }
-.row .span10 {
+.span10 {
   width: 580px;
 }
-.row .span11 {
+.span11 {
   width: 640px;
 }
-.row .span12 {
+.span12 {
   width: 700px;
 }
-.row .span13 {
+.span13 {
   width: 760px;
 }
-.row .span14 {
+.span14 {
   width: 820px;
 }
-.row .span15 {
+.span15 {
   width: 880px;
 }
-.row .span16 {
+.span16 {
   width: 940px;
 }
-.row .offset1 {
+.offset1 {
   margin-left: 80px;
 }
-.row .offset2 {
+.offset2 {
   margin-left: 140px;
 }
-.row .offset3 {
+.offset3 {
   margin-left: 200px;
 }
-.row .offset4 {
+.offset4 {
   margin-left: 260px;
 }
-.row .offset5 {
+.offset5 {
   margin-left: 320px;
 }
-.row .offset6 {
+.offset6 {
   margin-left: 380px;
 }
-.row .offset7 {
+.offset7 {
   margin-left: 440px;
 }
-.row .offset8 {
+.offset8 {
   margin-left: 500px;
 }
-.row .offset9 {
+.offset9 {
   margin-left: 560px;
 }
-.row .offset10 {
+.offset10 {
   margin-left: 620px;
 }
-.row .offset11 {
+.offset11 {
   margin-left: 680px;
 }
-.row .offset12 {
+.offset12 {
   margin-left: 740px;
 }
 html, body {

--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sat Aug 27 21:50:03 PDT 2011
+ * Date: Sat Aug 27 21:59:00 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -635,13 +635,13 @@ ul.unstyled {
 dl {
   margin-bottom: 18px;
 }
-dl dt, dl dd {
+dt, dd {
   line-height: 18px;
 }
-dl dt {
+dt {
   font-weight: bold;
 }
-dl dd {
+dd {
   margin-left: 9px;
 }
 hr {

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -92,9 +92,10 @@ ul{list-style:disc;}
 ol{list-style:decimal;}
 li{line-height:18px;color:#808080;}
 ul.unstyled{list-style:none;margin-left:0;}
-dl{margin-bottom:18px;}dl dt,dl dd{line-height:18px;}
-dl dt{font-weight:bold;}
-dl dd{margin-left:9px;}
+dl{margin-bottom:18px;}
+dt,dd{line-height:18px;}
+dt{font-weight:bold;}
+dd{margin-left:9px;}
 hr{margin:0 0 19px;border:0;border-bottom:1px solid #eee;}
 strong{font-style:inherit;font-weight:bold;line-height:inherit;}
 em{font-style:italic;font-weight:inherit;line-height:inherit;}

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -162,27 +162,29 @@ input[readonly]:focus,textarea[readonly]:focus,input.disabled{background:#f5f5f5
 .form-stacked .inputs-list label{font-weight:normal;padding-top:0;}
 .form-stacked div.error{padding-top:10px;padding-bottom:10px;padding-left:10px;margin-top:0;margin-left:-10px;}
 .form-stacked .actions{margin-left:-20px;padding-left:20px;}
-table{width:100%;margin-bottom:18px;padding:0;border-collapse:separate;font-size:13px;}table th,table td{padding:10px 10px 9px;line-height:13.5px;text-align:left;vertical-align:middle;border-bottom:1px solid #ddd;}
-table th{padding-top:9px;font-weight:bold;border-bottom-width:2px;}
-.zebra-striped tbody tr:nth-child(odd) td{background-color:#f9f9f9;}
-.zebra-striped tbody tr:hover td{background-color:#f5f5f5;}
+table{width:100%;margin-bottom:18px;padding:0;border-collapse:separate;font-size:13px;}
+th,td{padding:10px 10px 9px;line-height:13.5px;text-align:left;vertical-align:middle;border-bottom:1px solid #ddd;}
+th{padding-top:9px;font-weight:bold;border-bottom-width:2px;}
+.zebra-striped tr:nth-child(odd) td{background-color:#f9f9f9;}
+.zebra-striped tr:hover td{background-color:#f5f5f5;}
 .zebra-striped .header{cursor:pointer;}.zebra-striped .header:after{content:"";float:right;margin-top:7px;border-width:0 4px 4px;border-style:solid;border-color:#000 transparent;visibility:hidden;}
-.zebra-striped .headerSortUp,.zebra-striped .headerSortDown{background-color:rgba(141, 192, 219, 0.25);text-shadow:0 1px 1px rgba(255, 255, 255, 0.75);-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;}
 .zebra-striped .header:hover:after{visibility:visible;}
 .zebra-striped .headerSortDown:after,.zebra-striped .headerSortDown:hover:after{visibility:visible;filter:alpha(opacity=60);-khtml-opacity:0.6;-moz-opacity:0.6;opacity:0.6;}
-.zebra-striped .headerSortUp:after{border-bottom:none;border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid #000;visibility:visible;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;filter:alpha(opacity=60);-khtml-opacity:0.6;-moz-opacity:0.6;opacity:0.6;}
+.zebra-striped .headerSortUp:after{visibility:visible;}
+.headerSortUp,.headerSortDown{background-color:rgba(141, 192, 219, 0.25);text-shadow:0 1px 1px rgba(255, 255, 255, 0.75);-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;}
+.headerSortUp:after{border-bottom:none;border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid #000;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;filter:alpha(opacity=60);-khtml-opacity:0.6;-moz-opacity:0.6;opacity:0.6;}
 table .blue{color:#049cdb;border-bottom-color:#049cdb;}
-table .headerSortUp.blue,table .headerSortDown.blue{background-color:#ade6fe;}
 table .green{color:#46a546;border-bottom-color:#46a546;}
-table .headerSortUp.green,table .headerSortDown.green{background-color:#cdeacd;}
 table .red{color:#9d261d;border-bottom-color:#9d261d;}
-table .headerSortUp.red,table .headerSortDown.red{background-color:#f4c8c5;}
 table .yellow{color:#ffc40d;border-bottom-color:#ffc40d;}
-table .headerSortUp.yellow,table .headerSortDown.yellow{background-color:#fff6d9;}
 table .orange{color:#f89406;border-bottom-color:#f89406;}
-table .headerSortUp.orange,table .headerSortDown.orange{background-color:#fee9cc;}
 table .purple{color:#7a43b6;border-bottom-color:#7a43b6;}
-table .headerSortUp.purple,table .headerSortDown.purple{background-color:#e2d5f0;}
+.headerSortUp.blue,.headerSortDown.blue{background-color:#ade6fe;}
+.headerSortUp.green,.headerSortDown.green{background-color:#cdeacd;}
+.headerSortUp.red,.headerSortDown.red{background-color:#f4c8c5;}
+.headerSortUp.yellow,.headerSortDown.yellow{background-color:#fff6d9;}
+.headerSortUp.orange,.headerSortDown.orange{background-color:#fee9cc;}
+.headerSortUp.purple,.headerSortDown.purple{background-color:#e2d5f0;}
 .topbar{height:40px;position:fixed;top:0;left:0;right:0;z-index:10000;overflow:visible;}.topbar .fill{background:#222;background-color:#222222;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#333333), to(#222222));background-image:-moz-linear-gradient(top, #333333, #222222);background-image:-ms-linear-gradient(top, #333333, #222222);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #333333), color-stop(100%, #222222));background-image:-webkit-linear-gradient(top, #333333, #222222);background-image:-o-linear-gradient(top, #333333, #222222);background-image:linear-gradient(top, #333333, #222222);-webkit-box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);-moz-box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);}
 .topbar a{color:#bfbfbf;text-shadow:0 -1px 0 rgba(0, 0, 0, 0.25);}
 .topbar a:hover,.topbar li.active a{background-color:#333;background-color:rgba(255, 255, 255, 0.05);color:#ffffff;text-decoration:none;}

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -180,24 +180,26 @@ table .purple{color:#7a43b6;border-bottom-color:#7a43b6;}
 table .headerSortUp.purple,table .headerSortDown.purple{background-color:#e2d5f0;}
 .topbar{height:40px;position:fixed;top:0;left:0;right:0;z-index:10000;overflow:visible;}.topbar .fill{background:#222;background-color:#222222;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#333333), to(#222222));background-image:-moz-linear-gradient(top, #333333, #222222);background-image:-ms-linear-gradient(top, #333333, #222222);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #333333), color-stop(100%, #222222));background-image:-webkit-linear-gradient(top, #333333, #222222);background-image:-o-linear-gradient(top, #333333, #222222);background-image:linear-gradient(top, #333333, #222222);-webkit-box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);-moz-box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);box-shadow:0 1px 3px rgba(0, 0, 0, 0.25),inset 0 -1px 0 rgba(0, 0, 0, 0.1);}
 .topbar a{color:#bfbfbf;text-shadow:0 -1px 0 rgba(0, 0, 0, 0.25);}
-.topbar a:hover,.topbar ul li.active a{background-color:#333;background-color:rgba(255, 255, 255, 0.05);color:#ffffff;text-decoration:none;}
+.topbar a:hover,.topbar li.active a{background-color:#333;background-color:rgba(255, 255, 255, 0.05);color:#ffffff;text-decoration:none;}
 .topbar h3{position:relative;}.topbar h3 a{float:left;display:block;padding:8px 20px 12px;margin-left:-20px;color:#ffffff;font-size:20px;font-weight:200;line-height:1;}
-.topbar form{float:left;margin:5px 0 0 0;position:relative;filter:alpha(opacity=100);-khtml-opacity:1;-moz-opacity:1;opacity:1;}.topbar form input{background-color:#444;background-color:rgba(255, 255, 255, 0.3);font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:normal;font-weight:13px;line-height:1;width:220px;padding:4px 9px;color:#fff;color:rgba(255, 255, 255, 0.75);border:1px solid #111;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);-moz-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);-webkit-transition:none;-moz-transition:none;transition:none;}.topbar form input:-moz-placeholder{color:#e6e6e6;}
-.topbar form input::-webkit-input-placeholder{color:#e6e6e6;}
-.topbar form input:hover{background-color:#bfbfbf;background-color:rgba(255, 255, 255, 0.5);color:#fff;}
-.topbar form input:focus,.topbar form input.focused{outline:none;background-color:#fff;color:#404040;text-shadow:0 1px 0 #fff;border:0;padding:5px 10px;-webkit-box-shadow:0 0 3px rgba(0, 0, 0, 0.15);-moz-box-shadow:0 0 3px rgba(0, 0, 0, 0.15);box-shadow:0 0 3px rgba(0, 0, 0, 0.15);}
+.topbar form{float:left;margin:5px 0 0 0;position:relative;filter:alpha(opacity=100);-khtml-opacity:1;-moz-opacity:1;opacity:1;}
+.topbar input{background-color:#444;background-color:rgba(255, 255, 255, 0.3);font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:normal;font-weight:13px;line-height:1;width:220px;padding:4px 9px;color:#fff;color:rgba(255, 255, 255, 0.75);border:1px solid #111;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);-moz-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.1),0 1px 0px rgba(255, 255, 255, 0.25);-webkit-transition:none;-moz-transition:none;transition:none;}.topbar input:-moz-placeholder{color:#e6e6e6;}
+.topbar input::-webkit-input-placeholder{color:#e6e6e6;}
+.topbar input:hover{background-color:#bfbfbf;background-color:rgba(255, 255, 255, 0.5);color:#fff;}
+.topbar input:focus,.topbar input.focused{outline:none;background-color:#fff;color:#404040;text-shadow:0 1px 0 #fff;border:0;padding:5px 10px;-webkit-box-shadow:0 0 3px rgba(0, 0, 0, 0.15);-moz-box-shadow:0 0 3px rgba(0, 0, 0, 0.15);box-shadow:0 0 3px rgba(0, 0, 0, 0.15);}
 .topbar ul{display:block;float:left;margin:0 10px 0 0;position:relative;}.topbar ul.secondary-nav{float:right;margin-left:10px;margin-right:0;}
-.topbar ul li{display:block;float:left;font-size:13px;}.topbar ul li a{display:block;float:none;padding:10px 10px 11px;line-height:19px;text-decoration:none;}.topbar ul li a:hover{color:#fff;text-decoration:none;}
-.topbar ul li.active a{background-color:#222;background-color:rgba(0, 0, 0, 0.5);}
-.topbar ul.primary-nav li ul{left:0;}
-.topbar ul.secondary-nav li ul{right:0;}
-.topbar ul li.menu{position:relative;}.topbar ul li.menu a.menu:after{width:0px;height:0px;display:inline-block;content:"&darr;";text-indent:-99999px;vertical-align:top;margin-top:8px;margin-left:4px;border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid #fff;filter:alpha(opacity=50);-khtml-opacity:0.5;-moz-opacity:0.5;opacity:0.5;}
-.topbar ul li.menu.open a.menu,.topbar ul li.menu.open a:hover{background-color:#444;background-color:rgba(255, 255, 255, 0.1);*background-color:#444;color:#fff;}
-.topbar ul li.menu.open ul{display:block;}.topbar ul li.menu.open ul li a{background-color:transparent;font-weight:normal;}.topbar ul li.menu.open ul li a:hover{background-color:rgba(255, 255, 255, 0.1);*background-color:#444;color:#fff;}
-.topbar ul li.menu.open ul li.active a{background-color:rgba(255, 255, 255, 0.1);font-weight:bold;}
-.topbar ul li ul{background-color:#333;float:left;display:none;position:absolute;top:40px;min-width:160px;max-width:220px;_width:160px;margin-left:0;margin-right:0;padding:0;text-align:left;border:0;zoom:1;-webkit-border-radius:0 0 5px 5px;-moz-border-radius:0 0 5px 5px;border-radius:0 0 5px 5px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);}.topbar ul li ul li{float:none;clear:both;display:block;background:none;font-size:12px;}.topbar ul li ul li a{display:block;padding:6px 15px;clear:both;font-weight:normal;line-height:19px;color:#bbb;}.topbar ul li ul li a:hover{background-color:#333;background-color:rgba(255, 255, 255, 0.25);color:#fff;}
-.topbar ul li ul li.divider{height:1px;overflow:hidden;background:#222;background:rgba(0, 0, 0, 0.2);border-bottom:1px solid rgba(255, 255, 255, 0.1);margin:5px 0;}
-.topbar ul li ul li span{clear:both;display:block;background:rgba(0, 0, 0, 0.2);padding:6px 15px;cursor:default;color:#808080;border-top:1px solid rgba(0, 0, 0, 0.2);}
+.topbar ul.primary-nav ul{left:0;}
+.topbar ul.secondary-nav ul{right:0;}
+.topbar ul ul{background-color:#333;float:left;display:none;position:absolute;top:40px;min-width:160px;max-width:220px;_width:160px;margin-left:0;margin-right:0;padding:0;text-align:left;border:0;zoom:1;-webkit-border-radius:0 0 5px 5px;-moz-border-radius:0 0 5px 5px;border-radius:0 0 5px 5px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);box-shadow:0 1px 2px rgba(0, 0, 0, 0.6);}.topbar ul ul a{display:block;padding:6px 15px;clear:both;font-weight:normal;line-height:19px;color:#bbb;}.topbar ul ul a:hover{background-color:#333;background-color:rgba(255, 255, 255, 0.25);color:#fff;}
+.topbar ul ul span{clear:both;display:block;background:rgba(0, 0, 0, 0.2);padding:6px 15px;cursor:default;color:#808080;border-top:1px solid rgba(0, 0, 0, 0.2);}
+.topbar li{display:block;float:left;font-size:13px;}.topbar li a{display:block;float:none;padding:10px 10px 11px;line-height:19px;text-decoration:none;}.topbar li a:hover{color:#fff;text-decoration:none;}
+.topbar li.active a{background-color:#222;background-color:rgba(0, 0, 0, 0.5);}
+.topbar li li{float:none;clear:both;display:block;background:none;font-size:12px;}.topbar li li.divider{height:1px;overflow:hidden;background:#222;background:rgba(0, 0, 0, 0.2);border-bottom:1px solid rgba(255, 255, 255, 0.1);margin:5px 0;}
+.topbar li.menu{position:relative;}.topbar li.menu.open a.menu,.topbar li.menu.open a:hover{background-color:#444;background-color:rgba(255, 255, 255, 0.1);*background-color:#444;color:#fff;}
+.topbar li.menu.open ul{display:block;}
+.topbar li.menu.open li a{background-color:transparent;font-weight:normal;}.topbar li.menu.open li a:hover{background-color:rgba(255, 255, 255, 0.1);*background-color:#444;color:#fff;}
+.topbar li.menu.open li.active a{background-color:rgba(255, 255, 255, 0.1);font-weight:bold;}
+.topbar a.menu:after{width:0px;height:0px;display:inline-block;content:"&darr;";text-indent:-99999px;vertical-align:top;margin-top:8px;margin-left:4px;border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid #fff;filter:alpha(opacity=50);-khtml-opacity:0.5;-moz-opacity:0.5;opacity:0.5;}
 .hero-unit{background-color:#f5f5f5;margin-top:60px;margin-bottom:30px;padding:60px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;}.hero-unit h1{margin-bottom:0;font-size:60px;line-height:1;letter-spacing:-1px;}
 .hero-unit p{font-size:18px;font-weight:200;line-height:27px;}
 footer{margin-top:17px;padding-top:17px;border-top:1px solid #eee;}
@@ -216,35 +218,38 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .alert-message .btn{-webkit-box-shadow:0 1px 0 rgba(255, 255, 255, 0.25);-moz-box-shadow:0 1px 0 rgba(255, 255, 255, 0.25);box-shadow:0 1px 0 rgba(255, 255, 255, 0.25);}
 .alert-message .close{float:right;margin-top:-2px;color:#000000;font-size:20px;font-weight:bold;text-shadow:0 1px 0 #ffffff;filter:alpha(opacity=20);-khtml-opacity:0.2;-moz-opacity:0.2;opacity:0.2;}.alert-message .close:hover{color:#000000;text-decoration:none;filter:alpha(opacity=40);-khtml-opacity:0.4;-moz-opacity:0.4;opacity:0.4;}
 .alert-message.block-message{background-image:none;background-color:#fdf5d9;padding:14px;border-color:#fceec1;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;}.alert-message.block-message p{margin-right:30px;}
-.alert-message.block-message .alert-actions{margin-top:5px;}
 .alert-message.block-message.error,.alert-message.block-message.success,.alert-message.block-message.info{color:#404040;text-shadow:0 1px 0 rgba(255, 255, 255, 0.5);}
 .alert-message.block-message.error{background-color:#fddfde;border-color:#fbc7c6;}
 .alert-message.block-message.success{background-color:#d1eed1;border-color:#bfe7bf;}
 .alert-message.block-message.info{background-color:#ddf4fb;border-color:#c6edf9;}
+.alert-message .alert-actions{margin-top:5px;}
 .tabs,.pills{margin:0 0 20px;padding:0;zoom:1;margin-bottom:18px;}.tabs:before,.pills:before,.tabs:after,.pills:after{display:table;content:"";}
 .tabs:after,.pills:after{clear:both;}
-.tabs li,.pills li{display:inline;}.tabs li a,.pills li a{float:left;width:auto;}
-.tabs{width:100%;border-bottom:1px solid #bfbfbf;}.tabs li a{margin-bottom:-1px;margin-right:2px;padding:0 15px;line-height:35px;-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;}.tabs li a:hover{background-color:#e6e6e6;border-bottom:1px solid #bfbfbf;}
+.tabs li,.pills li{display:inline;}
+.tabs a,.pills a{float:left;width:auto;}
+.tabs{width:100%;border-bottom:1px solid #bfbfbf;}.tabs a{margin-bottom:-1px;margin-right:2px;padding:0 15px;line-height:35px;-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;}.tabs a:hover{background-color:#e6e6e6;border-bottom:1px solid #bfbfbf;}
 .tabs li.active a{background-color:#fff;padding:0 14px;border:1px solid #ccc;border-bottom:0;color:#808080;}
-.pills li a{margin:5px 3px 5px 0;padding:0 15px;text-shadow:0 1px 1px #fff;line-height:30px;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px;}.pills li a:hover{background:#0050a3;color:#fff;text-decoration:none;text-shadow:0 1px 1px rgba(0, 0, 0, 0.25);}
+.pills a{margin:5px 3px 5px 0;padding:0 15px;text-shadow:0 1px 1px #fff;line-height:30px;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px;}.pills a:hover{background:#0050a3;color:#fff;text-decoration:none;text-shadow:0 1px 1px rgba(0, 0, 0, 0.25);}
 .pills li.active a{background:#0069d6;color:#fff;text-shadow:0 1px 1px rgba(0, 0, 0, 0.25);}
-.pagination{height:36px;margin:18px 0;}.pagination ul{float:left;margin:0;border:1px solid #ddd;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);}.pagination ul li{display:inline;}.pagination ul li a{float:left;padding:0 14px;line-height:34px;border-right:1px solid;border-right-color:#ddd;border-right-color:rgba(0, 0, 0, 0.15);*border-right-color:#ddd;text-decoration:none;}
-.pagination ul li a:hover,.pagination ul li.active a{background-color:#c7eefe;}
-.pagination ul li.disabled a,.pagination ul li.disabled a:hover{background-color:transparent;color:#bfbfbf;}
-.pagination ul li.next a{border:0;}
+.pagination{height:36px;margin:18px 0;}.pagination ul{float:left;margin:0;border:1px solid #ddd;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);}
+.pagination li{display:inline;}.pagination li a{float:left;padding:0 14px;line-height:34px;border-right:1px solid;border-right-color:#ddd;border-right-color:rgba(0, 0, 0, 0.15);*border-right-color:#ddd;text-decoration:none;}
+.pagination li a:hover,.pagination li.active a{background-color:#c7eefe;}
+.pagination li.disabled a,.pagination li.disabled a:hover{background-color:transparent;color:#bfbfbf;}
+.pagination li.next a{border:0;}
 .well{background-color:#f5f5f5;margin-bottom:20px;padding:19px;min-height:20px;border:1px solid #eee;border:1px solid rgba(0, 0, 0, 0.05);-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);-moz-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);}
 .modal-backdrop{background-color:rgba(0, 0, 0, 0.5);position:fixed;top:0;left:0;right:0;bottom:0;z-index:1000;}
-.modal{position:fixed;top:50%;left:50%;z-index:2000;width:560px;margin:-280px 0 0 -250px;background-color:#ffffff;border:1px solid #999;border:1px solid rgba(0, 0, 0, 0.3);*border:1px solid #999;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-moz-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}.modal .modal-header{border-bottom:1px solid #eee;padding:5px 20px;}.modal .modal-header .close{position:absolute;right:10px;top:10px;color:#999;line-height:10px;font-size:18px;}
-.modal .modal-body{padding:20px;}
-.modal .modal-footer{background-color:#f5f5f5;padding:14px 20px 15px;border-top:1px solid #ddd;-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;zoom:1;margin-bottom:18px;margin-bottom:0;}.modal .modal-footer:before,.modal .modal-footer:after{display:table;content:"";}
-.modal .modal-footer:after{clear:both;}
-.modal .modal-footer .btn{float:right;margin-left:10px;}
+.modal{position:fixed;top:50%;left:50%;z-index:2000;width:560px;margin:-280px 0 0 -250px;background-color:#ffffff;border:1px solid #999;border:1px solid rgba(0, 0, 0, 0.3);*border:1px solid #999;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-moz-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}
+.modal-header{border-bottom:1px solid #eee;padding:5px 20px;}.modal-header .close{position:absolute;right:10px;top:10px;color:#999;line-height:10px;font-size:18px;}
+.modal-body{padding:20px;}
+.modal-footer{background-color:#f5f5f5;padding:14px 20px 15px;border-top:1px solid #ddd;-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;zoom:1;margin-bottom:18px;margin-bottom:0;}.modal-footer:before,.modal-footer:after{display:table;content:"";}
+.modal-footer:after{clear:both;}
+.modal-footer .btn{float:right;margin-left:10px;}
 .twipsy{display:block;position:absolute;visibility:visible;padding:5px;font-size:11px;z-index:1000;filter:alpha(opacity=80);-khtml-opacity:0.8;-moz-opacity:0.8;opacity:0.8;}.twipsy.above .twipsy-arrow{bottom:0;left:50%;margin-left:-5px;border-left:5px solid transparent;border-right:5px solid transparent;border-top:5px solid #000000;}
 .twipsy.left .twipsy-arrow{top:50%;right:0;margin-top:-5px;border-top:5px solid transparent;border-bottom:5px solid transparent;border-left:5px solid #000000;}
 .twipsy.below .twipsy-arrow{top:0;left:50%;margin-left:-5px;border-left:5px solid transparent;border-right:5px solid transparent;border-bottom:5px solid #000000;}
 .twipsy.right .twipsy-arrow{top:50%;left:0;margin-top:-5px;border-top:5px solid transparent;border-bottom:5px solid transparent;border-right:5px solid #000000;}
-.twipsy .twipsy-inner{padding:3px 8px;background-color:#000;color:white;text-align:center;max-width:200px;text-decoration:none;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}
-.twipsy .twipsy-arrow{position:absolute;width:0;height:0;}
+.twipsy-inner{padding:3px 8px;background-color:#000;color:white;text-align:center;max-width:200px;text-decoration:none;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}
+.twipsy-arrow{position:absolute;width:0;height:0;}
 .popover{position:absolute;top:0;left:0;z-index:1000;padding:5px;display:none;}.popover.above .arrow{bottom:0;left:50%;margin-left:-5px;border-left:5px solid transparent;border-right:5px solid transparent;border-top:5px solid #000000;}
 .popover.right .arrow{top:50%;left:0;margin-top:-5px;border-top:5px solid transparent;border-bottom:5px solid transparent;border-right:5px solid #000000;}
 .popover.below .arrow{top:0;left:50%;margin-left:-5px;border-left:5px solid transparent;border-right:5px solid transparent;border-bottom:5px solid #000000;}
@@ -252,4 +257,5 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .popover .arrow{position:absolute;width:0;height:0;}
 .popover .inner{background-color:#333;background-color:rgba(0, 0, 0, 0.8);*background-color:#333;padding:3px;overflow:hidden;width:280px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-moz-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);}
 .popover .title{background-color:#f5f5f5;padding:9px 15px;line-height:1;-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;border-bottom:1px solid #eee;}
-.popover .content{background-color:#ffffff;padding:14px;-webkit-border-radius:0 0 3px 3px;-moz-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}.popover .content p,.popover .content ul,.popover .content ol{margin-bottom:0;}
+.popover .content{background-color:#ffffff;padding:14px;-webkit-border-radius:0 0 3px 3px;-moz-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}
+.popover p,.popover ul,.popover ol{margin-bottom:0;}

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -31,35 +31,35 @@ table{border-collapse:collapse;border-spacing:0;}
 .btn.info,.alert-message.info{background-color:#339bb9;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#5bc0de), to(#339bb9));background-image:-moz-linear-gradient(top, #5bc0de, #339bb9);background-image:-ms-linear-gradient(top, #5bc0de, #339bb9);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #5bc0de), color-stop(100%, #339bb9));background-image:-webkit-linear-gradient(top, #5bc0de, #339bb9);background-image:-o-linear-gradient(top, #5bc0de, #339bb9);background-image:linear-gradient(top, #5bc0de, #339bb9);text-shadow:0 -1px 0 rgba(0, 0, 0, 0.25);border-color:#339bb9 #339bb9 #22697d;border-color:rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);}
 .row{zoom:1;margin-bottom:18px;margin-left:-20px;}.row:before,.row:after{display:table;content:"";}
 .row:after{clear:both;}
-.row .span1,.row .span2,.row .span3,.row .span4,.row .span5,.row .span6,.row .span7,.row .span8,.row .span9,.row .span10,.row .span11,.row .span12,.row .span13,.row .span14,.row .span15,.row .span16{display:inline;float:left;margin-left:20px;}
-.row .span1{width:40px;}
-.row .span2{width:100px;}
-.row .span3{width:160px;}
-.row .span4{width:220px;}
-.row .span5{width:280px;}
-.row .span6{width:340px;}
-.row .span7{width:400px;}
-.row .span8{width:460px;}
-.row .span9{width:520px;}
-.row .span10{width:580px;}
-.row .span11{width:640px;}
-.row .span12{width:700px;}
-.row .span13{width:760px;}
-.row .span14{width:820px;}
-.row .span15{width:880px;}
-.row .span16{width:940px;}
-.row .offset1{margin-left:80px;}
-.row .offset2{margin-left:140px;}
-.row .offset3{margin-left:200px;}
-.row .offset4{margin-left:260px;}
-.row .offset5{margin-left:320px;}
-.row .offset6{margin-left:380px;}
-.row .offset7{margin-left:440px;}
-.row .offset8{margin-left:500px;}
-.row .offset9{margin-left:560px;}
-.row .offset10{margin-left:620px;}
-.row .offset11{margin-left:680px;}
-.row .offset12{margin-left:740px;}
+.span1,.span2,.span3,.span4,.span5,.span6,.span7,.span8,.span9,.span10,.span11,.span12,.span13,.span14,.span15,.span16{display:inline;float:left;margin-left:20px;}
+.span1{width:40px;}
+.span2{width:100px;}
+.span3{width:160px;}
+.span4{width:220px;}
+.span5{width:280px;}
+.span6{width:340px;}
+.span7{width:400px;}
+.span8{width:460px;}
+.span9{width:520px;}
+.span10{width:580px;}
+.span11{width:640px;}
+.span12{width:700px;}
+.span13{width:760px;}
+.span14{width:820px;}
+.span15{width:880px;}
+.span16{width:940px;}
+.offset1{margin-left:80px;}
+.offset2{margin-left:140px;}
+.offset3{margin-left:200px;}
+.offset4{margin-left:260px;}
+.offset5{margin-left:320px;}
+.offset6{margin-left:380px;}
+.offset7{margin-left:440px;}
+.offset8{margin-left:500px;}
+.offset9{margin-left:560px;}
+.offset10{margin-left:620px;}
+.offset11{margin-left:680px;}
+.offset12{margin-left:740px;}
 html,body{background-color:#fff;}
 body{margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:18px;color:#808080;text-rendering:optimizeLegibility;}
 .container{width:940px;margin:0 auto;}

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -106,7 +106,8 @@ code,pre{padding:0 3px 2px;font-family:Monaco, Andale Mono, Courier New, monospa
 code{background-color:#fee9cc;color:rgba(0, 0, 0, 0.75);padding:1px 3px;}
 pre{background-color:#f5f5f5;display:block;padding:17px;margin:0 0 18px;line-height:18px;font-size:12px;border:1px solid #ccc;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;white-space:pre;white-space:pre-wrap;word-wrap:break-word;}
 form{margin-bottom:18px;}
-fieldset{margin-bottom:18px;padding-top:18px;}fieldset legend{display:block;margin-left:150px;font-size:20px;line-height:1;*margin:0 0 5px 145px;*line-height:1.5;color:#404040;}
+fieldset{margin-bottom:18px;padding-top:18px;}
+legend{display:block;margin-left:150px;font-size:20px;line-height:1;*margin:0 0 5px 145px;*line-height:1.5;color:#404040;}
 .clearfix{margin-bottom:18px;}
 label,input,select,textarea{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:normal;}
 label{padding-top:6px;font-size:13px;line-height:18px;float:left;width:130px;text-align:right;color:#404040;}
@@ -120,9 +121,9 @@ textarea{height:auto;}
 ::-webkit-input-placeholder{color:#bfbfbf;}
 input[type=text],input[type=password],select,textarea{-webkit-transition:border linear 0.2s,box-shadow linear 0.2s;-moz-transition:border linear 0.2s,box-shadow linear 0.2s;transition:border linear 0.2s,box-shadow linear 0.2s;-webkit-box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1);-moz-box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1);box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1);}
 input[type=text]:focus,input[type=password]:focus,textarea:focus{outline:none;border-color:rgba(82, 168, 236, 0.8);-webkit-box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1),0 0 8px rgba(82, 168, 236, 0.6);-moz-box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1),0 0 8px rgba(82, 168, 236, 0.6);box-shadow:inset 0 1px 3px rgba(0, 0, 0, 0.1),0 0 8px rgba(82, 168, 236, 0.6);}
-form div.error{background:#fae5e3;padding:10px 0;margin:-10px 0 10px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}form div.error>label,form div.error span.help-inline,form div.error span.help-block{color:#9d261d;}
+form div.error{background:#fae5e3;padding:10px 0;margin:-10px 0 10px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}form div.error>label,form div.error .help-inline,form div.error .help-block{color:#9d261d;}
 form div.error input[type=text],form div.error input[type=password],form div.error textarea{border-color:#c87872;-webkit-box-shadow:0 0 3px rgba(171, 41, 32, 0.25);-moz-box-shadow:0 0 3px rgba(171, 41, 32, 0.25);box-shadow:0 0 3px rgba(171, 41, 32, 0.25);}form div.error input[type=text]:focus,form div.error input[type=password]:focus,form div.error textarea:focus{border-color:#b9554d;-webkit-box-shadow:0 0 6px rgba(171, 41, 32, 0.5);-moz-box-shadow:0 0 6px rgba(171, 41, 32, 0.5);box-shadow:0 0 6px rgba(171, 41, 32, 0.5);}
-form div.error .input-prepend span.add-on,form div.error .input-append span.add-on{background:#f4c8c5;border-color:#c87872;color:#b9554d;}
+form div.error .add-on{background:#f4c8c5;border-color:#c87872;color:#b9554d;}
 .input-mini,input.mini,textarea.mini,select.mini{width:60px;}
 .input-small,input.small,textarea.small,select.small{width:90px;}
 .input-medium,input.medium,textarea.medium,select.medium{width:150px;}
@@ -131,7 +132,8 @@ form div.error .input-prepend span.add-on,form div.error .input-append span.add-
 .input-xxlarge,input.xxlarge,textarea.xxlarge,select.xxlarge{width:530px;}
 textarea.xxlarge{overflow-y:scroll;}
 input[readonly]:focus,textarea[readonly]:focus,input.disabled{background:#f5f5f5;border-color:#ddd;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;}
-.actions{background:#f5f5f5;margin-top:18px;margin-bottom:18px;padding:17px 20px 18px 150px;border-top:1px solid #ddd;-webkit-border-radius:0 0 3px 3px;-moz-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;}.actions .secondary-action{float:right;}.actions .secondary-action a{line-height:30px;}.actions .secondary-action a:hover{text-decoration:underline;}
+.actions{background:#f5f5f5;margin-top:18px;margin-bottom:18px;padding:17px 20px 18px 150px;border-top:1px solid #ddd;-webkit-border-radius:0 0 3px 3px;-moz-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;}
+.secondary-action{float:right;}.secondary-action a{line-height:30px;}.secondary-action a:hover{text-decoration:underline;}
 .help-inline,.help-block{font-size:12px;line-height:18px;color:#bfbfbf;}
 .help-inline{padding-left:5px;*position:relative;*top:-5px;}
 .help-block{display:block;max-width:600px;}
@@ -145,16 +147,19 @@ input[readonly]:focus,textarea[readonly]:focus,input.disabled{background:#f5f5f5
 .input-prepend .add-on{*margin-top:1px;}
 .input-append input[type=text],.input-append input[type=password]{float:left;-webkit-border-radius:3px 0 0 3px;-moz-border-radius:3px 0 0 3px;border-radius:3px 0 0 3px;}
 .input-append .add-on{-webkit-border-radius:0 3px 3px 0;-moz-border-radius:0 3px 3px 0;border-radius:0 3px 3px 0;border-right-width:1px;border-left-width:0;}
-.inputs-list{margin:0 0 5px;width:100%;}.inputs-list li{display:block;padding:0;width:100%;}.inputs-list li label{display:block;float:none;width:auto;padding:0;line-height:18px;text-align:left;white-space:normal;}.inputs-list li label strong{color:#808080;}
-.inputs-list li label small{font-size:12px;font-weight:normal;}
-.inputs-list li ul.inputs-list{margin-left:25px;margin-bottom:10px;padding-top:0;}
-.inputs-list li:first-child{padding-top:5px;}
+.inputs-list{margin:0 0 5px;width:100%;}.inputs-list li{display:block;padding:0;width:100%;}.inputs-list li:first-child{padding-top:5px;}
+.inputs-list li label{line-height:18px;}
+.inputs-list label{display:block;float:none;width:auto;padding:0;text-align:left;white-space:normal;}.inputs-list label strong{color:#808080;}
+.inputs-list label small{font-size:12px;font-weight:normal;}
+.inputs-list ul.inputs-list{margin-left:25px;margin-bottom:10px;padding-top:0;}
 .inputs-list input[type=radio],.inputs-list input[type=checkbox]{margin-bottom:0;}
 .form-stacked{padding-left:20px;}.form-stacked fieldset{padding-top:9px;}
 .form-stacked legend{margin-left:0;}
 .form-stacked label{display:block;float:none;width:auto;font-weight:bold;text-align:left;line-height:20px;padding-top:0;}
-.form-stacked .clearfix{margin-bottom:9px;}.form-stacked .clearfix div.input{margin-left:0;}
-.form-stacked .inputs-list{margin-bottom:0;}.form-stacked .inputs-list li{padding-top:0;}.form-stacked .inputs-list li label{font-weight:normal;padding-top:0;}
+.form-stacked .clearfix{margin-bottom:9px;}
+.form-stacked div.input{margin-left:0;}
+.form-stacked .inputs-list{margin-bottom:0;}.form-stacked .inputs-list li{padding-top:0;}
+.form-stacked .inputs-list label{font-weight:normal;padding-top:0;}
 .form-stacked div.error{padding-top:10px;padding-bottom:10px;padding-left:10px;margin-top:0;margin-left:-10px;}
 .form-stacked .actions{margin-left:-20px;padding-left:20px;}
 table{width:100%;margin-bottom:18px;padding:0;border-collapse:separate;font-size:13px;}table th,table td{padding:10px 10px 9px;line-height:13.5px;text-align:left;vertical-align:middle;border-bottom:1px solid #ddd;}

--- a/lib/forms.less
+++ b/lib/forms.less
@@ -14,15 +14,16 @@ form {
 fieldset {
   margin-bottom: @baseline;
   padding-top: @baseline;
-  legend {
-    display: block;
-    margin-left: 150px;
-    font-size: 20px;
-    line-height: 1;
-    *margin: 0 0 5px 145px; /* IE6-7 */
-    *line-height: 1.5; /* IE6-7 */
-    color: @grayDark;
-  }
+}
+
+legend {
+  display: block;
+  margin-left: 150px;
+  font-size: 20px;
+  line-height: 1;
+  *margin: 0 0 5px 145px; /* IE6-7 */
+  *line-height: 1.5; /* IE6-7 */
+  color: @grayDark;
 }
 
 // Parent element that clears floats and wraps labels and fields together
@@ -124,8 +125,8 @@ form div.error {
   .border-radius(4px);
   @error-text: desaturate(lighten(@red, 25%), 25%);
   > label,
-  span.help-inline,
-  span.help-block {
+  .help-inline,
+  .help-block {
     color: @red;
   }
   input[type=text],
@@ -138,13 +139,10 @@ form div.error {
       .box-shadow(0 0 6px rgba(171,41,32,.5));
     }
   }
-  .input-prepend,
-  .input-append {
-    span.add-on {
-      background: lighten(@red, 50%);
-      border-color: @error-text;
-      color: darken(@error-text, 10%);
-    }
+  .add-on {
+    background: lighten(@red, 50%);
+    border-color: @error-text;
+    color: darken(@error-text, 10%);
   }
 }
 
@@ -188,13 +186,14 @@ input.disabled {
   padding: (@baseline - 1) 20px @baseline 150px;
   border-top: 1px solid #ddd;
   .border-radius(0 0 3px 3px);
-  .secondary-action {
-    float: right;
-    a {
-      line-height: 30px;
-      &:hover {
-        text-decoration: underline;
-      }
+}
+
+.secondary-action {
+  float: right;
+  a {
+    line-height: 30px;
+    &:hover {
+      text-decoration: underline;
     }
   }
 }
@@ -264,10 +263,8 @@ input.disabled {
     border-color: @green;
   }
 }
-.input-prepend {
-  .add-on {
-    *margin-top: 1px; /* IE6-7 */
-  }
+.input-prepend .add-on {
+  *margin-top: 1px; /* IE6-7 */
 }
 .input-append {
   input[type=text],
@@ -290,30 +287,34 @@ input.disabled {
     display: block;
     padding: 0;
     width: 100%;
-    label {
-      display: block;
-      float: none;
-      width: auto;
-      padding: 0;
-      line-height: @baseline;
-      text-align: left;
-      white-space: normal;
-      strong {
-        color: @gray;
-      }
-      small {
-        font-size: 12px;
-        font-weight: normal;
-      }
-    }
-    ul.inputs-list {
-      margin-left: 25px;
-      margin-bottom: 10px;
-      padding-top: 0;
-    }
     &:first-child {
       padding-top: 5px;
     }
+    label {
+      // cannot be factored out into the label block below because it must have
+      // greater priority than .form-stacked label, which is defined later on
+      line-height: @baseline;
+    }
+  }
+  label {
+    display: block;
+    float: none;
+    width: auto;
+    padding: 0;
+    text-align: left;
+    white-space: normal;
+    strong {
+      color: @gray;
+    }
+    small {
+      font-size: 12px;
+      font-weight: normal;
+    }
+  }
+  ul.inputs-list {
+    margin-left: 25px;
+    margin-bottom: 10px;
+    padding-top: 0;
   }
   input[type=radio],
   input[type=checkbox] {
@@ -341,18 +342,18 @@ input.disabled {
   }
   .clearfix {
     margin-bottom: @baseline / 2;
-    div.input {
-      margin-left: 0;
-    }
+  }
+  div.input {
+    margin-left: 0;
   }
   .inputs-list {
     margin-bottom: 0;
     li {
       padding-top: 0;
-      label {
-        font-weight: normal;
-        padding-top: 0;
-      }
+    }
+    label {
+      font-weight: normal;
+      padding-top: 0;
     }
   }
   div.error {

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -32,7 +32,7 @@
 
   // Hover and active states
   a:hover,
-  ul li.active a {
+  li.active a {
     background-color: #333;
     background-color: rgba(255,255,255,.05);
     color: @white;
@@ -60,44 +60,45 @@
     margin: 5px 0 0 0;
     position: relative;
     .opacity(100);
-    input {
-      background-color: #444;
-      background-color: rgba(255,255,255,.3);
-      #font > .sans-serif(13px, normal, 1);
-      width: 220px;
-      padding: 4px 9px;
-      color: #fff;
-      color: rgba(255,255,255,.75);
-      border: 1px solid #111;
-      .border-radius(4px);
-      @shadow: inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0px rgba(255,255,255,.25);
-      .box-shadow(@shadow);
-      .transition(none);
+  }
 
-      // Placeholder text gets special styles; can't be bundled together though for some reason
-      &:-moz-placeholder {
-        color: @grayLighter;
-      }
-      &::-webkit-input-placeholder {
-        color: @grayLighter;
-      }
-      // Hover states
-      &:hover {
-        background-color: @grayLight;
-        background-color: rgba(255,255,255,.5);
-        color: #fff;
-      }
-      // Focus states (we use .focused since IE8 and down doesn't support :focus)
-      &:focus,
-      &.focused {
-        outline: none;
-        background-color: #fff;
-        color: @grayDark;
-        text-shadow: 0 1px 0 #fff;
-        border: 0;
-        padding: 5px 10px;
-        .box-shadow(0 0 3px rgba(0,0,0,.15));
-      }
+  input {
+    background-color: #444;
+    background-color: rgba(255,255,255,.3);
+    #font > .sans-serif(13px, normal, 1);
+    width: 220px;
+    padding: 4px 9px;
+    color: #fff;
+    color: rgba(255,255,255,.75);
+    border: 1px solid #111;
+    .border-radius(4px);
+    @shadow: inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0px rgba(255,255,255,.25);
+    .box-shadow(@shadow);
+    .transition(none);
+
+    // Placeholder text gets special styles; can't be bundled together though for some reason
+    &:-moz-placeholder {
+      color: @grayLighter;
+    }
+    &::-webkit-input-placeholder {
+      color: @grayLighter;
+    }
+    // Hover states
+    &:hover {
+      background-color: @grayLight;
+      background-color: rgba(255,255,255,.5);
+      color: #fff;
+    }
+    // Focus states (we use .focused since IE8 and down doesn't support :focus)
+    &:focus,
+    &.focused {
+      outline: none;
+      background-color: #fff;
+      color: @grayDark;
+      text-shadow: 0 1px 0 #fff;
+      border: 0;
+      padding: 5px 10px;
+      .box-shadow(0 0 3px rgba(0,0,0,.15));
     }
   }
 
@@ -112,81 +113,16 @@
       margin-left: 10px;
       margin-right: 0;
     }
-    li {
-      display: block;
-      float: left;
-      font-size: 13px;
-      a {
-        display: block;
-        float: none;
-        padding: 10px 10px 11px;
-        line-height: 19px;
-        text-decoration: none;
-        &:hover {
-          color: #fff;
-          text-decoration: none;
-        }
-      }
-      &.active a {
-        background-color: #222;
-        background-color: rgba(0,0,0,.5);
-      }
-    }
 
     // Dropdowns
-    &.primary-nav li ul {
+    &.primary-nav ul {
       left: 0;
     }
-    &.secondary-nav li ul {
+    &.secondary-nav ul {
       right: 0;
     }
-    li.menu {
-      position: relative;
-      a.menu {
-        &:after {
-          width: 0px;
-          height: 0px;
-          display: inline-block;
-          content: "&darr;";
-          text-indent: -99999px;
-          vertical-align: top;
-          margin-top: 8px;
-          margin-left: 4px;
-          border-left: 4px solid transparent;
-          border-right: 4px solid transparent;
-          border-top: 4px solid #fff;
-          .opacity(50);
-        }
-      }
-      &.open {
-        a.menu,
-        a:hover {
-          background-color: #444;
-          background-color: rgba(255,255,255,.1);
-          *background-color: #444; /* IE6-7 */
-          color: #fff;
-        }
-        ul {
-          display: block;
-          li {
-            a {
-              background-color: transparent;
-              font-weight: normal;
-              &:hover {
-                background-color: rgba(255,255,255,.1);
-                *background-color: #444; /* IE6-7 */
-                color: #fff;
-              }
-            }
-            &.active a {
-              background-color: rgba(255,255,255,.1);
-              font-weight: bold;
-            }
-          }
-        }
-      }
-    }
-    li ul {
+
+    ul {
       background-color: #333;
       float: left;
       display: none;
@@ -203,48 +139,115 @@
       zoom: 1;
       .border-radius(0 0 5px 5px);
       .box-shadow(0 1px 2px rgba(0,0,0,0.6));
-      li {
-        float: none;
+      a {
+        display: block;
+        padding: 6px 15px;
+        clear: both;
+        font-weight: normal;
+        line-height: 19px;
+        color: #bbb;
+        &:hover {
+          background-color: #333;
+          background-color: rgba(255,255,255,.25);
+          color: #fff;
+        }
+      }
+
+      // Section separaters
+      span {
         clear: both;
         display: block;
-        background: none;
-        font-size: 12px;
+        background: rgba(0,0,0,.2);
+        padding: 6px 15px;
+        cursor: default;
+        color: @gray;
+        border-top: 1px solid rgba(0,0,0,.2);
+      }
+    }
+  }
+
+  li {
+    display: block;
+    float: left;
+    font-size: 13px;
+    a {
+      display: block;
+      float: none;
+      padding: 10px 10px 11px;
+      line-height: 19px;
+      text-decoration: none;
+      &:hover {
+        color: #fff;
+        text-decoration: none;
+      }
+    }
+    &.active a {
+      background-color: #222;
+      background-color: rgba(0,0,0,.5);
+    }
+    li {
+      float: none;
+      clear: both;
+      display: block;
+      background: none;
+      font-size: 12px;
+
+      // Dividers (basically an hr)
+      &.divider {
+        height: 1px;
+        overflow: hidden;
+        background: #222;
+        background: rgba(0,0,0,.2);
+        border-bottom: 1px solid rgba(255,255,255,.1);
+        margin: 5px 0;
+      }
+    }
+  }
+
+  li.menu {
+    position: relative;
+    &.open {
+      a.menu,
+      a:hover {
+        background-color: #444;
+        background-color: rgba(255,255,255,.1);
+        *background-color: #444; /* IE6-7 */
+        color: #fff;
+      }
+      ul {
+        display: block;
+      }
+      li {
         a {
-          display: block;
-          padding: 6px 15px;
-          clear: both;
+          background-color: transparent;
           font-weight: normal;
-          line-height: 19px;
-          color: #bbb;
           &:hover {
-            background-color: #333;
-            background-color: rgba(255,255,255,.25);
+            background-color: rgba(255,255,255,.1);
+            *background-color: #444; /* IE6-7 */
             color: #fff;
           }
         }
-
-        // Dividers (basically an hr)
-        &.divider {
-          height: 1px;
-          overflow: hidden;
-          background: #222;
-          background: rgba(0,0,0,.2);
-          border-bottom: 1px solid rgba(255,255,255,.1);
-          margin: 5px 0;
-        }
-
-        // Section separaters
-        span {
-          clear: both;
-          display: block;
-          background: rgba(0,0,0,.2);
-          padding: 6px 15px;
-          cursor: default;
-          color: @gray;
-          border-top: 1px solid rgba(0,0,0,.2);
+        &.active a {
+          background-color: rgba(255,255,255,.1);
+          font-weight: bold;
         }
       }
     }
+  }
+
+  a.menu:after {
+    width: 0px;
+    height: 0px;
+    display: inline-block;
+    content: "&darr;";
+    text-indent: -99999px;
+    vertical-align: top;
+    margin-top: 8px;
+    margin-left: 4px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 4px solid #fff;
+    .opacity(50);
   }
 }
 
@@ -426,9 +429,6 @@ input[type=submit].btn {
     p {
       margin-right: 30px;
     }
-    .alert-actions {
-      margin-top: 5px;
-    }
     &.error,
     &.success,
     &.info {
@@ -448,6 +448,10 @@ input[type=submit].btn {
       border-color: lighten(#6bd0ee, 20%);
     }
   }
+
+  .alert-actions {
+    margin-top: 5px;
+  }
 }
 
 // NAVIGATION
@@ -461,10 +465,10 @@ input[type=submit].btn {
   .clearfix();
   li {
     display: inline;
-    a {
-      float: left;
-      width: auto;
-    }
+  }
+  a {
+    float: left;
+    width: auto;
   }
 }
 
@@ -472,49 +476,48 @@ input[type=submit].btn {
 .tabs {
   width: 100%;
   border-bottom: 1px solid @grayLight;
-  li {
-    a {
-      margin-bottom: -1px;
-      margin-right: 2px;
-      padding: 0 15px;
-      line-height: (@baseline * 2) - 1;
-      .border-radius(3px 3px 0 0);
-      &:hover {
-        background-color: @grayLighter;
-        border-bottom: 1px solid @grayLight;
-      }
+
+  a {
+    margin-bottom: -1px;
+    margin-right: 2px;
+    padding: 0 15px;
+    line-height: (@baseline * 2) - 1;
+    .border-radius(3px 3px 0 0);
+    &:hover {
+      background-color: @grayLighter;
+      border-bottom: 1px solid @grayLight;
     }
-    &.active a {
-      background-color: #fff;
-      padding: 0 14px;
-      border: 1px solid #ccc;
-      border-bottom: 0;
-      color: @gray;
-    }
+  }
+
+  li.active a {
+    background-color: #fff;
+    padding: 0 14px;
+    border: 1px solid #ccc;
+    border-bottom: 0;
+    color: @gray;
   }
 }
 
 // Basic pill nav
 .pills {
-  li {
-    a {
-      margin: 5px 3px 5px 0;
-      padding: 0 15px;
-      text-shadow: 0 1px 1px #fff;
-      line-height: 30px;
-      .border-radius(15px);
-      &:hover {
-        background: @linkColorHover;
-        color: #fff;
-        text-decoration: none;
-        text-shadow: 0 1px 1px rgba(0,0,0,.25);
-      }
-    }
-    &.active a {
-      background: @linkColor;
+  a {
+    margin: 5px 3px 5px 0;
+    padding: 0 15px;
+    text-shadow: 0 1px 1px #fff;
+    line-height: 30px;
+    .border-radius(15px);
+    &:hover {
+      background: @linkColorHover;
       color: #fff;
+      text-decoration: none;
       text-shadow: 0 1px 1px rgba(0,0,0,.25);
     }
+  }
+
+  li.active a {
+    background: @linkColor;
+    color: #fff;
+    text-shadow: 0 1px 1px rgba(0,0,0,.25);
   }
 }
 
@@ -532,30 +535,31 @@ input[type=submit].btn {
     border: 1px solid rgba(0,0,0,.15);
     .border-radius(3px);
     .box-shadow(0 1px 2px rgba(0,0,0,.05));
-    li {
-      display: inline;
-      a {
-        float: left;
-        padding: 0 14px;
-        line-height: (@baseline * 2) - 2;
-        border-right: 1px solid;
-        border-right-color: #ddd;
-        border-right-color: rgba(0,0,0,.15);
-        *border-right-color: #ddd; /* IE6-7 */
-        text-decoration: none;
-      }
-      a:hover,
-      &.active a {
-        background-color: lighten(@blue, 45%);
-      }
-      &.disabled a,
-      &.disabled a:hover {
-        background-color: transparent;
-        color: @grayLight;
-      }
-      &.next a {
-        border: 0;
-      }
+  }
+
+  li {
+    display: inline;
+    a {
+      float: left;
+      padding: 0 14px;
+      line-height: (@baseline * 2) - 2;
+      border-right: 1px solid;
+      border-right-color: #ddd;
+      border-right-color: rgba(0,0,0,.15);
+      *border-right-color: #ddd; /* IE6-7 */
+      text-decoration: none;
+    }
+    a:hover,
+    &.active a {
+      background-color: lighten(@blue, 45%);
+    }
+    &.disabled a,
+    &.disabled a:hover {
+      background-color: transparent;
+      color: @grayLight;
+    }
+    &.next a {
+      border: 0;
     }
   }
 }
@@ -602,33 +606,33 @@ input[type=submit].btn {
   .border-radius(6px);
   .box-shadow(0 3px 7px rgba(0,0,0,0.3));
   .background-clip(padding-box);
-  .modal-header {
-    border-bottom: 1px solid #eee;
-    padding: 5px 20px;
-    .close {
-      position: absolute;
-      right: 10px;
-      top: 10px;
-      color: #999;
-      line-height:10px;
-      font-size: 18px;
-    }
+}
+.modal-header {
+  border-bottom: 1px solid #eee;
+  padding: 5px 20px;
+  .close {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    color: #999;
+    line-height:10px;
+    font-size: 18px;
   }
-  .modal-body {
-    padding: 20px;
-  }
-  .modal-footer {
-    background-color: #f5f5f5;
-    padding: 14px 20px 15px;
-    border-top: 1px solid #ddd;
-    .border-radius(0 0 6px 6px);
-    .box-shadow(inset 0 1px 0 #fff);
-    .clearfix();
-    margin-bottom: 0;
-    .btn {
-      float: right;
-      margin-left: 10px;
-    }
+}
+.modal-body {
+  padding: 20px;
+}
+.modal-footer {
+  background-color: #f5f5f5;
+  padding: 14px 20px 15px;
+  border-top: 1px solid #ddd;
+  .border-radius(0 0 6px 6px);
+  .box-shadow(inset 0 1px 0 #fff);
+  .clearfix();
+  margin-bottom: 0;
+  .btn {
+    float: right;
+    margin-left: 10px;
   }
 }
 
@@ -686,20 +690,20 @@ input[type=submit].btn {
   &.left .twipsy-arrow    { #popoverArrow > .left(); }
   &.below .twipsy-arrow   { #popoverArrow > .below(); }
   &.right .twipsy-arrow   { #popoverArrow > .right(); }
-  .twipsy-inner {
-    padding: 3px 8px;
-    background-color: #000;
-    color: white;
-    text-align: center;
-    max-width: 200px;
-    text-decoration: none;
-    .border-radius(4px);
-  }
-  .twipsy-arrow {
-    position: absolute;
-    width: 0;
-    height: 0;
-  }
+}
+.twipsy-inner {
+  padding: 3px 8px;
+  background-color: #000;
+  color: white;
+  text-align: center;
+  max-width: 200px;
+  text-decoration: none;
+  .border-radius(4px);
+}
+.twipsy-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
 }
 
 
@@ -744,8 +748,8 @@ input[type=submit].btn {
     padding: 14px;
     .border-radius(0 0 3px 3px);
     .background-clip(padding-box);
-    p, ul, ol {
-      margin-bottom: 0;
-    }
+  }
+  p, ul, ol {
+    margin-bottom: 0;
   }
 }

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -10,61 +10,61 @@
 .row {
   .clearfix();
   margin-left: -20px;
-
-  // Default columns
-  .span1,
-  .span2,
-  .span3,
-  .span4,
-  .span5,
-  .span6,
-  .span7,
-  .span8,
-  .span9,
-  .span10,
-  .span11,
-  .span12,
-  .span13,
-  .span14,
-  .span15,
-  .span16 {
-    display: inline;
-    float: left;
-    margin-left: 20px;
-  }
-
-  // Default columns
-  .span1     { .columns(1); }
-  .span2     { .columns(2); }
-  .span3     { .columns(3); }
-  .span4     { .columns(4); }
-  .span5     { .columns(5); }
-  .span6     { .columns(6); }
-  .span7     { .columns(7); }
-  .span8     { .columns(8); }
-  .span9     { .columns(9); }
-  .span10    { .columns(10); }
-  .span11    { .columns(11); }
-  .span12    { .columns(12); }
-  .span13    { .columns(13); }
-  .span14    { .columns(14); }
-  .span15    { .columns(15); }
-  .span16    { .columns(16); }
-
-  // Offset column options
-  .offset1   { .offset(1); }
-  .offset2   { .offset(2); }
-  .offset3   { .offset(3); }
-  .offset4   { .offset(4); }
-  .offset5   { .offset(5); }
-  .offset6   { .offset(6); }
-  .offset7   { .offset(7); }
-  .offset8   { .offset(8); }
-  .offset9   { .offset(9); }
-  .offset10  { .offset(10); }
-  .offset11  { .offset(11); }
-  .offset12  { .offset(12); }
 }
+
+// Default columns
+.span1,
+.span2,
+.span3,
+.span4,
+.span5,
+.span6,
+.span7,
+.span8,
+.span9,
+.span10,
+.span11,
+.span12,
+.span13,
+.span14,
+.span15,
+.span16 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
+}
+
+// Default columns
+.span1     { .columns(1); }
+.span2     { .columns(2); }
+.span3     { .columns(3); }
+.span4     { .columns(4); }
+.span5     { .columns(5); }
+.span6     { .columns(6); }
+.span7     { .columns(7); }
+.span8     { .columns(8); }
+.span9     { .columns(9); }
+.span10    { .columns(10); }
+.span11    { .columns(11); }
+.span12    { .columns(12); }
+.span13    { .columns(13); }
+.span14    { .columns(14); }
+.span15    { .columns(15); }
+.span16    { .columns(16); }
+
+// Offset column options
+.offset1   { .offset(1); }
+.offset2   { .offset(2); }
+.offset3   { .offset(3); }
+.offset4   { .offset(4); }
+.offset5   { .offset(5); }
+.offset6   { .offset(6); }
+.offset7   { .offset(7); }
+.offset8   { .offset(8); }
+.offset9   { .offset(9); }
+.offset10  { .offset(10); }
+.offset11  { .offset(11); }
+.offset12  { .offset(12); }
 
 
 // STRUCTURAL LAYOUT

--- a/lib/tables.less
+++ b/lib/tables.less
@@ -13,18 +13,18 @@ table {
   padding: 0;
   border-collapse: separate;
   font-size: 13px;
-  th, td {
-    padding: 10px 10px 9px;
-    line-height: @baseline * .75;
-    text-align: left;
-    vertical-align: middle;
-    border-bottom: 1px solid #ddd;
-  }
-  th {
-    padding-top: 9px;
-    font-weight: bold;
-    border-bottom-width: 2px;
-  }
+}
+th, td {
+  padding: 10px 10px 9px;
+  line-height: @baseline * .75;
+  text-align: left;
+  vertical-align: middle;
+  border-bottom: 1px solid #ddd;
+}
+th {
+  padding-top: 9px;
+  font-weight: bold;
+  border-bottom-width: 2px;
 }
 
 
@@ -33,13 +33,11 @@ table {
 
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 .zebra-striped {
-  tbody {
-    tr:nth-child(odd) td {
-      background-color: #f9f9f9;
-    }
-    tr:hover td {
-      background-color: #f5f5f5;
-    }
+  tr:nth-child(odd) td {
+    background-color: #f9f9f9;
+  }
+  tr:hover td {
+    background-color: #f5f5f5;
   }
 
   // Tablesorting styles w/ jQuery plugin
@@ -55,20 +53,13 @@ table {
       visibility: hidden;
     }
   }
-  // Style the sorted column headers (THs)
-  .headerSortUp,
-  .headerSortDown {
-    background-color: rgba(141,192,219,.25);
-    text-shadow: 0 1px 1px rgba(255,255,255,.75);
-    .border-radius(3px 3px 0 0);
-  }
   // Style the ascending (reverse alphabetical) column header
-  .header:hover {
-    &:after {
-      visibility:visible;
-    }
+  .header:hover:after {
+    visibility:visible;
   }
-  // Style the descending (alphabetical) column header
+
+  // Up/down arrow styling must have priority over .zebra-striped .header:after,
+  // so the following styles may not be factored out
   .headerSortDown,
   .headerSortDown:hover {
     &:after {
@@ -76,18 +67,26 @@ table {
       .opacity(60);
     }
   }
-  // Style the ascending (reverse alphabetical) column header
-  .headerSortUp {
-    &:after {
-      border-bottom: none;
-      border-left: 4px solid transparent;
-      border-right: 4px solid transparent;
-      border-top: 4px solid #000;
-      visibility:visible;
-      .box-shadow(none); //can't add boxshadow to downward facing arrow :(
-      .opacity(60);
-    }
+  .headerSortUp:after {
+    visibility:visible;
   }
+}
+
+// Style the sorted column headers (THs)
+.headerSortUp,
+.headerSortDown {
+  background-color: rgba(141,192,219,.25);
+  text-shadow: 0 1px 1px rgba(255,255,255,.75);
+  .border-radius(3px 3px 0 0);
+}
+// Style the ascending (reverse alphabetical) column header
+.headerSortUp:after {
+  border-bottom: none;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid #000;
+  .box-shadow(none); //can't add boxshadow to downward facing arrow :(
+  .opacity(60);
 }
 
 table {
@@ -96,53 +95,57 @@ table {
     color: @blue;
     border-bottom-color: @blue;
   }
-  .headerSortUp.blue,
-  .headerSortDown.blue {
-    background-color: lighten(@blue, 40%);
-  }
   // Green Table Headings
   .green {
     color: @green;
     border-bottom-color: @green;
-  }
-  .headerSortUp.green,
-  .headerSortDown.green {
-    background-color: lighten(@green, 40%);
   }
   // Red Table Headings
   .red {
     color: @red;
     border-bottom-color: @red;
   }
-  .headerSortUp.red,
-  .headerSortDown.red {
-    background-color: lighten(@red, 50%);
-  }
   // Yellow Table Headings
   .yellow {
     color: @yellow;
     border-bottom-color: @yellow;
-  }
-  .headerSortUp.yellow,
-  .headerSortDown.yellow {
-    background-color: lighten(@yellow, 40%);
   }
   // Orange Table Headings
   .orange {
     color: @orange;
     border-bottom-color: @orange;
   }
-  .headerSortUp.orange,
-  .headerSortDown.orange {
-    background-color: lighten(@orange, 40%);
-  }
   // Purple Table Headings
   .purple {
     color: @purple;
     border-bottom-color: @purple;
   }
-  .headerSortUp.purple,
-  .headerSortDown.purple {
-    background-color: lighten(@purple, 40%);
-  }
+}
+
+// these may be factored out of the above table tag because they contain
+// non-generic class names; .headerSortUp and .headerSortDown are unlikely
+// to show up anywhere else, but .blue, .green, and .red are (see above)
+.headerSortUp.blue,
+.headerSortDown.blue {
+  background-color: lighten(@blue, 40%);
+}
+.headerSortUp.green,
+.headerSortDown.green {
+  background-color: lighten(@green, 40%);
+}
+.headerSortUp.red,
+.headerSortDown.red {
+  background-color: lighten(@red, 50%);
+}
+.headerSortUp.yellow,
+.headerSortDown.yellow {
+  background-color: lighten(@yellow, 40%);
+}
+.headerSortUp.orange,
+.headerSortDown.orange {
+  background-color: lighten(@orange, 40%);
+}
+.headerSortUp.purple,
+.headerSortDown.purple {
+  background-color: lighten(@purple, 40%);
 }

--- a/lib/type.less
+++ b/lib/type.less
@@ -97,15 +97,15 @@ ul.unstyled {
 // Description Lists
 dl {
   margin-bottom: @baseline;
-  dt, dd {
-    line-height: @baseline;
-  }
-  dt {
-    font-weight: bold;
-  }
-  dd {
-    margin-left: @baseline / 2;
-  }
+}
+dt, dd {
+  line-height: @baseline;
+}
+dt {
+  font-weight: bold;
+}
+dd {
+  margin-left: @baseline / 2;
 }
 
 // MISC
@@ -184,5 +184,4 @@ pre {
   white-space: pre;
   white-space: pre-wrap;
   word-wrap: break-word;
-
 }


### PR DESCRIPTION
As per my description on issue #100, selectors like these:

``` css
.topbar form input
.pagination ul li a
.topbar ul li ul li a
.tabs li a
```

should be replaced by more efficient and simplified counterparts that don't have prodigal descendants:

``` css
.topbar input
.pagination ul a /* or */ .pagination li a
.topbar ul ul a /* or */ .topbar li li a
.tabs a
```

The commits associated with this pull request achieve many optimizations similar to the ones above in all LESS files that need them. In addition to the aforementioned examples, selectors with non-generic class names as descendants, like so:

``` css
.modal .modal-body
table .headerSortUp
```

have also been optimized by simply removing the parent selector:

``` css
.modal-body
.headerSortUp
```

This has only been done where class names are unique and quite unlikely to be re-used elsewhere.

In terms of statistics, five of the eight LESS files benefited from these optimizations, many in a significant manner. More than just greater efficiency, this also cut down about 700 bytes (~2%) from the minified stylesheet. Considering that the only change was to selectors, I would say this is a nice bonus.

Even though this takes care of many optimizations, there are still various methods to accomplish even more. For example, because a decent number of class names are generic, the selectors including them require more context and therefore more complexity. Changing the markup to supplant optimization and circumvent these cases is a frontier not explored in these commits. Re-thinking the CSS structure as a whole can also result in insights of what can be consolidated. For these reasons, I ask that you continue to keep issue #100 open so that further optimization—and discussion regarding it—is continually strived for.
