### PR TITLE
Fixed compile problem with LESS 1.2.1.

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -21,14 +21,14 @@
   height: 14px;
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url(@iconSpritePath);
+  background-image: url("@{iconSpritePath}");
   background-position: 14px 14px;
   background-repeat: no-repeat;
 
   .ie7-restore-right-whitespace();
 }
 .icon-white {
-  background-image: url(@iconWhiteSpritePath);
+  background-image: url("@{iconWhiteSpritePath}");
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
The sprite path variables introduced in v2.0.1 prevents bootstrap.less to
compile with LESS v1.2.1. Updated the variables to use the @{name}
construct in sprites.less, as outlined in the LESS documentation. This
change makes the LESS files compile with LESS v1.2.1.
