### PR TITLE
2.0-wip: Remove specific top value from large btn-dropdown.

### DIFF
--- a/lib/button-groups.less
+++ b/lib/button-groups.less
@@ -90,7 +90,6 @@
   display: block;
   margin-top: 1px;
   .border-radius(5px);
-  &.large { top: 40px; }
 }
 .btn-group.open .dropdown-toggle {
   background-image: none;


### PR DESCRIPTION
Fixes [1046](https://github.com/twitter/bootstrap/pull/1046#issuecomment-3620393)!
