### PR TITLE
Center pagination

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -755,7 +755,11 @@ input[type=submit].btn {
   height: @baseline * 2;
   margin: @baseline 0;
   ul {
+    display: -moz-inline-box; /* FF2 or lower */
     display: inline-block;
+    /* IE6/7 inline-block hack */
+    *display: inline;
+    *zoom: 1;
     overflow: hidden;
     margin: 0;
     border: 1px solid #ddd;
@@ -788,6 +792,10 @@ input[type=submit].btn {
   .next a {
     border: 0;
   }
+}
+
+.pagination.center {
+  text-align: center;
 }
 
 

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -760,7 +760,6 @@ input[type=submit].btn {
     /* IE6/7 inline-block hack */
     *display: inline;
     *zoom: 1;
-    overflow: hidden;
     margin: 0;
     border: 1px solid #ddd;
     border: 1px solid rgba(0,0,0,.15);

--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -755,7 +755,8 @@ input[type=submit].btn {
   height: @baseline * 2;
   margin: @baseline 0;
   ul {
-    float: left;
+    display: inline-block;
+    overflow: hidden;
     margin: 0;
     border: 1px solid #ddd;
     border: 1px solid rgba(0,0,0,.15);


### PR DESCRIPTION
Use <code>display: inline-block</code> instead of <code>float: left</code> for _.pagination ul_. This allows centering the pagination in a user-defined stylesheet by setting <code>.pagination { text-align: center }</code>. I think this is easier to understand and therefore preferable above the solution shown on https://github.com/twitter/bootstrap/issues/304.
