### PR TITLE
Fix: Twipsy rollover wasn't centered for SVG elements.

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -86,8 +86,8 @@
           .prependTo(document.body)
 
         pos = $.extend({}, this.$element.offset(), {
-          width: this.$element[0].offsetWidth
-        , height: this.$element[0].offsetHeight
+          width: this.$element[0].getBoundingClientRect().width
+        , height: this.$element[0].getBoundingClientRect().height
         })
 
         actualWidth = $tip[0].offsetWidth


### PR DESCRIPTION
Twipsy was only checking for offsetHeight and offsetWidth to center
the popover. However, SVG elements don't have an offsetHeight or an
offsetWidth. Use getBBox() for their height and width instead.
