### PR TITLE
Alter typeahead to accept synchronous/asynchronous data source

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1385,9 +1385,9 @@ $('.carousel').carousel({
             <tbody>
               <tr>
                <td>{{_i}}source{{/i}}</td>
-               <td>{{_i}}array{{/i}}</td>
+               <td>{{_i}}array, function{{/i}}</td>
                <td>[ ]</td>
-               <td>{{_i}}The data source to query against.{{/i}}</td>
+               <td>{{_i}}The data source to query against. May be an array of strings or a function. The function is passed two arguments, the <code>query</code> value in the input field and the <code>process</code> callback. The function may be used synchronously by returning the data source directly or asynchronously via the <code>process</code> callback's single argument.{{/i}}</td>
              </tr>
              <tr>
                <td>{{_i}}items{{/i}}</td>

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -77,9 +77,7 @@
     }
 
   , lookup: function (event) {
-      var that = this
-        , items
-        , q
+      var items
 
       this.query = this.$element.val()
 
@@ -87,7 +85,15 @@
         return this.shown ? this.hide() : this
       }
 
-      items = $.grep(this.source, function (item) {
+      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+
+      return items ? this.process(items) : this
+    }
+
+  , process: function (items) {
+      var that = this
+
+      items = $.grep(items, function (item) {
         return that.matcher(item)
       })
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -52,6 +52,42 @@ $(function () {
         typeahead.$menu.remove()
       })
 
+      test("should accept data source via synchronous function", function () {
+        var $input = $('<input />').typeahead({
+              source: function () {
+                return ['aa', 'ab', 'ac']
+              }
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        typeahead.$menu.remove()
+      })
+
+      test("should accept data source via asynchronous function", function () {
+        var $input = $('<input />').typeahead({
+              source: function (query, process) {
+                process(['aa', 'ab', 'ac'])
+              }
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        typeahead.$menu.remove()
+      })
+
       test("should not explode when regex chars are entered", function () {
         var $input = $('<input />').typeahead({
               source: ['aa', 'ab', 'ac', 'mdo*', 'fat+']


### PR DESCRIPTION
@fat: From existing pull request (#3250) against 2.1.0-wip. Sorry for not submitting it against a *-wip branch earlier.

This is a simple change to allow both synchronous and asynchronous data sources for the typeahead widget via a function/callback. This references issue #1336. Example:

``` js
$("input").typeahead({
  source: function (query, process) {
    $.get('/autocomplete', { q: query }, function (data) {
      process(data)
    })
  }
})
```

Because of the recently-added "updater" option, you can also handle objects:

``` js
var labels
  , mapped
$("input").typeahead({
  source: function (query, process) {
    $.get('/autocomplete', { q: query }, function (data) {
      labels = []
      mapped = {}

      $.each(data, function (i, item) {
        mapped[item.label] = item.value
        labels.push(item.label)
      })

      process(labels)
    })
  }
, updater: function (item) {
    return mapped[item]
  }
})
```
