### PR TITLE
Add close and closed hooks for alert

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -765,6 +765,30 @@ $('.tabs a').bind('change', function (e) {
           <h4>.alert('close')</h4>
           <p>Closes an alert.</p>
           <pre class="prettyprint linenums">$(".alert-message").alert('close')</pre>
+          <h3>Events</h3>
+          <p>Bootstrap's alert class exposes a few events for hooking into alert functionality. </p>
+          <table class="zebra-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">Event</th>
+               <th>Description</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>close</td>
+               <td>This event fires immediately when the <code>close</code> instance method is called.</td>
+             </tr>
+             <tr>
+               <td>closed</td>
+               <td>This event is fired when the alert has been closed (will wait for css transitions to complete).</td>
+             </tr>
+            </tbody>
+          </table>
+<pre class="prettyprint linenums">
+$('#my-alert').bind('closed', function () {
+  // do something ...
+})</pre>
           <h3>Demo</h3>
           <div class="alert-message warning fade in" data-alert="alert" >
             <a class="close" href="#">&times;</a>

--- a/js/bootstrap-alerts.js
+++ b/js/bootstrap-alerts.js
@@ -68,6 +68,8 @@
 
       $element = $element.hasClass(className) ? $element : $element.parent()
 
+      $element.trigger('close')
+
       e && e.preventDefault()
       $element.removeClass('in')
 
@@ -78,6 +80,8 @@
       $.support.transition && $element.hasClass('fade') ?
         $element.bind(transitionEnd, removeElement) :
         removeElement()
+
+      $element.trigger('closed')
     }
 
   }


### PR DESCRIPTION
Basically, I have alerts in my app that are contained within a fixed layout - when closing the alert I need a hook so that I can remove a class from my fixed layout to "shift" it up by 30px or so to account for the space created when the alert is no longer there. FYI, the actual listener I use is this:

``` js
$(".alert-message").bind("closed", function() {
    if ($(this).hasClass("flash")) {
        $(".with-flashes").each(function(i, item) {
            $(item).removeClass("with-flashes");
        });
    }
});
```
