### PR TITLE
ScrollSpy parent dropdown check

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -108,7 +108,7 @@
           .parent('li')
           .addClass('active')
 
-        if (active.parent('.dropdown-menu'))  {
+        if (active.parent('.dropdown-menu').length > 0)  {
           active = active.closest('li.dropdown').addClass('active')
         }
 


### PR DESCRIPTION
The check for a parent dropdown menu was always passing. Needs to look at the length of the array, to see if it's empty or not.
