### PR TITLE
.add-on vertical alignment behavior inconsistent.

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1019,7 +1019,7 @@ select:focus:required:invalid:focus {
   line-height: 18px;
   text-align: center;
   text-shadow: 0 1px 0 #ffffff;
-  vertical-align: middle;
+  vertical-align: top;
   background-color: #eeeeee;
   border: 1px solid #ccc;
 }

--- a/less/forms.less
+++ b/less/forms.less
@@ -385,7 +385,7 @@ select:focus:required:invalid {
     line-height: @baseLineHeight;
     text-align: center;
     text-shadow: 0 1px 0 @white;
-    vertical-align: middle;
+    vertical-align: top;
     background-color: @grayLighter;
     border: 1px solid #ccc;
   }


### PR DESCRIPTION
Changed from vertical-align: middle to top

Example: http://twitter.github.com/bootstrap/base-css.html with the "Email address" prepend (at bottom of page)
