### PR TITLE
Uses data attribute to adjust tooltip positioning for fixed elements

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -123,6 +123,11 @@
 
         pos = this.getPosition(inside)
 
+        if (this.$element.data('tooltip-position') === 'fixed') {
+          pos.top -= $(window).scrollTop()
+          pos.left -= $(window).scrollLeft()
+        }
+
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
 


### PR DESCRIPTION
Tooltips associated with fixed elements must account for scroll position.

The developer is still responsible for making sure the tooltip itself is fixed. This can be done by passing in a different template for fixed tooltips, such as:

```
<div class="tooltip tooltip-fixed"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>
```
