### PR TITLE
code: remove hard-coded font-size from pre block

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -25,7 +25,6 @@ pre {
   display: block;
   padding: (@baseLineHeight - 1) / 2;
   margin: 0 0 @baseLineHeight / 2;
-  font-size: 12px;
   line-height: @baseLineHeight;
   background-color: #f5f5f5;
   border: 1px solid #ccc; // fallback for IE7-8


### PR DESCRIPTION
The size was already set based on @baseFontSize at the beginning of the
file.
