### PR TITLE
update compilation docs to include installing jshint and recess

### DIFF
--- a/docs/less.html
+++ b/docs/less.html
@@ -975,8 +975,8 @@
   <div class="row">
     <div class="span4">
       <h3>Node with makefile</h3>
-      <p>Install the LESS command line compiler and uglify-js globally with npm by running the following command:</p>
-      <pre>$ npm install -g less uglify-js</pre>
+      <p>Install jshint, the LESS command line compiler, recess, and uglify-js globally with npm by running the following command:</p>
+      <pre>$ npm install -g jshint less recess uglify-js</pre>
       <p>Once installed just run <code>make</code> from the root of your bootstrap directory and you're all set.</p>
       <p>Additionally, if you have <a href="https://github.com/mynyml/watchr">watchr</a> installed, you may run <code>make watch</code> to have bootstrap automatically rebuilt every time you edit a file in the bootstrap lib (this isn't required, just a convenience method).</p>
     </div><!-- /span4 -->


### PR DESCRIPTION
A little story in the form of a shell transcript:

```
$ npm install -g less uglify-js
...

$ make

/bin/sh: jshint: command not found
make: *** [build] Error 127

$ npm install -g jshint
...

$ make

/bin/sh: recess: command not found
make: *** [build] Error 127

$ npm install -g recess
...

$ make
Bootstrap successfully built at 09:15AM.

```
