### PR TITLE
css class .cancel will now do the same as .close

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -57,7 +57,7 @@
   var Modal = function ( content, options ) {
     this.settings = $.extend({}, $.fn.modal.defaults, options)
     this.$element = $(content)
-      .delegate('.close', 'click.modal', $.proxy(this.hide, this))
+      .delegate('.close, .cancel', 'click.modal', $.proxy(this.hide, this))
 
     if ( this.settings.show ) {
       this.show()


### PR DESCRIPTION
Modals usually have a cancel button. Adding a .close class gives the button the correct functionality, but messes up the button css. 
