### PR TITLE
Required Input fields

### DIFF
--- a/lib/forms.less
+++ b/lib/forms.less
@@ -153,7 +153,6 @@ form div.error {
   padding: 10px 0;
   margin: -10px 0 10px;
   .border-radius(4px);
-  @error-text: desaturate(lighten(@red, 25%), 25%);
   > label,
   span.help-inline,
   span.help-block {
@@ -174,6 +173,28 @@ form div.error {
       background: lighten(@red, 50%);
       border-color: @error-text;
       color: darken(@error-text, 10%);
+    }
+  }
+}
+
+// Required Style
+form div.required {
+  .border-radius(4px);
+  input,
+  textarea {
+    border-color: @required-text;
+    .box-shadow(0 0 3px rgba(171,41,32,.25));
+    &:focus {
+      border-color: darken(@required-text, 10%);
+      .box-shadow(0 0 6px rgba(171,41,32,.5));
+    }
+  }
+  .input-prepend,
+  .input-append {
+    span.add-on {
+      background: lighten(@red, 50%);
+      border-color: @required-text;
+      color: darken(@required-text, 10%);
     }
   }
 }

--- a/lib/preboot.less
+++ b/lib/preboot.less
@@ -28,6 +28,11 @@
 @pink:              #c3325f;
 @purple:            #7a43b6;
 
+// Text Colors
+@error-text: desaturate(lighten(@red, 25%), 25%);
+@required-text: @error-text;
+
+
 // Baseline grid
 @basefont:          13px;
 @baseline:          18px;


### PR DESCRIPTION
Make input fields stand out if they are required.

Example would show the red outline when required, but could move to the error of the full span when an issue happens.

 <a target='_blank' title='ImageShack - Image And Video Hosting' href='http://imageshack.us/photo/my-images/855/errorof.png/'><img src='http://img855.imageshack.us/img855/6302/errorof.png' border='0'/></a>
