### PR TITLE
Re issue #664, added option "stay" (default = false). When stay = true, ...

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -259,16 +259,18 @@
     }
 
     function leave() {
-      var twipsy = get(this)
-      twipsy.hoverState = 'out'
-      if (options.delayOut == 0) {
-        twipsy.hide()
-      } else {
-        setTimeout(function() {
-          if (twipsy.hoverState == 'out') {
-            twipsy.hide()
-          }
-        }, options.delayOut)
+      if (!options.stay) {
+        var twipsy = get(this)
+        twipsy.hoverState = 'out'
+        if (options.delayOut == 0) {
+          twipsy.hide()
+        } else {
+          setTimeout(function() {
+            if (twipsy.hoverState == 'out') {
+              twipsy.hide()
+            }
+          }, options.delayOut)
+        }
       }
     }
 
@@ -294,6 +296,7 @@
     animate: true
   , delayIn: 0
   , delayOut: 0
+  , stay: false
   , fallback: ''
   , placement: 'above'
   , html: false


### PR DESCRIPTION
...the twipsy/popover does not close when the mouse leaves. Coder can then choose how/when to close the twipsy/popover explicitly with twipsy('hide').
