### PR TITLE
Spelling error in documentation for Javascript buttons

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1051,7 +1051,7 @@ $('#my-alert').bind('closed', function () {
 </pre>
           <h3>Methods</h3>
           <h4>$().button('toggle')</h4>
-          <p>Toggles push state. Gives the button the look that it has been activated.</p>
+          <p>Toggles push state. Gives the button the appearance that it has been activated.</p>
           <div class="alert alert-info">
             <strong>Heads up!</strong>
             You can enable auto toggling of a button by using the <code>data-toggle</code> attribute.

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1051,7 +1051,7 @@ $('#my-alert').bind('closed', function () {
 </pre>
           <h3>Methods</h3>
           <h4>$().button('toggle')</h4>
-          <p>Toggles push state. Gives btn the look that it hass been activated.</p>
+          <p>Toggles push state. Gives the button the look that it has been activated.</p>
           <div class="alert alert-info">
             <strong>Heads up!</strong>
             You can enable auto toggling of a button by using the <code>data-toggle</code> attribute.


### PR DESCRIPTION
Fixed spelling error and word usage.
