### PR TITLE
Comment change: rename the ul, ol, dl section from COLORS to LISTS.

### DIFF
--- a/lib/type.less
+++ b/lib/type.less
@@ -66,7 +66,7 @@ h6 {
 }
 
 
-// COLORS
+// LISTS
 // ------
 
 // Unordered and Ordered lists


### PR DESCRIPTION
Noticed a section heading of "colors" appears before definition of list element (ul, ol, dl) styles in type.less.

Change the comment for the section to "lists" to better match the content in the section.
