### PR TITLE
Fixed user icon button example in docs/base-css.html

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1495,7 +1495,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
           <a class="btn" href="#"><i class="icon-align-justify"></i></a>
         </div>
         <div class="btn-group">
-          <a class="btn btn-primary" href="#"><i class="icon white user"></i> User</a>
+          <a class="btn btn-primary" href="#"><i class="icon-user icon-white"></i> User</a>
           <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><a href="#"><i class="icon-pencil"></i> Edit</a></li>


### PR DESCRIPTION
The example user button with a dropdown does not display the icon currently because the markup uses the wrong classes.
