### PR TITLE
Include `from` and `to` indexes in Carousel `slide` event

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1346,7 +1346,7 @@ $('.myCarousel').carousel({
             <tbody>
              <tr>
                <td>slide</td>
-               <td>This event fires immediately when the <code>slide</code> instance method is invoked.</td>
+               <td>This event fires immediately when the <code>slide</code> instance method is invoked. The callback will receive the indexes of the items that the carousel is transitioning <em>from</em> and <em>to</em> as the <em>second</em> and <em>third</em> arguments, respectively.</td>
              </tr>
              <tr>
                <td>slid</td>

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -82,6 +82,8 @@
         , direction = type == 'next' ? 'left' : 'right'
         , fallback  = type == 'next' ? 'first' : 'last'
         , that = this
+        , fromIndex
+        , toIndex
 
       if (!$next.length) return
 
@@ -91,8 +93,10 @@
 
       $next = $next.length ? $next : this.$element.find('.item')[fallback]()
 
+      fromIndex = $active.index();
+      toIndex = $next.index();
       if (!$.support.transition && this.$element.hasClass('slide')) {
-        this.$element.trigger('slide')
+        this.$element.trigger('slide', [fromIndex, toIndex])
         $active.removeClass('active')
         $next.addClass('active')
         this.sliding = false
@@ -102,7 +106,7 @@
         $next[0].offsetWidth // force reflow
         $active.addClass(direction)
         $next.addClass(direction)
-        this.$element.trigger('slide')
+        this.$element.trigger('slide', [fromIndex, toIndex])
         this.$element.one($.support.transition.end, function () {
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))


### PR DESCRIPTION
The `slide` event callback will now receive the indexes of the items that the carousel is transitioning _from_ and _to_ as the _second_ and _third_ arguments, respectively.

Example:

```
someCarousel.bind('slide', function (event, fromIndex, toIndex) {
...
});
```

I chose to pass the indexes instead of the actual DOM elements, to be consistent with the `.carousel(number)` function, which uses a zero-based index to the desired carousel item.

This should also address issue #2240.
