### PR TITLE
ensure definitions in mixins.less do not output

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -8,38 +8,6 @@
  * Designed and built with all the love in the world @twitter by @mdo and @fat.
  */
 
-.clearfix {
-  *zoom: 1;
-}
-
-.clearfix:before,
-.clearfix:after {
-  display: table;
-  content: "";
-}
-
-.clearfix:after {
-  clear: both;
-}
-
-.hide-text {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
-.input-block-level {
-  display: block;
-  width: 100%;
-  min-height: 28px;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-      -ms-box-sizing: border-box;
-          box-sizing: border-box;
-}
-
 .hidden {
   display: none;
   visibility: hidden;

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -119,38 +119,6 @@ textarea {
   vertical-align: top;
 }
 
-.clearfix {
-  *zoom: 1;
-}
-
-.clearfix:before,
-.clearfix:after {
-  display: table;
-  content: "";
-}
-
-.clearfix:after {
-  clear: both;
-}
-
-.hide-text {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
-.input-block-level {
-  display: block;
-  width: 100%;
-  min-height: 28px;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-      -ms-box-sizing: border-box;
-          box-sizing: border-box;
-}
-
 body {
   margin: 0;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -1488,6 +1456,16 @@ legend + .control-group {
 
 .form-horizontal .form-actions {
   padding-left: 160px;
+}
+
+.input-block-level {
+  display: block;
+  width: 100%;
+  min-height: 28px;
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+      -ms-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 table {
@@ -4937,6 +4915,28 @@ a.badge:hover {
   font-weight: 200;
   line-height: 27px;
   color: inherit;
+}
+
+.clearfix {
+  *zoom: 1;
+}
+
+.clearfix:before,
+.clearfix:after {
+  display: table;
+  content: "";
+}
+
+.clearfix:after {
+  clear: both;
+}
+
+.hide-text {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
 }
 
 .pull-right {

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -5,7 +5,7 @@
 // Make the div behave like a button
 .btn-group {
   position: relative;
-  .clearfix(); // clears the floated buttons
+  #utilities > .clearfix(); // clears the floated buttons
   .ie7-restore-left-whitespace();
 }
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -330,7 +330,7 @@ select:focus:required:invalid {
   margin-bottom: @baseLineHeight;
   background-color: @formActionsBackground;
   border-top: 1px solid #ddd;
-  .clearfix(); // Adding clearfix to allow for .pull-right button containers
+  #utilities > .clearfix(); // Adding clearfix to allow for .pull-right button containers
 }
 
 // For text that needs to appear as an input but should not be an input
@@ -551,7 +551,7 @@ legend + .control-group {
   // Increase spacing between groups
   .control-group {
     margin-bottom: @baseLineHeight;
-    .clearfix();
+    #utilities > .clearfix();
   }
   // Float the labels left
   .control-label {
@@ -581,4 +581,8 @@ legend + .control-group {
   .form-actions {
     padding-left: 160px;
   }
+}
+
+.input-block-level {
+  #forms > .input-block-level();
 }

--- a/less/layouts.less
+++ b/less/layouts.less
@@ -13,5 +13,5 @@
 .container-fluid {
   padding-right: @gridGutterWidth;
   padding-left: @gridGutterWidth;
-  .clearfix();
+  #utilities > .clearfix();
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -6,18 +6,31 @@
 // UTILITY MIXINS
 // --------------------------------------------------
 
-// Clearfix
-// --------
-// For clearing floats like a boss h5bp.com/q
-.clearfix {
-  *zoom: 1;
-  &:before,
-  &:after {
-    display: table;
-    content: "";
+#utilities {
+  // Clearfix
+  // --------
+  // For clearing floats like a boss h5bp.com/q
+  .clearfix() {
+    *zoom: 1;
+    &:before,
+    &:after {
+      display: table;
+      content: "";
+    }
+    &:after {
+      clear: both;
+    }
   }
-  &:after {
-    clear: both;
+
+  // CSS image replacement
+  // -------------------------
+  // Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
+  .hide-text() {
+    font: 0/0 a;
+    color: transparent;
+    text-shadow: none;
+    background-color: transparent;
+    border: 0;
   }
 }
 
@@ -98,17 +111,6 @@
   white-space: nowrap;
 }
 
-// CSS image replacement
-// -------------------------
-// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
-.hide-text {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
 
 // FONTS
 // --------------------------------------------------
@@ -148,12 +150,14 @@
 // FORMS
 // --------------------------------------------------
 
-// Block level inputs
-.input-block-level {
-  display: block;
-  width: 100%;
-  min-height: 28px;        // Make inputs at least the height of their button counterpart
-  .box-sizing(border-box); // Makes inputs behave like true block-level elements
+#forms {
+  // Block level inputs
+  .input-block-level() {
+    display: block;
+    width: 100%;
+    min-height: 28px;        // Make inputs at least the height of their button counterpart
+    .box-sizing(border-box); // Makes inputs behave like true block-level elements
+  }
 }
 
 
@@ -505,7 +509,7 @@
 .container-fixed() {
   margin-right: auto;
   margin-left: auto;
-  .clearfix();
+  #utilities > .clearfix();
 }
 
 // Table columns
@@ -519,7 +523,7 @@
 // Use .makeRow and .makeColumn to assign semantic layouts grid system behavior
 .makeRow() {
   margin-left: @gridGutterWidth * -1;
-  .clearfix();
+  #utilities > .clearfix();
 }
 .makeColumn(@columns: 1, @offset: 0) {
   float: left;
@@ -554,7 +558,7 @@
 
     .row {
       margin-left: @gridGutterWidth * -1;
-      .clearfix();
+      #utilities > .clearfix();
     }
 
     [class*="span"] {
@@ -588,9 +592,9 @@
 
     .row-fluid {
       width: 100%;
-      .clearfix();
+      #utilities > .clearfix();
       [class*="span"] {
-        .input-block-level();
+        #forms > .input-block-level();
         float: left;
         margin-left: @fluidGridGutterWidth;
         *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);

--- a/less/modals.less
+++ b/less/modals.less
@@ -76,7 +76,7 @@
   border-top: 1px solid #ddd;
   .border-radius(0 0 6px 6px);
   .box-shadow(inset 0 1px 0 @white);
-  .clearfix(); // clear it in case folks use .pull-* classes on buttons
+  #utilities > .clearfix(); // clear it in case folks use .pull-* classes on buttons
 
   // Properly space out buttons
   .btn + .btn {

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -81,7 +81,7 @@
 // Navbar forms
 .navbar-form {
   margin-bottom: 0; // remove default bottom margin
-  .clearfix();
+  #utilities > .clearfix();
   input,
   select,
   .radio,

--- a/less/navs.less
+++ b/less/navs.less
@@ -82,7 +82,7 @@
 // Common styles
 .nav-tabs,
 .nav-pills {
-  .clearfix();
+  #utilities > .clearfix();
 }
 .nav-tabs > li,
 .nav-pills > li {
@@ -263,7 +263,7 @@
 
 // Clear any floats
 .tabbable {
-  .clearfix();
+  #utilities > .clearfix();
 }
 .tab-content {
   overflow: auto; // prevent content from running below tabs

--- a/less/pager.less
+++ b/less/pager.less
@@ -6,7 +6,7 @@
   margin-bottom: @baseLineHeight;
   list-style: none;
   text-align: center;
-  .clearfix();
+  #utilities > .clearfix();
 }
 .pager li {
   display: inline;

--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -135,7 +135,7 @@
   select[class*="span"],
   textarea[class*="span"],
   .uneditable-input {
-    .input-block-level();
+    #forms > .input-block-level();
   }
   // But don't let it screw up prepend/append inputs
   .input-prepend input,

--- a/less/thumbnails.less
+++ b/less/thumbnails.less
@@ -6,7 +6,7 @@
 .thumbnails {
   margin-left: -@gridGutterWidth;
   list-style: none;
-  .clearfix();
+  #utilities > .clearfix();
 }
 // Fluid rows have no left margin
 .row-fluid .thumbnails {

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -1,6 +1,14 @@
 // UTILITY CLASSES
 // ---------------
 
+.clearfix {
+  #utilities > .clearfix();
+}
+
+.hide-text {
+  #utilities > .hide-text();
+}
+
 // Quick floats
 .pull-right {
   float: right;


### PR DESCRIPTION
this change allows one to...

```
@import "twitter/bootstrap/mixins.less"
```

multiple times, without any output that is not explicitly called for.

to accomplish this,
1. three remaining mixins (.clearfix, .hide-text and .input-block-level) have been made parametric
2. non-parametric versions (simple calls to the parametric) have been added to forms.less and utilities.less, in order to allow these to be used as class attribute values and to maintain backward compatibility
3. all bootstrap-internal calls make use of the parametric versions, to ensure nothing breaks.

an example of this, in fact, working may be seen in the changes to the generated bootstrap.css and bootstrap-responsive.css.  the former still includes the output rulesets, while bootstrap-responsive.css no longer includes those definitions (which would be duplication).
