### PR TITLE
Corrected punctuation and typo in JavaScript docs

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -134,7 +134,7 @@
         <div class="span3">
           <label>
             <h3><a href="./javascript.html#tooltips">Tooltips</a></h3>
-            <p>A new take on the jQuery Tipsy plugin, Tooltips don't rely on images, uss CSS3 for animations, and data-attributes for local title storage.</p>
+            <p>A new take on the jQuery Tipsy plugin. Tooltips don't rely on images, use CSS3 for animations, and data-attributes for local title storage.</p>
           </label>
         </div>
         <div class="span3">


### PR DESCRIPTION
Sorry about last pull request... github's editor didn't work as expected.
