### PR TITLE
$.fn.dropdown propagates click events if the dropdown menu is already displayed

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -33,7 +33,7 @@
 
         clearMenus()
         !isActive && li.toggleClass('open')
-        return false
+        return isActive
       })
     })
   }


### PR DESCRIPTION
This way, if the dropdown-toggle element has an href, it can actually be used as a navigation element in the submenu.  If it doesn't, then behavior is unchanged by this patch.
