### PR TITLE
[forms] Opacity of icons in .input-prepend and .input-append

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -388,6 +388,10 @@ select:focus:required:invalid {
     border: 1px solid #ccc;
     .border-radius(3px 0 0 3px);
   }
+  [class*="icon-"] {
+    opacity: 0.5;
+    filter: alpha(opacity=5);
+  }
   .active {
     background-color: lighten(@green, 30);
     border-color: @green;

--- a/less/forms.less
+++ b/less/forms.less
@@ -389,8 +389,7 @@ select:focus:required:invalid {
     .border-radius(3px 0 0 3px);
   }
   [class*="icon-"] {
-    opacity: 0.5;
-    filter: alpha(opacity=5);
+    .opacity(50);
   }
   .active {
     background-color: lighten(@green, 30);


### PR DESCRIPTION
Text color in this elements in lighter, but icons don't match this
color. This changes the opacity to match a lighter grey when icons are
used in .input-prepend and .input-append
