### PR TITLE
Make "#translucent > .background" truly translucent in IE.

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -313,7 +313,13 @@
 // Add an alphatransparency value to any background or border color (via Elyse Holladay)
 #translucent {
   .background(@color: @white, @alpha: 1) {
-    background-color: hsla(hue(@color), saturation(@color), lightness(@color), @alpha);
+    @rgba: hsla(hue(@color), saturation(@color), lightness(@color), @alpha);
+    @argb: argb(@rgba); //Get #AARRGGBB color code for IE fileter
+    @filter: ~"progid:DXImageTransform.Microsoft.gradient(startColorstr=@{argb},endColorstr=@{argb})";
+    background-color: @rgba;
+    *background:transparent;
+	   filter: @filter;
+	   border-radius: ~"0\9\0"; //Reset border-radius for IE9 only. Since the filter background in this version is not clipped.
   }
   .border(@color: @white, @alpha: 1) {
     border-color: hsla(hue(@color), saturation(@color), lightness(@color), @alpha);


### PR DESCRIPTION
Now translucent mixin use HSLA color code for add alpha to color. It doesn't work in IE7-8 doesn't understand the alpha transparency in HSLA mode. For this purpose, the code added ARGB conversion model, and creating a filter for IE.
Unfortunately, because a background in filter not clipping with border-radius in IE9, appended to the hagfish style leads radius to 0 in this version.
