### PR TITLE
Fixed colors for warnings in docs/less.html

### DIFF
--- a/docs/less.html
+++ b/docs/less.html
@@ -348,13 +348,13 @@
         <tbody>
           <tr>
             <td class="span3"><code>@warningText</code></td>
-            <td>#f3edd2</td>
-            <td class="swatch-col"><span class="swatch" style="background-color: #f3edd2;"></span></td>
+            <td>#c09853</td>
+            <td class="swatch-col"><span class="swatch" style="background-color: #c09853;"></span></td>
           </tr>
           <tr>
             <td><code>@warningBackground</code></td>
-            <td>#c09853</td>
-            <td><span class="swatch" style="background-color: #c09853;"></span></td>
+            <td>#fcf8e3</td>
+            <td><span class="swatch" style="background-color: #fcf8e3;"></span></td>
           </tr>
           <tr>
             <td><code>@errorText</code></td>


### PR DESCRIPTION
Fixed the colors for `@warningText` and `@warningBackground` in the docs to match the colors defined in `less/variables.less`.
