### PR TITLE
(another) typeahead remote datasource solution

### DIFF
--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -30,6 +30,8 @@
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
+    this.remoteuri = this.options.remoteuri
+    this.remotexhr = null
     this.listen()
   }
 
@@ -75,12 +77,21 @@
         return this.shown ? this.hide() : this
       }
 
-      items = $.grep(this.source, function (item) {
-        if (that.matcher(item)) return item
-      })
+      if (this.remoteuri) {
+        if (this.remotexhr) this.remotexhr.abort()
+        this.remotexhr = $.get(this.remoteuri, {max:this.options.items,q:this.query}, null, 'json')
+          .success($.proxy(this.processItems, this))
+      }
+      else 
+        return this.processItems($.grep(this.source, function (item) {
+          if (that.matcher(item)) return item
+        }))
 
+      return this
+    }
+
+  , processItems: function(items) {
       items = this.sorter(items)
-
       if (!items.length) {
         return this.shown ? this.hide() : this
       }

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1418,6 +1418,12 @@ $('.myCarousel').carousel({
                <td>highlights all default matches</td>
                <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
              </tr>
+             <tr>
+              <td>remoteuri</td>
+              <td>string</td>
+              <td>n/a</td>
+              <td>When a uri is provided a remote request will be made to retrieve autocomplete results instead of referring to 'source'. A GET request will be issued with two querystring arguments. <code>q</code> contains the value of the query. <code>max</code> contains the maximum number of results to return as set by the 'items' setting. A JSON array of values is the expected response.</td>
+             </tr>
             </tbody>
           </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -30,6 +30,8 @@
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
+    this.remoteuri = this.options.remoteuri
+    this.remotexhr = null
     this.listen()
   }
 
@@ -75,12 +77,21 @@
         return this.shown ? this.hide() : this
       }
 
-      items = $.grep(this.source, function (item) {
-        if (that.matcher(item)) return item
-      })
+      if (this.remoteuri) {
+        if (this.remotexhr) this.remotexhr.abort()
+        this.remotexhr = $.get(this.remoteuri, {max:this.options.items,q:this.query}, null, 'json')
+          .success($.proxy(this.processItems, this))
+      }
+      else 
+        return this.processItems($.grep(this.source, function (item) {
+          if (that.matcher(item)) return item
+        }))
 
+      return this
+    }
+
+  , processItems: function(items) {
       items = this.sorter(items)
-
       if (!items.length) {
         return this.shown ? this.hide() : this
       }


### PR DESCRIPTION
added support for a remote datasource. makes a get request with 2 args q and max. q is the query, max is the value of the items setting. Expects a JSON array as the response

Docs are updated, you just add a data-remoteuri attribute to the element.
