### PR TITLE
Add support for vertical tabs/pills to the framework.

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Thu Sep 22 12:52:42 PDT 2011
+ * Date: Wed Sep 28 11:10:12 ART 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -1577,6 +1577,9 @@ a.menu:after, .dropdown-toggle:after {
 .tabs > li > a, .pills > li > a {
   display: block;
 }
+.tabs.vertical > li, .pills.vertical > li {
+  float: none;
+}
 .tabs {
   float: left;
   width: 100%;
@@ -1606,6 +1609,42 @@ a.menu:after, .dropdown-toggle:after {
   border: 1px solid #ddd;
   border-bottom-color: transparent;
 }
+.tabs.vertical {
+  border-right: 1px solid #ddd;
+  border-bottom-color: transparent;
+  width: 24.5%;
+  margin-top: 6px;
+}
+.tabs.vertical > li > a {
+  -webkit-border-radius: 4px 0 0 4px;
+  -moz-border-radius: 4px 0 0 4px;
+  border-radius: 4px 0 0 4px;
+  margin-bottom: 2px;
+  margin-right: 0;
+}
+.tabs.vertical > li > a:hover {
+  border-color: #ddd #eee #ddd #ddd;
+}
+.tabs.vertical > li.active > a {
+  border: 1px solid #ddd;
+  border-right-color: transparent;
+}
+.tabs.vertical  + .tab-content {
+  zoom: 1;
+  clear: none;
+  display: table;
+  padding: 15px;
+  width: 75%;
+}
+.tabs.vertical  + .tab-content:before, .tabs.vertical  + .tab-content:after {
+  display: table;
+  content: "";
+  zoom: 1;
+  *display: inline;
+}
+.tabs.vertical  + .tab-content:after {
+  clear: both;
+}
 .tabs .menu-dropdown, .tabs .dropdown-menu {
   top: 35px;
   border-width: 1px;
@@ -1627,6 +1666,18 @@ a.menu:after, .dropdown-toggle:after {
 .tab-content {
   clear: both;
 }
+.tabs-container {
+  zoom: 1;
+}
+.tabs-container:before, .tabs-container:after {
+  display: table;
+  content: "";
+  zoom: 1;
+  *display: inline;
+}
+.tabs-container:after {
+  clear: both;
+}
 .pills a {
   margin: 5px 3px 5px 0;
   padding: 0 15px;
@@ -1646,6 +1697,33 @@ a.menu:after, .dropdown-toggle:after {
   background: #0069d6;
   color: #ffffff;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
+}
+.pills.vertical {
+  width: 25%;
+  float: left;
+}
+.pills.vertical a {
+  margin: 5px 3px 5px 3px;
+}
+.pills.vertical  + .tab-content {
+  zoom: 1;
+  clear: none;
+  float: left;
+  display: table;
+  padding: 15px;
+  width: 75%;
+}
+.pills.vertical  + .tab-content:before, .pills.vertical  + .tab-content:after {
+  display: table;
+  content: "";
+  zoom: 1;
+  *display: inline;
+}
+.pills.vertical  + .tab-content:after {
+  clear: both;
+}
+.pills.vertical:parent {
+  clear: both;
 }
 .tab-content > *, .pill-content > * {
   display: none;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -240,15 +240,26 @@ a.menu:after,.dropdown-toggle:after{width:0;height:0;display:inline-block;conten
 .tabs,.pills{margin:0 0 20px;padding:0;list-style:none;zoom:1;}.tabs:before,.pills:before,.tabs:after,.pills:after{display:table;content:"";zoom:1;*display:inline;}
 .tabs:after,.pills:after{clear:both;}
 .tabs>li,.pills>li{float:left;}.tabs>li>a,.pills>li>a{display:block;}
+.tabs.vertical>li,.pills.vertical>li{float:none;}
 .tabs{float:left;width:100%;border-bottom:1px solid #ddd;}.tabs>li{position:relative;top:1px;}.tabs>li>a{padding:0 15px;margin-right:2px;line-height:36px;border:1px solid transparent;-webkit-border-radius:4px 4px 0 0;-moz-border-radius:4px 4px 0 0;border-radius:4px 4px 0 0;}.tabs>li>a:hover{text-decoration:none;background-color:#eee;border-color:#eee #eee #ddd;}
 .tabs>li.active>a{color:#808080;background-color:#ffffff;border:1px solid #ddd;border-bottom-color:transparent;}
+.tabs.vertical{border-right:1px solid #ddd;border-bottom-color:transparent;width:24.5%;margin-top:6px;}.tabs.vertical>li>a{-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px;margin-bottom:2px;margin-right:0;}.tabs.vertical>li>a:hover{border-color:#ddd #eee #ddd #ddd;}
+.tabs.vertical>li.active>a{border:1px solid #ddd;border-right-color:transparent;}
+.tabs.vertical +.tab-content{zoom:1;clear:none;display:table;padding:15px;width:75%;}.tabs.vertical +.tab-content:before,.tabs.vertical +.tab-content:after{display:table;content:"";zoom:1;*display:inline;}
+.tabs.vertical +.tab-content:after{clear:both;}
 .tabs .menu-dropdown,.tabs .dropdown-menu{top:35px;border-width:1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px;}
 .tabs a.menu:after,.tabs .dropdown-toggle:after{border-top-color:#999;margin-top:15px;margin-left:5px;}
 .tabs li.open.menu .menu,.tabs .open.dropdown .dropdown-toggle{border-color:#999;}
 .tabs li.open a.menu:after,.tabs .dropdown.open .dropdown-toggle:after{border-top-color:#555;}
 .tab-content{clear:both;}
+.tabs-container{zoom:1;}.tabs-container:before,.tabs-container:after{display:table;content:"";zoom:1;*display:inline;}
+.tabs-container:after{clear:both;}
 .pills a{margin:5px 3px 5px 0;padding:0 15px;text-shadow:0 1px 1px #ffffff;line-height:30px;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px;}.pills a:hover{background:#00438a;color:#ffffff;text-decoration:none;text-shadow:0 1px 1px rgba(0, 0, 0, 0.25);}
 .pills .active a{background:#0069d6;color:#ffffff;text-shadow:0 1px 1px rgba(0, 0, 0, 0.25);}
+.pills.vertical{width:25%;float:left;}.pills.vertical a{margin:5px 3px 5px 3px;}
+.pills.vertical +.tab-content{zoom:1;clear:none;float:left;display:table;padding:15px;width:75%;}.pills.vertical +.tab-content:before,.pills.vertical +.tab-content:after{display:table;content:"";zoom:1;*display:inline;}
+.pills.vertical +.tab-content:after{clear:both;}
+.pills.vertical:parent{clear:both;}
 .tab-content>*,.pill-content>*{display:none;}
 .tab-content>.active,.pill-content>.active{display:block;}
 .breadcrumb{margin:0 0 18px;padding:7px 14px;background-color:#f5f5f5;background-repeat:repeat-x;background-image:-khtml-gradient(linear, left top, left bottom, from(#ffffff), to(#f5f5f5));background-image:-moz-linear-gradient(top, #ffffff, #f5f5f5);background-image:-ms-linear-gradient(top, #ffffff, #f5f5f5);background-image:-webkit-gradient(linear, left top, left bottom, color-stop(0%, #ffffff), color-stop(100%, #f5f5f5));background-image:-webkit-linear-gradient(top, #ffffff, #f5f5f5);background-image:-o-linear-gradient(top, #ffffff, #f5f5f5);background-image:linear-gradient(top, #ffffff, #f5f5f5);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f5f5f5', GradientType=0);border:1px solid #ddd;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;}.breadcrumb li{display:inline;text-shadow:0 1px 0 #ffffff;}

--- a/examples/container-app.html
+++ b/examples/container-app.html
@@ -71,6 +71,8 @@
     <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
     <link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png">
     <link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
+    <script src="../js/bootstrap-tabs.js"></script>
   </head>
 
   <body>
@@ -102,6 +104,34 @@
         <div class="row">
           <div class="span10">
             <h2>Main content</h2>
+            <div class="tabs-container">
+              <ul class="pills vertical" data-pills="pills">
+                <li class="active"><a href="#first-pill">Pill 1</a></li>
+                <li><a href="#second-pill">Pill 2</a></li>
+                <li><a href="#third-pill">Pill 3</a></li>
+              </ul>
+              <div class="tab-content">
+                <div class="active" id="first-pill">
+                  <p>First pill's content goes in here.</p>
+                </div>
+                <div id="second-pill">Second pill's content goes in here.</div>
+                <div id="third-pill">Third pill's content goes in here.</div>
+              </div>
+            </div>
+            <div class="tabs-container">
+              <ul class="tabs vertical" data-tabs="tabs">
+                <li class="active"><a href="#first-tab">Tab 1</a></li>
+                <li><a href="#second-tab">Tab 2</a></li>
+                <li><a href="#third-tab">Tab 3</a></li>
+              </ul>
+              <div class="tab-content">
+                <div class="active" id="first-tab">
+                  <p>First tab's content goes in here.</p>
+                </div>
+                <div id="second-tab">Second tab's content goes in here.</div>
+                <div id="third-tab">Third tab's content goes in here.</div>
+              </div>
+            </div>
           </div>
           <div class="span4">
             <h3>Secondary content</h3>

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -331,6 +331,11 @@ a.menu:after,
       display: block;
     }
   }
+  &.vertical {
+    > li {
+      float: none;
+    }
+  }
 }
 
 // Basic Tabs
@@ -358,6 +363,33 @@ a.menu:after,
       background-color: @white;
       border: 1px solid #ddd;
       border-bottom-color: transparent;
+    }
+  }
+  &.vertical {
+    border-right: 1px solid #ddd;
+    border-bottom-color: transparent;
+    width: 24.5%;
+    margin-top: 6px;
+    > li {
+      > a {
+        .border-radius(4px 0 0 4px);
+        margin-bottom: 2px;
+        margin-right: 0;
+        &:hover {
+          border-color: #ddd #eee #ddd #ddd;
+        }
+      }
+      &.active > a {
+        border: 1px solid #ddd;
+        border-right-color: transparent;
+      }
+    }
+    & + .tab-content {
+      .clearfix();
+      clear: none;
+      display: table;
+      padding: 15px;
+      width: 75%;
     }
   }
   // first one for backwards compatibility
@@ -389,10 +421,14 @@ a.menu:after,
   clear: both;
 }
 
+.tabs-container {
+  .clearfix();
+}
+
 // Basic pill nav
 .pills {
   a {
-      margin: 5px 3px 5px 0;
+    margin: 5px 3px 5px 0;
     padding: 0 15px;
     text-shadow: 0 1px 1px @white;
     line-height: 30px;
@@ -408,6 +444,24 @@ a.menu:after,
     background: @linkColor;
     color: @white;
     text-shadow: 0 1px 1px rgba(0,0,0,.25);
+  }
+  &.vertical {
+    width: 25%;
+    float: left;
+    a {
+      margin: 5px 3px 5px 3px;
+    }
+    & + .tab-content {
+      .clearfix();
+      clear: none;
+      float: left;
+      display: table;
+      padding: 15px;
+      width: 75%;
+    }
+    &:parent {
+      clear: both;
+    }
   }
 }
 


### PR DESCRIPTION
It includes an edit for the `container-app.html` example in order to show the functionality added.

As a container class for the tabs might be needed to avoid floating elements to slide into the `.tab-content` area a new `.tabs-container` class has been added which simply makes use of the `.clearfix()` mixin.
