### PR TITLE
Adding flag to prevent backdrop click hiding modal

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -106,6 +106,12 @@
                <td>Includes a modal-backdrop element</td>
              </tr>
              <tr>
+               <td>backdropClickHides</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>A click on the modal-backdrop element hides the modal</td>
+             </tr>
+             <tr>
                <td>keyboard</td>
                <td>boolean</td>
                <td>false</td>

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -133,8 +133,10 @@
       , animate = this.$element.hasClass('fade') ? 'fade' : ''
     if ( this.isShown && this.settings.backdrop ) {
       this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .click($.proxy(this.hide, this))
-        .appendTo(document.body)
+      if ( this.settings.backdropClickHides ) {
+          this.$backdrop.click($.proxy(this.hide, this))
+      }
+      this.$backdrop.appendTo(document.body)
 
       setTimeout(function () {
         that.$backdrop && that.$backdrop.addClass('in')
@@ -208,6 +210,7 @@
 
   $.fn.modal.defaults = {
     backdrop: false
+  , backdropClickHides: true
   , keyboard: false
   , show: true
   }

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -86,4 +86,66 @@ $(function () {
           })
           .modal("toggle")
       })
+
+      test("should add backdrop when desired", function () {
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'></div>")
+        div
+          .modal({backdrop:true})
+          .modal("show")
+          .bind("shown", function () {
+            equal($('.modal-backdrop').length, 1, 'modal backdrop inserted into dom')
+            start()
+            div.remove()
+            $('.modal-backdrop').remove()
+          })
+      })
+
+      test("should not add backdrop when not desired", function () {
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'></div>")
+        div
+          .modal({backdrop:false})
+          .modal("show")
+          .bind("shown", function () {
+            equal($('.modal-backdrop').length, 0, 'modal backdrop not inserted into dom')
+            start()
+            div.remove()
+          })
+      })
+
+      test("should close backdrop when clicked", function () {
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'></div>")
+        div
+          .modal({backdrop:true})
+          .modal("show")
+          .bind("shown", function () {
+            equal($('.modal-backdrop').length, 1, 'modal backdrop inserted into dom')
+            $('.modal-backdrop').click()
+            equal($('.modal-backdrop').length, 0, 'modal backdrop removed from dom')
+            start()
+            div.remove()
+          })
+      })
+
+      test("should not close backdrop when click disabled", function () {
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'></div>")
+        div
+          .modal({backdrop:true, backdropClickHides:false})
+          .modal("show")
+          .bind("shown", function () {
+            equal($('.modal-backdrop').length, 1, 'modal backdrop inserted into dom')
+            $('.modal-backdrop').click()
+            equal($('.modal-backdrop').length, 1, 'modal backdrop still in dom')
+            start()
+            div.remove()
+            $('.modal-backdrop').remove()
+          })
+      })
 })


### PR DESCRIPTION
I have a use case where the only reasonable exits are via the buttons supplied in the modal, I imagine it might be of use to others.

Defaults to the original behavior, added tests for original backdrop behavior as well as the modification.
