### PR TITLE
IE10 uses 'transitionend', not 'MSTransitionEnd'

### DIFF
--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -37,7 +37,7 @@
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd'
-            ,  'msTransition'     : 'MSTransitionEnd'
+            ,  'msTransition'     : 'transitionend'
             ,  'transition'       : 'transitionend'
             }
           , name


### PR DESCRIPTION
Test case: http://jsfiddle.net/7mEjC/

Only the transitionend event is fired after transitions. This is documented here: http://msdn.microsoft.com/en-us/library/ie/hh673535(v=vs.85).aspx#transitions_dom_events

Tested in IE 10.0.8400
