### PR TITLE
Allow alternate text for assistive devices in icon tags

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -18,7 +18,9 @@
 [class*=" icon-"] {
   display: inline-block;
   width: 14px;
-  height: 14px;
+  height: 0;
+  padding-top:14px;
+  overflow:hidden;
   .ie7-restore-right-whitespace();
   line-height: 14px;
   vertical-align: text-top;


### PR DESCRIPTION
When you have a button containing only an icon (such as just displaying a magnifying glass to indicate the submit button for a search input), there's no alternate display for assistive devices. This can be accounted for by placing text within the `<i>` tag, but Bootstrap does not currently visually hide text within an `<i>` tag.

See: http://jsfiddle.net/chrisdpratt/N2xym/

The first group of buttons shows what happens currently when text is placed inside an `<i>` tag. The second group shows the display after the suggested change.
