### PR TITLE
Added box model: "box-sizing: border-box;"  to thumbnail class

### DIFF
--- a/less/thumbnails.less
+++ b/less/thumbnails.less
@@ -17,6 +17,10 @@
   border: 1px solid #ddd;
   .border-radius(4px);
   .box-shadow(0 1px 1px rgba(0,0,0,.075));
+  /* Box Model >IE8, Sorry no IE7 */
+  -webkit-box-sizing: border-box; 
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 // Add a hover state for linked versions only
 a.thumbnail:hover {


### PR DESCRIPTION
This workarround lets you put images at 100% width without overflowing the grid with:
.-the 4px padding plus
.-the 1px border.

Now works everywhere except IE7 and older.
http://caniuse.com/css3-boxsizing
