### PR TITLE
Content Typo Fix in Docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -215,7 +215,7 @@
             <div class="span4">
               <img class="icon" src="assets/img/glyphicons/glyphicons_214_resize_small.png">
               <h2>Responsive design</h2>
-              <p>With Bootstrap 2, we've gone fully responsive. Our components are scale according to a range of resolutions and devices to provide a consistent experience, no matter what.</p>
+              <p>With Bootstrap 2, we've gone fully responsive. Our components are scaled according to a range of resolutions and devices to provide a consistent experience, no matter what.</p>
             </div>
             <div class="span4">
               <img class="icon" src="assets/img/glyphicons/glyphicons_266_book_open.png">


### PR DESCRIPTION
I changed "scale" to "scaled". 

Alternatively, "are" could be deleted and "scale" could remain unchanged.
