### PR TITLE
Invert progress-bar-stripes direction (proposal)

### DIFF
--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -7,26 +7,26 @@
 
 // Webkit
 @-webkit-keyframes progress-bar-stripes {
-  from  { background-position: 0 0; }
-  to    { background-position: 40px 0; }
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
 }
 
 // Firefox
 @-moz-keyframes progress-bar-stripes {
-  from  { background-position: 0 0; }
-  to    { background-position: 40px 0; }
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
 }
 
 // IE9
 @-ms-keyframes progress-bar-stripes {
-  from  { background-position: 0 0; }
-  to    { background-position: 40px 0; }
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
 }
 
 // Spec
 @keyframes progress-bar-stripes {
-  from  { background-position: 0 0; }
-  to    { background-position: 40px 0; }
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
 }
 
 


### PR DESCRIPTION
Based on [a NewScientist's article](http://www.newscientist.com/article/dn18754-visual-tricks-can-make-downloads-seem-quicker.html?DCMP=OTC-rss&nsref=online-news) and OSX's progress-bars as a reference I'd propose to invert the direction the striped progress-bar is moving. Essentially it's "pushing the progress" vs "flashing past scenery".
