### PR TITLE
Inputs are screws when contained in an html block with z-index > 2.

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -369,7 +369,7 @@ select:focus:required:invalid {
     .border-radius(0 3px 3px 0);
     &:focus {
       position: relative;
-      z-index: 2;
+      z-index: 100000000;
     }
   }
   .uneditable-input {


### PR DESCRIPTION
Hi guys,

i think their is a tricky part in the tw-bootstrap... 
Consider that your inputs are contained in a box which is layered with a z-index 1000;
What happen on focus? Your input goes behind it's container, then you see nothing :-(

So, i pushed a naive fix, hope it helps.
