### PR TITLE
Allow use of a numeric value in data-slide to create carousel controls that navigate directly to the slide with the given index

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -167,7 +167,7 @@
     $('body').on('click.carousel.data-api', '[data-slide]', function ( e ) {
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-        , options = !$target.data('modal') && $.extend({}, $target.data(), $this.data())
+        , options = $.isNumeric($this.data('slide')) ? +($this.data('slide')) : !$target.data('modal') && $.extend({}, $target.data(), $this.data())
       $target.carousel(options)
       e.preventDefault()
     })

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -39,4 +39,18 @@ $(function () {
           .carousel('next')
       })
 
+
+      test("should set active on slide with given numeric index", function () {
+        var carouselHtml = '<div id="myCarousel" class="carousel">'
+          + '<div class="carousel-inner">'
+          + '<div class="active item"/>'
+          + '<div class="item"/>'
+          + '</div>'
+          + '<a class="carousel-control" href="#myCarousel" data-slide="1">1</a>'
+          + '</div>';
+    	$('#qunit-fixture').append(carouselHtml);
+        $('#myCarousel').carousel();
+        $('#myCarousel').find('.carousel-control').click();
+        ok($('#myCarousel').find('.item').eq($('#myCarousel').find('.carousel-control').data('slide')).hasClass('active'));
+      })
 })

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -39,18 +39,17 @@ $(function () {
           .carousel('next')
       })
 
-
-      test("should set active on slide with given numeric index", function () {
-        var carouselHtml = '<div id="myCarousel" class="carousel">'
-          + '<div class="carousel-inner">'
-          + '<div class="active item"/>'
-          + '<div class="item"/>'
-          + '</div>'
-          + '<a class="carousel-control" href="#myCarousel" data-slide="1">1</a>'
-          + '</div>';
-    	$('#qunit-fixture').append(carouselHtml);
-        $('#myCarousel').carousel();
-        $('#myCarousel').find('.carousel-control').click();
-        ok($('#myCarousel').find('.item').eq($('#myCarousel').find('.carousel-control').data('slide')).hasClass('active'));
-      })
+	test("should set active on slide with given numeric index", function () {
+		var carouselHtml = '<div id="myCarousel" class="carousel">'
+			+ '<div class="carousel-inner">'
+			+ '<div class="active item"/>'
+			+ '<div class="item"/>'
+			+ '</div>'
+			+ '<a class="carousel-control" href="#myCarousel" data-slide="1">1</a>'
+			+ '</div>';
+		$('#qunit-fixture').append(carouselHtml);
+		$('#myCarousel').carousel();
+		$('#myCarousel').find('.carousel-control').click();
+		ok($('#myCarousel').find('.item').eq($('#myCarousel').find('.carousel-control').data('slide')).hasClass('active'));
+	})
 })

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -51,5 +51,6 @@ $(function () {
 		$('#myCarousel').carousel();
 		$('#myCarousel').find('.carousel-control').click();
 		ok($('#myCarousel').find('.item').eq($('#myCarousel').find('.carousel-control').data('slide')).hasClass('active'));
+		$('#myCarousel').remove();
 	})
 })


### PR DESCRIPTION
Added a unit test to previously closed submission.

Example:

``` html
<a class='thumbnail carousel-control' href='#myCarousel' data-slide='1'><img src='assets/images/main/NAIOP2011-150w.jpg' alt='Click this image to navigate the carousel to the second image' /></a>
```
