### PR TITLE
Minor typo: Success-label was 'New', should be 'Success'

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1091,7 +1091,7 @@
           <span class="label label-success">Success</span>
         </td>
         <td>
-          <code>&lt;span class="label label-success"&gt;New&lt;/span&gt;</code>
+          <code>&lt;span class="label label-success"&gt;Success&lt;/span&gt;</code>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
In the Label-section of the Components documentation, there is a small inconsistency. Each label class is shown with a rendered label and a markup example. The markup example for the Success label shows the text 'New' but the rendered label shows 'Success'. 
