### PR TITLE
Alert dismissal change

### DIFF
--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -54,7 +54,7 @@
       $parent.removeClass('in')
 
       function removeElement() {
-        $parent.remove()
+        $parent.hide()
         $parent.trigger('closed')
       }
 


### PR DESCRIPTION
Changed the alert dismissal from remove() to hide(). It's kind of wonky if one wants to show that alert again and it's completely missing from the DOM.
