### PR TITLE
Comma separated CSS properties with mixins (box-shadow, transition, and newly added text-shadow)

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -203,19 +203,29 @@
 }
 
 // Drop shadows
-.box-shadow(@shadow) {
-  -webkit-box-shadow: @shadow;
-     -moz-box-shadow: @shadow;
-          box-shadow: @shadow;
+.box-shadow(@shadowA, @shadowB:X, ...) {
+  @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+  -webkit-box-shadow: @props;
+     -moz-box-shadow: @props;
+          box-shadow: @props;
+}
+
+// Text shadows
+.text-shadow(@shadowA, @shadowB:X, ...) {
+  @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+  -webkit-text-shadow: @props;
+     -moz-text-shadow: @props;
+          text-shadow: @props;
 }
 
 // Transitions
 .transition(@transition) {
-  -webkit-transition: @transition;
-     -moz-transition: @transition;
-      -ms-transition: @transition;
-       -o-transition: @transition;
-          transition: @transition;
+  @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+  -webkit-transition: @props;
+     -moz-transition: @props;
+      -ms-transition: @props;
+       -o-transition: @props;
+          transition: @props;
 }
 
 // Transformations


### PR DESCRIPTION
This adds the ability to pass multiple properties to the box-shadow and transition mixins (without having to pass an escaped string). It also adds a text-shadow mixin (with the same ability)

For example:

```
.box-shadow(1px 1px 0 rgba(0,0,0,0.5), inset -1px -1px rgba(255,255,255,0.5));
```

In short, when passing a single parameter to a LESS mixin with no arguments limit (e.g., using "..."), it will insert commas for every space character found. Thus, this implementation registers a default value for the second parameter (while still allowing 2+) and filters out the default value when parsing the @arguments variable.

See this post for a full description and reasoning behind the @arguments parsing and regex'ing:
http://www.toekneestuck.com/blog/2012/05/15/less-css-arguments-variable/
