### PR TITLE
Fixfonts

### DIFF
--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -60,7 +60,7 @@
       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     }
     .monospace() {
-      font-family: Menlo, Monaco, Courier New, monospace;
+      font-family: Menlo, Monaco, "Courier New", monospace;
     }
   }
   .shorthand(@size: @baseFontSize, @weight: normal, @lineHeight: @baseLineHeight) {


### PR DESCRIPTION
http://www.w3schools.com/cssref/pr_font_font-family.asp

"If a font name contains white-space, it must be quoted."
