### PR TITLE
Active link to modal div when scrollspy is used fix

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -47,7 +47,7 @@
           .find(this.selector)
           .map(function () {
             var href = $(this).attr('href')
-            return /^#\w/.test(href) && $(href).length ? href : null
+            return /^#\w/.test(href) && $(href).length && !($(this).attr('data-toggle') == 'modal') ? href : null
           })
 
         this.offsets = $.map(this.targets, function (id) {


### PR DESCRIPTION
Dear all,

I found a wrong behaviour when using both modals and scrollspy in the same navbar.

If you put in a navbar a link to a modal - let's say to #myModal - and scrollspy enabled, the #myModal link is rendered as active.

This edit prevents the scrollspy plugin to check for links to modal divs, replacing line 50 of js/bootstrap-scrollspy.js with

``` js
return /^#\w/.test(href) && $(href).length && !($(this).attr('data-toggle') == 'modal') ? href : null
```

Maybe a better solution is possible

Best Regards

GT
