### PR TITLE
Mentioned "navbar-text" class for <p> tags in navbars

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1134,7 +1134,7 @@
       <p><a class="btn" href="./javascript.html#dropdowns">Get the javascript &rarr;</a></p>
       <hr>
       <h3>Text in the navbar</h3>
-      <p>Wrap strings of text in a <code>&lt;p&gt;</code> tag for proper leading and color.</p>
+      <p>Wrap strings of text in a <code>&lt;p class="navbar-text"&gt;</code> tag for proper leading and color.</p>
     </div><!-- /.span -->
   </div><!-- /.row -->
 


### PR DESCRIPTION
Learned about this class via the examples, and I thought it would be prudent to add it to the documentation as well.
