### PR TITLE
Fix for incorrect rounded borders for `.input-append .uneditable-input`

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -406,7 +406,7 @@ select:focus:required:invalid {
 }
 .input-append {
   input,
-  select
+  select,
   .uneditable-input {
     .border-radius(3px 0 0 3px);
   }


### PR DESCRIPTION
Incorrect rounded borders for `.input-append .uneditable-input` because of missing comma.
