### PR TITLE
[2.0-wip] update example layouts

### DIFF
--- a/examples/container-app.html
+++ b/examples/container-app.html
@@ -25,7 +25,7 @@
         text-align: center; /* center align it with the container */
       }
       .container {
-        width: 820px; /* downsize our container to make the content feel a bit tighter and more cohesive. NOTE: this removes two full columns from the grid, meaning you only go to 14 columns and not 16. */
+        width: 820px; /* downsize our container to make the content feel a bit tighter and more cohesive. NOTE: this removes two full columns from the grid, meaning you only go to 10 columns and not 12. */
       }
 
       /* The white background content wrapper */

--- a/examples/fluid-reverse.html
+++ b/examples/fluid-reverse.html
@@ -28,7 +28,7 @@
 
   <body>
 
-    <div class="navbar navbar-fixed">
+    <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="fluid-container">
           <a class="brand" href="#">Project name</a>
@@ -37,7 +37,7 @@
             <li><a href="#about">About</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>
-          <p class="pull-right">Logged in as <a href="#">username</a></p>
+          <p class="navbar-text pull-right">Logged in as <a href="#">username</a></p>
         </div>
       </div>
     </div>
@@ -45,24 +45,23 @@
     <div class="fluid-container sidebar-right">
       <div class="fluid-sidebar">
         <div class="well">
-          <h5>Sidebar</h5>
-          <ul>
+          <ul class="nav list">
+            <li class="nav-header">Sidebar</li>
+            <li class="active"><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+
+            <li class="nav-header">Sidebar</li>
             <li><a href="#">Link</a></li>
             <li><a href="#">Link</a></li>
             <li><a href="#">Link</a></li>
             <li><a href="#">Link</a></li>
-          </ul>
-          <h5>Sidebar</h5>
-          <ul>
             <li><a href="#">Link</a></li>
             <li><a href="#">Link</a></li>
+
+            <li class="nav-header">Sidebar</li>
             <li><a href="#">Link</a></li>
-            <li><a href="#">Link</a></li>
-            <li><a href="#">Link</a></li>
-            <li><a href="#">Link</a></li>
-          </ul>
-          <h5>Sidebar</h5>
-          <ul>
             <li><a href="#">Link</a></li>
             <li><a href="#">Link</a></li>
           </ul>

--- a/examples/fluid.html
+++ b/examples/fluid.html
@@ -28,7 +28,7 @@
 
   <body>
 
-    <div class="navbar navbar-fixed">
+    <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="fluid-container">
           <a class="brand" href="#">Project name</a>
@@ -37,7 +37,7 @@
             <li><a href="#about">About</a></li>
             <li><a href="#contact">Contact</a></li>
           </ul>
-          <p class="pull-right">Logged in as <a href="#">username</a></p>
+          <p class="navbar-text pull-right">Logged in as <a href="#">username</a></p>
         </div>
       </div>
     </div>
@@ -45,26 +45,25 @@
     <div class="fluid-container sidebar-left">
       <div class="fluid-sidebar">
         <div class="well side-nav">
-          <h5 class="nav-label">Sidebar</h5>
-          <ul class="nav-group">
-            <li class="active"><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-          </ul>
-          <h5 class="nav-label">Sidebar</h5>
-          <ul class="nav-group">
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
-          </ul>
-          <h5 class="nav-label">Sidebar</h5>
-          <ul class="nav-group">
-            <li><a class="nav-item" href="#">Link</a></li>
-            <li><a class="nav-item" href="#">Link</a></li>
+          <ul class="nav list">
+            <li class="nav-header">Sidebar</li>
+            <li class="active"><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+
+            <li class="nav-header">Sidebar</li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+
+            <li class="nav-header">Sidebar</li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
+            <li><a href="#">Link</a></li>
           </ul>
         </div>
       </div>
@@ -83,12 +82,12 @@
            <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
             <p><a class="btn" href="#">View details &raquo;</a></p>
           </div>
-          <div class="span5">
+          <div class="span4">
             <h2>Heading</h2>
              <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
             <p><a class="btn" href="#">View details &raquo;</a></p>
          </div>
-          <div class="span5">
+          <div class="span4">
             <h2>Heading</h2>
             <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
             <p><a class="btn" href="#">View details &raquo;</a></p>
@@ -104,12 +103,12 @@
            <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
             <p><a class="btn" href="#">View details &raquo;</a></p>
           </div>
-          <div class="span5">
+          <div class="span4">
             <h2>Heading</h2>
              <p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
             <p><a class="btn" href="#">View details &raquo;</a></p>
          </div>
-          <div class="span5">
+          <div class="span4">
             <h2>Heading</h2>
             <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
             <p><a class="btn" href="#">View details &raquo;</a></p>

--- a/examples/hero.html
+++ b/examples/hero.html
@@ -28,7 +28,7 @@
 
   <body>
 
-    <div class="navbar navbar-fixed">
+    <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
           <a class="brand" href="#">Project name</a>


### PR DESCRIPTION
Not sure what the plan is with the example layouts for 2.0, but some were a bit out of sync with the latest changes. This should bring them up to date.

Included changes:
- Navbar positioning on hero and fluid layouts
- Navbar text on fluid layouts
- Sidebar on fluid layouts now use ul.nav.list
- Fluid layout updated for 12 column grid
- Update css note on container app to reflect fewer columns
