### PR TITLE
Added styles to enable input state toggle buttons

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -24,6 +24,11 @@
   }
 }
 
+// Optional: Hide direct input children
+.btn-group > input {
+  display: none;
+}
+
 // Float them, remove border radius, then re-add to first and last elements
 .btn-group .btn {
   position: relative;
@@ -32,7 +37,8 @@
   .border-radius(0);
 }
 // Set corners individual because sometimes a single button can be in a .btn-group and we need :first-child and :last-child to both match
-.btn-group .btn:first-child {
+.btn-group .btn:first-child,
+.btn-group input:first-child + .btn {
   margin-left: 0;
      -webkit-border-top-left-radius: 4px;
          -moz-border-radius-topleft: 4px;
@@ -51,7 +57,8 @@
           border-bottom-right-radius: 4px;
 }
 // Reset corners for large buttons
-.btn-group .btn.large:first-child {
+.btn-group .btn.large:first-child,
+.btn-group input:first-child + .btn.large {
   margin-left: 0;
      -webkit-border-top-left-radius: 6px;
          -moz-border-radius-topleft: 6px;

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -134,41 +134,55 @@ input[disabled] + label.btn {
 .btn-dark.active {
   .buttonExtraContrast;
 }
-input:checked {
-  + .btn-primary,
-  + .btn-warning,
-  + .btn-danger,
-  + .btn-success,
-  + .btn-info,
-  + .btn-dark {
-    .buttonExtraContrast;
-  }
-}
 
 // Set the backgrounds
 // -------------------------
 .btn-primary {
   .buttonBackground(@primaryButtonBackground, spin(@primaryButtonBackground, 20));
 }
+input:checked + label.btn-primary {
+  .buttonExtraContrast;
+  background-color: spin(@primaryButtonBackground, 20);
+}
 // Warning appears are orange
 .btn-warning {
   .buttonBackground(lighten(@orange, 15%), @orange);
+}
+input:checked + label.btn-warning {
+  .buttonExtraContrast;
+  background-color: @orange;
 }
 // Danger and error appear as red
 .btn-danger {
   .buttonBackground(#ee5f5b, #bd362f);
 }
+input:checked + label.btn-danger {
+  .buttonExtraContrast;
+  background-color: #bd362f;
+}
 // Success appears as green
 .btn-success {
   .buttonBackground(#62c462, #51a351);
+}
+input:checked + label.btn-success {
+  .buttonExtraContrast;
+  background-color: #51a351;
 }
 // Info appears as a neutral blue
 .btn-info {
   .buttonBackground(#5bc0de, #2f96b4);
 }
+input:checked + label.btn-info {
+  .buttonExtraContrast;
+  background-color: #2f96b4;
+}
 // Inverse appears as dark gray
 .btn-inverse {
   .buttonBackground(#454545, #262626);
+}
+input:checked + label.btn-inverse {
+  .buttonExtraContrast;
+  background-color: #262626;
 }
 
 

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -48,7 +48,8 @@
 
 // Active state
 .btn.active,
-.btn:active {
+.btn:active,
+input:checked + label.btn {
   background-image: none;
   @shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   .box-shadow(@shadow);
@@ -59,7 +60,8 @@
 
 // Disabled state
 .btn.disabled,
-.btn[disabled] {
+.btn[disabled],
+input[disabled] + label.btn {
   cursor: default;
   background-image: none;
   background-color: darken(@white, 10%);
@@ -120,6 +122,9 @@
   text-shadow: 0 -1px 0 rgba(0,0,0,.25);
   color: @white;
 }
+.buttonExtraContrast() {
+  color: rgba(255,255,255,.75);
+}
 // Provide *some* extra contrast for those who can get it
 .btn-primary.active,
 .btn-warning.active,
@@ -127,7 +132,17 @@
 .btn-success.active,
 .btn-info.active,
 .btn-dark.active {
-  color: rgba(255,255,255,.75);
+  .buttonExtraContrast;
+}
+input:checked {
+  + .btn-primary,
+  + .btn-warning,
+  + .btn-danger,
+  + .btn-success,
+  + .btn-info,
+  + .btn-dark {
+    .buttonExtraContrast;
+  }
 }
 
 // Set the backgrounds


### PR DESCRIPTION
The following styles allow usage of fully functional toggle buttons that rely on inputs instead of js to persist state. IMHO it's a semantically better way of defining toggle buttons.

Before writing any doc/examples I was eager  to get some feedback about this approach.

A live example can be seen here http://jsfiddle.net/charettes/SauLj/.

This issue was discussed in #1161
