### PR TITLE
Add "inline" style so that a component can be set to display completely inline

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4981,3 +4981,7 @@ a.badge:hover {
 .invisible {
   visibility: hidden;
 }
+
+.inline {
+  display: inline;
+}


### PR DESCRIPTION
This is particularly useful for inline forms in regions with limited space, e.g. a navbar (see http://jsfiddle.net/9ttH5/4/).
