### PR TITLE
Check for maxScroll, it isn't always ready at initial load of the page, ...

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -77,7 +77,7 @@
           , activeTarget = this.activeTarget
           , i
 
-        if (scrollTop >= maxScroll) {
+        if (maxScroll && scrollTop >= maxScroll) {
           return activeTarget != (i = targets.last()[0])
             && this.activate ( i )
         }


### PR DESCRIPTION
...so the last nav entry is marked by default in 90% of page loads (current Safari, Chrome, FF on OSX )
