### PR TITLE
wrapping .btn states into .btn parent

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -27,46 +27,46 @@
   .border-radius(4px);
   .ie7-restore-left-whitespace(); // Give IE7 some love
   .box-shadow(~"inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
+
+  // Hover state
+  &:hover {
+    color: @grayDark;
+    text-decoration: none;
+    background-color: darken(@white, 10%);
+    *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
+    background-position: 0 -15px;
+  
+    // transition is only when going to hover, otherwise the background
+    // behind the gradient (there for IE<=9 fallback) gets mismatched
+    .transition(background-position .1s linear);
+  }
+  
+  // Focus state for keyboard and accessibility
+  &:focus {
+    .tab-focus();
+  }
+  
+  // Active state
+  &.active,
+  &:active {
+    background-color: darken(@white, 10%);
+    background-color: darken(@white, 15%) e("\9");
+    background-image: none;
+    outline: 0;
+    .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
+  }
+
+  // Disabled state
+  &.disabled,
+  &[disabled] {
+    cursor: default;
+    background-color: darken(@white, 10%);
+    background-image: none;
+    .opacity(65);
+    .box-shadow(none);
+  }
+
 }
-
-// Hover state
-.btn:hover {
-  color: @grayDark;
-  text-decoration: none;
-  background-color: darken(@white, 10%);
-  *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
-  background-position: 0 -15px;
-
-  // transition is only when going to hover, otherwise the background
-  // behind the gradient (there for IE<=9 fallback) gets mismatched
-  .transition(background-position .1s linear);
-}
-
-// Focus state for keyboard and accessibility
-.btn:focus {
-  .tab-focus();
-}
-
-// Active state
-.btn.active,
-.btn:active {
-  background-color: darken(@white, 10%);
-  background-color: darken(@white, 15%) e("\9");
-  background-image: none;
-  outline: 0;
-  .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
-}
-
-// Disabled state
-.btn.disabled,
-.btn[disabled] {
-  cursor: default;
-  background-color: darken(@white, 10%);
-  background-image: none;
-  .opacity(65);
-  .box-shadow(none);
-}
-
 
 // Button Sizes
 // --------------------------------------------------


### PR DESCRIPTION
I like to have the .btn states wrapped inside .btn. Because when i want to add the btn style to a element i simple just can't with mixins right now

```
.mybtn {
 .btn();
}
```

will work but it will not mix the hover states and so on in. And less fails to ...

```
.mybtn {
 .btn;
 .btn:hover;
}
```

... do something like that. I think there are other places in bootstrap like that. I really would appreciate if less would be used in full extent, like its supposed to be, meaning wrapping almost everything inside parent elements if possible. Some consistency would be nice. It's done right on so many other places in bootstrap. 

We could of course edit out buttons inside bootstrap core and have even less css in the end, but i would like to keep bootsrap untouched or small things like that. I am developing a theme framework and some elements should just not always look like .btn so just adding the classes is not the best solution for this.

During my less development i started doing thinks like this the 'CSS way' but now i tend to wrap everything i can into patents, it not only good for mixins functionality, its also very readable.
