### PR TITLE
Dropdown docs error in example

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -489,12 +489,12 @@ $('#myModal').on('hidden', function () {
 <pre class="prettyprint linenums">
 &lt;ul class="nav pills"&gt;
   &lt;li class="active"&gt;&lt;a href="#"&gt;Regular link&lt;/a&gt;&lt;/li&gt;
-  &lt;li class="dropdown"&gt;
+  &lt;li class="dropdown" id="menu1"&gt;
     &lt;a class="dropdown-toggle" data-toggle="dropdown" href="#menu1"&gt;
       Dropdown
       &lt;b class="caret"&gt;&lt;/b&gt;
     &lt;/a&gt;
-    &lt;ul id="menu1" class="dropdown-menu"&gt;
+    &lt;ul class="dropdown-menu"&gt;
       &lt;li&gt;&lt;a href="#"&gt;Action&lt;/a&gt;&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;Another action&lt;/a&gt;&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;Something else here&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
The ID specified by an `href` or `data-target` attribute should match the `li.dropdown`, not the `ul.dropdown-menu`.

This should solve the confusion from issues like #1093
