### PR TITLE
Grid Update: Added .insetX columns for better mobile control

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -169,9 +169,9 @@
     width: 100%;
     min-height: 28px;
     /* Make inputs at least the height of their button counterpart */
-
+  
     /* Makes inputs behave like true block-level elements */
-
+  
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     -ms-box-sizing: border-box;
@@ -275,6 +275,42 @@
   }
   .offset1 {
     margin-left: 82px;
+  }
+  .inset12 {
+    margin-left: -724px;
+  }
+  .inset11 {
+    margin-left: -662px;
+  }
+  .inset10 {
+    margin-left: -600px;
+  }
+  .inset9 {
+    margin-left: -538px;
+  }
+  .inset8 {
+    margin-left: -476px;
+  }
+  .inset7 {
+    margin-left: -414px;
+  }
+  .inset6 {
+    margin-left: -352px;
+  }
+  .inset5 {
+    margin-left: -290px;
+  }
+  .inset4 {
+    margin-left: -228px;
+  }
+  .inset3 {
+    margin-left: -166px;
+  }
+  .inset2 {
+    margin-left: -104px;
+  }
+  .inset1 {
+    margin-left: -42px;
   }
   .row-fluid {
     width: 100%;
@@ -580,6 +616,42 @@
   }
   .offset1 {
     margin-left: 130px;
+  }
+  .inset12 {
+    margin-left: -1170px;
+  }
+  .inset11 {
+    margin-left: -1070px;
+  }
+  .inset10 {
+    margin-left: -970px;
+  }
+  .inset9 {
+    margin-left: -870px;
+  }
+  .inset8 {
+    margin-left: -770px;
+  }
+  .inset7 {
+    margin-left: -670px;
+  }
+  .inset6 {
+    margin-left: -570px;
+  }
+  .inset5 {
+    margin-left: -470px;
+  }
+  .inset4 {
+    margin-left: -370px;
+  }
+  .inset3 {
+    margin-left: -270px;
+  }
+  .inset2 {
+    margin-left: -170px;
+  }
+  .inset1 {
+    margin-left: -70px;
   }
   .row-fluid {
     width: 100%;

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -239,6 +239,42 @@ a:hover {
 .offset1 {
   margin-left: 100px;
 }
+.inset12 {
+  margin-left: -940px;
+}
+.inset11 {
+  margin-left: -860px;
+}
+.inset10 {
+  margin-left: -780px;
+}
+.inset9 {
+  margin-left: -700px;
+}
+.inset8 {
+  margin-left: -620px;
+}
+.inset7 {
+  margin-left: -540px;
+}
+.inset6 {
+  margin-left: -460px;
+}
+.inset5 {
+  margin-left: -380px;
+}
+.inset4 {
+  margin-left: -300px;
+}
+.inset3 {
+  margin-left: -220px;
+}
+.inset2 {
+  margin-left: -140px;
+}
+.inset1 {
+  margin-left: -60px;
+}
 .row-fluid {
   width: 100%;
   *zoom: 1;

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -210,6 +210,36 @@
 
   <br>
 
+  <h2>Insetting columns</h2>
+  <div class="row show-grid">
+    <div class="span4">4</div>
+    <div class="span4 offset4">4 offset 4</div>
+    <div class="span4 inset8">4 inset 8</div>
+  </div><!-- /row -->
+  <div class="row show-grid">
+    <div class="span3 offset3">3 offset 3</div>
+    <div class="span3 inset6">3 inset 6</div>
+  </div><!-- /row -->
+  <div class="row show-grid">
+    <div class="span8 offset4">8 offset 4</div>
+    <div class="span4 inset12">4 inset 12</div>
+  </div><!-- /row -->
+  <div class="row">
+    <div class="span6">
+      <p>Inset columns allow you to stack your markup for mobile and tablet devices while providing an alternate layout on larger screen resolutions.</p>
+      <p>To calculate the proper amount of inset columns simply add the columns values from the div above. <code>.span4 .offset4</code> would use <code>.inset8</code></p>
+    </div>
+    <div class="span6">
+<pre class="prettyprint linenums">
+&lt;div class="row"&gt;
+  &lt;div class="span4"&gt;Displays on the left&lt;/div&gt;
+  &lt;div class="span4 offset4"&gt;Displays on the right&lt;/div&gt;
+  &lt;div class="span4 inset8"&gt;Displays in the center&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+    </div>
+  </div>
+
   <h2>Nesting columns</h2>
   <div class="row">
     <div class="span6">

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -534,6 +534,16 @@
       margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2);
     }
 
+    .insetX (@index) when (@index > 0) {
+      (~".inset@{index}") { .inset(@index); }
+      .insetX(@index - 1);
+    }
+    .insetX (0) {}
+
+    .inset (@columns) {
+      margin-left: -((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2) - (@gridGutterWidth * 2));
+    }
+
     .span (@columns) {
       width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
     }
@@ -553,9 +563,10 @@
     .navbar-fixed-top .container,
     .navbar-fixed-bottom .container { .span(@gridColumns); }
 
-    // generate .spanX and .offsetX
+    // generate .spanX, .offsetX and .insetX
     .spanX (@gridColumns);
     .offsetX (@gridColumns);
+    .insetX (@gridColumns);
 
   }
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -541,7 +541,7 @@
     .insetX (0) {}
 
     .inset (@columns) {
-      margin-left: -((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2) - (@gridGutterWidth * 2));
+      margin-left: -((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)));
     }
 
     .span (@columns) {


### PR DESCRIPTION
I created the opposite of the .offsetX class called .insetX

I updated the mixin.less section to auto create the classes based off the existing pattern and updated the docs with a working example.

This is helpful when you need the ability to display content on a mobile or tablet device one way and differently for larger screens.

You use .inset similar to .offset except it pulls the column to the left.
