### PR TITLE
Added callback events to tooltip 

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -788,6 +788,44 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           <h4>.tooltip('toggle')</h4>
           <p>Toggles an elements tooltip.</p>
           <pre class="prettyprint linenums">$('#element').tooltip('toggle')</pre>
+          <h3>Events</h3>
+          <p>Bootstrap's tooltip class exposes a few events for hooking into tooltip functionality.</p>
+          <table class="table table-bordered table-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">Event</th>
+               <th>Description</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>show</td>
+               <td>This event fires immediately when the <code>show</code> instance method is called.</td>
+             </tr>
+             <tr>
+               <td>shown</td>
+               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).</td>
+             </tr>
+             <tr>
+               <td>hide</td>
+               <td>This event is fired immediately when the <code>hide</code> instance method has been called.</td>
+             </tr>
+             <tr>
+               <td>hidden</td>
+               <td>This event is fired when the modal has finished being hidden from the user (will wait for css transitions to complete).</td>
+             </tr>
+            </tbody>
+          </table>
+
+<pre class="prettyprint linenums">
+$('#element').on('show', function () {
+  // do important stuff
+})</pre>
+
+          <div class="alert alert-info">
+            <strong>Heads up!</strong>
+            Event are fired on tooltip trigger element since tooltips elements are added or removed from DOM when triggered by event. 
+          </div>
         </div>
       </div>
     </section>

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -110,6 +110,8 @@
         $tip = this.tip()
         this.setContent()
 
+		this.$element.trigger('show');
+
         if (this.options.animation) {
           $tip.addClass('fade')
         }
@@ -150,6 +152,8 @@
           .addClass(placement)
           .addClass('in')
       }
+
+	  this.$element.trigger('shown');
     }
 
   , setContent: function () {
@@ -162,6 +166,7 @@
       var that = this
         , $tip = this.tip()
 
+      this.$element.trigger('hide')
       $tip.removeClass('in')
 
       function removeWithAnimation() {
@@ -178,6 +183,8 @@
       $.support.transition && this.$tip.hasClass('fade') ?
         removeWithAnimation() :
         $tip.remove()
+
+      this.$element.trigger('hidden')
     }
 
   , fixTitle: function () {


### PR DESCRIPTION
I've added callback events to tooltip that match modal events.

These events are:
- show
- shown
- hide
- hidden

Also, I updated documentation. This is related to issue #2150 but i needed a way to know when the tooltip was done being created in the page.
