### PR TITLE
fixes #258, clicking a tab remove .active class from all elements on the page

### DIFF
--- a/js/bootstrap-tabs.js
+++ b/js/bootstrap-tabs.js
@@ -28,7 +28,7 @@
   function tab( e ) {
     var $this = $(this)
       , href = $this.attr('href')
-      , $ul = $(e.liveFired)
+      , $ul = $this.closest('ul')
       , $controlled
 
     if (/^#\w+/.test(href)) {


### PR DESCRIPTION
fixes #258, clicking a tab remove .active class from all elements on the page
