### PR TITLE
fix sprite base path variables problems

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -21,14 +21,14 @@
   height: 14px;
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url(@iconSpritePath);
+  background-image: url("@iconSpritePath");
   background-position: 14px 14px;
   background-repeat: no-repeat;
 
   .ie7-restore-right-whitespace();
 }
 .icon-white {
-  background-image: url(@iconWhiteSpritePath);
+  background-image: url("@iconWhiteSpritePath");
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
...
    <link type="text/less" rel="stylesheet/less" href="{{ STATIC_URL }}css/base.less" charset="utf-8"/>
    ...

I have bootstrap pulled down as a git submodule

```
$ ls ./project/base/static/css/ -al
total 20
drwxrwxr-x 4 airtonix airtonix 4096 2012-02-26 09:02 .
drwxrwxr-x 6 airtonix airtonix 4096 2012-02-23 20:09 ..
-rwxrwxr-x 1 airtonix airtonix  296 2012-02-26 09:03 base.less
lrwxrwxrwx 1 airtonix airtonix   31 2012-02-23 20:40 bootstrap -> ../../../../lib/bootstrap/less/
drwxrwxr-x 2 airtonix airtonix 4096 2012-02-24 21:40 global
drwxrwxr-x 2 airtonix airtonix 4096 2012-02-24 08:48 mixins
```

./project/base/static/css/base.less

```
@import "bootstrap/bootstrap";
```

Even though these two variables are available and ready for use at this point, it fails until you wrap them in quotes.
