### PR TITLE
Add meta viewport to docs, examples (hero, fluid)

### DIFF
--- a/docs/examples/fluid.html
+++ b/docs/examples/fluid.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Bootstrap, from Twitter</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
 

--- a/docs/examples/hero.html
+++ b/docs/examples/hero.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Bootstrap, from Twitter</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
 

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -356,6 +356,7 @@
           </tr>
         </tbody>
       </table>
+      <p>To make sure that devices display your responsive pages properly, you'll want to add the viewport meta tag to your page: <code>&lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;</code>.</p>
 
       <h3>What they do</h3>
       <p>Media queries allow for custom CSS based on a number of conditions&mdash;ratios, widths, display type, etc&mdash;but usually focuses around <code>min-width</code> and <code>max-width</code>.</p>


### PR DESCRIPTION
Addressing issues #1683 and #1624, this pull request adds the viewport meta tag to the examples so that the pages will render properly on smaller-screened devices.
