### PR TITLE
Always toggle the dropdowns when clicking on the toggle trigger

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -41,9 +41,7 @@
 
       $parent.length || ($parent = $this.parent())
 
-      clearMenus()
-
-      !$parent.hasClass('open') && $parent.toggleClass('open')
+      $parent.toggleClass('open')
 
       return false
     }


### PR DESCRIPTION
Before this commit, whenever a dropdown menu is open and you click on the `.dropdown-toggle` link, it would remain open.

This commit will change that so the menu is closed by clicking again on the trigger.
