### PR TITLE
Automatically set Tooltip z-index according to the parent's z-index 

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -145,6 +145,10 @@
             break
         }
 
+        tp.zIndex = this.options.zIndex || parseInt(this.$element.parents().filter(function() {
+          return $(this).css('z-index') != 'auto';
+        }).first().css('z-index'))+10
+
         $tip
           .css(tp)
           .addClass(placement)
@@ -265,6 +269,7 @@
   , trigger: 'hover'
   , title: ''
   , template: '<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+  , zIndex: null
   }
 
 }( window.jQuery )


### PR DESCRIPTION
I went ahead and made some changes to fix the z-indexes as described in #1109. 
This code automatically sets increased z-index of its parent (if any parent has z-index set at all) to make Tooltips and Popovers visible in `.modal`. 

I didn't want to restrict it to a class name so I filter parents by finding the closest one with that CSS attribute set. This way it will work not only in modals but with other elements users might create.

Works fine on Opera/Chrome/Firefox. The only concern might be performance, but in Bootstrap docs even in the worst scenario (Tooltips are not in modals, therefore filter checks parents up to `<html>`) this is only 8 elements to check => no visible slow-downs.

@fat, can you take a look? Demo => http://okonski.org/bootstrap-zindex/docs/javascript.html#modals

EDIT: Seems to work just fine for fixed navbars, too! :)
