### PR TITLE
New loop option for bootstrap-carousel.js

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -83,7 +83,7 @@
         , fallback  = type == 'next' ? 'first' : 'last'
         , that = this
 
-      if (!$next.length) return
+      if (!$next.length && !this.options.loop) return
 
       this.sliding = true
 
@@ -135,7 +135,8 @@
   }
 
   $.fn.carousel.defaults = {
-    interval: 5000
+    interval: 5000,
+    loop: false
   }
 
   $.fn.carousel.Constructor = Carousel


### PR DESCRIPTION
Added new loop option to the carousel that repeats the slides continuously instead of pausing on the last slide. Based on suggestion by @titaniumbones for issue #2189.
