### PR TITLE
Removed outline from links when focused (cleans up the topbar Navigation menus)

### DIFF
--- a/lib/reset.less
+++ b/lib/reset.less
@@ -27,8 +27,8 @@ html {
       -ms-text-size-adjust: 100%;
 }
 // Focus states
-a:focus {
-  outline: thin dotted;
+a, a:active, a:focus, a:hover {
+  outline: none;
 }
 
 // Display in IE6-9 and FF3


### PR DESCRIPTION
This prevents outlines from showing on dropdown menus when clicked. I suppose a less invasive fix could be to add an extra rule to the style for the topbar itself, but I think most people usually don't like these outlines. Just a thought. 
