### PR TITLE
Fix grammatically incorrect sentence (copy-paste oversight?)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1237,7 +1237,7 @@
                 <li>
                   <label>
                     <input type="radio" name="optionsRadios" value="option2" />
-                    <span>Option two can is something else and selecting it will deselect options 1</span>
+                    <span>Option two is something else and selecting it will deselect option 1</span>
                   </label>
                 </li>
               </ul>


### PR DESCRIPTION
This pull request fixes a sample sentence that is used to demonstrate radio buttons on the main docs page. It looks like it was initially copied over from the one used to demonstrate lists of checkboxes, "Option two can also be checked and included in form results", but someone accidentally left in the "can" and pluralized the word "option".
