### PR TITLE
fix for #1690: Nav DropDown Problem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ nbproject
 .svn
 .CVS
 .idea
+bootstrap

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ docs: bootstrap
 	rm docs/assets/bootstrap.zip
 	zip -r docs/assets/bootstrap.zip bootstrap
 	rm -r bootstrap
-	lessc ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
-	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > ${BOOTSTRAP_RESPONSIVE}
+	${LESS_COMPRESSOR} ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
+	${LESS_COMPRESSOR} ${BOOTSTRAP_RESPONSIVE_LESS} > ${BOOTSTRAP_RESPONSIVE}
 	node docs/build
 	cp img/* docs/assets/img/
 	cp js/*.js docs/assets/js/
@@ -31,10 +31,10 @@ bootstrap:
 	mkdir -p bootstrap/css
 	mkdir -p bootstrap/js
 	cp img/* bootstrap/img/
-	lessc ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
-	lessc --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
+	${LESS_COMPRESSOR} ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
+	${LESS_COMPRESSOR} --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
+	${LESS_COMPRESSOR} ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
+	${LESS_COMPRESSOR} --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.js
 

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -293,6 +293,7 @@
 @media (min-width: 980px) {
   .nav-collapse.collapse {
     height: auto !important;
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
I noticed this had already been addressed in a pull request, but It doesn't look like that solution is working. This seems like a css, not a js issue so I thought I would propose my own solution.

This method avoids modifying any JavaScript by just changing the nav bar to overflow: hidden when it needs to. It seems like a better route to go because there's no reason to risk hiding the entire menu in situations like this.
