### PR TITLE
Removed control-label class from docs code. 

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -903,14 +903,14 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
         <fieldset>
           <legend>Controls Bootstrap supports</legend>
           <div class="control-group">
-            <label class="control-label" for="input01">Text input</label>
+            <label for="input01">Text input</label>
             <div class="controls">
               <input type="text" class="input-xlarge" id="input01">
               <p class="help-block">In addition to freeform text, any HTML5 text-based input appears like so.</p>
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="optionsCheckbox">Checkbox</label>
+            <label for="optionsCheckbox">Checkbox</label>
             <div class="controls">
               <label class="checkbox">
                 <input type="checkbox" id="optionsCheckbox" value="option1">
@@ -919,7 +919,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="select01">Select list</label>
+            <label for="select01">Select list</label>
             <div class="controls">
               <select id="select01">
                 <option>something</option>
@@ -931,7 +931,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="multiSelect">Multicon-select</label>
+            <label for="multiSelect">Multicon-select</label>
             <div class="controls">
               <select multiple="multiple" id="multiSelect">
                 <option>1</option>
@@ -943,13 +943,13 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="fileInput">File input</label>
+            <label for="fileInput">File input</label>
             <div class="controls">
               <input class="input-file" id="fileInput" type="file">
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="textarea">Textarea</label>
+            <label for="textarea">Textarea</label>
             <div class="controls">
               <textarea class="input-xlarge" id="textarea" rows="3"></textarea>
             </div>
@@ -987,25 +987,25 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
         <fieldset>
           <legend>Form control states</legend>
           <div class="control-group">
-            <label class="control-label" for="focusedInput">Focused input</label>
+            <label for="focusedInput">Focused input</label>
             <div class="controls">
               <input class="input-xlarge focused" id="focusedInput" type="text" value="This is focused…">
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label">Uneditable input</label>
+            <label>Uneditable input</label>
             <div class="controls">
               <span class="input-xlarge uneditable-input">Some value here</span>
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="disabledInput">Disabled input</label>
+            <label for="disabledInput">Disabled input</label>
             <div class="controls">
               <input class="input-xlarge disabled" id="disabledInput" type="text" placeholder="Disabled input here…" disabled>
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="optionsCheckbox2">Disabled checkbox</label>
+            <label for="optionsCheckbox2">Disabled checkbox</label>
             <div class="controls">
               <label class="checkbox">
                 <input type="checkbox" id="optionsCheckbox2" value="option1" disabled>
@@ -1014,28 +1014,28 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group warning">
-            <label class="control-label" for="inputWarning">Input with warning</label>
+            <label for="inputWarning">Input with warning</label>
             <div class="controls">
               <input type="text" id="inputWarning">
               <span class="help-inline">Something may have gone wrong</span>
             </div>
           </div>
           <div class="control-group error">
-            <label class="control-label" for="inputError">Input with error</label>
+            <label for="inputError">Input with error</label>
             <div class="controls">
               <input type="text" id="inputError">
               <span class="help-inline">Please correct the error</span>
             </div>
           </div>
           <div class="control-group success">
-            <label class="control-label" for="inputSuccess">Input with success</label>
+            <label for="inputSuccess">Input with success</label>
             <div class="controls">
               <input type="text" id="inputSuccess">
               <span class="help-inline">Woohoo!</span>
             </div>
           </div>
           <div class="control-group success">
-            <label class="control-label" for="selectError">Select with success</label>
+            <label for="selectError">Select with success</label>
             <div class="controls">
               <select id="selectError">
                 <option>1</option>
@@ -1077,7 +1077,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
         <fieldset>
           <legend>Extending form controls</legend>
           <div class="control-group">
-            <label class="control-label">Form sizes</label>
+            <label>Form sizes</label>
             <div class="controls docs-input-sizes">
               <input class="span1" type="text" placeholder=".span1">
               <input class="span2" type="text" placeholder=".span2">
@@ -1107,7 +1107,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="prependedInput">Prepended text</label>
+            <label for="prependedInput">Prepended text</label>
             <div class="controls">
               <div class="input-prepend">
                 <span class="add-on">@</span>
@@ -1117,7 +1117,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="appendedInput">Appended text</label>
+            <label for="appendedInput">Appended text</label>
             <div class="controls">
               <div class="input-append">
                 <input class="span2" id="appendedInput" size="16" type="text">
@@ -1127,7 +1127,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="inlineCheckboxes">Inline checkboxes</label>
+            <label for="inlineCheckboxes">Inline checkboxes</label>
             <div class="controls">
               <label class="checkbox inline">
                 <input type="checkbox" id="inlineCheckbox1" value="option1"> 1
@@ -1141,7 +1141,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="optionsCheckboxList">Checkboxes</label>
+            <label for="optionsCheckboxList">Checkboxes</label>
             <div class="controls">
               <label class="checkbox">
                 <input type="checkbox" name="optionsCheckboxList1" value="option1">
@@ -1159,7 +1159,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label">Radio buttons</label>
+            <label>Radio buttons</label>
             <div class="controls">
               <label class="radio">
                 <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
@@ -1530,7 +1530,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
     <div class="span4">
       <form>
         <div class="control-group">
-          <label class="control-label" for="inputIcon">Email address</label>
+          <label for="inputIcon">Email address</label>
           <div class="controls">
             <div class="input-prepend">
               <span class="add-on"><i class="icon-envelope"></i></span>


### PR DESCRIPTION
As far as I can tell there's no CSS associated with it. And it's not mentioned in docs.
