### PR TITLE
Make .input-xxlarge responsive

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -388,6 +388,10 @@ select:focus:required:invalid {
     border: 1px solid #ccc;
     .border-radius(3px 0 0 3px);
   }
+  [class*="icon-"] {
+    opacity: 0.5;
+    filter: alpha(opacity=5);
+  }
   .active {
     background-color: lighten(@green, 30);
     border-color: @green;

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -49,7 +49,9 @@
     line-height: @baseLineHeight;
   }
 
-  // Make span* classes full width
+  // Make span* and input-*xlarge classes full width
+  .input-xlarge,
+  .input-xxlarge,
   input[class*="span"],
   select[class*="span"],
   textarea[class*="span"],
@@ -64,6 +66,8 @@
             box-sizing: border-box; /* CSS3 spec*/
   }
   // But don't let it screw up prepend/append inputs
+  .input-prepend input[class*="xlarge"],
+  .input-append input[class*="xlarge"],
   .input-prepend input[class*="span"],
   .input-append input[class*="span"] {
     width: auto;


### PR DESCRIPTION
When using the widest form control style (.input-xxlarge), controls
don't adapt to smaller screens. This fixes it and extends the solution
to .input-xlarge controls (they are almost 300px anyway…).

This doesn't solve an existing problem for  LANDSCAPE PHONE TO SMALL
DESKTOP & PORTRAIT TABLETS: in this screen sizes, the widest ".span*"
classes and ".input-xxlarge" can still give problems.

Also, is there any reason not to make all input width classes
(".input-xsmall", ".input-small", …) 100%? What is the conceptual
difference between a input.span1 and input.input-xsmall?
