### PR TITLE
Update .placeholder() mixin call

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -344,7 +344,7 @@ select:focus:required:invalid {
 }
 
 // Placeholder text gets special styles; can't be bundled together though for some reason
-.placeholder(@grayLight);
+.placeholder();
 
 
 


### PR DESCRIPTION
In `less/mixins.less` this mixin is being created with `@placeholderText`
color as default, which is actually set as `@placeholderText: @grayLight`
in `less/variables.less` so it's redundant to make call like this:

`.placeholder(@grayLight);`
