### PR TITLE
Mark required controls

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -291,6 +291,19 @@ textarea[readonly] {
   .formFieldState(@successText, @successText, @successBackground);
 }
 
+// Mark required controls
+.control-group.required > label::after {
+	content: '\000a0*';
+	vertical-align: top;
+	color: @infoText;
+}
+.control-group.required.error > label::after {
+	color: @errorText;
+}
+.control-group.required.warning > label::after {
+	color: @warningText;
+}
+
 // HTML5 invalid states
 // Shares styles with the .control-group.error above
 input:focus:required:invalid,


### PR DESCRIPTION
Currently, required controls cannot be easily identified. This patch marks required controls by adding an asterisk to their label. Initially, the asterisk has the color `@infoText` but the color is changed to `@errorText` or `@warningText` if the control group has the class `.error` or `.warning`.

I already use it for my toolkit, you can check it out here:
- http://brickrouge.org#form: Notice the "required" control in the "Required and validated" section.
- http://brickrouge.org#alerts: Notice the "required" control in with the `.error` class in the "Goes great with javascript" section.
