### PR TITLE
Docs: Update HTML example for modals with data attr. for Close button

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -299,7 +299,7 @@
   &lt;/div&gt;
   &lt;div class="modal-footer"&gt;
     &lt;a href="#" class="btn btn-primary"&gt;Save changes&lt;/a&gt;
-    &lt;a href="#" class="btn"&gt;Close&lt;/a&gt;
+    &lt;a href="#" class="btn" data-dismiss="modal"&gt;Close&lt;/a&gt;
   &lt;/div&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
The modal example in the docs permits closing the box by pressing the Close button.
The markup example beneath does not include this "hook" however, and it threw me off initially.

This change fixes that :) :clap:
