### PR TITLE
Small grammer correction

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -780,13 +780,13 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           <h4>$().tooltip(options)</h4>
           <p>Attaches a tooltip handler to an element collection.</p>
           <h4>.tooltip('show')</h4>
-          <p>Reveals an elements tooltip.</p>
+          <p>Reveals an element's tooltip.</p>
           <pre class="prettyprint linenums">$('#element').tooltip('show')</pre>
           <h4>.tooltip('hide')</h4>
-          <p>Hides an elements tooltip.</p>
+          <p>Hides an element's tooltip.</p>
           <pre class="prettyprint linenums">$('#element').tooltip('hide')</pre>
           <h4>.tooltip('toggle')</h4>
-          <p>Toggles an elements tooltip.</p>
+          <p>Toggles an element's tooltip.</p>
           <pre class="prettyprint linenums">$('#element').tooltip('toggle')</pre>
         </div>
       </div>


### PR DESCRIPTION
Make the word "elements" possessive
