### PR TITLE
Allow dropdown item hover state via a class, in addition to :hover

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -266,7 +266,8 @@ a.menu:after,
     color: @gray;
     text-shadow: 0 1px 0 #fff;
     // Hover state
-    &:hover {
+    &:hover,
+    &.hover {
       #gradient > .vertical(#eeeeee, #dddddd);
       color: @grayDark;
       text-decoration: none;


### PR DESCRIPTION
This is useful when using the dropdowns with keyboard navigation, for example, when the `:hover` pseudo-class is not useable.
