### PR TITLE
Change typeahead case sensitivity matching

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -35,7 +35,7 @@
     constructor: Typeahead
 
   , matcher: function (item, query) {
-      return ~item.indexOf(query)
+      return item.toLowerCase().indexOf(query) !== -1
     }
 
   , select: function () {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -35,7 +35,7 @@
     constructor: Typeahead
 
   , matcher: function (item, query) {
-      return item.toLowerCase().indexOf(query) !== -1
+      return item.toLowerCase().indexOf(query.toLowerCase()) !== -1
     }
 
   , select: function () {


### PR DESCRIPTION
In the current Typeahead plug-in, typing "tex" will not match "Texas" (using the docs page as an example, since it uses states as the data.)  I adjusted the `matcher` function to not be case sensitive.  If you (@fat) wanted it to be case sensitive, maybe we could allow an option to match case?
