### PR TITLE
Column width of the tablet-landscape grid is 42px, not 44px.

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -339,7 +339,7 @@
           <tr>
             <td>Landscape tablets</td>
             <td>768px to 980px</td>
-            <td>44px</td>
+            <td>42px</td>
             <td>20px</td>
           </tr>
           <tr>


### PR DESCRIPTION
Updated the documentation on the page to indicate the correct 42px width vs. the incorrect 44px width shown in the responsive section of the page.
