### PR TITLE
Allow reuse of makefile to easily override bootstrap without any modifications in repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BOOTSTRAP = ./docs/assets/css/bootstrap.css
-BOOTSTRAP_LESS = ./less/bootstrap.less
+BOOTSTRAP_LESS ?= ./less/bootstrap.less
 BOOTSTRAP_RESPONSIVE = ./docs/assets/css/bootstrap-responsive.css
-BOOTSTRAP_RESPONSIVE_LESS = ./less/responsive.less
+BOOTSTRAP_RESPONSIVE_LESS ?= ./less/responsive.less
 DATE=$(shell date +%I:%M%p)
 CHECK=\033[32m✔\033[39m
 HR=\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#


### PR DESCRIPTION
Set values of BOOTSTRAP_LESS and BOOSTRAP_RESPONSIVE_LESS only if they not already set

When twitter boostrap makefile used in sub-make call, BOOTSTRAP_LESS and BOOSTRAP_RESPONSIVE_LESS can be set and exported in parent makefile.

example: https://github.com/Xerkus/CustomTwBootstrap
