### PR TITLE
Support for changing the default bootstrap icons

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -182,7 +182,10 @@
 @infoBorder:              darken(spin(@infoBackground, -10), 7%);
 
 
-
+// Icons
+// -------------------------
+@lightIcons:              "../img/glyphicons-halflings-white.png";
+@darkIcons:               "../img/glyphicons-halflings.png";
 
 // GRID
 // --------------------------------------------------


### PR DESCRIPTION
Some themes require the change of white icons to the black icon, specifically for active states.
