### PR TITLE
Fixed comment lines in media query code to better aid copy-paste.

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -529,17 +529,17 @@
     </div><!-- /.span -->
     <div class="span8">
 <pre class="prettyprint linenums">
-  // Landscape phones and down
-  @media (max-width: 480px) { ... }
+  /* Landscape phones and down */
+  @media (max-width: 480px) { /*...*/ }
 
-  // Landscape phone to portrait tablet
-  @media (max-width: 767px) { ... }
+  /* Landscape phone to portrait tablet */
+  @media (max-width: 767px) { /*...*/ }
 
-  // Portrait tablet to landscape and desktop
-  @media (min-width: 768px) and (max-width: 979px) { ... }
+  /* Portrait tablet to landscape and desktop */
+  @media (min-width: 768px) and (max-width: 979px) { /*...*/ }
 
-  // Large desktop
-  @media (min-width: 1200px) { ... }
+  /* Large desktop */
+  @media (min-width: 1200px) { /*...*/ }
 </pre>
     </div><!-- /.span -->
   </div><!-- /.row -->


### PR DESCRIPTION
Took me a while to figure out why the media query code didn't work when I pasted it in my CSS.
