### PR TITLE
Update docs/examples: Add protocol back to html5shim URLs

### DIFF
--- a/docs/examples/fluid.html
+++ b/docs/examples/fluid.html
@@ -22,7 +22,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <!-- Le fav and touch icons -->

--- a/docs/examples/hero.html
+++ b/docs/examples/hero.html
@@ -19,7 +19,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <!-- Le fav and touch icons -->

--- a/docs/examples/starter-template.html
+++ b/docs/examples/starter-template.html
@@ -18,7 +18,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <!-- Le fav and touch icons -->


### PR DESCRIPTION
This is analogous to commit a72ef967ba7e.

Now 'git grep html5shim' shows that all of the html5shim URLs have a protocol.
