### PR TITLE
Add CSS3 Hyphenation mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -312,6 +312,15 @@
           column-gap: @columnGap;
 }
 
+// Optional hyphenation
+.hyphens(@mode: auto) {
+  -webkit-hyphens: @mode;
+     -moz-hyphens: @mode;
+      -ms-hyphens: @mode;
+          hyphens: @mode;
+        word-wrap:break-word;
+}
+
 // Opacity
 .opacity(@opacity) {
   opacity: @opacity / 100;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -317,6 +317,7 @@
   -webkit-hyphens: @mode;
      -moz-hyphens: @mode;
       -ms-hyphens: @mode;
+       -o-hyphens: @mode;
           hyphens: @mode;
         word-wrap: break-word;
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -318,7 +318,7 @@
      -moz-hyphens: @mode;
       -ms-hyphens: @mode;
           hyphens: @mode;
-        word-wrap:break-word;
+        word-wrap: break-word;
 }
 
 // Opacity


### PR DESCRIPTION
This is for #3305.

This is a straightforward mixin for adding CSS3 hyphenation rules. It's not applied anywhere, but I'd suggest it would work best on the smaller responsive layouts where it allows you to get more text on-screen and improves readability. The jury is out on whether to apply this anywhere by default (please see the ticket for more discussion on that), so I'm submitting it as is.
