### PR TITLE
Use expanded margin properties

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -91,7 +91,10 @@ h6 {
 // Unordered and Ordered lists
 ul, ol {
   padding: 0;
-  margin: 0 0 @baseLineHeight / 2 25px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: @baseLineHeight / 2;
+  margin-left: 25px;
 }
 ul ul,
 ul ol,


### PR DESCRIPTION
This change makes it easier to convert bootstrap to RTL with rtlit.
