### PR TITLE
Bug fix for hide-before-show bug

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -101,7 +101,7 @@
         e && e.preventDefault()
 
         if (! this.isShown) {
-            return
+            return this
         }
 
         var that = this

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -100,7 +100,9 @@
     , hide: function (e) {
         e && e.preventDefault()
 
-        if (! this.isShown) return
+        if (! this.isShown) {
+            return
+        }
 
         var that = this
         this.isShown = false

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -100,6 +100,8 @@
     , hide: function (e) {
         e && e.preventDefault()
 
+        if (! this.isShown) return
+
         var that = this
         this.isShown = false
 


### PR DESCRIPTION
there [seems to be a bug](http://jsfiddle.net/aaronj1335/7hH89/8/) that throws a JS error when `.modal('hide')` is called before `.modal('show')`.  this commit is a fix.
