### PR TITLE
Fixing typo in Striped Tables section.

### DIFF
--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -524,7 +524,7 @@
   <div class="row">
     <div class="span4">
       <p>{{_i}}Get a little fancy with your tables by adding zebra-striping&mdash;just add the <code>.table-striped</code> class.{{/i}}</p>
-      <p class="muted">{{_i}}<strong>Note:</strong> Sprited tables use the <code>:nth-child</code> CSS selector and is not available in IE7-IE8.{{/i}}</p>
+      <p class="muted">{{_i}}<strong>Note:</strong> Striped tables use the <code>:nth-child</code> CSS selector and is not available in IE7-IE8.{{/i}}</p>
 <pre class="prettyprint linenums" style="margin-bottom: 18px;">
 &lt;table class="table table-striped"&gt;
   …


### PR DESCRIPTION
"Sprited" changed to "Striped". Trivial.
