### PR TITLE
uglify-js install information in compiling section at less.html. Improve issue #1756

### DIFF
--- a/docs/templates/pages/less.mustache
+++ b/docs/templates/pages/less.mustache
@@ -641,8 +641,8 @@
   <div class="row">
     <div class="span4">
       <h3>{{_i}}Node with makefile{{/i}}</h3>
-      <p>{{_i}}Install the LESS command line compiler globally with npm by running the following command:{{/i}}</p>
-      <pre>$ npm install -g less</pre>
+      <p>{{_i}}Install the LESS command line compiler and uglify-js globally with npm by running the following command:{{/i}}</p>
+      <pre>$ npm install -g less uglify-js</pre>
       <p>{{_i}}Once installed just run <code>make</code> from the root of your bootstrap directory and you're all set.{{/i}}</p>
       <p>{{_i}}Additionally, if you have <a href="https://github.com/mynyml/watchr">watchr</a> installed, you may run <code>make watch</code> to have bootstrap automatically rebuilt every time you edit a file in the bootstrap lib (this isn't required, just a convenience method).{{/i}}</p>
     </div><!-- /span4 -->


### PR DESCRIPTION
uglify-js is required to compile the project, but this is just in README.md
