### PR TITLE
allow navbar dropdowns to have different styles for active and hover states

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1895,11 +1895,15 @@ table .span24 {
   white-space: nowrap;
 }
 .dropdown-menu li > a:hover,
-.dropdown-menu .active > a,
 .dropdown-menu .active > a:hover {
   color: #ffffff;
   text-decoration: none;
   background-color: #0088cc;
+}
+.dropdown-menu .active > a {
+  color: #ffffff;
+  text-decoration: none;
+  background-color: #0070a8;
 }
 .open {
   *z-index: 1000;
@@ -3122,8 +3126,8 @@ input[type="submit"].btn.btn-mini {
   color: #ffffff;
   text-decoration: none;
 }
-.navbar .nav .active > a,
-.navbar .nav .active > a:hover {
+.navbar .nav > .active > a,
+.navbar .nav > .active > a:hover {
   color: #ffffff;
   text-decoration: none;
   background-color: #222222;

--- a/docs/components.html
+++ b/docs/components.html
@@ -963,7 +963,7 @@
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <li><a href="#">Action</a></li>
-                <li><a href="#">Another action</a></li>
+                <li class="active"><a href="#">Another Action</a></li>
                 <li><a href="#">Something else here</a></li>
                 <li class="divider"></li>
                 <li class="nav-header">Nav header</li>

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -89,11 +89,17 @@
 // Hover state
 // -----------
 .dropdown-menu li > a:hover,
-.dropdown-menu .active > a,
 .dropdown-menu .active > a:hover {
   color: @dropdownLinkColorHover;
   text-decoration: none;
-  background-color: @dropdownLinkBackgroundHover;
+  background-color: @dropdownLinkBackgroundHover; 
+}
+// separated a from a:hover to allow for different styles on dropdown
+// and active navbar at the same time.
+.dropdown-menu .active > a {
+  color: @dropdownLinkColorHover;
+  text-decoration: none;
+  background-color: @dropdownLinkBackgroundActive;
 }
 
 // Open state for the dropdown

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -241,8 +241,9 @@
 }
 
 // Active nav items
-.navbar .nav .active > a,
-.navbar .nav .active > a:hover {
+// angle brackets before .active gives extra specificity and allows dropdown active links to have different styling than active navbar links
+.navbar .nav > .active > a, 
+.navbar .nav > .active > a:hover {
   color: @navbarLinkColorActive;
   text-decoration: none;
   background-color: @navbarLinkBackgroundActive;

--- a/less/variables.less
+++ b/less/variables.less
@@ -107,6 +107,7 @@
 @dropdownLinkColor:             @grayDark;
 @dropdownLinkColorHover:        @white;
 @dropdownLinkBackgroundHover:   @linkColor;
+@dropdownLinkBackgroundActive:  darken(@linkColor, 7%);
 
 
 


### PR DESCRIPTION
This pull request allows for different styling for active and hover states for navbar dropdown menu items. 

Currently, when a navbar dropdown menu item is given an active state, the active dropdown item shares the same active styling as an active item on the navbar itself.

I separated the active and hover styles for dropdown menu items in dropdowns.less, to allow for different styling on each state. 

Added right angle brackets to active nav items in navbar.less to provide the extra specificity required to allow active dropdown items to have different styling than active navbar items.

Added variable @dropdownLinkBackgroundActive to variables.less.

Updated example navbar in components.html to include a dropdown item with active state.
