### PR TITLE
Added .css extension to compiled responsive CSS files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ bootstrap:
 	cp img/* bootstrap/img/
 	lessc ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
 	lessc --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap.responsive
-	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap.min.responsive
+	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap.responsive.css
+	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap.min.responsive.css
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.js
 


### PR DESCRIPTION
Not sure if this was an oversight in the Makefile or if it's intentional but the 2 compiled responsive CSS files don't have a ".css" extension.
