### PR TITLE
If there is a form on a item on the dropdown menu, don't toggle the visibility of the menu.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -42,7 +42,9 @@
         , selector = $this.attr('data-target')
         , $parent
         , isActive
-
+      
+      
+      
       if (!selector) {
         selector = $this.attr('href')
         selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
@@ -50,6 +52,10 @@
 
       $parent = $(selector)
       $parent.length || ($parent = $this.parent())
+      
+      $parent.find('form').click(function(event){
+        event.stopPropagation();
+      });
 
       isActive = $parent.hasClass('open')
 


### PR DESCRIPTION
This is a simple enhancement, that feels just to be a good default behavior for the dropdown library.

As the twitter account menu it self on the homepage, it has a login form as a item of the menu, while the user writes his username and passwords, it's incorrect that the menu hides on when selecting the form.

The feature is do by just disabling the click event on any form inside the dropdown menu.

```
  $parent.find('form').click(function(event){
    event.stopPropagation();
  });
```

Optionally will be good, after stopping the propagation of the click on the form, that can be trigger again if the click event comes from a button tag:

```
  $parent.find('form button').click(function(event) {
    $parent.trigger('click');
  });
```

I'm not so sure if this will be a good behavior.

Maybe is the best, just to stop the propagation on the items that the user needs for input, like input, select and option tags.
