### PR TITLE
Fixed  with active list items and dropdown

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -236,7 +236,8 @@
 
 // Active nav items
 .navbar .nav .active > a,
-.navbar .nav .active > a:hover {
+.navbar .nav .active > a:hover,
+.navbar .nav li.active {
   color: @navbarLinkColorActive;
   text-decoration: none;
   background-color: @navbarLinkBackgroundActive;


### PR DESCRIPTION
This addition rule allows for "active" dropdown list items. Otherwise "active" dropdown list items will not change background-color.
