### PR TITLE
Typo fix for bootstrap /docs/components.html

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1040,7 +1040,7 @@
 </pre>
         </div><!--/span-->
       </div><!--/row-->
-      <p>When you affix the navbar, remember to account for the hidden area underneath. Add 40px or more of apdding to the <code>&lt;body&gt;</code>. Be sure to add this after the core Bootstrap CSS and before the optional responsive CSS.</p>
+      <p>When you affix the navbar, remember to account for the hidden area underneath. Add 40px or more of padding to the <code>&lt;body&gt;</code>. Be sure to add this after the core Bootstrap CSS and before the optional responsive CSS.</p>
       <h3>Brand name</h3>
       <p>A simple link to show your brand or project name only requires an anchor tag.</p>
 <pre class="prettyprint linenums">


### PR DESCRIPTION
Fixed a typo "apdding" -> "padding"
