### PR TITLE
Remove hover style for disabled links

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -212,6 +212,11 @@
   background-color: @navbarBackground;
 }
 
+// Disabled nav items
+.navbar .nav > li > a.disabled:hover {
+  color: @navbarLinkColor;
+}
+
 // Dividers (basically a vertical hr)
 .navbar .divider-vertical {
   height: @navbarHeight;


### PR DESCRIPTION
This removes the hover style (dimmed color) for links in the navbar with the `disabled` class.
