### PR TITLE
Adding 'connect' npm requirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Developers
 We have included a makefile with convenience methods for working with the Bootstrap library.
 
 + **dependencies**
-Our makefile depends on you having recess, uglify.js, and jshint installed. To install, just run the following command in npm:
+Our makefile depends on you having recess, connect, uglify.js, and jshint installed. To install, just run the following command in npm:
 
 ```
-$ npm install recess uglify-js jshint -g
+$ npm install recess connect uglify-js jshint -g
 ```
 
 + **build** - `make`


### PR DESCRIPTION
Adding 'connect' npm requirement as it is required to run `make test` (in order for it to run `node js/tests/server.js`)
