### PR TITLE
Modal 'Cancel' buttons via a data-cancel-modal attribute

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -256,5 +256,13 @@
       $('#' + $this.attr('data-controls-modal')).modal( $this.data() )
     })
   })
+  
+  $(document).ready(function () {
+    $('body').delegate('[data-cancel-modal]', 'click', function (e) {
+      e.preventDefault()
+      var $this = $(this).data('show', false)
+      $('#' + $this.attr('data-cancel-modal')).modal( $this.data() )
+    })
+  })
 
 }( window.jQuery || window.ender );


### PR DESCRIPTION
Add a click listener to elements that have the data-cancel-modal attribute set. This allows for adding in 'Cancel' buttons to modal dialogs without needing to write any JS.
