### PR TITLE
[2.0-wip] IE7/8 fixes for components.html

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
- * Date: Fri Jan 27 11:07:13 PST 2012
+ * Date: Fri Jan 27 16:39:29 EST 2012
  */
 article,
 aside,
@@ -814,6 +814,10 @@ input:focus:required:invalid:focus, textarea:focus:required:invalid:focus, selec
 }
 .help-inline {
   display: inline-block;
+  *display: inline;
+  /* IE7 inline-block hack */
+
+  *zoom: 1;
   margin-bottom: 9px;
   vertical-align: middle;
   padding-left: 5px;
@@ -1083,6 +1087,10 @@ table .span12 {
   vertical-align: text-top;
   width: 14px;
   height: 14px;
+  *margin-right: .3em;
+}
+.icon:last-child {
+  *margin-left: 0;
 }
 .icon.white {
   background-image: url(../img/glyphicons-halflings-sprite-white.png);
@@ -1360,11 +1368,15 @@ table .span12 {
 .dropdown {
   position: relative;
 }
+.dropdown .dropdown-toggle {
+  *margin-bottom: -3px;
+}
 .caret {
   display: inline-block;
   width: 0;
   height: 0;
   text-indent: -99999px;
+  *text-indent: 0;
   vertical-align: top;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
@@ -1376,7 +1388,6 @@ table .span12 {
 .dropdown .caret {
   margin-top: 8px;
   margin-left: 2px;
-  *margin-top: 7px;
 }
 .dropdown:hover .caret, .open.dropdown .caret {
   opacity: 1;
@@ -1385,6 +1396,7 @@ table .span12 {
 .dropdown-menu {
   position: absolute;
   top: 100%;
+  left: 0;
   z-index: 1000;
   float: left;
   display: none;
@@ -1408,7 +1420,6 @@ table .span12 {
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding;
   background-clip: padding-box;
-  zoom: 1;
   *border-right-width: 2px;
   *border-bottom-width: 2px;
 }
@@ -1423,6 +1434,8 @@ table .span12 {
   overflow: hidden;
   background-color: #e5e5e5;
   border-bottom: 1px solid #ffffff;
+  *width: 100%;
+  *margin: -5px 0 5px;
 }
 .dropdown-menu a {
   display: block;
@@ -1437,6 +1450,9 @@ table .span12 {
   color: #ffffff;
   text-decoration: none;
   background-color: #0088cc;
+}
+.dropdown.open {
+  *z-index: 1000;
 }
 .dropdown.open .dropdown-toggle {
   color: #ffffff;
@@ -1742,6 +1758,7 @@ table .span12 {
 }
 .tabs-left .tabs .active > a, .tabs-left .tabs .active > a:hover {
   border-color: #ddd transparent #ddd #ddd;
+  *border-right-color: #ffffff;
 }
 .tabs-right .tabs {
   float: right;
@@ -1759,6 +1776,7 @@ table .span12 {
 }
 .tabs-right .tabs .active > a, .tabs-right .tabs .active > a:hover {
   border-color: #ddd #ddd #ddd transparent;
+  *border-left-color: #ffffff;
 }
 .navbar {
   overflow: visible;
@@ -1826,7 +1844,7 @@ table .span12 {
   line-height: 1;
   color: #ffffff;
   color: rgba(255, 255, 255, 0.75);
-  background: #444;
+  background: #6a6a6a;
   background: rgba(255, 255, 255, 0.3);
   border: 1px solid #111;
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1), 0 1px 0px rgba(255, 255, 255, 0.15);
@@ -2455,8 +2473,6 @@ table .span12 {
 .btn {
   display: inline-block;
   padding: 4px 10px 4px;
-  *padding: 2px 10px;
-  *margin-left: 4px;
   font-size: 13px;
   line-height: 18px;
   color: #333333;
@@ -2478,6 +2494,7 @@ table .span12 {
   -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   cursor: pointer;
+  *margin-left: .3em;
 }
 .btn:first-child {
   *margin-left: 0;
@@ -2525,7 +2542,7 @@ table .span12 {
   box-shadow: none;
 }
 .btn.large {
-  padding: 9px 14px 9px;
+  padding: 9px 14px;
   font-size: 15px;
   line-height: normal;
   -webkit-border-radius: 5px;
@@ -2536,20 +2553,33 @@ table .span12 {
   margin-top: 1px;
 }
 .btn.small {
-  padding: 5px 9px 5px;
+  padding: 5px 9px;
   font-size: 11px;
   line-height: 16px;
 }
 .btn.small .icon {
   margin-top: -2px;
 }
+button.btn, input[type=submit].btn {
+  *padding-top: 2px;
+  *padding-bottom: 2px;
+}
 button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
+button.btn.large, input[type=submit].btn.large {
+  *padding-top: 7px;
+  *padding-bottom: 7px;
+}
+button.btn.small, input[type=submit].btn.small {
+  *padding-top: 3px;
+  *padding-bottom: 3px;
+}
 .btn-group {
   position: relative;
   *zoom: 1;
+  *margin-left: .3em;
 }
 .btn-group:before, .btn-group:after {
   display: table;
@@ -2558,11 +2588,18 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
 .btn-group:after {
   clear: both;
 }
+.btn-group:first-child {
+  *margin-left: 0;
+}
 .btn-group + .btn-group {
   margin-left: 5px;
 }
 .btn-toolbar .btn-group {
   display: inline-block;
+  *display: inline;
+  /* IE7 inline-block hack */
+
+  *zoom: 1;
 }
 .btn-group .btn {
   position: relative;
@@ -2615,6 +2652,11 @@ button.btn::-moz-focus-inner, input[type=submit].btn::-moz-focus-inner {
   -webkit-box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   -moz-box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
   box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.125), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+  *padding-top: 5px;
+  *padding-bottom: 5px;
+}
+.btn-group.open {
+  *z-index: 1000;
 }
 .btn-group.open .dropdown-menu {
   display: block;

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1035,6 +1035,12 @@
             </div>
           </div>
           <div class="control-group">
+            <label class="control-label">Uneditable input</label>
+            <div class="controls">
+              <span class="input-xlarge uneditable-input">Some value here</span>
+            </div>
+          </div>
+          <div class="control-group">
             <label class="control-label" for="disabledInput">Disabled input</label>
             <div class="controls">
               <input class="input-xlarge disabled" id="disabledInput" type="text" placeholder="Disabled input here…" disabled>
@@ -1490,6 +1496,7 @@
     </div>
   </div>
 </section>
+
 
      <!-- Footer
       ================================================== -->

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -970,6 +970,12 @@
             </div>
           </div>
           <div class="control-group">
+            <label class="control-label">Uneditable input</label>
+            <div class="controls">
+              <span class="input-xlarge uneditable-input">Some value here</span>
+            </div>
+          </div>
+          <div class="control-group">
             <label class="control-label" for="disabledInput">{{_i}}Disabled input{{/i}}</label>
             <div class="controls">
               <input class="input-xlarge disabled" id="disabledInput" type="text" placeholder="{{_i}}Disabled input here…{{/i}}" disabled>

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -17,6 +17,7 @@
 .btn-toolbar {
   .btn-group {
     display: inline-block;
+    .ie7-inline-block;
   }
 }
 

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -6,6 +6,7 @@
 .btn-group {
   position: relative;
   .clearfix(); // clears the floated buttons
+  .ie7-restore-left-whitespace;
 }
 
 // Space out series of button groups
@@ -84,18 +85,27 @@
   padding-right: 8px;
   @shadow: inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   .box-shadow(@shadow);
+  *padding-top: 5px;
+  *padding-bottom: 5px;
 }
 
-// Reposition menu on open and round all corners
-.btn-group.open .dropdown-menu {
-  display: block;
-  margin-top: 1px;
-  .border-radius(5px);
-}
-.btn-group.open .dropdown-toggle {
-  background-image: none;
-  @shadow: inset 0 1px 6px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
-  .box-shadow(@shadow);
+.btn-group.open {
+  // IE7's z-index only goes to the nearest positioned ancestor, which would
+  // make the menu appear below buttons that appeared later on the page
+  *z-index: @zindexDropdown;
+
+  // Reposition menu on open and round all corners
+  .dropdown-menu {
+    display: block;
+    margin-top: 1px;
+    .border-radius(5px);
+  }
+
+  .dropdown-toggle {
+    background-image: none;
+    @shadow: inset 0 1px 6px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+    .box-shadow(@shadow);
+  }
 }
 
 // Reposition the caret

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -67,7 +67,6 @@
   // Button Base
   display: inline-block;
   padding: 4px 10px 4px;
-  *padding: 2px 10px;
   // IE7 likes to collapse the whitespace before the button, so bring it back...
   *margin-left: 4px;
   &:first-child {
@@ -151,6 +150,8 @@
 // Help Firefox not be a jerk about adding extra padding to buttons
 button.btn,
 input[type=submit].btn {
+  // IE7 has some default padding on button controls
+  *padding: 2px 10px;
   &::-moz-focus-inner {
   	padding: 0;
   	border: 0;

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -67,12 +67,6 @@
   // Button Base
   display: inline-block;
   padding: 4px 10px 4px;
-  // IE7 likes to collapse the whitespace before the button, so bring it back...
-  *margin-left: 4px;
-  &:first-child {
-    // ...but not before the first button
-    *margin-left: 0;
-  }
   font-size: @baseFontSize;
   line-height: @baseLineHeight;
   color: @grayDark;
@@ -84,6 +78,8 @@
   @shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   .box-shadow(@shadow);
   cursor: pointer;
+
+  .ie7-restore-left-whitespace;
 
   &:hover {
     color: @grayDark;
@@ -129,7 +125,7 @@
 
   // Button Sizes
   &.large {
-    padding: 9px 14px 9px;
+    padding: 9px 14px;
     font-size: @baseFontSize + 2px;
     line-height: normal;
     .border-radius(5px);
@@ -138,7 +134,7 @@
     margin-top: 1px;
   }
   &.small {
-    padding: 5px 9px 5px;
+    padding: 5px 9px;
     font-size: @baseFontSize - 2px;
     line-height: @baseLineHeight - 2px;
   }
@@ -150,10 +146,20 @@
 // Help Firefox not be a jerk about adding extra padding to buttons
 button.btn,
 input[type=submit].btn {
-  // IE7 has some default padding on button controls
-  *padding: 2px 10px;
   &::-moz-focus-inner {
   	padding: 0;
   	border: 0;
+  }
+
+  // IE7 has some default padding on button controls
+  *padding-top: 2px;
+  *padding-bottom: 2px;
+  &.large {
+    *padding-top: 7px;
+    *padding-bottom: 7px;
+  }
+  &.small {
+    *padding-top: 3px;
+    *padding-bottom: 3px;
   }
 }

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -35,31 +35,6 @@
   }
 }
 
-
-// Mixin for generating button backgrounds
-// ---------------------------------------
-.buttonBackground(@startColor, @endColor) {
-  // gradientBar will set the background to a pleasing blend of these, to support IE<=9
-  .gradientBar(@startColor, @endColor);
-
-  // in these cases the gradient won't cover the background, so we override
-  &:hover, &:active, &.active, &.disabled {
-    background-color: @endColor;
-  }
-
-  // called out separately because IE8 would ignore otherwise
-  &[disabled] {
-    background-color: @endColor;
-  }
-
-  // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
-  &:active,
-  &.active {
-    background-color: darken(@endColor, 10%) e("\9");
-  }
-}
-
-
 // Base styles
 // -----------
 

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -5,12 +5,19 @@
 .dropdown {
   position: relative;
 }
+.dropdown .dropdown-toggle {
+  // The caret makes the toggle a bit too tall in IE7
+  *margin-bottom: -3px;
+}
 // Dropdown arrow/caret
 .caret {
   display: inline-block;
   width: 0;
   height: 0;
   text-indent: -99999px;
+  // IE7 won't do the border trick if there's a text indent, but it doesn't
+  // do the content that text-indent is hiding, either, so we're ok.
+  *text-indent: 0;
   vertical-align: top;
   border-left:  4px solid transparent;
   border-right: 4px solid transparent;
@@ -21,7 +28,6 @@
 .dropdown .caret {
   margin-top: 8px;
   margin-left: 2px;
-  *margin-top: 7px;
 }
 .dropdown:hover .caret,
 .open.dropdown .caret {
@@ -31,6 +37,7 @@
 .dropdown-menu {
   position: absolute;
   top: 100%;
+  left: 0;
   z-index: @zindexDropdown;
   float: left;
   display: none; // none by default, but block on "open" of the menu
@@ -50,7 +57,6 @@
   -webkit-background-clip: padding-box;
      -moz-background-clip: padding;
           background-clip: padding-box;
-  zoom: 1; // do we need this?
   *border-right-width: 2px;
   *border-bottom-width: 2px;
 
@@ -68,6 +74,13 @@
     overflow: hidden;
     background-color: #e5e5e5;
     border-bottom: 1px solid @white;
+
+    // IE7 needs a set width since we gave a height. Restricting just
+    // to IE7 to keep the 1px left/right space in other browsers.
+    // It is unclear where IE is getting the extra space that we need
+    // to negative-margin away, but so it goes.
+    *width: 100%;
+    *margin: -5px 0 5px;
   }
 
   // Links within the dropdown menu
@@ -93,6 +106,10 @@
 
 // Open state for the dropdown
 .dropdown.open {
+  // IE7's z-index only goes to the nearest positioned ancestor, which would
+  // make the menu appear below buttons that appeared later on the page
+  *z-index: @zindexDropdown;
+
   .dropdown-toggle {
     color: @white;
     background: #ccc;

--- a/less/forms.less
+++ b/less/forms.less
@@ -377,6 +377,7 @@ select:focus:required:invalid {
 
 .help-inline {
   display: inline-block;
+  .ie7-inline-block;
   margin-bottom: 9px;
   vertical-align: middle;
   padding-left: 5px;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -339,6 +339,29 @@
 }
 
 
+// Mixin for generating button backgrounds
+// ---------------------------------------
+.buttonBackground(@startColor, @endColor) {
+  // gradientBar will set the background to a pleasing blend of these, to support IE<=9
+  .gradientBar(@startColor, @endColor);
+
+  // in these cases the gradient won't cover the background, so we override
+  &:hover, &:active, &.active, &.disabled {
+    background-color: @endColor;
+  }
+
+  // called out separately because IE8 would ignore otherwise
+  &[disabled] {
+    background-color: @endColor;
+  }
+
+  // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
+  &:active,
+  &.active {
+    background-color: darken(@endColor, 10%) e("\9");
+  }
+}
+
 
 // COMPONENT MIXINS
 // --------------------------------------------------

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -36,6 +36,28 @@
   *zoom: 1;
 }
 
+// IE7 likes to collapse whitespace on either side of the inline-block elements.
+// Ems because we're attempting to match the width of a space character. Left
+// version is for form buttons, which typically come after other elements, and
+// right version is for icons, which come before. Applying both is ok, but it will
+// mean that space between those elements will be .6em (~2 space characters) in IE7,
+// instead of the 1 space in other browsers.
+.ie7-restore-left-whitespace() {
+  *margin-left: .3em;
+
+  &:first-child {
+    *margin-left: 0;
+  }
+}
+
+.ie7-restore-right-whitespace() {
+  *margin-right: .3em;
+
+  &:last-child {
+    *margin-left: 0;
+  }
+}
+
 // Sizing shortcuts
 // -------------------------
 .size(@height: 5px, @width: 5px) {

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -74,7 +74,7 @@
     #font > .sans-serif(13px, normal, 1);
     color: @white;
     color: rgba(255,255,255,.75);
-    background: #444;
+    background: #6a6a6a;
     background: rgba(255,255,255,.3);
     border: 1px solid #111;
     @shadow: inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0px rgba(255,255,255,.15);

--- a/less/navs.less
+++ b/less/navs.less
@@ -317,6 +317,7 @@
 .tabs-left .tabs .active > a,
 .tabs-left .tabs .active > a:hover {
   border-color: #ddd transparent #ddd #ddd;
+  *border-right-color: @white;
 }
 
 // Tabs on the right
@@ -335,4 +336,5 @@
 .tabs-right .tabs .active > a,
 .tabs-right .tabs .active > a:hover {
   border-color: #ddd #ddd #ddd transparent;
+  *border-left-color: @white;
 }

--- a/less/sprites.less
+++ b/less/sprites.less
@@ -19,6 +19,8 @@
   vertical-align: text-top;
   width: 14px;
   height: 14px;
+
+  .ie7-restore-right-whitespace;
 }
 .icon.white {
   background-image: url(../img/glyphicons-halflings-sprite-white.png);


### PR DESCRIPTION
Fixes to get IE7 in line for combo buttons and dropdowns. Also fixes some minor rendering around tab borders.

Changes the background of search in the nav to better match what rgba-capable browsers are showing against the default nav background (IE7 and IE8).

Also:
- Brings back the uneditable text input example from 1.x
- Moves the buttonBackground mixin to mixins.less (issue #1292)
