### PR TITLE
Fixed wrong behaviour when using collapse + dropdown in responsive css

### DIFF
--- a/less/responsive.less
+++ b/less/responsive.less
@@ -297,6 +297,7 @@
 @media (min-width: 980px) {
   .nav-collapse.collapse {
     height: auto !important;
+    overflow: visible !important;
   }
 }
 


### PR DESCRIPTION
Dear all,

I noticed a wrong behaviour when using collapse, dropdown menus and the responsive layout.

You can check it out yourselves on your examples page:

http://twitter.github.com/bootstrap/components.html#navbar

1) Reduce the width of the page until the navbar "project name" collapses
(scroll down the page and find the navbar again)
2) Click on the collapse button
3) Expand the page again until the navbar "project-name" un-collapses
4) Click on the dropdown menu

It will not appear 'cause bootstrap remembers that the navbar is collapsed and the overflow property is hidden

This patch adds

```
    overflow : visible !important;
```

at line 398 of bootstrap-responsive.less
