### PR TITLE
nest h1 inside .page-header rule

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -81,9 +81,9 @@ h6 {
   padding-bottom: @baseLineHeight - 1;
   margin: @baseLineHeight 0;
   border-bottom: 1px solid @grayLighter;
-}
-.page-header h1 {
-  line-height: 1;
+  h1 {
+    line-height: 1;
+  }
 }
 
 


### PR DESCRIPTION
Just a small nit I saw while doing some customization of bootstrap. This seemed to break from the convention of nesting rules in the `.less` files. This doesn't change the compiled CSS, so there's no update to that.
