### PR TITLE
Changed z-index for modal-backdrop and modal

### DIFF
--- a/bootstrap-1.2.0.css
+++ b/bootstrap-1.2.0.css
@@ -1785,13 +1785,13 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1000;
+  z-index: 11000;
 }
 .modal {
   position: fixed;
   top: 50%;
   left: 50%;
-  z-index: 2000;
+  z-index: 12000;
   width: 560px;
   margin: -280px 0 0 -250px;
   background-color: #ffffff;

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -655,13 +655,13 @@ input[type=submit].btn {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1000;
+  z-index: 11000;
 }
 .modal {
   position: fixed;
   top: 50%;
   left: 50%;
-  z-index: 2000;
+  z-index: 12000;
   width: 560px;
   margin: -280px 0 0 -250px;
   background-color: @white;


### PR DESCRIPTION
The z-index for modal-backdrop was lower than the z-index for topbar. 

It shouldn't be possible to use the topbar when a modal dialog is open.
