### PR TITLE
Fix grammar error in docs

### DIFF
--- a/base-css.html
+++ b/base-css.html
@@ -1316,7 +1316,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
       <tr>
         <td><button class="btn btn-info" href="#">Info</button></td>
         <td><code>btn btn-info</code></td>
-        <td>Used as an alternate to the default styles</td>
+        <td>Used as an alternative to the default styles</td>
       </tr>
       <tr>
         <td><button class="btn btn-success" href="#">Success</button></td>


### PR DESCRIPTION
Changed 'alternate' to 'alternative' in base-css.html
