### PR TITLE
add a link to phantomjs, for not-so-js-skilled bootstrap-noobs like me

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ npm install recess uglify-js jshint -g
 Runs the recess compiler to rebuild the `/less` files and compiles the docs pages. Requires recess and uglify-js. <a href="http://twitter.github.com/bootstrap/less.html#compiling">Read more in our docs &raquo;</a>
 
 + **test** - `make test`
-Runs jshint and qunit tests headlessly in phantom js (used for ci). Depends on having phatomjs installed.
+Runs jshint and qunit tests headlessly in phantom js (used for ci). Depends on having [phatomjs] (http://code.google.com/p/phantomjs/) installed.
 
 + **watch** - `make watch`
 This is a convenience method for watching just Less files and automatically building them whenever you save. Requires the Watchr gem.


### PR DESCRIPTION
I'm having issues trying to run make test... one of them was that it was not clear enough to me that I needed to google for and install this phantomjs instead of a nodejs module named phantom.
