### PR TITLE
Added option to include responsive styles via LESS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 BOOTSTRAP = ./docs/assets/css/bootstrap.css
 BOOTSTRAP_LESS = ./less/bootstrap.less
-BOOTSTRAP_RESPONSIVE = ./docs/assets/css/bootstrap-responsive.css
-BOOTSTRAP_RESPONSIVE_LESS = ./less/responsive.less
 LESS_COMPRESSOR ?= `which lessc`
 WATCHR ?= `which watchr`
 
@@ -14,7 +12,6 @@ docs: bootstrap
 	zip -r docs/assets/bootstrap.zip bootstrap
 	rm -r bootstrap
 	lessc ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
-	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > ${BOOTSTRAP_RESPONSIVE}
 	node docs/build
 	cp img/* docs/assets/img/
 	cp js/*.js docs/assets/js/
@@ -32,8 +29,6 @@ bootstrap:
 	cp img/* bootstrap/img/
 	lessc ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
 	lessc --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
 	echo "/**\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -522,7 +522,7 @@
       <p>Bootstrap doesn't automatically include these media queries, but understanding and adding them is very easy and requires minimal setup. You have a few options for including the responsive features of Bootstrap:</p>
       <ol>
         <li>Use the compiled responsive version, bootstrap-responsive.css</li>
-        <li>Add @import "responsive.less" and recompile Bootstrap</li>
+        <li>Change <code>@responsive</code> variable to <code>true</code> in variables.less and recompile Bootstrap</li>
         <li>Modify and recompile responsive.less as a separate file</li>
       </ol>
       <p><strong>Why not just include it?</strong> Truth be told, not everything needs to be responsive. Instead of encouraging developers to remove this feature, we figure it best to enable it.</p>

--- a/docs/templates/pages/scaffolding.mustache
+++ b/docs/templates/pages/scaffolding.mustache
@@ -445,7 +445,7 @@
       <p>{{_i}}Bootstrap doesn't automatically include these media queries, but understanding and adding them is very easy and requires minimal setup. You have a few options for including the responsive features of Bootstrap:{{/i}}</p>
       <ol>
         <li>{{_i}}Use the compiled responsive version, bootstrap-responsive.css{{/i}}</li>
-        <li>{{_i}}Add @import "responsive.less" and recompile Bootstrap{{/i}}</li>
+        <li>{{_i}}Change <code>@responsive</code> variable to <code>true</code> in variables.less and recompile Bootstrap{{/i}}</li>
         <li>{{_i}}Modify and recompile responsive.less as a separate file{{/i}}</li>
       </ol>
       <p>{{_i}}<strong>Why not just include it?</strong> Truth be told, not everything needs to be responsive. Instead of encouraging developers to remove this feature, we figure it best to enable it.{{/i}}</p>

--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -58,5 +58,13 @@
 @import "carousel.less";
 @import "hero-unit.less";
 
+// Responsive styles
+.responsive(@_) {
+}
+.responsive(true) {
+  @import "responsive.less";
+}
+.responsive(@responsive);
+
 // Utility classes
 @import "utilities.less"; // Has to be last to override when necessary

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -15,11 +15,16 @@
 
 // REPEAT VARIABLES & MIXINS
 // -------------------------
-// Required since we compile the responsive stuff separately
+// Required if compiling the responsive stuff separately
 
-@import "variables.less"; // Modify this for custom colors, font-sizes, etc
-@import "mixins.less";
-
+// Responsive styles
+.responsive-vars(@_) {
+  @import "variables.less"; // Modify this for custom colors, font-sizes, etc
+  @import "mixins.less";
+}
+.responsive-vars(true) {
+}
+.responsive-vars(@responsive);
 
 // RESPONSIVE CLASSES
 // ------------------

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -1,30 +1,7 @@
-/*!
- * Bootstrap Responsive v2.0.3
- *
- * Copyright 2012 Twitter, Inc
- * Licensed under the Apache License v2.0
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Designed and built with all the love in the world @twitter by @mdo and @fat.
- */
-
 // Responsive.less
 // For phone and tablet devices
 // -------------------------------------------------------------
 
-
-// REPEAT VARIABLES & MIXINS
-// -------------------------
-// Required if compiling the responsive stuff separately
-
-// Responsive styles
-.responsive-vars(@_) {
-  @import "variables.less"; // Modify this for custom colors, font-sizes, etc
-  @import "mixins.less";
-}
-.responsive-vars(true) {
-}
-.responsive-vars(@responsive);
 
 // RESPONSIVE CLASSES
 // ------------------

--- a/less/variables.less
+++ b/less/variables.less
@@ -203,3 +203,10 @@
 // -------------------------
 @fluidGridColumnWidth:    6.382978723%;
 @fluidGridGutterWidth:    2.127659574%;
+
+
+
+// RESPONSIVE
+// --------------------------------------------------
+
+@responsive: false;


### PR DESCRIPTION
Set `@responsive` variable in `variables.less` to `true` and `responsive.less` will be compiled into `bootstrap.css`.

Alternatively, set the variable to `false` (default) and everything is as before (i.e.: compile `responsive.less` yourself or don't bother at all).

This pull request is based on issue #2796. I finally got around to making my own fork so I could create pull requests instead of being lazy! :)
