### PR TITLE
Improvements to #font mixin

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -539,8 +539,6 @@ code, pre {
   padding: 0 3px 2px;
   font-family: Monaco, Courier New, monospace;
   font-size: 12px;
-  font-weight: normal;
-  line-height: 20px;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;

--- a/bootstrap.css
+++ b/bootstrap.css
@@ -537,7 +537,7 @@ address {
 }
 code, pre {
   padding: 0 3px 2px;
-  font-family: "Monaco", Courier New, monospace;
+  font-family: Monaco, Courier New, monospace;
   font-size: 12px;
   font-weight: normal;
   line-height: 20px;

--- a/bootstrap.css
+++ b/bootstrap.css
@@ -537,8 +537,10 @@ address {
 }
 code, pre {
   padding: 0 3px 2px;
-  font-family: Monaco, Andale Mono, Courier New, monospace;
+  font-family: "Monaco", Courier New, monospace;
   font-size: 12px;
+  font-weight: normal;
+  line-height: 20px;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -100,7 +100,7 @@ em{font-style:italic;font-weight:inherit;line-height:inherit;}
 blockquote{margin-bottom:18px;border-left:5px solid #eee;padding-left:15px;}blockquote p{font-size:14px;font-weight:300;line-height:18px;margin-bottom:0;}
 blockquote small{display:block;font-size:12px;font-weight:300;line-height:18px;color:#bfbfbf;}blockquote small:before{content:'\2014 \00A0';}
 address{display:block;line-height:18px;margin-bottom:18px;}
-code,pre{padding:0 3px 2px;font-family:Monaco, Andale Mono, Courier New, monospace;font-size:12px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+code,pre{padding:0 3px 2px;font-family:"Monaco",Courier New,monospace;font-size:12px;font-weight:normal;line-height:20px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 code{background-color:#fee9cc;color:rgba(0, 0, 0, 0.75);padding:1px 3px;}
 pre{background-color:#f5f5f5;display:block;padding:8.5px;margin:0 0 18px;line-height:18px;font-size:12px;border:1px solid #ccc;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;white-space:pre;white-space:pre-wrap;word-wrap:break-word;}
 form{margin-bottom:18px;}

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -100,7 +100,7 @@ em{font-style:italic;font-weight:inherit;line-height:inherit;}
 blockquote{margin-bottom:18px;border-left:5px solid #eee;padding-left:15px;}blockquote p{font-size:14px;font-weight:300;line-height:18px;margin-bottom:0;}
 blockquote small{display:block;font-size:12px;font-weight:300;line-height:18px;color:#bfbfbf;}blockquote small:before{content:'\2014 \00A0';}
 address{display:block;line-height:18px;margin-bottom:18px;}
-code,pre{padding:0 3px 2px;font-family:"Monaco",Courier New,monospace;font-size:12px;font-weight:normal;line-height:20px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+code,pre{padding:0 3px 2px;font-family:Monaco, Courier New, monospace;font-size:12px;font-weight:normal;line-height:20px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 code{background-color:#fee9cc;color:rgba(0, 0, 0, 0.75);padding:1px 3px;}
 pre{background-color:#f5f5f5;display:block;padding:8.5px;margin:0 0 18px;line-height:18px;font-size:12px;border:1px solid #ccc;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;white-space:pre;white-space:pre-wrap;word-wrap:break-word;}
 form{margin-bottom:18px;}

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -100,7 +100,7 @@ em{font-style:italic;font-weight:inherit;line-height:inherit;}
 blockquote{margin-bottom:18px;border-left:5px solid #eee;padding-left:15px;}blockquote p{font-size:14px;font-weight:300;line-height:18px;margin-bottom:0;}
 blockquote small{display:block;font-size:12px;font-weight:300;line-height:18px;color:#bfbfbf;}blockquote small:before{content:'\2014 \00A0';}
 address{display:block;line-height:18px;margin-bottom:18px;}
-code,pre{padding:0 3px 2px;font-family:Monaco, Courier New, monospace;font-size:12px;font-weight:normal;line-height:20px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+code,pre{padding:0 3px 2px;font-family:Monaco, Courier New, monospace;font-size:12px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 code{background-color:#fee9cc;color:rgba(0, 0, 0, 0.75);padding:1px 3px;}
 pre{background-color:#f5f5f5;display:block;padding:8.5px;margin:0 0 18px;line-height:18px;font-size:12px;border:1px solid #ccc;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;white-space:pre;white-space:pre-wrap;word-wrap:break-word;}
 form{margin-bottom:18px;}

--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -47,13 +47,13 @@
 #font {
   #family {
     .serif() {
-      font-family: "Georgia", Times New Roman, Times, serif;
+      font-family: Georgia, Times New Roman, Times, serif;
     }
     .sans-serif() {
       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     }
     .monospace() {
-      font-family: "Monaco", Courier New, monospace;
+      font-family: Monaco, Courier New, monospace;
     }
     .cursive() {
       font-family: cursive;

--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -45,28 +45,40 @@
 
 // Font Stacks
 #font {
+  #family {
+    .serif {
+      font-family: "Georgia", Times New Roman, Times, serif;
+    }
+    .sans-serif {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    }
+    .monospace {
+      font-family: "Monaco", Courier New, monospace;
+    }
+    .cursive {
+      font-family: cursive;
+    }
+  }
   .shorthand(@weight: normal, @size: 14px, @lineHeight: 20px) {
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;
   }
-  .sans-serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: @size;
-    font-weight: @weight;
-    line-height: @lineHeight;
-  }
   .serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Georgia", Times New Roman, Times, serif;
-    font-size: @size;
-    font-weight: @weight;
-    line-height: @lineHeight;
+    #font > #family > .serif;
+    #font > .shorthand(@weight, @size, @lineHeight);
+  }
+  .sans-serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
+    #font > #family > .sans-serif;
+    #font > .shorthand(@weight, @size, @lineHeight);
   }
   .monospace(@weight: normal, @size: 12px, @lineHeight: 20px) {
-    font-family: "Monaco", Courier New, monospace;
-    font-size: @size;
-    font-weight: @weight;
-    line-height: @lineHeight;
+    #font > #family > .monospace;
+    #font > .shorthand(@weight, @size, @lineHeight);
+  }
+  .cursive(@weight: normal, @size: 14px, @lineHeight: 20px) {
+    #font > #family > .cursive;
+    #font > .shorthand(@weight, @size, @lineHeight);
   }
 }
 

--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -46,16 +46,16 @@
 // Font Stacks
 #font {
   #family {
-    .serif {
+    .serif() {
       font-family: "Georgia", Times New Roman, Times, serif;
     }
-    .sans-serif {
+    .sans-serif() {
       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     }
-    .monospace {
+    .monospace() {
       font-family: "Monaco", Courier New, monospace;
     }
-    .cursive {
+    .cursive() {
       font-family: cursive;
     }
   }

--- a/lib/type.less
+++ b/lib/type.less
@@ -161,8 +161,7 @@ address {
 // Inline and block code styles
 code, pre {
   padding: 0 3px 2px;
-  font-family: Monaco, Andale Mono, Courier New, monospace;
-  font-size: 12px;
+  #font > .monospace;
   .border-radius(3px);
 }
 code {

--- a/lib/type.less
+++ b/lib/type.less
@@ -161,7 +161,8 @@ address {
 // Inline and block code styles
 code, pre {
   padding: 0 3px 2px;
-  #font > .monospace;
+  #font > #family > .monospace;
+  font-size: 12px;
   .border-radius(3px);
 }
 code {


### PR DESCRIPTION
Two main changes:

1) Added <code>#font.family</code> mixin - provides ability to call <code>#font &gt; #family &gt; .[type]</code> to embed the font-family property for the specified type. Means that the same font-family only needs to be configured once. This also makes it easier to customize the font-family set by overriding just a single mixin. Fully backwards compatible.

2) Changed <code>&lt;pre&gt;</code> and <code>&lt;code&gt;</code> to use <code>#font &gt; #family &gt; .monospace</code> mixin

NB: Also added 'cursive' set to the available font styles.
