### PR TITLE
Closing alert-message inside the modal

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -57,7 +57,7 @@
   var Modal = function ( content, options ) {
     this.settings = $.extend({}, $.fn.modal.defaults, options)
     this.$element = $(content)
-      .delegate('.close', 'click.modal', $.proxy(this.hide, this))
+      .delegate(':not(.alert-message) > .close', 'click.modal', $.proxy(this.hide, this))
 
     if ( this.settings.show ) {
       this.show()

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -87,6 +87,52 @@ $(function () {
          .modal("toggle")
      })
 
+     test("should not .close modal when closing an .alert-message in the modal", function () {
+       stop()
+       $.support.transition = false
+       var div = $('<div id="modal-test"><span class="close"></span>'
+          + '<div class="alert-message warning fade in">'
+          + '<a class="close" id="close-alert" href="#">×</a>'
+          + '<p><strong>Holy guacamole!</strong> Best check yo self, you’re not looking too good.</p>'
+          + '</div>'
+          + '</div>')
+       div
+         .modal()
+         .bind("shown", function () {
+           ok($('#modal-test').is(":visible"), 'modal visible')
+           ok($('#modal-test').length, 'modal insterted into dom')
+           div.find('#close-alert').click()
+           ok($('#modal-test').is(":visible"), 'modal visible')
+           start()
+           div.remove()
+         })
+         .modal('show')
+     })
+
+     test("should .close modal even if it have an .alert-message in it", function () {
+       stop()
+       $.support.transition = false
+       var div = $('<div id="modal-test"><span class="close" id="close-modal"></span>'
+          + '<div class="alert-message warning fade in">'
+          + '<a class="close" href="#">×</a>'
+          + '<p><strong>Holy guacamole!</strong> Best check yo self, you’re not looking too good.</p>'
+          + '</div>'
+          + '</div>')
+       div
+         .modal()
+         .bind("shown", function () {
+           ok($('#modal-test').is(":visible"), 'modal visible')
+           ok($('#modal-test').length, 'modal insterted into dom')
+           div.find('#close-modal').click()
+         })
+         .bind("hidden", function() {
+           ok(!$('#modal-test').is(":visible"), 'modal hidden')
+           start()
+           div.remove()
+         })
+         .modal("toggle")
+     })
+
      test("should add backdrop when desired", function () {
        stop()
        $.support.transition = false


### PR DESCRIPTION
When i tried to put an alert-message inside a modal and closed it, the modal closed aswell. I fixed this issue and now its possible to close an alert-message without closing the modal. I also added tests to that situation.
