### PR TITLE
Typo fix.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -345,7 +345,7 @@ $('#my-modal').bind('hidden', function () {
 <pre class="prettyprint linenums">&lt;button class="btn" data-complete-text="finished!" &gt;...&lt;/button&gt;
 &lt;script&gt;
   $('.btn').button('complete')
-&lt;/scrip&gt;</pre>
+&lt;/script&gt;</pre>
           <h3>Demo</h3>
           <button id="fat-btn" data-loading-text="loading..." class="btn danger">Loading Demo</button>
           <button class="btn" data-toggle="toggle">Toggle Demo</button>


### PR DESCRIPTION
Just a small typo fix in the JavaScript documentation page.
