### PR TITLE
Fixing topbar issue of right side items not being accessible when window is below a certain width.

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -190,7 +190,7 @@ body {
   color: #404040;
 }
 .container {
-  width: 940px;
+  max-width: 940px;
   margin-left: auto;
   margin-right: auto;
   zoom: 1;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -21,7 +21,7 @@ input[type="search"]{-webkit-appearance:textfield;-webkit-box-sizing:content-box
 input[type="search"]::-webkit-search-decoration{-webkit-appearance:none;}
 textarea{overflow:auto;vertical-align:top;}
 body{background-color:#ffffff;margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:18px;color:#404040;}
-.container{width:940px;margin-left:auto;margin-right:auto;zoom:1;}.container:before,.container:after{display:table;content:"";zoom:1;}
+.container{max-width:940px;margin-left:auto;margin-right:auto;zoom:1;}.container:before,.container:after{display:table;content:"";zoom:1;}
 .container:after{clear:both;}
 .container-fluid{position:relative;min-width:940px;padding-left:20px;padding-right:20px;zoom:1;}.container-fluid:before,.container-fluid:after{display:table;content:"";zoom:1;}
 .container-fluid:after{clear:both;}

--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -72,7 +72,7 @@
 
 // Grid System
 .fixed-container() {
-  width: @siteWidth;
+  max-width: @siteWidth;
   margin-left: auto;
   margin-right: auto;
   .clearfix();


### PR DESCRIPTION
Modified width of .container and .fixed-container() to fix the issue of not being able to access items on the right side of topbar when the window is resized to a width that's too small
