### PR TITLE
Documentation bug for javascript buttons

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -923,7 +923,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
             <h4 class="alert-heading">Oh snap! You got an error!</h4>
             <p>Change this and that and try again. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum.</p>
             <p>
-              <a class="btn btn-danger small" href="#">Take this action</a> <a class="btn small" href="#">Or do this</a>
+              <a class="btn btn-danger btn-small" href="#">Take this action</a> <a class="btn btn-small" href="#">Or do this</a>
             </p>
           </div>
           <hr>


### PR DESCRIPTION
fixed a little css class bug in the javascript buttons docs. Replaced `small` with `btn-small`
