### PR TITLE
webkit legend margin fix for non-horizontal forms

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -459,15 +459,16 @@ select:focus:required:invalid {
   margin-bottom: @baseLineHeight / 2;
 }
 
+// Legend collapses margin, so next element is responsible for spacing
+legend + .control-group {
+  margin-top: @baseLineHeight;
+  -webkit-margin-top-collapse: separate;
+}
+
 // Horizontal-specific styles
 // --------------------------
 
 .form-horizontal {
-  // Legend collapses margin, so we're relegated to padding
-  legend + .control-group {
-    margin-top: @baseLineHeight;
-    -webkit-margin-top-collapse: separate;
-  }
   // Increase spacing between groups
   .control-group {
     margin-bottom: @baseLineHeight;


### PR DESCRIPTION
Because margin-bottom always collapses on legend elements in webkit, the element following the legend must be responsible for vertical spacing. A fix for this had already been applied in bootstrap for .form-horizontal forms, but stacked forms don't benefit from that.

This pull request simply moves the fix out of the .form-horizontal specific styling, and applies it to all .control-group elements that immediately follow a legend.
