### PR TITLE
added styles so that form field states can be displayed in help text only

### DIFF
--- a/bootstrap.css
+++ b/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Sun Dec 25 20:18:31 PST 2011
+ * Date: Tue Jan 17 16:11:00 PST 2012
  */
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
@@ -772,6 +772,15 @@ form .clearfix.success .input-prepend .add-on, form .clearfix.success .input-app
   color: #468847;
   background-color: #bcddbc;
   border-color: #468847;
+}
+form .clearfix .help-inline.error, form .clearfix .help-block.error {
+  color: #b94a48;
+}
+form .clearfix .help-inline.warning, form .clearfix .help-block.warning {
+  color: #c09853;
+}
+form .clearfix .help-inline.success, form .clearfix .help-block.success {
+  color: #468847;
 }
 .input-mini,
 input.mini,

--- a/bootstrap.min.css
+++ b/bootstrap.min.css
@@ -134,6 +134,9 @@ form .clearfix.warning .input-prepend .add-on,form .clearfix.warning .input-appe
 form .clearfix.success>label,form .clearfix.success .help-block,form .clearfix.success .help-inline{color:#468847;}
 form .clearfix.success input,form .clearfix.success textarea{color:#468847;border-color:#57a957;}form .clearfix.success input:focus,form .clearfix.success textarea:focus{border-color:#458845;-webkit-box-shadow:0 0 6px #9acc9a;-moz-box-shadow:0 0 6px #9acc9a;box-shadow:0 0 6px #9acc9a;}
 form .clearfix.success .input-prepend .add-on,form .clearfix.success .input-append .add-on{color:#468847;background-color:#bcddbc;border-color:#468847;}
+form .clearfix .help-inline.error,form .clearfix .help-block.error{color:#b94a48;}
+form .clearfix .help-inline.warning,form .clearfix .help-block.warning{color:#c09853;}
+form .clearfix .help-inline.success,form .clearfix .help-block.success{color:#468847;}
 .input-mini,input.mini,textarea.mini,select.mini{width:60px;}
 .input-small,input.small,textarea.small,select.small{width:90px;}
 .input-medium,input.medium,textarea.medium,select.medium{width:150px;}

--- a/lib/forms.less
+++ b/lib/forms.less
@@ -208,6 +208,19 @@ form .clearfix.success {
   .formFieldState(#468847, #57a957, lighten(#57a957, 30%));
 }
 
+// Form field states displayed in help only
+form .clearfix .help-inline, form .clearfix .help-block {
+  &.error {
+    color: #b94a48
+  }
+  &.warning {
+    color: #c09853
+  }
+  &.success {
+    color: #468847
+  }
+}
+
 
 // Form element sizes
 // TODO v2: remove duplication here and just stick to .input-[size] in light of adding .spanN sizes


### PR DESCRIPTION
Only the color of the text is needed to indicate field state. 
I needed this. I know I could have just extended my style on my local copy. But I thought I'd add to forms.less and submit it just for fun.
