### PR TITLE
[2.0-wip] Added a dynamic source to typeahead, also updated docs + added unit test

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1384,9 +1384,9 @@ $('.myCarousel').carousel({
             <tbody>
               <tr>
                <td>source</td>
-               <td>array</td>
+               <td>array | function</td>
                <td>[ ]</td>
-               <td>The data source to query against.</td>
+               <td>The data source to query against. If using a function a "query" parameter is passed and an array is expected to be returned.</td>
              </tr>
              <tr>
                <td>items</td>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1412,6 +1412,12 @@ $('.myCarousel').carousel({
                <td>highlights all default matches</td>
                <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
              </tr>
+             <tr>
+               <td>onSelect</td>
+               <td>function</td>
+               <td></td>
+               <td>Event fired when an element is selected from within typeahead.</td>
+             </tr>
             </tbody>
           </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -29,6 +29,7 @@
     this.highlighter = this.options.highlighter || this.highlighter
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
+    this.onSelect = this.options.onSelect || this.onSelect
     this.shown = false
     this.listen()
   }
@@ -36,10 +37,13 @@
   Typeahead.prototype = {
 
     constructor: Typeahead
+  , onSelect: function() {
 
+  }
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
       this.$element.val(val)
+      this.onSelect(val);
       return this.hide()
     }
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -75,9 +75,20 @@
         return this.shown ? this.hide() : this
       }
 
-      items = $.grep(this.source, function (item) {
-        if (that.matcher(item)) return item
-      })
+      var isFunction = function (object) {
+        var getClass = {}.toString;
+        return object && getClass.call(object) == "[object Function]";
+      }
+
+      if(isFunction(this.source)) {
+        // run source and get items
+        items = this.source(this.query);
+
+      } else { // presume an array
+        items = $.grep(this.source, function (item) {
+          if (that.matcher(item)) return item
+        })
+      }
 
       items = this.sorter(items)
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -145,4 +145,25 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+
+      test("should set input value to selected item, and fire onSelect function", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac'],
+              onSelect: function(val) {
+                equals($input.val(), 'ac', 'input value was correctly set')
+              }
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        //equals($input.val(), 'ac', 'input value was correctly set')
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+
+        typeahead.$menu.remove()
+      })
 })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -125,4 +125,24 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+
+      test("should set input value to selected item, from a dynamic source", function () {
+        var $input = $('<input />').typeahead({
+              source: function(query) {
+                return ['aa', 'ab', 'ac'];
+              }
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac', 'input value was correctly set')
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+
+        typeahead.$menu.remove()
+      })
 })


### PR DESCRIPTION
I have added modified the lookup function to allow "source" to be a function (passing a query parameter) to allow dynamic a item array.

Also updated docs + added a unit test.

This addresses my own issue with typeahead and also issue 1336
