### PR TITLE
Navbar needs a @navbarBackgroundHover

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -194,7 +194,7 @@
 }
 // Hover
 .navbar .nav > li > a:hover {
-  background-color: transparent;
+  background-color: @navbarLinkBackgroundColorHover;
   color: @navbarLinkColorHover;
   text-decoration: none;
 }
@@ -205,7 +205,6 @@
   color: @navbarLinkColorHover;
   text-decoration: none;
   background-color: @navbarBackground;
-  background-color: rgba(0,0,0,.5);
 }
 
 // Dividers (basically a vertical hr)


### PR DESCRIPTION
Actually navbar background color is transparent for hover state.

```
.navbar .nav > li > a:hover {
    background-color: transparent;
    color: @navbarLinkColorHover;
    text-decoration: none;
  }
```

 For a better control/customization please add a @navbarBackgroundHover color definition...

However i'm not sure if it's more consistent to have a @navbarBackgroundHover (same pattern as @navbarBackgroundHighlight),  or a @navbarLinkBackgroundColorHover as it's more close to what it is really... 
