### PR TITLE
alert close/closed events fix

### DIFF
--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -45,17 +45,19 @@
       }
 
       $parent = $(selector)
-      $parent.trigger('close')
 
       e && e.preventDefault()
 
       $parent.length || ($parent = $this.hasClass('alert') ? $this : $this.parent())
 
+      $parent.trigger('close')
+      
       $parent.removeClass('in')
 
       function removeElement() {
-        $parent.remove()
+        $parent.detach()
         $parent.trigger('closed')
+        $parent.remove()
       }
 
       $.support.transition && $parent.hasClass('fade') ?


### PR DESCRIPTION
"close" works only after parent determined.
"closed" triggers before real "remove" when event handlers are present.
