### PR TITLE
Inset mixin to allow for negative span positioning and source ordering

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -533,6 +533,16 @@
     .offset (@columns) {
       margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)) + (@gridGutterWidth * 2);
     }
+    
+    .insetX (@index) when (@index > 0) {
+      (~".inset@{index}") { .inset(@index); }
+      .insetX(@index - 1);
+    }
+    .insetX (0) {}
+    
+    .inset (@columns) {
+      margin-left: 0 - ((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1))); 
+    }
 
     .span (@columns) {
       width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
@@ -553,10 +563,11 @@
     .navbar-fixed-top .container,
     .navbar-fixed-bottom .container { .span(@gridColumns); }
 
-    // generate .spanX and .offsetX
+    // generate .spanX, .offsetX and .insetX
     .spanX (@gridColumns);
     .offsetX (@gridColumns);
-
+    .insetX (@gridColumns);
+    
   }
 
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {


### PR DESCRIPTION
 I had a project I was working where I needed specific source ordering on a responsive design. I looked through the project for something that would allow me to use negative margins to pull content where I wanted at different screen widths.

The only thing I found was in the discussion of the project with different people coming up with their own ways or asking for that ability.  This is possible in other CSS frameworks like Blueprint and 960.gs so I could see it as a nice addition to bootstrap.
