### PR TITLE
Doc Typo Fix

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -422,7 +422,7 @@
         </div><!-- /btn-group -->
       </div><!-- /btn-toolbar -->
       <h3>Sizes</h3>
-      <p>Utilize the extra button classe <code>.btn-mini</code>, <code>.btn-small</code>, or <code>.btn-large</code> for sizing.</p>
+      <p>Utilize the extra button classes <code>.btn-mini</code>, <code>.btn-small</code>, or <code>.btn-large</code> for sizing.</p>
       <div class="btn-toolbar">
         <div class="btn-group">
           <button class="btn btn-large">Large action</button>

--- a/docs/templates/pages/components.mustache
+++ b/docs/templates/pages/components.mustache
@@ -345,7 +345,7 @@
         </div><!-- /btn-group -->
       </div><!-- /btn-toolbar -->
       <h3>{{_i}}Sizes{{/i}}</h3>
-      <p>{{_i}}Utilize the extra button classe <code>.btn-mini</code>, <code>.btn-small</code>, or <code>.btn-large</code> for sizing.{{/i}}</p>
+      <p>{{_i}}Utilize the extra button classes <code>.btn-mini</code>, <code>.btn-small</code>, or <code>.btn-large</code> for sizing.{{/i}}</p>
       <div class="btn-toolbar">
         <div class="btn-group">
           <button class="btn btn-large">{{_i}}Large action{{/i}}</button>


### PR DESCRIPTION
This typo was pointed out in #3028, updated the fix to based on `2.0.3-wip` as docs have changed a bit from `master`.
