### PR TITLE
[2.0-wip] Adding contrast color for the focus

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -109,6 +109,16 @@
   text-shadow: 0 -1px 0 rgba(0,0,0,.25);
   color: @white;
 }
+
+// Adding contrast colot for the focus
+.btn-primary:focus,
+.btn-warning:focus,
+.btn-danger:focus,
+.btn-success:focus,
+.btn-info:focus{
+ outline-color : @textColor;
+}
+
 // Provide *some* extra contrast for those who can get it
 .btn-primary.active,
 .btn-warning.active,


### PR DESCRIPTION
Hello,

Here is a fix to see the outline when a button is focus :

// Adding contrast color for the focus
.btn-primary:focus,
.btn-warning:focus,
.btn-danger:focus,
.btn-success:focus,
.btn-info:focus{
 outline-color : #333;
}
