### PR TITLE
Add 'selectitem' event to typeahead

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1415,6 +1415,21 @@ $('.carousel').carousel({
              </tr>
             </tbody>
           </table>
+          <h3>{{_i}}Events{{/i}}</h3>
+          <table class="table table-bordered table-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">{{_i}}Event{{/i}}</th>
+               <th>{{_i}}Description{{/i}}</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>{{_i}}select{{/i}}</td>
+               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.{{/i}}</td>
+            </tr>
+            </tbody>
+          </table>
 
           <h3>{{_i}}Markup{{/i}}</h3>
           <p>{{_i}}Add data attributes to register an element with typeahead functionality.{{/i}}</p>

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -45,9 +45,13 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
+        , e = $.Event('select')
+
       this.$element
         .val(this.updater(val))
         .change()
+        .trigger(e)
+      if (e.isDefaultPrevented()) return
       return this.hide()
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -145,4 +145,52 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+      test("should trigger select event on choosing an item from dropdown menu", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+            })
+          , typeahead = $input.data('typeahead')
+          , selected = false
+
+        $input.val('a')
+
+        // test:
+        typeahead.lookup()
+        $input.bind("select", function() { selected = true })
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+
+        // check:
+        ok(selected, 'a change event was fired')
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+
+        // teardown:
+        typeahead.$menu.remove()
+      })
+
+      test("should can prevent closing dropdown menu in select event handler", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        // sanity check that the test is correct:
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+        ok(!typeahead.$menu.is(':visible'), 'the menu was closed')
+
+
+        // test:
+        typeahead.lookup()
+        $input.bind("select", function(e) { e.preventDefault(); })
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+
+        // check:
+        ok(typeahead.$menu.is(':visible'), 'the menu is still visible')
+
+        // teardown:
+        typeahead.$menu.remove()
+      })
 })


### PR DESCRIPTION
typeahead: added 'select' event (triggered by selecting an item from dropdown menu)

Fixes #3102
