### PR TITLE
span.input-append should be glued to input

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -416,7 +416,7 @@ select:focus:required:invalid {
   }
   .add-on,
   .btn {
-    margin-left: -1px;
+    margin-left: -5px;
     .border-radius(0 3px 3px 0);
   }
 }


### PR DESCRIPTION
``` html
<form>
    <div class="input-append">
        <input class="span2" />
        <span class="add-on">test</span>
    </div>
</form>

<form class="form-horizontal">
    <div class="input-append">
        <input class="span2" />
        <span class="add-on">test</span>
    </div>
</form>
```

—>

![](http://sedictor.ru/12/04/02/1333394740.png)

2.0.3-wip branch, Chrome 18.0.1025.142, Firefox 11.0
