### PR TITLE
Fixed URLs in JavaScript comment blocks

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-carousel.js v2.0.0
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * http://twitter.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2011 Twitter, Inc.
  *

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-typeahead.js v2.0.0
- * http://twitter.github.com/bootstrap/javascript.html#collapsible
+ * http://twitter.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2011 Twitter, Inc.
  *


### PR DESCRIPTION
Just a small fix to the URLs in the header comment blocks in the JavaScript files; a couple had the wrong URL fragment.
