### PR TITLE
Basic Docs Markup change

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -916,7 +916,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
 &lt;form class="well form-inline"&gt;
   &lt;input type="text" class="input-small" placeholder="Email"&gt;
   &lt;input type="password" class="input-small" placeholder="Password"&gt;
-  &lt;button type="submit" class="btn"&gt;Go&lt;/button&gt;
+  &lt;button type="submit" class="btn"&gt;Sign In&lt;/button&gt;
 &lt;/form&gt;
 </pre>
     </div>


### PR DESCRIPTION
There was a mismatch between the markup and the example for the "Inline Form" example in the "Base CSS" section of the documentation. I just changed the pre code to match the rendered example form's button name (Changed "Go" to "Sign In").
