### PR TITLE
Allows table cells to be hidden with responsive .hidden-phone, and .hidden-tablet calls

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -40,35 +40,50 @@
   display: none;
   visibility: hidden;
 }
-.visible-phone {
+.visible-phone, th.visible-phone, td.visible-phone {
   display: none;
 }
-.visible-tablet {
+.visible-tablet, th.visible-tablet, td.visible-tablet {
   display: none;
 }
 .visible-desktop {
   display: block;
 }
+th.visible-desktop, td.visible-desktop {
+  display: table-cell;
+}
 .hidden-phone {
   display: block;
+}
+th.hidden-phone, td.hidden-phone {
+  display: table-cell;
 }
 .hidden-tablet {
   display: block;
 }
-.hidden-desktop {
+th.hidden-tablet, td.hidden-tablet {
+  display: table-cell;
+}
+.hidden-desktop, th.hidden-desktop, td.hidden-desktop {
   display: none;
 }
 @media (max-width: 767px) {
   .visible-phone {
     display: block;
   }
-  .hidden-phone {
+  th.visible-phone, td.visible-phone {
+    display: table-cell;
+  }
+  .hidden-phone, th.hidden-phone, td.hidden-phone {
     display: none;
   }
   .hidden-desktop {
     display: block;
   }
-  .visible-desktop {
+  th.hidden-desktop, td.hidden-desktop {
+    display: table-cell;
+  }
+  .visible-desktop, th.visible-desktop, td.visible-desktop {
     display: none;
   }
 }
@@ -76,13 +91,19 @@
   .visible-tablet {
     display: block;
   }
-  .hidden-tablet {
+  th.visible-tablet, td.visible-tablet {
+    display: table-cell;
+  }
+  .hidden-tablet, th.hidden-tablet, td.hidden-tablet {
     display: none;
   }
   .hidden-desktop {
     display: block;
   }
-  .visible-desktop {
+  th.hidden-desktop, td.hidden-desktop {
+    display: table-cell;
+  }
+  .visible-desktop, th.visible-desktop, td.visible-desktop {
     display: none;
   }
 }

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -34,33 +34,40 @@
 // Visibility utilities
 
 // For desktops
-.visible-phone     { display: none; }
-.visible-tablet    { display: none; }
+.visible-phone, th.visible-phone, td.visible-phone     { display: none; }
+.visible-tablet, th.visible-tablet, td.visible-tablet    { display: none; }
 .visible-desktop   { display: block; }
+th.visible-desktop, td.visible-desktop   { display: table-cell; }
 .hidden-phone      { display: block; }
+th.hidden-phone, td.hidden-phone      { display: table-cell; }
 .hidden-tablet     { display: block; }
-.hidden-desktop    { display: none; }
+th.hidden-tablet, td.hidden-tablet     { display: table-cell; }
+.hidden-desktop, th.hidden-desktop, td.hidden-desktop    { display: none; }
 
 // Phones only
 @media (max-width: 767px) {
   // Show
   .visible-phone     { display: block; }
+  th.visible-phone, td.visible-phone	{ display: table-cell; }
   // Hide
-  .hidden-phone      { display: none; }
+  .hidden-phone, th.hidden-phone, td.hidden-phone      { display: none; }
   // Hide everything else
   .hidden-desktop    { display: block; }
-  .visible-desktop   { display: none; }
+  th.hidden-desktop, td.hidden-desktop	{ display: table-cell; }
+  .visible-desktop, th.visible-desktop, td.visible-desktop   { display: none; }
 }
 
 // Tablets & small desktops only
 @media (min-width: 768px) and (max-width: 979px) {
   // Show
   .visible-tablet    { display: block; }
+  th.visible-tablet, td.visible-tablet	{ display: table-cell; }
   // Hide
-  .hidden-tablet     { display: none; }
+  .hidden-tablet, th.hidden-tablet, td.hidden-tablet     { display: none; }
   // Hide everything else
   .hidden-desktop    { display: block; }
-  .visible-desktop   { display: none; }
+  th.hidden-desktop, td.hidden-desktop	{ display: table-cell; }
+  .visible-desktop, th.visible-desktop, td.visible-desktop   { display: none; }
 }
 
 


### PR DESCRIPTION
I noticed that adding classes like .hidden-phone and .hidden-tablet to table cells would break them visually. This is because the cells would try to display as blocks. This pull allows td's and th's to be hidden/visible with the same classes as other elements would normally use.

This allows for hiding less important columns of information on phones and tablets.
