### PR TITLE
Typeahead menu appendToBody -> insertAfterElement

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -33,7 +33,11 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
-    this.$menu = $(this.options.menu).appendTo('body')
+    if (this.options.appendToBody) {
+      this.$menu = $(this.options.menu).appendTo('body')
+    } else {
+      this.$menu = $(this.options.menu).insertAfter(this.$element)
+    }
     this.source = this.options.source
     this.shown = false
     this.listen()


### PR DESCRIPTION
Changes:
- Keeps the dynamic typeahead-menu HTML-code close to the input-field.
- Provides an option to use the old method, just in case.

Advantages:
- Easier unload typeahead-menu dynamically.
- Properties applied to the input-field will also effect the typeahead-menu e.g styling.
- Easier to ascertain the input-field's menu when using multiple typeahead menu's on the same page.

Usage:
.typeahead({source: source})​;​

AppendToBody Usage:
.typeahead({source: source, appendToBody: true})​;​

PS: Sorry for the long commit message. This is my first time using github's web interface to send a pull request.
