### PR TITLE
[2.0-wip] Fix mustache glob when building

### DIFF
--- a/docs/build/index.js
+++ b/docs/build/index.js
@@ -13,6 +13,9 @@ pages = fs.readdirSync(__dirname + '/../templates/pages')
 
 // iterate over pages
 pages.forEach(function (name) {
+  if (!name.match(/\.mustache$/)) {
+    return;
+  }
 
   var page = fs.readFileSync(__dirname  + '/../templates/pages/' + name, 'utf-8')
     , context = {}


### PR DESCRIPTION
Changes index.js to only build files that end in ".mustache".

This keeps it from processing (and erroring on) files like the invisible ".swp" files that vim adds to the directory.
