### PR TITLE
Fix dropdown items alignment for resolution < 480px 

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1844,6 +1844,7 @@ table .span24 {
   padding: 3px 15px;
   clear: both;
   font-weight: normal;
+  text-align: left;
   line-height: 18px;
   color: #333333;
   white-space: nowrap;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -81,6 +81,7 @@
     padding: 3px 15px;
     clear: both;
     font-weight: normal;
+    text-align: left;
     line-height: @baseLineHeight;
     color: @dropdownLinkColor;
     white-space: nowrap;


### PR DESCRIPTION
When using responsive.less and resize window < 480px, items list are centered on dropdown.
Adding "text-align: left" to ".dropdown-menu a" fix this.
