### PR TITLE
Added dropdown-header that acts like nav-header for dropdowns

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -295,8 +295,10 @@ $('#myModal').on('hidden', function () {
                   <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{_i}}Dropdown{{/i}} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
+                      <li class="dropdown-header">Header</li>
                       <li><a href="#">{{_i}}Action{{/i}}</a></li>
                       <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                      <li class="dropdown-header">Another header</li>
                       <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                       <li class="divider"></li>
                       <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -305,8 +307,10 @@ $('#myModal').on('hidden', function () {
                   <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{_i}}Dropdown 2 {{/i}}<b class="caret"></b></a>
                     <ul class="dropdown-menu">
+                      <li class="dropdown-header">Header</li>
                       <li><a href="#">{{_i}}Action{{/i}}</a></li>
                       <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                      <li class="dropdown-header">Another header</li>
                       <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                       <li class="divider"></li>
                       <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -317,8 +321,10 @@ $('#myModal').on('hidden', function () {
                   <li id="fat-menu" class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{_i}}Dropdown 3{{/i}} <b class="caret"></b></a>
                     <ul class="dropdown-menu">
+                      <li class="dropdown-header">Header</li>
                       <li><a href="#">{{_i}}Action{{/i}}</a></li>
                       <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                      <li class="dropdown-header">Another header</li>
                       <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                       <li class="divider"></li>
                       <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -334,8 +340,10 @@ $('#myModal').on('hidden', function () {
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{_i}}Dropdown{{/i}} <b class="caret"></b></a>
               <ul id="menu1" class="dropdown-menu">
+                <li class="dropdown-header">Header</li>
                 <li><a href="#">{{_i}}Action{{/i}}</a></li>
                 <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                <li class="dropdown-header">Another header</li>
                 <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                 <li class="divider"></li>
                 <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -344,8 +352,10 @@ $('#myModal').on('hidden', function () {
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{_i}}Dropdown 2{{/i}} <b class="caret"></b></a>
               <ul id="menu2" class="dropdown-menu">
+                <li class="dropdown-header">Header</li>
                 <li><a href="#">{{_i}}Action{{/i}}</a></li>
                 <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                <li class="dropdown-header">Another header</li>
                 <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                 <li class="divider"></li>
                 <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -354,8 +364,10 @@ $('#myModal').on('hidden', function () {
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{_i}}Dropdown 3{{/i}} <b class="caret"></b></a>
               <ul id="menu3" class="dropdown-menu">
+                <li class="dropdown-header">Header</li>
                 <li><a href="#">{{_i}}Action{{/i}}</a></li>
                 <li><a href="#">{{_i}}Another action{{/i}}</a></li>
+                <li class="dropdown-header">Another header</li>
                 <li><a href="#">{{_i}}Something else here{{/i}}</a></li>
                 <li class="divider"></li>
                 <li><a href="#">{{_i}}Separated link{{/i}}</a></li>
@@ -383,8 +395,10 @@ $('#myModal').on('hidden', function () {
       &lt;b class="caret"&gt;&lt;/b&gt;
     &lt;/a&gt;
     &lt;ul class="dropdown-menu"&gt;
+      &lt;li class="dropdown-header"&gt;Header&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;{{_i}}Action{{/i}}&lt;/a&gt;&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;{{_i}}Another action{{/i}}&lt;/a&gt;&lt;/li&gt;
+      &lt;li class="dropdown-header"&gt;Another Header&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;{{_i}}Something else here{{/i}}&lt;/a&gt;&lt;/li&gt;
       &lt;li class="divider"&gt;&lt;/li&gt;
       &lt;li&gt;&lt;a href="#"&gt;{{_i}}Separated link{{/i}}&lt;/a&gt;&lt;/li&gt;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -87,7 +87,7 @@
 
   // Dropdown menu header
   .dropdown-header {
-    .list-header();
+    .list-header;
   }
 }
 

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -84,6 +84,11 @@
     color: @dropdownLinkColor;
     white-space: nowrap;
   }
+
+  // Dropdown menu header
+  .dropdown-header {
+    .list-header();
+  }
 }
 
 // Hover state

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -644,3 +644,16 @@
   }
 
 }
+
+// List header style
+
+.list-header () {
+  display: block;
+  padding: 3px 15px;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: @baseLineHeight;
+  color: @grayLight;
+  text-shadow: 0 1px 0 rgba(255,255,255,.5);
+  text-transform: uppercase;
+}

--- a/less/navs.less
+++ b/less/navs.less
@@ -28,14 +28,7 @@
 
 // Nav headers (for dropdowns and lists)
 .nav .nav-header {
-  display: block;
-  padding: 3px 15px;
-  font-size: 11px;
-  font-weight: bold;
-  line-height: @baseLineHeight;
-  color: @grayLight;
-  text-shadow: 0 1px 0 rgba(255,255,255,.5);
-  text-transform: uppercase;
+  .list-header;
 }
 // Space them out when they follow another list item (link)
 .nav li + .nav-header {


### PR DESCRIPTION
Currently it is possible to have nav-headers inside of dropdowns only if dropdown is inside a nav. This patch fixes that shortcoming by adding "dropdown-header" class that works inside any dropdown-menu.
