### PR TITLE
Bordered/Padded Grid Spans

### DIFF
--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -78,7 +78,13 @@
   .clearfix();
 }
 .columns(@columnSpan: 1) {
+  box-sizing: border-box;
+
   width: (@gridColumnWidth * @columnSpan) + (@gridGutterWidth * (@columnSpan - 1));
+  .row {
+    box-sizing: border-box;
+    width: (@gridColumnWidth * @columnSpan) + (@gridGutterWidth * @columnSpan);
+  }
 }
 .offset(@columnOffset: 1) {
   margin-left: (@gridColumnWidth * @columnOffset) + (@gridGutterWidth * (@columnOffset - 1)) + @extraSpace;

--- a/lib/scaffolding.less
+++ b/lib/scaffolding.less
@@ -86,33 +86,38 @@ a {
   .gridColumn();
 }
 
-// Default columns
-.span1     { .columns(1); }
-.span2     { .columns(2); }
-.span3     { .columns(3); }
-.span4     { .columns(4); }
-.span5     { .columns(5); }
-.span6     { .columns(6); }
-.span7     { .columns(7); }
-.span8     { .columns(8); }
-.span9     { .columns(9); }
-.span10    { .columns(10); }
-.span11    { .columns(11); }
-.span12    { .columns(12); }
-.span13    { .columns(13); }
-.span14    { .columns(14); }
-.span15    { .columns(15); }
-.span16    { .columns(16); }
+
+// Sorted greatest to least for the smaller spans to take priority
+// over the larger spans when styling child row elements
 
 // For optional 24-column grid
-.span17    { .columns(17); }
-.span18    { .columns(18); }
-.span19    { .columns(19); }
-.span20    { .columns(20); }
-.span21    { .columns(21); }
-.span22    { .columns(22); }
-.span23    { .columns(23); }
 .span24    { .columns(24); }
+.span23    { .columns(23); }
+.span22    { .columns(22); }
+.span21    { .columns(21); }
+.span20    { .columns(20); }
+.span19    { .columns(19); }
+.span18    { .columns(18); }
+.span17    { .columns(17); }
+
+// Default columns
+.span16    { .columns(16); }
+.span15    { .columns(15); }
+.span14    { .columns(14); }
+.span13    { .columns(13); }
+.span12    { .columns(12); }
+.span11    { .columns(11); }
+.span10    { .columns(10); }
+.span9     { .columns(9); }
+.span8     { .columns(8); }
+.span7     { .columns(7); }
+.span6     { .columns(6); }
+.span5     { .columns(5); }
+.span4     { .columns(4); }
+.span3     { .columns(3); }
+.span2     { .columns(2); }
+.span1     { .columns(1); }
+
 
 // Offset column options
 .row {


### PR DESCRIPTION
Hello,

I'm submitting a patch for an adjustment I needed for a project to allow for the grid elements to have both a padding and a border.  I thought it might be worthwhile for the bootstrap community at large.  

I found that I needed to add padding to some of the spans in the table for a theme, and that it was throwing off the entire grid.  I've made a small adjustment, which shouldn't throw off the rest of the grid, which would allow one to add both a border and padding to the same HTML element.  The grid can still have child rows, and these have their widths reset based on their inclusion in an existing span.  

Adam
