### PR TITLE
Fix IE bug in the docs.css for "docked" sub navbar in fixed position.

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -190,6 +190,7 @@ hr.soften {
     -webkit-box-shadow: inset 0 1px 0 #fff, 0 1px 5px rgba(0,0,0,.1);
        -moz-box-shadow: inset 0 1px 0 #fff, 0 1px 5px rgba(0,0,0,.1);
             box-shadow: inset 0 1px 0 #fff, 0 1px 5px rgba(0,0,0,.1);
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false); /* IE6-9 */
   }
   .subnav-fixed .nav {
     width: 938px;


### PR DESCRIPTION
Added an overriding filter: progid:DXImageTransform.Microsoft.gradient(enabled=false) to the .subnav-fixed class that fixes the bug caused on nav dropdown menus when "docked" in the fixed position.
