### PR TITLE
Fix small in bootstrap

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -28,6 +28,10 @@ legend {
   color: @grayDark;
   border: 0;
   border-bottom: 1px solid #eee;
+  small {
+    font-size: @baseFontSize - 2;
+    color: @grayLight;
+  }
 }
 
 // Set font for forms

--- a/less/modals.less
+++ b/less/modals.less
@@ -30,7 +30,7 @@
   top: 50%;
   left: 50%;
   z-index: @zindexModal;
-  max-height: 500px;
+  max-height: 90%;
   overflow: auto;
   width: 560px;
   margin: -250px 0 0 -280px;

--- a/less/type.less
+++ b/less/type.less
@@ -47,7 +47,7 @@ h2 {
   font-size: 24px;
   line-height: @baseLineHeight * 2;
   small {
-    font-size: 18px;
+    font-size: 16px;
   }
 }
 h3 {


### PR DESCRIPTION
Small support for legend. Small h2 should be 16 px and not the same as h1 (18px).
