### PR TITLE
incorrect docs for bordered-table

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -667,9 +667,8 @@
       </tr>
     </tbody>
   </table>
-  <p><strong>Note:</strong> Zebra-striping is a progressive enhancement not available for older browsers like IE8 and below.</p>
 <pre class="prettyprint linenums">
-&lt;table class="striped-table"&gt;
+&lt;table class="bordered-table"&gt;
   ...
 &lt;/table&gt;</pre>
   <h3>4. Condensed table</h3>


### PR DESCRIPTION
The docs for bordered-table appear to have been copied from striped-table, including the HTML example. This corrects the error.
