### PR TITLE
Don't style all abbr's as initialism

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -76,7 +76,7 @@
   line-height: normal;
   .border-radius(5px);
 }
-.btn-large .icon {
+.btn-large [class^="icon-"] {
   margin-top: 1px;
 }
 
@@ -86,7 +86,7 @@
   font-size: @baseFontSize - 2px;
   line-height: @baseLineHeight - 2px;
 }
-.btn-small .icon {
+.btn-small [class^="icon-"] {
   margin-top: -1px;
 }
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -456,8 +456,8 @@
     background-image: -webkit-radial-gradient(circle, @innerColor, @outerColor);
     background-image: -moz-radial-gradient(circle, @innerColor, @outerColor);
     background-image: -ms-radial-gradient(circle, @innerColor, @outerColor);
+    background-image: -o-radial-gradient(circle, @innerColor, @outerColor);
     background-repeat: no-repeat;
-    // Opera cannot do radial gradients yet
   }
   .striped(@color, @angle: -45deg) {
     background-color: @color;

--- a/less/type.less
+++ b/less/type.less
@@ -153,11 +153,13 @@ em {
 }
 
 // Abbreviations and acronyms
-abbr {
-  font-size: 90%;
-  text-transform: uppercase;
+abbr[title] {
   border-bottom: 1px dotted #ddd;
   cursor: help;
+}
+abbr.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
 }
 
 // Blockquotes


### PR DESCRIPTION
Abbreviations with title attributes are commonly used in for instance table headers if a word does not fit, then you would not want it to be uppercased.

Also only show help styling for abbr's with a title attribute present.

Read more:
- http://developers.whatwg.org/text-level-semantics.html#the-abbr-element
- http://en.wikipedia.org/wiki/Abbreviation
- http://en.wikipedia.org/wiki/Initialism
