### PR TITLE
".linenums .tag" should be ".prettyprint .tag".

### DIFF
--- a/docs/assets/js/google-code-prettify/prettify.css
+++ b/docs/assets/js/google-code-prettify/prettify.css
@@ -3,7 +3,7 @@
 .pun, .opn, .clo { color: #93a1a1; }
 .fun { color: #dc322f; }
 .str, .atv { color: #D14; }
-.kwd, .linenums .tag { color: #1e347b; }
+.kwd, .prettyprint .tag { color: #1e347b; }
 .typ, .atn, .dec, .var { color: teal; }
 .pln { color: #48484c; }
 


### PR DESCRIPTION
prettyprint does not apply a color to XML tag when we use the default prettyprint.css.
.linunums .tag should be .prettyprint .tag.
This patch resolves this prettyprint color issue.

&lt;pre class="prettyprint lang-xml"&gt;
&amp;lt;root&amp;gt;
  &amp;lt;item&amp;gt;item1&amp;lt;/item&amp;gt;
  &amp;lt;item&amp;gt;item2&amp;lt;/item&amp;gt;
  &amp;lt;item&amp;gt;item3&amp;lt;/item&amp;gt;
&amp;lt;/root&amp;gt;
&lt;/pre&gt;
