### PR TITLE
Change on JS Tabs documentation on 'shown' callback

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -682,7 +682,7 @@ $('#myModal').on('hidden', function () {
           </table>
 
           <pre class="prettyprint linenums">
-$('a[data-toggle="tab"]').on('shown', function (e) {
+$('body').on('shown', 'a[data-toggle="tab"]', function (e) {
   e.target // activated tab
   e.relatedTarget // previous tab
 })</pre>


### PR DESCRIPTION
Changed the example so it's bind to the `body` and not the the `a[data-toggle='tab']`
