### PR TITLE
IE7 Button Group Dropdowns

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -94,22 +94,20 @@
   padding-left: 8px;
   padding-right: 8px;
   .box-shadow(~"inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
-  *padding-top: 3px;
-  *padding-bottom: 3px;
+  *padding-top: 6px;
+  *padding-bottom: 6px;
 }
 .btn-group > .btn-mini.dropdown-toggle {
   padding-left: 5px;
   padding-right: 5px;
-  *padding-top: 1px;
-  *padding-bottom: 1px;
-}
-.btn-group > .btn-small.dropdown-toggle {
-  *padding-top: 4px;
-  *padding-bottom: 4px;
+  *padding-top: 2px;
+  *padding-bottom: 2px;
 }
 .btn-group > .btn-large.dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px;
+  *padding-top: 9px;
+  *padding-bottom: 9px;
 }
 
 .btn-group.open {


### PR DESCRIPTION
As pointed out a few times the arrow for button group dropdowns is off in IE7. I think padding changed somewhere so I took the time to find proper values to fix the display of the mini,small,standard, and large styles.

As I am not setup to compile using recess yet, I have left out the compiled CSS but you can test the fix at [bootstrap.simplydev.com/ie7-patch](http://bootstrap.simplydev.com/ie7-patch/base-css.html#forms)
