### PR TITLE
Documentation for Popovers incomplete - missing 'toggle' method (2.0-wip)

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -704,6 +704,9 @@ $('.tabs a').bind('change', function (e) {
           <h4>.popover('hide')</h4>
           <p>Hides an elements popover.</p>
           <pre class="prettyprint linenums">$('#element').popover('hide')</pre>
+          <h4>.popover('toggle')</h4>
+          <p>Toggles an elements popover.</p>
+          <pre class="prettyprint linenums">$('#element').popover('toggle')</pre>
           <h3>Demo</h3>
           <a href="#" class="btn danger" rel="popover" title="A title" data-content="And here's some amazing content. It's very engaging. right?">hover for popover</a>
           <script>


### PR DESCRIPTION
this pull request adds documentation for the 'toggle' method for Popovers.
