### PR TITLE
Headers are broken in IE, FF

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -50,7 +50,7 @@
 @baseLineHeight:        18px;
 @altFontFamily:         Georgia, "Times New Roman", Times, serif;
 
-@headingsFontFamily:    ''; // empty to use BS default, @baseFontFamily
+@headingsFontFamily:    @baseFontFamily; // empty to use BS default, @baseFontFamily
 @headingsFontWeight:    normal; // instead of browser default, bold
 @headingsColor:         ''; // empty to use BS default, @textColor
 


### PR DESCRIPTION
03bdf82ca270f5c50e310b452b37d01f81a15ba3 broke the header fonts in IE/FF.

IE/FF does not inherit the base font for headings, which makes all headings in IE
"Times New Roman".

This change explicitly sets @headingsFontFamily to make sure all browser use the proper font.

Here is a build of the latest 2.0.2-wip docs:
http://pelme.se/~andreas/private/bootstrap_docs/

Open in IE or Firefox and notice how the headers are in Times New Roman. (Also note that the font-weight changed to be non-bold, is that intentional?)
