### PR TITLE
jQuery Fallback for unsupported CSS transitions (IE7/IE8/IE9)

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -80,6 +80,9 @@
     }
 
   , slide: function (type, next) {
+      if(!$.support.transition && this.$element.hasClass('slide')) {
+        this.$element.find('.item').stop(true, true); //Finish animation and jump to end.
+      }
       var $active = this.$element.find('.active')
         , $next = next || $active[type]()
         , isCycling = this.interval
@@ -108,6 +111,17 @@
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false
           setTimeout(function () { that.$element.trigger('slid') }, 0)
+        })
+      }else if(!$.support.transition && this.$element.hasClass('slide')) {
+        this.$element.trigger(e)
+        if (e.isDefaultPrevented()) return
+        $active.animate({left: (direction == 'right' ? '100%' : '-100%')}, 600, function(){
+            $active.removeClass('active')
+            that.sliding = false
+            setTimeout(function () { that.$element.trigger('slid') }, 0)
+        })
+        $next.addClass(type).css({left: (direction == 'right' ? '-100%' : '100%')}).animate({left: '0'}, 600,  function(){
+            $next.removeClass(type).addClass('active')
         })
       } else {
         this.$element.trigger(e)

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -19,6 +19,7 @@
     display: none;
     position: relative;
     .transition(.6s ease-in-out left);
+    width: 100%;
   }
 
   // Account for jankitude on images
@@ -39,7 +40,6 @@
   .prev {
     position: absolute;
     top: 0;
-    width: 100%;
   }
 
   .next {


### PR DESCRIPTION
This commit provides a jQuery fallback, used when css transitions are not available.

It also changes carousel.less, because of an issue with the image dissapearing in IE7 (with this fallback).

I don't know if this is the fastest/best way, but it seems to be working on the sites I've tried it (and it is better then no transition..)
(As reported in Issue #2726)
