### PR TITLE
Fix: Select elements with a size attribute should not have fixed height

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Wed Dec  7 20:14:59 EST 2011
+ * Date: Sun Dec 11 13:56:05 EST 2011
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -674,7 +674,7 @@ select, input[type=file] {
   /* For IE7, add top margin to align select with labels */
 
 }
-select[multiple] {
+select[multiple], select[size] {
   height: inherit;
   background-color: #ffffff;
 }

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -117,7 +117,7 @@ input[type=checkbox],input[type=radio]{width:auto;height:auto;padding:0;margin:3
 input[type=file]{background-color:#ffffff;padding:initial;border:initial;line-height:initial;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;}
 input[type=button],input[type=reset],input[type=submit]{width:auto;height:auto;}
 select,input[type=file]{height:27px;*height:auto;line-height:27px;*margin-top:4px;}
-select[multiple]{height:inherit;background-color:#ffffff;}
+select[multiple],select[size]{height:inherit;background-color:#ffffff;}
 textarea{height:auto;}
 .uneditable-input{background-color:#ffffff;display:block;border-color:#eee;-webkit-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.025);-moz-box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.025);box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.025);cursor:not-allowed;}
 :-moz-placeholder{color:#bfbfbf;}

--- a/lib/forms.less
+++ b/lib/forms.less
@@ -117,8 +117,9 @@ input[type=file] {
   *margin-top: 4px; /* For IE7, add top margin to align select with labels */
 }
 
-// Make multiple select elements height not fixed
-select[multiple] {
+// Make multiple or sized select elements height not fixed
+select[multiple],
+select[size] {
   height: inherit;
   background-color: @white; // Fixes Chromium bug of unreadable items
 }


### PR DESCRIPTION
This fixes #784.

`select` with a `size` attribute but no `multiple` attribute incorrectly gets a fixed height applied to it.
