### PR TITLE
Problem with backdrop

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -114,7 +114,6 @@
   function hideModal( that ) {
     this.$element
       .hide()
-      .trigger('hidden')
 
     backdrop.call(this)
   }
@@ -156,6 +155,7 @@
   function removeBackdrop() {
     this.$backdrop.remove()
     this.$backdrop = null
+    this.$element.trigger('hidden')
   }
 
   function escape() {


### PR DESCRIPTION
This solve a 'race' problem with the hidden event.

Base on the documentation : hidden  "This event is fired when the modal has finished being hidden from the user (will wait for css transitions to complete)."

But in reality the modal has not finished being hidden. And will accumulate backdrop elements.

How to reproduce :
Call show on a 'hidden' event

This could be bypass by using 'backdrop': 'static' in SOME cases.

This work for static and fix the other cases.
