### PR TITLE
Allow buttons-radio options to be deselected

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1062,6 +1062,23 @@ $('#my-alert').bind('closed', function () {
 &lt;/div&gt;
 </pre>
 
+  <h4>{{_i}}Radio - Optional{{/i}}</h4>
+  <p>{{_i}}Add data-toggle="buttons-radio-optional" for radio style toggling on btn-group, where deselecting a choice is allowed.{{/i}}</p>
+  <div class="bs-docs-example" style="padding-bottom: 24px;">
+    <div class="btn-group" data-toggle="buttons-radio-optional">
+      <button class="btn btn-primary">{{_i}}Left{{/i}}</button>
+      <button class="btn btn-primary">{{_i}}Middle{{/i}}</button>
+      <button class="btn btn-primary">{{_i}}Right{{/i}}</button>
+    </div>
+  </div>{{! /example }}
+<pre class="prettyprint linenums">
+&lt;div class="btn-group" data-toggle="buttons-radio-optional"&gt;
+  &lt;button class="btn"&gt;Left&lt;/button&gt;
+  &lt;button class="btn"&gt;Middle&lt;/button&gt;
+  &lt;button class="btn"&gt;Right&lt;/button&gt;
+&lt;/div&gt;
+</pre>
+
 
   <hr class="bs-docs-separator">
 

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -51,13 +51,21 @@
   }
 
   Button.prototype.toggle = function () {
-    var $parent = this.$element.parent('[data-toggle="buttons-radio"]')
-
-    $parent && $parent
-      .find('.active')
-      .removeClass('active')
+    var $parent = this.$element.parent('[data-toggle="buttons-radio"], [data-toggle="buttons-radio-optional"]')
 
     this.$element.toggleClass('active')
+
+    if ($parent && $parent.attr('data-toggle') == 'buttons-radio') {
+      $parent
+        .find('.active')
+        .removeClass('active');
+      this.$element.toggleClass('active')
+    } else if ($parent) {
+      $parent
+        .find('.active')
+        .not(this.$element)
+        .removeClass('active');
+    }
   }
 
 


### PR DESCRIPTION
Simple change: `buttons-radio-optional` behaves like `buttons-radio` except it allows the user to deselect a chosen button.

Basically, if you have two buttons in a `buttons-radio` group, by using `buttons-radio-optional` instead you could have a 3rd state of neither button selected.
