### PR TITLE
Stop using inlining for appended/prepended elements

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1244,6 +1244,7 @@ select:focus:required:invalid:focus {
 .input-prepend,
 .input-append {
   margin-bottom: 5px;
+  font-size: 0;
 }
 
 .input-prepend input,
@@ -1255,6 +1256,7 @@ select:focus:required:invalid:focus {
   position: relative;
   margin-bottom: 0;
   *margin-left: 0;
+  font-size: 13px;
   vertical-align: middle;
   -webkit-border-radius: 0 3px 3px 0;
      -moz-border-radius: 0 3px 3px 0;
@@ -1296,6 +1298,7 @@ select:focus:required:invalid:focus {
 .input-prepend .btn,
 .input-append .btn {
   margin-left: -1px;
+  font-size: 13px;
   -webkit-border-radius: 0;
      -moz-border-radius: 0;
           border-radius: 0;

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1193,7 +1193,8 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             <label class="control-label" for="prependedInput">Prepended text</label>
             <div class="controls">
               <div class="input-prepend">
-                <span class="add-on">@</span><input class="span2" id="prependedInput" size="16" type="text">
+                <span class="add-on">@</span>
+                <input class="span2" id="prependedInput" size="16" type="text">
               </div>
               <p class="help-block">Here's some help text</p>
             </div>
@@ -1202,7 +1203,8 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             <label class="control-label" for="appendedInput">Appended text</label>
             <div class="controls">
               <div class="input-append">
-                <input class="span2" id="appendedInput" size="16" type="text"><span class="add-on">.00</span>
+                <input class="span2" id="appendedInput" size="16" type="text">
+                <span class="add-on">.00</span>
               </div>
               <span class="help-inline">Here's more help text</span>
             </div>
@@ -1211,7 +1213,9 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             <label class="control-label" for="appendedPrependedInput">Append and prepend</label>
             <div class="controls">
               <div class="input-prepend input-append">
-                <span class="add-on">$</span><input class="span2" id="appendedPrependedInput" size="16" type="text"><span class="add-on">.00</span>
+                <span class="add-on">$</span>
+                <input class="span2" id="appendedPrependedInput" size="16" type="text">
+                <span class="add-on">.00</span>
               </div>
             </div>
           </div>
@@ -1219,7 +1223,8 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             <label class="control-label" for="appendedInputButton">Append with button</label>
             <div class="controls">
               <div class="input-append">
-                <input class="span2" id="appendedInputButton" size="16" type="text"><button class="btn" type="button">Go!</button>
+                <input class="span2" id="appendedInputButton" size="16" type="text">
+                <button class="btn" type="button">Go!</button>
               </div>
             </div>
           </div>
@@ -1227,7 +1232,9 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             <label class="control-label" for="appendedInputButtons">Two-button append</label>
             <div class="controls">
               <div class="input-append">
-                <input class="span2" id="appendedInputButtons" size="16" type="text"><button class="btn" type="button">Search</button><button class="btn" type="button">Options</button>
+                <input class="span2" id="appendedInputButtons" size="16" type="text">
+                <button class="btn" type="button">Search</button>
+                <button class="btn" type="button">Options</button>
               </div>
             </div>
           </div>

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1141,9 +1141,6 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
       <p>Up to v1.4, Bootstrap required extra markup around checkboxes and radios to stack them. Now, it's a simple matter of repeating the <code>&lt;label class="checkbox"&gt;</code> that wraps the <code>&lt;input type="checkbox"&gt;</code>.</p>
       <p>Inline checkboxes and radios are also supported. Just add <code>.inline</code> to any <code>.checkbox</code> or <code>.radio</code> and you're done.</p>
       <hr>
-      <h4>Inline forms and append/prepend</h4>
-      <p>To use prepend or append inputs in an inline form, be sure to place the <code>.add-on</code> and <code>input</code> on the same line, without spaces.</p>
-      <hr>
       <h4>Form help text</h4>
       <p>To add help text for your form inputs, include inline help text with <code>&lt;span class="help-inline"&gt;</code> or a help text block with <code>&lt;p class="help-block"&gt;</code> after the input element.</p>
     </div>

--- a/less/forms.less
+++ b/less/forms.less
@@ -376,10 +376,12 @@ select:focus:required:invalid {
 // Allow us to put symbols and text within the input field for a cleaner look
 .input-prepend,
 .input-append {
+  font-size: 0;
   margin-bottom: 5px;
   input,
   select,
   .uneditable-input {
+    font-size: @baseFontSize;
     position: relative; // placed here by default so that on :focus we can place the input above the .add-on for full border and box-shadow goodness
     margin-bottom: 0; // prevent bottom margin from screwing up alignment in stacked forms
     *margin-left: 0;
@@ -409,6 +411,7 @@ select:focus:required:invalid {
   }
   .add-on,
   .btn {
+    font-size: @baseFontSize;
     margin-left: -1px;
     .border-radius(0);
   }


### PR DESCRIPTION
Instead of this

``` html
<div class="input-prepend">
  <span class="add-on">@</span><input class="span2" id="prependedInput" size="16" type="text">
</div>
```

Now you can use

``` html
<div class="input-prepend">
  <span class="add-on">@</span>
  <input class="span2" id="prependedInput" size="16" type="text">
</div>
```

without spaces between prepend/appended elements.
