### PR TITLE
Topbar optimizations

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -55,7 +55,7 @@
   }
 
   // Search Form
-  form {
+  .search-form {
     float: left;
     margin: 5px 0 0 0;
     position: relative;
@@ -116,7 +116,7 @@
       display: block;
       float: left;
       font-size: 13px;
-      a {
+      > a {
         display: block;
         float: none;
         padding: 10px 10px 11px;
@@ -137,8 +137,10 @@
     &.primary-nav li ul {
       left: 0;
     }
-    &.secondary-nav li ul {
-      right: 0;
+    &.secondary-nav li {
+        ul, .menu-dropdown {
+            right: 0;
+        }
     }
     li.menu {
       position: relative;
@@ -166,8 +168,11 @@
           *background-color: #444; /* IE6-7 */
           color: #fff;
         }
+        .menu-dropdown, ul {
+            display: block;
+        }
+
         ul {
-          display: block;
           li {
             a {
               background-color: transparent;
@@ -186,7 +191,8 @@
         }
       }
     }
-    li ul {
+
+    ul, .menu-dropdown {
       background-color: #333;
       float: left;
       display: none;

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -55,7 +55,7 @@
   }
 
   // Search Form
-  .search-form {
+  form {
     float: left;
     margin: 5px 0 0 0;
     position: relative;
@@ -116,7 +116,7 @@
       display: block;
       float: left;
       font-size: 13px;
-      > a {
+      a {
         display: block;
         float: none;
         padding: 10px 10px 11px;
@@ -137,10 +137,8 @@
     &.primary-nav li ul {
       left: 0;
     }
-    &.secondary-nav li {
-        ul, .menu-dropdown {
-            right: 0;
-        }
+    &.secondary-nav li ul {
+      right: 0;
     }
     li.menu {
       position: relative;
@@ -168,11 +166,8 @@
           *background-color: #444; /* IE6-7 */
           color: #fff;
         }
-        .menu-dropdown, ul {
-            display: block;
-        }
-
         ul {
+          display: block;
           li {
             a {
               background-color: transparent;
@@ -191,8 +186,7 @@
         }
       }
     }
-
-    ul, .menu-dropdown {
+    li ul {
       background-color: #333;
       float: left;
       display: none;

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -82,7 +82,7 @@ body {
 
 // Container (centered, fixed-width layouts)
 .container {
-  width: @siteWidth;
+  width: 940px;
   margin: 0 auto;
 }
 
@@ -90,11 +90,11 @@ body {
 .container-fluid {
   padding: 0 20px;
   .clearfix();
-  .sidebar {
+  > .sidebar {
     float: left;
     width: 220px;
   }
-  .content {
+  > .content {
     min-width: 700px;
     max-width: 1180px;
     margin-left: 240px;

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -82,7 +82,7 @@ body {
 
 // Container (centered, fixed-width layouts)
 .container {
-  width: 940px;
+  width: @siteWidth;
   margin: 0 auto;
 }
 
@@ -90,11 +90,11 @@ body {
 .container-fluid {
   padding: 0 20px;
   .clearfix();
-  > .sidebar {
+  .sidebar {
     float: left;
     width: 220px;
   }
-  > .content {
+  .content {
     min-width: 700px;
     max-width: 1180px;
     margin-left: 240px;


### PR DESCRIPTION
Fixes form related stuff in `.topbar`
- Requires `.search-form` to be attached to the search form and thus allows other forms to be present in drop-down without applying the search form style to them 
- Allows other elements than `<ul>` to represent the drop-down menu, if they have a `.menu-dropdown` class.The following html snipped would be a valid sub-menu: 

``` html
<ul class="nav secondary-nav">
    <li class="menu">
        <a href="#" class="menu">Login</a>
        <div class="menu-dropdown">
            <form class="form-stacked" action="#" method="post">
                <fieldset>
                    <div class="clearfix">
                        <label for="name">User name</label>
                        <div class="input">
                            <input type="text" class="medium" id="name" name="name">
                        </div>
                    </div>
                    <!-- other form elements -->
                </fieldset>

                <p>Some notes on login</p>
                <!-- other related stuff -->
            </form>
        </div>
    </li>
</ul>
```
