### PR TITLE
Move the clearfix definition out of mixins and into reset

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -6,24 +6,6 @@
 // UTILITY MIXINS
 // --------------------------------------------------
 
-// Clearfix
-// --------
-// For clearing floats like a boss h5bp.com/q
-.clearfix {
-  *zoom: 1;
-  &:before,
-  &:after {
-    display: table;
-    content: "";
-    // Fixes Opera/contenteditable bug:
-    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
-    line-height: 0;
-  }
-  &:after {
-    clear: both;
-  }
-}
-
 // Webkit-style focus
 // ------------------
 .tab-focus() {

--- a/less/reset.less
+++ b/less/reset.less
@@ -132,3 +132,21 @@ textarea {
   overflow: auto; // Remove vertical scrollbar in IE6-9
   vertical-align: top; // Readability and alignment cross-browser
 }
+
+// Clearfix
+// --------
+// For clearing floats like a boss h5bp.com/q
+.clearfix {
+  *zoom: 1;
+  &:before,
+  &:after {
+    display: table;
+    content: "";
+    // Fixes Opera/contenteditable bug:
+    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
+    line-height: 0;
+  }
+  &:after {
+    clear: both;
+  }
+}


### PR DESCRIPTION
This means that people who want to only use the Bootstrap mixins will no longer have a rule inserted into their stylesheet when importing only mixins.less.

Reset seems like the most appropriate place for it to go, although I suppose utilities would also be a valid location.

See also thomas-mcdonald/bootstrap-sass#166
