### PR TITLE
fix radio toggle buttons can be clicked when active or disabled

### DIFF
--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -52,6 +52,8 @@
 
   Button.prototype.toggle = function () {
     var $parent = this.$element.parent('[data-toggle="buttons-radio"]')
+    
+    if ($parent && (this.$element.hasClass('disabled') || this.$element.hasClass('active'))) return
 
     $parent && $parent
       .find('.active')


### PR DESCRIPTION
I was having an issue with the radio toggle button effect was being implemented when user clicks on a radio button that is disabled. Also added a conditional so event would not trigger if it is already active.
