### PR TITLE
New Attribute parentContainer for twipsy

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -83,7 +83,7 @@
         $tip
           .remove()
           .css({ top: 0, left: 0, display: 'block' })
-          .prependTo(document.body)
+          .prependTo($(this.options.parentContainer))
 
         pos = $.extend({}, this.$element.offset(), {
           width: this.$element[0].offsetWidth
@@ -301,6 +301,7 @@
   , offset: 0
   , title: 'title'
   , trigger: 'hover'
+  , parentContainer: 'body'
   , template: '<div class="twipsy-arrow"></div><div class="twipsy-inner"></div>'
   }
 


### PR DESCRIPTION
When refreshing fragment of page with Ajax (pjax in my case), the twipsy remains on the page.

By default twipsy are prepend to `document.body`, refreshing with ajax some fragment of page will not remove the twipsy.

The solution, adding a parameter to explicitely define the tag at which the twipsy is prepend to. (keep document.body as default)
