### PR TITLE
Patch 3

### DIFF
--- a/js/bootstrap-buttons.js
+++ b/js/bootstrap-buttons.js
@@ -30,14 +30,19 @@
     data.resetText || $el.data('resetText', $el.html())
 
     $el.html( data[state] || $.fn.button.defaults[state] )
-
+    
+    el.className = el.className.replace(/\b(\sstate-.*)?\b/g, '')
+	  $el.addClass('state-'+state)
+	
     state == 'loadingText' ?
       $el.addClass(d).attr(d, d) :
       $el.removeClass(d).removeAttr(d)
   }
 
   function toggle(el) {
-    $(el).toggleClass('active')
+   	var $el = $(el)
+   	$el.toggleClass('active')
+   	$el.hasClass('active') ? setState(el, 'active') : setState(el, 'reset')
   }
 
   $.fn.button = function(options) {


### PR DESCRIPTION
Adding and removing classes when using $().button so you can style each state differently...

Also, giving $().button('toggle') some love if there is "active" text in the element. Might help with the follow/unfollow stuff here: #522

`('.btn').button('toggle');` now performs a text swap.

`$('.btn').button('saved');` adds a class 'state-savedText'
`$('.btn').button('love');` adds a class 'state-loveText' 
`$('.btn').button('hate');` adds a class 'state-hateText'
etc...

So you can style each state differently...
