### PR TITLE
Auto hide Modal when show = false

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,6 +30,7 @@
     this.options = options
     this.$element = $(content)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
+    this.isShown = this.$element.is(':visible')
   }
 
   Modal.prototype = {
@@ -189,6 +190,7 @@
       if (!data) $this.data('modal', (data = new Modal(this, options)))
       if (typeof option == 'string') data[option]()
       else if (options.show) data.show()
+      else data.hide()
     })
   }
 


### PR DESCRIPTION
I needed a modal to be hidden from start, but using {show:false} didn't hide it, only the backdrop. I realise that I could just set display:none on the element, or otherwise hide it manually, but I thought it logical that bootstrap would do it for me since I'm explicitly setting show=false.

Check out this fiddle http://jsfiddle.net/SKtKa/5/ to see what i mean.
