### PR TITLE
Fix static navbar container

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -550,6 +550,7 @@
 
     // Set the container width, and override it for fixed navbars in media queries
     .container,
+    .navbar .container,
     .navbar-fixed-top .container,
     .navbar-fixed-bottom .container { .span(@gridColumns); }
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -315,6 +315,12 @@
   .background(@color: @white, @alpha: 1) {
     background-color: hsla(hue(@color), saturation(@color), lightness(@color), @alpha);
   }
+  .background(@color: @white){
+    background-color: @color;
+    @ie_col: argb(@color);
+    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d')",@ie_col,@ie_col));
+    zoom:1; //needed for IE7
+  }
   .border(@color: @white, @alpha: 1) {
     border-color: hsla(hue(@color), saturation(@color), lightness(@color), @alpha);
     .background-clip(padding-box);


### PR DESCRIPTION
This fixes the static navbar to be part of the grid mixing and overwrite the 2.0.2 change .navbar .container {width: auto;}
#2548
