### PR TITLE
Carets don't line up right in btn-small and btn-mini button dropdowns

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -143,6 +143,11 @@
 
 // Small button dropdowns
 .btn-small .caret {
-  margin-top: 4px;
+  margin-top: 7px;
+}
+
+// Mini button dropdowns
+.btn-mini .caret {
+  margin-top: 5px;
 }
 


### PR DESCRIPTION
Small was sitting a little high
Mini had no styling whatsoever

This seems related to #2206 but I differ on the required btn-small margin.
