### PR TITLE
Optional color-stop support on gradient mixin

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2016,12 +2016,12 @@ button.close {
   text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
   vertical-align: middle;
   background-color: #f5f5f5;
-  background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -ms-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
-  background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: linear-gradient(top, #ffffff, #e6e6e6);
+  background-image: -moz-linear-gradient(top, #ffffff 0%, #e6e6e6 100%);
+  background-image: -ms-linear-gradient(top, #ffffff 0%, #e6e6e6 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #ffffff), color-stop(1, #e6e6e6));
+  background-image: -webkit-linear-gradient(top, #ffffff 0%, #e6e6e6 100%);
+  background-image: -o-linear-gradient(top, #ffffff 0%, #e6e6e6 100%);
+  background-image: linear-gradient(top, #ffffff 0%, #e6e6e6 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#e6e6e6', GradientType=0);
   border-color: #e6e6e6 #e6e6e6 #bfbfbf;
@@ -2149,12 +2149,12 @@ button.close {
 }
 .btn-primary {
   background-color: #0074cc;
-  background-image: -moz-linear-gradient(top, #0088cc, #0055cc);
-  background-image: -ms-linear-gradient(top, #0088cc, #0055cc);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0055cc));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0055cc);
-  background-image: -o-linear-gradient(top, #0088cc, #0055cc);
-  background-image: linear-gradient(top, #0088cc, #0055cc);
+  background-image: -moz-linear-gradient(top, #0088cc 0%, #0055cc 100%);
+  background-image: -ms-linear-gradient(top, #0088cc 0%, #0055cc 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #0088cc), color-stop(1, #0055cc));
+  background-image: -webkit-linear-gradient(top, #0088cc 0%, #0055cc 100%);
+  background-image: -o-linear-gradient(top, #0088cc 0%, #0055cc 100%);
+  background-image: linear-gradient(top, #0088cc 0%, #0055cc 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0055cc', GradientType=0);
   border-color: #0055cc #0055cc #003580;
@@ -2178,12 +2178,12 @@ button.close {
 }
 .btn-warning {
   background-color: #faa732;
-  background-image: -moz-linear-gradient(top, #fbb450, #f89406);
-  background-image: -ms-linear-gradient(top, #fbb450, #f89406);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fbb450), to(#f89406));
-  background-image: -webkit-linear-gradient(top, #fbb450, #f89406);
-  background-image: -o-linear-gradient(top, #fbb450, #f89406);
-  background-image: linear-gradient(top, #fbb450, #f89406);
+  background-image: -moz-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -ms-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #fbb450), color-stop(1, #f89406));
+  background-image: -webkit-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -o-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: linear-gradient(top, #fbb450 0%, #f89406 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fbb450', endColorstr='#f89406', GradientType=0);
   border-color: #f89406 #f89406 #ad6704;
@@ -2207,12 +2207,12 @@ button.close {
 }
 .btn-danger {
   background-color: #da4f49;
-  background-image: -moz-linear-gradient(top, #ee5f5b, #bd362f);
-  background-image: -ms-linear-gradient(top, #ee5f5b, #bd362f);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#bd362f));
-  background-image: -webkit-linear-gradient(top, #ee5f5b, #bd362f);
-  background-image: -o-linear-gradient(top, #ee5f5b, #bd362f);
-  background-image: linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: -moz-linear-gradient(top, #ee5f5b 0%, #bd362f 100%);
+  background-image: -ms-linear-gradient(top, #ee5f5b 0%, #bd362f 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #ee5f5b), color-stop(1, #bd362f));
+  background-image: -webkit-linear-gradient(top, #ee5f5b 0%, #bd362f 100%);
+  background-image: -o-linear-gradient(top, #ee5f5b 0%, #bd362f 100%);
+  background-image: linear-gradient(top, #ee5f5b 0%, #bd362f 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ee5f5b', endColorstr='#bd362f', GradientType=0);
   border-color: #bd362f #bd362f #802420;
@@ -2236,12 +2236,12 @@ button.close {
 }
 .btn-success {
   background-color: #5bb75b;
-  background-image: -moz-linear-gradient(top, #62c462, #51a351);
-  background-image: -ms-linear-gradient(top, #62c462, #51a351);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#62c462), to(#51a351));
-  background-image: -webkit-linear-gradient(top, #62c462, #51a351);
-  background-image: -o-linear-gradient(top, #62c462, #51a351);
-  background-image: linear-gradient(top, #62c462, #51a351);
+  background-image: -moz-linear-gradient(top, #62c462 0%, #51a351 100%);
+  background-image: -ms-linear-gradient(top, #62c462 0%, #51a351 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #62c462), color-stop(1, #51a351));
+  background-image: -webkit-linear-gradient(top, #62c462 0%, #51a351 100%);
+  background-image: -o-linear-gradient(top, #62c462 0%, #51a351 100%);
+  background-image: linear-gradient(top, #62c462 0%, #51a351 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#62c462', endColorstr='#51a351', GradientType=0);
   border-color: #51a351 #51a351 #387038;
@@ -2265,12 +2265,12 @@ button.close {
 }
 .btn-info {
   background-color: #49afcd;
-  background-image: -moz-linear-gradient(top, #5bc0de, #2f96b4);
-  background-image: -ms-linear-gradient(top, #5bc0de, #2f96b4);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5bc0de), to(#2f96b4));
-  background-image: -webkit-linear-gradient(top, #5bc0de, #2f96b4);
-  background-image: -o-linear-gradient(top, #5bc0de, #2f96b4);
-  background-image: linear-gradient(top, #5bc0de, #2f96b4);
+  background-image: -moz-linear-gradient(top, #5bc0de 0%, #2f96b4 100%);
+  background-image: -ms-linear-gradient(top, #5bc0de 0%, #2f96b4 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #5bc0de), color-stop(1, #2f96b4));
+  background-image: -webkit-linear-gradient(top, #5bc0de 0%, #2f96b4 100%);
+  background-image: -o-linear-gradient(top, #5bc0de 0%, #2f96b4 100%);
+  background-image: linear-gradient(top, #5bc0de 0%, #2f96b4 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#5bc0de', endColorstr='#2f96b4', GradientType=0);
   border-color: #2f96b4 #2f96b4 #1f6377;
@@ -2294,12 +2294,12 @@ button.close {
 }
 .btn-inverse {
   background-color: #414141;
-  background-image: -moz-linear-gradient(top, #555555, #222222);
-  background-image: -ms-linear-gradient(top, #555555, #222222);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#555555), to(#222222));
-  background-image: -webkit-linear-gradient(top, #555555, #222222);
-  background-image: -o-linear-gradient(top, #555555, #222222);
-  background-image: linear-gradient(top, #555555, #222222);
+  background-image: -moz-linear-gradient(top, #555555 0%, #222222 100%);
+  background-image: -ms-linear-gradient(top, #555555 0%, #222222 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #555555), color-stop(1, #222222));
+  background-image: -webkit-linear-gradient(top, #555555 0%, #222222 100%);
+  background-image: -o-linear-gradient(top, #555555 0%, #222222 100%);
+  background-image: linear-gradient(top, #555555 0%, #222222 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#555555', endColorstr='#222222', GradientType=0);
   border-color: #222222 #222222 #000000;
@@ -2878,12 +2878,12 @@ input[type="submit"].btn.btn-mini {
   padding-left: 20px;
   padding-right: 20px;
   background-color: #2c2c2c;
-  background-image: -moz-linear-gradient(top, #333333, #222222);
-  background-image: -ms-linear-gradient(top, #333333, #222222);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#333333), to(#222222));
-  background-image: -webkit-linear-gradient(top, #333333, #222222);
-  background-image: -o-linear-gradient(top, #333333, #222222);
-  background-image: linear-gradient(top, #333333, #222222);
+  background-image: -moz-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -ms-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #333333), color-stop(1, #222222));
+  background-image: -webkit-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -o-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: linear-gradient(top, #333333 0%, #222222 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#333333', endColorstr='#222222', GradientType=0);
   -webkit-border-radius: 4px;
@@ -2903,12 +2903,12 @@ input[type="submit"].btn.btn-mini {
   margin-left: 5px;
   margin-right: 5px;
   background-color: #2c2c2c;
-  background-image: -moz-linear-gradient(top, #333333, #222222);
-  background-image: -ms-linear-gradient(top, #333333, #222222);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#333333), to(#222222));
-  background-image: -webkit-linear-gradient(top, #333333, #222222);
-  background-image: -o-linear-gradient(top, #333333, #222222);
-  background-image: linear-gradient(top, #333333, #222222);
+  background-image: -moz-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -ms-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #333333), color-stop(1, #222222));
+  background-image: -webkit-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: -o-linear-gradient(top, #333333 0%, #222222 100%);
+  background-image: linear-gradient(top, #333333 0%, #222222 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#333333', endColorstr='#222222', GradientType=0);
   border-color: #222222 #222222 #000000;
@@ -3205,12 +3205,12 @@ input[type="submit"].btn.btn-mini {
   margin: 0 0 18px;
   list-style: none;
   background-color: #fbfbfb;
-  background-image: -moz-linear-gradient(top, #ffffff, #f5f5f5);
-  background-image: -ms-linear-gradient(top, #ffffff, #f5f5f5);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#f5f5f5));
-  background-image: -webkit-linear-gradient(top, #ffffff, #f5f5f5);
-  background-image: -o-linear-gradient(top, #ffffff, #f5f5f5);
-  background-image: linear-gradient(top, #ffffff, #f5f5f5);
+  background-image: -moz-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background-image: -ms-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #ffffff), color-stop(1, #f5f5f5));
+  background-image: -webkit-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background-image: -o-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background-image: linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f5f5f5', GradientType=0);
   border: 1px solid #ddd;
@@ -3777,12 +3777,12 @@ a.badge:hover {
   height: 18px;
   margin-bottom: 18px;
   background-color: #f7f7f7;
-  background-image: -moz-linear-gradient(top, #f5f5f5, #f9f9f9);
-  background-image: -ms-linear-gradient(top, #f5f5f5, #f9f9f9);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f5f5f5), to(#f9f9f9));
-  background-image: -webkit-linear-gradient(top, #f5f5f5, #f9f9f9);
-  background-image: -o-linear-gradient(top, #f5f5f5, #f9f9f9);
-  background-image: linear-gradient(top, #f5f5f5, #f9f9f9);
+  background-image: -moz-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
+  background-image: -ms-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #f5f5f5), color-stop(1, #f9f9f9));
+  background-image: -webkit-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
+  background-image: -o-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
+  background-image: linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f5f5f5', endColorstr='#f9f9f9', GradientType=0);
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
@@ -3800,12 +3800,12 @@ a.badge:hover {
   text-align: center;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #0e90d2;
-  background-image: -moz-linear-gradient(top, #149bdf, #0480be);
-  background-image: -ms-linear-gradient(top, #149bdf, #0480be);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#149bdf), to(#0480be));
-  background-image: -webkit-linear-gradient(top, #149bdf, #0480be);
-  background-image: -o-linear-gradient(top, #149bdf, #0480be);
-  background-image: linear-gradient(top, #149bdf, #0480be);
+  background-image: -moz-linear-gradient(top, #149bdf 0%, #0480be 100%);
+  background-image: -ms-linear-gradient(top, #149bdf 0%, #0480be 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #149bdf), color-stop(1, #0480be));
+  background-image: -webkit-linear-gradient(top, #149bdf 0%, #0480be 100%);
+  background-image: -o-linear-gradient(top, #149bdf 0%, #0480be 100%);
+  background-image: linear-gradient(top, #149bdf 0%, #0480be 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#149bdf', endColorstr='#0480be', GradientType=0);
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
@@ -3843,12 +3843,12 @@ a.badge:hover {
 }
 .progress-danger .bar {
   background-color: #dd514c;
-  background-image: -moz-linear-gradient(top, #ee5f5b, #c43c35);
-  background-image: -ms-linear-gradient(top, #ee5f5b, #c43c35);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#c43c35));
-  background-image: -webkit-linear-gradient(top, #ee5f5b, #c43c35);
-  background-image: -o-linear-gradient(top, #ee5f5b, #c43c35);
-  background-image: linear-gradient(top, #ee5f5b, #c43c35);
+  background-image: -moz-linear-gradient(top, #ee5f5b 0%, #c43c35 100%);
+  background-image: -ms-linear-gradient(top, #ee5f5b 0%, #c43c35 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #ee5f5b), color-stop(1, #c43c35));
+  background-image: -webkit-linear-gradient(top, #ee5f5b 0%, #c43c35 100%);
+  background-image: -o-linear-gradient(top, #ee5f5b 0%, #c43c35 100%);
+  background-image: linear-gradient(top, #ee5f5b 0%, #c43c35 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ee5f5b', endColorstr='#c43c35', GradientType=0);
 }
@@ -3863,12 +3863,12 @@ a.badge:hover {
 }
 .progress-success .bar {
   background-color: #5eb95e;
-  background-image: -moz-linear-gradient(top, #62c462, #57a957);
-  background-image: -ms-linear-gradient(top, #62c462, #57a957);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#62c462), to(#57a957));
-  background-image: -webkit-linear-gradient(top, #62c462, #57a957);
-  background-image: -o-linear-gradient(top, #62c462, #57a957);
-  background-image: linear-gradient(top, #62c462, #57a957);
+  background-image: -moz-linear-gradient(top, #62c462 0%, #57a957 100%);
+  background-image: -ms-linear-gradient(top, #62c462 0%, #57a957 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #62c462), color-stop(1, #57a957));
+  background-image: -webkit-linear-gradient(top, #62c462 0%, #57a957 100%);
+  background-image: -o-linear-gradient(top, #62c462 0%, #57a957 100%);
+  background-image: linear-gradient(top, #62c462 0%, #57a957 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#62c462', endColorstr='#57a957', GradientType=0);
 }
@@ -3883,12 +3883,12 @@ a.badge:hover {
 }
 .progress-info .bar {
   background-color: #4bb1cf;
-  background-image: -moz-linear-gradient(top, #5bc0de, #339bb9);
-  background-image: -ms-linear-gradient(top, #5bc0de, #339bb9);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5bc0de), to(#339bb9));
-  background-image: -webkit-linear-gradient(top, #5bc0de, #339bb9);
-  background-image: -o-linear-gradient(top, #5bc0de, #339bb9);
-  background-image: linear-gradient(top, #5bc0de, #339bb9);
+  background-image: -moz-linear-gradient(top, #5bc0de 0%, #339bb9 100%);
+  background-image: -ms-linear-gradient(top, #5bc0de 0%, #339bb9 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #5bc0de), color-stop(1, #339bb9));
+  background-image: -webkit-linear-gradient(top, #5bc0de 0%, #339bb9 100%);
+  background-image: -o-linear-gradient(top, #5bc0de 0%, #339bb9 100%);
+  background-image: linear-gradient(top, #5bc0de 0%, #339bb9 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#5bc0de', endColorstr='#339bb9', GradientType=0);
 }
@@ -3903,12 +3903,12 @@ a.badge:hover {
 }
 .progress-warning .bar {
   background-color: #faa732;
-  background-image: -moz-linear-gradient(top, #fbb450, #f89406);
-  background-image: -ms-linear-gradient(top, #fbb450, #f89406);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fbb450), to(#f89406));
-  background-image: -webkit-linear-gradient(top, #fbb450, #f89406);
-  background-image: -o-linear-gradient(top, #fbb450, #f89406);
-  background-image: linear-gradient(top, #fbb450, #f89406);
+  background-image: -moz-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -ms-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop(0, #fbb450), color-stop(1, #f89406));
+  background-image: -webkit-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: -o-linear-gradient(top, #fbb450 0%, #f89406 100%);
+  background-image: linear-gradient(top, #fbb450 0%, #f89406 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fbb450', endColorstr='#f89406', GradientType=0);
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -343,36 +343,42 @@
 
 // Gradients
 #gradient {
-  .horizontal(@startColor: #555, @endColor: #333) {
+  .horizontal(@startColor: #555, @endColor: #333, @startPosition: 0, @endPosition: 100) {
+    @startPosPercent: (@startPosition + 0%);
+    @endPosPercent: (@endPosition + 0%);
     background-color: @endColor;
-    background-image: -moz-linear-gradient(left, @startColor, @endColor); // FF 3.6+
-    background-image: -ms-linear-gradient(left, @startColor, @endColor); // IE10
-    background-image: -webkit-gradient(linear, 0 0, 100% 0, from(@startColor), to(@endColor)); // Safari 4+, Chrome 2+
-    background-image: -webkit-linear-gradient(left, @startColor, @endColor); // Safari 5.1+, Chrome 10+
-    background-image: -o-linear-gradient(left, @startColor, @endColor); // Opera 11.10
-    background-image: linear-gradient(left, @startColor, @endColor); // Le standard
+    background-image: -moz-linear-gradient(left, @startColor @startPosPercent, @endColor @endPosPercent); // FF 3.6+
+    background-image: -ms-linear-gradient(left, @startColor @startPosPercent, @endColor @endPosPercent); // IE10
+    background-image: -webkit-gradient(linear, 0 0, 100% 0, color-stop((@startPosition / 100), @startColor), color-stop((@endPosition / 100), @endColor)); // Safari 4+, Chrome 2+
+    background-image: -webkit-linear-gradient(left, @startColor @startPosPercent, @endColor @endPosPercent); // Safari 5.1+, Chrome 10+
+    background-image: -o-linear-gradient(left, @startColor @startPosPercent, @endColor @endPosPercent); // Opera 11.10
+    background-image: linear-gradient(left, @startColor @startPosPercent, @endColor @endPosPercent); // Le standard
     background-repeat: repeat-x;
     filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",@startColor,@endColor)); // IE9 and down
   }
-  .vertical(@startColor: #555, @endColor: #333) {
+  .vertical(@startColor: #555, @endColor: #333, @startPosition: 0, @endPosition: 100) {
+    @startPosPercent: (@startPosition + 0%);
+    @endPosPercent: (@endPosition + 0%);
     background-color: mix(@startColor, @endColor, 60%);
-    background-image: -moz-linear-gradient(top, @startColor, @endColor); // FF 3.6+
-    background-image: -ms-linear-gradient(top, @startColor, @endColor); // IE10
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), to(@endColor)); // Safari 4+, Chrome 2+
-    background-image: -webkit-linear-gradient(top, @startColor, @endColor); // Safari 5.1+, Chrome 10+
-    background-image: -o-linear-gradient(top, @startColor, @endColor); // Opera 11.10
-    background-image: linear-gradient(top, @startColor, @endColor); // The standard
+    background-image: -moz-linear-gradient(top, @startColor @startPosPercent, @endColor @endPosPercent); // FF 3.6+
+    background-image: -ms-linear-gradient(top, @startColor @startPosPercent, @endColor @endPosPercent); // IE10
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, color-stop((@startPosition / 100), @startColor), color-stop((@endPosition / 100), @endColor)); // Safari 4+, Chrome 2+
+    background-image: -webkit-linear-gradient(top, @startColor @startPosPercent, @endColor @endPosPercent); // Safari 5.1+, Chrome 10+
+    background-image: -o-linear-gradient(top, @startColor @startPosPercent, @endColor @endPosPercent); // Opera 11.10
+    background-image: linear-gradient(top, @startColor @startPosPercent, @endColor @endPosPercent); // The standard
     background-repeat: repeat-x;
     filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@startColor,@endColor)); // IE9 and down
   }
-  .directional(@startColor: #555, @endColor: #333, @deg: 45deg) {
+  .directional(@startColor: #555, @endColor: #333, @deg: 45deg, @startPosition: 0, @endPosition: 100) {
+    @startPosPercent: (@startPosition + 0%);
+    @endPosPercent: (@endPosition + 0%);
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -moz-linear-gradient(@deg, @startColor, @endColor); // FF 3.6+
-    background-image: -ms-linear-gradient(@deg, @startColor, @endColor); // IE10
-    background-image: -webkit-linear-gradient(@deg, @startColor, @endColor); // Safari 5.1+, Chrome 10+
-    background-image: -o-linear-gradient(@deg, @startColor, @endColor); // Opera 11.10
-    background-image: linear-gradient(@deg, @startColor, @endColor); // The standard
+    background-image: -moz-linear-gradient(@deg, @startColor @startPosPercent, @endColor @endPosPercent); // FF 3.6+
+    background-image: -ms-linear-gradient(@deg, @startColor @startPosPercent, @endColor @endPosPercent); // IE10
+    background-image: -webkit-linear-gradient(@deg, @startColor @startPosPercent, @endColor @endPosPercent); // Safari 5.1+, Chrome 10+
+    background-image: -o-linear-gradient(@deg, @startColor @startPosPercent, @endColor @endPosPercent); // Opera 11.10
+    background-image: linear-gradient(@deg, @startColor @startPosPercent, @endColor @endPosPercent); // The standard
   }
   .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {
     background-color: mix(@midColor, @endColor, 80%);


### PR DESCRIPTION
**Browser tested on:**
- Chrome 18
- Firefox 11
- Safari 5
- Opera 11.62
- IE 7,8,9

IE ignores the color stop and instead just displays the gradient as a default blend of the two colours.
Current usage of the mixin is not affected by the additional arguments
