### PR TITLE
Fix for tooltips made from empty title string

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -206,6 +206,8 @@
       title = $e.attr('data-original-title')
         || (typeof o.title == 'function' ? o.title.call($e[0]) :  o.title)
 
+      if (!title) title = '';
+      
       title = title.toString().replace(/(^\s*|\s*$)/, "")
 
       return title


### PR DESCRIPTION
If you create a tooltip from an element with an empty title attribute (<td title="">), the code will error on line 209 with "Cannot call method toString from undefined". That's because 'data-original-attribute' is an empty string at that point, which evaluates to false, and it doesn't find a title in options. I put in a simple fix but you could put in a better one.
