### PR TITLE
Fix responsive css for 768px width

### DIFF
--- a/less/responsive.less
+++ b/less/responsive.less
@@ -154,7 +154,7 @@
 // PORTRAIT TABLET TO DEFAULT DESKTOP
 // ----------------------------------
 
-@media (min-width: 768px) and (max-width: 980px) {
+@media (min-width: 769px) and (max-width: 980px) {
 
   // Fixed grid
   #gridSystem > .generate(12, 42px, 20px);


### PR DESCRIPTION
When a device is _exactly_ 768px wide (e.g. a portrait iPad) it uses 2
sets of conflicting `@media` rules. This fix simply adds a pixel to
the "portrait tablet to default desktop" rule.

Before the fix is applied, `.row` has `margin-left: -20px` applied.

![Before fix](http://f.cl.ly/items/3E1X1H0c2g321b3D191o/photo%201.PNG)

With the fix, devices at 768px have correct alignment.

![After fix](http://f.cl.ly/items/0n0b2E1x121V1h3b0q0K/photo%202.PNG)
