### PR TITLE
Fixes a bug when the [data-tabs] or [data-pills] called multiple times

### DIFF
--- a/js/bootstrap-tabs.js
+++ b/js/bootstrap-tabs.js
@@ -56,7 +56,7 @@
   }
 
   $(document).ready(function () {
-    $('body').tabs('ul[data-tabs] li > a, ul[data-pills] > li > a')
+    $('ul.tabs[data-tabs], ul.pills[data-pills]').tabs();
   })
 
 }( window.jQuery || window.ender )


### PR DESCRIPTION
Fixes a bug where using the [data-tabs] or [data-pills] multiple times in a page causes all tabs to be associated together.

Sample code to trigger bug on a page w/ bootstrap being used:

`<ul class="tabs" data-tabs="tabgroup1">
  <li class="active"><a href="#area1">Link1</a></li>
  <li><a href="#area2">Link2</a></li>
</ul>
<ul class="tabs" data-tabs="tabgroup2">
  <li class="active"><a href="#area3">Link1</a></li>
  <li><a href="#area4">Link2</a></li>
</ul>`

If you clicked on "Link2" in "tabgroup1" after loading the page, it will become active and all other tabs (including those in "tabgroup2" would become inactive, even though they are in a different tabgroup.
