### PR TITLE
Fix missing .alert .close line-height

### DIFF
--- a/lib/alerts.less
+++ b/lib/alerts.less
@@ -20,6 +20,7 @@
   *margin-top: 3px; /* IE7 spacing */
   position: relative;
   right: -21px;
+  line-height: 18px;
 }
 
 // Alternate styles


### PR DESCRIPTION
This fixes the line-height for `.close` inside alerts so it's properly aligned (especially visible in one-line alerts).

It should be 18px just like the rest of the text inside alerts.

**Before**:
![before](http://i.imgur.com/1t3bd.png)

**After**:
![after](http://i.imgur.com/1PWK9.png)
