### PR TITLE
Fix for #1473: Hovered nav list active link

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -54,6 +54,9 @@
   text-shadow: 0 -1px 0 rgba(0,0,0,.2);
   background-color: @linkColor;
 }
+.nav-list .active > a:hover {
+  background-color: @linkColorHover;
+}
 .nav-list .icon {
   margin-right: 2px;
 }


### PR DESCRIPTION
This patch fixes the unreadable `.nav-item .active` background issue described in #1473; it uses `@linkColorHover` instead of `#eee` on active items.
