### PR TITLE
A tagmanager for bootstrap

### DIFF
--- a/docs/assets/css/bootstrap-tagmanager.css
+++ b/docs/assets/css/bootstrap-tagmanager.css
@@ -1,0 +1,36 @@
+  .myTag
+  {
+    background: none repeat scroll 0 0 #CDE69C;
+    border: 1px solid #A5D24A;
+    border-radius: 3px 3px 3px 3px;
+    color: #638421;
+    //display: block;
+    //float: left;
+    font-family: helvetica;
+    font-size: 13px;
+    margin-bottom: 5px;
+    margin-right: 5px;
+    //padding-top: 6px;
+    //padding-bottom: 5px;
+    padding: 6px 5px 5px 5px;
+    text-decoration: none;
+    
+    vertical-align: middle;
+    line-height: 18px;
+    height:18px;
+    -moz-transition: border 0.2s linear 0s, box-shadow 0.2s linear 0s;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
+  }      
+  .myTagError
+  {
+    background-color: #F2DEDE;
+  }      
+  .myTagRemover
+  {
+    color:silver;
+  }
+  .tagManager
+  {
+    border-radius: 3px 3px 3px 3px;
+    margin-top:0;
+  }

--- a/docs/assets/js/bootstrap-tagmanager.js
+++ b/docs/assets/js/bootstrap-tagmanager.js
@@ -136,7 +136,13 @@
       }
    };
 
-   jQuery.fn.popTag = function () {
+   jQuery.fn.popTag = function (robj) {
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
       if (tagLiID.length > 0) {
          var TagId = tagLiID.pop();
          tagList.pop();
@@ -144,7 +150,7 @@
               "TagIdToRemove: " + TagId
             );
          jQuery("#myTag_" + TagId).remove();
-         jQuery(inputObj).refreshHiddenTagList();
+         jQuery(obj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
@@ -211,10 +217,18 @@
       };
       jQuery.extend(tagManagerOptions, options);
 
+      var obj = jQuery(this);
+
       delimeters = tagManagerOptions.delimeters;
       backspace = tagManagerOptions.backspace;
+      hiddenTagList = null;
 
-      var obj = jQuery(this);
+      if (lastTagId > 0) {
+         while (lastTagId > 0) {
+            obj.popTag(obj);
+            lastTagId--;
+         }
+      }
 
       if (tagManagerOptions.typeahead) {
          obj.setupTypeahead();

--- a/docs/assets/js/bootstrap-tagmanager.js
+++ b/docs/assets/js/bootstrap-tagmanager.js
@@ -185,7 +185,7 @@
    jQuery.fn.tagsManager = function (options) {
       tagManagerOptions = {
          preventSubmitOnEnter: true,
-         typeahead: true,
+         typeahead: false,
          typeaheadAjaxSource: null,
          typeaheadSource: null,
          delimeters: [44, 188, 13],
@@ -228,7 +228,16 @@
       });
 
       obj.on("keyup", function (e) {
+         var p = jQuery.inArray(e.which, delimeters);
+         if (-1 != p) {
+            //user just entered a valid delimeter
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            user_input = jQuery(this).trimTag(user_input);
+            jQuery(this).pushTag(user_input);
+         }
+      });
 
+      obj.on("keydown", function (e) {
          var p = jQuery.inArray(e.which, backspace);
          if (-1 != p) {
             //user just entered backspace or equivalent
@@ -241,22 +250,16 @@
                jQuery(this).popTag();
             }
          }
+      });
 
-         p = jQuery.inArray(e.which, delimeters);
-         if (-1 != p) {
-            //user just entered a valid delimeter
+      if (!tagManagerOptions.typeahead) {
+         obj.on("blur", function (e) {
+            //lost focus
             var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
             user_input = jQuery(this).trimTag(user_input);
             jQuery(this).pushTag(user_input);
-         }
-      });
-
-      obj.on("blur", function (e) {
-         //lost focus
-         var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
-         user_input = jQuery(this).trimTag(user_input);
-         jQuery(this).pushTag(user_input);
-      });
+         });
+      }
 
    }
 })(jQuery);

--- a/docs/assets/js/bootstrap-tagmanager.js
+++ b/docs/assets/js/bootstrap-tagmanager.js
@@ -94,6 +94,31 @@
       }
    };
 
+   jQuery.fn.refreshHiddenTagList = function (robj) {
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
+      if (hiddenTagList == null || hiddenTagList == undefined) {
+         var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+         if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+            hiddenTagList = lhiddenTagList[0];
+         else {
+            html = "";
+            html += "<input name='hiddenTagList' type='hidden' value=''/>";
+            obj.before(html);
+            lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+               hiddenTagList = lhiddenTagList[0];
+         }
+      }
+      if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
+         jQuery(hiddenTagList).val(tagList.join(","));
+      }
+   };
+
    jQuery.fn.spliceTag = function (TagId) {
       console.log(
               "TagIdToRemove: " + TagId
@@ -106,6 +131,7 @@
          jQuery("#myTag_" + TagId).remove();
          tagList.splice(p, 1);
          tagLiID.splice(p, 1);
+         jQuery(inputObj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
@@ -118,16 +144,25 @@
               "TagIdToRemove: " + TagId
             );
          jQuery("#myTag_" + TagId).remove();
+         jQuery(inputObj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
 
-   jQuery.fn.pushTag = function (tag) {
+   jQuery.fn.pushTag = function (tag, robj) {
       if (!tag || tag.length <= 0) {
          return;
       }
+      if (tagManagerOptions.CapitalizeFirstLetter && tag.length > 1) {
+         tag = tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+      }
 
-      var obj = jQuery(this);
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
       var alreadyInList = false;
       var p = jQuery.inArray(tag, tagList);
       if (-1 != p) {
@@ -156,26 +191,7 @@
             jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
          });
 
-         if (hiddenTagList == null || hiddenTagList == undefined) {
-            var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
-            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
-               hiddenTagList = lhiddenTagList[0];
-            else {
-               html = "";
-               html += "<input name='hiddenTagList' type='hidden' value=''/>";
-               obj.before(html);
-               lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
-               if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
-                  hiddenTagList = lhiddenTagList[0];
-            }
-         }
-         if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
-            jQuery(hiddenTagList).val(tagList.join(","));
-         }
-         //            jQuery("#myHidden" + TagId).on("click", function (e) {
-         //              var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
-         //              jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
-         //            });
+         obj.refreshHiddenTagList(obj);
 
       }
       obj.val("");
@@ -184,6 +200,8 @@
 
    jQuery.fn.tagsManager = function (options) {
       tagManagerOptions = {
+         prefilled: null,
+         CapitalizeFirstLetter: true,
          preventSubmitOnEnter: true,
          typeahead: false,
          typeaheadAjaxSource: null,
@@ -259,6 +277,24 @@
             user_input = jQuery(this).trimTag(user_input);
             jQuery(this).pushTag(user_input);
          });
+      }
+
+      if (tagManagerOptions.prefilled != null) {
+         if (typeof (tagManagerOptions.prefilled) == "object") {
+            var pta = tagManagerOptions.prefilled;
+            jQuery.each(pta, function (key, val) {
+               var a = 1;
+               obj.pushTag(val, obj);
+            });
+         } else if (typeof (tagManagerOptions.prefilled) == "string") {
+            var pta = tagManagerOptions.prefilled.split(',');
+
+            jQuery.each(pta, function (key, val) {
+               var a = 1;
+               obj.pushTag(val, obj);
+            });
+
+         }
       }
 
    }

--- a/docs/assets/js/bootstrap-tagmanager.js
+++ b/docs/assets/js/bootstrap-tagmanager.js
@@ -1,0 +1,262 @@
+/*
+
+
+*/
+
+(function (jQuery) {
+   var SourceArray = ["Lombardia", "Abruzzo", "Toscana", "Liguria"];
+   var SourceAjaxArray = new Array();
+
+   var delimeters = new Array();
+   var backspace = new Array();
+   var inputObj = null;
+   var tagList = new Array();
+   var tagLiID = new Array();
+   var lastTagId = 0;
+   var hiddenTagList = null;
+
+   var tagManagerOptions = null;
+
+   inputObj = this;
+
+   jQuery.fn.trimTag = function (tag) {
+      var txt = jQuery.trim(tag);
+
+      var l = txt.length;
+      var t = 0;
+
+      //          console.log(
+      //                "tag to trim : " + txt
+      //              );
+      //remove from end
+      for (var i = l - 1; i >= 0; i--) {
+         //            console.log(
+         //                "char to evaluate : " + txt[i] + " (" + txt.charCodeAt(i) + ")"
+         //              );
+         if (-1 != jQuery.inArray(txt.charCodeAt(i), delimeters)) {
+            //              console.log(
+            //                "char to remove from end: " + txt[i]
+            //              );
+            t++;
+         } else
+            break;
+      }
+      txt = txt.substring(0, l - t);
+      l = txt.length;
+      t = 0;
+      //remove from head
+      for (var i = 0; i < l; i++) {
+         //            console.log(
+         //                "char to evaluate : " + txt[i] + " (" + txt.charCodeAt(i) + ")"
+         //              );
+         if (-1 != jQuery.inArray(txt.charCodeAt(i), delimeters)) {
+            //              console.log(
+            //                "char to remove from head: " + txt[i]
+            //              );
+            t++;
+         } else
+            break;
+      }
+
+      txt = txt.substring(t, l);
+      //          console.log(
+      //                "trimmed to : " + txt
+      //              );
+
+      return txt;
+   };
+
+   jQuery.fn.setupTypeahead = function (tag) {
+      var obj = jQuery(this);
+
+      if (tagManagerOptions.typeaheadSource != null) {
+         obj.typeahead();
+         obj.data('active', true);
+         obj.data('typeahead').source = tagManagerOptions.typeaheadSource;
+         obj.data('active', false);
+      } else if (tagManagerOptions.typeaheadAjaxSource != null) {
+         obj.typeahead();
+         jQuery.getJSON(tagManagerOptions.typeaheadAjaxSource, function (data) {
+            if (data != undefined && data.tags != undefined) {
+               //SourceAjaxArray.clear();
+               jQuery.each(data.tags, function (key, val) {
+                  var a = 1;
+                  //jQuery('#addexpenses select[name="who"]').append('<option value="' + val.who + '">' + val.name + '</option>');
+                  SourceAjaxArray.push(val.tag);
+                  //obj.attr("data-sources", SourceArray);
+                  obj.data('active', true);
+                  obj.data('typeahead').source = SourceAjaxArray;
+                  obj.data('active', false);
+                  //obj.attr("data-sources", SourceAjaxArray.join(", "));
+               });
+            }
+         });
+      }
+   };
+
+   jQuery.fn.spliceTag = function (TagId) {
+      console.log(
+              "TagIdToRemove: " + TagId
+            );
+      var p = jQuery.inArray(TagId, tagLiID)
+      console.log(
+              "position: " + p
+            );
+      if (-1 != p) {
+         jQuery("#myTag_" + TagId).remove();
+         tagList.splice(p, 1);
+         tagLiID.splice(p, 1);
+         console.log(tagList);
+      }
+   };
+
+   jQuery.fn.popTag = function () {
+      if (tagLiID.length > 0) {
+         var TagId = tagLiID.pop();
+         tagList.pop();
+         console.log(
+              "TagIdToRemove: " + TagId
+            );
+         jQuery("#myTag_" + TagId).remove();
+         console.log(tagList);
+      }
+   };
+
+   jQuery.fn.pushTag = function (tag) {
+      if (!tag || tag.length <= 0) {
+         return;
+      }
+
+      var obj = jQuery(this);
+      var alreadyInList = false;
+      var p = jQuery.inArray(tag, tagList);
+      if (-1 != p) {
+         console.log(
+                "tag:" + tag + " !!already in list!!"
+              );
+         alreadyInList = true;
+      }
+
+      if (alreadyInList) {
+         var pTagId = tagLiID[p];
+         jQuery("#myTag_" + pTagId).stop().animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100);
+      } else {
+         var TagId = lastTagId++;
+         tagList.push(tag);
+         tagLiID.push(TagId);
+
+         var html = '';
+         html += '<span class="myTag" id="myTag_' + TagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="myRemover_' + TagId + '" TagIdToRemove="' + TagId + '" title="Removing tag">x</a></span>';
+         console.log(
+              "tagList: " + tagList
+            );
+         obj.before(html);
+         jQuery("#myRemover_" + TagId).on("click", function (e) {
+            var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
+            jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
+         });
+
+         if (hiddenTagList == null || hiddenTagList == undefined) {
+            var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+               hiddenTagList = lhiddenTagList[0];
+            else {
+               html = "";
+               html += "<input name='hiddenTagList' type='hidden' value=''/>";
+               obj.before(html);
+               lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+               if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+                  hiddenTagList = lhiddenTagList[0];
+            }
+         }
+         if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
+            jQuery(hiddenTagList).val(tagList.join(","));
+         }
+         //            jQuery("#myHidden" + TagId).on("click", function (e) {
+         //              var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
+         //              jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
+         //            });
+
+      }
+      obj.val("");
+
+   };
+
+   jQuery.fn.tagsManager = function (options) {
+      tagManagerOptions = {
+         preventSubmitOnEnter: true,
+         typeahead: true,
+         typeaheadAjaxSource: null,
+         typeaheadSource: null,
+         delimeters: [44, 188, 13],
+         backspace: [8]
+      };
+      jQuery.extend(tagManagerOptions, options);
+
+      delimeters = tagManagerOptions.delimeters;
+      backspace = tagManagerOptions.backspace;
+
+      var obj = jQuery(this);
+
+      if (tagManagerOptions.typeahead) {
+         obj.setupTypeahead();
+         //obj.typeahead({ source: SourceArray })
+      }
+
+      // disable submit on enter for this input field
+      obj.on("focus", function (e) {
+         if (jQuery(this).popover) {
+            jQuery(this).popover("hide");
+            //jQuery(this).popover = null;
+         }
+      });
+
+      obj.on("keypress", function (e) {
+         if (jQuery(this).popover) {
+            jQuery(this).popover("hide");
+            //jQuery(this).popover = null;
+         }
+         if (tagManagerOptions.preventSubmitOnEnter) {
+            if (e.which == 13) {
+               e.cancelBubble = true;
+               e.returnValue = false;
+               e.stopPropagation();
+               e.preventDefault();
+               //e.keyCode = 9;
+            }
+         }
+      });
+
+      obj.on("keyup", function (e) {
+
+         var p = jQuery.inArray(e.which, backspace);
+         if (-1 != p) {
+            //user just entered backspace or equivalent
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            var i = user_input.length;
+            if (i <= 0) {
+               console.log(
+                  "backspace detected"
+                );
+               jQuery(this).popTag();
+            }
+         }
+
+         p = jQuery.inArray(e.which, delimeters);
+         if (-1 != p) {
+            //user just entered a valid delimeter
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            user_input = jQuery(this).trimTag(user_input);
+            jQuery(this).pushTag(user_input);
+         }
+      });
+
+      obj.on("blur", function (e) {
+         //lost focus
+         var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+         user_input = jQuery(this).trimTag(user_input);
+         jQuery(this).pushTag(user_input);
+      });
+
+   }
+})(jQuery);

--- a/docs/tagmanager.html
+++ b/docs/tagmanager.html
@@ -92,6 +92,7 @@ Hope the options are pretty obvious, yes there is an ajax source option for the 
         var SourceArray = ["Lombardia", "Abruzzo", "Toscana", "Liguria"];
 
         $(".tagManager").tagsManager({
+          prefilled: "Scarpe,Vestiti,Pranzo",
           preventSubmitOnEnter: true,
           typeahead: true,
           typeaheadAjaxSource: null,

--- a/docs/tagmanager.html
+++ b/docs/tagmanager.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Bootstrap, from Twitter</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <!-- Le styles -->
+    <link href="assets/css/bootstrap.css" rel="stylesheet">
+    <style>
+      body {
+        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
+      }
+    </style>
+    <link href="assets/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="assets/css/bootstrap-tagmanager.css" rel="stylesheet">
+
+    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+    <!-- Le fav and touch icons -->
+    <link rel="shortcut icon" href="images/favicon.ico">
+    <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png">
+
+  </head>
+
+  <body>
+
+    <div class="navbar navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </a>
+          <a class="brand" href="#">bootstrap tagmanager plugin</a>
+          <div class="nav-collapse">
+            <ul class="nav">
+              <li class="active"><a href="#">Home</a></li>
+            </ul>
+          </div><!--/.nav-collapse -->
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+
+    <div class="row">
+
+        <form class="wwell form-inline" id="addexpenses">
+
+        <div class="input-prepend"><input type="text" class="input-small" placeholder="Billing date" size="16" name="postingdate"/><span class="add-on"><i class="icon-calendar"></i></span></div>
+        <input type="text" class="input-small span2 control-group error" placeholder="Description" name="description"/>
+        <input type="text" class="input-small tagManager typeahead" style=""placeholder="Tags" name="tags" data-provide="typeahead" data-items="6" autocomplete="off"/>
+        <div class="input-prepend" style="white-space: nowrap;-webkit-padding-end: 27px;"><span class="add-on currencySymbol" >$</span><input type="text" class="input-small" placeholder="How much"  size="16" name="howmuch"/></div>
+        <button type="submit" class="btn btn-inverse submit">Add record</button>
+        
+        </form>
+
+        <form class="wwell form-inline" id="addexpenses">
+
+        <div class="input-prepend"><input type="text" class="input-small" placeholder="Posting date" size="16" name="postingdate"/><span class="add-on"><i class="icon-calendar"></i></span></div>
+        <input type="text" class="input-small tagManager typeahead" style=""placeholder="Tags" name="tags" data-provide="typeahead" data-items="6" autocomplete="off"/>
+        <div class="input-prepend" style="white-space: nowrap;-webkit-padding-end: 27px;"><span class="add-on currencySymbol" >$</span><input type="text" class="input-small" placeholder="How much"  size="16" name="howmuch"/></div>
+        <button type="submit" class="btn btn-inverse submit">Add record</button>
+        
+        </form>
+
+    </div>
+
+    <div class="row">
+
+<p>
+Type something in field "tags" and end it with a comma or tab or hit return.
+In this example typeahead is activated.
+</p>
+
+<h3>How to initialize it.</h3>
+<p>
+Hope the options are pretty obvious, yes there is an ajax source option for the typeahead, it actually refresh the array from the ajax source only on setup right now, I will make it more flexible soon I hope, for my needs this was enough.
+</p>
+
+<div>
+<pre class="prettyprint linenums">
+        var SourceArray = ["Lombardia", "Abruzzo", "Toscana", "Liguria"];
+
+        $(".tagManager").tagsManager({
+          preventSubmitOnEnter: true,
+          typeahead: true,
+          typeaheadAjaxSource: null,
+          typeaheadSource: SourceArray,
+          blinkBGColor_1: '#FFFF9C',
+          blinkBGColor_2: '#CDE69C'
+        });
+</pre>
+</div>
+
+<h3>Remember to...</h3>
+<p>
+Include all the necessary files!
+</p>
+
+<div>
+<pre class="prettyprint linenums">
+  /css/bootstrap-tagmanager.css
+  /js/bootstrap-tagmanager.js
+</pre>
+</div>
+
+    </div>
+
+    </div> <!-- /container -->
+
+    <!-- Le javascript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="assets/js/jquery.js"></script>
+    <script src="assets/js/bootstrap-transition.js"></script>
+    <script src="assets/js/bootstrap-alert.js"></script>
+    <script src="assets/js/bootstrap-modal.js"></script>
+    <script src="assets/js/bootstrap-dropdown.js"></script>
+    <script src="assets/js/bootstrap-scrollspy.js"></script>
+    <script src="assets/js/bootstrap-tab.js"></script>
+    <script src="assets/js/bootstrap-tooltip.js"></script>
+    <script src="assets/js/bootstrap-popover.js"></script>
+    <script src="assets/js/bootstrap-button.js"></script>
+    <script src="assets/js/bootstrap-collapse.js"></script>
+    <script src="assets/js/bootstrap-carousel.js"></script>
+    <script src="assets/js/bootstrap-typeahead.js"></script>
+    <script src="assets/js/bootstrap-tagmanager.js"></script>
+
+    <script>
+
+      jQuery(document).ready(function () {
+
+        var SourceArray = ["Lombardia", "Abruzzo", "Toscana", "Liguria"];
+
+        $(".tagManager").tagsManager({
+          preventSubmitOnEnter: true,
+          typeahead: true,
+          typeaheadAjaxSource: null,
+          typeaheadSource: SourceArray,
+          blinkBGColor_1: '#FFFF9C',
+          blinkBGColor_2: '#CDE69C'
+        });
+      });
+    </script>
+
+  </body>
+</html>

--- a/js/bootstrap-tagmanager.js
+++ b/js/bootstrap-tagmanager.js
@@ -136,7 +136,13 @@
       }
    };
 
-   jQuery.fn.popTag = function () {
+   jQuery.fn.popTag = function (robj) {
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
       if (tagLiID.length > 0) {
          var TagId = tagLiID.pop();
          tagList.pop();
@@ -144,7 +150,7 @@
               "TagIdToRemove: " + TagId
             );
          jQuery("#myTag_" + TagId).remove();
-         jQuery(inputObj).refreshHiddenTagList();
+         jQuery(obj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
@@ -211,10 +217,18 @@
       };
       jQuery.extend(tagManagerOptions, options);
 
+      var obj = jQuery(this);
+
       delimeters = tagManagerOptions.delimeters;
       backspace = tagManagerOptions.backspace;
+      hiddenTagList = null;
 
-      var obj = jQuery(this);
+      if (lastTagId > 0) {
+         while (lastTagId > 0) {
+            obj.popTag(obj);
+            lastTagId--;
+         }
+      }
 
       if (tagManagerOptions.typeahead) {
          obj.setupTypeahead();

--- a/js/bootstrap-tagmanager.js
+++ b/js/bootstrap-tagmanager.js
@@ -185,7 +185,7 @@
    jQuery.fn.tagsManager = function (options) {
       tagManagerOptions = {
          preventSubmitOnEnter: true,
-         typeahead: true,
+         typeahead: false,
          typeaheadAjaxSource: null,
          typeaheadSource: null,
          delimeters: [44, 188, 13],
@@ -228,7 +228,16 @@
       });
 
       obj.on("keyup", function (e) {
+         var p = jQuery.inArray(e.which, delimeters);
+         if (-1 != p) {
+            //user just entered a valid delimeter
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            user_input = jQuery(this).trimTag(user_input);
+            jQuery(this).pushTag(user_input);
+         }
+      });
 
+      obj.on("keydown", function (e) {
          var p = jQuery.inArray(e.which, backspace);
          if (-1 != p) {
             //user just entered backspace or equivalent
@@ -241,22 +250,16 @@
                jQuery(this).popTag();
             }
          }
+      });
 
-         p = jQuery.inArray(e.which, delimeters);
-         if (-1 != p) {
-            //user just entered a valid delimeter
+      if (!tagManagerOptions.typeahead) {
+         obj.on("blur", function (e) {
+            //lost focus
             var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
             user_input = jQuery(this).trimTag(user_input);
             jQuery(this).pushTag(user_input);
-         }
-      });
-
-      obj.on("blur", function (e) {
-         //lost focus
-         var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
-         user_input = jQuery(this).trimTag(user_input);
-         jQuery(this).pushTag(user_input);
-      });
+         });
+      }
 
    }
 })(jQuery);

--- a/js/bootstrap-tagmanager.js
+++ b/js/bootstrap-tagmanager.js
@@ -94,6 +94,31 @@
       }
    };
 
+   jQuery.fn.refreshHiddenTagList = function (robj) {
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
+      if (hiddenTagList == null || hiddenTagList == undefined) {
+         var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+         if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+            hiddenTagList = lhiddenTagList[0];
+         else {
+            html = "";
+            html += "<input name='hiddenTagList' type='hidden' value=''/>";
+            obj.before(html);
+            lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+               hiddenTagList = lhiddenTagList[0];
+         }
+      }
+      if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
+         jQuery(hiddenTagList).val(tagList.join(","));
+      }
+   };
+
    jQuery.fn.spliceTag = function (TagId) {
       console.log(
               "TagIdToRemove: " + TagId
@@ -106,6 +131,7 @@
          jQuery("#myTag_" + TagId).remove();
          tagList.splice(p, 1);
          tagLiID.splice(p, 1);
+         jQuery(inputObj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
@@ -118,16 +144,25 @@
               "TagIdToRemove: " + TagId
             );
          jQuery("#myTag_" + TagId).remove();
+         jQuery(inputObj).refreshHiddenTagList();
          console.log(tagList);
       }
    };
 
-   jQuery.fn.pushTag = function (tag) {
+   jQuery.fn.pushTag = function (tag, robj) {
       if (!tag || tag.length <= 0) {
          return;
       }
+      if (tagManagerOptions.CapitalizeFirstLetter && tag.length > 1) {
+         tag = tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+      }
 
-      var obj = jQuery(this);
+      var obj;
+      if (robj == null)
+         obj = jQuery(this);
+      else
+         obj = robj;
+
       var alreadyInList = false;
       var p = jQuery.inArray(tag, tagList);
       if (-1 != p) {
@@ -156,26 +191,7 @@
             jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
          });
 
-         if (hiddenTagList == null || hiddenTagList == undefined) {
-            var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
-            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
-               hiddenTagList = lhiddenTagList[0];
-            else {
-               html = "";
-               html += "<input name='hiddenTagList' type='hidden' value=''/>";
-               obj.before(html);
-               lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
-               if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
-                  hiddenTagList = lhiddenTagList[0];
-            }
-         }
-         if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
-            jQuery(hiddenTagList).val(tagList.join(","));
-         }
-         //            jQuery("#myHidden" + TagId).on("click", function (e) {
-         //              var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
-         //              jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
-         //            });
+         obj.refreshHiddenTagList(obj);
 
       }
       obj.val("");
@@ -184,6 +200,8 @@
 
    jQuery.fn.tagsManager = function (options) {
       tagManagerOptions = {
+         prefilled: null,
+         CapitalizeFirstLetter: true,
          preventSubmitOnEnter: true,
          typeahead: false,
          typeaheadAjaxSource: null,
@@ -259,6 +277,24 @@
             user_input = jQuery(this).trimTag(user_input);
             jQuery(this).pushTag(user_input);
          });
+      }
+
+      if (tagManagerOptions.prefilled != null) {
+         if (typeof (tagManagerOptions.prefilled) == "object") {
+            var pta = tagManagerOptions.prefilled;
+            jQuery.each(pta, function (key, val) {
+               var a = 1;
+               obj.pushTag(val, obj);
+            });
+         } else if (typeof (tagManagerOptions.prefilled) == "string") {
+            var pta = tagManagerOptions.prefilled.split(',');
+
+            jQuery.each(pta, function (key, val) {
+               var a = 1;
+               obj.pushTag(val, obj);
+            });
+
+         }
       }
 
    }

--- a/js/bootstrap-tagmanager.js
+++ b/js/bootstrap-tagmanager.js
@@ -1,0 +1,262 @@
+/*
+
+
+*/
+
+(function (jQuery) {
+   var SourceArray = ["Lombardia", "Abruzzo", "Toscana", "Liguria"];
+   var SourceAjaxArray = new Array();
+
+   var delimeters = new Array();
+   var backspace = new Array();
+   var inputObj = null;
+   var tagList = new Array();
+   var tagLiID = new Array();
+   var lastTagId = 0;
+   var hiddenTagList = null;
+
+   var tagManagerOptions = null;
+
+   inputObj = this;
+
+   jQuery.fn.trimTag = function (tag) {
+      var txt = jQuery.trim(tag);
+
+      var l = txt.length;
+      var t = 0;
+
+      //          console.log(
+      //                "tag to trim : " + txt
+      //              );
+      //remove from end
+      for (var i = l - 1; i >= 0; i--) {
+         //            console.log(
+         //                "char to evaluate : " + txt[i] + " (" + txt.charCodeAt(i) + ")"
+         //              );
+         if (-1 != jQuery.inArray(txt.charCodeAt(i), delimeters)) {
+            //              console.log(
+            //                "char to remove from end: " + txt[i]
+            //              );
+            t++;
+         } else
+            break;
+      }
+      txt = txt.substring(0, l - t);
+      l = txt.length;
+      t = 0;
+      //remove from head
+      for (var i = 0; i < l; i++) {
+         //            console.log(
+         //                "char to evaluate : " + txt[i] + " (" + txt.charCodeAt(i) + ")"
+         //              );
+         if (-1 != jQuery.inArray(txt.charCodeAt(i), delimeters)) {
+            //              console.log(
+            //                "char to remove from head: " + txt[i]
+            //              );
+            t++;
+         } else
+            break;
+      }
+
+      txt = txt.substring(t, l);
+      //          console.log(
+      //                "trimmed to : " + txt
+      //              );
+
+      return txt;
+   };
+
+   jQuery.fn.setupTypeahead = function (tag) {
+      var obj = jQuery(this);
+
+      if (tagManagerOptions.typeaheadSource != null) {
+         obj.typeahead();
+         obj.data('active', true);
+         obj.data('typeahead').source = tagManagerOptions.typeaheadSource;
+         obj.data('active', false);
+      } else if (tagManagerOptions.typeaheadAjaxSource != null) {
+         obj.typeahead();
+         jQuery.getJSON(tagManagerOptions.typeaheadAjaxSource, function (data) {
+            if (data != undefined && data.tags != undefined) {
+               //SourceAjaxArray.clear();
+               jQuery.each(data.tags, function (key, val) {
+                  var a = 1;
+                  //jQuery('#addexpenses select[name="who"]').append('<option value="' + val.who + '">' + val.name + '</option>');
+                  SourceAjaxArray.push(val.tag);
+                  //obj.attr("data-sources", SourceArray);
+                  obj.data('active', true);
+                  obj.data('typeahead').source = SourceAjaxArray;
+                  obj.data('active', false);
+                  //obj.attr("data-sources", SourceAjaxArray.join(", "));
+               });
+            }
+         });
+      }
+   };
+
+   jQuery.fn.spliceTag = function (TagId) {
+      console.log(
+              "TagIdToRemove: " + TagId
+            );
+      var p = jQuery.inArray(TagId, tagLiID)
+      console.log(
+              "position: " + p
+            );
+      if (-1 != p) {
+         jQuery("#myTag_" + TagId).remove();
+         tagList.splice(p, 1);
+         tagLiID.splice(p, 1);
+         console.log(tagList);
+      }
+   };
+
+   jQuery.fn.popTag = function () {
+      if (tagLiID.length > 0) {
+         var TagId = tagLiID.pop();
+         tagList.pop();
+         console.log(
+              "TagIdToRemove: " + TagId
+            );
+         jQuery("#myTag_" + TagId).remove();
+         console.log(tagList);
+      }
+   };
+
+   jQuery.fn.pushTag = function (tag) {
+      if (!tag || tag.length <= 0) {
+         return;
+      }
+
+      var obj = jQuery(this);
+      var alreadyInList = false;
+      var p = jQuery.inArray(tag, tagList);
+      if (-1 != p) {
+         console.log(
+                "tag:" + tag + " !!already in list!!"
+              );
+         alreadyInList = true;
+      }
+
+      if (alreadyInList) {
+         var pTagId = tagLiID[p];
+         jQuery("#myTag_" + pTagId).stop().animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_1 }, 100).animate({ backgroundColor: tagManagerOptions.blinkBGColor_2 }, 100);
+      } else {
+         var TagId = lastTagId++;
+         tagList.push(tag);
+         tagLiID.push(TagId);
+
+         var html = '';
+         html += '<span class="myTag" id="myTag_' + TagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="myRemover_' + TagId + '" TagIdToRemove="' + TagId + '" title="Removing tag">x</a></span>';
+         console.log(
+              "tagList: " + tagList
+            );
+         obj.before(html);
+         jQuery("#myRemover_" + TagId).on("click", function (e) {
+            var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
+            jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
+         });
+
+         if (hiddenTagList == null || hiddenTagList == undefined) {
+            var lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+            if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+               hiddenTagList = lhiddenTagList[0];
+            else {
+               html = "";
+               html += "<input name='hiddenTagList' type='hidden' value=''/>";
+               obj.before(html);
+               lhiddenTagList = obj.siblings("input[name='hiddenTagList']");
+               if (lhiddenTagList != null && lhiddenTagList != undefined && lhiddenTagList[0] != undefined)
+                  hiddenTagList = lhiddenTagList[0];
+            }
+         }
+         if (hiddenTagList != null || hiddenTagList != undefined && lhiddenTagList[0] != undefined) {
+            jQuery(hiddenTagList).val(tagList.join(","));
+         }
+         //            jQuery("#myHidden" + TagId).on("click", function (e) {
+         //              var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
+         //              jQuery(this).spliceTag(parseInt(jQuery(this).attr("TagIdToRemove")));
+         //            });
+
+      }
+      obj.val("");
+
+   };
+
+   jQuery.fn.tagsManager = function (options) {
+      tagManagerOptions = {
+         preventSubmitOnEnter: true,
+         typeahead: true,
+         typeaheadAjaxSource: null,
+         typeaheadSource: null,
+         delimeters: [44, 188, 13],
+         backspace: [8]
+      };
+      jQuery.extend(tagManagerOptions, options);
+
+      delimeters = tagManagerOptions.delimeters;
+      backspace = tagManagerOptions.backspace;
+
+      var obj = jQuery(this);
+
+      if (tagManagerOptions.typeahead) {
+         obj.setupTypeahead();
+         //obj.typeahead({ source: SourceArray })
+      }
+
+      // disable submit on enter for this input field
+      obj.on("focus", function (e) {
+         if (jQuery(this).popover) {
+            jQuery(this).popover("hide");
+            //jQuery(this).popover = null;
+         }
+      });
+
+      obj.on("keypress", function (e) {
+         if (jQuery(this).popover) {
+            jQuery(this).popover("hide");
+            //jQuery(this).popover = null;
+         }
+         if (tagManagerOptions.preventSubmitOnEnter) {
+            if (e.which == 13) {
+               e.cancelBubble = true;
+               e.returnValue = false;
+               e.stopPropagation();
+               e.preventDefault();
+               //e.keyCode = 9;
+            }
+         }
+      });
+
+      obj.on("keyup", function (e) {
+
+         var p = jQuery.inArray(e.which, backspace);
+         if (-1 != p) {
+            //user just entered backspace or equivalent
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            var i = user_input.length;
+            if (i <= 0) {
+               console.log(
+                  "backspace detected"
+                );
+               jQuery(this).popTag();
+            }
+         }
+
+         p = jQuery.inArray(e.which, delimeters);
+         if (-1 != p) {
+            //user just entered a valid delimeter
+            var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+            user_input = jQuery(this).trimTag(user_input);
+            jQuery(this).pushTag(user_input);
+         }
+      });
+
+      obj.on("blur", function (e) {
+         //lost focus
+         var user_input = jQuery(this).val(); //user_input = jQuery().inArray(delimeters[p]);
+         user_input = jQuery(this).trimTag(user_input);
+         jQuery(this).pushTag(user_input);
+      });
+
+   }
+})(jQuery);


### PR DESCRIPTION
On the project I am working on I am using bootstrap and I love it, but I was also  in need of a <b>"tag manager"</b> plugin, I tried many I found for jQuery but was hard to make them compatible (for me at least), so I created my own.

I added <b>/docs/tagmanager.html</b> with an example of usage.

And two files:
bootstrap-tagmanager.css
bootstrap-tagmanager.js

Basically in the input field you can type what you want followed by a comma, and the plugin will style it as a tag, <b>typeahead</b> is supported, with <b>ajaxsource</b> too.
