### PR TITLE
Get the text for tooltip with $.data (not $.attr)

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -210,7 +210,7 @@
         , $e = this.$element
         , o = this.options
 
-      title = $e.attr('data-original-title')
+      title = $e.data('original-title')
         || (typeof o.title == 'function' ? o.title.call($e[0]) :  o.title)
 
       return title


### PR DESCRIPTION
fix for issue #3477
