### PR TITLE
Use proper span classes for three column layout in hero example

### DIFF
--- a/examples/hero.html
+++ b/examples/hero.html
@@ -52,17 +52,17 @@
 
       <!-- Example row of columns -->
       <div class="row">
-        <div class="span6">
+        <div class="span-one-third">
           <h2>Heading</h2>
           <p>Etiam porta sem malesuada magna mollis euismod. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</p>
           <p><a class="btn" href="#">View details &raquo;</a></p>
         </div>
-        <div class="span5">
+        <div class="span-one-third">
           <h2>Heading</h2>
            <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
           <p><a class="btn" href="#">View details &raquo;</a></p>
        </div>
-        <div class="span5">
+        <div class="span-one-third">
           <h2>Heading</h2>
           <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
           <p><a class="btn" href="#">View details &raquo;</a></p>


### PR DESCRIPTION
Noticed that the hero example layout uses "span6", "span 5", "span 5" instead of the new "span-one-third" class
