### PR TITLE
Audio/Video issue with HTML5 in a Modal

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -201,8 +201,9 @@
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
         , option = $target.data('modal') ? 'toggle' : $.extend({}, $target.data(), $this.data())
-
-      e.preventDefault()
+      if (!$(e.target).is("audio,video")) {
+        e.preventDefault()
+      }
       $target.modal(option)
     })
   })


### PR DESCRIPTION
Hi,

Apologies if I'm doing this all wrong, but I noticed a bug today which wouldn't allow you to click HTML5 audio/video controls (Chrome tested) when embedding them in a Bootstrap modal window. Fix is included in this small patch.

If I'm doing things wrong let me know! I can only learn what I am taught, and contributing to open source projects is new to me.

```
diff --git a/js/bootstrap-modal.js b/js/bootstrap-modal.js
index e929706..ef63ed5 100644
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -201,10 +201,11 @@
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
         , option = $target.data('modal') ? 'toggle' : $.extend({}, $target.data(), $this.data())
-
-      e.preventDefault()
+      if (!$(e.target).is("audio,video")) {
+        e.preventDefault()
+      }
       $target.modal(option)
     })
   })

-}( window.jQuery );
\ No newline at end of file
+}( window.jQuery );
```
