### PR TITLE
IE7 & IE8: Text fields within a parent with opacity filter show no text

### DIFF
--- a/less/component-animations.less
+++ b/less/component-animations.less
@@ -2,10 +2,10 @@
 // --------------------
 
 .fade {
-  .opacity(0);
+  opacity: 0;
   .transition(opacity .15s linear);
   &.in {
-    .opacity(100);
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
Seems there is a bug in IE<9 where text fields (and textareas) that are in a container which has `filter: alpha(opacity=[number]);` applied are not re-rendered when being typed in. 

Curiously enough, if you move your mouse out of the parent with the filter, the text will magically appear / update.

A straightforward use case where this happens is having a form inside a fade-in modal, as the `.fade.in` class has `filter: alpha(opacity=100);`. When you type, nothing will come up (but you can see the text cursor moving), and if you move the mouse into the overlay area, the text will appear/update.

Here is a test page:

http://www.cactilio.com/bootstrap-filter-test.html

A fix would be to not use a filter in IE<9 for `.fade.in`. It doesn't really give anything for IE<9 as the modals just pop-in and have no fading animation anyway!
