### PR TITLE
added fade effect to carousel

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -60,6 +60,27 @@
     left: 100%;
   }
 
+  // Fade effect
+  &.carousel-fade {
+    .item {
+     .transition(opacity 2s ease-in-out);
+    }
+    .active {
+      &.left, &.right {
+        left: 0;
+        z-index: 2;
+        .opacity(0);
+      }
+    }
+    .next, .prev {
+      left: 0;
+      z-index: 1;
+    }
+    .carousel-control {
+      z-index : 3;
+    }
+  }
+
 }
 
 // Left/right controls for nav


### PR DESCRIPTION
Dear all,

I needed a carousel with fade in effect for my bootstrap-based project, so I added a new class to carousel called `carousel-fade`.

It works on latest version of opera (win), firefox (win), chrome (win/mac) and safari (win).

It doesn't work with internet explorer (of course).

You can try it there: http://jsfiddle.net/Jh3rF/

I want to thanks these guys:
http://stackoverflow.com/questions/10335181/twitter-bootstraps-carousel-fade-transition
http://stackoverflow.com/questions/9526970/can-the-twitter-bootstrap-carousel-plugin-fade-in-and-out-on-slide-transition

Hope it helps

GT
