### PR TITLE
Added semicolons to ensure minification doesnt break the dropdown plugin.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -29,11 +29,11 @@
     return this.each(function () {
       $(this).delegate(selector || d, 'click', function (e) {
         var li = $(this).parent('li')
-          , isActive = li.hasClass('open')
+          , isActive = li.hasClass('open');
 
-        clearMenus()
-        !isActive && li.toggleClass('open')
-        return false
+        clearMenus();
+        !isActive && li.toggleClass('open');
+        return false;
       })
     })
   }
@@ -44,12 +44,12 @@
   var d = 'a.menu, .dropdown-toggle'
 
   function clearMenus() {
-    $(d).parent('li').removeClass('open')
+    $(d).parent('li').removeClass('open');
   }
 
   $(function () {
-    $('html').bind("click", clearMenus)
-    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' )
+    $('html').bind("click", clearMenus);
+    $('body').dropdown( '[data-dropdown] a.menu, [data-dropdown] .dropdown-toggle' );
   })
 
 }( window.jQuery || window.ender );


### PR DESCRIPTION
Added semicolons to ensure minification doesnt break the dropdown plugin. When I minified my scripts, the dropdown plugin broke everything because there were not semicolons at the end of each line. This fixed it.
