### PR TITLE
Adding tooltip example to javascript docs.

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -697,6 +697,9 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           </div>
           <h3>{{_i}}Markup{{/i}}</h3>
           <p>{{_i}}For performance reasons, the Tooltip and Popover data-apis are opt in. If you would like to use them just specify a selector option.{{/i}}</p>
+<pre class="prettyprint linenums">
+&lt;a href="#" rel="tooltip" title="first tooltip"&gt;{{_i}}hover over me{{/i}}&lt;/a&gt;
+</pre>
           <h3>{{_i}}Methods{{/i}}</h3>
           <h4>$().tooltip({{_i}}options{{/i}})</h4>
           <p>{{_i}}Attaches a tooltip handler to an element collection.{{/i}}</p>


### PR DESCRIPTION
 It's particularly helpful to show the starting HTML for tooltips, as inspecting the source will show post-processed HTML with data-original-title attributes and may confuse folks (where folks=me :).
