### PR TITLE
IE10 uses 'transition' and 'transitionend'

### DIFF
--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -37,7 +37,6 @@
                'WebkitTransition' : 'webkitTransitionEnd'
             ,  'MozTransition'    : 'transitionend'
             ,  'OTransition'      : 'oTransitionEnd otransitionend'
-            ,  'msTransition'     : 'MSTransitionEnd'
             ,  'transition'       : 'transitionend'
             }
           , name


### PR DESCRIPTION
msTransition, while supported in IE, should be ignored in favor of the
unprefixed property. Additionally, MSTransitionEnd should also be
ignored in favor of the unprefixed event transitionend.

Current unit test requires no attention in light of this change.

MSDN:
http://msdn.microsoft.com/en-us/library/ie/hh673535(v=vs.85).aspx#transitions_dom_events
