### PR TITLE
Adding .clearfix() to .form-actions to allow for .pull-right buttons

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -324,6 +324,7 @@ select:focus:required:invalid {
   margin-bottom: @baseLineHeight;
   background-color: #f5f5f5;
   border-top: 1px solid #ddd;
+  .clearfix(); // Adding clearfix to allow for .pull-right button containers
 }
 
 // For text that needs to appear as an input but should not be an input


### PR DESCRIPTION
I need Cancel, Save, and friends to be right aligned on some of my forms. This commit makes that possible.
