### PR TITLE
remove redundant padding for error fields within form-stacked

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -1086,8 +1086,6 @@ textarea[readonly] {
   padding-top: 0;
 }
 .form-stacked div.clearfix.error {
-  padding-top: 10px;
-  padding-bottom: 10px;
   padding-left: 10px;
   margin-top: 0;
   margin-left: -10px;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -181,7 +181,7 @@ input[disabled],select[disabled],textarea[disabled],input[readonly],select[reado
 .form-stacked label{display:block;float:none;width:auto;font-weight:bold;text-align:left;line-height:20px;padding-top:0;}
 .form-stacked .clearfix{margin-bottom:9px;}.form-stacked .clearfix div.input{margin-left:0;}
 .form-stacked .inputs-list{margin-bottom:0;}.form-stacked .inputs-list li{padding-top:0;}.form-stacked .inputs-list li label{font-weight:normal;padding-top:0;}
-.form-stacked div.clearfix.error{padding-top:10px;padding-bottom:10px;padding-left:10px;margin-top:0;margin-left:-10px;}
+.form-stacked div.clearfix.error{padding-left:10px;margin-top:0;margin-left:-10px;}
 .form-stacked .actions{margin-left:-20px;padding-left:20px;}
 table{width:100%;margin-bottom:18px;padding:0;font-size:13px;border-collapse:collapse;}table th,table td{padding:10px 10px 9px;line-height:18px;text-align:left;}
 table th{padding-top:9px;font-weight:bold;vertical-align:middle;}

--- a/lib/forms.less
+++ b/lib/forms.less
@@ -466,8 +466,6 @@ textarea[readonly] {
     }
   }
   div.clearfix.error {
-    padding-top: 10px;
-    padding-bottom: 10px;
     padding-left: 10px;
     margin-top: 0;
     margin-left: -10px;


### PR DESCRIPTION
It looks like redundant legacy from previous version when error fields were surrounded with red background. Now it looks odd, since the shape of the form changes its size and distort existing layout.
