### PR TITLE
Fix typo in base-css.html#forms

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1272,7 +1272,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
               </label>
               <label class="radio">
                 <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                Option two can is something else and selecting it will deselect option one
+                Option two is something else and selecting it will deselect option one
               </label>
             </div>
           </div>

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -1195,7 +1195,7 @@
               </label>
               <label class="radio">
                 <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
-                {{_i}}Option two can is something else and selecting it will deselect option one{{/i}}
+                {{_i}}Option two is something else and selecting it will deselect option one{{/i}}
               </label>
             </div>
           </div>


### PR DESCRIPTION
Fixes typo in http://twitter.github.com/bootstrap/base-css.html#forms:

![I saaaay....](https://img.skitch.com/20120522-fj4fkfthxea2tqhtarb6s64295.png)
