### PR TITLE
Make Brand Links Follow NavBar

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2868,7 +2868,7 @@ input[type="submit"].btn.btn-mini {
   font-size: 20px;
   font-weight: 200;
   line-height: 1;
-  color: #ffffff;
+  color: #999999;
 }
 .navbar .navbar-text {
   margin-bottom: 0;

--- a/docs/download.html
+++ b/docs/download.html
@@ -335,6 +335,8 @@
       <input type="text" class="span3" placeholder="darken(@navbarSearchBackground, 30%)">
       <label>@navbarSearchPlaceholderColor</label>
       <input type="text" class="span3" placeholder="#ccc">
+      <label>@navbarBrandColor</label>
+      <input type="text" class="span3" placeholder="@navbarLinkColor">
 
       <h3>Dropdowns</h3>
       <label>@dropdownBackground</label>

--- a/docs/templates/pages/download.mustache
+++ b/docs/templates/pages/download.mustache
@@ -259,6 +259,8 @@
       <input type="text" class="span3" placeholder="darken(@navbarSearchBackground, 30%)">
       <label>@navbarSearchPlaceholderColor</label>
       <input type="text" class="span3" placeholder="#ccc">
+      <label>@navbarBrandColor</label>
+      <input type="text" class="span3" placeholder="@navbarLinkColor">
 
       <h3>{{_i}}Dropdowns{{/i}}</h3>
       <label>@dropdownBackground</label>

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -74,7 +74,7 @@
     font-size: 20px;
     font-weight: 200;
     line-height: 1;
-    color: @white;
+    color: @navbarBrandColor;
   }
   // Plain text in topbar
   .navbar-text {

--- a/less/variables.less
+++ b/less/variables.less
@@ -154,6 +154,7 @@
 @navbarSearchBackgroundFocus:     @white;
 @navbarSearchBorder:              darken(@navbarSearchBackground, 30%);
 @navbarSearchPlaceholderColor:    #ccc;
+@navbarBrandColor:                @navbarLinkColor;
 
 
 // Hero unit


### PR DESCRIPTION
Issue #2593 brought up a good point with brand link in navbar being hardcoded and not following `navbarLinkColor`.

I have added a new variable `navbarBrandColor` that inherits `navbarLinkColor` by default but allows you also is override-able in advanced cases.
