### PR TITLE
Add radio input to form examples

### DIFF
--- a/base-css.html
+++ b/base-css.html
@@ -993,6 +993,15 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
+            <label class="control-label" for="optionsRadio">Radio</label>
+            <div class="controls">
+              <label class="radio">
+                <input type="radio" id="optionsRadio" value ="radio1">
+                Radio buttons are lots of fun!
+              </label>
+            </div>
+          </div>
+          <div class="control-group">
             <label class="control-label" for="select01">Select list</label>
             <div class="controls">
               <select id="select01">
@@ -1005,7 +1014,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="multiSelect">Multicon-select</label>
+            <label class="control-label" for="multiSelect">Multiple-select</label>
             <div class="controls">
               <select multiple="multiple" id="multiSelect">
                 <option>1</option>


### PR DESCRIPTION
Add example radio input to match up with list of supported form controls.

Also fixed spelling of "Multiple" from "Multicon"
