### PR TITLE
less specific default alignment for table cells

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -24,7 +24,6 @@ table {
   td {
     padding: 8px;
     line-height: @baseLineHeight;
-    text-align: left;
     vertical-align: top;
     border-top: 1px solid @tableBorder;
   }
@@ -50,7 +49,10 @@ table {
   }
 }
 
-
+th,
+td {
+  text-align: center;
+}
 
 // CONDENSED TABLE W/ HALF PADDING
 // -------------------------------


### PR DESCRIPTION
table th, table td is giving me unsolicited headaches and less love than I deserve when it comes to customize the alignment of some cells in my tables via small utility classes like 

``` html
<table class="table">
...
  <td>hey an item</td>
  <td class="text-center"><img src="myEditIcon" /></td>
...
</table>
```

``` css
...
text-center {
  text-align: center;
}
...
```

So, I moved the default text-align for table cells outside the `.table` selector.
This way, I have both the default alignment and the power to easily override it only where I need to.
