### PR TITLE
Aligned close buttons to the middle of alert message

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -520,6 +520,10 @@ footer {
   &.info:hover {
     color: @white
   }
+  // Sets the close button to the middle of message
+  .close{
+	line-height: 18px;
+  }
   // Danger and error appear as red
   &.danger,
   &.error {

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -522,7 +522,8 @@ footer {
   }
   // Sets the close button to the middle of message
   .close{
-	line-height: 18px;
+    font-family: Arial;
+    line-height: 18px;
   }
   // Danger and error appear as red
   &.danger,


### PR DESCRIPTION
Well, this may sound silly, but it's not. Just a little fix to align the close button on alert messages in the center.

Turning this
![img1](http://img18.imageshack.us/img18/6479/screenshot00978.jpg)

Into this
![img2](http://img198.imageshack.us/img198/7086/screenshot00979.jpg)

Tested in all browsers.
