### PR TITLE
IE8 fix for image width

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -78,6 +78,7 @@ sub {
 
 img {
   max-width: 100%; // Make images inherently responsive
+  width:auto\9; // IE8 Fix
   height: auto; // Make images inherently responsive
   vertical-align: middle;
   border: 0;


### PR DESCRIPTION
When images are at 100%, height is not adjusted correctly. The code "width: auto\9;" fixed it.

The problem appear when the default width and height is set in the image tag: &lt;img src=&quot;myimage.jpg&quot; width=&quot;800&quot; height=&quot;600&quot; /&gt;

Here is the picture to explain the problem: http://i50.tinypic.com/mbqt8l.jpg
