### PR TITLE
Twipsy now respects custom classes

### DIFF
--- a/js/bootstrap-twipsy.js
+++ b/js/bootstrap-twipsy.js
@@ -155,7 +155,7 @@
   , setContent: function () {
       var $tip = this.tip()
       $tip.find('.twipsy-inner').html(this.getTitle())
-      $tip[0].className = 'twipsy'
+      $tip.removeClass('fade in top bottom left right')
     }
 
   , hide: function () {

--- a/js/tests/unit/bootstrap-twipsy.js
+++ b/js/tests/unit/bootstrap-twipsy.js
@@ -48,4 +48,15 @@ $(function () {
         ok(!$(".twipsy").length, 'twipsy removed')
       })
 
+      test("should respect custom classes", function () {
+        var twipsy = $('<a href="#" rel="twipsy" title="Another twipsy"></a>')
+          .appendTo('#qunit-fixture')
+          .twipsy({ template: '<div class="twipsy some-class"><div class="twipsy-arrow"/><div class="twipsy-inner"/></div>'})
+          .twipsy('show')
+
+        ok($('.twipsy').hasClass('some-class'), 'custom class is present')
+        twipsy.twipsy('hide')
+        ok(!$(".twipsy").length, 'twipsy removed')
+      })
+
 })


### PR DESCRIPTION
Before all custom classes were overwritten by twipsy if you used a template.

This fixes that, twipsy will only remove classes that it adds itself.

This fixes [issue #908](https://github.com/twitter/bootstrap/issues/908).
