### PR TITLE
adding nav-list toggable functionality

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2359,6 +2359,14 @@ button.btn.small, input[type="submit"].btn.small {
 .tabbable:after {
   clear: both;
 }
+
+.nav-list-content > .nav-list-pane {
+  display: none;
+}
+.nav-list-content > .active{
+  display: block;
+}
+
 .tab-content {
   overflow: hidden;
 }

--- a/docs/assets/js/bootstrap-navlist.js
+++ b/docs/assets/js/bootstrap-navlist.js
@@ -1,0 +1,115 @@
+﻿/* ========================================================
+* bootstrap-navlist.js v1.0.0
+* ========================================================
+* Copyright 2012 Jakub Gutkowski,
+* ======================================================== */
+
+!function ($) {
+
+    "use strict";
+
+    /* NAV LIST CLASS DEFINITION
+    * ==================== */
+
+    var NavList = function (element) {
+        this.element = $(element);
+    };
+
+    NavList.prototype = {
+        constructor: NavList,
+        show: function () {
+            var $this = this.element,
+                $ul = $this.closest('ul:not(.dropdown-menu)'),
+                selector = $this.attr('data-target'),
+                previous,
+                $target;
+
+            if (!selector) {
+                selector = $this.attr('href');
+                selector = selector && selector.replace(/.*(?=#[^\s]*$)/, ''); //strip for ie7
+                selector = selector && selector.replace(/\//gi, '-'); // replace / character i.e. #/test/something
+                selector = selector && selector.replace('#-', '#');  // replace #- with #
+            }
+
+            if ($this.parent('li').hasClass('active')) {
+                return;
+            }
+
+            previous = $ul.find('.active a').last()[0];
+
+            $this.trigger({
+                type: 'show',
+                relatedTarget: previous
+            });
+
+            $target = $(selector);
+
+            this.activate($this.parent('li'), $ul);
+            this.activate($target, $target.parent(), function () {
+                $this.trigger({
+                    type: 'shown',
+                    relatedTarget: previous
+                });
+            });
+        },
+        activate: function (element, container, callback) {
+            var $active = container.find('> .active'), transition = callback
+                && $.support.transition
+                    && $active.hasClass('fade');
+
+            function next() {
+                $active
+                    .removeClass('active')
+                    .find('> .dropdown-menu > .active')
+                    .removeClass('active');
+
+                element.addClass('active');
+
+                if (transition) {
+                    element[0].offsetWidth; // reflow for transition
+                    element.addClass('in');
+                } else {
+                    element.removeClass('fade');
+                }
+
+                if (element.parent('.dropdown-menu')) {
+                    element.closest('li.dropdown').addClass('active');
+                }
+
+                callback && callback();
+            }
+
+            transition ?
+                $active.one($.support.transition.end, next) :
+                next();
+
+            $active.removeClass('in');
+        }
+    };
+
+
+    /* NAV LIST PLUGIN DEFINITION
+    * ===================== */
+
+    $.fn.navList = function (option) {
+        return this.each(function () {
+            var $this = $(this), data = $this.data('navList');
+            if (!data) $this.data('navList', (data = new NavList(this)));
+            if (typeof option == 'string') data[option]();
+        });
+    };
+
+    $.fn.navList.Constructor = NavList;
+
+
+    /* NAV-LIST DATA-API
+    * ============ */
+
+    $(function () {
+        $('body').on('click.nav-list.data-api', '[data-toggle="nav-list"]', function (e) {
+            e.preventDefault();
+            $(this).navList('show') ;
+        });
+    });
+
+} (window.jQuery)

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -86,6 +86,7 @@
             <li><a href="#dropdowns">Dropdown</a></li>
             <li><a href="#scrollspy">Scrollspy</a></li>
             <li><a href="#tabs">Tab</a></li>
+            <li><a href="#navlist">Nav List</a></li>
             <li><a href="#tooltips">Tooltip</a></li>
             <li><a href="#popovers">Popover</a></li>
             <li><a href="#alerts">Alert</a></li>
@@ -689,6 +690,61 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
        </div>
       </div>
     </section>
+
+    <!-- Nav List
+    ================================================== -->
+      <section id="navlist">
+          <div class="page-header">
+              <h1>Togglable nav list <small>bootstrap-navlist.js</small></h1>
+          </div>
+          <div class="row">
+              <div class="span3 columns">
+                  <p>This plugin adds quick, dynamic nav list functionality for transitioning through local content.</p>
+                  <a href="assets/js/bootstrap-navlist.js" target="_blank" class="btn">Download file</a>
+              </div>
+              <div class="span9 columns">
+                  <h2>Example nav list</h2>
+                  <p>Click the navigation below to toggle between hidden panes, even via dropdown menus.</p>
+
+                  <div class="row">
+                      <div class="span3 columns">
+                          <div class="well" style="padding: 8px 0;">
+                          <ul id="nav-list" class="nav nav-list">
+                              <li class="nav-header">Header 1</li>
+                              <li class="active"><a href="#home1" data-toggle="nav-list">Home</a></li>
+                              <li><a href="#profile1" data-toggle="nav-list">Profile</a></li>
+                              <li class="nav-header">Header 2</li>
+                              <li class="dropdown">
+                                  <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
+                                  <ul class="dropdown-menu">
+                                      <li><a href="#dropdown1n" data-toggle="nav-list">@fat</a></li>
+                                      <li><a href="#dropdown2n" data-toggle="nav-list">@mdo</a></li>
+                                  </ul>
+                              </li>
+                          </ul>
+                          </div>
+                      </div>
+                      <div class="span6 columns">
+                          <div id="myNavListContent" class="nav-list-content">
+                              <div class="nav-list-pane fade in active" id="home1">
+                                  <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+                              </div>
+                              <div class="nav-list-pane fade" id="profile1">
+                                  <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
+                              </div>
+                              <div class="nav-list-pane fade" id="dropdown1n">
+                                  <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+                              </div>
+                              <div class="nav-list-pane fade" id="dropdown2n">
+                                  <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+
+              </div>
+          </div>
+      </section>
 
 
     <!-- Tooltips
@@ -1463,6 +1519,7 @@ $('.myCarousel').carousel({
     <script src="assets/js/bootstrap-dropdown.js"></script>
     <script src="assets/js/bootstrap-scrollspy.js"></script>
     <script src="assets/js/bootstrap-tab.js"></script>
+    <script src="assets/js/bootstrap-navlist.js"></script>
     <script src="assets/js/bootstrap-tooltip.js"></script>
     <script src="assets/js/bootstrap-popover.js"></script>
     <script src="assets/js/bootstrap-button.js"></script>

--- a/js/bootstrap-navlist.js
+++ b/js/bootstrap-navlist.js
@@ -1,0 +1,115 @@
+﻿/* ========================================================
+* bootstrap-navlist.js v1.0.0
+* ========================================================
+* Copyright 2012 Jakub Gutkowski,
+* ======================================================== */
+
+!function ($) {
+
+    "use strict";
+
+    /* NAV LIST CLASS DEFINITION
+    * ==================== */
+
+    var NavList = function (element) {
+        this.element = $(element);
+    };
+
+    NavList.prototype = {
+        constructor: NavList,
+        show: function () {
+            var $this = this.element,
+                $ul = $this.closest('ul:not(.dropdown-menu)'),
+                selector = $this.attr('data-target'),
+                previous,
+                $target;
+
+            if (!selector) {
+                selector = $this.attr('href');
+                selector = selector && selector.replace(/.*(?=#[^\s]*$)/, ''); //strip for ie7
+                selector = selector && selector.replace(/\//gi, '-'); // replace / character i.e. #/test/something
+                selector = selector && selector.replace('#-', '#');  // replace #- with #
+            }
+
+            if ($this.parent('li').hasClass('active')) {
+                return;
+            }
+
+            previous = $ul.find('.active a').last()[0];
+
+            $this.trigger({
+                type: 'show',
+                relatedTarget: previous
+            });
+
+            $target = $(selector);
+
+            this.activate($this.parent('li'), $ul);
+            this.activate($target, $target.parent(), function () {
+                $this.trigger({
+                    type: 'shown',
+                    relatedTarget: previous
+                });
+            });
+        },
+        activate: function (element, container, callback) {
+            var $active = container.find('> .active'), transition = callback
+                && $.support.transition
+                    && $active.hasClass('fade');
+
+            function next() {
+                $active
+                    .removeClass('active')
+                    .find('> .dropdown-menu > .active')
+                    .removeClass('active');
+
+                element.addClass('active');
+
+                if (transition) {
+                    element[0].offsetWidth; // reflow for transition
+                    element.addClass('in');
+                } else {
+                    element.removeClass('fade');
+                }
+
+                if (element.parent('.dropdown-menu')) {
+                    element.closest('li.dropdown').addClass('active');
+                }
+
+                callback && callback();
+            }
+
+            transition ?
+                $active.one($.support.transition.end, next) :
+                next();
+
+            $active.removeClass('in');
+        }
+    };
+
+
+    /* NAV LIST PLUGIN DEFINITION
+    * ===================== */
+
+    $.fn.navList = function (option) {
+        return this.each(function () {
+            var $this = $(this), data = $this.data('navList');
+            if (!data) $this.data('navList', (data = new NavList(this)));
+            if (typeof option == 'string') data[option]();
+        });
+    };
+
+    $.fn.navList.Constructor = NavList;
+
+
+    /* NAV-LIST DATA-API
+    * ============ */
+
+    $(function () {
+        $('body').on('click.nav-list.data-api', '[data-toggle="nav-list"]', function (e) {
+            e.preventDefault();
+            $(this).navList('show') ;
+        });
+    });
+
+} (window.jQuery)

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -20,6 +20,7 @@
   <script src="../../js/bootstrap-modal.js"></script>
   <script src="../../js/bootstrap-scrollspy.js"></script>
   <script src="../../js/bootstrap-tab.js"></script>
+  <script src="../../js/bootstrap-navlist.js"></script>
   <script src="../../js/bootstrap-tooltip.js"></script>
   <script src="../../js/bootstrap-popover.js"></script>
   <script src="../../js/bootstrap-typeahead.js"></script>
@@ -33,6 +34,7 @@
   <script src="unit/bootstrap-modal.js"></script>
   <script src="unit/bootstrap-scrollspy.js"></script>
   <script src="unit/bootstrap-tab.js"></script>
+  <script src="unit/bootstrap-navlist.js"></script>
   <script src="unit/bootstrap-tooltip.js"></script>
   <script src="unit/bootstrap-popover.js"></script>
   <script src="unit/bootstrap-typeahead.js"></script>

--- a/js/tests/unit/bootstrap-navlist.js
+++ b/js/tests/unit/bootstrap-navlist.js
@@ -1,0 +1,29 @@
+$(function () {
+
+    module("bootstrap-navlists");
+
+      test("should be defined on jquery object", function () {
+        ok($(document.body).navList, 'navList method is defined')
+      });
+
+      test("should return element", function () {
+        ok($(document.body).navList()[0] == document.body, 'document.body returned')
+      });
+
+      test("should activate element by navList id", function () {
+        var navListHTML =
+            '<ul class=" nav-list">'
+          + '<li><a href="#home">Home</a></li>'
+          + '<li><a href="#profile">Profile</a></li>'
+          + '</ul>'
+
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-fixture");
+
+        $(navListHTML).find('li:last a').navList('show');
+        equals($("#qunit-fixture").find('.active').attr('id'), "profile");
+
+        $(navListHTML).find('li:first a').navList('show');
+        equals($("#qunit-fixture").find('.active').attr('id'), "home");
+      });
+
+});

--- a/less/navs.less
+++ b/less/navs.less
@@ -266,6 +266,14 @@
   border-bottom: 0;
 }
 
+// Show/hide toggable areas
+.nav-list-content > .nav-list-pane {
+    display: none;
+}
+.nav-list-content > .active{
+    display: block;
+}
+
 // Show/hide tabbable areas
 .tab-content > .tab-pane,
 .pill-content > .pill-pane {


### PR DESCRIPTION
making nav-list to work similar to tabs. so we could add data-toggable attribute of value `nav-list` and javascript code will do the rest.

this check-in contains:
- JavaScript code based on Tabs code (almost the same)
- JavaScript Unit Tests for Nav-List
- nav.less update to include new class nav-list-content (it is added as a separate class but could be merged with tab-content
- example on javascript.html - simple one, without doc, just to show how it works.

in one of the project I needed that functionality and I thought it could be useful to have it by default on bootstrap, or maybe someone else will needed too.
