### PR TITLE
the element should be passed as an argument to the callback function

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -59,7 +59,7 @@
         , o = this.options
 
       content = $e.attr('data-content')
-        || (typeof o.content == 'function' ? o.content.call($e[0]) :  o.content)
+        || (typeof o.content == 'function' ? o.content.call(this, $e[0]) :  o.content)
 
       return content
     }

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -211,7 +211,7 @@
         , o = this.options
 
       title = $e.attr('data-original-title')
-        || (typeof o.title == 'function' ? o.title.call($e[0]) :  o.title)
+        || (typeof o.title == 'function' ? o.title.call(this, $e[0]) :  o.title)
 
       return title
     }


### PR DESCRIPTION
When the content is fetched via a callback function ,the current element should be passed as an
argument. ie. if the following behavior is wanted:

```
    //the content should be the href attribute of the currnet element
$(function(){
    var options = {};
    options.title = "Some title";
    options.content = function(el) {
        return $(el).attr("href");
    }
    $('a').popover(options)
})
```
