### PR TITLE
Wrap long breadcrumb trails

### DIFF
--- a/less/breadcrumbs.less
+++ b/less/breadcrumbs.less
@@ -9,7 +9,7 @@
   .border-radius(3px);
   .box-shadow(inset 0 1px 0 @white);
   li {
-    display: inline;
+    display: inline-block;
     text-shadow: 0 1px 0 @white;
   }
   .divider {


### PR DESCRIPTION
When breadcrumbs trails become too long, they should wrap to the next line rather than extending beyond the page.
The current implementation works correctly in FF, but not Chrome.

Example: http://imgur.com/a/uDL9n#MY4Mz
I'm using breadcrumbs inside a dialog window.
