### PR TITLE
Making mixins parameteric: .clearfix(), .hide-text(), .input-block-level()

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -9,7 +9,7 @@
 // Clearfix
 // --------
 // For clearing floats like a boss h5bp.com/q
-.clearfix {
+.clearfix() {
   *zoom: 1;
   &:before,
   &:after {
@@ -101,7 +101,7 @@
 // New image replacement
 // -------------------------
 // Source: http://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/
-.hide-text {
+.hide-text() {
   overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
@@ -147,7 +147,7 @@
 // --------------------------------------------------
 
 // Block level inputs
-.input-block-level {
+.input-block-level() {
   display: block;
   width: 100%;
   min-height: 28px; /* Make inputs at least the height of their button counterpart */


### PR DESCRIPTION
I just upgraded to the latest release and it looks like there are three non-parametric mixins defined. This means these mixins will be included in the CSS output everywhere the mixins.less file is imported.

.clearfix
.hide-text
.input-block-level

This seems like it must be a mistake. So I've updated these so rulesets are hidden from CSS output, allowing mixins.less to be imported in multiple files.

If this is intentional, can someone please explain why?
