### PR TITLE
allow passing the selector as an option to the Alert class

### DIFF
--- a/js/bootstrap-alerts.js
+++ b/js/bootstrap-alerts.js
@@ -88,11 +88,14 @@
     return this.each(function () {
       var $this = $(this)
 
-      if ( typeof options == 'string' ) {
+      if ( typeof options == 'string' && typeof Alert.prototype[options] == 'function') {
         return $this.data('alert')[options]()
       }
 
-      $(this).data('alert', new Alert( this ))
+      if (typeof options == 'string')
+        $(this).data('alert', new Alert( this , options ))
+      else
+        $(this).data('alert', new Alert( this ))
 
     })
   }


### PR DESCRIPTION
Not sure if I did this correctly - I think I interpreted line 91 correctly - but this change allows one to specify the `selector` used for the `.close` link. I require this as the Modal plugin uses the same `.close` selector to delegate closing the modal, and having an alert within a modal will ensure that the alert's `.close` link closes the modal, not the alert.

If there is a better way to do this, I'm all ears.
