### PR TITLE
Fix for Scaffolding Documentation

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -234,11 +234,11 @@
     <div class="span6">
 <pre class="prettyprint linenums">
 &lt;div class="row"&gt;
-  &lt;div class="span12"&gt;
+  &lt;div class="span6"&gt;
     Level 1 of column
     &lt;div class="row"&gt;
-      &lt;div class="span6"&gt;Level 2&lt;/div&gt;
-      &lt;div class="span6"&gt;Level 2&lt;/div&gt;
+      &lt;div class="span3"&gt;Level 2&lt;/div&gt;
+      &lt;div class="span3"&gt;Level 2&lt;/div&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/div&gt;


### PR DESCRIPTION
Bug  Fix for Issue #3578
docs/scaffolding.html in Nesting Columns example on line 240 span12,span6 used but the text and example shown both use span6,span3 
