### PR TITLE
Correcting modal 'show' flag documentation

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -114,7 +114,7 @@
              <tr>
                <td>show</td>
                <td>boolean</td>
-               <td>false</td>
+               <td>true</td>
                <td>Opens modal on class initialization</td>
              </tr>
             </tbody>


### PR DESCRIPTION
The default value for show is 'true', documentation has 'false'.
