### PR TITLE
Passing further info to the hide/hidden events to see which object triggered the event

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -40,7 +40,7 @@
     if ( $.support.transition ) {
       transitionEnd = "TransitionEnd"
       if ( $.browser.webkit ) {
-      	transitionEnd = "webkitTransitionEnd"
+        transitionEnd = "webkitTransitionEnd"
       } else if ( $.browser.mozilla ) {
       	transitionEnd = "transitionend"
       } else if ( $.browser.opera ) {
@@ -113,12 +113,12 @@
         escape.call(this)
 
         this.$element
-          .trigger('hide')
+          .trigger('hide', e)
           .removeClass('in')
 
         $.support.transition && this.$element.hasClass('fade') ?
-          hideWithTransition.call(this) :
-          hideModal.call(this)
+          hideWithTransition.call(this, e) :
+          hideModal.call(this, e)
 
         return this
       }
@@ -129,24 +129,24 @@
  /* MODAL PRIVATE METHODS
   * ===================== */
 
-  function hideWithTransition() {
+  function hideWithTransition(e) {
     // firefox drops transitionEnd events :{o
     var that = this
       , timeout = setTimeout(function () {
           that.$element.unbind(transitionEnd)
-          hideModal.call(that)
+          hideModal.call(that, e)
         }, 500)
 
     this.$element.one(transitionEnd, function () {
       clearTimeout(timeout)
-      hideModal.call(that)
+      hideModal.call(that, e)
     })
   }
 
-  function hideModal (that) {
+  function hideModal (e) {
     this.$element
       .hide()
-      .trigger('hidden')
+      .trigger('hidden', e)
 
     backdrop.call(this)
   }


### PR DESCRIPTION
I was in the situation of having a modal with an 'ok' and 'cancel' button and needed to figure out which caused the modal to close.

I needed the event info that was passed to the `Modal.hide()` function to be passed to the `hide` and `hidden` events as well. So now I can do this:

```
$('#modal-from-dom').bind('hidden', function(e, f) {
  if ($.inArray("cancel",f.srcElement.classList) < 0) {
    // some stuff
  }
});
```

Given these elements:

```
<a href="#" class="close btn primary">Ok</a>  
<a href="#" class="close cancel btn secondary">Cancel</a>
```
