### PR TITLE
Adjust wording for apps (on 2.1.0-wip)

### DIFF
--- a/docs/extend.html
+++ b/docs/extend.html
@@ -156,13 +156,13 @@
   <p><a href="http://incident57.com/less/">The unofficial Mac app</a> watches directories of .less files and compiles the code to local files after every save of a watched .less file.</p>
   <p>If you like, you can toggle preferences in the app for automatic minifying and which directory the compiled files end up in.</p>
 
-  <h3>More Mac apps</h3>
+  <h3>More apps</h3>
   <h4><a href="http://crunchapp.net/" target="_blank">Crunch</a></h4>
   <p>Crunch is a great looking LESS editor and compiler built on Adobe Air.</p>
   <h4><a href="http://incident57.com/codekit/" target="_blank">CodeKit</a></h4>
   <p>Created by the same guy as the unofficial Mac app, CodeKit is a Mac app that compiles LESS, SASS, Stylus, and CoffeeScript.</p>
   <h4><a href="http://wearekiss.com/simpless" target="_blank">Simpless</a></h4>
-  <p>Mac, Linux, and PC app for drag and drop compiling of LESS files. Plus, the <a href="https://github.com/Paratron/SimpLESS" target="_blank">source code is on GitHub</a>.</p>
+  <p>Mac, Linux, and Windows app for drag and drop compiling of LESS files. Plus, the <a href="https://github.com/Paratron/SimpLESS" target="_blank">source code is on GitHub</a>.</p>
 
 </section>
 

--- a/docs/templates/pages/extend.mustache
+++ b/docs/templates/pages/extend.mustache
@@ -79,12 +79,12 @@
   <p>{{_i}}<a href="http://incident57.com/less/">The unofficial Mac app</a> watches directories of .less files and compiles the code to local files after every save of a watched .less file.{{/i}}</p>
   <p>{{_i}}If you like, you can toggle preferences in the app for automatic minifying and which directory the compiled files end up in.{{/i}}</p>
 
-  <h3>{{_i}}More Mac apps{{/i}}</h3>
+  <h3>{{_i}}More apps{{/i}}</h3>
   <h4><a href="http://crunchapp.net/" target="_blank">Crunch</a></h4>
   <p>{{_i}}Crunch is a great looking LESS editor and compiler built on Adobe Air.{{/i}}</p>
   <h4><a href="http://incident57.com/codekit/" target="_blank">CodeKit</a></h4>
   <p>{{_i}}Created by the same guy as the unofficial Mac app, CodeKit is a Mac app that compiles LESS, SASS, Stylus, and CoffeeScript.{{/i}}</p>
   <h4><a href="http://wearekiss.com/simpless" target="_blank">Simpless</a></h4>
-  <p>{{_i}}Mac, Linux, and PC app for drag and drop compiling of LESS files. Plus, the <a href="https://github.com/Paratron/SimpLESS" target="_blank">source code is on GitHub</a>.{{/i}}</p>
+  <p>{{_i}}Mac, Linux, and Windows app for drag and drop compiling of LESS files. Plus, the <a href="https://github.com/Paratron/SimpLESS" target="_blank">source code is on GitHub</a>.{{/i}}</p>
 
 </section>


### PR DESCRIPTION
This is the same change as #4029, but updated per @fat:

> we don't take pulls against gh-pages, you need to change the docs in the -wip branch

Original description from #4029:

> Two of the three apps listed are for Linux/Windows.  I adjusted the wording to clarify, as I originally skipped this section because I'm not using OS X.
> 
> Just a simple change.  :smile:
> 
> **Note:** this is just a pull request for the `gh-pages` branch.
