### PR TITLE
Added vendor-prefixes to CSS animations rules.

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3753,6 +3753,8 @@ a.thumbnail:hover {
 .progress.active .bar {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
   -moz-animation: progress-bar-stripes 2s linear infinite;
+  -ms-animation: progress-bar-stripes 2s linear infinite;
+  -o-animation: progress-bar-stripes 2s linear infinite;
   animation: progress-bar-stripes 2s linear infinite;
 }
 .progress-danger .bar {

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -23,6 +23,12 @@
   to    { background-position: 40px 0; }
 }
 
+// Opera
+@-o-keyframes progress-bar-stripes {
+  from  { background-position: 0 0; }
+  to    { background-position: 40px 0; }
+}
+
 // Spec
 @keyframes progress-bar-stripes {
   from  { background-position: 0 0; }
@@ -68,6 +74,8 @@
 .progress.active .bar {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
      -moz-animation: progress-bar-stripes 2s linear infinite;
+      -ms-animation: progress-bar-stripes 2s linear infinite;
+       -o-animation: progress-bar-stripes 2s linear infinite;
           animation: progress-bar-stripes 2s linear infinite;
 }
 


### PR DESCRIPTION
Added -o- and -ms- prefixes to make the animated progress bars to work
in the latest/upcoming versions of IE and Opera.
