### PR TITLE
Fix form control states for uneditable-input

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -167,6 +167,7 @@
   }
   // Style inputs accordingly
   input,
+  .uneditable-input,
   select,
   textarea {
     color: @textColor;


### PR DESCRIPTION
An uneditable-input field did not adhere the control-group class to be used for validation styles.
This can come in handy when an uneditable field requires validation feedback if it's changed by an external component.
