### PR TITLE
Improved Typeahead keyboard navigation

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -141,7 +141,6 @@
         return i[0]
       })
 
-      items.first().addClass('active')
       this.$menu.html(items)
       return this
     }
@@ -187,7 +186,8 @@
       if (!this.shown) return
 
       switch(e.keyCode) {
-        case 9: // tab
+        case 16: // shift, used in combination with tab (shift tab for reverse tabbing)
+          break
         case 13: // enter
         case 27: // escape
           e.preventDefault()

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -47,7 +47,7 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
 
         typeahead.$menu.remove()
       })
@@ -65,7 +65,7 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
 
         typeahead.$menu.remove()
       })
@@ -83,7 +83,7 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
 
         typeahead.$menu.remove()
       })
@@ -99,7 +99,7 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 1, 'has 1 item in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
 
         typeahead.$menu.remove()
       })
@@ -116,7 +116,7 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
 
         $input.blur()
 
@@ -139,12 +139,19 @@ $(function () {
 
         ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
         equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
-        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
-        ok(typeahead.$menu.find('li').first().hasClass('active'), "first item is active")
+        equals(typeahead.$menu.find('.active').length, 0, 'no item is active')
+        ok(typeahead.$menu.find('li').first().hasClass('active') === false, "first item is not active")
 
         $input.trigger({
           type: 'keydown'
-        , keyCode: 40
+          , keyCode: 40
+        })
+
+        ok(typeahead.$menu.find('li').first().hasClass('active'), "first item is now active")
+
+        $input.trigger({
+          type: 'keydown'
+          , keyCode: 40
         })
 
         ok(typeahead.$menu.find('li').first().next().hasClass('active'), "second item is active")

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -144,14 +144,14 @@ $(function () {
 
         $input.trigger({
           type: 'keydown'
-          , keyCode: 40
+        , keyCode: 40
         })
 
         ok(typeahead.$menu.find('li').first().hasClass('active'), "first item is now active")
 
         $input.trigger({
           type: 'keydown'
-          , keyCode: 40
+        , keyCode: 40
         })
 
         ok(typeahead.$menu.find('li').first().next().hasClass('active'), "second item is active")


### PR DESCRIPTION
**Note** – resubmitted issue rebased on latest 2.1.0-wip branch.

TAB and SHIFT+TAB navigation is difficult, especially when the dropdown shows up on focus (before anything has been typed):
- `tab`: the first item is selected either we are just navigating with the key. Traveling through a form selects unwanted data.
- `shift+tab`: an item is selected for us, and worse, we remain in the field despite we expected to be relocated in the previous field

So basically this PR is a mimic of the `<select>` tag behavior: nothing selected when the dropdown is displayed, moving painlessly through form inputs.
