### PR TITLE
Fixing path to jQuery in example starter template

### DIFF
--- a/examples/starter-template.html
+++ b/examples/starter-template.html
@@ -60,7 +60,7 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
-    <script src="../assets/js/tests/vendor/jquery.js"></script>
+    <script src="../assets/js/jquery.js"></script>
     <script src="../assets/js/bootstrap-transition.js"></script>
     <script src="../assets/js/bootstrap-alert.js"></script>
     <script src="../assets/js/bootstrap-modal.js"></script>


### PR DESCRIPTION
jQuery.js is under assets/js instead of assets/js/tests/vendor.
