### PR TITLE
Make tooltips work with SVG elements

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -190,7 +190,7 @@
     }
 
   , getPosition: function (inside) {
-      return $.extend({}, this.$element[0].getBoundingClientRect(), (inside ? {top: 0, left: 0} : {}))
+      return $.extend({}, this.$element[0].getBoundingClientRect(), (inside ? {top: 0, left: 0} : this.$element.offset()))
     }
 
   , getTitle: function () {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -190,10 +190,7 @@
     }
 
   , getPosition: function (inside) {
-      return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
-        width: this.$element[0].offsetWidth
-      , height: this.$element[0].offsetHeight
-      })
+      return $.extend({}, this.$element[0].getBoundingClientRect(), (inside ? {top: 0, left: 0} : {}))
     }
 
   , getTitle: function () {


### PR DESCRIPTION
This will use `getBoundingClientRect` instead of `offsetWidth`/`offsetHeight` because it works with SVG elements instead.

[`getBoundingClientRect` is supported in all major browsers.](https://developer.mozilla.org/en/DOM/element.getBoundingClientRect#Browser_compatibility)
