### PR TITLE
Fixed size reset for collapses in IE (and other browsers which does not supporttransitions)

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -90,7 +90,7 @@
 
       $.support.transition && this.$element.hasClass('collapse') ?
         this.$element.one($.support.transition.end, complete) :
-        complete()
+        setTimeout(complete, 1)
   	}
 
   , toggle: function () {


### PR DESCRIPTION
reset() is called after the collapsible content has been resized by a
transition, to set the width or height to auto.

Practically, this means that .collapse gets a fixed height in IE, so any content that changes its height will overflow the collapse instead of the collapse adjusting its size.

However, when transitions are not supported, the reset() callback is called
immediately, which causes the reset to take place BEFORE the width/height change
it is supposed to reset.
This makes the reset() call useless, since the content gets the static
width/height anyways.

This changes uses setTimeout to make sure that the reset() callback is called
after the width/height is set.
