### PR TITLE
[2.0.1-wip] black/dark button

### DIFF
--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -1206,6 +1206,11 @@
         <td><code>.btn-danger</code></td>
         <td>{{_i}}Indicates a dangerous or potentially negative action{{/i}}</td>
       </tr>
+	  <tr>
+        <td><a class="btn btn-dark" href="#">{{_i}}Dark{{/i}}</a></td>
+        <td><code>.btn-dark</code></td>
+        <td>{{_i}}Indicates a potential abort or black magic{{/i}}</td>
+      </tr>
     </tbody>
   </table>
 

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -133,7 +133,8 @@
 .btn-primary,
 .btn-danger,
 .btn-info,
-.btn-success {
+.btn-success,
+.btn-dark {
   .caret {
     border-top-color: @white;
     .opacity(75);

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -107,7 +107,9 @@
 .btn-success,
 .btn-success:hover,
 .btn-info,
-.btn-info:hover {
+.btn-info:hover,
+.btn-dark,
+.btn-dark:hover {
   text-shadow: 0 -1px 0 rgba(0,0,0,.25);
   color: @white;
 }
@@ -116,7 +118,8 @@
 .btn-warning.active,
 .btn-danger.active,
 .btn-success.active,
-.btn-info.active {
+.btn-info.active,
+.btn-dark.active {
   color: rgba(255,255,255,.75);
 }
 
@@ -140,6 +143,10 @@
 // Info appears as a neutral blue
 .btn-info {
   .buttonBackground(#5bc0de, #2f96b4);
+}
+// Dark appears as black
+.btn-dark {
+  .buttonBackground(#454545, #262626);
 }
 
 


### PR DESCRIPTION
According to 
https://github.com/twitter/bootstrap/issues/1594
i've added a .btn.dark in the buttons.less and the docs to add a black button
