### PR TITLE
bootstrap-scrollspy.js: enable work around for body { height: 100%; }

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -70,7 +70,7 @@
 
     , process: function () {
         var scrollTop = this.$scrollElement.scrollTop() + this.options.offset
-          , scrollHeight = this.$scrollElement[0].scrollHeight || this.$body[0].scrollHeight
+          , scrollHeight = (this.options.wrap || this.$scrollElement[0] || this.$body[0]).scrollHeight
           , maxScroll = scrollHeight - this.$scrollElement.height()
           , offsets = this.offsets
           , targets = this.targets


### PR DESCRIPTION
I might have missed some other easy way to fix this but this works, after hours of tracking it down.

In case you define

  html, body {height: 100%;}

in your css, as suggeted on
http://www.cssstickyfooter.com/using-sticky-footer-code.html

which is working fine otherwise, scrollspy breaks.

This patch enables you to work around that issue by calling
scrollspy like this:

  $(window).scrollspy({wrap: $('#wrap')[0]});
