### PR TITLE
Remove position style from .collapse class

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2532,7 +2532,6 @@ table .span24 {
 }
 
 .collapse {
-  position: relative;
   height: 0;
   overflow: hidden;
   -webkit-transition: height 0.35s ease;


### PR DESCRIPTION
The "position: relative;" style in the .collapse class was causing issues for me. It didn't seem like it was necessary for the style to exist so I removed it. I've tested and haven't noticed anything that I broke, but I'm not 100% confident.

Imagine a multi-column page in which the far left column contains "draggable" content (something you can drag from the far left column into another column). Because of the way "overflow: auto;" works, content dragged from the left column will disappear at the boundaries of the column. By removing the "position: relative" style, we are able to overcome this issue while maintaining proper collapsing functionality.
