### PR TITLE
Allow updater function in bootstrap-typeahead.js (updates the value of the input field) to be overridden

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1493,8 +1493,8 @@ $('.carousel').carousel({
              <tr>
                <td>updater</td>
                <td>function</td>
-               <td>updates input with selection</td>
-               <td>Method used to update input contents. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return a string.</td>
+               <td>replaces contents of text input with typeahead selection</td>
+               <td>Method used to update contents of text input. Accepts a single argument, the <code>item</code> selected from the typeahead, and has the scope of the typeahead instance. Should return a string.</td>
              </tr>
             </tbody>
           </table>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1490,6 +1490,12 @@ $('.carousel').carousel({
                <td>highlights all default matches</td>
                <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
              </tr>
+             <tr>
+               <td>updater</td>
+               <td>function</td>
+               <td>updates input with selection</td>
+               <td>Method used to update input contents. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return a string.</td>
+             </tr>
             </tbody>
           </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -32,6 +32,7 @@
     this.matcher = this.options.matcher || this.matcher
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
+    this.updater = this.options.updater || this.updater
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
@@ -45,9 +46,13 @@
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
       this.$element
-        .val(val)
+        .val(this.updater(val))
         .change()
       return this.hide()
+    }
+
+  , updater: function (item) {
+      return item
     }
 
   , show: function () {


### PR DESCRIPTION
This update separates out the code that updates the input field once a user selects a typeahead item. It also adds in an option for a developer to override this function. This means you can specify something like

``` js
var updater = function (item) {
  var tokens = this.query.split(' ');

  // Replace last (incomplete) token with completed selection
  tokens.splice(-1, 1, item + ' ');

  return tokens.join(' ');
}
```

to have a typeahead where you can string together a chain of autocompleted tokens.
