### PR TITLE
Change the .size() mixin to accept first width, then height.

### DIFF
--- a/docs/less.html
+++ b/docs/less.html
@@ -704,8 +704,8 @@
       </tr>
       <tr>
         <td><code>.size()</code></td>
-        <td><code>@height: 5px, @width: 5px</code></td>
-        <td>Quickly set the height and width on one line</td>
+        <td><code>@width: 5px, @height: 5px</code></td>
+        <td>Quickly set the width and height on one line</td>
       </tr>
       <tr>
         <td><code>.square()</code></td>

--- a/docs/templates/pages/less.mustache
+++ b/docs/templates/pages/less.mustache
@@ -627,8 +627,8 @@
       </tr>
       <tr>
         <td><code>.size()</code></td>
-        <td><code>@height: 5px, @width: 5px</code></td>
-        <td>{{_i}}Quickly set the height and width on one line{{/i}}</td>
+        <td><code>@width: 5px, @height: 5px</code></td>
+        <td>{{_i}}Quickly set the width and height on one line{{/i}}</td>
       </tr>
       <tr>
         <td><code>.square()</code></td>

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -70,7 +70,7 @@
 
 // Sizing shortcuts
 // -------------------------
-.size(@height: 5px, @width: 5px) {
+.size(@width: 5px, @height: 5px) {
   width: @width;
   height: @height;
 }


### PR DESCRIPTION
I think it's more convenient to specify width followed by height, not the opposite. 

First open-source contribution!
