### PR TITLE
Swapped out .hasClass() with .is() when checking for multiple classes

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -87,7 +87,6 @@
       if (this.timeout) clearTimeout(this.timeout)
       if (!self.options.delay || !self.options.delay.hide) return self.hide()
 
-      clearTimeout(this.timeout)
       self.hoverState = 'out'
       this.timeout = setTimeout(function() {
         if (self.hoverState == 'out') self.hide()

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,6 +84,7 @@
   , leave: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      if (this.timeout) clearTimeout(this.timeout)
       if (!self.options.delay || !self.options.delay.hide) return self.hide()
 
       clearTimeout(this.timeout)

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -78,6 +78,25 @@ $(function () {
         }, 100)
       })
 
+      test("should not show tooltip if leave event occurs before delay expires, even if hide delay is 0", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({ delay: { show: 200, hide: 0} })
+
+        stop()
+
+        tooltip.trigger('mouseenter')
+
+        setTimeout(function () {
+          ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
+          tooltip.trigger('mouseout')
+          setTimeout(function () {
+            ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
+            start()
+          }, 200)
+        }, 100)
+      })
+
       test("should not show tooltip if leave event occurs before delay expires", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -33,7 +33,7 @@ $(function () {
           .tooltip({placement: 'bottom'})
           .tooltip('show')
 
-        ok($(".tooltip").hasClass('fade bottom in'), 'has correct classes applied')
+        ok($(".tooltip").is('.fade.bottom.in'), 'has correct classes applied')
         tooltip.tooltip('hide')
       })
 
@@ -69,10 +69,10 @@ $(function () {
         tooltip.trigger('mouseenter')
 
         setTimeout(function () {
-          ok(!$(".tooltip").hasClass('fade in'), 'tooltip is not faded in')
+          ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
           tooltip.trigger('mouseout')
           setTimeout(function () {
-            ok(!$(".tooltip").hasClass('fade in'), 'tooltip is not faded in')
+            ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
             start()
           }, 200)
         }, 100)
@@ -104,10 +104,10 @@ $(function () {
         stop()
         tooltip.trigger('mouseenter')
         setTimeout(function () {
-          ok(!$(".tooltip").hasClass('fade in'), 'tooltip is not faded in')
+          ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
           tooltip.trigger('mouseout')
           setTimeout(function () {
-            ok(!$(".tooltip").hasClass('fade in'), 'tooltip is not faded in')
+            ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
             start()
           }, 100)
         }, 50)
@@ -120,9 +120,9 @@ $(function () {
         stop()
         tooltip.trigger('mouseenter')
         setTimeout(function () {
-          ok(!$(".tooltip").hasClass('fade in'), 'tooltip is not faded in')
+          ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
           setTimeout(function () {
-            ok(!$(".tooltip").hasClass('fade in'), 'tooltip has faded in')
+            ok(!$(".tooltip").is('.fade.in'), 'tooltip has faded in')
             start()
           }, 200)
         }, 100)


### PR DESCRIPTION
.hasClass() just checks if the classes appear in the exact order you specify, without any other classes inbetween. Using .is() ensures that you get a positive response even if classes are shuffled and/or mixed with other classes.

This seems to be a problem with some of the unit test for bootstrap-tooltip that was testing for:
.hasClass("fade in") when the actual class would have been "fade top in" when the tooltip module failed. This would give the impression that the test passed when it actually failed.
