### PR TITLE
Font Family Mixin Variables

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -116,13 +116,13 @@
 #font {
   #family {
     .serif() {
-      font-family: Georgia, "Times New Roman", Times, serif;
+      font-family: @serifFontFamily;
     }
     .sans-serif() {
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-family: @sansFontFamily;
     }
     .monospace() {
-      font-family: Menlo, Monaco, "Courier New", monospace;
+      font-family: @monoFontFamily;
     }
   }
   .shorthand(@size: @baseFontSize, @weight: normal, @lineHeight: @baseLineHeight) {

--- a/less/variables.less
+++ b/less/variables.less
@@ -54,6 +54,9 @@
 @headingsFontWeight:    bold;    // instead of browser default, bold
 @headingsColor:         inherit; // empty to use BS default, @textColor
 
+@serifFontFamily:       Georgia, "Times New Roman", Times, serif;
+@sansFontFamily:        "Helvetica Neue", Helvetica, Arial, sans-serif;
+@monoFontFamily:        Menlo, Monaco, "Courier New", monospace;
 
 // Tables
 // -------------------------


### PR DESCRIPTION
I have replaced the hardcoded `font-family` properties in the `#font #family` mixin to be more customizable with the use of 3 new variables.
