### PR TITLE
removing hack/fix for jank Helvetica Neue font bug because causes uneven line-height between dd and dt that isn't always appropriate

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -124,7 +124,6 @@ dd {
 }
 dt {
   font-weight: bold;
-  line-height: @baseLineHeight - 1; // fix jank Helvetica Neue font bug
 }
 dd {
   margin-left: @baseLineHeight / 2;

--- a/less/type.less
+++ b/less/type.less
@@ -140,6 +140,11 @@ dd {
   dd {
     margin-left: 130px;
   }
+  &:after {
+    display: table;
+    content: "";
+    clear: both;
+  }
 }
 
 // MISC


### PR DESCRIPTION
... line-height between dd and dt that isn't always appropriate
