### PR TITLE
UI alignment error at bottom right of http://twitter.github.com/bootstra...

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -385,7 +385,7 @@ select:focus:required:invalid {
     line-height: @baseLineHeight;
     text-align: center;
     text-shadow: 0 1px 0 @white;
-    vertical-align: middle;
+    vertical-align: top;
     background-color: @grayLighter;
     border: 1px solid #ccc;
   }


### PR DESCRIPTION
http://twitter.github.com/bootstrap/base-css.html
bottom-right corner "add-on" alignment is incorrect.

add-on aligned on "top" looks correct on Chrome, Safari & Firefox on MacOSX
fixed and tested on these browsers
