### PR TITLE
MakeFile .PHONY Points to Non-Existent 'dist' Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,4 @@ watch:
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 
-.PHONY: dist docs watch gh-pages
+.PHONY: bootstrap docs watch gh-pages


### PR DESCRIPTION
In the MakeFile's .PHONY section, there is a reference to a `dist` target which doesn't exist. I assumed this was supposed to point to the `bootstrap` target and updated the file accordningly.
