### PR TITLE
ul.nav > li > a.btn:hover bug

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -233,6 +233,9 @@
   color: @navbarLinkColorHover;
   text-decoration: none;
 }
+.navbar .nav > li > a.btn:hover {
+  .buttonBackground(@btnPrimaryBackground, @btnPrimaryBackgroundHighlight); // for buttons placed in a nav list
+}
 
 // Active nav items
 .navbar .nav .active > a,


### PR DESCRIPTION
using the top nav, when I try and add a link with class "btn"' it will display properly until I mouseover the link. Then it loses the bottom half of the link. The background defaults to transparent.

``` html
<ul class="nav">
    <li><a href="#" class="btn">Thing</a></li>
</ul>
```

Removing the li makes it work also. example:

``` html
<div class="nav">
    <a href="#" class="btn">Thing</a>
</div>
```

I have added in an extra style for a.btn:hover to catch the background of the button.
