### PR TITLE
Added a .delegate for a .cancel class so cancel buttons can be easily add

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -56,6 +56,7 @@
     this.settings = $.extend({}, $.fn.modal.defaults, options)
     this.$element = $(content)
       .delegate('.close', 'click.modal', $.proxy(this.hide, this))
+      .delegate('.cancel', 'click.modal', $.proxy(this.hide, this))
 
     if ( this.settings.show ) {
       this.show()


### PR DESCRIPTION
Added a .delegate for a .cancel class so cancel buttons can be easily added to modals without having the .close CSS applied to the button.
