### PR TITLE
Scope carousel .active to .item

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -88,7 +88,7 @@
     }
 
   , slide: function (type, next) {
-      var $active = this.$element.find('.active')
+      var $active = this.$element.find('.item.active')
         , $next = next || $active[type]()
         , isCycling = this.interval
         , direction = type == 'next' ? 'left' : 'right'


### PR DESCRIPTION
When adding different elements, that also are .active (like an indicator), it is possible to have multiple .active classes. Scope the selector to only find a .item with the class .active.
