### PR TITLE
Fix to make toggling work properly for radio/checkbox buttons that have icons

### DIFF
--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -25,7 +25,7 @@
   * ============================== */
 
   var Button = function ( element, options ) {
-    this.$element = $(element)
+    this.$element = $(element).closest('button, a')
     this.options = $.extend({}, $.fn.button.defaults, options)
   }
 


### PR DESCRIPTION
Right now, clicking a radio/checkbox button\* that has an icon only changes its state when the text of the button or the edge of the button around the icon is clicked.  When the icon of the button is clicked, the state of the button is not toggled.

This fix makes toggling buttons work by making sure the element to be toggled is actually a "button" or an "a" element and not the "i" tag that holds the image inside of it.

*) This applies to the radio/checkbox buttons that are part of a .btn-group. Not the input elements.
