### PR TITLE
Docs: updated upgrade docs for popover placement change

### DIFF
--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -248,6 +248,7 @@
   <h3>Popovers</h3>
   <ul>
     <li>Child elements now properly namespaced: <code>.title</code> to <code>.popover-title</code>, <code>.inner</code> to <code>.popover-inner</code>, and <code>.content</code> to <code>.popover-content</code>.</li>
+    <li>Placing a popover above or below an element now requires the placement property to be <code>top</code> or <code>bottom</code></li>  
   </ul>
   <h3>New plugins</h3>
   <ul>

--- a/docs/upgrading.html
+++ b/docs/upgrading.html
@@ -248,7 +248,7 @@
   <h3>Popovers</h3>
   <ul>
     <li>Child elements now properly namespaced: <code>.title</code> to <code>.popover-title</code>, <code>.inner</code> to <code>.popover-inner</code>, and <code>.content</code> to <code>.popover-content</code>.</li>
-    <li>Placing a popover above or below an element now requires the placement property to be <code>top</code> or <code>bottom</code></li>  
+    <li>Placing a popover above or below an element now requires the placement property to be <code>top</code> or <code>bottom</code> respectively.</li>  
   </ul>
   <h3>New plugins</h3>
   <ul>


### PR DESCRIPTION
Change in popover placement from 'above' and 'below' to 'top' and 'bottom' caught me of guard. Added doc for the benefit of others.
