### PR TITLE
Windows batch version of bootstrap Makefile target

### DIFF
--- a/make-bootstrap.bat
+++ b/make-bootstrap.bat
@@ -1,0 +1,35 @@
+@echo off
+
+set "BOOTSTRAP=docs/assets/css/bootstrap.css"
+set "BOOTSTRAP_LESS=less/bootstrap.less"
+set "BOOTSTRAP_RESPONSIVE=docs/assets/css/bootstrap-responsive.css"
+set "BOOTSTRAP_RESPONSIVE_LESS=less/responsive.less"
+
+mkdir bootstrap\img
+mkdir bootstrap\css
+mkdir bootstrap\js
+cp img/* bootstrap/img
+
+call lessc %BOOTSTRAP_LESS% bootstrap/css/bootstrap.css
+call lessc --compress %BOOTSTRAP_LESS% bootstrap/css/bootstrap.min.css
+call lessc %BOOTSTRAP_RESPONSIVE_LESS% bootstrap/css/bootstrap-responsive.css
+call lessc --compress %BOOTSTRAP_RESPONSIVE_LESS% bootstrap/css/bootstrap-responsive.min.css
+
+cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
+
+call uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
+
+setlocal EnableDelayedExpansion
+set "COPYRIGHT1=/**"
+set "COPYRIGHT2=* Bootstrap.js by @fat & @mdo"
+set "COPYRIGHT3=* Copyright 2012 Twitter, Inc."
+set "COPYRIGHT4=* http://www.apache.org/licenses/LICENSE-2.0.txt"
+set "COPYRIGHT5=*/"
+echo !COPYRIGHT1! > bootstrap/js/copyright.js
+echo.!COPYRIGHT2! >> bootstrap/js/copyright.js
+echo.!COPYRIGHT3! >> bootstrap/js/copyright.js
+echo.!COPYRIGHT4! >> bootstrap/js/copyright.js
+echo.!COPYRIGHT5! >> bootstrap/js/copyright.js
+
+cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
+rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js

--- a/make-bootstrap.bat
+++ b/make-bootstrap.bat
@@ -1,23 +1,24 @@
 @echo off
 
-set "BOOTSTRAP=docs/assets/css/bootstrap.css"
-set "BOOTSTRAP_LESS=less/bootstrap.less"
-set "BOOTSTRAP_RESPONSIVE=docs/assets/css/bootstrap-responsive.css"
-set "BOOTSTRAP_RESPONSIVE_LESS=less/responsive.less"
+set "BOOTSTRAP=.\docs\assets\css\bootstrap.css"
+set "BOOTSTRAP_LESS=.\less\bootstrap.less"
+set "BOOTSTRAP_RESPONSIVE=.\docs\assets\css\bootstrap-responsive.css"
+set "BOOTSTRAP_RESPONSIVE_LESS=.\less\responsive.less"
 
-mkdir bootstrap\img
-mkdir bootstrap\css
-mkdir bootstrap\js
-cp img/* bootstrap/img
+mkdir bootstrap\img 2>nul
+mkdir bootstrap\css 2>nul
+mkdir bootstrap\js 2>nul
 
-call lessc %BOOTSTRAP_LESS% bootstrap/css/bootstrap.css
-call lessc --compress %BOOTSTRAP_LESS% bootstrap/css/bootstrap.min.css
-call lessc %BOOTSTRAP_RESPONSIVE_LESS% bootstrap/css/bootstrap-responsive.css
-call lessc --compress %BOOTSTRAP_RESPONSIVE_LESS% bootstrap/css/bootstrap-responsive.min.css
+copy /Y img bootstrap\img > nul
 
-cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js > bootstrap/js/bootstrap.js
+call lessc %BOOTSTRAP_LESS% bootstrap\css\bootstrap.css
+call lessc --compress %BOOTSTRAP_LESS% bootstrap\css\bootstrap.min.css
+call lessc %BOOTSTRAP_RESPONSIVE_LESS% bootstrap\css\bootstrap-responsive.css
+call lessc --compress %BOOTSTRAP_RESPONSIVE_LESS% bootstrap\css\bootstrap-responsive.min.css
 
-call uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
+type js\bootstrap-transition.js js\bootstrap-alert.js js\bootstrap-button.js js\bootstrap-carousel.js js\bootstrap-collapse.js js\bootstrap-dropdown.js js\bootstrap-modal.js js\bootstrap-tooltip.js js\bootstrap-popover.js js\bootstrap-scrollspy.js js\bootstrap-tab.js js\bootstrap-typeahead.js > bootstrap\js\bootstrap.js 2> nul
+
+call uglifyjs -nc bootstrap\js\bootstrap.js > bootstrap\js\bootstrap.min.tmp.js
 
 setlocal EnableDelayedExpansion
 set "COPYRIGHT1=/**"
@@ -25,11 +26,11 @@ set "COPYRIGHT2=* Bootstrap.js by @fat & @mdo"
 set "COPYRIGHT3=* Copyright 2012 Twitter, Inc."
 set "COPYRIGHT4=* http://www.apache.org/licenses/LICENSE-2.0.txt"
 set "COPYRIGHT5=*/"
-echo !COPYRIGHT1! > bootstrap/js/copyright.js
-echo.!COPYRIGHT2! >> bootstrap/js/copyright.js
-echo.!COPYRIGHT3! >> bootstrap/js/copyright.js
-echo.!COPYRIGHT4! >> bootstrap/js/copyright.js
-echo.!COPYRIGHT5! >> bootstrap/js/copyright.js
+echo !COPYRIGHT1! > bootstrap\js\copyright.js
+echo.!COPYRIGHT2! >> bootstrap\js\copyright.js
+echo.!COPYRIGHT3! >> bootstrap\js\copyright.js
+echo.!COPYRIGHT4! >> bootstrap\js\copyright.js
+echo.!COPYRIGHT5! >> bootstrap\js\copyright.js
 
-cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
-rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
+type bootstrap\js\copyright.js bootstrap\js\bootstrap.min.tmp.js > bootstrap\js\bootstrap.min.js 2>nul
+del bootstrap\js\copyright.js bootstrap\js\bootstrap.min.tmp.js


### PR DESCRIPTION
This adds a "make-bootstrap.bat" Windows batch script that duplicates the functionality of the "bootstrap" target from the included Makefile.

I'm working on a Windows system, so I tried to build bootstrap from the Makefile (using Cygwin). However, I found that the Windows version of Node.js was not able to operate while running in Cygwin due to an inability to locate packages with Cygwin's path scheme.

I know you can build bootstrap on Windows manually using lessc (as in #245), and that there might be other ways to get Makefiles to run on Windows that would allow Node.js to operate. Still, I'm assuming there are benefits to using the build script, and if someone already has Node.js installed (with uglify-js and lessc) on their Windows machine, this would make it easier to get the same convenience as the Makefile would allow.
