### PR TITLE
Changing copyright year in footer examples from 2011 to 2012

### DIFF
--- a/examples/container-app.html
+++ b/examples/container-app.html
@@ -110,7 +110,7 @@
       </div>
 
       <footer>
-        <p>&copy; Company 2011</p>
+        <p>&copy; Company 2012</p>
       </footer>
 
     </div> <!-- /container -->

--- a/examples/fluid.html
+++ b/examples/fluid.html
@@ -113,7 +113,7 @@
           </div>
         </div>
         <footer>
-          <p>&copy; Company 2011</p>
+          <p>&copy; Company 2012</p>
         </footer>
       </div>
     </div>

--- a/examples/hero.html
+++ b/examples/hero.html
@@ -70,7 +70,7 @@
       </div>
 
       <footer>
-        <p>&copy; Company 2011</p>
+        <p>&copy; Company 2012</p>
       </footer>
 
     </div> <!-- /container -->


### PR DESCRIPTION
Simple text changes to the three example footers in the /examples folder
