### PR TITLE
Prevent buttons from breaking on hover when using custom colors

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -32,8 +32,6 @@
 .btn:hover {
   color: @grayDark;
   text-decoration: none;
-  background-color: darken(@white, 10%);
-  *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
   background-position: 0 -15px;
 
   // transition is only when going to hover, otherwise the background


### PR DESCRIPTION
If you only change the @btnBackground and @btnBackgroundHighlight variables for customizing default button colors you always have a semi-white background when you hover the buttons. This way, the background hover animation still works and prevents it from breaking your custom colors.
