### PR TITLE
make test: wait for the server to be up and accepting connections, before trying to access via phantomjs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ test:
 	jshint js/*.js --config js/.jshintrc
 	jshint js/tests/unit/*.js --config js/.jshintrc
 	node js/tests/server.js &
+	@echo "Waiting for the server to be up and accepting connections..."
+	while [ ! -f js/tests/pid.txt ]; do sleep 1; done
+	@echo "Server is up, starting phantomjs..."
 	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
 	kill -9 `cat js/tests/pid.txt`
 	rm js/tests/pid.txt


### PR DESCRIPTION
Waiting just 1 second per cycle, until the server is up and running.
Without this, in my laptop the server is up and running _after_ phantomjs starts its job, so the tests fail.
With this, after just 1 second the tests can proceed further and happily pass.
