### PR TITLE
Changes to make modal accomodate any content height and have the whole page scroll, rather than internal modal scrollbars

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3287,7 +3287,6 @@ input[type="submit"].btn.btn-mini {
   margin: 0;
   z-index: 1050;
   overflow: auto;
-  width: 560px;
   background-color: #ffffff;
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.3);

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3255,30 +3255,39 @@ input[type="submit"].btn.btn-mini {
   z-index: 2070;
 }
 .modal-backdrop {
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.8);
   position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000000;
 }
 .modal-backdrop.fade {
-  opacity: 0;
+  background: rgba(0, 0, 0, 0);
 }
 .modal-backdrop,
 .modal-backdrop.fade.in {
-  opacity: 0.8;
-  filter: alpha(opacity=80);
+  background: rgba(0, 0, 0, 0.8);
+}
+.modal-wrapper {
+  top: 50px;
+  left: 50%;
+  margin-left: -280px;
+  z-index: 1050;
+  width: 560px;
+  position: absolute;
+  padding-bottom: 80px;
+  overflow: visible;
 }
 .modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
+  position: static;
+  margin: 0;
   z-index: 1050;
   overflow: auto;
   width: 560px;
-  margin: -250px 0 0 -280px;
   background-color: #ffffff;
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.3);
@@ -3315,7 +3324,6 @@ input[type="submit"].btn.btn-mini {
 }
 .modal-body {
   overflow-y: auto;
-  max-height: 400px;
   padding: 15px;
 }
 .modal-form {

--- a/docs/assets/js/bootstrap-modal.js
+++ b/docs/assets/js/bootstrap-modal.js
@@ -127,7 +127,11 @@
       var doAnimate = $.support.transition && animate
 
       this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .appendTo(document.body)
+        .insertBefore(this.$element)
+      this.$elementWrapper = $('<div class="modal-wrapper clearfix" />')
+        .prependTo(this.$backdrop)
+      this.$element.remove().prependTo(this.$elementWrapper)
+      $('html').css({ 'overflow' : 'hidden'  })
 
       if (this.options.backdrop != 'static') {
         this.$backdrop.click($.proxy(this.hide, this))
@@ -154,8 +158,10 @@
   }
 
   function removeBackdrop() {
+    this.$element.remove().insertAfter(this.$backdrop)
     this.$backdrop.remove()
     this.$backdrop = null
+    $('html').css({ 'overflow' : 'auto'  })
   }
 
   function escape() {

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -127,7 +127,11 @@
       var doAnimate = $.support.transition && animate
 
       this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-        .appendTo(document.body)
+        .insertBefore(this.$element)
+      this.$elementWrapper = $('<div class="modal-wrapper clearfix" />')
+        .prependTo(this.$backdrop)
+      this.$element.remove().prependTo(this.$elementWrapper)
+      $('html').css({ 'overflow' : 'hidden'  })
 
       if (this.options.backdrop != 'static') {
         this.$backdrop.click($.proxy(this.hide, this))
@@ -154,8 +158,10 @@
   }
 
   function removeBackdrop() {
+    this.$element.remove().insertAfter(this.$backdrop)
     this.$backdrop.remove()
     this.$backdrop = null
+    $('html').css({ 'overflow' : 'auto'  })
   }
 
   function escape() {

--- a/less/modals.less
+++ b/less/modals.less
@@ -47,7 +47,6 @@
   margin: 0;
   z-index: @zindexModal;
   overflow: auto;
-  width: 560px;
   background-color: @white;
   border: 1px solid #999;
   border: 1px solid rgba(0,0,0,.3);

--- a/less/modals.less
+++ b/less/modals.less
@@ -11,31 +11,43 @@
 
 // Background
 .modal-backdrop {
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.8);
   position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
   z-index: @zindexModalBackdrop;
-  background-color: @black;
   // Fade for backdrop
-  &.fade { opacity: 0; }
+  &.fade { background: rgba(0, 0, 0, 0.0); }
 }
 
 .modal-backdrop,
 .modal-backdrop.fade.in {
-  .opacity(80);
+  background: rgba(0, 0, 0, 0.8);
 }
 
 // Base modal
-.modal {
-  position: fixed;
-  top: 50%;
+
+// To achieve dynamic height page scroll modal
+.modal-wrapper {
+  top: 50px;
   left: 50%;
+  margin-left: -280px;
+  z-index: 1050;
+  width: 560px;
+  position: absolute;
+  padding-bottom: 80px;
+  overflow: visible;
+}
+.modal {
+  position: static;
+  margin: 0;
   z-index: @zindexModal;
   overflow: auto;
   width: 560px;
-  margin: -250px 0 0 -280px;
   background-color: @white;
   border: 1px solid #999;
   border: 1px solid rgba(0,0,0,.3);
@@ -59,7 +71,6 @@
 // Body (where all modal content resises)
 .modal-body {
   overflow-y: auto;
-  max-height: 400px;
   padding: 15px;
 }
 // Remove bottom margin if need be


### PR DESCRIPTION
Makes using for modals for apps a lot easier when they can accomodate any content height. I noticed there was an issue with people asking for it (https://github.com/twitter/bootstrap/issues/407) and I wanted it myself. I took notes from how Trello handles this.
