### PR TITLE
Properly align buttons (including btn-navbar) in the navbar for custom heights

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -78,7 +78,7 @@
   // Buttons in navbar
   .btn,
   .btn-group {
-    margin-top: 5px; // make buttons vertically centered in navbar
+    margin-top: (@navbarHeight - 30px) / 2;
   }
   .btn-group .btn {
     margin-top: 0;


### PR DESCRIPTION
Buttons within the navbar are given a static top margin value of 5px, which assumes that the navbar has a height of 40px. Changing the height of the navbar results in buttons that are not vertically aligned.

This patch still hard-codes the assumed button height, which I dislike, but I don't see it as any worse than hardcoding the margin for 40px assumed height of the navbar.
