### PR TITLE
Added className option to tooltip

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -110,6 +110,10 @@
           $tip.addClass('fade')
         }
 
+        if (this.options.className) {
+          $tip.addClass(this.options.className)
+        }
+
         placement = typeof this.options.placement == 'function' ?
           this.options.placement.call(this, $tip[0], this.$element[0]) :
           this.options.placement
@@ -270,6 +274,7 @@
   , trigger: 'hover'
   , title: ''
   , delay: 0
+  , className: ''
   }
 
 }(window.jQuery);


### PR DESCRIPTION
This adds a convenient `className` option for customizing individual or groups of tooltips.

The `template` option can achieve the same result but with a lot of code duplication because we must rewrite the entire template with the additional class.
