### PR TITLE
Small typo fix in scaffolding documentation

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -82,7 +82,7 @@
         <div class="subnav">
           <ul class="nav nav-pills">
             <li><a href="#gridSystem">Grid system</a></li>
-            <li><a href="#fluidGridSystem">Fluid gird system</a></li>
+            <li><a href="#fluidGridSystem">Fluid grid system</a></li>
             <li><a href="#gridCustomization">Customizing</a></li>
             <li><a href="#layouts">Layouts</a></li>
             <li><a href="#responsive">Responsive design</a></li>


### PR DESCRIPTION
Just a small typo fix in the scaffolding documentation.
