### PR TITLE
Inline form in form examples has class .form-search

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -886,7 +886,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
       <p>Inputs are block level to start. For <code>.form-inline</code> and <code>.form-horizontal</code>, we use inline-block.</p>
     </div>
     <div class="span9">
-      <form class="well form-search">
+      <form class="well form-inline">
         <input type="text" class="input-small" placeholder="Email">
         <input type="password" class="input-small" placeholder="Password">
         <button type="submit" class="btn">Go</button>

--- a/docs/components.html
+++ b/docs/components.html
@@ -605,7 +605,7 @@
     <div class="span4">
       <h3>Custom jQuery plugin</h3>
       <p>All tabbable tabs are powered by our lightweight jQuery plugin. Read more about how to bring tabbable tabs to life on the javascript docs page.</p>
-      <p><a class="btn" href="./javascript.html/#tabs">Get the javascript &rarr;</a></p>
+      <p><a class="btn" href="./javascript.html#tabs">Get the javascript &rarr;</a></p>
     </div>
   </div>
 

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -810,7 +810,7 @@
       <p>{{_i}}Inputs are block level to start. For <code>.form-inline</code> and <code>.form-horizontal</code>, we use inline-block.{{/i}}</p>
     </div>
     <div class="span9">
-      <form class="well form-search">
+      <form class="well form-inline">
         <input type="text" class="input-small" placeholder="{{_i}}Email{{/i}}">
         <input type="password" class="input-small" placeholder="{{_i}}Password{{/i}}">
         <button type="submit" class="btn">{{_i}}Go{{/i}}</button>

--- a/docs/templates/pages/components.mustache
+++ b/docs/templates/pages/components.mustache
@@ -529,7 +529,7 @@
     <div class="span4">
       <h3>{{_i}}Custom jQuery plugin{{/i}}</h3>
       <p>{{_i}}All tabbable tabs are powered by our lightweight jQuery plugin. Read more about how to bring tabbable tabs to life on the javascript docs page.{{/i}}</p>
-      <p><a class="btn" href="./javascript.html/#tabs">{{_i}}Get the javascript &rarr;{{/i}}</a></p>
+      <p><a class="btn" href="./javascript.html#tabs">{{_i}}Get the javascript &rarr;{{/i}}</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
Hello

I'm not quite sure if this is intended, as it makes no seemingly visual difference, but I would guess that either .form-inline or .form-horizontal was meant to be used in the example?
