### PR TITLE
Remove border-radius on the first tbody row

### DIFF
--- a/lib/tables.less
+++ b/lib/tables.less
@@ -37,12 +37,6 @@ table {
   tr + tr td {
     border-top: 1px solid #ddd;
   }
-  tbody tr:first-child td:first-child {
-    .border-radius(4px 0 0 0);
-  }
-  tbody tr:first-child td:last-child {
-    .border-radius(0 4px 0 0);
-  }
   tbody tr:last-child td:first-child {
     .border-radius(0 0 0 4px);
   }


### PR DESCRIPTION
Remove border-radius on the first tbody row, it is likely not something that is desirable.

The border radius is not visible when the table is placed on a white background, but when using a darker background it will be visible and ugly.
