### PR TITLE
find only open childs and you can use accordion effect on other collaps elements with data-parent selector

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -56,7 +56,7 @@
 
       dimension = this.dimension()
       scroll = $.camelCase(['scroll', dimension].join('-'))
-      actives = this.$parent && this.$parent.find('> .accordion-group > .in')
+      actives = this.$parent && this.$parent.find('.in')
 
       if (actives && actives.length) {
         hasData = actives.data('collapse')


### PR DESCRIPTION
like :
`<div id="selector">`
`<button class="btn btn-danger" data-toggle="collapse" data-parent="#selector" data-target="#demo">`
`simple collapsible`
`</button>`
`<div id="demo" class="collapse in"> … </div>`
`<button class="btn btn-danger" data-toggle="collapse" data-parent="#selector" data-target="#demo1">`
`simple collapsible`
`</button>`
`<div id="demo1" class="collapse"> … </div>`
`<button class="btn btn-danger" data-toggle="collapse" data-parent="#selector" data-target="#demo2">`
`simple collapsible`
`</button>`
`<div id="demo2" class="collapse"> … </div>`
`</div>`
