### PR TITLE
[2.0-wip] Documentation: Typo in base-css.html

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -105,7 +105,7 @@
   <div class="row">
     <div class="span4">
       <h3>Typographic scale</h3>
-      <p>The entire typographic grid is based on two Less variables in our preboot.less file: <code>@baseFontSize</code> and <code>@baseLineHeight</code>. The first is the base font-size used throughout and the second is the base line-height.</p>
+      <p>The entire typographic grid is based on two Less variables in our variables.less file: <code>@baseFontSize</code> and <code>@baseLineHeight</code>. The first is the base font-size used throughout and the second is the base line-height.</p>
       <p>We use those variables, and some math, to create the margins, paddings, and line-heights of all our type and more.</p>
     </div>
     <div class="span4">


### PR DESCRIPTION
There is no "preboot.less" file in the repo. Should refer to "variables.less".
