### PR TITLE
Make $().button work for input[type=submit]

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -349,12 +349,20 @@ $('#my-modal').bind('hidden', function () {
           <h3>Demo</h3>
           <button id="fat-btn" data-loading-text="loading..." class="btn danger">Loading Demo</button>
           <button class="btn" data-toggle="toggle">Toggle Demo</button>
+          <input id="submit-btn" data-loading-text="loading..." class="btn" type="submit" value="Form submit button" />
           <script>
             $(function() {
               var btn = $('#fat-btn').click(function () {
                 btn.button('loading')
                 setTimeout(function () {
                   btn.button('reset')
+                }, 3000)
+              });
+
+              var submitBtn = $('#submit-btn').click(function () {
+                submitBtn.button('loading')
+                setTimeout(function () {
+                  submitBtn.button('reset')
                 }, 3000)
               })
             })

--- a/js/bootstrap-buttons.js
+++ b/js/bootstrap-buttons.js
@@ -25,11 +25,17 @@
     var d = 'disabled'
       , $el = $(el)
       , data = $el.data()
+      , isSubmit = $el.is("input") && $el.attr("type") == "submit"
+      , text = data[state] || $.fn.button.defaults[state] 
 
     state = state + 'Text'
-    data.resetText || $el.data('resetText', $el.html())
+    data.resetText || $el.data('resetText', isSubmit ? $el.attr('value') : $el.html())
 
-    $el.html( data[state] || $.fn.button.defaults[state] )
+    if (isSubmit) {
+      $el.attr("value", text)
+    } else {
+      $el.html(text)
+    }
 
     setTimeout(function () {
       state == 'loadingText' ?


### PR DESCRIPTION
The JavaScript $().button() function replaced the innerHTML, but for form submit buttons, we need to replace the contents of the value-attribute instead.
