### PR TITLE
Fixed escaping of single quote in Unit test. 

### DIFF
--- a/js/tests/unit/bootstrap-alert.js
+++ b/js/tests/unit/bootstrap-alert.js
@@ -13,7 +13,7 @@ $(function () {
       test("should fade element out on clicking .close", function () {
         var alertHTML = '<div class="alert-message warning fade in">'
           + '<a class="close" href="#" data-dismiss="alert">×</a>'
-          + '<p><strong>Holy guacamole!</strong> Best check yo self, you're not looking too good.</p>'
+          + '<p><strong>Holy guacamole!</strong> Best check yo self, you\'re not looking too good.</p>'
           + '</div>'
           , alert = $(alertHTML).alert()
 
@@ -27,7 +27,7 @@ $(function () {
 
         var alertHTML = '<div class="alert-message warning fade in">'
           + '<a class="close" href="#" data-dismiss="alert">×</a>'
-          + '<p><strong>Holy guacamole!</strong> Best check yo self, you're not looking too good.</p>'
+          + '<p><strong>Holy guacamole!</strong> Best check yo self, you\'re not looking too good.</p>'
           + '</div>'
           , alert = $(alertHTML).appendTo('#qunit-fixture').alert()
 


### PR DESCRIPTION
A very small contribution. 
There was an escaping problem with the bootstrap-alert.js unit test. This was causing a JS failure. 
