### PR TITLE
A failing test for entities in tooltip.isHTML

### DIFF
--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -133,4 +133,8 @@ $(function () {
         ok($.fn.tooltip.Constructor.prototype.isHTML($('<div></div>')), 'correctly detected html')
       })
 
+      test("should detect if title string is html or text: foo&amp;amp;bar", function () {
+        ok($.fn.tooltip.Constructor.prototype.isHTML('foo&amp;bar'), 'correctly detected html')
+      })
+
 })


### PR DESCRIPTION
bootstrap-tooltip incorrectly identifies strings which containing html entities (but not tags) as "text". For example:

``` html
<a title="this is&nbsp;rad!">hover</a>
<script>$('a').tooltip();</script>
```

The tooltip title will be treated as text rather than HTML.
