### PR TITLE
Image resizing bug in Chrome

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -75,7 +75,6 @@ sub {
 // -------------------------
 
 img {
-  max-width: 100%; // Make images inherently responsive
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;


### PR DESCRIPTION
Since about bootstrap 2.0.3 there is a bug that seemed to resize images randomly. It only occured in Chrome. After tracking it down, if found this CSS:

```
img {
  max-width: 100%;
}
```

This obiously constraints image sizes to 100% of the outer element, which is sometimes smaller than the image itself. This is mostly not a problem, except when the size of the outer element depends on the size of the image. So this effictively breaks images in tables. The following jsfiddle demonstrates the issue:

http://jsfiddle.net/SqfEC/
