### PR TITLE
Fix icon margins in large buttons.

### DIFF
--- a/lib/buttons.less
+++ b/lib/buttons.less
@@ -128,6 +128,9 @@
     line-height: normal;
     .border-radius(5px);
   }
+  &.large .icon {
+    margin-top: 1px;
+  }
   &.small {
     padding: 7px 9px 7px;
     font-size: @baseFontSize - 2px;


### PR DESCRIPTION
Icons in large buttons are positioned a little too high. This adds some margin to the top. Sample before/after below.

![before](http://dl.dropbox.com/u/293038/github/before.png)![after](http://dl.dropbox.com/u/293038/github/after.png)
