### PR TITLE
Fix documentation error in Javascript dropdown example

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -219,7 +219,7 @@ $('#my-modal').bind('hidden', function () {
           <h3>Markup</h3>
           <p>To quickly add dropdown functionality to any nav element, use the <code>data-dropdown</code> attribute. Any valid bootstrap dropdown will automatically be activated.</p>
 <pre class="prettyprint linenums">
-&lt;ul class="tabs"&gt;
+&lt;ul class="nav"&gt;
   &lt;li class="active"&gt;&lt;a href="#"&gt;Home&lt;/a&gt;&lt;/li&gt;
   &lt;li class="dropdown" data-dropdown="dropdown" &gt;
     &lt;a href="#" class="dropdown-toggle"&gt;Dropdown&lt;/a&gt;


### PR DESCRIPTION
Issue #224 points out a spelling error in the code portion of the dropdown example in the javascript docs. Instead of `<ul class="tabs">` it should be `<ul class="nav">`.
