### PR TITLE
changed npm package name to less

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1974,7 +1974,7 @@ Lorem ipsum dolar sit amet illo error <a href="#" title="below">ipsum</a> verita
           <td>Node with makefile</td>
           <td>
             <p>Install the less command line compiler with npm by running the following command:</p>
-            <pre>$ npm install lessc</pre>
+            <pre>$ npm install less</pre>
             <p>Once installed just run <code>make</code> from the root of your bootstrap directory and you're all set.</p>
             <p>Additionally, if you have <a href="https://github.com/mynyml/watchr">watchr</a> installed, you may run <code>make watch</code> to have bootstrap automatically rebuilt every time you edit a file in the bootstrap lib (this isn't required, just a convenience method).</p>
           </td>


### PR DESCRIPTION
Hi there,

I found a small typo in the less paragraph. The npm´s package name is less not lessc only the binary is called "lessc".

Cheers,

Alex
