### PR TITLE
Make sure that ".row-fluid .spanX" doesn't not prevent table cell sizing.

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -148,7 +148,7 @@ table {
 // -----------------
 
 // Change the columns
-table {
+table, .row-fluid table {
   .span1     { .tableColumns(1); }
   .span2     { .tableColumns(2); }
   .span3     { .tableColumns(3); }


### PR DESCRIPTION
Here is a commit prenventing that the change from ".row-fluid > .spanX" to  ".row-fluid .spanX" does not override table cell sizing for the fluid layout.
It fixes fixes twitter/bootstrap#3227.
