### PR TITLE
Cancel button on modal demo

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -190,7 +190,7 @@ $('#my-modal').bind('hidden', function () {
             </div>
             <div class="modal-footer">
               <a href="#" class="btn primary">Primary</a>
-              <a href="#" class="btn secondary">Secondary</a>
+              <a href="#" class="btn secondary close">Cancel</a>
             </div>
           </div>
 


### PR DESCRIPTION
I realized you can easily make a cancel button by adding close class to the secondary button. From his tweet to me, I think @mdo is a fan of providing a cancel button in the dialog. If that's a best practice, maybe it should be in the docs? (Or if you think cancel buttons are overkill, then that's cool. Your call).
