### PR TITLE
Don't show tooltip/popover if leave event occurs before delay expires

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -74,9 +74,10 @@
         self.show()
       } else {
         self.hoverState = 'in'
-        setTimeout(function() {
+        self.delayedShow = setTimeout(function() {
           if (self.hoverState == 'in') {
             self.show()
+            self.delayedShow = undefined
           }
         }, self.options.delay.show)
       }
@@ -84,6 +85,11 @@
 
   , leave: function ( e ) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
+
+      if (self.delayedShow) {
+        clearTimeout(self.delayedShow)
+        return
+      }
 
       if (!self.options.delay || !self.options.delay.hide) {
         self.hide()


### PR DESCRIPTION
Setting the delay to 1 second on a tooltip or popover means "don't show this tip unless the 'enter' event persists for 1 second straight". Currently, it just means whenever an enter event occurs, show the tip 1 second later no matter what. This can cause a lot of tooltip flashing that make no sense.

This change clears the setTimeout to show the tip if the hide event occurs before the delayed tip has shown.
