### PR TITLE
Text rendering fix for Android (and arguably for Windows)

### DIFF
--- a/bootstrap-1.1.1.css
+++ b/bootstrap-1.1.1.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Aug 26 19:31:44 PDT 2011
+ * Date: Wed Aug 31 14:03:54 EDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -394,7 +394,6 @@ body {
   font-weight: normal;
   line-height: 18px;
   color: #808080;
-  text-rendering: optimizeLegibility;
 }
 .container {
   width: 940px;

--- a/bootstrap-1.1.1.min.css
+++ b/bootstrap-1.1.1.min.css
@@ -61,7 +61,7 @@ table{border-collapse:collapse;border-spacing:0;}
 .row .offset11{margin-left:680px;}
 .row .offset12{margin-left:740px;}
 html,body{background-color:#fff;}
-body{margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:18px;color:#808080;text-rendering:optimizeLegibility;}
+body{margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:18px;color:#808080;}
 .container{width:940px;margin:0 auto;}
 .container-fluid{padding:0 20px;zoom:1;margin-bottom:18px;}.container-fluid:before,.container-fluid:after{display:table;content:"";}
 .container-fluid:after{clear:both;}

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -77,7 +77,11 @@ body {
   margin: 0;
   #font > .sans-serif(normal,@basefont,@baseline);
   color: @gray;
-  text-rendering: optimizeLegibility;
+
+  // The following line breaks text rendering on Android and degrades it on
+  // Windows:
+  //
+  // text-rendering: optimizeLegibility;
 }
 
 // Container (centered, fixed-width layouts)


### PR DESCRIPTION
I understand that your project doesn't officially support WebKit on Android as a browser, but it's a shame to have Bootstrap sites be garbled on Android when they don't have to be. I've found the CSS rule that was causing failure on Android (text-rendering: optimizeLegibility) and commented it out.

As a side effect of removing this line, I have found that fonts on my site render much better on Windows. The "optimizeLegibility" declaration was causing Windows to adopt an aggressive hinting strategy that actively changed the heights of some glyphs, giving text a haphazard appearance.

Of course, you should weigh this benefit against whatever motivation you had to include that rule.
