### PR TITLE
fix styles to allow for valid table markup variations

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Mon Oct 10 14:31:07 CDT 2011
+ * Date: Fri Oct 21 14:14:48 CDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -1108,10 +1108,15 @@ table th {
 table td {
   vertical-align: top;
 }
-table th + th, table td + td {
+table th + th, table th + td, table td + td {
   border-left: 1px solid #ddd;
 }
-table tr + tr td {
+table tr + tr th,
+table tr + tr td,
+table tfoot th,
+table tfoot td,
+table tbody + tbody tr:first-child th,
+table tbody + tbody tr:first-child td {
   border-top: 1px solid #ddd;
 }
 table tbody tr:first-child td:first-child {

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -183,8 +183,8 @@ input[disabled],select[disabled],textarea[disabled],input[readonly],select[reado
 table{width:100%;margin-bottom:18px;padding:0;border-collapse:separate;*border-collapse:collapse;font-size:13px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}table th,table td{padding:10px 10px 9px;line-height:18px;text-align:left;}
 table th{padding-top:9px;font-weight:bold;vertical-align:middle;border-bottom:1px solid #ddd;}
 table td{vertical-align:top;}
-table th+th,table td+td{border-left:1px solid #ddd;}
-table tr+tr td{border-top:1px solid #ddd;}
+table th+th,table th+td,table td+td{border-left:1px solid #ddd;}
+table tr+tr th,table tr+tr td,table tfoot th,table tfoot td,table tbody+tbody tr:first-child th,table tbody+tbody tr:first-child td{border-top:1px solid #ddd;}
 table tbody tr:first-child td:first-child{-webkit-border-radius:4px 0 0 0;-moz-border-radius:4px 0 0 0;border-radius:4px 0 0 0;}
 table tbody tr:first-child td:last-child{-webkit-border-radius:0 4px 0 0;-moz-border-radius:0 4px 0 0;border-radius:0 4px 0 0;}
 table tbody tr:last-child td:first-child{-webkit-border-radius:0 0 0 4px;-moz-border-radius:0 0 0 4px;border-radius:0 0 0 4px;}

--- a/lib/tables.less
+++ b/lib/tables.less
@@ -31,10 +31,16 @@ table {
     vertical-align: top;
   }
   th + th,
+  th + td,
   td + td {
     border-left: 1px solid #ddd;
   }
-  tr + tr td {
+  tr + tr th,
+  tr + tr td,
+  tfoot th,
+  tfoot td,
+  tbody + tbody tr:first-child th,
+  tbody + tbody tr:first-child td {
     border-top: 1px solid #ddd;
   }
   tbody tr:first-child td:first-child {


### PR DESCRIPTION
The baseline table styles are a bit messed up if you have multiple  `<tbody>s` a `<tfoot>` and `<th>s` in either of those. This is all perfectly valid markup. This commit fixes the styling in those cases.

Here is some example table markup:

``` html
<table>
    <thead>
        <tr scope="col">column heading</tr>
        <tr scope="col">column heading</tr>
        <tr scope="col">column heading</tr>
    </thead>

    <tfoot>
        <tr>
            <th scope="row" colspan="2">Row heading</th>
            <td>data</td>
        </tr>
    </tfoot>

    <tbody>
        <tr>
            <th scope="row">Row heading</th>
            <td>data</td>
            <td>data</td>
        </tr>
        <tr>
            <th scope="row">Row heading</th>
            <td>data</td>
            <td>data</td>
        </tr>
    </tbody>

    <tbody>
        <tr>
            <th scope="row">Row heading</th>
            <td>data</td>
            <td>data</td>
        </tr>
        <tr>
            <th scope="row">Row heading</th>
            <td>data</td>
            <td>data</td>
        </tr>
    <tbody>
</table>
```
