### PR TITLE
add margin between consecutive fields with error

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Thu Sep 22 12:52:42 PDT 2011
+ * Date: Fri Sep 23 21:39:40 EDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -746,6 +746,9 @@ form div.clearfix.error .input-prepend span.add-on, form div.clearfix.error .inp
   background: #f4c8c5;
   border-color: #c87872;
   color: #b9554d;
+}
+form div.clearfix.error + div.clearfix.error {
+  margin-top: 10px;
 }
 .input-mini,
 input.mini,

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -128,6 +128,7 @@ input[type=file]:focus,input[type=checkbox]:focus,select:focus{-webkit-box-shado
 form div.clearfix.error{background:#fae5e3;padding:10px 0;margin:-10px 0 10px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}form div.clearfix.error>label,form div.clearfix.error span.help-inline,form div.clearfix.error span.help-block{color:#9d261d;}
 form div.clearfix.error input,form div.clearfix.error textarea{border-color:#c87872;-webkit-box-shadow:0 0 3px rgba(171, 41, 32, 0.25);-moz-box-shadow:0 0 3px rgba(171, 41, 32, 0.25);box-shadow:0 0 3px rgba(171, 41, 32, 0.25);}form div.clearfix.error input:focus,form div.clearfix.error textarea:focus{border-color:#b9554d;-webkit-box-shadow:0 0 6px rgba(171, 41, 32, 0.5);-moz-box-shadow:0 0 6px rgba(171, 41, 32, 0.5);box-shadow:0 0 6px rgba(171, 41, 32, 0.5);}
 form div.clearfix.error .input-prepend span.add-on,form div.clearfix.error .input-append span.add-on{background:#f4c8c5;border-color:#c87872;color:#b9554d;}
+form div.clearfix.error+div.clearfix.error{margin-top:10px;}
 .input-mini,input.mini,textarea.mini,select.mini{width:60px;}
 .input-small,input.small,textarea.small,select.small{width:90px;}
 .input-medium,input.medium,textarea.medium,select.medium{width:150px;}

--- a/lib/forms.less
+++ b/lib/forms.less
@@ -187,6 +187,9 @@ form div.clearfix.error {
       color: darken(@error-text, 10%);
     }
   }
+  + div.clearfix.error {
+    margin-top: 10px;
+  }
 }
 
 // Form element sizes


### PR DESCRIPTION
When form fields appear consecutively with errors, there is no margin between them. This is caused by a negative top margin added to fields with error (to account for padding), but when they appear consecutively it causes the outer div.clearfix.error containers to touch up to one another with no margin. This fix adds back the margin on the subsequent consecutive fields. Similar to common "p + p" css margin fixes.
