### PR TITLE
Retina Display Classes

### DIFF
--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -1,5 +1,7 @@
-// RESPONSIVE CLASSES
-// ------------------
+//
+// Responsive: Utility classes
+// --------------------------------------------------
+
 
 // Hide from screenreaders and browsers
 // Credit: HTML5 Boilerplate
@@ -17,6 +19,19 @@
 .hidden-phone      { }
 .hidden-tablet     { }
 .hidden-desktop    { display: none !important; }
+.hidden-hd         { display: inherit !important; }
+.visible-hd        { display: none !important; }
+
+// Tablets & small desktops only
+@media (min-width: 768px) and (max-width: 979px) {
+  // Show
+  .visible-tablet    { display: inherit !important; }
+  // Hide
+  .hidden-tablet     { display: none !important; }
+  // Hide everything else
+  .hidden-desktop    { display: inherit !important; }
+  .visible-desktop   { display: none !important ; }
+}
 
 // Phones only
 @media (max-width: 767px) {
@@ -29,13 +44,8 @@
   .visible-desktop   { display: none !important; }
 }
 
-// Tablets & small desktops only
-@media (min-width: 768px) and (max-width: 979px) {
-  // Show
-  .visible-tablet    { display: inherit !important; }
-  // Hide
-  .hidden-tablet     { display: none !important; }
-  // Hide everything else
-  .hidden-desktop    { display: inherit !important; }
-  .visible-desktop   { display: none !important ; }
+// Retina display devices only
+@media all and (-webkit-min-device-pixel-ratio : 1.5) {
+  .hidden-hd         { display: none !important; }
+  .visible-hd        { display: inherit !important; }
 }


### PR DESCRIPTION
Adding classes for toggling visibility on elements on retina displays.

These work in the same way as the `.visible-phone` or `.hidden-desktop` etc. classes work by toggling between "none" or "inherit" for the "display" attribute.  By default, `.visible-hd` is not shown.
