### PR TITLE
Columns in a fluid row ought to span the whole row, despite rounding errors

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -434,6 +434,15 @@
   }
 }
 
+@media (min-width: 768px) and (max-width: 979px) and (min-width: 768px) {
+  [class*="span"] + [class*="span"]:last-child {
+    float: right;
+  }
+  [class*="span"] + [class*="span"].end {
+    float: left;
+  }
+}
+
 @media (min-width: 1200px) {
   .row {
     margin-left: -30px;
@@ -676,6 +685,15 @@
   }
   .row-fluid .thumbnails {
     margin-left: 0;
+  }
+}
+
+@media (min-width: 1200px) and (min-width: 768px) {
+  [class*="span"] + [class*="span"]:last-child {
+    float: right;
+  }
+  [class*="span"] + [class*="span"].end {
+    float: left;
   }
 }
 

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -324,6 +324,15 @@ a:hover {
   margin-left: 0;
 }
 
+@media (min-width: 768px) {
+  .row-fluid [class*="span"] + [class*="span"]:last-child {
+    float: right;
+  }
+  .row-fluid [class*="span"] + [class*="span"].end {
+    float: left;
+  }
+}
+
 .row-fluid .span12 {
   width: 99.99999998999999%;
   *width: 99.94680850063828%;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -598,7 +598,20 @@
       [class*="span"]:first-child {
         margin-left: 0;
       }
-
+      
+      @media (min-width: 768px) {
+        // It's preferable to have the last column in a fluid row
+        // stick to that row's right edge. This ensures that the
+        // columns fully span the row, despite rounding errors.
+        [class*="span"] + [class*="span"]:last-child { float: right; }
+      
+        // If you happen to be in a situation where you have a fluid
+        // row whose columns' span values don't add up to 12 (ie. you
+        // have intentionally left space to the right of the last column)
+        // give that last column the .end class to keep it in place.
+        [class*="span"] + [class*="span"].end { float: left; }
+      }
+      
       // generate .spanX
       .spanX (@gridColumns);
     }

--- a/less/tests/css-tests.html
+++ b/less/tests/css-tests.html
@@ -285,6 +285,23 @@
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="span12">12 (containing columns that only span 11)
+      <div class="row-fluid">
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1">1</div>
+        <div class="span1 end">1 (end)</div>
+      </div>
+    </div>
+  </div>
 </div> <!-- fluid grids -->
 
 


### PR DESCRIPTION
The code in this pull request makes the last column in a `.row-fluid` glue itself to the row's right edge, unless that column has the class `.end`. This ensures an even right edge, at the expense of a less-even column gutter.

I believe this is a desirable compromise. Do you agree?

(Concept shamelessly stolen from Zurb Foundation)
