### PR TITLE
Remove "control-label" class

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -505,7 +505,7 @@ legend + .control-group {
     .clearfix();
   }
   // Float the labels left
-  .control-label {
+  label {
     float: left;
     width: 140px;
     padding-top: 5px;


### PR DESCRIPTION
The "control-label" class adds a lot of extra markup to horizontal forms. Might I suggest changing it?
