### PR TITLE
Allow for namespacing of modal (and backdrop) window

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -82,7 +82,7 @@
         escape.call(this)
         backdrop.call(this, function () {
           that.$element
-            .appendTo(document.body)
+            .appendTo(that.settings.parent || document.body)
             .show()
 
           if ($.support.transition && that.$element.hasClass('fade')) {
@@ -137,7 +137,7 @@
       var doAnimate = $.support.transition && animate
 
       this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .appendTo(document.body)
+        .appendTo(that.settings.parent || document.body)
 
       if ( this.settings.backdrop != 'static' ) {
         this.$backdrop.click($.proxy(this.hide, this))


### PR DESCRIPTION
I made this change for my personal use a few days ago but figured it might be something others would want. Not sure if I implemented it correctly (but I tested it, and it works) as I am far from being a Javascript/jQuery expert.

This commit makes it possible to namespace your modal windows.

The use case for this is a page where you allow for clients to have custom html & css, but also have some static html/css of your own. Not namespacing your own css means that it could be overwritten by accident by the custom code.

I still wanted to use the Bootstrap elements so I simply added a class namespace inside the LESS files by wrapping all the css inside a new block:

``` css
.my_custom_namespace {
  ... original bootstrap css here ...
}
```

This is very easy to do yourself and it works great, except that I can't use the vanilla JS with this because it places elements directly in the body of the page instead of the namespaced element.

With this commit, if you want a different parent element than the `document.body`, you pass it the `parent` option.

``` coffeescript
$("#my_modal").modal
  show: true
  parent: ".my_custom_namespace"
  backdrop: "static"
```

Now the modal will be positioned inside the element with class: `my_custom_namespace` on hiding/showing.

If this is any good, and people are interested, perhaps it would be a good idea to port this functionality to the other JS files as well, but I haven't had a chance to check those out yet.
