### PR TITLE
Carousel slide event should include the next item

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -101,7 +101,7 @@
       if ($next.hasClass('active')) return
 
       if ($.support.transition && this.$element.hasClass('slide')) {
-        this.$element.trigger(e)
+        this.$element.trigger(e, $next)
         if (e.isDefaultPrevented()) return
         $next.addClass(type)
         $next[0].offsetWidth // force reflow
@@ -114,7 +114,7 @@
           setTimeout(function () { that.$element.trigger('slid') }, 0)
         })
       } else {
-        this.$element.trigger(e)
+        this.$element.trigger(e, $next)
         if (e.isDefaultPrevented()) return
         $active.removeClass('active')
         $next.addClass('active')


### PR DESCRIPTION
If the slide event presented which is the next item to be displayed, it is possible to implement clickable thumbnails of the slided images with proper animation.
