### PR TITLE
Fixed a typo in the documentation for the page-header class

### DIFF
--- a/components.html
+++ b/components.html
@@ -1189,7 +1189,7 @@
     </div>
     <div class="span8">
 <pre class="prettyprint linenums">
-&lt;div class="page-haeder"&gt;
+&lt;div class="page-header"&gt;
   &lt;h1&gt;Example page header&lt;/h1&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
Offending line can be found here: http://twitter.github.com/bootstrap/components.html#typography

```
<div class="page-haeder">
    <h1>Example page header</h1>
</div>
```

Should be:

```
<div class="page-header">
    <h1>Example page header</h1>
</div>
```
