### PR TITLE
Add "sibling" placement option

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -95,11 +95,11 @@
 
   , show: function () {
       var $tip
-        , inside
         , pos
         , actualWidth
         , actualHeight
         , placement
+        , relationship
         , tp
 
       if (this.hasContent() && this.enabled) {
@@ -114,19 +114,30 @@
           this.options.placement.call(this, $tip[0], this.$element[0]) :
           this.options.placement
 
-        inside = /in/.test(placement)
+        relationship = (/^sibling|^in/.exec(placement) || [])[0]
 
         $tip
           .remove()
           .css({ top: 0, left: 0, display: 'block' })
-          .appendTo(inside ? this.$element : document.body)
 
-        pos = this.getPosition(inside)
+        switch (relationship) {
+          case 'sibling':
+            $tip.insertBefore(this.$element)
+            break
+          case 'in':
+            $tip.appendTo(this.$element)
+            break
+          case undefined:
+            $tip.appendTo(document.body)
+            break
+        }
+
+        pos = this.getPosition(relationship)
 
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
 
-        switch (inside ? placement.split(' ')[1] : placement) {
+        switch ((relationship) ? placement.split(' ')[1] : placement) {
           case 'bottom':
             tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2}
             break
@@ -198,8 +209,17 @@
       return this.getTitle()
     }
 
-  , getPosition: function (inside) {
-      return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
+  , getOffset: function (relationship) {
+    if(relationship === undefined) {
+      return this.$element.offset()
+    }
+    else {
+      return (relationship === 'sibling') ? this.$element.position() : {top: 0, left: 0}
+    }
+  }
+
+  , getPosition: function (relationship) {
+      return $.extend({}, (this.getOffset(relationship)), {
         width: this.$element[0].offsetWidth
       , height: this.$element[0].offsetHeight
       })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -37,6 +37,39 @@ $(function () {
         tooltip.tooltip('hide')
       })
 
+      test("should place tooltips according to the optional 'relationship', appending to the &lt;body&gt; by default", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({placement: 'top'})
+          .tooltip('show')
+
+        ok($(".tooltip").parent().is('body'), 'is appended to the body')
+        tooltip.tooltip('hide')
+      })
+
+      test("should place tooltips according to the optional 'relationship', when defined as 'in'", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({placement: 'in top'})
+          .tooltip('show')
+
+        ok($(".tooltip").parent().is('a[rel="tooltip"]'), 'is appended inside the source element')
+        tooltip.tooltip('hide')
+      })
+
+      test("should place tooltips according to the optional 'relationship', when defined as 'sibling'", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({placement: 'sibling top'})
+          .tooltip('show')
+
+        ok($(".tooltip").next().is('a[rel="tooltip"]'), 'is inserted before the source element')
+        tooltip.tooltip('hide')
+      })
+
       test("should always allow html entities", function () {
         $.support.transition = false
         var tooltip = $('<a href="#" rel="tooltip" title="<b>@fat</b>"></a>')


### PR DESCRIPTION
prefixing placement with "sibling" will insert the tooltip _before_ the source element, and position it based on the source element's position relative to its offset parent.

this change allows for tooltips that will remain properly positioned on window resize & content change, without inserting the tooltip "in" the element, which would be invalid for `<input>` source elements, for example.

a closed issue that this change should resolve: https://github.com/twitter/bootstrap/issues/3067
