### PR TITLE
[2.0-wip] IE fixes

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -21,6 +21,7 @@
   @shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   .box-shadow(@shadow);
   cursor: pointer;
+  .reset-filter();
 
   // Give IE7 some love
   .ie7-restore-left-whitespace();

--- a/less/forms.less
+++ b/less/forms.less
@@ -112,7 +112,7 @@ select,
 input[type="file"] {
   height: 28px; /* In IE7, the height of the select element cannot be changed by height, only font-size */
   *margin-top: 4px; /* For IE7, add top margin to align select with labels */
-  line-height: 28px;
+  line-height: 18px;
 }
 
 // Chrome on Linux and Mobile Safari need background-color

--- a/less/forms.less
+++ b/less/forms.less
@@ -198,7 +198,6 @@ textarea:focus {
   @shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
   .box-shadow(@shadow);
   outline: 0;
-  outline: thin dotted \9; /* IE6-8 */
 }
 input[type="file"]:focus,
 input[type="checkbox"]:focus,


### PR DESCRIPTION
- Fix hover effect on default gray buttons in IE (one of the issues reported on #1358)
- Fix Issue #1424 - since the value of "outline: thin dotted \9; /\* IE6-8 */" was being matched also in IE9, it will be better not to show any focus effect
- Fix file input vertical alignment in IE
