### PR TITLE
Rounding pagination list boundary items

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Mon Oct 10 14:31:07 CDT 2011
+ * Date: Sun Oct 23 19:13:26 CDT 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -2033,8 +2033,11 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   background-color: transparent;
   color: #bfbfbf;
 }
-.pagination .next a {
-  border: 0;
+.pagination li:first-child a {
+  border-left: 0;
+}
+.pagination li:last-child a {
+  border-right: 0;
 }
 .well {
   background-color: #f5f5f5;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -291,7 +291,8 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .pagination a{float:left;padding:0 14px;line-height:34px;border-right:1px solid;border-right-color:#ddd;border-right-color:rgba(0, 0, 0, 0.15);*border-right-color:#ddd;text-decoration:none;}
 .pagination a:hover,.pagination .active a{background-color:#c7eefe;}
 .pagination .disabled a,.pagination .disabled a:hover{background-color:transparent;color:#bfbfbf;}
-.pagination .next a{border:0;}
+.pagination li:first-child a{border-left:0;}
+.pagination li:last-child a{border-right:0;}
 .well{background-color:#f5f5f5;margin-bottom:20px;padding:19px;min-height:20px;border:1px solid #eee;border:1px solid rgba(0, 0, 0, 0.05);-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);-moz-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);}.well blockquote{border-color:#ddd;border-color:rgba(0, 0, 0, 0.15);}
 .modal-backdrop{background-color:#000000;position:fixed;top:0;left:0;right:0;bottom:0;z-index:10000;}.modal-backdrop.fade{opacity:0;}
 .modal-backdrop,.modal-backdrop.fade.in{filter:alpha(opacity=80);-khtml-opacity:0.8;-moz-opacity:0.8;opacity:0.8;}

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -740,8 +740,11 @@ input[type=submit].btn {
     background-color: transparent;
     color: @grayLight;
   }
-  .next a {
-    border: 0;
+  li:first-child a {
+    border-left: 0;
+  }
+  li:last-child a {
+    border-right: 0;
   }
 }
 


### PR DESCRIPTION
Previously you would use `prev` and `next` to round the corners of the
items in the pagination list.  I changed it to use the `first-child`
and 'last-child' becuase you want the corners rounded regardless of
whether or not you have a list item marked with the `prev` or `next`
class.  For example, I have the following pagination list:

```
[1][...][12][13][14][15][16][...][23]
```

I could have added the `prev` and `next` classes to the boundary
items (1 and 23), however it's semantically incorrect, and I think
this solution is more flexible.
