### PR TITLE
Full height progress bar

### DIFF
--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -54,7 +54,7 @@
 // Bar of progress
 .progress .bar {
   width: 0%;
-  height: 18px;
+  height: 100%;
   color: @white;
   font-size: 12px;
   text-align: center;


### PR DESCRIPTION
Teeny tiny change.

``` css
.progress .bar {
  height: 100%
}
```

This way, you can have progress bars of variable height on `.progress` and not have to overwrite `.progress .bar` as well
