### PR TITLE
2.0.4 wip fix placeholder

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3713,6 +3713,10 @@ input[type="submit"].btn.btn-mini {
   color: #cccccc;
 }
 
+.navbar-search .search-query:-ms-input-placeholder {
+  color: #cccccc;
+}
+
 .navbar-search .search-query::-webkit-input-placeholder {
   color: #cccccc;
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -81,13 +81,13 @@
 // Placeholder text
 // -------------------------
 .placeholder(@color: @placeholderText) {
-  :-moz-placeholder {
+  &:-moz-placeholder {
     color: @color;
   }
-  :-ms-input-placeholder {
+  &:-ms-input-placeholder {
     color: @color;
   }
-  ::-webkit-input-placeholder {
+  &::-webkit-input-placeholder {
     color: @color;
   }
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -123,13 +123,7 @@
     .box-shadow(~"inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0 rgba(255,255,255,.15)");
     .transition(none);
 
-    // Placeholder text gets special styles; can't be a grouped selector
-    &:-moz-placeholder {
-      color: @navbarSearchPlaceholderColor;
-    }
-    &::-webkit-input-placeholder {
-      color: @navbarSearchPlaceholderColor;
-    }
+    .placeholder(@navbarSearchPlaceholderColor);
 
     // Focus states (we use .focused since IE7-8 and down doesn't support :focus)
     &:focus,


### PR DESCRIPTION
adding the `&` combinator to `.placeholder` makes it work for the global case (in forms.less) as well as within `.navbar-search .search-query`

the result can be seen in the generated bootstrap.css, which now includes the -ms vendor extension.
