### PR TITLE
Fix Opera .clearfix bug when using contenteditable

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -15,6 +15,9 @@
   &:after {
     display: table;
     content: "";
+    // Fixes Opera/contenteditable bug:
+    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
+    line-height: 0;
   }
   &:after {
     clear: both;


### PR DESCRIPTION
Fixes a bug w/ the .clearfix trick affecting Opera browsers when there is a contenteditable div on the page. We ran into this ourselves w/ Disqus (in Opera 12), but it has been reported by at least one other user on Nicholas Gallagher's blog post:

> In Opera 11.62 if on page we have any div.clearfix and any `<div contenteditable="true">`, the blocks with clearfix have additional height.

http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952

In the comments, Nick suggests using `height: 0` or `font: 0/0` – we made this fix before finding the blog post (sigh), and found `line-height: 0` worked fine.

If you're curious _just how much height_ this added, here's a screen shot of Disqus in Opera 12 _before_ this patch was applied: http://dl.dropbox.com/u/421333/Screenshots/avu~_coot-_-.png
