### PR TITLE
[2.0-wip] Add form help text information to docs

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1155,7 +1155,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
                 <input type="checkbox" name="optionsCheckboxList3" value="option3">
                 Option three can&mdash;yes, you guessed it&mdash;also be checked and included in form results
               </label>
-              <p class="help-text"><strong>Note:</strong> Labels surround all the options for much larger click areas and a more usable form.</p>
+              <p class="help-block"><strong>Note:</strong> Labels surround all the options for much larger click areas and a more usable form.</p>
             </div>
           </div>
           <div class="control-group">
@@ -1188,6 +1188,9 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
       <hr>
       <h4>Inline forms and append/prepend</h4>
       <p>To use prepend or append inputs in an inline form, be sure to place the <code>.add-on</code> and <code>input</code> on the same line, without spaces.</p>
+      <hr>
+      <h4>Form help text</h4>
+      <p>To add help text for your form inputs, include inline help text with <code>&lt;span class="help-inline"&gt;</code> or a help text block with <code>&lt;p class="help-block"&gt;</code> after the input element.</p>
     </div>
   </div><!-- /row -->
 </section>

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -1079,7 +1079,7 @@
                 <input type="checkbox" name="optionsCheckboxList3" value="option3">
                 {{_i}}Option three can&mdash;yes, you guessed it&mdash;also be checked and included in form results{{/i}}
               </label>
-              <p class="help-text">{{_i}}<strong>Note:</strong> Labels surround all the options for much larger click areas and a more usable form.{{/i}}</p>
+              <p class="help-block">{{_i}}<strong>Note:</strong> Labels surround all the options for much larger click areas and a more usable form.{{/i}}</p>
             </div>
           </div>
           <div class="control-group">
@@ -1112,6 +1112,9 @@
       <hr>
       <h4>{{_i}}Inline forms and append/prepend{{/i}}</h4>
       <p>{{_i}}To use prepend or append inputs in an inline form, be sure to place the <code>.add-on</code> and <code>input</code> on the same line, without spaces.{{/i}}</p>
+      <hr>
+      <h4>{{_i}}Form help text{{/i}}</h4>
+      <p>{{_i}}To add help text for your form inputs, include inline help text with <code>&lt;span class="help-inline"&gt;</code> or a help text block with <code>&lt;p class="help-block"&gt;</code> after the input element.{{/i}}</p>
     </div>
   </div><!-- /row -->
 </section>


### PR DESCRIPTION
Adds another information block for forms describing the `help-inline` and `help-block` markup/classes for adding help text.
