### PR TITLE
Add jquery.ready hook after defining plugin, to avoid breakage with modernizr/yepnope 

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -20,17 +20,6 @@
 
 !function( $ ){
 
-  var d = 'a.menu, .dropdown-toggle'
-
-  function clearMenus() {
-    $(d).parent('li').removeClass('open')
-  }
-
-  $(function () {
-    $('html').bind("click", clearMenus)
-    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' )
-  })
-
   /* DROPDOWN PLUGIN DEFINITION
    * ========================== */
 
@@ -46,5 +35,19 @@
       })
     })
   }
+
+  /* APPLY TO STANDARD DROPDOWN ELEMENTS
+   * =================================== */
+
+  var d = 'a.menu, .dropdown-toggle'
+
+  function clearMenus() {
+    $(d).parent('li').removeClass('open')
+  }
+
+  $(function () {
+    $('html').bind("click", clearMenus)
+    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' )
+  })
 
 }( window.jQuery || window.ender );


### PR DESCRIPTION
See https://gist.github.com/1258742 for an example, which results in the error:

"TypeError: Object has no method 'dropdown' at bootstrap-dropdown.js line 31"

It looks like in these circumstances, the functions hooked into
jquery.ready get run immediately, and so applying the dropdown
behavior to specific elements before defining the 'dropdown' method
causes breakage.

-Steve
