### PR TITLE
Allow inputs in dropdown menus.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -22,8 +22,15 @@
 
   var d = 'a.menu, .dropdown-toggle'
 
-  function clearMenus() {
-    $(d).parent('li').removeClass('open')
+  function clearMenus(e) {
+    var _parent = $(d).parent('li')
+    if (e != undefined) {
+      var srcEl = e.srcElement
+        , isInput = $(srcEl).hasClass('no-close')
+        , insideParent = _parent.has(srcEl).length > 0
+      if (isInput && insideParent) return
+    }
+    _parent.removeClass('open')
   }
 
   $(function () {
@@ -40,7 +47,7 @@
         var li = $(this).parent('li')
           , isActive = li.hasClass('open')
 
-        clearMenus()
+        clearMenus(e)
         !isActive && li.toggleClass('open')
         return false
       })
@@ -48,3 +55,4 @@
   }
 
 }( window.jQuery || window.ender )
+


### PR DESCRIPTION
I added some code into the clearMenus method that checks to see if the element that was clicked is inside the open drop down menu, and if it is, checks to see if it has the class 'no-close'. If it has that class, it doesn't close the drop down. This way, a user could have a form in a drop down, and the inputs could gain focus without toggling the drop down.

See it in action: http://jsfiddle.net/pthrasher/uLRtY/
