### PR TITLE
You can't use HTML entities as values of the `content` property

### DIFF
--- a/lib/patterns.less
+++ b/lib/patterns.less
@@ -227,7 +227,7 @@ a.menu:after,
   width: 0;
   height: 0;
   display: inline-block;
-  content: "&darr;";
+  content: "\2193";
   text-indent: -99999px;
   vertical-align: top;
   margin-top: 8px;


### PR DESCRIPTION
You can't use HTML entities (i.e. &darr;) as values of the `content` property. Changed &darr; to its hex value.
