### PR TITLE
Fix css issue - repsonsive form

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -118,7 +118,7 @@
   }
   // Make all grid-sized elements block level again
   [class*="span"],
-  .row-fluid [class*="span"] {
+  .row-fluid > [class*="span"] {
     float: none;
     display: block;
     width: auto;


### PR DESCRIPTION
The form elements (input, textearea...) with a span class are not resized correctly
