### PR TITLE
Replaced find() calls with children() in typeahead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This is a convenience method for watching just Less files and automatically buil
 Contributing
 ------------
 
-Please make all pull requests against wip-* branches. Also, if your unit test contains javascript patches or features - you must include relevant unit tests. Thanks!
+Please make all pull requests against wip-* branches. Also, if your pull request contains javascript patches or features - you must include relevant unit tests. Thanks!
 
 
 Authors

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -151,7 +151,7 @@
         , next = active.next()
 
       if (!next.length) {
-        next = $(this.$menu.find('li')[0])
+        next = $(this.$menu.children('li')[0])
       }
 
       next.addClass('active')
@@ -162,7 +162,7 @@
         , prev = active.prev()
 
       if (!prev.length) {
-        prev = this.$menu.find('li').last()
+        prev = this.$menu.children('li').last()
       }
 
       prev.addClass('active')

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -177,10 +177,9 @@
       if ($.browser.webkit || $.browser.msie) {
         this.$element.on('keydown', $.proxy(this.keydown, this))
       }
-
-      this.$menu
-        .on('click', $.proxy(this.click, this))
-        .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
+      
+      this.$menu.on('click', $.proxy(this.click, this))
+      this.$menu.children('li').on('mouseenter', $.proxy(this.mouseenter, this))
     }
 
   , move: function (e) {


### PR DESCRIPTION
Fixed error in typeahead module that were caused by ul/li inside of item in $menu.
Also update documentation.
