### PR TITLE
Add span to pagination

### DIFF
--- a/less/pagination.less
+++ b/less/pagination.less
@@ -16,7 +16,7 @@
 .pagination li {
     display: inline;
   }
-.pagination a {
+.pagination a, span {
   float: left;
   padding: 0 14px;
   line-height: (@baseLineHeight * 2) - 2;

--- a/less/pagination.less
+++ b/less/pagination.less
@@ -16,7 +16,8 @@
 .pagination li {
     display: inline;
   }
-.pagination a, span {
+.pagination a,
+.pagination span {
   float: left;
   padding: 0 14px;
   line-height: (@baseLineHeight * 2) - 2;


### PR DESCRIPTION
To use the pagination without an anchor tag as suggested in ticket #1406 , the span tag must also have the default class rule applied so that text will align correctly and such, eg:
`<li class="disabled"><span>Prev</span></li>`
