### PR TITLE
Fix transition end name for opera 11+12

### DIFF
--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -36,7 +36,7 @@
           , transEndEventNames = {
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
-            ,  'OTransition'      : 'otransitionend'
+            ,  'OTransition'      : 'oTransitionEnd otransitionend'
             ,  'msTransition'     : 'MSTransitionEnd'
             ,  'transition'       : 'transitionend'
             }


### PR DESCRIPTION
Fix transition end name for Opera 11 and Opera 12.
Should fix issues: #3896, #3897, #4157, #4158
