### PR TITLE
Responsive reference for navbar collapse

### DIFF
--- a/components.html
+++ b/components.html
@@ -1088,7 +1088,7 @@
 &lt;/div&gt;
 </pre>
       <div class="alert alert-info">
-        <strong>Heads up!</strong> The responsive navbar requires the <a href="./javascript.html#collapse">collapse plugin</a>.
+        <strong>Heads up!</strong> The responsive navbar requires the <a href="./javascript.html#collapse">collapse plugin</a> and <a href="./scaffolding.html#responsive"> the optional responsive CSS file</a>.
       </div>
 
     </div><!-- /.span -->


### PR DESCRIPTION
Added reference to responsive CSS for navbar collapse and a link to relevant information for it, not obvious in documentation and potentially confusing for new users, took two of us a good half hour or so to realise we'd missed it.
