### PR TITLE
Tooltips can now fire events "show", "hide", "shown" and "hidden"

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -103,6 +103,9 @@
         , tp
 
       if (this.hasContent() && this.enabled) {
+        var triggerEvent = $.Event('show')
+        this.$element.trigger(triggerEvent)
+
         $tip = this.tip()
         this.setContent()
 
@@ -145,6 +148,9 @@
           .css(tp)
           .addClass(placement)
           .addClass('in')
+
+          triggerEvent = $.Event('shown')
+          this.$element.trigger(triggerEvent)
       }
     }
 
@@ -159,6 +165,9 @@
   , hide: function () {
       var that = this
         , $tip = this.tip()
+
+      var triggerEvent = $.Event('hide')
+      this.$element.trigger(triggerEvent)
 
       $tip.removeClass('in')
 
@@ -176,6 +185,9 @@
       $.support.transition && this.$tip.hasClass('fade') ?
         removeWithAnimation() :
         $tip.remove()
+
+        triggerEvent = $.Event('hidden')
+        this.$element.trigger(triggerEvent)
     }
 
   , fixTitle: function () {


### PR DESCRIPTION
As requested, I ported the patch from #3346 to 2.1.0-wip
