### PR TITLE
Initial Carousel Swipe Support

### DIFF
--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -34,17 +34,20 @@
       .on('mouseleave', $.proxy(this.cycle, this))
     
     this.touch = {
-       supported: "ontouchend" in document,
-       maxTime: 1000,
-       maxDistance: 50,
-       startedAt: 0,
-       startPosition: 0
+       supported: "ontouchend" in document
+    ,  startedAt: 0
+    ,  startPosition: 0
     }
     
-    this.touch.supported == true && this.$element
-      .on('touchstart', $.proxy(this.touchstart, this))
-      .on('touchend', $.proxy(this.touchend, this))
-      .on('touchmove', $.proxy(this.touchmove, this))
+    if (this.options.touch && this.touch.supported == true) {
+      this.$element
+        .on('touchstart', $.proxy(this.touchstart, this))
+        .on('touchend', $.proxy(this.touchend, this))
+        .on('touchmove', $.proxy(this.touchmove, this))
+        
+      this.options.touchHideControls && this.$element
+        .children('.carousel-control').fadeOut('slow')
+    }
   }
 
   Carousel.prototype = {
@@ -149,7 +152,7 @@
           currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
           currentTime = e.timeStamp
 
-      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
         if (currentX < this.touch.startPosition) {
           this.prev().pause();
         } else if (currentX > this.touch.startPosition) {
@@ -181,6 +184,10 @@
   $.fn.carousel.defaults = {
     interval: 5000
   , pause: 'hover'
+  , touch: true
+  , touchMaxTime: 1000
+  , touchMaxDistance: 50
+  , touchHideControls: true
   }
 
   $.fn.carousel.Constructor = Carousel

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -154,9 +154,9 @@
 
       if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
         if (currentX < this.touch.startPosition) {
-          this.prev().pause();
-        } else if (currentX > this.touch.startPosition) {
           this.next().pause();
+        } else if (currentX > this.touch.startPosition) {
+          this.prev().pause();
         }
 
         this.touch.startedAt = 0

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -159,11 +159,13 @@
       this.touch.endedAt = e.timeStamp
       var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
       
-      if (!this.touch.isScroll && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
-        if (this.touch.endX < this.touch.startX) {
-          this.next().pause();
-        } else if (this.touch.endX > this.touch.startX) {
-          this.prev().pause();
+      if (!this.touch.isScroll && this.touch.startedAt !== 0) {
+        if ((this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+          if (this.touch.endX < this.touch.startX) {
+            this.next().pause();
+          } else if (this.touch.endX > this.touch.startX) {
+            this.prev().pause();
+          }
         }
       }
       

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -39,6 +39,9 @@
     ,  endedAt: 0
     ,  startX: 0
     ,  endX: 0
+    ,  startY: 0
+    ,  endY: 0
+    ,  isScroll: false
     }
     
     if (this.options.touch && this.touch.supported == true) {
@@ -140,18 +143,23 @@
   , touchstart: function(e) {
       this.touch.startedAt = e.timeStamp
       this.touch.startX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      this.touch.startY = e.originalEvent.touches ? e.originalEvent.touches[0].pageY : e.pageY
     }
     
   , touchmove: function(e) {
       this.touch.endX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
-      e.preventDefault();
+      this.touch.endY = e.originalEvent.touches ? e.originalEvent.touches[0].pageY : e.pageY
+      
+      this.touch.isScroll = !!(Math.abs(this.touch.endX - this.touch.startX) < Math.abs(this.touch.endY - this.touch.startY))
+      
+      !this.touch.isScroll && e.preventDefault();
     }
 
   , touchend: function(e) {
       this.touch.endedAt = e.timeStamp
       var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
       
-      if (this.touch.startedAt !== 0 && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+      if (!this.touch.isScroll && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
         if (this.touch.endX < this.touch.startX) {
           this.next().pause();
         } else if (this.touch.endX > this.touch.startX) {
@@ -163,6 +171,9 @@
       this.touch.endedAt = 0
       this.touch.startX = 0
       this.touch.endX = 0
+      this.touch.startY = 0
+      this.touch.endY = 0
+      this.touch.isScroll = false
     }
   }
 

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -34,12 +34,12 @@
       .on('mouseleave', $.proxy(this.cycle, this))
     
     this.touch = {
-        supported: "ontouchend" in document,
-        maxTime: 1000,
-        maxDistance: 50,
-        startedAt: 0,
-        startPosition: 0
-    };
+       supported: "ontouchend" in document,
+       maxTime: 1000,
+       maxDistance: 50,
+       startedAt: 0,
+       startPosition: 0
+    }
     
     this.touch.supported == true && this.$element
       .on('touchstart', $.proxy(this.touchstart, this))
@@ -132,33 +132,33 @@
       return this
     }
     
-    ,touchstart: function(e) {
-        e.preventDefault();
-        this.touch.startedAt = e.timeStamp
-        this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+  , touchstart: function(e) {
+      e.preventDefault();
+      this.touch.startedAt = e.timeStamp
+      this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
     }
     
-    ,touchend: function() {
-        this.touch.startedAt = 0
-        this.touch.startPosition = 0
+  , touchend: function() {
+      this.touch.startedAt = 0
+      this.touch.startPosition = 0
     }
 
-    ,touchmove: function(e) {
-        e.preventDefault();
-        var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
-            currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
-            currentTime = e.timeStamp
-            
-        if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
-            if (currentX < this.touch.startPosition) {
-                this.prev().pause();
-            } else if (currentX > this.touch.startPosition) {
-                this.next().pause();
-            }
-            
-            this.touch.startedAt = 0
-            this.touch.startPosition = 0
+  , touchmove: function(e) {
+      e.preventDefault();
+      var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
+          currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
+          currentTime = e.timeStamp
+
+      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+        if (currentX < this.touch.startPosition) {
+          this.prev().pause();
+        } else if (currentX > this.touch.startPosition) {
+          this.next().pause();
         }
+
+        this.touch.startedAt = 0
+        this.touch.startPosition = 0
+      }
     }
   }
 

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -36,15 +36,17 @@
     this.touch = {
        supported: "ontouchend" in document
     ,  startedAt: 0
-    ,  startPosition: 0
+    ,  endedAt: 0
+    ,  startX: 0
+    ,  endX: 0
     }
     
     if (this.options.touch && this.touch.supported == true) {
       this.$element
         .on('touchstart', $.proxy(this.touchstart, this))
-        .on('touchend', $.proxy(this.touchend, this))
         .on('touchmove', $.proxy(this.touchmove, this))
-        
+        .on('touchend', $.proxy(this.touchend, this))
+
       this.options.touchHideControls && this.$element
         .children('.carousel-control').fadeOut('slow')
     }
@@ -136,32 +138,31 @@
     }
     
   , touchstart: function(e) {
-      e.preventDefault();
       this.touch.startedAt = e.timeStamp
-      this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      this.touch.startX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
     }
     
-  , touchend: function() {
-      this.touch.startedAt = 0
-      this.touch.startPosition = 0
+  , touchmove: function(e) {
+      this.touch.endX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      e.preventDefault();
     }
 
-  , touchmove: function(e) {
-      e.preventDefault();
-      var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
-          currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
-          currentTime = e.timeStamp
-
-      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
-        if (currentX < this.touch.startPosition) {
+  , touchend: function(e) {
+      this.touch.endedAt = e.timeStamp
+      var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
+      
+      if (this.touch.startedAt !== 0 && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+        if (this.touch.endX < this.touch.startX) {
           this.next().pause();
-        } else if (currentX > this.touch.startPosition) {
+        } else if (this.touch.endX > this.touch.startX) {
           this.prev().pause();
         }
-
-        this.touch.startedAt = 0
-        this.touch.startPosition = 0
       }
+      
+      this.touch.startedAt = 0
+      this.touch.endedAt = 0
+      this.touch.startX = 0
+      this.touch.endX = 0
     }
   }
 

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -32,6 +32,19 @@
     this.options.pause == 'hover' && this.$element
       .on('mouseenter', $.proxy(this.pause, this))
       .on('mouseleave', $.proxy(this.cycle, this))
+    
+    this.touch = {
+        supported: "ontouchend" in document,
+        maxTime: 1000,
+        maxDistance: 50,
+        startedAt: 0,
+        startPosition: 0
+    };
+    
+    this.touch.supported == true && this.$element
+      .on('touchstart', $.proxy(this.touchstart, this))
+      .on('touchend', $.proxy(this.touchend, this))
+      .on('touchmove', $.proxy(this.touchmove, this))
   }
 
   Carousel.prototype = {
@@ -118,7 +131,35 @@
 
       return this
     }
+    
+    ,touchstart: function(e) {
+        e.preventDefault();
+        this.touch.startedAt = e.timeStamp
+        this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+    }
+    
+    ,touchend: function() {
+        this.touch.startedAt = 0
+        this.touch.startPosition = 0
+    }
 
+    ,touchmove: function(e) {
+        e.preventDefault();
+        var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
+            currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
+            currentTime = e.timeStamp
+            
+        if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+            if (currentX < this.touch.startPosition) {
+                this.prev().pause();
+            } else if (currentX > this.touch.startPosition) {
+                this.next().pause();
+            }
+            
+            this.touch.startedAt = 0
+            this.touch.startPosition = 0
+        }
+    }
   }
 
 

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1316,6 +1316,30 @@ $('#myCollapsible').on('hidden', function () {
                <td>"hover"</td>
                <td>Pauses the cycling of the carousel on mouseenter and resumes the cycling of the carousel on mouseleave.</td>
              </tr>
+             <tr>
+               <td>touch</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>Enables basic swipe-to-slide support (when touch support is detected).</td>
+             </tr>
+             <tr>
+               <td>touchMaxTime</td>
+               <td>number</td>
+               <td>1000</td>
+               <td>The amount of time (in milliseconds) that sets a touch and swipe apart.</td>
+             </tr>
+             <tr>
+               <td>touchMaxDistance</td>
+               <td>number</td>
+               <td>50</td>
+               <td>The distance (in pixels) from starting touch that sets a touch and swipe apart.</td>
+             </tr>
+             <tr>
+               <td>touchHideControls</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>Hides (fades out) next and prev controls when touch support is detected and touch is enabled.</td>
+             </tr>
             </tbody>
           </table>
           <h3>Markup</h3>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1240,6 +1240,30 @@ $('#myCollapsible').on('hidden', function () {
                <td>"hover"</td>
                <td>{{_i}}Pauses the cycling of the carousel on mouseenter and resumes the cycling of the carousel on mouseleave.{{/i}}</td>
              </tr>
+             <tr>
+               <td>touch</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>Enables basic swipe-to-slide support (when touch support is detected).</td>
+             </tr>
+             <tr>
+               <td>touchMaxTime</td>
+               <td>number</td>
+               <td>1000</td>
+               <td>The amount of time (in milliseconds) that sets a touch and swipe apart.</td>
+             </tr>
+             <tr>
+               <td>touchMaxDistance</td>
+               <td>number</td>
+               <td>50</td>
+               <td>The distance (in pixels) from starting touch that sets a touch and swipe apart.</td>
+             </tr>
+             <tr>
+               <td>touchHideControls</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>Hides (fades out) next and prev controls when touch support is detected and touch is enabled.</td>
+             </tr>
             </tbody>
           </table>
           <h3>{{_i}}Markup{{/i}}</h3>

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -34,17 +34,20 @@
       .on('mouseleave', $.proxy(this.cycle, this))
     
     this.touch = {
-       supported: "ontouchend" in document,
-       maxTime: 1000,
-       maxDistance: 50,
-       startedAt: 0,
-       startPosition: 0
+       supported: "ontouchend" in document
+    ,  startedAt: 0
+    ,  startPosition: 0
     }
     
-    this.touch.supported == true && this.$element
-      .on('touchstart', $.proxy(this.touchstart, this))
-      .on('touchend', $.proxy(this.touchend, this))
-      .on('touchmove', $.proxy(this.touchmove, this))
+    if (this.options.touch && this.touch.supported == true) {
+      this.$element
+        .on('touchstart', $.proxy(this.touchstart, this))
+        .on('touchend', $.proxy(this.touchend, this))
+        .on('touchmove', $.proxy(this.touchmove, this))
+        
+      this.options.touchHideControls && this.$element
+        .children('.carousel-control').fadeOut('slow')
+    }
   }
 
   Carousel.prototype = {
@@ -149,7 +152,7 @@
           currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
           currentTime = e.timeStamp
 
-      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
         if (currentX < this.touch.startPosition) {
           this.prev().pause();
         } else if (currentX > this.touch.startPosition) {
@@ -181,6 +184,10 @@
   $.fn.carousel.defaults = {
     interval: 5000
   , pause: 'hover'
+  , touch: true
+  , touchMaxTime: 1000
+  , touchMaxDistance: 50
+  , touchHideControls: true
   }
 
   $.fn.carousel.Constructor = Carousel

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -154,9 +154,9 @@
 
       if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
         if (currentX < this.touch.startPosition) {
-          this.prev().pause();
-        } else if (currentX > this.touch.startPosition) {
           this.next().pause();
+        } else if (currentX > this.touch.startPosition) {
+          this.prev().pause();
         }
 
         this.touch.startedAt = 0

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -159,11 +159,13 @@
       this.touch.endedAt = e.timeStamp
       var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
       
-      if (!this.touch.isScroll && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
-        if (this.touch.endX < this.touch.startX) {
-          this.next().pause();
-        } else if (this.touch.endX > this.touch.startX) {
-          this.prev().pause();
+      if (!this.touch.isScroll && this.touch.startedAt !== 0) {
+        if ((this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+          if (this.touch.endX < this.touch.startX) {
+            this.next().pause();
+          } else if (this.touch.endX > this.touch.startX) {
+            this.prev().pause();
+          }
         }
       }
       

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -39,6 +39,9 @@
     ,  endedAt: 0
     ,  startX: 0
     ,  endX: 0
+    ,  startY: 0
+    ,  endY: 0
+    ,  isScroll: false
     }
     
     if (this.options.touch && this.touch.supported == true) {
@@ -140,18 +143,23 @@
   , touchstart: function(e) {
       this.touch.startedAt = e.timeStamp
       this.touch.startX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      this.touch.startY = e.originalEvent.touches ? e.originalEvent.touches[0].pageY : e.pageY
     }
     
   , touchmove: function(e) {
       this.touch.endX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
-      e.preventDefault();
+      this.touch.endY = e.originalEvent.touches ? e.originalEvent.touches[0].pageY : e.pageY
+      
+      this.touch.isScroll = !!(Math.abs(this.touch.endX - this.touch.startX) < Math.abs(this.touch.endY - this.touch.startY))
+      
+      !this.touch.isScroll && e.preventDefault();
     }
 
   , touchend: function(e) {
       this.touch.endedAt = e.timeStamp
       var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
       
-      if (this.touch.startedAt !== 0 && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+      if (!this.touch.isScroll && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
         if (this.touch.endX < this.touch.startX) {
           this.next().pause();
         } else if (this.touch.endX > this.touch.startX) {
@@ -163,6 +171,9 @@
       this.touch.endedAt = 0
       this.touch.startX = 0
       this.touch.endX = 0
+      this.touch.startY = 0
+      this.touch.endY = 0
+      this.touch.isScroll = false
     }
   }
 

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -34,12 +34,12 @@
       .on('mouseleave', $.proxy(this.cycle, this))
     
     this.touch = {
-        supported: "ontouchend" in document,
-        maxTime: 1000,
-        maxDistance: 50,
-        startedAt: 0,
-        startPosition: 0
-    };
+       supported: "ontouchend" in document,
+       maxTime: 1000,
+       maxDistance: 50,
+       startedAt: 0,
+       startPosition: 0
+    }
     
     this.touch.supported == true && this.$element
       .on('touchstart', $.proxy(this.touchstart, this))
@@ -132,33 +132,33 @@
       return this
     }
     
-    ,touchstart: function(e) {
-        e.preventDefault();
-        this.touch.startedAt = e.timeStamp
-        this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+  , touchstart: function(e) {
+      e.preventDefault();
+      this.touch.startedAt = e.timeStamp
+      this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
     }
     
-    ,touchend: function() {
-        this.touch.startedAt = 0
-        this.touch.startPosition = 0
+  , touchend: function() {
+      this.touch.startedAt = 0
+      this.touch.startPosition = 0
     }
 
-    ,touchmove: function(e) {
-        e.preventDefault();
-        var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
-            currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
-            currentTime = e.timeStamp
-            
-        if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
-            if (currentX < this.touch.startPosition) {
-                this.prev().pause();
-            } else if (currentX > this.touch.startPosition) {
-                this.next().pause();
-            }
-            
-            this.touch.startedAt = 0
-            this.touch.startPosition = 0
+  , touchmove: function(e) {
+      e.preventDefault();
+      var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
+          currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
+          currentTime = e.timeStamp
+
+      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+        if (currentX < this.touch.startPosition) {
+          this.prev().pause();
+        } else if (currentX > this.touch.startPosition) {
+          this.next().pause();
         }
+
+        this.touch.startedAt = 0
+        this.touch.startPosition = 0
+      }
     }
   }
 

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -36,15 +36,17 @@
     this.touch = {
        supported: "ontouchend" in document
     ,  startedAt: 0
-    ,  startPosition: 0
+    ,  endedAt: 0
+    ,  startX: 0
+    ,  endX: 0
     }
     
     if (this.options.touch && this.touch.supported == true) {
       this.$element
         .on('touchstart', $.proxy(this.touchstart, this))
-        .on('touchend', $.proxy(this.touchend, this))
         .on('touchmove', $.proxy(this.touchmove, this))
-        
+        .on('touchend', $.proxy(this.touchend, this))
+
       this.options.touchHideControls && this.$element
         .children('.carousel-control').fadeOut('slow')
     }
@@ -136,32 +138,31 @@
     }
     
   , touchstart: function(e) {
-      e.preventDefault();
       this.touch.startedAt = e.timeStamp
-      this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      this.touch.startX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
     }
     
-  , touchend: function() {
-      this.touch.startedAt = 0
-      this.touch.startPosition = 0
+  , touchmove: function(e) {
+      this.touch.endX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+      e.preventDefault();
     }
 
-  , touchmove: function(e) {
-      e.preventDefault();
-      var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
-          currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
-          currentTime = e.timeStamp
-
-      if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.options.touchMaxTime && currentDistance > this.options.touchMaxDistance) {
-        if (currentX < this.touch.startPosition) {
+  , touchend: function(e) {
+      this.touch.endedAt = e.timeStamp
+      var distance = (this.touch.startX === 0) ? 0 : Math.abs(this.touch.endX - this.touch.startX)
+      
+      if (this.touch.startedAt !== 0 && (this.touch.endedAt - this.touch.startedAt) < this.options.touchMaxTime && distance > this.options.touchMaxDistance) {
+        if (this.touch.endX < this.touch.startX) {
           this.next().pause();
-        } else if (currentX > this.touch.startPosition) {
+        } else if (this.touch.endX > this.touch.startX) {
           this.prev().pause();
         }
-
-        this.touch.startedAt = 0
-        this.touch.startPosition = 0
       }
+      
+      this.touch.startedAt = 0
+      this.touch.endedAt = 0
+      this.touch.startX = 0
+      this.touch.endX = 0
     }
   }
 

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -32,6 +32,19 @@
     this.options.pause == 'hover' && this.$element
       .on('mouseenter', $.proxy(this.pause, this))
       .on('mouseleave', $.proxy(this.cycle, this))
+    
+    this.touch = {
+        supported: "ontouchend" in document,
+        maxTime: 1000,
+        maxDistance: 50,
+        startedAt: 0,
+        startPosition: 0
+    };
+    
+    this.touch.supported == true && this.$element
+      .on('touchstart', $.proxy(this.touchstart, this))
+      .on('touchend', $.proxy(this.touchend, this))
+      .on('touchmove', $.proxy(this.touchmove, this))
   }
 
   Carousel.prototype = {
@@ -118,7 +131,35 @@
 
       return this
     }
+    
+    ,touchstart: function(e) {
+        e.preventDefault();
+        this.touch.startedAt = e.timeStamp
+        this.touch.startPosition = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX
+    }
+    
+    ,touchend: function() {
+        this.touch.startedAt = 0
+        this.touch.startPosition = 0
+    }
 
+    ,touchmove: function(e) {
+        e.preventDefault();
+        var currentX = e.originalEvent.touches ? e.originalEvent.touches[0].pageX : e.pageX,
+            currentDistance = (this.touch.startPosition === 0) ? 0 : Math.abs(currentX - this.touch.startPosition),
+            currentTime = e.timeStamp
+            
+        if (this.touch.startedAt !== 0 && currentTime - this.touch.startedAt < this.touch.maxTime && currentDistance > this.touch.maxDistance) {
+            if (currentX < this.touch.startPosition) {
+                this.prev().pause();
+            } else if (currentX > this.touch.startPosition) {
+                this.next().pause();
+            }
+            
+            this.touch.startedAt = 0
+            this.touch.startPosition = 0
+        }
+    }
   }
 
 


### PR DESCRIPTION
I have made the needed changes to enable basic swiping on mobile devices. This should be a start for the feature requested in #2468. Hopefully with a little testing this can become a staple feature.

Functionality:
- Basic Back / Forward Swiping of Slides
- Cycle Stops on Swipe
- Ability to hide controls when touch is detected and enabled

Tested on:
- Android 2.3.7 (webkit)
- iPhone 4S and iPad 2 (mobile safari)
- Would love to hear from some iOS users. 

I am hosting a demo site to make it easier to test: [bootstrap.simplydev.com](http://bootstrap.simplydev.com/javascript.html)

Code inspired and adapted from:
http://wowmotty.blogspot.com/2011/10/adding-swipe-support.html
