### PR TITLE
Forms inside modals should have margin-bottom 0px

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -804,6 +804,9 @@ input[type=submit].btn {
     top: -25%;
   }
   &.fade.in { top: 50%; }
+  form {
+    margin-bottom: 0px;
+  }
 }
 .modal-header {
   border-bottom: 1px solid #eee;


### PR DESCRIPTION
Implementing bootstrap into a rails app today, and ran into this issue.  When a form is placed inside a modal, the margin-bottom: 18px; causes there to be a white bar at the bottom of the modal if the submit button is inside '.modal-footer'.  The attached code should fix this specific case.
