### PR TITLE
[2.0-wip] Documentation: Typo in javascript.html

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1288,7 +1288,7 @@ $('#myCollapsible').on('hidden', function () {
                <td>interval</td>
                <td>number</td>
                <td>5000</td>
-               <td>The amount of type to delay between automatically cycling an item.</td>
+               <td>The amount of time to delay between automatically cycling an item.</td>
              </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Update docs/javascript.html - fix typo "The amount of type..." should say "The amount of time..."
