### PR TITLE
2.1.0 wip

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -22,7 +22,7 @@ legend {
   display: block;
   width: 100%;
   padding: 0;
-  margin-bottom: @baseLineHeight * 1.5;
+  margin-bottom: 0px;
   font-size: @baseFontSize * 1.5;
   line-height: @baseLineHeight * 2;
   color: @grayDark;
@@ -34,6 +34,11 @@ legend {
     font-size: @baseLineHeight * .75;
     color: @grayLight;
   }
+}
+
+legend + * {
+  -webkit-margin-top-collapse : separate;
+  margin-top                  : @baseLineHeight * 1.5;
 }
 
 // Set font for forms


### PR DESCRIPTION
Fixes legend margin-bottom spacing bug in WebKit browsers, retains proper spacing for non-webkit browsers.

Tested FF on PC/MAC: no double margins.

Tested IE8 on PC: no double margins.

Tested Safari MAC: correct margins.

Tested Chrome MAC/PC: correct margins.

Credit to: http://stackoverflow.com/questions/6063071/getting-webkit-to-pay-attention-to-legend-margins
