### PR TITLE
Fixed broken anchors on js docs page

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -528,7 +528,7 @@ $('#myModal').on('hidden', function () {
 
     <!-- Tabs
     ================================================== -->
-    <section id="tab">
+    <section id="tabs">
       <div class="page-header">
         <h1>Togglable tabs <small>bootstrap-tab.js</small></h1>
       </div>
@@ -832,7 +832,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
 
     <!-- Alert
     ================================================== -->
-    <section id="alert">
+    <section id="alerts">
       <div class="page-header">
         <h1>Alert messages <small>bootstrap-alert.js</small></h1>
       </div>
@@ -901,7 +901,7 @@ $('#my-alert').bind('closed', function () {
 
     <!-- Buttons
     ================================================== -->
-    <section id="button">
+    <section id="buttons">
       <div class="page-header">
         <h1>Buttons <small>bootstrap-button.js</small></h1>
       </div>


### PR DESCRIPTION
In javascript docs page some anchors doesn't works
