### PR TITLE
Add the code for the form's block-level example

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -893,6 +893,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
   &lt;label&gt;Label name&lt;/label&gt;
   &lt;input type="text" class="span3" placeholder="Type something…"&gt;
   &lt;span class="help-inline"&gt;Associated help text!&lt;/span&gt;
+  &lt;p class="help-block"&gt;Example block-level help text here.&lt;/p&gt;
   &lt;label class="checkbox"&gt;
     &lt;input type="checkbox"&gt; Check me out
   &lt;/label&gt;


### PR DESCRIPTION
On the base-css page there's an example for the form's block-level help-block but the code below does not include the form's help-block.
