### PR TITLE
Added support for multiple selections in Typeahead

### DIFF
--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -206,9 +206,6 @@
   , keypress: function (e) {
       e.stopPropagation()
 
-      if (e.keyCode === 8 && this.mode === 'multiple' && !this.shown)
-        e.preventDefault()
-
       if (!this.shown) return
 
       switch(e.keyCode) {

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -75,7 +75,7 @@
       var that = this
         , items
         , q
-        , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
+        , input = this.mode === 'multiple' ? this.$element.val().split(this.formatteddelimiter()) : [this.$element.val()]
 
       this.selections = input.slice(0, input.length - 1)
 

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -30,7 +30,10 @@
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
+    this.delimiter = this.options.delimiter || this.delimiter
     this.listen()
+    this.mode = this.options.mode || this.mode
+    this.selections = []
   }
 
   Typeahead.prototype = {
@@ -39,7 +42,11 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
-      this.$element.val(val)
+      if( this.mode === 'multiple' ) {
+        this.selections.push(val)
+        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
+      }
+      this.$element.val( val )
       return this.hide()
     }
 
@@ -68,8 +75,9 @@
       var that = this
         , items
         , q
+        , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
 
-      this.query = this.$element.val()
+      this.query = $.trim(input[input.length - 1])
 
       if (!this.query) {
         return this.shown ? this.hide() : this
@@ -164,6 +172,10 @@
         .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
     }
 
+  , formatteddelimiter: function(){
+      return this.delimiter + ' ';
+    }
+
   , keyup: function (e) {
       e.stopPropagation()
       e.preventDefault()
@@ -251,6 +263,8 @@
   , items: 8
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
+  , delimiter: ','
+  , mode: 'single'
   }
 
   $.fn.typeahead.Constructor = Typeahead

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -44,22 +44,10 @@
       var val = this.$menu.find('.active').attr('data-value')
       if( this.mode === 'multiple' ) {
         this.selections.push(val)
-        val = this.selections.join(this.formatteddelimiter())
-        if (val.length) val += this.formatteddelimiter()
+        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
       }
       this.$element.val( val )
       return this.hide()
-    }
-
-  , pop: function () {
-      var val = null
-      if( this.mode === 'multiple' ) {
-        this.selections.pop()
-        val = this.selections.join(this.formatteddelimiter())
-        if (val.length) val += this.formatteddelimiter()
-      }
-      this.$element.val( val )
-      return this
     }
 
   , show: function () {
@@ -88,6 +76,8 @@
         , items
         , q
         , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
+
+      this.selections = input.slice(0, input.length - 1)
 
       this.query = $.trim(input[input.length - 1])
 
@@ -191,14 +181,10 @@
   , keyup: function (e) {
       e.stopPropagation()
       e.preventDefault()
-      
+
       switch(e.keyCode) {
         case 40: // down arrow
         case 38: // up arrow
-          break
-
-        case 8: // backspace
-          if (this.mode === 'multiple' && !this.shown) this.pop()
           break
 
         case 9: // tab

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -44,10 +44,22 @@
       var val = this.$menu.find('.active').attr('data-value')
       if( this.mode === 'multiple' ) {
         this.selections.push(val)
-        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
+        val = this.selections.join(this.formatteddelimiter())
+        if (val.length) val += this.formatteddelimiter()
       }
       this.$element.val( val )
       return this.hide()
+    }
+
+  , pop: function () {
+      var val = null
+      if( this.mode === 'multiple' ) {
+        this.selections.pop()
+        val = this.selections.join(this.formatteddelimiter())
+        if (val.length) val += this.formatteddelimiter()
+      }
+      this.$element.val( val )
+      return this
     }
 
   , show: function () {
@@ -173,16 +185,20 @@
     }
 
   , formatteddelimiter: function(){
-      return this.delimiter + ' ';
+      return this.delimiter + ' '
     }
 
   , keyup: function (e) {
       e.stopPropagation()
       e.preventDefault()
-
+      
       switch(e.keyCode) {
         case 40: // down arrow
         case 38: // up arrow
+          break
+
+        case 8: // backspace
+          if (this.mode === 'multiple' && !this.shown) this.pop()
           break
 
         case 9: // tab
@@ -203,6 +219,10 @@
 
   , keypress: function (e) {
       e.stopPropagation()
+
+      if (e.keyCode === 8 && this.mode === 'multiple' && !this.shown)
+        e.preventDefault()
+
       if (!this.shown) return
 
       switch(e.keyCode) {

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1418,6 +1418,18 @@ $('.myCarousel').carousel({
                <td>highlights all default matches</td>
                <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
              </tr>
+             <tr>
+              <td>mode</td>
+              <td>string</td>
+              <td>single</td>
+              <td>Setting used to allow single or multiple items to be selected from the autocomplete results. Accepts a single value of either 'single' or 'multiple'.</td>
+             </tr>
+             <tr>
+              <td>delimiter</td>
+              <td>string</td>
+              <td>,</td>
+              <td>Delimiter used to seperate selected autocomplete results from one another. Only used when setting 'mode' is 'multiple'.</td>
+             </tr>
             </tbody>
           </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -206,9 +206,6 @@
   , keypress: function (e) {
       e.stopPropagation()
 
-      if (e.keyCode === 8 && this.mode === 'multiple' && !this.shown)
-        e.preventDefault()
-
       if (!this.shown) return
 
       switch(e.keyCode) {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
       var val = this.$menu.find('.active').attr('data-value')
       if( this.mode === 'multiple' ) {
         this.selections.push(val)
-        val = this.selections.join(this.delimiter)
+        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
       }
       this.$element.val( val )
       return this.hide()
@@ -170,6 +170,10 @@
       this.$menu
         .on('click', $.proxy(this.click, this))
         .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
+    }
+
+  , formatteddelimiter: function(){
+      return this.delimiter + ' ';
     }
 
   , keyup: function (e) {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -75,7 +75,7 @@
       var that = this
         , items
         , q
-        , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
+        , input = this.mode === 'multiple' ? this.$element.val().split(this.formatteddelimiter()) : [this.$element.val()]
 
       this.selections = input.slice(0, input.length - 1)
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -30,7 +30,10 @@
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
+    this.delimiter = this.options.delimiter || this.delimiter
     this.listen()
+    this.mode = this.options.mode || this.mode
+    this.selections = []
   }
 
   Typeahead.prototype = {
@@ -39,7 +42,11 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
-      this.$element.val(val)
+      if( this.mode === 'multiple' ) {
+        this.selections.push(val)
+        val = this.selections.join(this.delimiter)
+      }
+      this.$element.val( val )
       return this.hide()
     }
 
@@ -68,8 +75,9 @@
       var that = this
         , items
         , q
+        , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
 
-      this.query = this.$element.val()
+      this.query = $.trim(input[input.length - 1])
 
       if (!this.query) {
         return this.shown ? this.hide() : this
@@ -251,6 +259,8 @@
   , items: 8
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
+  , delimiter: ','
+  , mode: 'single'
   }
 
   $.fn.typeahead.Constructor = Typeahead

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,22 +44,10 @@
       var val = this.$menu.find('.active').attr('data-value')
       if( this.mode === 'multiple' ) {
         this.selections.push(val)
-        val = this.selections.join(this.formatteddelimiter())
-        if (val.length) val += this.formatteddelimiter()
+        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
       }
       this.$element.val( val )
       return this.hide()
-    }
-
-  , pop: function () {
-      var val = null
-      if( this.mode === 'multiple' ) {
-        this.selections.pop()
-        val = this.selections.join(this.formatteddelimiter())
-        if (val.length) val += this.formatteddelimiter()
-      }
-      this.$element.val( val )
-      return this
     }
 
   , show: function () {
@@ -88,6 +76,8 @@
         , items
         , q
         , input = this.mode === 'multiple' ? this.$element.val().split(this.delimiter) : [this.$element.val()]
+
+      this.selections = input.slice(0, input.length - 1)
 
       this.query = $.trim(input[input.length - 1])
 
@@ -191,14 +181,10 @@
   , keyup: function (e) {
       e.stopPropagation()
       e.preventDefault()
-      
+
       switch(e.keyCode) {
         case 40: // down arrow
         case 38: // up arrow
-          break
-
-        case 8: // backspace
-          if (this.mode === 'multiple' && !this.shown) this.pop()
           break
 
         case 9: // tab

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,10 +44,22 @@
       var val = this.$menu.find('.active').attr('data-value')
       if( this.mode === 'multiple' ) {
         this.selections.push(val)
-        val = this.selections.join(this.formatteddelimiter()) + this.formatteddelimiter()
+        val = this.selections.join(this.formatteddelimiter())
+        if (val.length) val += this.formatteddelimiter()
       }
       this.$element.val( val )
       return this.hide()
+    }
+
+  , pop: function () {
+      var val = null
+      if( this.mode === 'multiple' ) {
+        this.selections.pop()
+        val = this.selections.join(this.formatteddelimiter())
+        if (val.length) val += this.formatteddelimiter()
+      }
+      this.$element.val( val )
+      return this
     }
 
   , show: function () {
@@ -173,16 +185,20 @@
     }
 
   , formatteddelimiter: function(){
-      return this.delimiter + ' ';
+      return this.delimiter + ' '
     }
 
   , keyup: function (e) {
       e.stopPropagation()
       e.preventDefault()
-
+      
       switch(e.keyCode) {
         case 40: // down arrow
         case 38: // up arrow
+          break
+
+        case 8: // backspace
+          if (this.mode === 'multiple' && !this.shown) this.pop()
           break
 
         case 9: // tab
@@ -203,6 +219,10 @@
 
   , keypress: function (e) {
       e.stopPropagation()
+
+      if (e.keyCode === 8 && this.mode === 'multiple' && !this.shown)
+        e.preventDefault()
+
       if (!this.shown) return
 
       switch(e.keyCode) {

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -138,12 +138,12 @@ $(function () {
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        $input.val( $input.val() + ',a')
+        $input.val( $input.val() + 'a')
         typeahead.lookup()
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        equals($input.val(), 'ac,ac', 'input value was correctly set')
+        equals($input.val(), 'ac, ac, ', 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
 
         typeahead.$menu.remove()
@@ -162,12 +162,12 @@ $(function () {
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        $input.val( $input.val() + ';a')
+        $input.val( $input.val() + 'a')
         typeahead.lookup()
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        equals($input.val(), 'ac;ac', 'input value was correctly set')
+        equals($input.val(), 'ac; ac; ', 'input value was correctly set')
       })
 
       test("should not allow multiple selection if multiple selection mode is not enabled", function () {
@@ -187,5 +187,47 @@ $(function () {
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
         equals($input.val(), 'ac', 'input value was correctly set')
+      })
+
+      test("should insert a space after the delimiter when multiple selection is enabled", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+              , delimiter: ','
+              , mode: 'multiple'
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac, ', 'delimiter was followed by a space')
+      })
+
+      test("should not append old matches when user clears input", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+              , delimiter: ','
+              , mode: 'multiple'
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + 'a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+
+        $input.val( 'ac, a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[0]).mouseover().click()
+
+        equals($input.val(), 'ac, aa, ', 'input value was correctly set')
       })
 })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -125,4 +125,67 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+      test("should allow multiple selections", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+              , mode: 'multiple'
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + ',a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac,ac', 'input value was correctly set')
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+
+        typeahead.$menu.remove()
+      })
+
+      test("should allow user to specify delimiter in options", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+              , delimiter: ';'
+              , mode: 'multiple'
+            })
+          , typeahead = $input.data('typeahead')
+
+          $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + ';a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac;ac', 'input value was correctly set')
+      })
+
+      test("should not allow multiple selection if multiple selection mode is not enabled", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + ', a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac', 'input value was correctly set')
+      })
 })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -230,4 +230,30 @@ $(function () {
 
         equals($input.val(), 'ac, aa, ', 'input value was correctly set')
       })
+
+      test("should not have extra spaces when multiple items are selected", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+              , delimiter: ';'
+              , mode: 'multiple'
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + 'a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        $input.val( $input.val() + 'a')
+        typeahead.lookup()
+
+        $(typeahead.$menu.find('li')[2]).mouseover().click()
+
+        equals($input.val(), 'ac; ac; ac; ', 'input value was correctly set')
+      })
 })


### PR DESCRIPTION
Added support for multiple selections in typeahead. Multiple selection is enabled by either adding a data attr `data-mode` or passing an option `mode`. I've added examples of both methods below.

Users can specify the delimiter in the data attributes, `data-delimiter=";"`, or as an option to the jquery plugin, a default delimiter of `,` is assumed. 

If you're using a comma as your delimiter already then you just need to add an attribute `data-mode="multiple"` on your input like so to enable multiple selection.

**Multiple selection using data attributes**

``` html
<input class="span5" data-items="10" 
    data-mode="multiple" 
    data-provide="typeahead" 
    data-source="[&quot;Catsd&quot;,&quot;Dogs&quot;,&quot;Mass Hysteria&quot;]" 
    id="post_tags" 
    name="post[tags]" size="30" type="text" value="" />
```

**Multiple selection using jquery plugin**

```
$('.myinput').typeahead({ mode: 'multiple' });
```
