### PR TITLE
Drop khtml gradient, shorten old webkit gradient

### DIFF
--- a/lib/mixins.less
+++ b/lib/mixins.less
@@ -279,10 +279,9 @@
 #gradient {
   .horizontal(@startColor: #555, @endColor: #333) {
     background-color: @endColor;
-    background-image: -khtml-gradient(linear, left top, right top, from(@startColor), to(@endColor)); // Konqueror
     background-image: -moz-linear-gradient(left, @startColor, @endColor); // FF 3.6+
     background-image: -ms-linear-gradient(left, @startColor, @endColor); // IE10
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0%, @startColor), color-stop(100%, @endColor)); // Safari 4+, Chrome 2+
+    background-image: -webkit-gradient(linear, 0 0, 100% 0, from(@startColor), to(@endColor)); // Safari 4+, Chrome 2+
     background-image: -webkit-linear-gradient(left, @startColor, @endColor); // Safari 5.1+, Chrome 10+
     background-image: -o-linear-gradient(left, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(left, @startColor, @endColor); // Le standard
@@ -291,10 +290,9 @@
   }
   .vertical(@startColor: #555, @endColor: #333) {
     background-color: @endColor;
-    background-image: -khtml-gradient(linear, left top, left bottom, from(@startColor), to(@endColor)); // Konqueror
     background-image: -moz-linear-gradient(top, @startColor, @endColor); // FF 3.6+
     background-image: -ms-linear-gradient(top, @startColor, @endColor); // IE10
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, @startColor), color-stop(100%, @endColor)); // Safari 4+, Chrome 2+
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), to(@endColor)); // Safari 4+, Chrome 2+
     background-image: -webkit-linear-gradient(top, @startColor, @endColor); // Safari 5.1+, Chrome 10+
     background-image: -o-linear-gradient(top, @startColor, @endColor); // Opera 11.10
     background-image: linear-gradient(top, @startColor, @endColor); // The standard


### PR DESCRIPTION
It seems that Konqueror does not have support for CSS gradients. Testing for CSS gradient support with Modernizr confirms it. 

Kubuntu for example comes with rekonq (https://en.wikipedia.org/wiki/Rekonq) installed as default browser, and it supports gradients, but does not use the -khtml prefix.

There are also so few Konqueror users that I don't see the point keeping it if it's not currently supported by the browser.

I've also shortened the old webkit syntax a bit.
## Tested khtml gradients with:
- Kubuntu 11.10: Konqueror 4.7.4, rekonq
- Ubuntu 11.10: Konqueror 4.74
## Tested old webkit syntax with:
- Win XP: Safari 4.0.5 
- iOS 4.2.1: Safari
