### PR TITLE
Renaming @gridColumnGutter to @gridGutterWidth

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -290,7 +290,7 @@
 }
 
 // CSS3 Content Columns
-.content-columns(@columnCount, @columnGap: @gridColumnGutter) {
+.content-columns(@columnCount, @columnGap: @gridGutterWidth) {
   -webkit-column-count: @columnCount;
      -moz-column-count: @columnCount;
           column-count: @columnCount;


### PR DESCRIPTION
Wrong var name is causing error when using mixin .content-columns()
