### PR TITLE
Patch 1

### DIFF
--- a/templates/pages/components.mustache
+++ b/templates/pages/components.mustache
@@ -1015,7 +1015,7 @@
           <span class="label label-success">{{_i}}Success{{/i}}</span>
         </td>
         <td>
-          <code>&lt;span class="label label-success"&gt;{{/_i}}New{{/i}}&lt;/span&gt;</code>
+          <code>&lt;span class="label label-success"&gt;{{/_i}}Success{{/i}}&lt;/span&gt;</code>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
The "Success" label example would have rendered a label saying "New"
