### PR TITLE
Fix problem with `examples/container-app.html` when adding popovers

### DIFF
--- a/examples/container-app.html
+++ b/examples/container-app.html
@@ -29,7 +29,7 @@
       }
 
       /* The white background content wrapper */
-      .content {
+      .container .content {
         background-color: #fff;
         padding: 20px;
         margin: 0 -20px; /* negative indent the amount of the padding to maintain the grid system */


### PR DESCRIPTION
Adding a popover to the `examples/container-app.html` file causes margins to be off. 

![Screen shot of problem](https://img.skitch.com/20111001-fr6fqk2my2b18nnhb9e4gnge3g.jpg)

Fixed by making CSS for `.content` more specific.
