### PR TITLE
[2.0-wip] Fix typehead plugin for IE7/8

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -79,7 +79,7 @@
 
       q = this.query.toLowerCase()
 
-      items = this.data.filter(function (item) {
+      items = jQuery.grep(this.data, function (item) {
         if (that.matcher(item, q)) return item
       })
 


### PR DESCRIPTION
(right branch this time)

Changes the typeahead JS plugin to use jQuery.grep rather than the JS filter method, which is not implemented in IE8 or 7.
