### PR TITLE
2.0 wip

### DIFF
--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -91,7 +91,7 @@
 
   $(function () {
     $('body').on('click.button.data-api', '[data-toggle^=button]', function ( e ) {
-      $(e.srcElement).button('toggle')
+      $(e.target).button('toggle')
     })
   })
 


### PR DESCRIPTION
Event.srcElement property does not work in Firefox. Replaced it with e.target, which is the recommended jQuery way.
