### PR TITLE
In Firefox, typeahead now accepts key up and down to solve Issue #3313

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -213,13 +213,11 @@
           break
 
         case 38: // up arrow
-          if (e.type != 'keydown') break
           e.preventDefault()
           this.prev()
           break
 
         case 40: // down arrow
-          if (e.type != 'keydown') break
           e.preventDefault()
           this.next()
           break


### PR DESCRIPTION
"if (e.type != 'keydown') break" code line deleted so that typeahead now accepts key up and down to select an item in Firefox.

Browsers tested : Firefox 12, Chrome 19.
