### PR TITLE
[2.0-wip] Fix base-css styles for IE7

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Jan 27 08:21:21 PST 2012
+ * Date: Fri Jan 27 12:16:22 EST 2012
  */
 article,
 aside,
@@ -887,6 +887,12 @@ input:focus:required:invalid:focus, textarea:focus:required:invalid:focus, selec
   -moz-border-radius: 0 3px 3px 0;
   border-radius: 0 3px 3px 0;
 }
+.input-append input:first-child {
+  *margin-left: -160px;
+}
+.input-append input:first-child + .add-on {
+  *margin-left: -21px;
+}
 .search-query {
   padding-left: 14px;
   padding-right: 14px;
@@ -972,6 +978,7 @@ table {
 .table-bordered {
   border: 1px solid #ddd;
   border-collapse: separate;
+  *border-collapse: collapsed;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -1834,7 +1841,7 @@ table .span12 {
 .navbar-search .search-query :-moz-placeholder {
   color: #eeeeee;
 }
-.navbar-search .search-query ::-webkit-input-placeholder {
+.navbar-search .search-query::-webkit-input-placeholder {
   color: #eeeeee;
 }
 .navbar-search .search-query:hover {
@@ -2448,6 +2455,8 @@ table .span12 {
 .btn {
   display: inline-block;
   padding: 4px 10px 4px;
+  *padding: 2px 10px;
+  *margin-left: 4px;
   font-size: 13px;
   line-height: 18px;
   color: #333333;
@@ -2469,6 +2478,9 @@ table .span12 {
   -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   cursor: pointer;
+}
+.btn:first-child {
+  *margin-left: 0;
 }
 .btn:hover {
   color: #333333;

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -67,6 +67,13 @@
   // Button Base
   display: inline-block;
   padding: 4px 10px 4px;
+  *padding: 2px 10px;
+  // IE7 likes to collapse the whitespace before the button, so bring it back...
+  *margin-left: 4px;
+  &:first-child {
+    // ...but not before the first button
+    *margin-left: 0;
+  }
   font-size: @baseFontSize;
   line-height: @baseLineHeight;
   color: @grayDark;

--- a/less/forms.less
+++ b/less/forms.less
@@ -440,6 +440,15 @@ select:focus:required:invalid {
     margin-left: -1px;
     .border-radius(0 3px 3px 0);
   }
+  input:first-child {
+    // In IE7, having a hasLayout container (from clearfix's zoom:1) can make the first input
+    // inherit the sum of its ancestors' margins.
+    *margin-left: -160px;
+
+    &+.add-on {
+      *margin-left: -21px;
+    }
+  }
 }
 
 

--- a/less/tables.less
+++ b/less/tables.less
@@ -64,6 +64,7 @@ table {
 .table-bordered {
   border: 1px solid #ddd;
   border-collapse: separate; // Done so we can round those corners!
+  *border-collapse: collapsed; // IE7 can't round corners anyway
   .border-radius(4px);
   th + th,
   td + td,


### PR DESCRIPTION
Corrects button sizing and spacing, table borders, and the super-crazy append text form input margin bug.

Makes everything is base CSS look legit in IE7.
