### PR TITLE
IE8 fix for image width

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -76,6 +76,7 @@ sub {
 
 img {
   max-width: 100%; // Make images inherently responsive
+  width: auto\9; // IE8 fix
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;


### PR DESCRIPTION
When images are at 100%, height is not adjusted correctly. The code "width: auto\9;" fixed it.
