### PR TITLE
Fix margins for elements after <legend>

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -514,7 +514,7 @@ select:focus:required:invalid {
 }
 
 // Legend collapses margin, so next element is responsible for spacing
-legend + .control-group {
+legend + * {
   margin-top: @baseLineHeight;
   -webkit-margin-top-collapse: separate;
 }


### PR DESCRIPTION
Currently, only `.control-group`s that follow a `<legend>` tag get their margins fixed. This means that using fieldsets in any non-`form-horizontal` area is broken. Alerts, `<p>` tags, tables, and other elements all get squished up against the legend.

This might be a bit sledge-hammery, but at worst the developer will need to specify their own `margin-top` value, which is a lot more intuitive than forcing them to class their elements as `control-group` (since they're not necessarily control groups) or specifying `-webkit-margin-top-collapse: separate`.
