### PR TITLE
Fixed IE-compatibility for `.fade` class

### DIFF
--- a/less/component-animations.less
+++ b/less/component-animations.less
@@ -3,9 +3,9 @@
 
 .fade {
   .transition(opacity .15s linear);
-  opacity: 0;
+  .opacity(0);
   &.in {
-    opacity: 1;
+    .opacity(100);
   }
 }
 


### PR DESCRIPTION
I noticed my fixed alert with `fade` class was always visible in IE. By using the `.opacity` mixin, IE-compatibility is ensured.
