### PR TITLE
JS Docs Typo

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -130,7 +130,7 @@
           <p>Activates your content as a modal. Accepts an optional options <code>object</code>.
 <pre class="prettyprint linenums">
 $('#my-modal').modal({
-  closeOnEscape: true
+  keyboard: true
 })</pre>
           <h4>.modal('toggle')</h4>
           <p>Manually toggles a modal.</p>


### PR DESCRIPTION
Think the option is supposed to be 'keyboard' in the docs, not 'closeOnEsc'.
