### PR TITLE
Fixed end of transition event for IE 10 (Windows 8)

### DIFF
--- a/docs/assets/js/bootstrap-transition.js
+++ b/docs/assets/js/bootstrap-transition.js
@@ -38,7 +38,7 @@
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd'
             ,  'transition'       : 'transitionend'
-			,  'msTransition'     : 'MSTransitionEnd'
+            ,  'msTransition'     : 'MSTransitionEnd'
             }
           , name
 

--- a/docs/assets/js/bootstrap-transition.js
+++ b/docs/assets/js/bootstrap-transition.js
@@ -37,8 +37,8 @@
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd'
-            ,  'msTransition'     : 'MSTransitionEnd'
             ,  'transition'       : 'transitionend'
+			,  'msTransition'     : 'MSTransitionEnd'
             }
           , name
 

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -107,7 +107,7 @@
         $next[0].offsetWidth // force reflow
         $active.addClass(direction)
         $next.addClass(direction)
-        this.$element.one("transitionEnd oTransitionEnd msTransitionEnd transitionend webkitTransitionEnd", function () {
+        this.$element.one($.support.transition.end, function () {
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -107,7 +107,7 @@
         $next[0].offsetWidth // force reflow
         $active.addClass(direction)
         $next.addClass(direction)
-        this.$element.one($.support.transition.end, function () {
+        this.$element.one("transitionEnd oTransitionEnd msTransitionEnd transitionend webkitTransitionEnd", function () {
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -38,7 +38,7 @@
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd'
             ,  'transition'       : 'transitionend'
-			,  'msTransition'     : 'MSTransitionEnd'
+            ,  'msTransition'     : 'MSTransitionEnd'
             }
           , name
 

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -37,8 +37,8 @@
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd'
-            ,  'msTransition'     : 'MSTransitionEnd'
             ,  'transition'       : 'transitionend'
+			,  'msTransition'     : 'MSTransitionEnd'
             }
           , name
 


### PR DESCRIPTION
Fix for my issue #4011: https://github.com/twitter/bootstrap/issues/4011
