### PR TITLE
Scalable dropdown menus

### DIFF
--- a/lib/button-groups.less
+++ b/lib/button-groups.less
@@ -88,7 +88,7 @@
 // Reposition menu on open and round all corners
 .btn-group.open .dropdown-menu {
   display: block;
-  top: 30px;
+  margin-top: 1px;
   .border-radius(5px);
   &.large { top: 40px; }
 }

--- a/lib/dropdowns.less
+++ b/lib/dropdowns.less
@@ -30,7 +30,7 @@
 // The dropdown menu (ul)
 .dropdown-menu {
   position: absolute;
-  top: 40px;
+  top: 100%;
   z-index: @zindexDropdown;
   float: left;
   display: none; // none by default, but block on "open" of the menu

--- a/lib/navbar.less
+++ b/lib/navbar.less
@@ -191,7 +191,7 @@
 
 // Menu position and menu carets
 .navbar .dropdown-menu {
-  top: 41px;
+  margin-top: 1px;
   .border-radius(4px);
   &:before {
     content: '';

--- a/lib/navs.less
+++ b/lib/navs.less
@@ -177,7 +177,7 @@
 // Position the menu
 .pills .dropdown-menu,
 .tabs .dropdown-menu {
-  top: 33px;
+  margin-top: 1px;
   border-width: 1px;
 }
 .pills .dropdown-menu {
@@ -239,7 +239,7 @@
 
 
 // COMMON STYLES
-// ------------- 
+// -------------
 
 // Clear any floats
 .tabbable {


### PR DESCRIPTION
Right now you have to define a specific `top: value` for all your dropdowns which isn't optimal. I suggest that we use `top: 100%` instead and use a `margin: value` for the extra space needed between the navbar and the dropdown for example.

This allows us to use whichever height we want on our elements without having to change the `top` value on the dropdown-menu.
