### PR TITLE
Corrected spelling error

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -14,7 +14,7 @@
   margin-bottom: @baseLineHeight;
 }
 
-// Gradient is applied to it's own element because overflow visible is not honored by IE when filter is present
+// Gradient is applied to its own element because overflow visible is not honored by IE when filter is present
 .navbar-inner {
   min-height: @navbarHeight;
   padding-left:  20px;


### PR DESCRIPTION
Mostly you get this right (it's vs its) in the comments, but here you made an error. I just figured you'd want to be as precise with your documentation as you are with your code.
