### PR TITLE
Update the makefile to preserve the JavaScript copyright when using YUI Compressor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ bootstrap:
 	lessc --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
 	lessc ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
 	lessc --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
-	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
+	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
+	cat bootstrap/js/copyright.js js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
-	echo "/**\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
 


### PR DESCRIPTION
The project I'm working on uses uncompressed resources during development, but compressed resources for release, courtesy of the YUI Compressor.  We are also building Bootstrap from source so that we can change variables.less as necessary.

When we compress the bootstrap/js/bootstrap.js produced by the makefile, it doesn't have the copyright that is prepended to bootstrap.min.js, and that copyright is stripped by the YUI Compressor as it does not begin with "/*!".

This simple change updates the copyright to begin with "/*!" and prepends it to both the uncompressed and compressed JavaScript files.
