### PR TITLE
Fix span query for not only first but descending classes (not working in 

### DIFF
--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -13,7 +13,7 @@
 
   // Find all .span# classes within .row and give them the necessary properties for grid columns (supported by all browsers back to IE7)
   // Credit to @dhg for the idea
-  [class^="span"] {
+  [class*="span"] {
     display: inline;
     float: left;
     margin-left: @gridGutterWidth;


### PR DESCRIPTION
Fix span query for not only first but descending classes (not working in Chrome beforehand, other browsers yet to test…)
