### PR TITLE
2.0 wip typo in docs/base-css.html 

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1055,7 +1055,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
       <p>Bootstrap features styles for browser-supported focused and <code>disabled</code> states. We remove the default Webkit <code>outline</code> and apply a <code>box-shadow</code> in it's place for <code>:focus</code>.</p>
       <hr>
       <h3>Form validation</h3>
-      <p>It also includes validation styles for errors, warnings, and success. To use, add the a class to the surrounding <code>.control-group</code>.</p>
+      <p>It also includes validation styles for errors, warnings, and success. To use, add the error class to the surrounding <code>.control-group</code>.</p>
 <pre class="prettyprint linenums">
 &lt;fieldset
   class="control-group error"&gt;


### PR DESCRIPTION
Under the "Form validation" section in docs/base-css.html, the doc says:

To use, add the a class to the surrounding .control-group.

...
 class="control-group error"
…

Changed it to:
To use, add the error class to the surrounding .control-group.
