### PR TITLE
Added attachto option to enable the tooltip to be attached to an alternative alement

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -199,9 +199,10 @@
     }
 
   , getPosition: function (inside) {
-      return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
-        width: this.$element[0].offsetWidth
-      , height: this.$element[0].offsetHeight
+	  var el = this.options.attachTo ? $(this.options.attachTo) : this.$element
+      return $.extend({}, (inside ? {top: 0, left: 0} : el.offset()), {
+        width: el[0].offsetWidth
+      , height: el[0].offsetHeight
       })
     }
 


### PR DESCRIPTION
My use case is that I have fields with elements appended to them using (input-append) and the only room for the tooltip is to the right.
