### PR TITLE
Fix: typeahead data storing in list items

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('value')
       this.$element
         .val(this.updater(val))
         .change()
@@ -130,7 +130,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('value', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -127,7 +127,45 @@ $(function () {
 
       test("should set input value to selected item", function () {
         var $input = $('<input />').typeahead({
-              source: [{text:'aa'}, {text:'ab'}, {text:'ac'}]
+              source: [
+                {
+                  text: 'aa',
+                  toLowerCase: function() {
+                    return this.text
+                  },
+                  indexOf    : function(str) {
+                    return this.text.indexOf(str)
+                  },
+                  replace    : function(pattern, replacement) {
+                    return this.text.indexOf(pattern, replacement)
+                  }
+                },
+                {text: 'ab',
+                  toLowerCase: function() {
+                    return this.text
+                  },
+                  indexOf    : function(str) {
+                    return this.text.indexOf(str)
+                  },
+                  replace    : function(pattern, replacement) {
+                    return this.text.indexOf(pattern, replacement)
+                  }
+                },
+                {text: 'ac'
+                  ,toLowerCase: function() {
+                  return this.text
+                },
+                  indexOf    : function(str) {
+                    return this.text.indexOf(str)
+                  },
+                  replace    : function(pattern, replacement) {
+                    return this.text.indexOf(pattern, replacement)
+                  }
+                }
+              ],
+              updater: function (item) {
+                return item.text
+              }
             })
           , typeahead = $input.data('typeahead')
           , changed = false
@@ -139,7 +177,7 @@ $(function () {
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        equals($input.val(), {text:'ac'}, 'input value was correctly set')
+        equals($input.val(), 'ac', 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
         ok(changed, 'a change event was fired')
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -127,7 +127,7 @@ $(function () {
 
       test("should set input value to selected item", function () {
         var $input = $('<input />').typeahead({
-              source: ['aa', 'ab', 'ac']
+              source: [{text:'aa'}, {text:'ab'}, {text:'ac'}]
             })
           , typeahead = $input.data('typeahead')
           , changed = false
@@ -139,7 +139,7 @@ $(function () {
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
-        equals($input.val(), 'ac', 'input value was correctly set')
+        equals($input.val(), {text:'ac'}, 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
         ok(changed, 'a change event was fired')
 


### PR DESCRIPTION
Unit test fails on typeahead with array of objects as source. When you use .attr('data-value') you can store only string there. To store objects you can use JSON.stringify or use $.data wich takes care of objects and it's shorter

For example I have

```
$.typeahead({
  source: [
    {firstName:'aa', lastName: 'oo'},
    {nickName: 'anon'}
  ]
})
```

And I want to search through all fields and do other magic.
I can override matcher sorter highlighter updater. But it's gonna pass `"[object Object]"` into updater function.
