### PR TITLE
Scrollspy. Allow to use 'dot', 'colon' and another characters inside the 'id' attribute.

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -56,7 +56,7 @@
           .map(function () {
             var $el = $(this)
               , href = $el.data('target') || $el.attr('href')
-              , $href = /^#\w/.test(href) && $(href)
+              , $href = /^#\w/.test(href) && $('[id="' + href.slice(1) + '"]')
             return ( $href
               && $href.length
               && [[ $href.position().top, href ]] ) || null


### PR DESCRIPTION
HTML4 spec lets to use 'dot' and 'colon' - http://www.w3.org/TR/html4/types.html#type-name, HTML5 - any character - http://www.w3.org/TR/html5/global-attributes.html#the-id-attribute. 

This solution isn't perfect, still some characters prevent jQuery from selecting an element from the dom tree. 
If you want I can add tests.
