### PR TITLE
Cancel delayed (show) timer when mouse leaves element for tooltips with hiding delay of 0 ms.

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,6 +84,7 @@
   , leave: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      if (this.timeout) clearTimeout(this.timeout)
       if (!self.options.delay || !self.options.delay.hide) return self.hide()
 
       clearTimeout(this.timeout)


### PR DESCRIPTION
Cancel running timer for tooltips with delayed show, but instant hide. This prevents delayed tooltips from appearing if the mouse leaves the elements before tooltip is showed and the hiding delay is 0.

Error is reproduced like this:
$(...).tooltip({delay: {show: 1000, hide: 0}});

Now let the mouse enter en leave the element within 1 second. The tooltip shows up after 1000 ms anyway.
