### PR TITLE
Small typo fixes in documentation

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1189,7 +1189,7 @@
     </div>
     <div class="span8">
 <pre class="prettyprint linenums">
-&lt;div class="page-haeder"&gt;
+&lt;div class="page-header"&gt;
   &lt;h1&gt;Example page header&lt;/h1&gt;
 &lt;/div&gt;
 </pre>

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -82,7 +82,7 @@
         <div class="subnav">
           <ul class="nav nav-pills">
             <li><a href="#gridSystem">Grid system</a></li>
-            <li><a href="#fluidGridSystem">Fluid gird system</a></li>
+            <li><a href="#fluidGridSystem">Fluid grid system</a></li>
             <li><a href="#gridCustomization">Customizing</a></li>
             <li><a href="#layouts">Layouts</a></li>
             <li><a href="#responsive">Responsive design</a></li>


### PR DESCRIPTION
I just corrected two small typos in the components and the scaffolding documentation.
