### PR TITLE
Removing unnecessary CSS3 browser vendor declarations

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -198,14 +198,12 @@
 // Border Radius
 .border-radius(@radius) {
   -webkit-border-radius: @radius;
-     -moz-border-radius: @radius;
           border-radius: @radius;
 }
 
 // Drop shadows
 .box-shadow(@shadow) {
   -webkit-box-shadow: @shadow;
-     -moz-box-shadow: @shadow;
           box-shadow: @shadow;
 }
 
@@ -213,7 +211,6 @@
 .transition(@transition) {
   -webkit-transition: @transition;
      -moz-transition: @transition;
-      -ms-transition: @transition;
        -o-transition: @transition;
           transition: @transition;
 }
@@ -281,7 +278,6 @@
        -o-background-size: @size;
           background-size: @size;
 }
-
 
 // Box sizing
 .box-sizing(@boxmodel) {


### PR DESCRIPTION
I have updated few css3 mixins as per browser vendor declarations on css3please.com which I find is most updated place to check these kind of things.
