### PR TITLE
Added a way of specifying a custom class for a twipsy

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -75,6 +75,7 @@
       if (this.hasContent() && this.enabled) {
         $tip = this.tip()
         this.setContent()
+        this.addCustomClass()
 
         if (this.options.animate) {
           $tip.addClass('fade')
@@ -122,6 +123,12 @@
       $tip.find('.twipsy-inner')[this.options.html ? 'html' : 'text'](this.getTitle())
       $tip[0].className = 'twipsy'
     }
+
+  , addCustomClass: function() {
+    if (this.options.class) {
+      this.tip().addClass(this.options.class)
+    }
+  }
 
   , hide: function() {
       var that = this

--- a/js/tests/unit/bootstrap-twipsy.js
+++ b/js/tests/unit/bootstrap-twipsy.js
@@ -78,4 +78,13 @@ $(function () {
         $('#qunit-runoff').empty()
       })
 
+      test("should apply the class if specified", function() {
+        var twipsy = $('<a href="#" rel="twipsy" title="Another twipsy"></a>').twipsy({ class: 'test-class' })
+        twipsy.twipsy('show')
+        ok($('.twipsy').hasClass('test-class'), 'has the specified class applied')
+        twipsy.twipsy('hide')
+        ok(!$(".twipsy").length, 'twipsy removed')
+        $('#qunit-runoff').empty()
+      })
+
 })


### PR DESCRIPTION
Before there was no way of applying a style on a per twipsy basis (my need comes from having to nudge a twipsy a bit).

I've now added an extra option called `class` which, if specified, will be added to the twipsy in the `show` method.

I also added a simple test case for this that verifies that the class is actually being added.
