### PR TITLE
Prevent 'inner' modals from closing 'outer' modals via click.dismiss.modal

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -82,6 +82,7 @@
 
     , hide: function (e) {
         e && e.preventDefault()
+        e && e.stopPropagation()
 
         var that = this
 

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -111,4 +111,18 @@ $(function () {
           })
           .modal("toggle")
       })
+
+      test("should only close inner-most modal when click [data-dismiss=modal]", function() {
+        stop()
+        $.support.transition = false
+        var outer = $("<div id='outer-modal'><div id='inner-modal'><span class='close' data-dismiss='modal'></span></div></div>")
+          , inner = outer.find('#inner-modal')
+        outer.modal("toggle")
+        inner.modal("toggle")
+        inner.find('.close').click()
+        ok(!$('#inner-modal').is(":visible"), 'inner modal hidden')
+        ok($('#outer-modal').is(":visible"), 'outer modal still visible')
+        outer.remove()
+        start()
+      })
 })


### PR DESCRIPTION
Fixes #3233

Use `stopPropagation()` for the `click.dismiss.modal` event, so only one modal is hidden rather than all.
