### PR TITLE
Moved font-family definitions to variables.less

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sun Dec 25 20:18:31 PST 2011
+ * Date: Fri 13 Jan 2012 20:12:02 GMT
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).

--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -51,19 +51,19 @@
     line-height: @lineHeight;
   }
   .sans-serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: @sansSerifFamily;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;
   }
   .serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Georgia", Times New Roman, Times, serif;
+    font-family: @serifFamily;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;
   }
   .monospace(@weight: normal, @size: 12px, @lineHeight: 20px) {
-    font-family: "Monaco", Courier New, monospace;
+    font-family: @monospaceFamily;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;

--- a/lib/variables.less
+++ b/lib/variables.less
@@ -50,7 +50,10 @@
 @analog1:           spin(@baseColor, 22);   // Analogs colors
 @analog2:           spin(@baseColor, -22);
 
-
+// Font families
+@sansSerifFamily:   "Helvetica Neue", Helvetica, Arial, sans-serif;
+@serifFamily:       Georgia, "Times New Roman", Times, serif;
+@monospaceFamily:   Monaco, "Courier New", monospace;
 
 // More variables coming soon:
 // - @basefont to @baseFontSize


### PR DESCRIPTION
I moved the font-family definitions from mixins.less to variables.less. I thought it would make more sense to have those there.
