### PR TITLE
Allow tooltips and popovers to position themselves correctly when used with svg elements. 

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -197,12 +197,12 @@
         var elementWidth, elementHeight;
         
         if ( e.nodeName == 'svg' ) {
-          var rect = this.$element[0].getBoundingClientRect();
+          var rect = e.getBoundingClientRect();
           elementWidth = rect.width;
           elementHeight = rect.height;
         } else {
-          elementWidth = this.$element[0].offsetWidth;
-          elementHeight = this.$element[0].offsetHeight;
+          elementWidth = e.offsetWidth;
+          elementHeight = e.offsetHeight;
         }
 
       return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -192,7 +192,7 @@
     }
 
   , getPosition: function (inside) {
-        e = this.$element[0];
+        var e = this.$element[0];
 
         var elementWidth, elementHeight;
         

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -192,9 +192,22 @@
     }
 
   , getPosition: function (inside) {
+        e = this.$element[0];
+
+        var elementWidth, elementHeight;
+        
+        if ( e.nodeName == 'svg' ) {
+          var rect = this.$element[0].getBoundingClientRect();
+          elementWidth = rect.width;
+          elementHeight = rect.height;
+        } else {
+          elementWidth = this.$element[0].offsetWidth;
+          elementHeight = this.$element[0].offsetHeight;
+        }
+
       return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
-        width: this.$element[0].offsetWidth
-      , height: this.$element[0].offsetHeight
+        width: elementWidth
+      , height: elementHeight
       })
     }
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -196,7 +196,7 @@
 
         var elementWidth, elementHeight;
         
-        if ( e.nodeName == 'svg' ) {
+        if ( e.getBoundingClientRect != undefined ) {
           var rect = e.getBoundingClientRect();
           elementWidth = rect.width;
           elementHeight = rect.height;


### PR DESCRIPTION
offsetWidth & offsetHeight don't work with svg elements.
This fix amends getPosition() so it uses getBoundingClientRect() when the tooltip is used with an svg element.
