### PR TITLE
Add Global Link Decoration Variable

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -242,6 +242,11 @@
       <input type="text" class="span3" placeholder="#08c">
       <label>@linkColorHover</label>
       <input type="text" class="span3" placeholder="darken(@linkColor, 15%)">
+      <label>@linkDecor</label>
+      <input type="text" class="span3" placeholder="none">
+      <label>@linkDecorHover</label>
+      <input type="text" class="span3" placeholder="underline">
+
       <h3>Colors</h3>
       <label>@blue</label>
       <input type="text" class="span3" placeholder="#049cdb">

--- a/docs/templates/pages/download.mustache
+++ b/docs/templates/pages/download.mustache
@@ -165,6 +165,11 @@
       <input type="text" class="span3" placeholder="#08c">
       <label>@linkColorHover</label>
       <input type="text" class="span3" placeholder="darken(@linkColor, 15%)">
+      <label>@linkDecor</label>
+      <input type="text" class="span3" placeholder="none">
+      <label>@linkDecorHover</label>
+      <input type="text" class="span3" placeholder="underline">
+
       <h3>{{_i}}Colors{{/i}}</h3>
       <label>@blue</label>
       <input type="text" class="span3" placeholder="#049cdb">

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -21,9 +21,9 @@ body {
 
 a {
   color: @linkColor;
-  text-decoration: none;
+  text-decoration: @linkDecor;
 }
 a:hover {
   color: @linkColorHover;
-  text-decoration: underline;
+  text-decoration: @linkDecorHover;
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -41,6 +41,8 @@
 // -------------------------
 @linkColor:             #08c;
 @linkColorHover:        darken(@linkColor, 15%);
+@linkDecor:             none;
+@linkDecorHover:        underline;
 
 
 // Typography


### PR DESCRIPTION
Almost every property in `scaffolding` allowed for variable override except link text-decoration. This should give a little more control of those properties.
