### PR TITLE
Update old button selectors 'small' and 'large'

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -172,11 +172,11 @@ input[type="submit"].btn {
   // IE7 has some default padding on button controls
   *padding-top: 2px;
   *padding-bottom: 2px;
-  &.large {
+  &.btn-large {
     *padding-top: 7px;
     *padding-bottom: 7px;
   }
-  &.small {
+  &.btn-small {
     *padding-top: 3px;
     *padding-bottom: 3px;
   }


### PR DESCRIPTION
Updated old button selectors 'small' and 'large' to be 'btn-small' and 'btn-large' respectively.
