### PR TITLE
Include note that all plugins are included in bootstrap.min.js

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -185,6 +185,7 @@
         </div>
       </div> <!-- /row -->
       <div class="alert alert-info"><strong>Heads up!</strong> All javascript plugins require the latest version of jQuery.</div>
+      <div class="alert alert-info"><strong>Heads up!</strong> If you have downloaded the latest version of Bootstrap, both bootstrap.js and bootstrap.min.js contain all of these plugins.</div>
     </section>
 
 


### PR DESCRIPTION
Several users have [experienced issues](https://github.com/twitter/bootstrap/issues/1611) with the modal plugin flashing on the screen and immediately disappearing. This is caused by including the modal plugin twice - once in bootstrap.min.js, and once explicitly.
