### PR TITLE
Make js/*.js pass jslint's checks; the existing JS broke when caching with Rails 3.0

### DIFF
--- a/js/bootstrap-alerts.js
+++ b/js/bootstrap-alerts.js
@@ -23,57 +23,57 @@
   /* CSS TRANSITION SUPPORT (https://gist.github.com/373874)
    * ======================================================= */
 
-   var transitionEnd
+   var transitionEnd;
 
    $(document).ready(function () {
 
      $.support.transition = (function () {
-       var thisBody = document.body || document.documentElement
-         , thisStyle = thisBody.style
-         , support = thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined
-       return support
-     })()
+       var thisBody = document.body || document.documentElement,
+         thisStyle = thisBody.style,
+         support = (thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined);
+       return support;
+     })();
 
      // set CSS transition event type
      if ( $.support.transition ) {
-       transitionEnd = "TransitionEnd"
+       transitionEnd = "TransitionEnd";
        if ( $.browser.webkit ) {
-       	transitionEnd = "webkitTransitionEnd"
+       	transitionEnd = "webkitTransitionEnd";
        } else if ( $.browser.mozilla ) {
-       	transitionEnd = "transitionend"
+       	transitionEnd = "transitionend";
        } else if ( $.browser.opera ) {
-       	transitionEnd = "oTransitionEnd"
+       	transitionEnd = "oTransitionEnd";
        }
      }
 
-   })
+   });
 
  /* ALERT CLASS DEFINITION
   * ====================== */
 
   var Alert = function ( content, selector ) {
-    this.$element = $(content)
-      .delegate(selector || '.close', 'click', this.close)
-  }
+    this.$element = $(content).
+      delegate(selector || '.close', 'click', this.close);
+  };
 
   Alert.prototype = {
 
     close: function (e) {
-      var $element = $(this).parent('.alert-message')
+      var $element = $(this).parent('.alert-message');
 
-      e && e.preventDefault()
-      $element.removeClass('in')
+      e && e.preventDefault();
+      $element.removeClass('in');
 
       function removeElement () {
-        $element.remove()
+        $element.remove();
       }
 
       $.support.transition && $element.hasClass('fade') ?
         $element.bind(transitionEnd, removeElement) :
-        removeElement()
+        removeElement();
     }
 
-  }
+  };
 
 
  /* ALERT PLUGIN DEFINITION
@@ -82,23 +82,23 @@
   $.fn.alert = function ( options ) {
 
     if ( options === true ) {
-      return this.data('alert')
+      return this.data('alert');
     }
 
     return this.each(function () {
-      var $this = $(this)
+      var $this = $(this);
 
       if ( typeof options == 'string' ) {
-        return $this.data('alert')[options]()
+        return $this.data('alert')[options]();
       }
 
-      $(this).data('alert', new Alert( this ))
+      $(this).data('alert', new Alert( this ));
 
-    })
-  }
+    });
+  };
 
   $(document).ready(function () {
-    new Alert($('body'), '.alert-message[data-alert] .close')
-  })
+    new Alert($('body'), '.alert-message[data-alert] .close');
+  });
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -20,16 +20,16 @@
 
 !function( $ ){
 
-  var d = 'a.menu, .dropdown-toggle'
+  var d = 'a.menu, .dropdown-toggle';
 
-  function clearMenus() {
-    $(d).parent('li').removeClass('open')
-  }
+  var clearMenus = function() {
+    $(d).parent('li').removeClass('open');
+  };
 
   $(function () {
-    $('html').bind("click", clearMenus)
-    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' )
-  })
+    $('html').bind("click", clearMenus);
+    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' );
+  });
 
   /* DROPDOWN PLUGIN DEFINITION
    * ========================== */
@@ -37,14 +37,14 @@
   $.fn.dropdown = function ( selector ) {
     return this.each(function () {
       $(this).delegate(selector || d, 'click', function (e) {
-        var li = $(this).parent('li')
-          , isActive = li.hasClass('open')
+        var li = $(this).parent('li'),
+          isActive = li.hasClass('open');
 
-        clearMenus()
-        !isActive && li.toggleClass('open')
-        return false
-      })
-    })
-  }
+        clearMenus();
+        !isActive && li.toggleClass('open');
+        return false;
+      });
+    });
+  };
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -23,162 +23,154 @@
  /* CSS TRANSITION SUPPORT (https://gist.github.com/373874)
   * ======================================================= */
 
-  var transitionEnd
+  var transitionEnd;
 
   $(document).ready(function () {
 
     $.support.transition = (function () {
-      var thisBody = document.body || document.documentElement
-        , thisStyle = thisBody.style
-        , support = thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined
-      return support
-    })()
+      var thisBody = document.body || document.documentElement,
+        thisStyle = thisBody.style,
+        support = (thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined);
+      return support;
+    })();
 
     // set CSS transition event type
     if ( $.support.transition ) {
-      transitionEnd = "TransitionEnd"
+      transitionEnd = "TransitionEnd";
       if ( $.browser.webkit ) {
-      	transitionEnd = "webkitTransitionEnd"
+      	transitionEnd = "webkitTransitionEnd";
       } else if ( $.browser.mozilla ) {
-      	transitionEnd = "transitionend"
+      	transitionEnd = "transitionend";
       } else if ( $.browser.opera ) {
-      	transitionEnd = "oTransitionEnd"
+      	transitionEnd = "oTransitionEnd";
       }
     }
 
-  })
+  });
 
 
  /* MODAL PUBLIC CLASS DEFINITION
   * ============================= */
 
   var Modal = function ( content, options ) {
-    this.settings = $.extend({}, $.fn.modal.defaults)
-    this.$element = $(content)
-      .delegate('.close', 'click.modal', $.proxy(this.hide, this))
+    this.settings = $.extend({}, $.fn.modal.defaults);
+    this.$element = $(content).
+      delegate('.close', 'click.modal', $.proxy(this.hide, this));
 
     if ( options ) {
-      $.extend( this.settings, options )
+      $.extend( this.settings, options );
 
       if ( options.show ) {
-        this.show()
+        this.show();
       }
     }
 
-    return this
-  }
+    return this;
+  };
 
   Modal.prototype = {
 
       toggle: function () {
-        return this[!this.isShown ? 'show' : 'hide']()
+        return this[!this.isShown ? 'show' : 'hide']();
       }
 
     , show: function () {
-        var that = this
-        this.isShown = true
-        this.$element.trigger('show')
+        var that = this;
+        this.isShown = true;
+        this.$element.trigger('show');
 
-        escape.call(this)
+        escape.call(this);
         backdrop.call(this, function () {
-          that.$element
-            .appendTo(document.body)
-            .show()
+          that.$element.appendTo(document.body).show();
 
           if ($.support.transition && that.$element.hasClass('fade')) {
-            that.$backdrop[0].offsetWidth // force reflow
+            that.$backdrop[0].offsetWidth; // force reflow
           }
 
-          that.$element
-            .addClass('in')
-            .trigger('shown')
-        })
+          that.$element.addClass('in').trigger('shown');
+        });
 
-        return this
+        return this;
       }
 
     , hide: function (e) {
-        e && e.preventDefault()
+        e && e.preventDefault();
 
-        var that = this
-        this.isShown = false
+        var that = this;
+        this.isShown = false;
 
-        escape.call(this)
+        escape.call(this);
 
-        this.$element
-          .trigger('hide')
-          .removeClass('in')
+        this.$element.trigger('hide').removeClass('in');
 
         function removeElement () {
-          that.$element
-            .hide()
-            .trigger('hidden')
+          that.$element.hide().trigger('hidden');
 
-          backdrop.call(that)
+          backdrop.call(that);
         }
 
         $.support.transition && this.$element.hasClass('fade') ?
           this.$element.one(transitionEnd, removeElement) :
-          removeElement()
+          removeElement();
 
-        return this
+        return this;
       }
 
-  }
+  };
 
 
  /* MODAL PRIVATE METHODS
   * ===================== */
 
   function backdrop ( callback ) {
-    var that = this
-      , animate = this.$element.hasClass('fade') ? 'fade' : ''
+    var that = this,
+      animate = this.$element.hasClass('fade') ? 'fade' : '';
     if ( this.isShown && this.settings.backdrop ) {
-      var doAnimate = $.support.transition && animate
+      var doAnimate = $.support.transition && animate;
 
-      this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .appendTo(document.body)
+      this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />').
+        appendTo(document.body);
 
       if ( this.settings.backdrop != 'static' ) {
-        this.$backdrop.click($.proxy(this.hide, this))
+        this.$backdrop.click($.proxy(this.hide, this));
       }
 
       if ( doAnimate ) {
-        that.$backdrop[0].offsetWidth // force reflow
+        that.$backdrop[0].offsetWidth; // force reflow
       }
 
-      that.$backdrop && that.$backdrop.addClass('in')
+      that.$backdrop && that.$backdrop.addClass('in');
 
       doAnimate ?
         that.$backdrop.one(transitionEnd, callback) :
-        callback()
+        callback();
 
     } else if ( !this.isShown && this.$backdrop ) {
-      this.$backdrop.removeClass('in')
+      this.$backdrop.removeClass('in');
 
       function removeElement() {
-        that.$backdrop.remove()
-        that.$backdrop = null
+        that.$backdrop.remove();
+        that.$backdrop = null;
       }
 
       $.support.transition && this.$element.hasClass('fade')?
         this.$backdrop.one(transitionEnd, removeElement) :
-        removeElement()
+        removeElement();
     } else if ( callback ) {
-       callback()
+       callback();
     }
   }
 
   function escape() {
-    var that = this
+    var that = this;
     if ( this.isShown && this.settings.keyboard ) {
       $(document).bind('keyup.modal', function ( e ) {
         if ( e.which == 27 ) {
-          that.hide()
+          that.hide();
         }
-      })
+      });
     } else if ( !this.isShown ) {
-      $(document).unbind('keyup.modal')
+      $(document).unbind('keyup.modal');
     }
   }
 
@@ -187,41 +179,41 @@
   * ======================= */
 
   $.fn.modal = function ( options ) {
-    var modal = this.data('modal')
+    var modal = this.data('modal');
 
     if (!modal) {
 
       if (typeof options == 'string') {
         options = {
           show: /show|toggle/.test(options)
-        }
+        };
       }
 
       return this.each(function () {
-        $(this).data('modal', new Modal(this, options))
-      })
+        $(this).data('modal', new Modal(this, options));
+      });
     }
 
     if ( options === true ) {
-      return modal
+      return modal;
     }
 
     if ( typeof options == 'string' ) {
-      modal[options]()
+      modal[options]();
     } else if ( modal ) {
-      modal.toggle()
+      modal.toggle();
     }
 
-    return this
-  }
+    return this;
+  };
 
-  $.fn.modal.Modal = Modal
+  $.fn.modal.Modal = Modal;
 
   $.fn.modal.defaults = {
-    backdrop: false
-  , keyboard: false
-  , show: true
-  }
+    backdrop: false,
+    keyboard: false,
+    show: true
+  };
 
 
  /* MODAL DATA- IMPLEMENTATION
@@ -229,10 +221,10 @@
 
   $(document).ready(function () {
     $('body').delegate('[data-controls-modal]', 'click', function (e) {
-      e.preventDefault()
-      var $this = $(this).data('show', true)
-      $('#' + $this.attr('data-controls-modal')).modal( $this.data() )
-    })
-  })
+      e.preventDefault();
+      var $this = $(this).data('show', true);
+      $('#' + $this.attr('data-controls-modal')).modal( $this.data() );
+    });
+  });
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -21,11 +21,11 @@
 !function( $ ) {
 
   var Popover = function ( element, options ) {
-    this.$element = $(element)
-    this.options = options
-    this.enabled = true
-    this.fixTitle()
-  }
+    this.$element = $(element);
+    this.options = options;
+    this.enabled = true;
+    this.fixTitle();
+  };
 
   /* NOTE: POPOVER EXTENDS BOOTSTRAP-TWIPSY.js
      ========================================= */
@@ -33,45 +33,45 @@
   Popover.prototype = $.extend({}, $.fn.twipsy.Twipsy.prototype, {
 
     setContent: function () {
-      var $tip = this.tip()
-      $tip.find('.title')[this.options.html ? 'html' : 'text'](this.getTitle())
-      $tip.find('.content p')[this.options.html ? 'html' : 'text'](this.getContent())
-      $tip[0].className = 'popover'
+      var $tip = this.tip();
+      $tip.find('.title')[this.options.html ? 'html' : 'text'](this.getTitle());
+      $tip.find('.content p')[this.options.html ? 'html' : 'text'](this.getContent());
+      $tip[0].className = 'popover';
     }
 
   , getContent: function () {
-      var content
-       , $e = this.$element
-       , o = this.options
+      var content,
+       $e = this.$element,
+       o = this.options
 
       if (typeof this.options.content == 'string') {
-        content = $e.attr(o.content)
+        content = $e.attr(o.content);
       } else if (typeof this.options.content == 'function') {
-        content = this.options.content.call(this.$element[0])
+        content = this.options.content.call(this.$element[0]);
       }
-      return content
+      return content;
     }
 
   , tip: function() {
       if (!this.$tip) {
-        this.$tip = $('<div class="popover" />')
-          .html('<div class="arrow"></div><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div>')
+        this.$tip = $('<div class="popover" />').
+          html('<div class="arrow"></div><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div>');
       }
-      return this.$tip
+      return this.$tip;
     }
 
-  })
+  });
 
 
  /* POPOVER PLUGIN DEFINITION
   * ======================= */
 
   $.fn.popover = function (options) {
-    if (typeof options == 'object') options = $.extend({}, $.fn.popover.defaults, options)
-    $.fn.twipsy.initWith.call(this, options, Popover, 'popover')
-    return this
-  }
+    if (typeof options == 'object') options = $.extend({}, $.fn.popover.defaults, options);
+    $.fn.twipsy.initWith.call(this, options, Popover, 'popover');
+    return this;
+  };
 
-  $.fn.popover.defaults = $.extend({} , $.fn.twipsy.defaults, { content: 'data-content', placement: 'right'})
+  $.fn.popover.defaults = $.extend({} , $.fn.twipsy.defaults, { content: 'data-content', placement: 'right'});
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -42,7 +42,7 @@
   , getContent: function () {
       var content,
        $e = this.$element,
-       o = this.options
+       o = this.options;
 
       if (typeof this.options.content == 'string') {
         content = $e.attr(o.content);

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -20,86 +20,86 @@
 
 !function ( $ ) {
 
-  var $window = $(window)
+  var $window = $(window);
 
   function ScrollSpy( topbar, selector ) {
-    var processScroll = $.proxy(this.processScroll, this)
-    this.$topbar = $(topbar)
-    this.selector = selector || 'li > a'
-    this.refresh()
-    this.$topbar.delegate(this.selector, 'click', processScroll)
-    $window.scroll(processScroll)
-    this.processScroll()
+    var processScroll = $.proxy(this.processScroll, this);
+    this.$topbar = $(topbar);
+    this.selector = selector || 'li > a';
+    this.refresh();
+    this.$topbar.delegate(this.selector, 'click', processScroll);
+    $window.scroll(processScroll);
+    this.processScroll();
   }
 
   ScrollSpy.prototype = {
 
       refresh: function () {
         this.targets = this.$topbar.find(this.selector).map(function () {
-          var href = $(this).attr('href')
-          return /^#\w/.test(href) && $(href).length ? href : null
-        })
+          var href = $(this).attr('href');
+          return (/^#\w/.test(href) && $(href).length) ? href : null;
+        });
 
         this.offsets = $.map(this.targets, function (id) {
-          return $(id).offset().top
-        })
+          return $(id).offset().top;
+        });
       }
 
     , processScroll: function () {
-        var scrollTop = $window.scrollTop() + 10
-          , offsets = this.offsets
-          , targets = this.targets
-          , activeTarget = this.activeTarget
-          , i
+        var scrollTop = $window.scrollTop() + 10,
+          offsets = this.offsets,
+          targets = this.targets,
+          activeTarget = this.activeTarget,
+          i;
 
         for (i = offsets.length; i--;) {
-          activeTarget != targets[i]
-            && scrollTop >= offsets[i]
-            && (!offsets[i + 1] || scrollTop <= offsets[i + 1])
-            && this.activateButton( targets[i] )
+          activeTarget != targets[i] &&
+            scrollTop >= offsets[i] &&
+            (!offsets[i + 1] || scrollTop <= offsets[i + 1]) &&
+            this.activateButton( targets[i] );
         }
       }
 
     , activateButton: function (target) {
-        this.activeTarget = target
+        this.activeTarget = target;
 
-        this.$topbar
-          .find(this.selector).parent('.active')
-          .removeClass('active')
+        this.$topbar.
+          find(this.selector).parent('.active').
+          removeClass('active');
 
-        this.$topbar
-          .find(this.selector + '[href="' + target + '"]')
-          .parent('li')
-          .addClass('active')
+        this.$topbar.
+          find(this.selector + '[href="' + target + '"]').
+          parent('li').
+          addClass('active');
       }
 
-  }
+  };
 
   /* SCROLLSPY PLUGIN DEFINITION
    * =========================== */
 
   $.fn.scrollSpy = function( options ) {
-    var scrollspy = this.data('scrollspy')
+    var scrollspy = this.data('scrollspy');
 
     if (!scrollspy) {
       return this.each(function () {
-        $(this).data('scrollspy', new ScrollSpy( this, options ))
-      })
+        $(this).data('scrollspy', new ScrollSpy( this, options ));
+      });
     }
 
     if ( options === true ) {
-      return scrollspy
+      return scrollspy;
     }
 
     if ( typeof options == 'string' ) {
-      scrollspy[options]()
+      scrollspy[options]();
     }
 
-    return this
-  }
+    return this;
+  };
 
   $(document).ready(function () {
-    $('body').scrollSpy('[data-scrollspy] li > a')
-  })
+    $('body').scrollSpy('[data-scrollspy] li > a');
+  });
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-tabs.js
+++ b/js/bootstrap-tabs.js
@@ -21,27 +21,27 @@
 !function( $ ){
 
   function activate ( element, container ) {
-    container.find('.active').removeClass('active')
-    element.addClass('active')
+    container.find('.active').removeClass('active');
+    element.addClass('active');
   }
 
   function tab( e ) {
-    var $this = $(this)
-      , href = $this.attr('href')
-      , $ul = $this.closest('ul')
-      , $controlled
+    var $this = $(this),
+      href = $this.attr('href'),
+      $ul = $this.closest('ul'),
+      $controlled;
 
     if (/^#\w+/.test(href)) {
-      e.preventDefault()
+      e.preventDefault();
 
       if ($this.hasClass('active')) {
-        return
+        return;
       }
 
-      $href = $(href)
+      $href = $(href);
 
-      activate($this.parent('li'), $ul)
-      activate($href, $href.parent())
+      activate($this.parent('li'), $ul);
+      activate($href, $href.parent());
     }
   }
 
@@ -51,12 +51,12 @@
 
   $.fn.tabs = $.fn.pills = function ( selector ) {
     return this.each(function () {
-      $(this).delegate(selector || '.tabs li > a, .pills > li > a', 'click', tab)
-    })
-  }
+      $(this).delegate(selector || '.tabs li > a, .pills > li > a', 'click', tab);
+    });
+  };
 
   $(document).ready(function () {
-    $('body').tabs('ul[data-tabs] li > a, ul[data-pills] > li > a')
-  })
+    $('body').tabs('ul[data-tabs] li > a, ul[data-pills] > li > a');
+  });
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );

--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -24,170 +24,170 @@
  /* CSS TRANSITION SUPPORT (https://gist.github.com/373874)
   * ======================================================= */
 
-  var transitionEnd
+  var transitionEnd;
 
   $(document).ready(function () {
 
     $.support.transition = (function () {
-      var thisBody = document.body || document.documentElement
-        , thisStyle = thisBody.style
-        , support = thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined
-      return support
-    })()
+      var thisBody = document.body || document.documentElement,
+        thisStyle = thisBody.style,
+        support = (thisStyle.transition !== undefined || thisStyle.WebkitTransition !== undefined || thisStyle.MozTransition !== undefined || thisStyle.MsTransition !== undefined || thisStyle.OTransition !== undefined);
+      return support;
+    })();
 
     // set CSS transition event type
     if ( $.support.transition ) {
-      transitionEnd = "TransitionEnd"
+      transitionEnd = "TransitionEnd";
       if ( $.browser.webkit ) {
-      	transitionEnd = "webkitTransitionEnd"
+      	transitionEnd = "webkitTransitionEnd";
       } else if ( $.browser.mozilla ) {
-      	transitionEnd = "transitionend"
+      	transitionEnd = "transitionend";
       } else if ( $.browser.opera ) {
-      	transitionEnd = "oTransitionEnd"
+      	transitionEnd = "oTransitionEnd";
       }
     }
 
-  })
+  });
 
 
  /* TWIPSY PUBLIC CLASS DEFINITION
   * ============================== */
 
   var Twipsy = function ( element, options ) {
-    this.$element = $(element)
-    this.options = options
-    this.enabled = true
-    this.fixTitle()
-  }
+    this.$element = $(element);
+    this.options = options;
+    this.enabled = true;
+    this.fixTitle();
+  };
 
   Twipsy.prototype = {
 
     show: function() {
-      var pos
-        , actualWidth
-        , actualHeight
-        , placement
-        , $tip
-        , tp
+      var pos,
+	actualWidth,
+	actualHeight,
+	placement,
+	$tip,
+	tp;
 
       if (this.getTitle() && this.enabled) {
-        $tip = this.tip()
-        this.setContent()
+        $tip = this.tip();
+        this.setContent();
 
         if (this.options.animate) {
-          $tip.addClass('fade')
+          $tip.addClass('fade');
         }
 
-        $tip
-          .remove()
-          .css({ top: 0, left: 0, display: 'block' })
-          .prependTo(document.body)
+        $tip.
+	  remove().
+	  css({ top: 0, left: 0, display: 'block' }).
+	  prependTo(document.body);
 
         pos = $.extend({}, this.$element.offset(), {
-          width: this.$element[0].offsetWidth
-        , height: this.$element[0].offsetHeight
-        })
+          width: this.$element[0].offsetWidth,
+          height: this.$element[0].offsetHeight
+        });
 
-        actualWidth = $tip[0].offsetWidth
-        actualHeight = $tip[0].offsetHeight
-        placement = _.maybeCall(this.options.placement, this.$element[0])
+        actualWidth = $tip[0].offsetWidth;
+        actualHeight = $tip[0].offsetHeight;
+        placement = _.maybeCall(this.options.placement, this.$element[0]);
 
         switch (placement) {
           case 'below':
-            tp = {top: pos.top + pos.height + this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2}
-            break
+            tp = {top: pos.top + pos.height + this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+            break;
           case 'above':
-            tp = {top: pos.top - actualHeight - this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2}
-            break
+            tp = {top: pos.top - actualHeight - this.options.offset, left: pos.left + pos.width / 2 - actualWidth / 2};
+            break;
           case 'left':
-            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - this.options.offset}
-            break
+            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - this.options.offset};
+            break;
           case 'right':
-            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset}
-            break
+            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + this.options.offset};
+            break;
         }
 
-        $tip
-          .css(tp)
-          .addClass(placement)
-          .addClass('in')
+        $tip.
+          css(tp).
+          addClass(placement).
+          addClass('in');
       }
     }
 
   , setContent: function () {
-      var $tip = this.tip()
-      $tip.find('.twipsy-inner')[this.options.html ? 'html' : 'text'](this.getTitle())
-      $tip[0].className = 'twipsy'
+      var $tip = this.tip();
+      $tip.find('.twipsy-inner')[this.options.html ? 'html' : 'text'](this.getTitle());
+      $tip[0].className = 'twipsy';
     }
 
   , hide: function() {
-      var that = this
-        , $tip = this.tip()
+      var that = this,
+        $tip = this.tip();
 
-      $tip.removeClass('in')
+      $tip.removeClass('in');
 
       function removeElement () {
-        $tip.remove()
+        $tip.remove();
       }
 
       $.support.transition && this.$tip.hasClass('fade') ?
         $tip.bind(transitionEnd, removeElement) :
-        removeElement()
+        removeElement();
     }
 
   , fixTitle: function() {
-      var $e = this.$element
+      var $e = this.$element;
       if ($e.attr('title') || typeof($e.attr('data-original-title')) != 'string') {
-        $e.attr('data-original-title', $e.attr('title') || '').removeAttr('title')
+        $e.attr('data-original-title', $e.attr('title') || '').removeAttr('title');
       }
     }
 
   , getTitle: function() {
-      var title
-        , $e = this.$element
-        , o = this.options
+      var title,
+        $e = this.$element,
+        o = this.options;
 
-        this.fixTitle()
+        this.fixTitle();
 
         if (typeof o.title == 'string') {
-          title = $e.attr(o.title == 'title' ? 'data-original-title' : o.title)
+          title = $e.attr(o.title == 'title' ? 'data-original-title' : o.title);
         } else if (typeof o.title == 'function') {
-          title = o.title.call($e[0])
+          title = o.title.call($e[0]);
         }
 
-        title = ('' + title).replace(/(^\s*|\s*$)/, "")
+        title = ('' + title).replace(/(^\s*|\s*$)/, "");
 
-        return title || o.fallback
+        return title || o.fallback;
     }
 
   , tip: function() {
       if (!this.$tip) {
-        this.$tip = $('<div class="twipsy" />').html('<div class="twipsy-arrow"></div><div class="twipsy-inner"></div>')
+        this.$tip = $('<div class="twipsy" />').html('<div class="twipsy-arrow"></div><div class="twipsy-inner"></div>');
       }
-      return this.$tip
+      return this.$tip;
     }
 
   , validate: function() {
       if (!this.$element[0].parentNode) {
-        this.hide()
-        this.$element = null
-        this.options = null
+        this.hide();
+        this.$element = null;
+        this.options = null;
       }
     }
 
   , enable: function() {
-      this.enabled = true
+      this.enabled = true;
     }
 
   , disable: function() {
-      this.enabled = false
+      this.enabled = false;
     }
 
   , toggleEnabled: function() {
-      this.enabled = !this.enabled
+      this.enabled = !this.enabled;
     }
 
-  }
+  };
 
 
  /* TWIPSY PRIVATE METHODS
@@ -196,112 +196,112 @@
    var _ = {
 
      maybeCall: function ( thing, ctx ) {
-       return (typeof thing == 'function') ? (thing.call(ctx)) : thing
+       return (typeof thing == 'function') ? (thing.call(ctx)) : thing;
      }
 
-   }
+   };
 
 
  /* TWIPSY PLUGIN DEFINITION
   * ======================== */
 
   $.fn.twipsy = function (options) {
-    $.fn.twipsy.initWith.call(this, options, Twipsy, 'twipsy')
-    return this
-  }
+    $.fn.twipsy.initWith.call(this, options, Twipsy, 'twipsy');
+    return this;
+  };
 
   $.fn.twipsy.initWith = function (options, Constructor, name) {
-    var twipsy
-      , binder
-      , eventIn
-      , eventOut
+    var twipsy,
+      binder,
+      eventIn,
+      eventOut;
 
     if (options === true) {
-      return this.data(name)
+      return this.data(name);
     } else if (typeof options == 'string') {
-      twipsy = this.data(name)
+      twipsy = this.data(name);
       if (twipsy) {
-        twipsy[options]()
+        twipsy[options]();
       }
-      return this
+      return this;
     }
 
-    options = $.extend({}, $.fn[name].defaults, options)
+    options = $.extend({}, $.fn[name].defaults, options);
 
     function get(ele) {
-      var twipsy = $.data(ele, name)
+      var twipsy = $.data(ele, name);
 
       if (!twipsy) {
-        twipsy = new Constructor(ele, $.fn.twipsy.elementOptions(ele, options))
-        $.data(ele, name, twipsy)
+        twipsy = new Constructor(ele, $.fn.twipsy.elementOptions(ele, options));
+        $.data(ele, name, twipsy);
       }
 
-      return twipsy
+      return twipsy;
     }
 
     function enter() {
-      var twipsy = get(this)
-      twipsy.hoverState = 'in'
+      var twipsy = get(this);
+      twipsy.hoverState = 'in';
 
       if (options.delayIn == 0) {
-        twipsy.show()
+        twipsy.show();
       } else {
-        twipsy.fixTitle()
+        twipsy.fixTitle();
         setTimeout(function() {
           if (twipsy.hoverState == 'in') {
-            twipsy.show()
+            twipsy.show();
           }
-        }, options.delayIn)
+        }, options.delayIn);
       }
     }
 
     function leave() {
-      var twipsy = get(this)
-      twipsy.hoverState = 'out'
+      var twipsy = get(this);
+      twipsy.hoverState = 'out';
       if (options.delayOut == 0) {
-        twipsy.hide()
+        twipsy.hide();
       } else {
         setTimeout(function() {
           if (twipsy.hoverState == 'out') {
-            twipsy.hide()
+            twipsy.hide();
           }
-        }, options.delayOut)
+        }, options.delayOut);
       }
     }
 
     if (!options.live) {
       this.each(function() {
-        get(this)
-      })
+        get(this);
+      });
     }
 
     if (options.trigger != 'manual') {
-      binder   = options.live ? 'live' : 'bind'
-      eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus'
-      eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur'
-      this[binder](eventIn, enter)[binder](eventOut, leave)
+      binder   = options.live ? 'live' : 'bind';
+      eventIn  = options.trigger == 'hover' ? 'mouseenter' : 'focus';
+      eventOut = options.trigger == 'hover' ? 'mouseleave' : 'blur';
+      this[binder](eventIn, enter)[binder](eventOut, leave);
     }
 
-    return this
-  }
+    return this;
+  };
 
-  $.fn.twipsy.Twipsy = Twipsy
+  $.fn.twipsy.Twipsy = Twipsy;
 
   $.fn.twipsy.defaults = {
-    animate: true
-  , delayIn: 0
-  , delayOut: 0
-  , fallback: ''
-  , placement: 'above'
-  , html: false
-  , live: false
-  , offset: 0
-  , title: 'title'
-  , trigger: 'hover'
-  }
+    animate: true,
+    delayIn: 0,
+    delayOut: 0,
+    fallback: '',
+    placement: 'above',
+    html: false,
+    live: false,
+    offset: 0,
+    title: 'title',
+    trigger: 'hover'
+  };
 
   $.fn.twipsy.elementOptions = function(ele, options) {
-    return $.metadata ? $.extend({}, options, $(ele).metadata()) : options
-  }
+    return $.metadata ? $.extend({}, options, $(ele).metadata()) : options;
+  };
 
-}( window.jQuery || window.ender )
+}( window.jQuery || window.ender );


### PR DESCRIPTION
When concatenating or naively minifying the existing JS, the lack of semicolons resulted in ambiguous code and resulting breakage in one of my Rails apps. This commit makes the JS pass JSLint's checks, and the result is safer behavior. (Sorry that it necessarily touched so many lines.)
Cheers!
-Steve
