### PR TITLE
Added changed event to bootstrap-tabs.js

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -357,6 +357,26 @@ $('#my-modal').bind('hidden', function () {
   })
 &lt;/script&gt;</pre>
           </p>
+					<h3>Events</h3>
+					<table class="zebra-striped">
+					  <thead>
+					   <tr>
+					     <th style="width: 150px;">Event</th>
+					     <th>Description</th>
+					   </tr>
+					  </thead>
+					  <tbody>
+					   <tr>
+					     <td>changed</td>
+					     <td>This event fires when the tabs are changed. The event provides an additional parameter which holds id of the previous tab and the id of the new current tab. This information is stored in an object with two properties called from and to, e.g. <code>{to: '#home', from: '#profile'}</code>. This event allows you load and change content of the tabs on request.</td>
+					   </tr>
+					  </tbody>
+					</table>
+
+					<pre class="prettyprint linenums">
+$('#.tabs').bind('changed', function (e, c) {
+  // do something with c.from and c.to ...
+})</pre>
           <h3>Demo</h3>
           <ul class="tabs" data-tabs="tabs" >
             <li class="active"><a href="#home">Home</a></li>

--- a/js/bootstrap-tabs.js
+++ b/js/bootstrap-tabs.js
@@ -30,11 +30,12 @@
       , href = $this.attr('href')
       , $ul = $(e.liveFired)
       , $controlled
+      , current = $ul.find('.active a').attr('href')
 
     if (/^#\w+/.test(href)) {
       e.preventDefault()
 
-      if ($this.hasClass('active')) {
+      if ($this.parent('li').hasClass('active')) {
         return
       }
 
@@ -42,6 +43,7 @@
 
       activate($this.parent('li'), $ul)
       activate($href, $href.parent())
+      $this.trigger("changed", {from:current, to:href})
     }
   }
 

--- a/js/tests/unit/bootstrap-tabs.js
+++ b/js/tests/unit/bootstrap-tabs.js
@@ -11,39 +11,61 @@ $(function () {
       })
 
       test("should activate element by tab id", function () {
-        var tabsHTML = '<ul class="tabs">'
+        var $tabsHTML = $('<ul class="tabs">'
           + '<li class="active"><a href="#home">Home</a></li>'
           + '<li><a href="#profile">Profile</a></li>'
-          + '</ul>'
+          + '</ul>')
 
 
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-runoff")
 
-        $(tabsHTML).tabs().find('a').last().click()
+        $tabsHTML.tabs().find('a').last().click()
         equals($("#qunit-runoff").find('.active').attr('id'), "profile")
 
-        $(tabsHTML).tabs().find('a').first().click()
+        $tabsHTML.tabs().find('a').first().click()
         equals($("#qunit-runoff").find('.active').attr('id'), "home")
 
         $("#qunit-runoff").empty()
       })
 
       test("should activate element by pill id", function () {
-        var pillsHTML = '<ul class="pills">'
+        var $pillsHTML = $('<ul class="pills">'
           + '<li class="active"><a href="#home">Home</a></li>'
           + '<li><a href="#profile">Profile</a></li>'
-          + '</ul>'
+          + '</ul>')
 
 
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-runoff")
 
-        $(pillsHTML).pills().find('a').last().click()
+        $pillsHTML.pills().find('a').last().click()
         equals($("#qunit-runoff").find('.active').attr('id'), "profile")
 
-        $(pillsHTML).pills().find('a').first().click()
+        $pillsHTML.pills().find('a').first().click()
         equals($("#qunit-runoff").find('.active').attr('id'), "home")
 
         $("#qunit-runoff").empty()
+      })
+      
+      test( "should trigger changed event on activate", function () {
+        var $tabsHTML = $('<ul class="tabs">'
+          + '<li class="active"><a href="#home">Home</a></li>'
+          + '<li><a href="#profile">Profile</a></li>'
+          + '</ul>')
+          , changeCount = 0
+          , from
+          , to;
+          
+        $tabsHTML.tabs().bind( "changed", function (e, c){
+          from = c.from;
+          to = c.to;
+          changeCount++
+        })
+        
+        $tabsHTML.tabs().find('a').last().click()
+
+        equals(from, "#home")
+        equals(to, "#profile")
+        equals(changeCount, 1)
       })
 
 })


### PR DESCRIPTION
This allows you to load and change tab content on request. e.g.

<pre>
$('.tabs').tabs().bind( 'changed', function( e, c ) {
  // eventually unhook event handling from $(c.from)

  // load content from server and update $(c.to).html
  $.get( '/foo/' + c.to, function(data) {
    $(c.to).html(data);
  });
} );
</pre>


Is meant to provide a very basic hook which allows you to load tab content with ajax. 
