### PR TITLE
Add section name to window titles on non-index pages.

### DIFF
--- a/docs/assets/js/application.js
+++ b/docs/assets/js/application.js
@@ -6,7 +6,12 @@
 
   $(function(){
 
-    // Disable certain links in docs
+    // Set the title on non-index pages. Done here to allow the head section to remain generic across page templates.
+      $("#overview h1").each(function(i,el){
+          document.title = document.title.concat(" | ", $(el).text());
+      });
+
+      // Disable certain links in docs
     $('section [href^=#]').click(function (e) {
       e.preventDefault()
     })


### PR DESCRIPTION
It makes it much easier to jump between doc pages in history or tabs when they have different window titles.

Done in application.js to allow the head section template to remain generic.
