### PR TITLE
Removed padding from container-fluid if inside a modal-body

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -62,10 +62,15 @@
   max-height: 400px;
   padding: 15px;
 }
+// Remove container padding if inside a modal body
+.modal-body > .container-fluid {
+  padding: 0;
+}
 // Remove bottom margin if need be
 .modal-form {
   margin-bottom: 0;
 }
+
 
 // Footer (for actions)
 .modal-footer {

--- a/less/modals.less
+++ b/less/modals.less
@@ -71,7 +71,6 @@
   margin-bottom: 0;
 }
 
-
 // Footer (for actions)
 .modal-footer {
   padding: 14px 15px 15px;


### PR DESCRIPTION
This PR removes the padding from .container-fluid if it is used inside a modal-body:

e.g:

``` html
<div class="modal hide fade" id="someDlg">
  <div class="modal-body">
    <div class="container-fluid"> <!-- Used here.. -->
      <div class="row-fluid">
        ...
      </div>
    </div>
  </div>
</div>
```
