### PR TITLE
Fix alignment of pre/appended form controls in v2.0.2

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -388,6 +388,7 @@ select:focus:required:invalid {
     vertical-align: middle;
     background-color: @grayLighter;
     border: 1px solid #ccc;
+    margin-bottom: 9px;
   }
   .add-on,
   .btn {


### PR DESCRIPTION
Form inputs at line 62 are given a 9px bottom margin in forms.less.
Prepended and appended inputs need their add-on to have a matching 9px
bottom margin for proper alignment when using align: middle.

Alternatively, add-on and input's margins could be zeroed when contained by input-prepend and input-prepend could take on the margin.
