### PR TITLE
Added to() support for carousel plugin's data api

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -128,7 +128,7 @@
         , data = $this.data('carousel')
         , options = typeof option == 'object' && option
       if (!data) $this.data('carousel', (data = new Carousel(this, options)))
-      if (typeof option == 'number') data.to(option)
+      if (typeof option == 'number' || (option = options.to) !== undefined) data.to(option)
       else if (typeof option == 'string' || (option = options.slide)) data[option]()
       else data.cycle()
     })
@@ -145,7 +145,7 @@
   * ================= */
 
   $(function () {
-    $('body').on('click.carousel.data-api', '[data-slide]', function ( e ) {
+    $('body').on('click.carousel.data-api', '[data-slide],[data-to]', function ( e ) {
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
         , options = !$target.data('modal') && $.extend({}, $target.data(), $this.data())


### PR DESCRIPTION
While it's easy enough to support navigating to a specific slide by binding to click events, it seems that since prev()/next() are supported by the data attributes then so should to().
