### PR TITLE
Typeahead menu appendToBody -> insertAfterElement

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -33,7 +33,7 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
-    this.$menu = $(this.options.menu).appendTo('body')
+    this.$menu = $(this.options.menu).insertAfter(this.$element)
     this.source = this.options.source
     this.shown = false
     this.listen()


### PR DESCRIPTION
Follow up commit on [pull 3145](https://github.com/twitter/bootstrap/pull/3145) fixes [issue 3088](https://github.com/twitter/bootstrap/issues/3088).
