### PR TITLE
Use -webkit-transform for much smoother iOS carousel animations

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -59,6 +59,45 @@
   .active.right {
     left: 100%;
   }
+  
+  /* Use the media query to determine if transforms are supported */
+  @media all and (-webkit-transform) {
+
+    .item {
+      -webkit-transition: 0.6s ease-in-out -webkit-transform;
+      -webkit-backface-visibility: hidden;
+    }
+    
+    .active {
+      -webkit-transform: translate(0%, 0%);
+    }
+    
+    .next {
+      -webkit-transform: translate(100%, 0%);
+      left: 0;
+    }
+    
+    .prev {
+      -webkit-transform: translate(-100%, 0%);
+      left: 0;
+    }
+    
+    .next.left, .prev.right {
+      -webkit-transform: translate(0%, 0%);
+      left: 0;
+    }
+    
+    .active.left {
+      -webkit-transform: translate(-100%, 0%);
+      left: 0;
+    }
+    
+    .active.right {
+      -webkit-transform: translate(100%, 0%);
+      left: 0;
+    }
+  
+  }
 
 }
 

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -59,9 +59,13 @@
   .active.right {
     left: 100%;
   }
+}
   
-  /* Use the media query to determine if transforms are supported */
-  @media all and (-webkit-transform) {
+/* Use the media query to determine if transforms are supported */
+/* For some reason, -webkit-transform isn't detected, but -webkit-transform-3d is */
+@media all and (-webkit-transform-3d) {
+
+  .carousel {
 
     .item {
       -webkit-transition: 0.6s ease-in-out -webkit-transform;
@@ -96,7 +100,6 @@
       -webkit-transform: translate(100%, 0%);
       left: 0;
     }
-  
   }
 
 }


### PR DESCRIPTION
The -webkit-transform extension causes webkit to switch to hardware-accelerated rendering on supported devices, which results in far smoother animations. This CSS change enables the extension for the carousel when it's available, and in practice we see iPad and iPhone animations improve from a juddery 2 frames-per-second at best, to something smooth enough to be native. For a demo, visit this page on an iOS device:

https://www.jetpac.com/carousel

I'm aware this is a bit bleeding-edge, but it's something we'll be using for our application, and I wanted to make it available to the community in case it's useful for anyone else.
