### PR TITLE
Added tooltips to upgrading doc

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -741,7 +741,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                <td>title</td>
                <td>string | function</td>
                <td>''</td>
-               <td>default title value if `title` tag isn't present</td>
+               <td>default title value if `data-original-title` isn't present</td>
              </tr>
              <tr>
                <td>trigger</td>
@@ -767,6 +767,9 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           </div>
           <h3>Markup</h3>
           <p>For performance reasons, the Tooltip and Popover data-apis are opt in. If you would like to use them just specify a selector option.</p>
+          <pre class="prettyprint linenums">
+          &lt;a href="#" rel="tooltip" data-original-title="first tooltip"&gt;hover over me&lt;/a&gt;
+
           <h3>Methods</h3>
           <h4>$().tooltip(options)</h4>
           <p>Attaches a tooltip handler to an element collection.</p>

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -252,7 +252,9 @@
     so you can't use that for your own purposes.
     <li>The <code>tooltip()</code> method now uses the <code>tooltip</code> class name, so you can't use that for your own purposes.
     <li>The <code>tooltip()</code> method now looks for <code>data-original-title</code> for the default tooltip text.
-    <li>The placement option that was <code>below</code> is now <code>bottom</code>.
+    <li>The <code>placement</code> option value that was <code>below</code> is now <code>bottom</code>.
+    <li>The <code>animate</code> option was renamed to <code>animation</code>.
+    <li>The <code>html</code> option was removed.
   </ul>
   <h3>Popovers</h3>
   <ul>

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -245,6 +245,15 @@
   <div class="alert alert-info">
     <strong>Heads up!</strong> We're rewritten just about everything for our plugins, so head on over to <a href="./javascript.html">the Javascript page</a> to learn more.
   </div>
+  <h3>Tooltips</h3>
+  <ul>
+    <li>The plugin method has been renamed from <code>twipsy()</code> to <code>tooltip()</code>.
+    <li>The <code>tooltip()</code> method assigns a <code>data-tooltip</code> attribute to store its internal instance,
+    so you can't use that for your own purposes.
+    <li>The <code>tooltip()</code> method now uses the <code>tooltip</code> class name, so you can't use that for your own purposes.
+    <li>The <code>tooltip()</code> method now looks for <code>data-original-title</code> for the default tooltip text.
+    <li>The placement option that was <code>below</code> is now <code>bottom</code>.
+  </ul>
   <h3>Popovers</h3>
   <ul>
     <li>Child elements now properly namespaced: <code>.title</code> to <code>.popover-title</code>, <code>.inner</code> to <code>.popover-inner</code>, and <code>.content</code> to <code>.popover-content</code>.</li>


### PR DESCRIPTION
I ran into several issues while upgrading tooltips that required more than just checking out the docs, because I used conventions that tooltip() itself now uses, like a data-tooltip attribute and a tooltip class attribute. (And using the wrong placement option bugged out in a weird way). So I thought it wouldn't hurt to add a tooltip upgrade section. Take a look. Thanks!
