### PR TITLE
Allow tab target to be any element not just an anchor.

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -49,7 +49,7 @@
 
       if ( $this.parent('li').hasClass('active') ) return
 
-      previous = $ul.find('.active a').last()[0]
+      previous = $ul.find('.active :first-child').last()[0]
 
       e = $.Event('show', {
         relatedTarget: previous

--- a/js/tests/unit/bootstrap-tab.js
+++ b/js/tests/unit/bootstrap-tab.js
@@ -58,23 +58,6 @@ $(function () {
           .tab('show')
       })
 
-      test("should add active class to target when collapse shown", function () {
-        $.support.transition = false
-        stop()
-
-        var target = $('<a data-toggle="collapse" href="#test1"></a>')
-          .appendTo($('#qunit-fixture'))
-
-        var collapsible = $('<div id="test1"></div>')
-          .appendTo($('#qunit-fixture'))
-          .on('show', function () {
-            ok(!target.hasClass('collapsed'))
-            start()
-          })
-
-        target.click()
-      })
-
       test("should set relatedTarget for any target element", function () {
 
         stop();

--- a/js/tests/unit/bootstrap-tab.js
+++ b/js/tests/unit/bootstrap-tab.js
@@ -58,4 +58,43 @@ $(function () {
           .tab('show')
       })
 
+      test("should add active class to target when collapse shown", function () {
+        $.support.transition = false
+        stop()
+
+        var target = $('<a data-toggle="collapse" href="#test1"></a>')
+          .appendTo($('#qunit-fixture'))
+
+        var collapsible = $('<div id="test1"></div>')
+          .appendTo($('#qunit-fixture'))
+          .on('show', function () {
+            ok(!target.hasClass('collapsed'))
+            start()
+          })
+
+        target.click()
+      })
+
+      test("should set relatedTarget for any target element", function () {
+
+        stop();
+
+        var pillsHTML =
+            '<ul class="pills">'
+          + '<li class="active"><span href="#home">Home</span></li>'
+          + '<li><span href="#profile">Profile</span></li>'
+          + '</ul>'
+
+        var pills = $(pillsHTML).appendTo($('#qunit-fixture'))
+        var tabContent = $('<ul><li class="in active" id="home"></li><li id="profile"></li></ul>').appendTo($('#qunit-fixture'))
+
+        pills.find('li:last span')
+          .on('show', function (e) {
+            equals(e.target, pills.find('li:last span')[0])
+            equals(e.relatedTarget, pills.find('li:first span')[0])
+            start()
+          })
+          .tab('show')
+
+      })
 })


### PR DESCRIPTION
This change loostens the requirement for the trigger element being an anchor to being the first element inside the li to give a more freedom to choose the markup used to define tabs.

Signed-off-by: James McCarthy james2mccarthy@gmail.com
