### PR TITLE
2.0-wip: Apostrophes and spelling

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -364,7 +364,7 @@
       <tr>
         <td><code>&lt;pre class="prettyprint"&gt;</code></td>
         <td>
-          <p>Using the google-code-prettify library, you're blocks of code get a slightly different visual style and automatic syntax highlighting. You can also add an additional class to add line numbers.</p>
+          <p>Using the google-code-prettify library, your blocks of code get a slightly different visual style and automatic syntax highlighting. You can also add an additional class to add line numbers.</p>
 <pre class="prettyprint">&lt;div&gt;
   &lt;h1&gt;Heading&lt;/h1&gt;
   &lt;p&gt;Something right here...&lt;/p&gt;
@@ -1103,7 +1103,7 @@
     <div class="span4">
       <div class="form-docs">
         <h3>Redesigned browser states</h3>
-        <p>Bootstrap features styles for browser-supported focused and <code>disabled</code> states. We remove the default Webkit <code>outline</code> and apply a <code>box-shadow</code> in it's place for <code>:focus</code>.</p>
+        <p>Bootstrap features styles for browser-supported focused and <code>disabled</code> states. We remove the default Webkit <code>outline</code> and apply a <code>box-shadow</code> in its place for <code>:focus</code>.</p>
         <hr>
         <h3>Form validation</h3>
         <p>It also includes validation styles for errors, warnings, and success. To use, add the a class to the surrounding <code>.control-group</code>.</p>

--- a/docs/components.html
+++ b/docs/components.html
@@ -1086,7 +1086,7 @@
   <div class="row">
     <div class="span4">
       <h3>Rewritten base class</h3>
-      <p>With Bootstrap 2, we've simplified the base class: <code>.alert</code> instead of <code>.alert-message</code>. We've also reduced the minimum required markup&mdash;no <code>&lt;p&gt;</code> is required by default, just the outter <code>&lt;div&gt;</code>.</p>
+      <p>With Bootstrap 2, we've simplified the base class: <code>.alert</code> instead of <code>.alert-message</code>. We've also reduced the minimum required markup&mdash;no <code>&lt;p&gt;</code> is required by default, just the outer <code>&lt;div&gt;</code>.</p>
       <h3>Single alert message</h3>
       <p>For a more durable component with less code, we've removed the differentiating look for block alerts, messages that come with more padding and typically more text. The class also has changed to <code>.alert-block</code>.</p>
       <hr>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -856,7 +856,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           <p><span class="label notice">Notice</span> Individual popover instance options can alternatively be specified through the use of data attributes.</code></p>
           <h3>Markup</h3>
           <p>
-          For performance reasons, the Tooltip and Popover data-apis are opt in. If you would like to use them just specify a the selector option.
+          For performance reasons, the Tooltip and Popover data-apis are opt in. If you would like to use them just specify a selector option.
           </p>
           <h3>Methods</h3>
           <h4>$().popover(options)</h4>

--- a/docs/less.html
+++ b/docs/less.html
@@ -73,7 +73,7 @@
       <div class="row">
         <div class="span4">
           <h3>Why LESS?</h3>
-          <p>Bootstrap is made with LESS at it's core, a dynamic stylesheet language created by <a href="http://cloudhead.io">Alexis Sellier</a>. It makes developing systems-based CSS faster, easier, and more fun.</p>
+          <p>Bootstrap is made with LESS at its core, a dynamic stylesheet language created by <a href="http://cloudhead.io">Alexis Sellier</a>. It makes developing systems-based CSS faster, easier, and more fun.</p>
         </div>
         <div class="span4">
           <h3>What's included?</h3>


### PR DESCRIPTION
Fixes some apostrophe usage, spelling, and typos in WIP 2.0 docs.
