### PR TITLE
Fixed option handling when multiple carousels are on same page

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -140,7 +140,8 @@
         , options = $.extend({}, $.fn.carousel.defaults, typeof option == 'object' && option)
       if (!data) $this.data('carousel', (data = new Carousel(this, options)))
       if (typeof option == 'number') data.to(option)
-      else if (typeof option == 'string' || (option = options.slide)) data[option]()
+      else if (typeof option == 'string') data[option]()
+      else if (options.slide) data[options.slide]()
       else if (options.interval) data.cycle()
     })
   }


### PR DESCRIPTION
With the current implementation, the carousel options get blown away when initializing the first carousel on a page.  All subsequent carousels will use default options.  This change fixes the bug.
