### PR TITLE
Static Navbar .container width fix

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -20,6 +20,14 @@
   .box-shadow(@shadow);
 }
 
+// Elements with .pull-right (fx) in static navbars, will now display correctly,
+// because .container divs inside does not force 940px width
+// (which is incorrect because 940px inside something already 940px + padding becomes
+// greater than 940px
+.navbar-inner .container {
+  width: auto;
+}
+
 // Navbar button for toggling navbar items in responsive layouts
 .btn-navbar {
   display: none;

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -20,10 +20,7 @@
   .box-shadow(@shadow);
 }
 
-// Elements with .pull-right (fx) in static navbars, will now display correctly,
-// because .container divs inside does not force 940px width
-// which is incorrect because 940px inside something already 940px + padding becomes
-// greater than 940px
+// Correctly sets the width of nested .containers inside static navbars
 .navbar-inner .container {
   width: auto;
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -22,7 +22,7 @@
 
 // Elements with .pull-right (fx) in static navbars, will now display correctly,
 // because .container divs inside does not force 940px width
-// (which is incorrect because 940px inside something already 940px + padding becomes
+// which is incorrect because 940px inside something already 940px + padding becomes
 // greater than 940px
 .navbar-inner .container {
   width: auto;


### PR DESCRIPTION
Hello

This patch fixes the width of the .container element inside a static navbar. Right now it doesnt display correctly because of the padding of .navbar-inner.
