### PR TITLE
On small screens, .input-large, .input-xlarge and .input-xxlarge should ...

### DIFF
--- a/less/responsive.less
+++ b/less/responsive.less
@@ -85,6 +85,12 @@
   input[type="radio"] {
     border: 1px solid #ccc;
   }
+  
+  .input-large,
+  .input-xlarge,
+  .input-xxlarge {
+    width: 100%;
+  }
 
   // Remove the horizontal form styles
   .form-horizontal .control-group > label {


### PR DESCRIPTION
...just use 100% of the available width.
