### PR TITLE
Fixed typo in button test message

### DIFF
--- a/js/tests/unit/bootstrap-button.js
+++ b/js/tests/unit/bootstrap-button.js
@@ -3,7 +3,7 @@ $(function () {
     module("bootstrap-buttons")
 
       test("should be defined on jquery object", function () {
-        ok($(document.body).button, 'tabs method is defined')
+        ok($(document.body).button, 'button method is defined')
       })
 
       test("should return element", function () {


### PR DESCRIPTION
"tabs" ==> "button"
