### PR TITLE
Sub-divide the desktop responsive utility classes to include specific desktop sizes

### DIFF
--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -13,15 +13,15 @@
 // Visibility utilities
 
 // For desktops (980px to 1199px)
-.visible-phone    { display: none !important; }
+.visible-phone    { display: none !important; }     // Do not display
 .visible-tablet   { display: none !important; }
 .visible-wide     { display: none !important; }
-.hidden-phone     { }
+.hidden-phone     { }                               // Do not set initially
 .hidden-tablet    { }
 .hidden-desktop   { display: none !important; }
 .hidden-normal    { display: none !important; }
 .hidden-wide      { }
-.visible-desktop  { display: inherit !important; }
+.visible-desktop  { display: inherit !important; }  // Use inherit to restore previous behavior
 .visible-normal   { display: inherit !important; }
 
 // Phones only
@@ -33,7 +33,7 @@
   .visible-normal   { display: none !important; }
   
   // Show
-  .visible-phone    { display: inherit !important; } // Use inherit to restore previous behavior
+  .visible-phone    { display: inherit !important; }
   
   // Hide
   .hidden-phone     { display: none !important; }

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -13,56 +13,56 @@
 // Visibility utilities
 
 // For desktops (980px to 1199px)
-.visible-phone     { display: none !important; }
-.visible-tablet    { display: none !important; }
-.visible-1200      { display: none !important; }
-.hidden-phone      { }
-.hidden-tablet     { }
-.hidden-desktop    { display: none !important; }
-.hidden-980        { display: none !important; }
-.hidden-1200       { }
-.visible-desktop   { display: inherit !important; }
-.visible-980       { display: inherit !important; }
+.visible-phone    { display: none !important; }
+.visible-tablet   { display: none !important; }
+.visible-wide     { display: none !important; }
+.hidden-phone     { }
+.hidden-tablet    { }
+.hidden-desktop   { display: none !important; }
+.hidden-normal    { display: none !important; }
+.hidden-wide      { }
+.visible-desktop  { display: inherit !important; }
+.visible-normal   { display: inherit !important; }
 
 // Phones only
 @media (max-width: 767px) {
   // Everything else
-  .hidden-desktop    { display: inherit !important; }
-  .hidden-980        { display: inherit !important; }
-  .visible-desktop   { display: none !important; }
-  .visible-980       { display: none !important; }
+  .hidden-desktop   { display: inherit !important; }
+  .hidden-normal    { display: inherit !important; }
+  .visible-desktop  { display: none !important; }
+  .visible-normal   { display: none !important; }
   
   // Show
-  .visible-phone     { display: inherit !important; } // Use inherit to restore previous behavior
+  .visible-phone    { display: inherit !important; } // Use inherit to restore previous behavior
   
   // Hide
-  .hidden-phone      { display: none !important; }
+  .hidden-phone     { display: none !important; }
 }
 
 // Tablets & small desktops only
 @media (min-width: 768px) and (max-width: 979px) {
   // Everything else
-  .hidden-desktop    { display: inherit !important; }
-  .hidden-980        { display: inherit !important; }
-  .visible-desktop   { display: none !important; }
-  .visible-980       { display: none !important; }
+  .hidden-desktop   { display: inherit !important; }
+  .hidden-normal    { display: inherit !important; }
+  .visible-desktop  { display: none !important; }
+  .visible-normal   { display: none !important; }
   
   // Show
-  .visible-tablet    { display: inherit !important; }
+  .visible-tablet   { display: inherit !important; }
   
   // Hide
-  .hidden-tablet     { display: none !important; }
+  .hidden-tablet    { display: none !important; }
 }
 
 // Desktops (1200px and above) only
 @media (min-width: 1200px) {
   // Everything else
-  .hidden-980        { display: inherit !important; }
-  .visible-980       { display: none !important; }
+  .hidden-normal    { display: inherit !important; }
+  .visible-normal   { display: none !important; }
   
   // Show
-  .visible-1200      { display: inherit !important; }
+  .visible-wide     { display: inherit !important; }
   
   // Hide
-  .hidden-1200       { display: none !important; }
+  .hidden-wide      { display: none !important; }
 }

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -1,5 +1,7 @@
-// RESPONSIVE CLASSES
-// ------------------
+//
+// Responsive: Utility classes
+// --------------------------------------------------
+
 
 // Hide from screenreaders and browsers
 // Credit: HTML5 Boilerplate

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -1,7 +1,5 @@
-//
-// Responsive: Utility classes
-// --------------------------------------------------
-
+// RESPONSIVE CLASSES
+// ------------------
 
 // Hide from screenreaders and browsers
 // Credit: HTML5 Boilerplate
@@ -12,32 +10,57 @@
 
 // Visibility utilities
 
-// For desktops
+// For desktops (980px to 1199px)
 .visible-phone     { display: none !important; }
 .visible-tablet    { display: none !important; }
+.visible-1200      { display: none !important; }
 .hidden-phone      { }
 .hidden-tablet     { }
 .hidden-desktop    { display: none !important; }
+.hidden-980        { display: none !important; }
+.hidden-1200       { }
 .visible-desktop   { display: inherit !important; }
+.visible-980       { display: inherit !important; }
+
+// Phones only
+@media (max-width: 767px) {
+  // Everything else
+  .hidden-desktop    { display: inherit !important; }
+  .hidden-980        { display: inherit !important; }
+  .visible-desktop   { display: none !important; }
+  .visible-980       { display: none !important; }
+  
+  // Show
+  .visible-phone     { display: inherit !important; } // Use inherit to restore previous behavior
+  
+  // Hide
+  .hidden-phone      { display: none !important; }
+}
 
 // Tablets & small desktops only
 @media (min-width: 768px) and (max-width: 979px) {
-  // Hide everything else
+  // Everything else
   .hidden-desktop    { display: inherit !important; }
-  .visible-desktop   { display: none !important ; }
+  .hidden-980        { display: inherit !important; }
+  .visible-desktop   { display: none !important; }
+  .visible-980       { display: none !important; }
+  
   // Show
   .visible-tablet    { display: inherit !important; }
+  
   // Hide
   .hidden-tablet     { display: none !important; }
 }
 
-// Phones only
-@media (max-width: 767px) {
-  // Hide everything else
-  .hidden-desktop    { display: inherit !important; }
-  .visible-desktop   { display: none !important; }
+// Desktops (1200px and above) only
+@media (min-width: 1200px) {
+  // Everything else
+  .hidden-980        { display: inherit !important; }
+  .visible-980       { display: none !important; }
+  
   // Show
-  .visible-phone     { display: inherit !important; } // Use inherit to restore previous behavior
+  .visible-1200      { display: inherit !important; }
+  
   // Hide
-  .hidden-phone      { display: none !important; }
+  .hidden-1200       { display: none !important; }
 }


### PR DESCRIPTION
This patch adds the `.visible-980`, `.visible-1200`, `.hidden-980`, and `.hidden-1200` classes.

**_Update:**_ scotty6435 recommended changing the pixel amounts into `normal` and `wide`. That sounded like a good idea, so I changed the classes into `.visible-normal`, `.visible-wide`, `.hidden-normal`, and `.hidden-wide`.

| Class | Phones | Tablets | Desktops (980-1199px) | Desktops (1200px and up) |
| --- | --- | --- | --- | --- |
| .visible-desktop | hidden | hidden | visible | visible |
| .visible-normal | hidden | hidden | visible | hidden |
| .visible-wide | hidden | hidden | hidden | visible |
| .hidden-desktop | visible | visible | hidden | hidden |
| .hidden-normal | visible | visible | hidden | visible |
| .hidden-wide | visible | visible | visible | hidden |
