### PR TITLE
Tooltip placement is wrong when the element is SVG in IE 9

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -200,8 +200,8 @@
 
   , getPosition: function (inside) {
       return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
-        width: this.$element[0].offsetWidth
-      , height: this.$element[0].offsetHeight
+        width: (this.$element[0].offsetWidth || 0)
+      , height: (this.$element[0].offsetHeight || 0)
       })
     }
 


### PR DESCRIPTION
IE 9 will return a null for `offsetWidth` and `offsetHeight` when the element is an SVG element.

The result is a NaN error when trying to do arithmetic with a null value when calculating the left/top values for the tooltip placement.

This fix is not perfect because it can result in an off center positioning, but it corrects the error where the top/left CSS will be set to 0 due to a NaN error in the math.
