### PR TITLE
No more secondary class for buttons, added to upgrade doc.

### DIFF
--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -149,6 +149,7 @@
   <h3>Buttons</h3>
   <ul>
     <li>New classes for colors and sizes, all prefixed with <code>.btn-</code></li>
+    <li>The "secondary" class was removed.
     <li>IE9: removed gradients and added rounded corners</li>
     <li>Updated active state to make styling clearer in button groups (new) and look better with custom transition</li>
     <li>New mixin, <code>.buttonBackground</code>, to set button gradients</li>


### PR DESCRIPTION
 Don't remember what it did in the old version..is there a semantic replacement?
