### PR TITLE
Only show tooltip when inside img are loaded (to have correct sizes)

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -94,7 +94,8 @@
     }
 
   , show: function () {
-      var $tip
+      var that = this
+        , $tip
         , inside
         , pos
         , actualWidth
@@ -102,26 +103,8 @@
         , placement
         , tp
 
-      if (this.hasContent() && this.enabled) {
-        $tip = this.tip()
-        this.setContent()
-
-        if (this.options.animation) {
-          $tip.addClass('fade')
-        }
-
-        placement = typeof this.options.placement == 'function' ?
-          this.options.placement.call(this, $tip[0], this.$element[0]) :
-          this.options.placement
-
-        inside = /in/.test(placement)
-
-        $tip
-          .remove()
-          .css({ top: 0, left: 0, display: 'block' })
-          .appendTo(inside ? this.$element : document.body)
-
-        pos = this.getPosition(inside)
+      function displayWhenReady() {
+        pos = that.getPosition(inside)
 
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
@@ -145,6 +128,27 @@
           .css(tp)
           .addClass(placement)
           .addClass('in')
+      }
+
+      if (this.hasContent() && this.enabled) {
+        $tip = this.tip()
+        this.setContent()
+
+        if (this.options.animation) {
+          $tip.addClass('fade')
+        }
+
+        placement = typeof this.options.placement == 'function' ?
+          this.options.placement.call(this, $tip[0], this.$element[0]) :
+          this.options.placement
+
+        inside = /in/.test(placement)
+
+        $tip
+          .remove()
+          .css({ top: 0, left: 0, display: 'block' })
+          .appendTo(inside ? this.$element : document.body)
+          .find('img').load(displayWhenReady).length || displayWhenReady();
       }
     }
 


### PR DESCRIPTION
Hi,

I was having difficulties with using img inside popover as they were loaded after the popover is displayed so they were always misplaced until the picture is already in cache. So here's my fix.

Hope this will help.
