### PR TITLE
Use `date` instead of `DATE`, that's the POS*X way.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=1.4.0
-DATE=$(shell DATE)
+DATE=$(shell date)
 BOOTSTRAP = ./bootstrap.css
 BOOTSTRAP_MIN = ./bootstrap.min.css
 BOOTSTRAP_LESS = ./lib/bootstrap.less


### PR DESCRIPTION
There was a pull request for this in the past, but it conflated lots of other changes and never has been applied afaik.
Also, what platform does DATE work on? It's the first time I've seen it used.
