### PR TITLE
Font Family Mixin Variables (corrected)

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -296,6 +296,12 @@
       <input type="text" class="span3" placeholder="inherit">
       <label>@heroUnitLeadColor</label>
       <input type="text" class="span3" placeholder="inherit">
+      <label>@serifFontFamily</label>
+      <input type="text" class="span3" placeholder="Georgia, 'Times New Roman', Times, serif">
+      <label>@sansFontFamily</label>
+      <input type="text" class="span3" placeholder="'Helvetica Neue', Helvetica, Arial, sans-serif">
+      <label>@monoFontFamily</label>
+      <input type="text" class="span3" placeholder="Menlo, Monaco, 'Courier New', monospace">
     </div><!-- /span -->
     <div class="span3">
       <h3>Tables</h3>

--- a/docs/templates/pages/download.mustache
+++ b/docs/templates/pages/download.mustache
@@ -220,6 +220,12 @@
       <input type="text" class="span3" placeholder="inherit">
       <label>@heroUnitLeadColor</label>
       <input type="text" class="span3" placeholder="inherit">
+      <label>@serifFontFamily</label>
+      <input type="text" class="span3" placeholder="Georgia, 'Times New Roman', Times, serif">
+      <label>@sansFontFamily</label>
+      <input type="text" class="span3" placeholder="'Helvetica Neue', Helvetica, Arial, sans-serif">
+      <label>@monoFontFamily</label>
+      <input type="text" class="span3" placeholder="Menlo, Monaco, 'Courier New', monospace">
     </div><!-- /span -->
     <div class="span3">
       <h3>{{_i}}Tables{{/i}}</h3>

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -116,13 +116,13 @@
 #font {
   #family {
     .serif() {
-      font-family: Georgia, "Times New Roman", Times, serif;
+      font-family: @serifFontFamily;
     }
     .sans-serif() {
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-family: @sansFontFamily;
     }
     .monospace() {
-      font-family: Menlo, Monaco, "Courier New", monospace;
+      font-family: @monoFontFamily;
     }
   }
   .shorthand(@size: @baseFontSize, @weight: normal, @lineHeight: @baseLineHeight) {

--- a/less/variables.less
+++ b/less/variables.less
@@ -54,6 +54,10 @@
 @headingsFontWeight:    bold;    // instead of browser default, bold
 @headingsColor:         inherit; // empty to use BS default, @textColor
 
+@serifFontFamily:       Georgia, "Times New Roman", Times, serif;
+@sansFontFamily:        "Helvetica Neue", Helvetica, Arial, sans-serif;
+@monoFontFamily:        Menlo, Monaco, "Courier New", monospace;
+
 
 // Tables
 // -------------------------


### PR DESCRIPTION
I have replaced the hardcoded `font-family` properties in the `#font #family` mixin to be more customizable with the use of 3 new variables.

This is a correction to pull request #2631 as I had confused the way pull requests work. sorry for the little mess!

original issue #2585
