### PR TITLE
Fix direct link to Dropdown component documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1813,7 +1813,7 @@ Lorem ipsum dolar sit amet illo error <a href="#" title="below">ipsum</a> verita
               <td>The alert plugin is a super tiny class for adding close functionality to alerts.</td>
             </tr>
             <tr>
-              <td><a href="./javascript.html#dropdowns">bootstrap-dropdown.js</a></td>
+              <td><a href="./javascript.html#dropdown">bootstrap-dropdown.js</a></td>
               <td>This plugin is for adding dropdown interaction to the bootstrap topbar or tabbed navigations.</td>
             </tr>
             <tr>


### PR DESCRIPTION
The link within the Javascript table on the main documentation points to #dropdowns, but it's named #dropdown on the actual Javascript documentation.
