### PR TITLE
[2.0-wip] added missing nav- prefixes to docs

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -360,7 +360,7 @@
     </div>
     <div class="span4">
       <h3>Basic tabs</h3>
-      <p>Take a regular <code>&lt;ul&gt;</code> of links and add <code>.tabs</code>:</p>
+      <p>Take a regular <code>&lt;ul&gt;</code> of links and add <code>.nav-tabs</code>:</p>
       <ul class="nav nav-tabs">
         <li class="active"><a href="#">Home</a></li>
         <li><a href="#">Profile</a></li>
@@ -378,7 +378,7 @@
     </div>
     <div class="span4">
       <h3>Basic pills</h3>
-      <p>Take that same HTML, but use <code>.pills</code> instead:</p>
+      <p>Take that same HTML, but use <code>.nav-pills</code> instead:</p>
       <ul class="nav nav-pills">
         <li class="active"><a href="#">Home</a></li>
         <li><a href="#">Profile</a></li>
@@ -400,7 +400,7 @@
   <div class="row">
     <div class="span4">
       <h3>How to stack 'em</h3>
-      <p>As tabs and pills are horizontal by default, just add a second class, <code>.stacked</code>, to make them appear vertically stacked.</p>
+      <p>As tabs and pills are horizontal by default, just add a second class, <code>.nav-stacked</code>, to make them appear vertically stacked.</p>
     </div>
     <div class="span4">
       <h3>Stacked tabs</h3>
@@ -514,7 +514,7 @@
     </div>
     <div class="span4">
       <h3>Example nav list</h3>
-      <p>Take a list of links and add <code>class="nav list"</code>:</p>
+      <p>Take a list of links and add <code>class="nav nav-list"</code>:</p>
       <div class="well" style="padding: 8px 0;">
         <ul class="nav nav-list">
           <li class="nav-header">List header</li>
@@ -582,7 +582,7 @@
     </div>
     <div class="span4">
       <h3>Tabbable example</h3>
-      <p>To make tabs tabbable, wrap the <code>.tabs</code> in another div with class <code>.tabbable</code>.</p>
+      <p>To make tabs tabbable, wrap the <code>.nav-tabs</code> in another div with class <code>.tabbable</code>.</p>
       <div class="tabbable" style="margin-bottom: 9px;">
         <ul class="nav nav-tabs">
           <li class="active"><a href="#1" data-toggle="tab">Section 1</a></li>

--- a/docs/templates/pages/components.mustache
+++ b/docs/templates/pages/components.mustache
@@ -284,7 +284,7 @@
     </div>
     <div class="span4">
       <h3>{{_i}}Basic tabs{{/i}}</h3>
-      <p>{{_i}}Take a regular <code>&lt;ul&gt;</code> of links and add <code>.tabs</code>:{{/i}}</p>
+      <p>{{_i}}Take a regular <code>&lt;ul&gt;</code> of links and add <code>.nav-tabs</code>:{{/i}}</p>
       <ul class="nav nav-tabs">
         <li class="active"><a href="#">{{_i}}Home{{/i}}</a></li>
         <li><a href="#">{{_i}}Profile{{/i}}</a></li>
@@ -302,7 +302,7 @@
     </div>
     <div class="span4">
       <h3>{{_i}}Basic pills{{/i}}</h3>
-      <p>{{_i}}Take that same HTML, but use <code>.pills</code> instead:{{/i}}</p>
+      <p>{{_i}}Take that same HTML, but use <code>.nav-pills</code> instead:{{/i}}</p>
       <ul class="nav nav-pills">
         <li class="active"><a href="#">{{_i}}Home{{/i}}</a></li>
         <li><a href="#">{{_i}}Profile{{/i}}</a></li>
@@ -324,7 +324,7 @@
   <div class="row">
     <div class="span4">
       <h3>{{_i}}How to stack 'em{{/i}}</h3>
-      <p>{{_i}}As tabs and pills are horizontal by default, just add a second class, <code>.stacked</code>, to make them appear vertically stacked.{{/i}}</p>
+      <p>{{_i}}As tabs and pills are horizontal by default, just add a second class, <code>.nav-stacked</code>, to make them appear vertically stacked.{{/i}}</p>
     </div>
     <div class="span4">
       <h3>{{_i}}Stacked tabs{{/i}}</h3>
@@ -438,7 +438,7 @@
     </div>
     <div class="span4">
       <h3>{{_i}}Example nav list{{/i}}</h3>
-      <p>{{_i}}Take a list of links and add <code>class="nav list"</code>:{{/i}}</p>
+      <p>{{_i}}Take a list of links and add <code>class="nav nav-list"</code>:{{/i}}</p>
       <div class="well" style="padding: 8px 0;">
         <ul class="nav nav-list">
           <li class="nav-header">{{_i}}List header{{/i}}</li>
@@ -506,7 +506,7 @@
     </div>
     <div class="span4">
       <h3>{{_i}}Tabbable example{{/i}}</h3>
-      <p>{{_i}}To make tabs tabbable, wrap the <code>.tabs</code> in another div with class <code>.tabbable</code>.{{/i}}</p>
+      <p>{{_i}}To make tabs tabbable, wrap the <code>.nav-tabs</code> in another div with class <code>.tabbable</code>.{{/i}}</p>
       <div class="tabbable" style="margin-bottom: 9px;">
         <ul class="nav nav-tabs">
           <li class="active"><a href="#1" data-toggle="tab">{{_i}}Section 1{{/i}}</a></li>


### PR DESCRIPTION
The `components.html` was missing the recently added nav- prefix in a few places for tabs, pills and stackable.  This adds the prefix to the needed places. 
