### PR TITLE
Prevent tooptip from displaying under navbar and off screen

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -120,9 +120,11 @@
 
         inside = /in/.test(placement)
 
+        tp = { top: 0, left: 0, display: 'block' };
+
         $tip
           .remove()
-          .css({ top: 0, left: 0, display: 'block' })
+          .css(tp)
           .appendTo(inside ? this.$element : document.body)
 
         pos = this.getPosition(inside)
@@ -144,6 +146,10 @@
             tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width}
             break
         }
+
+        /******** prevents tip from display off screen ************/
+        if (tp.top < 0) { tp.top = 0; }
+        if (tp.left < 0) { tp.left = 0; }
 
         $tip
           .css(tp)

--- a/less/variables.less
+++ b/less/variables.less
@@ -115,7 +115,7 @@
 // Try to avoid customizing these :)
 @zindexDropdown:          1000;
 @zindexPopover:           1010;
-@zindexTooltip:           1020;
+@zindexTooltip:           1031;
 @zindexFixedNavbar:       1030;
 @zindexModalBackdrop:     1040;
 @zindexModal:             1050;


### PR DESCRIPTION
Tooltip/popover fix: 
- Increased z-index to 1031 to allow tooltips and popovers to display on top of navbar. 
- Added fix to tooltip to prevent it from rendering off screen (negative top or left values)

To reproduce the issue, add a popover to $(".branding") in one of the demo pages
