### PR TITLE
gitignore css files in lib/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
+lib/*.css
 .DS_Store
 thumbs.db


### PR DESCRIPTION
When using bootstrap as a git submodule i get "untracked content" for bootstrap as less.app in  os x builds each file in lib/ to a css file.  

This pull request fixes that by adding a line to gitignore to ignore css files in the lib directory where only less files should reside. 
