### PR TITLE
bootstrap-twipsy ender support

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -30,9 +30,10 @@
 
   var transitionEnd
 
+  !$.support && ($.support = {})
+
   $(document).ready(function () {
 
-    !$.support && ($.support = {})
     $.support.transition = (function () {
       var thisBody = document.body || document.documentElement
         , thisStyle = thisBody.style

--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -18,6 +18,10 @@
  * limitations under the License.
  * ========================================================== */
 
+/*
+ * Ender support requires: qwery (or other selector engine) domready bowser bonzo bean valentine
+ * Note that bean does not currently support the 'live' option.
+ */
 
 !function( $ ) {
 
@@ -28,6 +32,7 @@
 
   $(document).ready(function () {
 
+    !$.support && ($.support = {})
     $.support.transition = (function () {
       var thisBody = document.body || document.documentElement
         , thisStyle = thisBody.style
@@ -127,6 +132,7 @@
       $tip.removeClass('in')
 
       function removeElement () {
+    	$tip.unbind(transitionEnd, removeElement)
         $tip.remove()
       }
 
@@ -229,11 +235,11 @@
     options = $.extend({}, $.fn[name].defaults, options)
 
     function get(ele) {
-      var twipsy = $.data(ele, name)
+      var twipsy = $(ele).data(name)
 
       if (!twipsy) {
         twipsy = new Constructor(ele, $.fn.twipsy.elementOptions(ele, options))
-        $.data(ele, name, twipsy)
+        $(ele).data(name, twipsy)
       }
 
       return twipsy
@@ -305,3 +311,5 @@
   }
 
 }( window.jQuery || window.ender );
+window.ender && ender.ender(ender.fn, true);
+	


### PR DESCRIPTION
Twipsy doesn't currently work with Ender for the following reasons:

`ender.support` isn't defined (as far as I can see anyway, perhaps there is a package that has it?). Seems like something that could go in to bowser though.

`ender.data()` is only bound to the internal chain so can't be called as `$.data(e, k, v)` but as far as I'm aware `$(e).data(k, v)` is fine by both Ender and jQuery. Perhaps `bonzo.data` should be bound to `ender` as well as `boosh`?

`ender.remove()` doesn't clean up like jQuery's does which leaves `transitionEnd` bound so on subsequent `show()`'s you get an immediate fade-out after the fade-in. An explicit `unbind()` seems to do the trick.

`ender.fn` doesn't actually do anything as far as I can tell so it seems appropriate to do an `ender.ender(ender.fn, true)` at the end of Twipsy to install it properly. Or perhaps just `ender.ender({twpsy: ender.fn.twipsy, true)` would be safest?

This pull request added Ender support and adds a little note about the dependencies. Let me know if you want anything adjusted.
