### PR TITLE
Calendar/Date Input - Refs #445.

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -2465,3 +2465,134 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -moz-box-shadow: 0 1px 4px rgba(0, 105, 214, 0.25);
   box-shadow: 0 1px 4px rgba(0, 105, 214, 0.25);
 }
+.datepicker {
+  background-color: #ffffff;
+  border-color: #999;
+  border-color: rgba(0, 0, 0, 0.2);
+  border-style: solid;
+  border-width: 1px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  display: none;
+  position: absolute;
+  z-index: 900;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 18px;
+  padding-bottom: 0.25em;
+  width: 17.75em;
+}
+.datepicker .nav {
+  font-weight: bold;
+  width: 100%;
+  padding: 0.5em 0;
+  background-color: #f5f5f5;
+  color: #808080;
+  border-bottom: 1px solid #ddd;
+  -webkit-box-shadow: inset 0 1px 0 #ffffff;
+  -moz-box-shadow: inset 0 1px 0 #ffffff;
+  box-shadow: inset 0 1px 0 #ffffff;
+  zoom: 1;
+}
+.datepicker .nav:before, .datepicker .nav:after {
+  display: table;
+  content: "";
+  zoom: 1;
+  *display: inline;
+}
+.datepicker .nav:after {
+  clear: both;
+}
+.datepicker .nav span {
+  display: block;
+  float: left;
+  text-align: center;
+  height: 28px;
+  line-height: 28px;
+  position: relative;
+}
+.datepicker .nav .bg {
+  width: 100%;
+  background-color: #ff6;
+  height: 28px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .nav .fg {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.datepicker .button {
+  font-size: 0.8em;
+  cursor: pointer;
+  padding: 0 0.5em;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .button:hover {
+  background-color: #808080;
+  color: #ffffff;
+}
+.datepicker .months {
+  float: left;
+  margin-left: 0.5em;
+}
+.datepicker .months .name {
+  width: 6em;
+  padding: 0;
+}
+.datepicker .years {
+  float: right;
+  margin-right: 0.5em;
+}
+.datepicker .years .name {
+  width: 3em;
+  padding: 0;
+}
+.datepicker .dow, .datepicker .days div {
+  float: left;
+  width: 2.5em;
+  padding: 0.5em 0;
+  text-align: center;
+}
+.datepicker .dow {
+  font-weight: bold;
+  color: #808080;
+}
+.datepicker .calendar {
+  padding: 0.25em;
+}
+.datepicker .days div {
+  cursor: pointer;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.datepicker .days div:hover {
+  background-color: #0064cd;
+  color: #ffffff;
+}
+.datepicker .selected {
+  background-color: #bfbfbf;
+  color: #ffffff;
+}
+.datepicker .overlap {
+  color: #bfbfbf;
+}
+.datepicker .today {
+  background-color: #fee9cc;
+}

--- a/bootstrap.css
+++ b/bootstrap.css
@@ -2486,13 +2486,13 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   margin-left: 0;
   margin-right: 0;
   margin-bottom: 18px;
-  padding-bottom: 0.25em;
-  width: 17.75em;
+  padding-bottom: 4px;
+  width: 218px;
 }
 .datepicker .nav {
   font-weight: bold;
   width: 100%;
-  padding: 0.5em 0;
+  padding: 4px 0;
   background-color: #f5f5f5;
   color: #808080;
   border-bottom: 1px solid #ddd;
@@ -2536,9 +2536,8 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   left: 0;
 }
 .datepicker .button {
-  font-size: 0.8em;
   cursor: pointer;
-  padding: 0 0.5em;
+  padding: 0 4px;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -2549,24 +2548,24 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 }
 .datepicker .months {
   float: left;
-  margin-left: 0.5em;
+  margin-left: 4px;
 }
 .datepicker .months .name {
-  width: 6em;
+  width: 72px;
   padding: 0;
 }
 .datepicker .years {
   float: right;
-  margin-right: 0.5em;
+  margin-right: 4px;
 }
 .datepicker .years .name {
-  width: 3em;
+  width: 36px;
   padding: 0;
 }
 .datepicker .dow, .datepicker .days div {
   float: left;
-  width: 2.5em;
-  padding: 0.5em 0;
+  width: 30px;
+  line-height: 25px;
   text-align: center;
 }
 .datepicker .dow {
@@ -2574,7 +2573,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   color: #808080;
 }
 .datepicker .calendar {
-  padding: 0.25em;
+  padding: 4px;
 }
 .datepicker .days div {
   cursor: pointer;
@@ -2586,13 +2585,13 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   background-color: #0064cd;
   color: #ffffff;
 }
-.datepicker .selected {
-  background-color: #bfbfbf;
-  color: #ffffff;
-}
 .datepicker .overlap {
   color: #bfbfbf;
 }
 .datepicker .today {
   background-color: #fee9cc;
+}
+.datepicker .selected {
+  background-color: #bfbfbf;
+  color: #ffffff;
 }

--- a/bootstrap.css
+++ b/bootstrap.css
@@ -2520,7 +2520,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 }
 .datepicker .nav .bg {
   width: 100%;
-  background-color: #ff6;
+  background-color: #fdf5d9;
   height: 28px;
   position: absolute;
   top: 0;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -354,18 +354,18 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .media-grid li{display:inline;}
 .media-grid a{float:left;padding:4px;margin:0 0 18px 20px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);-moz-box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);}.media-grid a img{display:block;}
 .media-grid a:hover{border-color:#0069d6;-webkit-box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);-moz-box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);}
-.datepicker{background-color:#ffffff;border-color:#999;border-color:rgba(0, 0, 0, 0.2);border-style:solid;border-width:1px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-moz-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;display:none;position:absolute;z-index:900;margin-left:0;margin-right:0;margin-bottom:18px;padding-bottom:0.25em;width:17.75em;}.datepicker .nav{font-weight:bold;width:100%;padding:0.5em 0;background-color:#f5f5f5;color:#808080;border-bottom:1px solid #ddd;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;zoom:1;}.datepicker .nav:before,.datepicker .nav:after{display:table;content:"";zoom:1;*display:inline;}
+.datepicker{background-color:#ffffff;border-color:#999;border-color:rgba(0, 0, 0, 0.2);border-style:solid;border-width:1px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-moz-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;display:none;position:absolute;z-index:900;margin-left:0;margin-right:0;margin-bottom:18px;padding-bottom:4px;width:218px;}.datepicker .nav{font-weight:bold;width:100%;padding:4px 0;background-color:#f5f5f5;color:#808080;border-bottom:1px solid #ddd;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;zoom:1;}.datepicker .nav:before,.datepicker .nav:after{display:table;content:"";zoom:1;}
 .datepicker .nav:after{clear:both;}
 .datepicker .nav span{display:block;float:left;text-align:center;height:28px;line-height:28px;position:relative;}
-.datepicker .nav .bg{width:100%;background-color:#ff6;height:28px;position:absolute;top:0;left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}
+.datepicker .nav .bg{width:100%;background-color:#fdf5d9;height:28px;position:absolute;top:0;left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}
 .datepicker .nav .fg{width:100%;position:absolute;top:0;left:0;}
-.datepicker .button{font-size:0.8em;cursor:pointer;padding:0 0.5em;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.datepicker .button:hover{background-color:#808080;color:#ffffff;}
-.datepicker .months{float:left;margin-left:0.5em;}.datepicker .months .name{width:6em;padding:0;}
-.datepicker .years{float:right;margin-right:0.5em;}.datepicker .years .name{width:3em;padding:0;}
-.datepicker .dow,.datepicker .days div{float:left;width:2.5em;padding:0.5em 0;text-align:center;}
+.datepicker .button{cursor:pointer;padding:0 4px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.datepicker .button:hover{background-color:#808080;color:#ffffff;}
+.datepicker .months{float:left;margin-left:4px;}.datepicker .months .name{width:72px;padding:0;}
+.datepicker .years{float:right;margin-right:4px;}.datepicker .years .name{width:36px;padding:0;}
+.datepicker .dow,.datepicker .days div{float:left;width:30px;line-height:25px;text-align:center;}
 .datepicker .dow{font-weight:bold;color:#808080;}
-.datepicker .calendar{padding:0.25em;}
+.datepicker .calendar{padding:4px;}
 .datepicker .days div{cursor:pointer;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.datepicker .days div:hover{background-color:#0064cd;color:#ffffff;}
-.datepicker .selected{background-color:#bfbfbf;color:#ffffff;}
 .datepicker .overlap{color:#bfbfbf;}
 .datepicker .today{background-color:#fee9cc;}
+.datepicker .selected{background-color:#bfbfbf;color:#ffffff;}

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -354,3 +354,18 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .media-grid li{display:inline;}
 .media-grid a{float:left;padding:4px;margin:0 0 18px 20px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);-moz-box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);box-shadow:0 1px 1px rgba(0, 0, 0, 0.075);}.media-grid a img{display:block;}
 .media-grid a:hover{border-color:#0069d6;-webkit-box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);-moz-box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);box-shadow:0 1px 4px rgba(0, 105, 214, 0.25);}
+.datepicker{background-color:#ffffff;border-color:#999;border-color:rgba(0, 0, 0, 0.2);border-style:solid;border-width:1px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-moz-box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);box-shadow:0 2px 4px rgba(0, 0, 0, 0.2);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;display:none;position:absolute;z-index:900;margin-left:0;margin-right:0;margin-bottom:18px;padding-bottom:0.25em;width:17.75em;}.datepicker .nav{font-weight:bold;width:100%;padding:0.5em 0;background-color:#f5f5f5;color:#808080;border-bottom:1px solid #ddd;-webkit-box-shadow:inset 0 1px 0 #ffffff;-moz-box-shadow:inset 0 1px 0 #ffffff;box-shadow:inset 0 1px 0 #ffffff;zoom:1;}.datepicker .nav:before,.datepicker .nav:after{display:table;content:"";zoom:1;*display:inline;}
+.datepicker .nav:after{clear:both;}
+.datepicker .nav span{display:block;float:left;text-align:center;height:28px;line-height:28px;position:relative;}
+.datepicker .nav .bg{width:100%;background-color:#ff6;height:28px;position:absolute;top:0;left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}
+.datepicker .nav .fg{width:100%;position:absolute;top:0;left:0;}
+.datepicker .button{font-size:0.8em;cursor:pointer;padding:0 0.5em;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.datepicker .button:hover{background-color:#808080;color:#ffffff;}
+.datepicker .months{float:left;margin-left:0.5em;}.datepicker .months .name{width:6em;padding:0;}
+.datepicker .years{float:right;margin-right:0.5em;}.datepicker .years .name{width:3em;padding:0;}
+.datepicker .dow,.datepicker .days div{float:left;width:2.5em;padding:0.5em 0;text-align:center;}
+.datepicker .dow{font-weight:bold;color:#808080;}
+.datepicker .calendar{padding:0.25em;}
+.datepicker .days div{cursor:pointer;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.datepicker .days div:hover{background-color:#0064cd;color:#ffffff;}
+.datepicker .selected{background-color:#bfbfbf;color:#ffffff;}
+.datepicker .overlap{color:#bfbfbf;}
+.datepicker .today{background-color:#fee9cc;}

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -325,6 +325,18 @@ $('#my-modal').bind('hidden', function () {
                 <td>1</td>
                 <td>Weekday to start the calendar on.<br>1 &rarr; Sun, 2 &rarr; Mon, etc.</td>
               </tr>
+              <tr>
+                <td>parse</td>
+                <td>function</td>
+                <td>RFC3339-compatible, e.g. <code>2011-04-17</code></td>
+                <td>Used to convert a string into a javascript Date object.</td>
+              </tr>
+              <tr>
+                <td>format</td>
+                <td>function</td>
+                <td>RFC3339-compatible</td>
+                <td>Used to convert a javascript Date object into a string.</td>
+              </tr>
             </tbody>
           </table>
           <h3>Markup</h3>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -23,6 +23,7 @@
     <script src="../js/bootstrap-scrollspy.js"></script>
     <script src="../js/bootstrap-tabs.js"></script>
     <script src="../js/bootstrap-buttons.js"></script>
+    <script src="../js/bootstrap-datepicker.js"></script>
 
     <!-- Le styles -->
     <link href="../bootstrap.css" rel="stylesheet">
@@ -48,6 +49,7 @@
             <li><a href="#overview">Overview</a></li>
             <li><a href="#modal">Modals</a></li>
             <li><a href="#dropdown">Dropdown</a></li>
+            <li><a href="#datepicker">DatePicker</a></li>
             <li><a href="#scrollspy">ScrollSpy</a></li>
             <li><a href="#buttons">Buttons</a></li>
             <li><a href="#tabs">Tabs</a></li>
@@ -279,7 +281,77 @@ $('#my-modal').bind('hidden', function () {
       </div>
     </section>
 
-   <!-- ScrollSpy
+    <!-- DatePicker
+    ================================================== -->
+    
+    <section id="datepicker">
+      <div class="page-header">
+        <h1>DatePicker <small>bootstrap-datepicker.js</small></h1>
+      </div>
+      <div class="row">
+        <div class="span4 columns">
+          <p>The datepicker plugin is a customizable calendar-based date entry widget.</p>
+          <a href="../js/bootstrap-datepicker.js" target="_blank" class="btn primary">Download</a>
+        </div>
+        <div class="span12 columns">
+          <h3>Using bootstrap-datepicker.js</h3>
+          <pre class="prettyprint linenums">$("#date").datepicker(options)</pre>
+          <h3>Options</h3>
+          <table class="zebra-striped">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>type</th>
+                <th>default</th>
+                <th>description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>monthNames</td>
+                <td>array of strings</td>
+                <td>January, February, March, April, May, June, July, August, September, October, November, December</td>
+                <td>Full month names to be used in navigation header. Can be overriden for localization.</td>
+              </tr>
+              <tr>
+                <td>shortMonthNames</td>
+                <td>array of strings</td>
+                <td>Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec</td>
+                <td>Short month names to be used in parsing and formatting dates. Can be overriden for localization.</td>
+              </tr>
+              <tr>
+                <td>shortDayNames</td>
+                <td>array of strings</td>
+                <td>Sun, Mon, Tue, Wed, Thu, Fri, Sat</td>
+                <td>Short day names to be used in calendar header cells. Can be overriden for localization.</td>
+              </tr>
+              <tr>
+                <td>startOfWeek</td>
+                <td>int</td>
+                <td>1</td>
+                <td>Weekday to start the calendar on.<br>1 &rarr; Sun, 2 &rarr; Mon, etc.</td>
+              </tr>
+            </tbody>
+          </table>
+          <h3>Markup</h3>
+          <p>Just add a <code>data-datepicker</code> attribute to your input field to automatically give them datepicker functionality.</p>
+          <pre class="prettyprint linenums">&lt;input type="text" value="5 May 2013" data-datepicker="datepicker" /&gt;</pre>
+          <p>If you want to customize datepickers, you can use the javascript method below.</p>
+          <h3>Methods</h3>
+          <h4>.datepicker(options)</h4>
+          <p>Enables an input field as a datepicker. Accepts an optional options <code>object</code>.
+<pre class="prettyprint linenums">
+$('#date').datepicker({
+  startOfWeek: 2
+})</pre>
+          <h3>Demo</h3>
+          <input data-datepicker="datepicker" class="small" type="text" value="13 Apr 2010" />
+          <span class="help-block">Click to show. Try using arrow keys for navigation.</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ScrollSpy
     ================================================== -->
 
     <section id="scrollspy">

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -314,12 +314,6 @@ $('#my-modal').bind('hidden', function () {
                 <td>Full month names to be used in navigation header. Can be overriden for localization.</td>
               </tr>
               <tr>
-                <td>shortMonthNames</td>
-                <td>array of strings</td>
-                <td>Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec</td>
-                <td>Short month names to be used in parsing and formatting dates. Can be overriden for localization.</td>
-              </tr>
-              <tr>
                 <td>shortDayNames</td>
                 <td>array of strings</td>
                 <td>Sun, Mon, Tue, Wed, Thu, Fri, Sat</td>
@@ -335,7 +329,7 @@ $('#my-modal').bind('hidden', function () {
           </table>
           <h3>Markup</h3>
           <p>Just add a <code>data-datepicker</code> attribute to your input field to automatically give them datepicker functionality.</p>
-          <pre class="prettyprint linenums">&lt;input type="text" value="5 May 2013" data-datepicker="datepicker" /&gt;</pre>
+          <pre class="prettyprint linenums">&lt;input type="text" value="2013-05-13" data-datepicker="datepicker" /&gt;</pre>
           <p>If you want to customize datepickers, you can use the javascript method below.</p>
           <h3>Methods</h3>
           <h4>.datepicker(options)</h4>
@@ -345,7 +339,7 @@ $('#date').datepicker({
   startOfWeek: 2
 })</pre>
           <h3>Demo</h3>
-          <input data-datepicker="datepicker" class="small" type="text" value="13 Apr 2010" />
+          <input data-datepicker="datepicker" class="small" type="text" value="2011-11-13" />
           <span class="help-block">Click to show. Try using arrow keys for navigation.</span>
         </div>
       </div>

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -19,17 +19,6 @@
  * Contributed by Scott Torborg - github.com/storborg
  * Loosely based on jquery.date_input.js by Jon Leighton, heavily updated and
  * rewritten to match bootstrap javascript approach and add UI features.
- * 
- * TODO
- * - Browser support!
- * - Make datepicker contents unselectable to prevent errant clicks from
- *   confusing users.
- * - Ensure all reset styling is in place to make the look consistent even in
- *   hostile CSS environments.
- * - Markup and CSS cleanup.
- * - Better hover style on buttons. Perhaps a well?
- * - Add ability to pass in format and parse functions to customize date format
- *   used in input element.
  * =========================================================== */
 
 
@@ -51,8 +40,10 @@
     this.$el = $(element);
     this.proxy('show').proxy('ahead').proxy('hide').proxy('keyHandler').proxy('selectDate');
 
-    if(!this.detectNative()) {
-      $.extend(this, $.fn.datepicker.defaults, options );
+    var options = $.extend({}, $.fn.datepicker.defaults, options );
+
+    if((!!options.parse) || (!!options.format) || !this.detectNative()) {
+      $.extend(this, options);
       this.$el.data('datepicker', this);
       all.push(this);
       this.init();
@@ -63,7 +54,9 @@
 
       detectNative: function(el) {
         // Attempt to activate the native datepicker, if there is a known good
-        // one. If successful, return true.
+        // one. If successful, return true. Note that input type="date"
+        // requires that the string be RFC3339, so if the format/parse methods
+        // have been overridden, this won't be used.
         if(navigator.userAgent.match(/(iPad|iPhone); CPU(\ iPhone)? OS 5_\d/i)) {
           // jQuery will only change the input type of a detached element.
           var $marker = $('<span>').insertBefore(this.$el);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1,0 +1,323 @@
+/* ===========================================================
+ * bootstrap-datepicker.js v1.3.0
+ * http://twitter.github.com/bootstrap/javascript.html#datepicker
+ * ===========================================================
+ * Copyright 2011 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributed by Scott Torborg - github.com/storborg
+ * Loosely based on jquery.date_input.js by Jon Leighton, heavily updated and
+ * rewritten to match bootstrap javascript approach and add UI features.
+ * 
+ * TODO
+ * - Browser support!
+ * - Make datepicker contents unselectable to prevent errant clicks from
+ *   confusing users.
+ * - When running on iOS 5 webkit, update datepicker elements to use input
+ *   type="date" instead of this. If there are other mobile platforms with the
+ *   ability to enable native datepickers, do that too.
+ * - Ensure all reset styling is in place to make the look consistent even in
+ *   hostile CSS environments.
+ * - Markup and CSS cleanup.
+ * - Better hover style on buttons. Perhaps a well?
+ * - Add ability to pass in format and parse functions to customize date format
+ *   used in input element.
+ * =========================================================== */
+
+
+!function ( $ ) { 
+
+  var selector = '[data-datepicker]';
+
+  function clearDatePickers(except) {
+    $(selector).each(function() {
+      var dp = $(this).data('datepicker');
+      if(dp != except) {
+        dp.hide();
+      }
+    });
+  }
+
+  function DatePicker( element, options ) {
+    this.$el = $(element);
+    $.extend(this, $.fn.datepicker.defaults, options );
+    this.$el.data('datepicker', this);
+    this.init();
+  }
+
+  DatePicker.prototype = {
+
+      init: function() {
+        this.proxy('show').proxy('ahead').proxy('hide').proxy('keyHandler').proxy('selectDate');
+
+        var $months = this.nav('months', 1);
+        var $years = this.nav('years', 12);
+
+        var $nav = $('<div>').addClass('nav').append($months, $years);
+
+        this.$month = $('.name', $months);
+        this.$year = $('.name', $years);
+
+        $calendar = $("<div>").addClass('calendar');
+
+        // Populate day of week headers, realigned by startOfWeek.
+        for (var i = 0; i < this.shortDayNames.length; i++) {
+          $calendar.append('<div class="dow">' + this.shortDayNames[(i + this.startOfWeek) % 7] + '</div>');
+        };
+
+        this.$days = $('<div>').addClass('days');
+        $calendar.append(this.$days);
+
+        this.$picker = $('<div>')
+          .click(function(e) { e.stopPropagation() })
+          .addClass('datepicker')
+          .append($nav, $calendar)
+          .insertAfter(this.$el);
+
+        this.$el
+          .focus(this.show)
+          .click(this.show)
+          .change($.proxy(function() { this.selectDate(); }, this));
+
+        this.selectDate();
+        this.hide();
+      }
+
+    , nav: function( c, months ) {
+        var $subnav = $('<div>' +
+                          '<span class="prev button">&#9664;</span>' +
+                          '<span class="name"></span>' +
+                          '<span class="next button">&#9654;</span>' +
+                        '</div>').addClass(c)
+        $('.prev', $subnav).click($.proxy(function() { this.ahead(-months, 0) }, this));
+        $('.next', $subnav).click($.proxy(function() { this.ahead(months, 0) }, this));
+        return $subnav;
+
+    }
+
+    , updateName: function($area, s) {
+        // Update either the month or year field, with a background flash
+        // animation.
+        var cur = $area.find('.fg').text(),
+            $fg = $('<div>').addClass('fg').append(s);
+        $area.empty();
+        if(cur != s) {
+          var $bg = $('<div>').addClass('bg');
+          $area.append($bg, $fg);
+          $bg.fadeOut('slow', function() {
+            $(this).remove();
+          });
+        } else {
+          $area.append($fg);
+        }
+    }
+
+    , selectMonth: function(date) {
+        var newMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+
+        if (!this.curMonth || !(this.curMonth.getFullYear() == newMonth.getFullYear() &&
+                                this.curMonth.getMonth() == newMonth.getMonth())) {
+
+          this.curMonth = newMonth;
+
+          var rangeStart = this.rangeStart(date), rangeEnd = this.rangeEnd(date);
+          var num_days = this.daysBetween(rangeStart, rangeEnd);
+          this.$days.empty();
+
+          for (var ii = 0; ii <= num_days; ii++) {
+            var thisDay = new Date(rangeStart.getFullYear(), rangeStart.getMonth(), rangeStart.getDate() + ii, 12, 00);
+            var $day = $('<div>').attr('date', this.format(thisDay));
+            $day.text(thisDay.getDate());
+
+            if (thisDay.getMonth() != date.getMonth()) {
+              $day.addClass('overlap');
+            };
+
+            this.$days.append($day);
+          };
+
+          this.updateName(this.$month, this.monthNames[date.getMonth()]);
+          this.updateName(this.$year, this.curMonth.getFullYear());
+
+          $('div', this.$days).click($.proxy(function(e) {
+            var $targ = $(e.target);
+
+            // The date= attribute is used here to provide relatively fast
+            // selectors for setting certain date cells.
+            this.update($targ.attr("date"));
+
+            // Don't consider this selection final if we're just going to an
+            // adjacent month.
+            if(!$targ.hasClass('overlap')) {
+              this.hide();
+            }
+
+          }, this));
+
+          $("[date='" + this.format(new Date()) + "']", this.$days).addClass('today');
+
+        };
+
+        $('.selected', this.$days).removeClass('selected');
+        $('[date="' + this.selectedDateStr + '"]', this.$days).addClass('selected');
+      }
+
+    , selectDate: function(date) {
+        if (typeof(date) == "undefined") {
+          date = this.parse(this.$el.val());
+        };
+        if (!date) date = new Date();
+
+          this.selectedDate = date;
+          this.selectedDateStr = this.format(this.selectedDate);
+          this.selectMonth(this.selectedDate);
+      }
+
+    , update: function(s) {
+        this.$el.val(s).change();
+      }
+
+    , show: function(e) {
+        e && e.stopPropagation();
+
+        // Hide all other datepickers.
+        clearDatePickers(this);
+
+        var offset = this.$el.offset();
+
+        this.$picker.css({
+          top: offset.top + this.$el.outerHeight() + 2,
+          left: offset.left
+        }).show();
+
+        $('html').keydown(this.keyHandler);
+      }
+
+    , hide: function() {
+        this.$picker.hide();
+        $('html').unbind('keydown', this.keyHandler);
+      }
+
+    , keyHandler: function(e) {
+        // Keyboard navigation shortcuts.
+        switch (e.keyCode)
+        {
+          case 9: 
+          case 27: 
+            // Tab or escape hides the datepicker. In this case, just return
+            // instead of breaking, so that the e doesn't get stopped.
+            this.hide(); return;
+          case 13: 
+            // Enter selects the currently highlighted date.
+            this.update(this.selectedDateStr); this.hide(); break;
+          case 38: 
+            // Arrow up goes to prev week.
+            this.ahead(0, -7); break;
+          case 40: 
+            // Arrow down goes to next week.
+            this.ahead(0, 7); break;
+          case 37: 
+            // Arrow left goes to prev day.
+            this.ahead(0, -1); break;
+          case 39: 
+            // Arrow right goes to next day.
+            this.ahead(0, 1); break;
+          default:
+            return;
+        }
+        e.preventDefault();
+      }
+
+    , parse: function(s) {
+        // Parse a string into a Date.
+        var ms = Date.parse(s);
+        if(ms) {
+          return new Date(ms);
+        } else {
+          return null;
+        }
+      }
+
+    , format: function(date) {
+        // Format a Date into a string.
+        return date.getDate() + " " + this.shortMonthNames[date.getMonth()] + " " + date.getFullYear();
+      }
+
+    , ahead: function(months, days) {
+        // Move ahead ``months`` months and ``days`` days, both integers, can be
+        // negative.
+        this.selectDate(new Date(this.selectedDate.getFullYear(),
+                                 this.selectedDate.getMonth() + months,
+                                 this.selectedDate.getDate() + days));
+      }
+
+    , proxy: function(meth) {
+        // Bind a method so that it always gets the datepicker instance for
+        // ``this``. Return ``this`` so chaining calls works.
+        this[meth] = $.proxy(this[meth], this);
+        return this;
+      }
+
+    , daysBetween: function(start, end) {
+        // Return number of days between ``start`` Date object and ``end``.
+        var start = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate());
+        var end = Date.UTC(end.getFullYear(), end.getMonth(), end.getDate());
+        return (end - start) / 86400000;
+      }
+
+    , findClosest: function(dow, date, direction) {
+        // From a starting date, find the first day ahead of behind it that is
+        // a given day of the week.
+        var difference = direction * (Math.abs(date.getDay() - dow - (direction * 7)) % 7);
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate() + difference);
+      }
+
+    , rangeStart: function(date) {
+        // Get the first day to show in the current calendar view.
+        return this.findClosest(this.startOfWeek,
+                                new Date(date.getFullYear(), date.getMonth()),
+                                -1);
+      }
+
+    , rangeEnd: function(date) {
+        // Get the last day to show in the current calendar view.
+        return this.findClosest((this.startOfWeek - 1) % 7,
+                                new Date(date.getFullYear(), date.getMonth() + 1, 0),
+                                1);
+      },
+  };
+  
+  /* DATEPICKER PLUGIN DEFINITION
+   * ============================ */
+
+  $.fn.datepicker = function( options ) {
+    return this.each(function() { new DatePicker(this, options); });
+  };
+
+  $(function() {
+    $(selector).datepicker();
+    $('html').click(clearDatePickers);
+  });
+
+  $.fn.datepicker.DatePicker = DatePicker;
+
+  $.fn.datepicker.defaults = {
+    monthNames: ["January", "February", "March", "April", "May", "June",
+                 "July", "August", "September", "October", "November", "December"]
+  , shortMonthNames: ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+  , shortDayNames: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+  , startOfWeek: 1
+  };
+}( window.jQuery || window.ender );

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -95,6 +95,7 @@
 
         this.$picker = $('<div>')
           .click(function(e) { e.stopPropagation() })
+          .bind('selectstart', function(e) { e.preventDefault() })
           .addClass('datepicker')
           .append($nav, $calendar)
           .insertAfter(this.$el);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -95,7 +95,8 @@
 
         this.$picker = $('<div>')
           .click(function(e) { e.stopPropagation() })
-          .bind('selectstart', function(e) { e.preventDefault() })
+          // Use this to prevent accidental text selection.
+          .bind('mousedown', function(e) { e.preventDefault() })
           .addClass('datepicker')
           .append($nav, $calendar)
           .insertAfter(this.$el);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -35,15 +35,16 @@
 
 !function ( $ ) { 
 
-  var selector = '[data-datepicker]';
+  var selector = '[data-datepicker]',
+      all = [];
 
   function clearDatePickers(except) {
-    $(selector).each(function() {
-      var dp = $(this).data('datepicker');
-      if(dp != except) {
-        dp.hide();
+    var ii;
+    for(ii = 0; ii < all.length; ii++) {
+      if(all[ii] != except) {
+        all[ii].hide();
       }
-    });
+    }
   }
 
   function DatePicker( element, options ) {
@@ -53,6 +54,7 @@
     if(!this.detectNative()) {
       $.extend(this, $.fn.datepicker.defaults, options );
       this.$el.data('datepicker', this);
+      all.push(this);
       this.init();
     }
   }

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -89,7 +89,7 @@
         this.$picker = $('<div>')
           .click(function(e) { e.stopPropagation() })
           // Use this to prevent accidental text selection.
-          .bind('mousedown', function(e) { e.preventDefault() })
+          .mousedown(function(e) { e.preventDefault() })
           .addClass('datepicker')
           .append($nav, $calendar)
           .insertAfter(this.$el);
@@ -210,12 +210,12 @@
           left: offset.left
         }).show();
 
-        $('html').keydown(this.keyHandler);
+        $('html').on('keydown', this.keyHandler);
       }
 
     , hide: function() {
         this.$picker.hide();
-        $('html').unbind('keydown', this.keyHandler);
+        $('html').off('keydown', this.keyHandler);
       }
 
     , keyHandler: function(e) {

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -318,7 +318,7 @@
         return this.findClosest((this.startOfWeek - 1) % 7,
                                 new Date(date.getFullYear(), date.getMonth() + 1, 0),
                                 1);
-      },
+      }
   };
   
   /* DATEPICKER PLUGIN DEFINITION

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -110,9 +110,9 @@
 
     , nav: function( c, months ) {
         var $subnav = $('<div>' +
-                          '<span class="prev button">&#9664;</span>' +
+                          '<span class="prev button">&larr;</span>' +
                           '<span class="name"></span>' +
-                          '<span class="next button">&#9654;</span>' +
+                          '<span class="next button">&rarr;</span>' +
                         '</div>').addClass(c)
         $('.prev', $subnav).click($.proxy(function() { this.ahead(-months, 0) }, this));
         $('.next', $subnav).click($.proxy(function() { this.ahead(months, 0) }, this));

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -18,6 +18,7 @@
   <script src="../../js/bootstrap-twipsy.js"></script>
   <script src="../../js/bootstrap-popover.js"></script>
   <script src="../../js/bootstrap-buttons.js"></script>
+  <script src="../../js/bootstrap-datepicker.js"></script>
 
   <!-- unit tests -->
   <script src="unit/bootstrap-alerts.js"></script>
@@ -27,6 +28,7 @@
   <script src="unit/bootstrap-tabs.js"></script>
   <script src="unit/bootstrap-twipsy.js"></script>
   <script src="unit/bootstrap-buttons.js"></script>
+  <script src="unit/bootstrap-datepicker.js"></script>
 
 <body>
   <div>
@@ -35,6 +37,7 @@
     <h2 id="qunit-userAgent"></h2>
     <ol id="qunit-tests"></ol>
     <div id="qunit-runoff"></div>
+    <div id="qunit-fixture"></div>
   </div>
 </body>
 </html>

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -4,7 +4,7 @@
   <title>Bootstrap Plugin Test Suite</title>
 
   <!-- jquery -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
 
   <!-- qunit -->
   <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen" />

--- a/js/tests/unit/bootstrap-datepicker.js
+++ b/js/tests/unit/bootstrap-datepicker.js
@@ -59,12 +59,62 @@ $(function () {
         equal(el.val(), '1986-09-19');
       })
 
-      test("advance to next month", function () {
+      test("click new date in adjacent month", function () {
         var el = $('<input type="text" value="1986-09-30" />'),
             fixture = $('#qunit-fixture').append(el);
         el.datepicker().click();
         var picker = fixture.find('.datepicker');
+        // Overlapping day 3 should be in the next month of October.
+        picker.find('.overlap:contains(3)').click();
+
+        // Datepicker should still be visible.
+        ok(picker.is(':visible'));
+        equal(picker.find('.months .name').text(), 'October');
+        equal(picker.find('.selected').text(), '3');
+
+        picker.find(':contains(19)').click();
+        equal(el.val(), '1986-10-19');
+      })
+
+      test("month and year button navigation", function () {
+        var el = $('<input type="text" value="1986-09-30" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker');
+
         picker.find('.months .next').click();
         equal(picker.find('.months .name').text(), 'October');
+        equal(picker.find('.years .name').text(), '1986');
+
+        picker.find('.years .next').click();
+        equal(picker.find('.months .name').text(), 'October');
+        equal(picker.find('.years .name').text(), '1987');
+
+        picker.find('.months .prev').click();
+        equal(picker.find('.months .name').text(), 'September');
+        equal(picker.find('.years .name').text(), '1987');
+
+        picker.find('.years .prev').click().click().click();
+        equal(picker.find('.years .name').text(), '1984');
+      })
+
+      test("keyboard navigation", function () {
+        var el = $('<input type="text" value="1986-09-30" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker');
+
+        // Arrow up goes back one week.
+        $('body').trigger($.Event('keydown', { keyCode: 38 }));
+        equal(picker.find('.selected').text(), '23');
+
+        // Arrow right goes forward one day.
+        $('body').trigger($.Event('keydown', { keyCode: 39 }));
+        equal(picker.find('.selected').text(), '24');
+
+        // Enter selects.
+        $('body').trigger($.Event('keydown', { keyCode: 13 }));
+
+        equal(el.val(), '1986-09-24');
       })
 })

--- a/js/tests/unit/bootstrap-datepicker.js
+++ b/js/tests/unit/bootstrap-datepicker.js
@@ -1,0 +1,70 @@
+$(function () {
+
+    module("bootstrap-datepicker")
+
+      test("should be defined on jquery object", function () {
+        var el = $('<input type="text" />')
+        ok(el.datepicker, 'datepicker method is defined')
+      })
+
+      test("should return element", function () {
+        var el = $('<input type="text" />')
+        ok(el.datepicker() == el, 'element returned')
+      })
+
+      test("should expose default settings", function () {
+        ok(!!$.fn.datepicker.defaults, 'defaults is defined')
+      })
+
+      test("should show when element is clicked", function () {
+        var el = $('<input type="text" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker();
+        el.click();
+        ok(fixture.find('.datepicker').is(':visible'));
+      })
+
+      test("should hide on click outside", function () {
+        var el = $('<input type="text" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        $('body').click();
+        ok(!fixture.find('.datepicker').is(':visible'));
+      })
+      
+      test("should not hide on click on datepicker", function () {
+        var el = $('<input type="text" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker').click();
+        ok(picker.is(':visible'));
+      })
+
+      test("set initial state to correct date", function () {
+        var el = $('<input type="text" value="1986-09-30" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker');
+        equal(picker.find('.months .name').text(), 'September');
+        equal(picker.find('.years .name').text(), '1986');
+        equal(picker.find('.selected').text(), '30');
+      })
+      
+      test("select new date in current month", function () {
+        var el = $('<input type="text" value="1986-09-30" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker');
+        picker.find(':contains(19)').click();
+        equal(el.val(), '1986-09-19');
+      })
+
+      test("advance to next month", function () {
+        var el = $('<input type="text" value="1986-09-30" />'),
+            fixture = $('#qunit-fixture').append(el);
+        el.datepicker().click();
+        var picker = fixture.find('.datepicker');
+        picker.find('.months .next').click();
+        equal(picker.find('.months .name').text(), 'October');
+      })
+})

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -1116,7 +1116,6 @@ input[type=submit].btn {
         }
     }
     .button {
-        font-size: 10px;
         cursor: pointer;
         padding: 0 4px;
         .border-radius(4px);

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -1058,3 +1058,120 @@ input[type=submit].btn {
     }
   }
 }
+
+
+// DATE PICKER
+// -----------
+.datepicker {
+    background-color: @white;
+    border-color: #999;
+    border-color: rgba(0, 0, 0, 0.2);
+    border-style: solid;
+    border-width: 1px;
+    .border-radius(4px);
+    .box-shadow(0 2px 4px rgba(0,0,0,.2));
+    .background-clip(padding-box);
+    display: none; // None by default, shown in javascript.
+    position: absolute;
+    z-index: 900;
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 18px;
+    padding-bottom: 0.25em;
+
+    width: 17.75em;
+
+    .nav {
+        font-weight: bold;
+        width: 100%;
+        padding: 0.5em 0;
+        background-color: #f5f5f5;
+        color: @gray;
+        border-bottom: 1px solid #ddd;
+        .box-shadow(inset 0 1px 0 @white);
+        .clearfix();
+
+        span {
+            display: block;
+            float: left;
+            text-align: center;
+            height: 28px;
+            line-height: 28px;
+            position: relative;
+        }
+        .bg {
+            width: 100%;
+            background-color: #ff6;
+            height: 28px;
+            position: absolute;
+            top: 0;
+            left: 0;
+            .border-radius(4px);
+        }
+        .fg {
+            width: 100%;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    }
+    .button {
+        font-size: 0.8em;
+        cursor: pointer;
+        padding: 0 0.5em;
+        .border-radius(4px);
+
+        &:hover {
+            background-color: @gray;
+            color: @white;
+        }
+    }
+    .months {
+        float: left;
+        margin-left: 0.5em;
+        .name {
+            width: 6em;
+            padding: 0;
+        }
+    }
+    .years {
+        float: right;
+        margin-right: 0.5em;
+        .name {
+            width: 3em;
+            padding: 0;
+        }
+    }
+    .dow, .days div {
+        float: left;
+        width: 2.5em;
+        padding: 0.5em 0;
+        text-align: center;
+    }
+
+    .dow {
+        font-weight: bold;
+        color: @gray;
+    }
+    .calendar {
+        padding: 0.25em;
+    }
+    .days div {
+        cursor: pointer;
+        .border-radius(4px);
+        &:hover {
+            background-color: @blueDark;
+            color: @white;
+        }
+    }
+    .selected {
+        background-color: @grayLight;
+        color: @white;
+    }
+    .overlap {
+        color: @grayLight;
+    }
+    .today {
+        background-color: #fee9cc;
+    }
+}

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -1101,7 +1101,7 @@ input[type=submit].btn {
         }
         .bg {
             width: 100%;
-            background-color: #ff6;
+            background-color: #fdf5d9;
             height: 28px;
             position: absolute;
             top: 0;

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -1077,14 +1077,14 @@ input[type=submit].btn {
     margin-left: 0;
     margin-right: 0;
     margin-bottom: 18px;
-    padding-bottom: 0.25em;
+    padding-bottom: 4px;
 
-    width: 17.75em;
+    width: 218px;
 
     .nav {
         font-weight: bold;
         width: 100%;
-        padding: 0.5em 0;
+        padding: 4px 0;
         background-color: #f5f5f5;
         color: @gray;
         border-bottom: 1px solid #ddd;
@@ -1116,9 +1116,9 @@ input[type=submit].btn {
         }
     }
     .button {
-        font-size: 0.8em;
+        font-size: 10px;
         cursor: pointer;
-        padding: 0 0.5em;
+        padding: 0 4px;
         .border-radius(4px);
 
         &:hover {
@@ -1128,33 +1128,32 @@ input[type=submit].btn {
     }
     .months {
         float: left;
-        margin-left: 0.5em;
+        margin-left: 4px;
         .name {
-            width: 6em;
+            width: 72px;
             padding: 0;
         }
     }
     .years {
         float: right;
-        margin-right: 0.5em;
+        margin-right: 4px;
         .name {
-            width: 3em;
+            width: 36px;
             padding: 0;
         }
     }
     .dow, .days div {
         float: left;
-        width: 2.5em;
-        padding: 0.5em 0;
+        width: 30px;
+        line-height: 25px;
         text-align: center;
     }
-
     .dow {
         font-weight: bold;
         color: @gray;
     }
     .calendar {
-        padding: 0.25em;
+        padding: 4px;
     }
     .days div {
         cursor: pointer;
@@ -1164,14 +1163,14 @@ input[type=submit].btn {
             color: @white;
         }
     }
-    .selected {
-        background-color: @grayLight;
-        color: @white;
-    }
     .overlap {
         color: @grayLight;
     }
     .today {
         background-color: #fee9cc;
+    }
+    .selected {
+        background-color: @grayLight;
+        color: @white;
     }
 }


### PR DESCRIPTION
This is a js date entry widget built expressly for bootstrap. It's fairly thin, at 2.1K min/gz, but still somewhat extensible. It supports keyboard navigation, reverts to iOS native date entry, and a few other little features. It's pretty thoroughly tested in all the browsers that Bootstrap lists support for, although the visual design could probably be improved.

Demo here:
http://dl.dropbox.com/u/143355/datepicker/datepicker.html
