### PR TITLE
Added '.item' selector to next/prev

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -85,7 +85,7 @@
 
   , slide: function (type, next) {
       var $active = this.$element.find('.active')
-        , $next = next || $active[type]()
+        , $next = next || $active[type]('.item')
         , isCycling = this.interval
         , direction = type == 'next' ? 'left' : 'right'
         , fallback  = type == 'next' ? 'first' : 'last'


### PR DESCRIPTION
Because if there are some other elements in '.carousel-inner', that do not have 'item' class - it will mess things up. The fallback on a few lines below already has this selector.
