### PR TITLE
Allow usage of static elements in pagination 

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sun Nov 20 20:05:48 PST 2011
+ * Date: Tue Nov 29 19:21:53 CET 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -2153,7 +2153,7 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 .pagination li {
   display: inline;
 }
-.pagination a {
+.pagination a, .pagination .static {
   float: left;
   padding: 0 14px;
   line-height: 34px;
@@ -2165,14 +2165,18 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   /* IE6-7 */
 
 }
-.pagination a:hover, .pagination .active a {
+.pagination a:hover, .pagination .active a, .pagination .active .static {
   background-color: #c7eefe;
 }
-.pagination .disabled a, .pagination .disabled a:hover {
+.pagination .static {
+  color: #0069d6;
+  cursor: default;
+}
+.pagination .disabled a, .pagination .disabled a:hover, .pagination .disabled .static {
   color: #bfbfbf;
   background-color: transparent;
 }
-.pagination .next a {
+.pagination .next a, .pagination .next .static {
   border: 0;
 }
 .modal-backdrop {

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -315,10 +315,11 @@ button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;
 .breadcrumb .active a{color:#404040;}
 .pagination{height:36px;margin:18px 0;}.pagination ul{float:left;margin:0;border:1px solid #ddd;border:1px solid rgba(0, 0, 0, 0.15);-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);-moz-box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);box-shadow:0 1px 2px rgba(0, 0, 0, 0.05);}
 .pagination li{display:inline;}
-.pagination a{float:left;padding:0 14px;line-height:34px;text-decoration:none;border-right:1px solid;border-right-color:#ddd;border-right-color:rgba(0, 0, 0, 0.15);*border-right-color:#ddd;}
-.pagination a:hover,.pagination .active a{background-color:#c7eefe;}
-.pagination .disabled a,.pagination .disabled a:hover{color:#bfbfbf;background-color:transparent;}
-.pagination .next a{border:0;}
+.pagination a,.pagination .static{float:left;padding:0 14px;line-height:34px;text-decoration:none;border-right:1px solid;border-right-color:#ddd;border-right-color:rgba(0, 0, 0, 0.15);*border-right-color:#ddd;}
+.pagination a:hover,.pagination .active a,.pagination .active .static{background-color:#c7eefe;}
+.pagination .static{color:#0069d6;cursor:default;}
+.pagination .disabled a,.pagination .disabled a:hover,.pagination .disabled .static{color:#bfbfbf;background-color:transparent;}
+.pagination .next a,.pagination .next .static{border:0;}
 .modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:10000;background-color:#000000;}.modal-backdrop.fade{opacity:0;}
 .modal-backdrop,.modal-backdrop.fade.in{filter:alpha(opacity=80);-moz-opacity:0.8;opacity:0.8;}
 .modal{position:fixed;top:50%;left:50%;z-index:11000;width:560px;margin:-250px 0 0 -250px;background-color:#ffffff;border:1px solid #999;border:1px solid rgba(0, 0, 0, 0.3);*border:1px solid #999;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-moz-box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);box-shadow:0 3px 7px rgba(0, 0, 0, 0.3);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box;}.modal .close{margin-top:7px;}

--- a/lib/pagination.less
+++ b/lib/pagination.less
@@ -15,7 +15,8 @@
   li {
     display: inline;
   }
-  a {
+  a,
+  .static {
     float: left;
     padding: 0 14px;
     line-height: (@baseLineHeight * 2) - 2;
@@ -26,15 +27,26 @@
     *border-right-color: #ddd; /* IE6-7 */
   }
   a:hover,
-  .active a {
+  .active a,
+  .active .static {
     background-color: lighten(@blue, 45%);
   }
-  .disabled a,
-  .disabled a:hover {
-    color: @grayLight;
-    background-color: transparent;
+  .static {
+    color: @linkColor;
+    cursor: default;
   }
-  .next a {
-    border: 0;
+  .disabled {
+    a,
+    a:hover,
+    .static {
+      color: @grayLight;
+      background-color: transparent;
+    }
+  }
+  .next {
+    a,
+    .static {
+      border: 0;
+    }
   }
 }


### PR DESCRIPTION
_Following https://github.com/twitter/bootstrap/pull/690 but on the 2.0-wip branch_

Make it possible to use other tags than `<a>` on current or disabled pagination items.
So we don't have to deal with `href="#"` and `event.preventDefault()`
