### PR TITLE
Extracting necessary column CSS from regexp matching rule to a mixin

### DIFF
--- a/bootstrap-1.2.0.css
+++ b/bootstrap-1.2.0.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Wed Sep  7 14:29:44 PDT 2011
+ * Date: Wed Sep  7 17:17:28 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -279,100 +279,57 @@ textarea {
 .row:after {
   clear: both;
 }
-.row .span1 {
+.row [class^="span"] {
   display: inline;
   float: left;
   margin-left: 20px;
+}
+.row .span1 {
   width: 40px;
 }
 .row .span2 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 100px;
 }
 .row .span3 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 160px;
 }
 .row .span4 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 220px;
 }
 .row .span5 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 280px;
 }
 .row .span6 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 340px;
 }
 .row .span7 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 400px;
 }
 .row .span8 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 460px;
 }
 .row .span9 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 520px;
 }
 .row .span10 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 580px;
 }
 .row .span11 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 640px;
 }
 .row .span12 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 700px;
 }
 .row .span13 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 760px;
 }
 .row .span14 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 820px;
 }
 .row .span15 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 880px;
 }
 .row .span16 {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 940px;
 }
 .row .offset1 {
@@ -412,15 +369,9 @@ textarea {
   margin-left: 740px;
 }
 .row .span-one-third {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 300px;
 }
 .row .span-two-thirds {
-  display: inline;
-  float: left;
-  margin-left: 20px;
   width: 620px;
 }
 .row .offset-one-third {

--- a/bootstrap-1.2.0.css
+++ b/bootstrap-1.2.0.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Sep  2 15:07:03 PDT 2011
+ * Date: Wed Sep  7 14:29:44 PDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -279,57 +279,100 @@ textarea {
 .row:after {
   clear: both;
 }
-.row [class^="span"] {
+.row .span1 {
   display: inline;
   float: left;
   margin-left: 20px;
-}
-.row .span1 {
   width: 40px;
 }
 .row .span2 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 100px;
 }
 .row .span3 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 160px;
 }
 .row .span4 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 220px;
 }
 .row .span5 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 280px;
 }
 .row .span6 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 340px;
 }
 .row .span7 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 400px;
 }
 .row .span8 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 460px;
 }
 .row .span9 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 520px;
 }
 .row .span10 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 580px;
 }
 .row .span11 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 640px;
 }
 .row .span12 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 700px;
 }
 .row .span13 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 760px;
 }
 .row .span14 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 820px;
 }
 .row .span15 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 880px;
 }
 .row .span16 {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 940px;
 }
 .row .offset1 {
@@ -369,9 +412,15 @@ textarea {
   margin-left: 740px;
 }
 .row .span-one-third {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 300px;
 }
 .row .span-two-thirds {
+  display: inline;
+  float: left;
+  margin-left: 20px;
   width: 620px;
 }
 .row .offset-one-third {

--- a/bootstrap-1.2.0.min.css
+++ b/bootstrap-1.2.0.min.css
@@ -30,22 +30,23 @@ textarea{overflow:auto;vertical-align:top;}
 .btn.info,.alert-message.info{background-color:#339bb9;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#5bc0de), to(#339bb9));background-image:-moz-linear-gradient(top, #5bc0de, #339bb9);background-image:-ms-linear-gradient(top, #5bc0de, #339bb9);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #5bc0de), color-stop(100%, #339bb9));background-image:-webkit-linear-gradient(top, #5bc0de, #339bb9);background-image:-o-linear-gradient(top, #5bc0de, #339bb9);background-image:linear-gradient(top, #5bc0de, #339bb9);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#5bc0de', endColorstr='#339bb9', GradientType=0);text-shadow:0 -1px 0 rgba(0, 0, 0, 0.25);border-color:#339bb9 #339bb9 #22697d;border-color:rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);}
 .row{zoom:1;margin-bottom:18px;margin-left:-20px;}.row:before,.row:after{display:table;content:"";}
 .row:after{clear:both;}
-.row .span1{display:inline;float:left;margin-left:20px;width:40px;}
-.row .span2{display:inline;float:left;margin-left:20px;width:100px;}
-.row .span3{display:inline;float:left;margin-left:20px;width:160px;}
-.row .span4{display:inline;float:left;margin-left:20px;width:220px;}
-.row .span5{display:inline;float:left;margin-left:20px;width:280px;}
-.row .span6{display:inline;float:left;margin-left:20px;width:340px;}
-.row .span7{display:inline;float:left;margin-left:20px;width:400px;}
-.row .span8{display:inline;float:left;margin-left:20px;width:460px;}
-.row .span9{display:inline;float:left;margin-left:20px;width:520px;}
-.row .span10{display:inline;float:left;margin-left:20px;width:580px;}
-.row .span11{display:inline;float:left;margin-left:20px;width:640px;}
-.row .span12{display:inline;float:left;margin-left:20px;width:700px;}
-.row .span13{display:inline;float:left;margin-left:20px;width:760px;}
-.row .span14{display:inline;float:left;margin-left:20px;width:820px;}
-.row .span15{display:inline;float:left;margin-left:20px;width:880px;}
-.row .span16{display:inline;float:left;margin-left:20px;width:940px;}
+.row [class^="span"]{display:inline;float:left;margin-left:20px;}
+.row .span1{width:40px;}
+.row .span2{width:100px;}
+.row .span3{width:160px;}
+.row .span4{width:220px;}
+.row .span5{width:280px;}
+.row .span6{width:340px;}
+.row .span7{width:400px;}
+.row .span8{width:460px;}
+.row .span9{width:520px;}
+.row .span10{width:580px;}
+.row .span11{width:640px;}
+.row .span12{width:700px;}
+.row .span13{width:760px;}
+.row .span14{width:820px;}
+.row .span15{width:880px;}
+.row .span16{width:940px;}
 .row .offset1{margin-left:80px;}
 .row .offset2{margin-left:140px;}
 .row .offset3{margin-left:200px;}
@@ -58,8 +59,8 @@ textarea{overflow:auto;vertical-align:top;}
 .row .offset10{margin-left:620px;}
 .row .offset11{margin-left:680px;}
 .row .offset12{margin-left:740px;}
-.row .span-one-third{display:inline;float:left;margin-left:20px;width:300px;}
-.row .span-two-thirds{display:inline;float:left;margin-left:20px;width:620px;}
+.row .span-one-third{width:300px;}
+.row .span-two-thirds{width:620px;}
 .row .offset-one-third{margin-left:340px;}
 .row .offset-two-thirds{margin-left:660px;}
 html,body{background-color:#fff;}

--- a/bootstrap-1.2.0.min.css
+++ b/bootstrap-1.2.0.min.css
@@ -30,23 +30,22 @@ textarea{overflow:auto;vertical-align:top;}
 .btn.info,.alert-message.info{background-color:#339bb9;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#5bc0de), to(#339bb9));background-image:-moz-linear-gradient(top, #5bc0de, #339bb9);background-image:-ms-linear-gradient(top, #5bc0de, #339bb9);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #5bc0de), color-stop(100%, #339bb9));background-image:-webkit-linear-gradient(top, #5bc0de, #339bb9);background-image:-o-linear-gradient(top, #5bc0de, #339bb9);background-image:linear-gradient(top, #5bc0de, #339bb9);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#5bc0de', endColorstr='#339bb9', GradientType=0);text-shadow:0 -1px 0 rgba(0, 0, 0, 0.25);border-color:#339bb9 #339bb9 #22697d;border-color:rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);}
 .row{zoom:1;margin-bottom:18px;margin-left:-20px;}.row:before,.row:after{display:table;content:"";}
 .row:after{clear:both;}
-.row [class^="span"]{display:inline;float:left;margin-left:20px;}
-.row .span1{width:40px;}
-.row .span2{width:100px;}
-.row .span3{width:160px;}
-.row .span4{width:220px;}
-.row .span5{width:280px;}
-.row .span6{width:340px;}
-.row .span7{width:400px;}
-.row .span8{width:460px;}
-.row .span9{width:520px;}
-.row .span10{width:580px;}
-.row .span11{width:640px;}
-.row .span12{width:700px;}
-.row .span13{width:760px;}
-.row .span14{width:820px;}
-.row .span15{width:880px;}
-.row .span16{width:940px;}
+.row .span1{display:inline;float:left;margin-left:20px;width:40px;}
+.row .span2{display:inline;float:left;margin-left:20px;width:100px;}
+.row .span3{display:inline;float:left;margin-left:20px;width:160px;}
+.row .span4{display:inline;float:left;margin-left:20px;width:220px;}
+.row .span5{display:inline;float:left;margin-left:20px;width:280px;}
+.row .span6{display:inline;float:left;margin-left:20px;width:340px;}
+.row .span7{display:inline;float:left;margin-left:20px;width:400px;}
+.row .span8{display:inline;float:left;margin-left:20px;width:460px;}
+.row .span9{display:inline;float:left;margin-left:20px;width:520px;}
+.row .span10{display:inline;float:left;margin-left:20px;width:580px;}
+.row .span11{display:inline;float:left;margin-left:20px;width:640px;}
+.row .span12{display:inline;float:left;margin-left:20px;width:700px;}
+.row .span13{display:inline;float:left;margin-left:20px;width:760px;}
+.row .span14{display:inline;float:left;margin-left:20px;width:820px;}
+.row .span15{display:inline;float:left;margin-left:20px;width:880px;}
+.row .span16{display:inline;float:left;margin-left:20px;width:940px;}
 .row .offset1{margin-left:80px;}
 .row .offset2{margin-left:140px;}
 .row .offset3{margin-left:200px;}
@@ -59,8 +58,8 @@ textarea{overflow:auto;vertical-align:top;}
 .row .offset10{margin-left:620px;}
 .row .offset11{margin-left:680px;}
 .row .offset12{margin-left:740px;}
-.row .span-one-third{width:300px;}
-.row .span-two-thirds{width:620px;}
+.row .span-one-third{display:inline;float:left;margin-left:20px;width:300px;}
+.row .span-two-thirds{display:inline;float:left;margin-left:20px;width:620px;}
 .row .offset-one-third{margin-left:340px;}
 .row .offset-two-thirds{margin-left:660px;}
 html,body{background-color:#fff;}

--- a/lib/preboot.less
+++ b/lib/preboot.less
@@ -125,7 +125,14 @@
   margin: 0 auto;
   .clearfix();
 }
+.columnMixin() {
+  display: inline;
+  float: left;
+  margin-left: @gridGutterWidth;
+}
+
 .columns(@columnSpan: 1) {
+  .columnMixin();
   width: (@gridColumnWidth * @columnSpan) + (@gridGutterWidth * (@columnSpan - 1));
 }
 .offset(@columnOffset: 1) {

--- a/lib/preboot.less
+++ b/lib/preboot.less
@@ -125,18 +125,22 @@
   margin: 0 auto;
   .clearfix();
 }
-.columnMixin() {
-  display: inline;
-  float: left;
-  margin-left: @gridGutterWidth;
-}
-
 .columns(@columnSpan: 1) {
-  .columnMixin();
   width: (@gridColumnWidth * @columnSpan) + (@gridGutterWidth * (@columnSpan - 1));
 }
 .offset(@columnOffset: 1) {
   margin-left: (@gridColumnWidth * @columnOffset) + (@gridGutterWidth * (@columnOffset - 1)) + @extraSpace;
+}
+// every grid column mixin should have this included.
+.gridColumnMixin() {
+  display: inline;
+  float: left;
+  margin-left: @gridGutterWidth;
+}
+// makeColumn can be used to mark element as a column from LESS file without changing markup.
+.makeColumn(@colspan: 1) {
+  .gridColumnMixin();
+  .columns(@colspan);
 }
 
 // Border Radius

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -11,14 +11,6 @@
   .clearfix();
   margin-left: -1 * @gridGutterWidth;
 
-  // Find all .span# classes within .row and give them the necessary properties for grid columns (supported by all browsers back to IE7)
-  // Credit to @dhg for the idea
-  [class^="span"] {
-    display: inline;
-    float: left;
-    margin-left: @gridGutterWidth;
-  }
-
   // Default columns
   .span1     { .columns(1); }
   .span2     { .columns(2); }
@@ -52,8 +44,8 @@
   .offset12  { .offset(12); }
 
   // Unique column sizes for 16-column grid
-  .span-one-third     { width: 300px; }
-  .span-two-thirds    { width: 620px; }
+  .span-one-third     { .columnMixin(); width: 300px; }
+  .span-two-thirds    { .columnMixin(); width: 620px; }
   .offset-one-third   { margin-left: 340px; }
   .offset-two-thirds  { margin-left: 660px; }
 }

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -11,6 +11,12 @@
   .clearfix();
   margin-left: -1 * @gridGutterWidth;
 
+  // Find all .span# classes within .row and give them the necessary properties for grid columns (supported by all browsers back to IE7)
+  // Credit to @dhg for the idea
+  [class^="span"] {
+    .gridColumnMixin();
+  }
+
   // Default columns
   .span1     { .columns(1); }
   .span2     { .columns(2); }
@@ -44,8 +50,8 @@
   .offset12  { .offset(12); }
 
   // Unique column sizes for 16-column grid
-  .span-one-third     { .columnMixin(); width: 300px; }
-  .span-two-thirds    { .columnMixin(); width: 620px; }
+  .span-one-third     { width: 300px; }
+  .span-two-thirds    {  width: 620px; }
   .offset-one-third   { margin-left: 340px; }
   .offset-two-thirds  { margin-left: 660px; }
 }

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -51,7 +51,7 @@
 
   // Unique column sizes for 16-column grid
   .span-one-third     { width: 300px; }
-  .span-two-thirds    {  width: 620px; }
+  .span-two-thirds    { width: 620px; }
   .offset-one-third   { margin-left: 340px; }
   .offset-two-thirds  { margin-left: 660px; }
 }


### PR DESCRIPTION
Extracting necessary column CSS from regexp matching rule
to a mixin. This allows specifying columns completely in less
rules without introducing layout into markup.

Example:

```
<span class="text1">text</span>
<span class="text2">text</span>

.text1 {
  .makeColumn(2);
}

.text2 {
  .makeColumn(3);
}
```
