### PR TITLE
Adds support for tables with records spanning multiple rows

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -143,6 +143,10 @@ table {
   tr:not(:first-child) th, tr:not(:first-child) td {
     border-top: none;
   }
+  tbody:hover td,
+  tbody:hover th {
+    background-color: @tableBackgroundHover;
+  }
 }
 
 

--- a/less/tables.less
+++ b/less/tables.less
@@ -132,6 +132,20 @@ table {
   }
 }
 
+// Default zebra-stripe styles (for multi-row records)
+.table-multirow-striped {
+  tbody:nth-child(odd) {
+    background-color: @tableBackgroundAccent;
+  }
+  tbody + tbody {
+    border-top: 1px solid @tableBorder;
+  }
+  tr:not(:first-child) th, tr:not(:first-child) td {
+    border-top: none;
+  }
+}
+
+
 
 // HOVER EFFECT
 // ------------


### PR DESCRIPTION
For records which span multiple rows, add ".table-multirow-striped" to the

<table> element instead of ".table-striped". Then, surround each record in the
table with a <tbody> element. Records may be rendered in multiple rows and will
striped properly.

Example:

<table class="table table-multirow-striped">

  <thead>
  <tr>
    <th>ID</th>
    <th>Name</th>
    <th>Actions</th>
  </tr>
  <tr>
    <th colspan="3">Notes</th>
  </tr>
  </thead>

  <tbody>
  <tr>
    <td>213</td>
    <td>Thomas the Tank</td>
    <td>Edit | Delete</td>
  </tr>
    <td colspan="3">Fun show to watch</td>
  </tr>
  </tbody>

  <tbody>
  <tr>
    <td>214</td>
    <td>Dora the Explorer</td>
    <td>Edit | Delete</td>
  </tr>
    <td colspan="3">Also a good show for kids</td>
  </tr>
  </tbody>

</table>
