### PR TITLE
Apply webkit margin-bottom fix for legends to non-horizontal forms as well

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -28,6 +28,12 @@ legend {
   color: @grayDark;
   border: 0;
   border-bottom: 1px solid #eee;
+  
+  // Legend collapses margin, so we need to move margin to following element
+  + .control-group {
+    margin-top: @baseLineHeight;
+    -webkit-margin-top-collapse: separate;
+  }
 }
 
 // Set font for forms
@@ -487,11 +493,6 @@ select:focus:required:invalid {
 // --------------------------
 
 .form-horizontal {
-  // Legend collapses margin, so we're relegated to padding
-  legend + .control-group {
-    margin-top: @baseLineHeight;
-    -webkit-margin-top-collapse: separate;
-  }
   // Increase spacing between groups
   .control-group {
     margin-bottom: @baseLineHeight;


### PR DESCRIPTION
Because `margin-bottom` always collapses on `legend` elements in webkit, the element following the `legend` must be responsible for vertical spacing.  A fix for this had already been applied in bootstrap for `.form-horizontal` forms, but stacked forms don't benefit from that.

This pull request simply moves the fix out of the `.form-horizontal` specific styling, and applies it to all `.control-group` elements that immediately follow a `legend`.
