### PR TITLE
Restrict navbar items that are collapsed to only those in .nav-collapse.

### DIFF
--- a/docs/examples/starter-template.html
+++ b/docs/examples/starter-template.html
@@ -39,6 +39,50 @@
             <span class="icon-bar"></span>
           </a>
           <a class="brand" href="#">Project name</a>
+
+          <div class="pull-right">
+
+            <div class="btn-group pull-right">
+              <button class="btn btn-primary"><i class="icon-user icon-white"></i> Bryan Petty</button>
+              <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu pull-right">
+                <li><a href="#">My Orders</a></li>
+                <li><a href="#">My Details</a></li>
+                <li class="divider"></li>
+                <li><a href="#">Sign Out</a></li>
+              </ul>
+            </div>
+
+            <div class="btn-group pull-right">
+              <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                <i class="icon-user"></i> Bryan Petty
+                <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li><a href="#">My Orders</a></li>
+                <li><a href="#">My Details</a></li>
+                <li class="divider"></li>
+                <li><a href="#">Sign Out</a></li>
+              </ul>
+            </div>
+
+            <div class="pull-right">
+              <ul class="nav">
+                <li class="dropdown">
+                  <a href="#" class="dropdown-toggle" data-toggle="dropdown">Account <b class="caret"></b></a>
+                  <ul class="dropdown-menu pull-right">
+                    <li><a href="#">Sign In</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Create Account</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+
+          </div>
+
           <div class="nav-collapse">
             <ul class="nav">
               <li class="active"><a href="#">Home</a></li>

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -245,40 +245,40 @@
     clear: left;
   }
   // Block-level the nav
-  .navbar .nav {
+  .navbar .nav-collapse .nav {
     float: none;
     margin: 0 0 (@baseLineHeight / 2);
   }
-  .navbar .nav > li {
+  .navbar .nav-collapse .nav > li {
     float: none;
   }
-  .navbar .nav > li > a {
+  .navbar .nav-collapse .nav > li > a {
     margin-bottom: 2px;
   }
-  .navbar .nav > .divider-vertical {
+  .navbar .nav-collapse .nav > .divider-vertical {
     display: none;
   }
-  .navbar .nav .nav-header {
+  .navbar .nav-collapse .nav .nav-header {
     color: @navbarText;
     text-shadow: none;
   }
   // Nav and dropdown links in navbar
-  .navbar .nav > li > a,
-  .navbar .dropdown-menu a {
+  .navbar .nav-collapse .nav > li > a,
+  .navbar .nav-collapse .dropdown-menu a {
     padding: 6px 15px;
     font-weight: bold;
     color: @navbarLinkColor;
     .border-radius(3px);
   }
-  .navbar .dropdown-menu li + li a {
+  .navbar .nav-collapse .dropdown-menu li + li a {
     margin-bottom: 2px;
   }
-  .navbar .nav > li > a:hover,
-  .navbar .dropdown-menu a:hover {
+  .navbar .nav-collapse .nav > li > a:hover,
+  .navbar .nav-collapse .dropdown-menu a:hover {
     background-color: @navbarBackground;
   }
   // Dropdowns in the navbar
-  .navbar .dropdown-menu {
+  .navbar .nav-collapse .dropdown-menu {
     position: static;
     top: auto;
     left: auto;
@@ -292,16 +292,16 @@
     .border-radius(0);
     .box-shadow(none);
   }
-  .navbar .dropdown-menu:before,
-  .navbar .dropdown-menu:after {
+  .navbar .nav-collapse .dropdown-menu:before,
+  .navbar .nav-collapse .dropdown-menu:after {
     display: none;
   }
-  .navbar .dropdown-menu .divider {
+  .navbar .nav-collapse .dropdown-menu .divider {
     display: none;
   }
   // Forms in navbar
-  .navbar-form,
-  .navbar-search {
+  .nav-collapse .navbar-form,
+  .nav-collapse .navbar-search {
     float: none;
     padding: (@baseLineHeight / 2) 15px;
     margin: (@baseLineHeight / 2) 0;
@@ -311,7 +311,7 @@
     .box-shadow(@shadow);
   }
   // Pull right (secondary) nav content
-  .navbar .nav.pull-right {
+  .navbar .nav-collapse .nav.pull-right {
     float: none;
     margin-left: 0;
   }


### PR DESCRIPTION
Please don't merge this PR as is, this is simply a proof of concept, it still needs some improvement.

In responsive Bootstrap layouts, the Navbar automatically hides any items contained within a .nav-collapse, and doesn't hide anything that isn't, however, it does still collapse _all_ items. This restricts designs from making use of any components they may want to always show in the Navbar even on smaller screens. Such items are typically things like account login and logout links which can easily still fit in the Navbar at 240px wide screens, and should always be shown by default.

These changes scope the Navbar nav collapse styles to only those contained in .nav-collapse. With these changes, you can now still use (floated) dropdown menus (regular and button dropdowns) which can still be managed with other responsive styles and never hidden on any screen.

The starter-template.html example included in this PR illustrates how this can be used. Please note the differences between desktop and tablet Navbar components.

The only thing you have to account for now is making sure your content that isn't in a .nav-collapse comes before anything that is in the HTML code so it doesn't expand the navbar on mobile (which is exactly the technique used to keep the menu collapse button up top), but you can still float components in either direction of the navbar. This can be tough depending on what you need up top and on which side. What it comes down to is that you can't have anything that isn't in a .nav-collapse between two items that are collapsible. This is still much more flexible than how Bootstrap is before these changes though.

Issues remaining:
- Button dropdowns need additional style fixes for correct placement and alignment of dropdown menus.
- The .nav-collapse scoping used here could be better engineered to handle .nav-collapse class added to non-containing elements (directly added to btn-group for example).
