### PR TITLE
Width fix on .tab-content

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -261,6 +261,7 @@
 }
 .tab-content {
   display: table; // prevent content from running below tabs
+  width: 100%;
 }
 
 // Remove border on bottom, left, right


### PR DESCRIPTION
Because .tab-content has display: table; (I dont know why it has it but there is a comment about tab content running away - I think this was applicable before the .tabbable container was introduced but Im not sure)  the .tab-content area sometimes doesn't get the equal width as the nav-tabs ul - specially when you do full container width tab navigation. 
