### PR TITLE
Call setContent after adding the tooltip to the page.

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -104,7 +104,6 @@
 
       if (this.hasContent() && this.enabled) {
         $tip = this.tip()
-        this.setContent()
 
         if (this.options.animation) {
           $tip.addClass('fade')
@@ -120,6 +119,8 @@
           .remove()
           .css({ top: 0, left: 0, display: 'block' })
           .appendTo(inside ? this.$element : document.body)
+          
+        this.setContent()
 
         pos = this.getPosition(inside)
 


### PR DESCRIPTION
As it is right now, if cloning existing page elements is performed in setContent, their event handlers get blown away when the $tip is attached to the document.

This patch would allow other components to extend setContent and clone ($.clone(true)) nodes into .tooltip-inner, and thus clone events as well.

In combination with trigger: 'manual' this would allow one to create pop-up menus containing buttons (and make them work with frameworks such as Backbone and KnockOut.js).
