### PR TITLE
Removing mention of "badges" from Components -> Miscellaneous documentation

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1524,7 +1524,7 @@
 ================================================== -->
 <section id="misc">
   <div class="page-header">
-    <h1>Miscellaneous <small>Wells, badges, and close icon</small></h1>
+    <h1>Miscellaneous <small>Wells and close icon</small></h1>
   </div>
   <div class="row">
     <div class="span4">


### PR DESCRIPTION
They have not been implemented yet, so mentioning them here is misleading.
