### PR TITLE
Put quotes around font-family: "Courier New" since it is TWO WORDS.

### DIFF
--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -60,7 +60,7 @@
       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     }
     .monospace() {
-      font-family: Menlo, Monaco, Courier New, monospace;
+      font-family: Menlo, Monaco, "Courier New", monospace;
     }
   }
   .shorthand(@size: @baseFontSize, @weight: normal, @lineHeight: @baseLineHeight) {


### PR DESCRIPTION
This is a resubmit of https://github.com/twitter/bootstrap/pull/868 because it was mistakenly closed and then ignored. I'm trying to help here, grrr...

This is a patch against 2.0-wip
