### PR TITLE
Spelling mistake in documentation. 

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1189,7 +1189,7 @@
     </div>
     <div class="span8">
 <pre class="prettyprint linenums">
-&lt;div class="page-haeder"&gt;
+&lt;div class="page-header"&gt;
   &lt;h1&gt;Example page header&lt;/h1&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
For documentation components.html, class name is corrected from "page-haeder" to "page-header" in example.
