### PR TITLE
Fix legend margin collapse across all (most) browsers

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -22,7 +22,6 @@ legend {
   display: block;
   width: 100%;
   padding: 0;
-  margin-bottom: @baseLineHeight * 1.5;
   font-size: @baseFontSize * 1.5;
   line-height: @baseLineHeight * 2;
   color: @grayDark;
@@ -483,15 +482,18 @@ select:focus:required:invalid {
   margin-bottom: @baseLineHeight / 2;
 }
 
+form {
+  // Legend collapses margin on webkit, so set margin on first control-group
+  legend + .control-group {
+    margin-top: @baseLineHeight * 1.5;
+    -webkit-margin-top-collapse: separate;
+  }
+}
+
 // Horizontal-specific styles
 // --------------------------
 
 .form-horizontal {
-  // Legend collapses margin, so we're relegated to padding
-  legend + .control-group {
-    margin-top: @baseLineHeight;
-    -webkit-margin-top-collapse: separate;
-  }
   // Increase spacing between groups
   .control-group {
     margin-bottom: @baseLineHeight;


### PR DESCRIPTION
On webkit, legends collapse margins, which d8e1001836f869436df2de2905411b2236c8cbad addresses.  However, on browsers that don't do this, that fix creates ~double margin between the legend and first control-group.  My solution is to never set margin on the legend, and instead always set it on the very next .control-group.  Should work in every browser that supports the adjacent sibling selector, which is all except ie6, I believe.

Also, that fix only applied to horizontal forms, I applied the styles to all forms, as they're all affected by this.
