### PR TITLE
carousel: stop previous cycles when calling cycle()

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -34,6 +34,8 @@
   Carousel.prototype = {
 
     cycle: function () {
+      if (this.interval)
+        this.pause()
       this.interval = setInterval($.proxy(this.next, this), this.options.interval)
       return this
     }


### PR DESCRIPTION
stop the previous cycle interval when calling cycle(). 
This was causing issues when pausing/unpausing using hoverevents on the next and previous buttons.
