### PR TITLE
Prevent .table-bordered from producing sharp corners

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -67,13 +67,17 @@ table {
 
 .table-bordered {
   border: 1px solid @tableBorder;
-  border-left: 0;
   border-collapse: separate; // Done so we can round those corners!
   *border-collapse: collapsed; // IE7 can't round corners anyway
   .border-radius(4px);
   th,
   td {
     border-left: 1px solid @tableBorder;
+  }
+  // Prevent sharp corners
+  th:first-child,
+  td:first-child {
+    border-left: 0;
   }
   // Prevent a double border
   thead:first-child tr:first-child th,


### PR DESCRIPTION
In some cases, the `.table-bordered` class can create sharp corners on the left-hand side. An example of this can be seen on the [docs page](http://twitter.github.com/bootstrap/base-css.html#tables) (and in the screenshot below).

![Sharp Corner](http://f.cl.ly/items/3q3H051Z0q451l1d2X0k/corner.png)
