### PR TITLE
fix .nav-list .active item not retaining @linkColor on :hover

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -49,7 +49,8 @@
 .nav-list > li + .nav-header {
   margin-top: 9px;
 }
-.nav-list .active > a {
+.nav-list .active > a,
+.nav-list .active > a:hover {
   color: @white;
   text-shadow: 0 -1px 0 rgba(0,0,0,.2);
   background-color: @linkColor;


### PR DESCRIPTION
Fixes #1473 by making .nav-list .active keep its usual background color on hover.
