### PR TITLE
Fixed incorrect path to download bootstrap-alert.js

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -871,7 +871,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
         <div class="span3 columns">
           <h3>About alerts</h3>
           <p>The alert plugin is a tiny class for adding close functionality to alerts.</p>
-          <a href="../js/bootstrap-alerts.js" target="_blank" class="btn">Download</a>
+          <a href="../js/bootstrap-alert.js" target="_blank" class="btn">Download</a>
         </div>
         <div class="span9 columns">
           <h2>Example alerts</h2>
@@ -889,7 +889,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
             </p>
           </div>
           <hr>
-          <h2>Using bootstrap-alerts.js</h2>
+          <h2>Using bootstrap-alert.js</h2>
           <p>Enable dismissal of an alert via javascript:</p>
           <pre class="prettyprint linenums">$(".alert-message").alert()</pre>
           <h3>Markup</h3>


### PR DESCRIPTION
The "Download" button for the alerts section of the javascript docs pointed to the old naming of the boostrap-alert.js file. This corrects the path.
