### PR TITLE
Added ability to stop and start carousel.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1296,6 +1296,12 @@ $('#myCollapsible').on('hidden', function () {
                <td>5000</td>
                <td>The amount of time to delay between automatically cycling an item.</td>
              </tr>
+             <tr>
+               <td>cycle</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>Cycles through all of the items.</td>
+             </tr>
             </tbody>
           </table>
           <h3>Markup</h3>
@@ -1320,9 +1326,13 @@ $('.myCarousel').carousel({
 })
 </pre>
           <h4>.carousel('cycle')</h4>
-          <p>Cycles through the carousel items from left to right.</p>
+          <p>Cycles through the carousel items from left to right, unless the carousel was created with cycle option set to false or was previsouly stopped using the stop method.</p>
+          <h4>.carousel('start')</h4>
+          <p>Cycles through the carousel items from left to right, even if the carousel was created with cycle option set to false or was previsouly stopped using the stop method.</p>
           <h4>.carousel('pause')</h4>
-          <p>Stops the carousel from cycling through items.</p>
+          <p>Pauses the carousel as it cycles through items.<br/>The carousel is unpaused if cycle, start, next or prev is called or if the carousel is cycled to a particular item.</p>
+          <h4>.carousel('stop')</h4>
+          <p>Stops the carousel from cycling through items.<br/>Once the carousel is stopped it will not resume cycling through the items as it will if it is paused.<br/><br/>Use start to resume cycling through the items.</p>
           <h4>.carousel(number)</h4>
           <p>Cycles the carousel to a particular frame (0 based, similar to an array).</p>
           <h4>.carousel('prev')</h4>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1220,6 +1220,12 @@ $('#myCollapsible').on('hidden', function () {
                <td>5000</td>
                <td>{{_i}}The amount of time to delay between automatically cycling an item.{{/i}}</td>
              </tr>
+             <tr>
+               <td>{{_i}}cycle{{/i}}</td>
+               <td>{{_i}}boolean{{/i}}</td>
+               <td>true</td>
+               <td>{{_i}}Cycles through all the items.{{/i}}</td>
+             </tr>
             </tbody>
           </table>
           <h3>{{_i}}Markup{{/i}}</h3>
@@ -1244,9 +1250,13 @@ $('.myCarousel').carousel({
 })
 </pre>
           <h4>.carousel('cycle')</h4>
-          <p>{{_i}}Cycles through the carousel items from left to right.{{/i}}</p>
+          <p>{{_i}}Cycles through the carousel items from left to right, unless the carousel was created with cycle option set to false or was previsouly stopped using the stop method.{{/i}}</p>
+          <h4>.carousel('start')</h4>
+          <p>{{_i}}Cycles through the carousel items from left to right, even if the carousel was created with cycle option set to false or was previsouly stopped using the stop method.{{/i}}</p>
           <h4>.carousel('pause')</h4>
-          <p>{{_i}}Stops the carousel from cycling through items.{{/i}}</p>
+          <p>{{_i}}Pauses the carousel as it cycles through items.<br/>The carousel is unpaused if cycle, start, next or prev is called or if the carousel is cycled to a particular item.{{/i}}</p>
+          <h4>.carousel('stop')</h4>
+          <p>{{_i}}Stops the carousel from cycling through items.<br/>Once the carousel is stopped it will not resume cycling through the items as it will if it is paused.<br/><br/>Use start to resume cycling through the items.{{/i}}</p>
           <h4>.carousel(number)</h4>
           <p>{{_i}}Cycles the carousel to a particular frame (0 based, similar to an array).{{/i}}</p>
           <h4>.carousel('prev')</h4>

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -29,12 +29,15 @@
     this.$element = $(element)
     this.options = $.extend({}, $.fn.carousel.defaults, options)
     this.options.slide && this.slide(this.options.slide)
+    this.stopped = !this.options.cycle
   }
 
   Carousel.prototype = {
 
     cycle: function () {
-      this.interval = setInterval($.proxy(this.next, this), this.options.interval)
+      if (!this.stopped) {
+        this.interval = setInterval($.proxy(this.next, this), this.options.interval)
+      }
       return this
     }
 
@@ -57,6 +60,16 @@
       }
 
       return this.slide(pos > activePos ? 'next' : 'prev', $(children[pos]))
+    }
+
+  , start: function() {
+      this.stopped = false
+      return this.cycle()
+    }
+
+  , stop: function() {
+      this.stopped = true
+      return this.pause()
     }
 
   , pause: function () {
@@ -133,6 +146,7 @@
 
   $.fn.carousel.defaults = {
     interval: 5000
+   ,cycle: true
   }
 
   $.fn.carousel.Constructor = Carousel


### PR DESCRIPTION
Solves issue 1992 on twitter/bootstrap.

Added a cycle option that allows you to specify whether or not the carousel should cycle automatically.

Added stop and start methods to allow the carousel to be stopped and started. When the carousel is stopped it will not automatically resume cycling as it does when it is paused.

Updated the docs to better describe the current pause and cycle methods and to include the additional features.
