### PR TITLE
Support .disabled on tabs and pills

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -47,7 +47,7 @@
         selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
       }
 
-      if ( $this.parent('li').hasClass('active') ) return
+      if ( $this.parent('li').hasClass('active') || $this.parent('li').hasClass('disabled') ) return
 
       previous = $ul.find('.active a').last()[0]
 

--- a/less/navs.less
+++ b/less/navs.less
@@ -128,6 +128,15 @@
   border-bottom-color: transparent;
   cursor: default;
 }
+// Disabled state, and it's :hover to override normal :hover
+.nav-tabs > .disabled > a,
+.nav-tabs > .disabled > a:hover {
+  color: @grayLight;
+  background-color: @white;
+  border: 1px solid transparent;
+  border-bottom-color: #ddd;
+  cursor: default;
+}
 
 
 // PILLS
@@ -148,7 +157,13 @@
   color: @white;
   background-color: @linkColor;
 }
-
+// Disabled state
+.nav-pills > .disabled > a,
+.nav-pills > .disabled > a:hover {
+  color: @grayLight;
+  background-color: transparent;
+  cursor: default;
+}
 
 
 // STACKED NAV


### PR DESCRIPTION
This is basicly an adaptation of @arnar work in https://github.com/twitter/bootstrap/pull/853 for bootstrap 2:
"This diff adds support for .disabled class on tabs and pills. They are rendered with light gray text and the JS ignores clicks."
