### PR TITLE
Prevent the body from scrolling, when user scrolls inside modal

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -1,6 +1,11 @@
 // MODALS
 // ------
 
+// Prevent the body from scrolling, when user scrolls inside modal
+body.modal-open {
+    overflow: hidden;
+}
+
 // Recalculate z-index where appropriate
 .modal-open {
   .dropdown-menu {  z-index: @zindexDropdown + @zindexModal; }


### PR DESCRIPTION
Setting overflow: hidden on the body.modal-open selector, prevents to body behind the modal backdrop from scrolling, when the user scrolls inside the modal, or on top of the backdrop.

Fixes #3353
