### PR TITLE
Force tooltips to honor delay time only if hovering for full delay time

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * bootstrap-tooltip.js v2.0.2
+ * bootstrap-tooltip.js v2.0.3
  * http://twitter.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
@@ -70,10 +70,11 @@
   , enter: function ( e ) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      self.hoverState = 'in'
+
       if (!self.options.delay || !self.options.delay.show) {
         self.show()
       } else {
-        self.hoverState = 'in'
         setTimeout(function() {
           if (self.hoverState == 'in') {
             self.show()
@@ -85,10 +86,11 @@
   , leave: function ( e ) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      self.hoverState = 'out'
+
       if (!self.options.delay || !self.options.delay.hide) {
         self.hide()
       } else {
-        self.hoverState = 'out'
         setTimeout(function() {
           if (self.hoverState == 'out') {
             self.hide()

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -33,6 +33,8 @@
 
     constructor: Tooltip
 
+  , hoverTimer: -1
+
   , init: function ( type, element, options ) {
       var eventIn
         , eventOut
@@ -47,6 +49,7 @@
         eventOut = this.options.trigger == 'hover' ? 'mouseleave' : 'blur'
         this.$element.on(eventIn, this.options.selector, $.proxy(this.enter, this))
         this.$element.on(eventOut, this.options.selector, $.proxy(this.leave, this))
+        this.$element.on("click", this.options.selector, $.proxy(this.click, this))
       }
 
       this.options.selector ?
@@ -71,11 +74,12 @@
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
       self.hoverState = 'in'
+      clearTimeout(this.hoverTimer)
 
       if (!self.options.delay || !self.options.delay.show) {
         self.show()
       } else {
-        setTimeout(function() {
+        this.hoverTimer = setTimeout(function() {
           if (self.hoverState == 'in') {
             self.show()
           }
@@ -87,15 +91,24 @@
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
       self.hoverState = 'out'
+      clearTimeout(this.hoverTimer)
 
       if (!self.options.delay || !self.options.delay.hide) {
         self.hide()
       } else {
-        setTimeout(function() {
+        this.hoverTimer = setTimeout(function() {
           if (self.hoverState == 'out') {
             self.hide()
           }
         }, self.options.delay.hide)
+      }
+    }
+
+  , click: function ( e ) {
+      var self = $(e.currentTarget)[this.type](this._options).data(this.type)
+
+      if (this.$element.attr("disabled")) {
+        self.hide()
       }
     }
 
@@ -107,6 +120,10 @@
         , actualHeight
         , placement
         , tp
+
+      if (this.$element.attr("disabled")) {
+        return;
+      }
 
       if (this.hasContent() && this.enabled) {
         $tip = this.tip()


### PR DESCRIPTION
(This pull request is against master since there's no WIP branch past 2.0.2 which was just released.)

The issue fixed by this pull request is that tooltips always showed up after the configured delay _even if the element triggering the tooltip was no longer being hovered over._

For example, if using a 500msec delay, you could quickly move the mouse past the triggering element (less than 500msec of hovering,) and the tooltip would still appear 500msec later.

This fix forces the user to hover for the full delay time in order for the tooltip to actually be displayed.
