### PR TITLE
Fixed small button caret and moved less code to dropdowns

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -141,8 +141,3 @@
   }
 }
 
-// Small button dropdowns
-.btn-small .caret {
-  margin-top: 4px;
-}
-

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -37,6 +37,10 @@
 .open.dropdown .caret {
   .opacity(100);
 }
+// Small button dropdowns
+.btn-small .caret {
+  margin-top: 6px;
+}
 // The dropdown menu (ul)
 .dropdown-menu {
   position: absolute;


### PR DESCRIPTION
Small button caret is not aligned with baseline (on FF and Chrome).

You can test it by adding `btn-small` class to dropdown buttons at http://twitter.github.com/bootstrap/components.html using an inspector of your choice.

I also moved the less code to dropdown since non-split dropdowns are no split buttons.
