### PR TITLE
Fix typo'd "gird" to "grid".

### DIFF
--- a/docs/templates/pages/scaffolding.mustache
+++ b/docs/templates/pages/scaffolding.mustache
@@ -6,7 +6,7 @@
         <div class="subnav">
           <ul class="nav nav-pills">
             <li><a href="#gridSystem">{{_i}}Grid system{{/i}}</a></li>
-            <li><a href="#fluidGridSystem">{{_i}}Fluid gird system{{/i}}</a></li>
+            <li><a href="#fluidGridSystem">{{_i}}Fluid grid system{{/i}}</a></li>
             <li><a href="#gridCustomization">{{_i}}Customizing{{/i}}</a></li>
             <li><a href="#layouts">{{_i}}Layouts{{/i}}</a></li>
             <li><a href="#responsive">{{_i}}Responsive design{{/i}}</a></li>


### PR DESCRIPTION
Fix typo'd "gird" to "grid".
