### PR TITLE
Fixes issue #2669 (.row {margin-left:0} ignored in Mobile Safari 5.1)

### DIFF
--- a/less/responsive.less
+++ b/less/responsive.less
@@ -158,7 +158,7 @@
   }
   // Undo negative margin on rows
   .row {
-    margin-left: 0;
+    margin-left: 0 !important;
   }
   // Make all columns even
   .row > [class*="span"],


### PR DESCRIPTION
Fixes issue #2669. This seems to be specific to mobile safari 5.1 and a simple !important on the rule ensures that the .row has no margin-left applied.
