### PR TITLE
Add a shorthand for borders

### DIFF
--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -95,6 +95,14 @@
   .columns(@columnSpan);
 }
 
+// Border shorthand
+.border(@top: 1px, @right: 1px, @bottom: 1px, @left: 1px, @color: #000, @type: solid) {
+  border-top: @top @type @color;
+  border-right: @right @type @color;
+  border-bottom: @bottom @type @color;
+  border-left: @left @type @color;
+}
+
 // Border Radius
 .border-radius(@radius: 5px) {
   -webkit-border-radius: @radius;


### PR DESCRIPTION
I'm using bootstrap for my project and I think that this shorthand I use may be useful to others. It's used like this:

<code>.border(1px, 0px, 1px, 0px, #ededed, dahsed)</code>

The first four parameters are the border width of the four borders in clockwise order starting from the top (top, right, bottom, left) the next two are color and type. I hope this will be helpful!
