### PR TITLE
ScrollSpy should work with pushState urls instead of hashes

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -46,7 +46,8 @@
         this.targets = this.$body
           .find(this.selector)
           .map(function () {
-            var href = $(this).attr('href')
+            var $el = $(this)
+              , href = $el.data('target') || $el.attr('href')
             return /^#\w/.test(href) && $(href).length ? href : null
           })
 
@@ -80,7 +81,7 @@
           .removeClass('active')
 
         active = this.$body
-          .find(this.selector + '[href="' + target + '"]')
+          .find(this.selector + '[data-target="' + target + '"],' + this.selector + '[href="' + target + '"]')
           .parent('li')
           .addClass('active')
 


### PR DESCRIPTION
I've added a simple implementation. Allows the use of `data-target` attributes to override the `href`. 

```
<a href="/scrollspy" data-target="#scrollspy">Scrollspy</a>
```

now works the same as

```
<a href="#scrollspy">Scrollspy</a>
```

It gives `data-target` priority over `href` when present, so `href` can point to anything.
