### PR TITLE
Docs fixes

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -40,7 +40,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>
@@ -928,7 +928,7 @@
       <p>States like error, warning, and success are included for each type of form control. Also included are styles for disabled controls.</p>
     </div>
   </div>
-  
+
   <h2>Four types of forms</h2>
   <p>Bootstrap provides simple markup and styles for four styles of common web forms.</p>
   <table class="bordered-table striped-table">

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -51,7 +51,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -72,6 +72,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/docs/components.html
+++ b/docs/components.html
@@ -72,6 +72,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">
@@ -1159,7 +1160,7 @@
 
 <!-- Progress bars
 ================================================== -->
-      <section id="progresss">
+      <section id="progress">
         <div class="page-header">
           <h1>Progress bars <small>For loading, redirecting, or action status</small></h1>
         </div>

--- a/docs/components.html
+++ b/docs/components.html
@@ -40,7 +40,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/components.html
+++ b/docs/components.html
@@ -844,7 +844,7 @@
 
 <!-- Pagination
 ================================================== -->
-<section id="carousel">
+<section id="pagination">
   <div class="page-header">
     <h1>Pagination <small></small></h1>
   </div>

--- a/docs/components.html
+++ b/docs/components.html
@@ -907,9 +907,9 @@
 
 
 
-<!-- Media
+<!-- Thumbnails
 ================================================== -->
-<section id="media">
+<section id="thumbnails">
   <div class="page-header">
     <h1>Thumbnails <small>Grids of images, videos, text, and more</small></h1>
   </div>

--- a/docs/components.html
+++ b/docs/components.html
@@ -51,7 +51,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,6 +73,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -73,6 +73,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown active">

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -41,7 +41,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -52,7 +52,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/less.html
+++ b/docs/less.html
@@ -40,7 +40,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/less.html
+++ b/docs/less.html
@@ -51,7 +51,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/less.html
+++ b/docs/less.html
@@ -72,6 +72,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -40,7 +40,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -51,7 +51,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -72,6 +72,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -40,7 +40,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./scaffolding.html#grid">Grid system</a></li>
+                <li><a href="./scaffolding.html#grid-system">Grid system</a></li>
                 <li><a href="./scaffolding.html#layouts">Layouts</a></li>
                 <li><a href="./scaffolding.html#responsive">Responsive design</a></li>
               </ul>

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -51,7 +51,7 @@
                 <b class="caret"></b>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="./base-css.html#type">Type</a></li>
+                <li><a href="./base-css.html#typography">Typography</a></li>
                 <li><a href="./base-css.html#tables">Tables</a></li>
                 <li><a href="./base-css.html#forms">Forms</a></li>
                 <li><a href="./base-css.html#buttons">Buttons</a></li>

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -72,6 +72,7 @@
                 <li><a href="./components.html#pagination">Pagination</a></li>
                 <li><a href="./components.html#thumbnails">Thumbnails</a></li>
                 <li><a href="./components.html#alerts">Alert messages</a></li>
+                <li><a href="./components.html#progress">Progress bars</a></li>
               </ul>
             </li>
             <li class="dropdown">


### PR DESCRIPTION
Fix some linking from the navbar to the various sections.

The Javascript dropdown still has an entry for "Transition" however there's no Transition section on the page. There's also a Transition link in the list of plugins for the builder that points to nothing.
