### PR TITLE
Simple fix to bootstrap-dropdown.js to allow it to be compressed by Asset Packager and other packaging tools

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -27,11 +27,11 @@
     return this.each(function () {
       $(this).delegate(selector || d, 'click', function (e) {
         var li = $(this).parent('li')
-          , isActive = li.hasClass('open')
+          , isActive = li.hasClass('open');
 
-        clearMenus()
-        !isActive && li.toggleClass('open')
-        return false
+        clearMenus();
+        !isActive && li.toggleClass('open');
+        return false;
       })
     })
   }
@@ -39,15 +39,15 @@
   /* APPLY TO STANDARD DROPDOWN ELEMENTS
    * =================================== */
 
-  var d = 'a.menu, .dropdown-toggle'
+  var d = 'a.menu, .dropdown-toggle';
 
   function clearMenus() {
-    $(d).parent('li').removeClass('open')
+    $(d).parent('li').removeClass('open');
   }
 
   $(function () {
-    $('html').bind("click", clearMenus)
-    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' )
+    $('html').bind("click", clearMenus);
+    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' );
   })
 
 }( window.jQuery || window.ender );


### PR DESCRIPTION
Added semicolons so that the file can easily be compressed by tools such as Asset Packager
