### PR TITLE
<img /> tag with `height` attr are not responsive

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -76,6 +76,7 @@ sub {
 
 img {
   max-width: 100%; // Make images inherently responsive
+  height: auto; // Make images inherently responsive
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;


### PR DESCRIPTION
My CMS (Typo3) add the `height` and `width`attributes in every `<img />` tags.

For a responsive website, the width is correctly adjusted (override) via CSS. This is not the case for the height. It remains fixed.

The `height: auto;` fix that.

Hope it will be usefull.

cédric
