### PR TITLE
Duplicate border in markdown code blocks

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -40,5 +40,6 @@ pre {
   code {
     padding: 0;
     background-color: transparent;
+    border: none;
   }
 }


### PR DESCRIPTION
Markdown wraps multiline `<code>` blocks with `<pre>`, as such:

```
<pre><code>
  This is 
  multiline
  code
</code>
</pre>
```

The current code stylesheet creates a border around the inline `<code>` element, as well as the surrounding `<pre>` element, which just looks bad. 

This pull request simply removes the border for code blocks that are within pre blocks.
