### PR TITLE
2.0 bordered table fix for rowspan

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Mon Dec 12 09:51:27 PST 2011
+ * Date: Tue Dec 13 19:09:22 CET 2011
  */
 html, body {
   margin: 0;
@@ -1021,11 +1021,18 @@ tbody tr:last-child th, tbody tr:last-child td {
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
+.bordered-table th, .bordered-table td {
+  border-bottom: 0px;
+  border-top: 1px solid #ddd;
+}
 .bordered-table th + th,
 .bordered-table td + td,
 .bordered-table th + td,
 .bordered-table td + th {
   border-left: 1px solid #ddd;
+}
+.bordered-table thead:first-child tr:first-child th, .bordered-table tbody:first-child tr:first-child td {
+  border-top: 0px;
 }
 .bordered-table thead:first-child tr:first-child th:first-child, .bordered-table tbody:first-child tr:first-child td:first-child {
   -webkit-border-radius: 4px 0 0 0;

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -168,7 +168,9 @@ th{font-weight:bold;vertical-align:bottom;}
 td{vertical-align:top;}
 tbody tr:last-child th,tbody tr:last-child td{border-bottom:0;}
 .condensed-table th,.condensed-table td{padding:4px 5px;}
-.bordered-table{border:1px solid #ddd;border-collapse:separate;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.bordered-table th+th,.bordered-table td+td,.bordered-table th+td,.bordered-table td+th{border-left:1px solid #ddd;}
+.bordered-table{border:1px solid #ddd;border-collapse:separate;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.bordered-table th,.bordered-table td{border-bottom:0px;border-top:1px solid #ddd;}
+.bordered-table th+th,.bordered-table td+td,.bordered-table th+td,.bordered-table td+th{border-left:1px solid #ddd;}
+.bordered-table thead:first-child tr:first-child th,.bordered-table tbody:first-child tr:first-child td{border-top:0px;}
 .bordered-table thead:first-child tr:first-child th:first-child,.bordered-table tbody:first-child tr:first-child td:first-child{-webkit-border-radius:4px 0 0 0;-moz-border-radius:4px 0 0 0;border-radius:4px 0 0 0;}
 .bordered-table thead:first-child tr:first-child th:last-child,.bordered-table tbody:first-child tr:first-child td:last-child{-webkit-border-radius:0 4px 0 0;-moz-border-radius:0 4px 0 0;border-radius:0 4px 0 0;}
 .bordered-table thead:last-child tr:last-child th:first-child,.bordered-table tbody:last-child tr:last-child td:first-child{-webkit-border-radius:0 0 0 4px;-moz-border-radius:0 0 0 4px;border-radius:0 0 0 4px;}

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -632,7 +632,6 @@
 &lt;/table&gt;</pre>
   <h3>3. Bordered table</h3>
   <p>Add borders around the entire table and between each row, plus a bit of rounded corners for aesthetic purposes.</p>
-  <p><span class="label">Note</span> Bordered tables do not work well with <code>rowspan</code> due to somewhat hacky CSS applied to the tables. Sorry about that!</p>
   <table class="bordered-table">
     <thead>
       <tr>
@@ -658,13 +657,12 @@
         <td>3</td>
         <td>Joe</td>
         <td>Sixpack</td>
-        <td>English</td>
+        <td rowspan="2">Code</td>
       </tr>
       <tr>
         <td>3</td>
         <td>Stu</td>
         <td>Dent</td>
-        <td>Code</td>
       </tr>
     </tbody>
   </table>

--- a/lib/tables.less
+++ b/lib/tables.less
@@ -50,11 +50,20 @@ tbody tr:last-child td {
   border: 1px solid #ddd;
   border-collapse: separate; // Done so we can round those corners!
   .border-radius(4px);
+  th,
+  td {
+    border-bottom: 0px;
+    border-top: 1px solid #ddd;
+  }
   th + th,
   td + td,
   th + td,
   td + th {
     border-left: 1px solid #ddd;
+  }
+  thead:first-child tr:first-child th,
+  tbody:first-child tr:first-child td {
+    border-top: 0px;
   }
   // For first th or td in the first row in the first thead or tbody
   thead:first-child tr:first-child th:first-child,


### PR DESCRIPTION
I've changed the bordering for <code>.bordered-table</code>, so it uses border-top instead of border-bottom. That way, using rowspan will work as expected.
