### PR TITLE
Allow to cancel modal hiding in `hide` event handler.

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -76,16 +76,20 @@
 
         if (!this.isShown) return
 
+        var event = jQuery.Event("hide")
+        
+        this.$element.trigger(event)
+        
+        if (event.isDefaultPrevented()) return
+        
+        this.$element.removeClass('in')
+
         var that = this
         this.isShown = false
 
         $('body').removeClass('modal-open')
 
         escape.call(this)
-
-        this.$element
-          .trigger('hide')
-          .removeClass('in')
 
         $.support.transition && this.$element.hasClass('fade') ?
           hideWithTransition.call(this) :


### PR DESCRIPTION
In case you show form in modal you might want to add confirmation on close button click. It is very easy to do:

```
$('#myModal').on('hide', function() {
    if (!saveButtonClicked && hasChanges) {
        return false;
    }
});
```

or 

```
$('#myModal').on('hide', function(e) {
    if (!saveButtonClicked && hasChanges) {
        e.preventDefault();
    }
});
```
