### PR TITLE
Allow labels to be links

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -14,3 +14,7 @@
 .label-warning   { background-color: @orange; }
 .label-success   { background-color: @successText; }
 .label-info      { background-color: @infoText; }
+.label:hover {
+  color: @white;
+  text-decoration: none;
+}


### PR DESCRIPTION
This fixes hover color and text-decoration for labels that are links:

```
<a href="#" class="label">Default</a>
```

Personally I like to use labels as show/edit/delete links for lists, usually inside table rows, as regular buttons are too big for this purpose. 

Plus I think there are other use cases too, like:

```
<a href="/inbox" class="label label-info">1 New Message</a>
```
