### PR TITLE
Added "MSTransitionEnd"

### DIFF
--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -38,6 +38,8 @@
           	transitionEnd = "webkitTransitionEnd"
           } else if ( $.browser.mozilla ) {
           	transitionEnd = "transitionend"
+          } else if ( $.browser.msie ) {
+            transitionEnd = "MSTransitionEnd"
           } else if ( $.browser.opera ) {
           	transitionEnd = "oTransitionEnd"
           }


### PR DESCRIPTION
Added support for "MSTransitionEnd" which is present in IE10 according to [this blog post](http://msdn.microsoft.com/en-us/hh778964)

It should be noted that I have not been able to test this patch (No Windows install right now to test on); I just noticed that it was missing, and couldn't find an existing issue.

If anyone has a Windows install, this should be double checked before merging.

**EDIT:** I should clarify, this is only present in IE10. I have heard that it is currently broken in the Windows 8 Consumer Preview build, but is working in the Windows 7 platform preview.

**EDIT 2:** More info, http://msdn.microsoft.com/en-us/library/ie/hh673535(v=vs.85).aspx#transitions_dom_events
