### PR TITLE
Added 'current' and 'next' elements to the 'slide' and 'slid' events

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -95,22 +95,22 @@
       if ($next.hasClass('active')) return
 
       if (!$.support.transition && this.$element.hasClass('slide')) {
-        this.$element.trigger('slide')
+        this.$element.trigger('slide', [$active, $next])
         $active.removeClass('active')
         $next.addClass('active')
         this.sliding = false
-        this.$element.trigger('slid')
+        this.$element.trigger('slid', [$active, $next])
       } else {
         $next.addClass(type)
         $next[0].offsetWidth // force reflow
         $active.addClass(direction)
         $next.addClass(direction)
-        this.$element.trigger('slide')
+        this.$element.trigger('slide', [$active, $next])
         this.$element.one($.support.transition.end, function () {
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false
-          setTimeout(function () { that.$element.trigger('slid') }, 0)
+          setTimeout(function () { that.$element.trigger('slid', [$active, $next]) }, 0)
         })
       }
 


### PR DESCRIPTION
Both `slide` and `slid` events do not pass along the current and the next elements to the event handler. This is very useful when using a custom thumbnail navigation, for example - the UI can react knowing what the next element is going to be.

The callback parameters are:
- `slide`: _event, currentElement, nextElement_
- `slid`: _event, previousElement, currentElement_
