### PR TITLE
Less greedy span selector using a starts-with pattern rather than a contains.

### DIFF
--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -82,7 +82,7 @@ a {
 
 // Find all .span# classes within .row and give them the necessary properties for grid columns (supported by all browsers back to IE7)
 // Credit to @dhg for the idea
-.row > [class*="span"] {
+.row > [class^="span"] {
   .gridColumn();
 }
 


### PR DESCRIPTION
The current wildcard span selector selects any class which contains the word 'span'.
Based on the classes bootstrap uses, it should be enough to just select where the class starts with span. 
That way there will be less conflicts with other css classes.

In my particular case, the conflicts are caused by a WYSIWYG editor which adds a class 'Apple-style-span'.

*Yes, I know WYSIWYG editors are flaky, but it's what my client wants ;)
