### PR TITLE
Add close and closed hooks for alert

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -750,6 +750,30 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           <h4>.alert('close')</h4>
           <p>Closes an alert.</p>
           <pre class="prettyprint linenums">$(".alert-message").alert('close')</pre>
+          <h3>Events</h3>
+          <p>Bootstrap's alert class exposes a few events for hooking into alert functionality. </p>
+          <table class="zebra-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">Event</th>
+               <th>Description</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>close</td>
+               <td>This event fires immediately when the <code>close</code> instance method is called.</td>
+             </tr>
+             <tr>
+               <td>closed</td>
+               <td>This event is fired when the alert has been closed (will wait for css transitions to complete).</td>
+             </tr>
+            </tbody>
+          </table>
+<pre class="prettyprint linenums">
+$('#my-alert').bind('closed', function () {
+  // do something ...
+})</pre>
           <h3>Demo</h3>
           <div class="alert-message warning fade in">
             <a class="close" data-dismiss="alert" href="#">&times;</a>

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -39,6 +39,8 @@
         , selector = $this.attr('data-target') || $this.attr('href')
         , $parent = $(selector)
 
+      $parent.trigger('close')
+
       e && e.preventDefault()
 
       $parent.length || ($parent = $this.hasClass('alert-message') ? $this : $this.parent())
@@ -47,6 +49,8 @@
 
       function removeElement() {
         $parent.remove()
+
+        $parent.trigger('closed')
       }
 
       $.support.transition && $parent.hasClass('fade') ?


### PR DESCRIPTION
Basically, I have alerts in my app that are contained within a fixed layout - when closing the alert I need a hook so that I can remove a class from my fixed layout to "shift" it up by 30px or so to account for the space created when the alert is no longer there. FYI, the actual listener I use is this:

``` js
$(".alert-message").bind("closed", function() {
    if ($(this).hasClass("flash")) {
        $(".with-flashes").each(function(i, item) {
            $(item).removeClass("with-flashes");
        });
    }
});
```
