### PR TITLE
Propagate data attributes to events

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -92,7 +92,7 @@
 
           transition ?
             that.$element.one(transitionEnd, function () { that.$element.trigger('shown') }) :
-            that.$element.trigger('shown', this.settings)
+            that.$element.trigger('shown', that.settings)
 
         })
 
@@ -118,7 +118,7 @@
         function removeElement () {
           that.$element
             .hide()
-            .trigger('hidden', this.settings)
+            .trigger('hidden', that.settings)
 
           backdrop.call(that)
         }

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -73,7 +73,7 @@
     , show: function () {
         var that = this
         this.isShown = true
-        this.$element.trigger('show')
+        this.$element.trigger('show', this.settings)
 
         escape.call(this)
         backdrop.call(this, function () {
@@ -92,7 +92,7 @@
 
           transition ?
             that.$element.one(transitionEnd, function () { that.$element.trigger('shown') }) :
-            that.$element.trigger('shown')
+            that.$element.trigger('shown', this.settings)
 
         })
 
@@ -112,13 +112,13 @@
         escape.call(this)
 
         this.$element
-          .trigger('hide')
+          .trigger('hide', this.settings)
           .removeClass('in')
 
         function removeElement () {
           that.$element
             .hide()
-            .trigger('hidden')
+            .trigger('hidden', this.settings)
 
           backdrop.call(that)
         }


### PR DESCRIPTION
So you intercept an event you can operate on a modal as defined per customer data attributes

e.g.

``` js
$('#ec-modal').bind('show', 
  function (_,a) { 
    alert(a.img);
});
```
