### PR TITLE
upd Makefile: scripts contained in bootstrap.js are more readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,19 @@ bootstrap:
 	lessc --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
 	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
 	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
-	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
+	cat js/bootstrap-transition.js \
+		js/bootstrap-alert.js \
+		js/bootstrap-button.js \
+		js/bootstrap-carousel.js \
+		js/bootstrap-collapse.js \
+		js/bootstrap-dropdown.js \
+		js/bootstrap-modal.js \
+		js/bootstrap-tooltip.js \
+		js/bootstrap-popover.js \
+		js/bootstrap-scrollspy.js \
+		js/bootstrap-tab.js \
+		js/bootstrap-typeahead.js \
+		> bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.js
 
 #


### PR DESCRIPTION
I use a similar Makefile in my own project and wanted to see in which order the scripts are put into bootstrap.js. Having one script per line makes it easier to read.
