### PR TITLE
Add a white-space: nowrap; for .label elements.

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -2309,6 +2309,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
+  white-space: nowrap;
 }
 .label.important {
   background-color: #c43c35;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -319,7 +319,7 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .popover .title{background-color:#f5f5f5;padding:9px 15px;line-height:1;-webkit-border-radius:3px 3px 0 0;-moz-border-radius:3px 3px 0 0;border-radius:3px 3px 0 0;border-bottom:1px solid #eee;}
 .popover .content{background-color:#ffffff;padding:14px;-webkit-border-radius:0 0 3px 3px;-moz-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}.popover .content p,.popover .content ul,.popover .content ol{margin-bottom:0;}
 .fade{-webkit-transition:opacity 0.15s linear;-moz-transition:opacity 0.15s linear;-ms-transition:opacity 0.15s linear;-o-transition:opacity 0.15s linear;transition:opacity 0.15s linear;opacity:0;}.fade.in{opacity:1;}
-.label{padding:1px 3px 2px;background-color:#bfbfbf;font-size:9.75px;font-weight:bold;color:#ffffff;text-transform:uppercase;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}.label.important{background-color:#c43c35;}
+.label{padding:1px 3px 2px;background-color:#bfbfbf;font-size:9.75px;font-weight:bold;color:#ffffff;text-transform:uppercase;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;white-space:nowrap;}.label.important{background-color:#c43c35;}
 .label.warning{background-color:#f89406;}
 .label.success{background-color:#46a546;}
 .label.notice{background-color:#62cffc;}

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -969,6 +969,7 @@ input[type=submit].btn {
   font-weight: bold;
   color: @white;
   text-transform: uppercase;
+  white-space: nowrap;
   .border-radius(3px);
   &.important { background-color: #c43c35; }
   &.warning   { background-color: @orange; }


### PR DESCRIPTION
Label should not split on two lines when it include more than a word, isn't it? I added white-space: nowrap; in both CSS and LESS files.
