### PR TITLE
Fixed collapse's first show issue

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -64,7 +64,7 @@
       this.$element[dimension](0)
       this.$element.css('overflow', 'hidden')
       this.transition('addClass', $.Event('show'), 'shown')
-      this.$element[dimension](this.$element[0][scroll])
+      this.$element[dimension]('auto')
     }
 
   , hide: function () {


### PR DESCRIPTION
Dear all,

I see you are working on the collapse navbar that seems to have issues.

Anyway, also in this branch there is a strange behaviour that happens only the first time you click on the collapse button.

It can be replicated this way (on almost all websites using responsive layout and bootstrap):

1) Go at http://twitter.github.com/bootstrap/index.html
2) Reduce the page until the collapse button appears
3) Click on the collapse button
4) Enlarge the page until the collapse button disappears

The collapsed navbar will not disappear, it will stay empty.

Now, if you reduce the page one more time, click two times on the collapse menu (hide navbar / show navbar) and then enlarge the page again, the behaviour will be as expected.

Why?

It seems to be a problem in the `show()` method of `bootstrap-collapse.js`. At the first run, `show()` sets height as the actual pixel height of the collapsed menu. After it sets height to auto.

This pull request deals with height attribute, setting it always to auto. Test passes. I don't know if this has effects on older browsers: the latest versions of Opera, Safari, IE, Firefox, Chrome and Opera Mobile works fine.

Thanks for your work and hope it helps

Best Regards

GT
