### PR TITLE
Show a delayed tooltip only if it is still enabled.

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -75,7 +75,7 @@
       } else {
         self.hoverState = 'in'
         setTimeout(function() {
-          if (self.hoverState == 'in') {
+          if (self.hoverState == 'in' && self.enabled) {
             self.show()
           }
         }, self.options.delay.show)


### PR DESCRIPTION
A delayed tooltip should also check that it is still enabled before appearing.
