### PR TITLE
removed padding and replaced with overflow: visible fix for button/input

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -170,14 +170,5 @@ input[type="submit"].btn {
   }
 
   // IE7 has some default padding on button controls
-  *padding-top: 2px;
-  *padding-bottom: 2px;
-  &.large {
-    *padding-top: 7px;
-    *padding-bottom: 7px;
-  }
-  &.small {
-    *padding-top: 3px;
-    *padding-bottom: 3px;
-  }
+  *overflow: visible;
 }


### PR DESCRIPTION
This is completely untested with Bootstrap but we used this technique on Y!Mail to normalize button padding in IE.
