### PR TITLE
Add 'selectitem' event to typeahead

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1492,6 +1492,21 @@ $('.carousel').carousel({
              </tr>
             </tbody>
           </table>
+          <h3>Events</h3>
+          <table class="table table-bordered table-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">Event</th>
+               <th>Description</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>selectitem</td>
+               <td>This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.</td>
+            </tr>
+            </tbody>
+          </table>
 
           <h3>Markup</h3>
           <p>Add data attributes to register an element with typeahead functionality.</p>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1503,10 +1503,14 @@ $('.carousel').carousel({
             <tbody>
              <tr>
                <td>selectitem</td>
-               <td>This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object.</td>
+               <td>This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object. The second argument keeps the selected value.</td>
             </tr>
             </tbody>
           </table>
+<pre class="prettyprint linenums">
+$('#myinput').bind('selectitem', function (e, val) {
+// val - selected value
+})</pre>
 
           <h3>Markup</h3>
           <p>Add data attributes to register an element with typeahead functionality.</p>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1503,7 +1503,7 @@ $('.carousel').carousel({
             <tbody>
              <tr>
                <td>selectitem</td>
-               <td>This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.</td>
+               <td>This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object.</td>
             </tr>
             </tbody>
           </table>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1425,7 +1425,7 @@ $('.carousel').carousel({
             </thead>
             <tbody>
              <tr>
-               <td>{{_i}}select{{/i}}</td>
+               <td>{{_i}}selectitem{{/i}}</td>
                <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.{{/i}}</td>
             </tr>
             </tbody>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1415,6 +1415,21 @@ $('.carousel').carousel({
              </tr>
             </tbody>
           </table>
+          <h3>{{_i}}Events{{/i}}</h3>
+          <table class="table table-bordered table-striped">
+            <thead>
+             <tr>
+               <th style="width: 150px;">{{_i}}Event{{/i}}</th>
+               <th>{{_i}}Description{{/i}}</th>
+             </tr>
+            </thead>
+            <tbody>
+             <tr>
+               <td>{{_i}}select{{/i}}</td>
+               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.{{/i}}</td>
+            </tr>
+            </tbody>
+          </table>
 
           <h3>{{_i}}Markup{{/i}}</h3>
           <p>{{_i}}Add data attributes to register an element with typeahead functionality.{{/i}}</p>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1426,10 +1426,14 @@ $('.carousel').carousel({
             <tbody>
              <tr>
                <td>{{_i}}selectitem{{/i}}</td>
-               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object.{{/i}}</td>
+               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object. The second argument keeps the selected value.{{/i}}</td>
             </tr>
             </tbody>
           </table>
+<pre class="prettyprint linenums">
+$('#myinput').bind('selectitem', function (e, val) {
+{{_i}}// val - selected value{{/i}}
+})</pre>
 
           <h3>{{_i}}Markup{{/i}}</h3>
           <p>{{_i}}Add data attributes to register an element with typeahead functionality.{{/i}}</p>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1426,7 +1426,7 @@ $('.carousel').carousel({
             <tbody>
              <tr>
                <td>{{_i}}selectitem{{/i}}</td>
-               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by ivoking preventDefault() method of Event object.{{/i}}</td>
+               <td>{{_i}}This event fires when an item is chosen from dropdown (autocomplete) menu. The event handler can prevent closing dropdown menu by invoking preventDefault() method of Event object.{{/i}}</td>
             </tr>
             </tbody>
           </table>

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -45,7 +45,7 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
-        , e = $.Event('select')
+        , e = $.Event('selectitem')
 
       this.$element
         .val(this.updater(val))

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,13 +44,13 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.updater( this.$menu.find('.active').attr('data-value') )
         , e = $.Event('selectitem')
 
       this.$element
-        .val(this.updater(val))
+        .val(val)
         .change()
-        .trigger(e)
+        .trigger(e, val)
       if (e.isDefaultPrevented()) return
       return this.hide()
     }

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -45,9 +45,13 @@
 
   , select: function () {
       var val = this.$menu.find('.active').attr('data-value')
+        , e = $.Event('select')
+
       this.$element
         .val(this.updater(val))
         .change()
+        .trigger(e)
+      if (e.isDefaultPrevented()) return
       return this.hide()
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -157,7 +157,13 @@ $(function () {
 
         // test:
         typeahead.lookup()
-        $input.bind("selectitem", function() { selected = true })
+        $input.bind("selectitem", function(ev, val) { 
+            selected = true 
+            ok(ev)
+            ok(val)
+            equal(val, "ab")	// as 'click' on item with index 1
+            equal($input.val(), "ab")
+        })
         $(typeahead.$menu.find('li')[1]).mouseover().click()
 
         // check:

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -146,7 +146,7 @@ $(function () {
         typeahead.$menu.remove()
       })
 
-      test("should trigger select event on choosing an item from dropdown menu", function() {
+      test("should trigger selectitem event on choosing an item from dropdown menu", function() {
         var $input = $('<input />').typeahead({
               source: ['aa', 'ab', 'ac']
             })
@@ -157,7 +157,7 @@ $(function () {
 
         // test:
         typeahead.lookup()
-        $input.bind("select", function() { selected = true })
+        $input.bind("selectitem", function() { selected = true })
         $(typeahead.$menu.find('li')[1]).mouseover().click()
 
         // check:
@@ -168,7 +168,7 @@ $(function () {
         typeahead.$menu.remove()
       })
 
-      test("should can prevent closing dropdown menu in select event handler", function() {
+      test("should can prevent closing dropdown menu in selectitem event handler", function() {
         var $input = $('<input />').typeahead({
               source: ['aa', 'ab', 'ac']
             })
@@ -184,7 +184,7 @@ $(function () {
 
         // test:
         typeahead.lookup()
-        $input.bind("select", function(e) { e.preventDefault(); })
+        $input.bind("selectitem", function(e) { e.preventDefault(); })
         $(typeahead.$menu.find('li')[1]).mouseover().click()
 
         // check:

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -145,4 +145,52 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+      test("should trigger select event on choosing an item from dropdown menu", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+            })
+          , typeahead = $input.data('typeahead')
+          , selected = false
+
+        $input.val('a')
+
+        // test:
+        typeahead.lookup()
+        $input.bind("select", function() { selected = true })
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+
+        // check:
+        ok(selected, 'a change event was fired')
+        ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
+
+        // teardown:
+        typeahead.$menu.remove()
+      })
+
+      test("should can prevent closing dropdown menu in select event handler", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac']
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        // sanity check that the test is correct:
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+        ok(!typeahead.$menu.is(':visible'), 'the menu was closed')
+
+
+        // test:
+        typeahead.lookup()
+        $input.bind("select", function(e) { e.preventDefault(); })
+        $(typeahead.$menu.find('li')[1]).mouseover().click()
+
+        // check:
+        ok(typeahead.$menu.is(':visible'), 'the menu is still visible')
+
+        // teardown:
+        typeahead.$menu.remove()
+      })
 })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -168,7 +168,7 @@ $(function () {
         typeahead.$menu.remove()
       })
 
-      test("should can prevent closing dropdown menu in selectitem event handler", function() {
+      test("should be able to prevent closing dropdown menu from within selectitem event handler", function() {
         var $input = $('<input />').typeahead({
               source: ['aa', 'ab', 'ac']
             })


### PR DESCRIPTION
'selectitem' event is triggered by selecting an item from dropdown menu

Fixes #3102
