### PR TITLE
Carousel: Use numeric data-slide to change slide

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -167,7 +167,7 @@
     $('body').on('click.carousel.data-api', '[data-slide]', function ( e ) {
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-        , options = !$target.data('modal') && $.extend({}, $target.data(), $this.data())
+        , options = $.isNumeric($this.data('slide')) ? +($this.data('slide')) : !$target.data('modal') && $.extend({}, $target.data(), $this.data())
       $target.carousel(options)
       e.preventDefault()
     })


### PR DESCRIPTION
Allows use of a numeric value in data-slide to create carousel controls
that navigate directly to a slide.

Example:

``` html
<a class='thumbnail carousel-control' href='#myCarousel' data-slide='1'><img src='assets/images/main/NAIOP2011-150w.jpg' alt='Click this image to navigate the carousel to the second image' /></a>
```
