### PR TITLE
Just fixing a little typo

### DIFF
--- a/scaffolding.html
+++ b/scaffolding.html
@@ -183,7 +183,7 @@
 </pre>
     </div><!-- /.span -->
     <div class="span4">
-      <p>As shown here, a basic layout can be created with two "columns," each spanning a number of the 12 foundational columns we defined as part of our grid system.</p>
+      <p>As shown here, a basic layout can be created with two "columns", each spanning a number of the 12 foundational columns we defined as part of our grid system.</p>
     </div><!-- /.span -->
   </div><!-- /.row -->
 

--- a/scaffolding.html
+++ b/scaffolding.html
@@ -172,7 +172,7 @@
   <div class="row">
     <div class="span4">
       <p>The default grid system provided as part of Bootstrap is a <strong>940px-wide, 12-column grid</strong>.</p>
-      <p>It also has four responsive variations for various devices and resolutions: phone, tablet portrait, table landscape and small desktops, and large widescreen desktops.</p>
+      <p>It also has four responsive variations for various devices and resolutions: phone, tablet portrait, tablet landscape and small desktops, and large widescreen desktops.</p>
     </div><!-- /.span -->
     <div class="span4">
 <pre class="prettyprint linenums">


### PR DESCRIPTION
Just fixing a little typo in Scaffolding page.
It was "table landscape" and it was suposed to be "tablet landscape".
