### PR TITLE
Fixed simple grammatical errors. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To get started -- checkout http://twitter.github.com/bootstrap!
 Versioning
 ----------
 
-For transparency and insight into our release cycle, and for striving to maintain backwards compatibility, Bootstrap will be maintained under the Semantic Versioning guidelines as much as possible.
+For transparency and insight into our release cycle, and for striving to maintain backward compatibility, Bootstrap will be maintained under the Semantic Versioning guidelines as much as possible.
 
 Releases will be numbered with the follow format:
 
@@ -17,8 +17,8 @@ Releases will be numbered with the follow format:
 
 And constructed with the following guidelines:
 
-* Breaking backwards compatibility bumps the major
-* New additions without breaking backwards compatibility bumps the minor
+* Breaking backward compatibility bumps the major
+* New additions without breaking backward compatibility bumps the minor
 * Bug fixes and misc changes bump the patch
 
 For more information on SemVer, please visit http://semver.org/.


### PR DESCRIPTION
http://grammar.quickanddirtytips.com/backward-versus-backwards.aspx

Backwards is never used as an adjective

More info:

Backwards is only used as an adverb in the United Kingdom.
If in the United States, only backward should be used, at all times.
