### PR TITLE
Fix icon example with input prepend.

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1639,8 +1639,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
           <label class="control-label" for="inputIcon">Email address</label>
           <div class="controls">
             <div class="input-prepend">
-              <span class="add-on"><i class="icon-envelope"></i></span>
-              <input class="span2" id="inputIcon" type="text">
+              <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text">
             </div>
           </div>
         </div>


### PR DESCRIPTION
Follow the documentation's own advice about no white-space between add-ons and input.
