### PR TITLE
remove img auto height google+ button bubble arrow not show correct

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -75,7 +75,7 @@ sub {
 // -------------------------
 
 img {
-  height: auto;
+/*  height: auto; */
   border: 0;
   -ms-interpolation-mode: bicubic;
   vertical-align: middle;


### PR DESCRIPTION
hover the "google+ button" on https://kippt.com/
