### PR TITLE
[2.0.2-wip] Typeahead friendly

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -40,6 +40,7 @@
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
       this.$element.val(val)
+      this.$element.change();
       return this.hide()
     }
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -178,6 +178,7 @@
           break
 
         case 27: // escape
+          if (!this.shown) return
           this.hide()
           break
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -165,9 +165,6 @@
     }
 
   , keyup: function (e) {
-      e.stopPropagation()
-      e.preventDefault()
-
       switch(e.keyCode) {
         case 40: // down arrow
         case 38: // up arrow
@@ -187,10 +184,11 @@
           this.lookup()
       }
 
+      e.stopPropagation()
+      e.preventDefault()
   }
 
   , keypress: function (e) {
-      e.stopPropagation()
       if (!this.shown) return
 
       switch(e.keyCode) {
@@ -210,12 +208,12 @@
           this.next()
           break
       }
+
+      e.stopPropagation()
     }
 
   , blur: function (e) {
       var that = this
-      e.stopPropagation()
-      e.preventDefault()
       setTimeout(function () { that.hide() }, 150)
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -114,14 +114,18 @@ $(function () {
               source: ['aa', 'ab', 'ac']
             })
           , typeahead = $input.data('typeahead')
+          , changed = false
 
         $input.val('a')
         typeahead.lookup()
+
+        $input.change(function() { changed = true });
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
         equals($input.val(), 'ac', 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+        ok(changed, 'a change event was fired')
 
         typeahead.$menu.remove()
       })


### PR DESCRIPTION
(re-opened against 2.0.2)

Three event-related fixes for typeahead:
- Allows key events to propagate / behave defaultly when the menu isn't open
- Doesn't swallow the blur event
- Fires off a change event when selecting an element, since calling $element.val(value) doesn't do it.
