### PR TITLE
Added offsets for .row-fluid working with offset on first-child

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -581,6 +581,17 @@
     }
     .spanX (0) {}
 
+    .offsetX (@index) when (@index > 0) {
+      (~'.offset@{index}, .row-fluid > .offset@{index}[class*="span"]') { .offset(@index); }
+      .offsetX(@index - 1);
+    }
+    .offsetX (0) {}
+
+    .offset (@columns) {
+      margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + @fluidGridGutterWidth;
+	  *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+    }
+
     .span (@columns) {
       width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1));
       *width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%);
@@ -599,8 +610,9 @@
         margin-left: 0;
       }
 
-      // generate .spanX
+      // generate .spanX and .offsetX
       .spanX (@gridColumns);
+      .offsetX (@gridColumns);
     }
 
   }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -597,7 +597,7 @@
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}, .row-fluid > .offset@{index}[class*="span"]') { .offset(@index); }
+      (~'.offset@{index}, .row-fluid .offset@{index}:first-child') { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}


### PR DESCRIPTION
Slight change from ajgon's initial pull request (7cc1526fcf4e8536a3926f6361d470971401d513).
This pull request allows offsets on fluid layouts to work still on the first-child.
