### PR TITLE
Add html option to popover/tooltip

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -895,6 +895,12 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                <td>apply a css fade transition to the tooltip</td>
              </tr>
              <tr>
+               <td>html</td>
+               <td>boolean</td>
+               <td>true</td>
+               <td>display content and title as html if detected in either field, otherwise display content and title as text</td>
+             </tr>
+             <tr>
                <td>placement</td>
                <td>string|function</td>
                <td>'right'</td>

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -42,9 +42,10 @@
       var $tip = this.tip()
         , title = this.getTitle()
         , content = this.getContent()
+        , o = this.options
 
-      $tip.find('.popover-title')[this.isHTML(title) ? 'html' : 'text'](title)
-      $tip.find('.popover-content > *')[this.isHTML(content) ? 'html' : 'text'](content)
+      $tip.find('.popover-title')[this.isHTML(title) && o.html ? 'html' : 'text'](title)
+      $tip.find('.popover-content > *')[this.isHTML(content) && o.html ? 'html' : 'text'](content)
 
       $tip.removeClass('fade top bottom left right in')
     }

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -264,6 +264,7 @@
 
   $.fn.tooltip.defaults = {
     animation: true
+  , html: true
   , placement: 'top'
   , selector: false
   , template: '<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'


### PR DESCRIPTION
There is an html option for popover/tooltip again. The option is defaulted to true.

Having this option allows us to force the popover to use the `.text()` method to set the title and content of the popover no matter if bootstrap thinks it detects html or not. The problem is that jQuery seems to unescape values grabbed with the `.attr()` method, so even if you escape `<script>alert('data');</script>` to `&lt;script&gt;alert(&quot;data&quot;)&lt;/script&gt;` and set it as your data-content, bootstrap will get the unescaped value from `.attr()`, detect that this is html and use the `.html()` method to set the content of the popover causing an XSS issue. Forcing the use of the `.text()` method by setting the html option to false lets us make sure that doesn't happen.
