### PR TITLE
Fix for #2043: Add option to show all Typeahead items

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -88,6 +88,28 @@
       return this.render(items.slice(0, this.options.items)).show()
     }
 
+  , showmenu: function (event) {
+      var that = this
+        , items
+        , q
+
+      this.query = this.$element.val()
+
+      if (this.query) {
+        return this.lookup(event)
+      }
+	  
+      items = jQuery.extend(true, new Array(), this.source);
+
+      items = this.sorter(items)
+
+      if (!items.length) {
+        return this.shown ? this.hide() : this
+      }
+
+      return this.render(items.slice(0, this.options.items)).show()
+    }
+
   , matcher: function (item) {
       return ~item.toLowerCase().indexOf(this.query.toLowerCase())
     }
@@ -154,6 +176,7 @@
         .on('blur',     $.proxy(this.blur, this))
         .on('keypress', $.proxy(this.keypress, this))
         .on('keyup',    $.proxy(this.keyup, this))
+        .on('focus',    $.proxy(this.focus, this))
 
       if ($.browser.webkit || $.browser.msie) {
         this.$element.on('keydown', $.proxy(this.keypress, this))
@@ -219,6 +242,16 @@
       setTimeout(function () { that.hide() }, 150)
     }
 
+  , focus: function (e) {
+      var that = this
+      e.stopPropagation()
+      e.preventDefault()
+	  if(that.options.focusshow)
+	  {
+        that.showmenu()
+	  }
+    }
+
   , click: function (e) {
       e.stopPropagation()
       e.preventDefault()
@@ -251,6 +284,7 @@
   , items: 8
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
+  , focusshow: false
   }
 
   $.fn.typeahead.Constructor = Typeahead


### PR DESCRIPTION
Added variable focusshow which defaults to false

When focusshow is true, it makes it so when you gain focus on typeahead it causes the menu to show up.

I added a focus listener to catch when the typeahead gains focus
I added a method called showmenu when will show then menu when typeahead gains focus
