### PR TITLE
Added an id to the Markup example for the modal

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -289,7 +289,7 @@
 </pre>
 
 <pre class="prettyprint linenums">
-&lt;div class="modal"&gt;
+&lt;div class="modal" id="myModal"&gt;
   &lt;div class="modal-header"&gt;
     &lt;a class="close" data-dismiss="modal"&gt;&times;&lt;/a&gt;
     &lt;h3&gt;Modal header&lt;/h3&gt;


### PR DESCRIPTION
Added an id to the Markup example for the modal so a user can copy and paste the example code and it will work out of the box. Currently it does not.
