### PR TITLE
[2.0 wip] Add alert support span in form

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -71,15 +71,28 @@
 
 // Span alert
 // ----------
-form .alert.span1  { .alert-columns(1);}
-form .alert.span2  { .alert-columns(2);}
-form .alert.span3  { .alert-columns(3);}
-form .alert.span4  { .alert-columns(4);}
-form .alert.span5  { .alert-columns(5);}
-form .alert.span6  { .alert-columns(6);}
-form .alert.span7  { .alert-columns(7);}
-form .alert.span8  { .alert-columns(8);}
-form .alert.span9  { .alert-columns(9);}
-form .alert.span10 { .alert-columns(10);}
-form .alert.span11 { .alert-columns(11);}
-form .alert.span12 { .alert-columns(12);}
+form .alert.span1 , .form-inline .alert.span1  { .alert-inline-columns(1);}
+form .alert.span2 , .form-inline .alert.span2  { .alert-inline-columns(2);}
+form .alert.span3 , .form-inline .alert.span3  { .alert-inline-columns(3);}
+form .alert.span4 , .form-inline .alert.span4  { .alert-inline-columns(4);}
+form .alert.span5 , .form-inline .alert.span5  { .alert-inline-columns(5);}
+form .alert.span6 , .form-inline .alert.span6  { .alert-inline-columns(6);}
+form .alert.span7 , .form-inline .alert.span7  { .alert-inline-columns(7);}
+form .alert.span8 , .form-inline .alert.span8  { .alert-inline-columns(8);}
+form .alert.span9 , .form-inline .alert.span9  { .alert-inline-columns(9);}
+form .alert.span10, .form-inline .alert.span10 { .alert-inline-columns(10);}
+form .alert.span11, .form-inline .alert.span11 { .alert-inline-columns(11);}
+form .alert.span12, .form-inline .alert.span12 { .alert-inline-columns(12);}
+
+.form-horizontal .alert.span1  { .alert-horizontal-columns(1);}
+.form-horizontal .alert.span2  { .alert-horizontal-columns(2);}
+.form-horizontal .alert.span3  { .alert-horizontal-columns(3);}
+.form-horizontal .alert.span4  { .alert-horizontal-columns(4);}
+.form-horizontal .alert.span5  { .alert-horizontal-columns(5);}
+.form-horizontal .alert.span6  { .alert-horizontal-columns(6);}
+.form-horizontal .alert.span7  { .alert-horizontal-columns(7);}
+.form-horizontal .alert.span8  { .alert-horizontal-columns(8);}
+.form-horizontal .alert.span9  { .alert-horizontal-columns(9);}
+.form-horizontal .alert.span10 { .alert-horizontal-columns(10);}
+.form-horizontal .alert.span11 { .alert-horizontal-columns(11);}
+.form-horizontal .alert.span12 { .alert-horizontal-columns(12);}

--- a/less/alerts.less
+++ b/less/alerts.less
@@ -67,3 +67,19 @@
 .alert-block p + p {
   margin-top: 5px;
 }
+
+
+// Span alert
+// ----------
+form .alert.span1  { .alert-columns(1);}
+form .alert.span2  { .alert-columns(2);}
+form .alert.span3  { .alert-columns(3);}
+form .alert.span4  { .alert-columns(4);}
+form .alert.span5  { .alert-columns(5);}
+form .alert.span6  { .alert-columns(6);}
+form .alert.span7  { .alert-columns(7);}
+form .alert.span8  { .alert-columns(8);}
+form .alert.span9  { .alert-columns(9);}
+form .alert.span10 { .alert-columns(10);}
+form .alert.span11 { .alert-columns(11);}
+form .alert.span12 { .alert-columns(12);}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -148,9 +148,15 @@
 .columns(@columns: 1) {
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
 }
-.alert-columns(@columns: 1) {
+.alert-inline-columns(@columns: 1) {
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) - 50;
   float: none;
+  margin-left:0;
+}
+.alert-horizontal-columns(@columns: 1) {
+  width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) - 50;
+  float: none;
+  margin-left: 160px;
 }
 .offset(@columns: 1) {
   margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2);

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -148,6 +148,10 @@
 .columns(@columns: 1) {
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
 }
+.alert-columns(@columns: 1) {
+  width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) - 50;
+  float: none;
+}
 .offset(@columns: 1) {
   margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2);
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -151,7 +151,7 @@
 .alert-inline-columns(@columns: 1) {
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) - 50;
   float: none;
-  margin-left:0;
+  margin-left: 0;
 }
 .alert-horizontal-columns(@columns: 1) {
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) - 50;


### PR DESCRIPTION
I just add span support for alert error inside form.

Example:

``` html
<div class="container">
    <div class="row">
        <div class="offet2 span8">
            <form novalidate class="form-horizontal well" method="post" action="#">
                <div class="control-group error">
                    <label class="required" for="input_text">Title</label>
                    <div class="controls">
                        <input type="text" id="input_text" required="required" class="span5" />
                    </div>
                </div>
                <div class="alert alert-error controls span5">
                    <a class="close" data-dismiss="alert">×</a>
                    <p>This value should not be blank</p>
                </div>
                <div class="control-group error">
                    <label class="required" for="textarea">Content</label>
                    <div class="controls">
                        <textarea id="textarea" class="span5"></textarea>
                    </div>
                </div>
                <div class="alert alert-error controls span5">
                    <a class="close" data-dismiss="alert">×</a>
                    <p>This value should not be blank</p>
                </div>
                <div class="well">
                    <input type="submit" value="Save" class="btn" />
                </div>
            </form>
        </div>
    </div>
</div>

```

Picture result:

![form example](http://img694.imageshack.us/img694/7397/capturedcran20120128170.jpg)
