### PR TITLE
Uses data-tooltip-position to handle tooltips related to fixed elements

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -123,6 +123,13 @@
 
         pos = this.getPosition(inside)
 
+        if (this.$element.data('tooltip-position') === 'fixed') {
+          pos.top -= $(window).scrollTop()
+          pos.left -= $(window).scrollLeft()
+
+          $tip.addClass('tooltip-fixed')
+        }
+
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -59,6 +59,16 @@ $(function () {
         ok(!$(".tooltip").length, 'tooltip removed')
       })
 
+      test("should respect fixed tooltip position", function () {
+        var tooltip = $('<a href="#" rel="tooltip" data-tooltip-position="fixed" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip('show')
+
+        ok($('.tooltip').hasClass('tooltip-fixed'), 'tooltip-fixed class is present')
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
       test("should not show tooltip if leave event occurs before delay expires", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')

--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -19,6 +19,11 @@
   &.left   { margin-left: -3px; }
 }
 
+// Fixed class
+.tooltip-fixed {
+  position: fixed;
+}
+
 // Wrapper for the tooltip content
 .tooltip-inner {
   max-width: 200px;


### PR DESCRIPTION
Tooltips associated with fixed elements must account for scroll position. If the tooltip-position is set to fixed, adjust the position of the tooltip and add a "tooltip-fixed" class to the tooltip, which has a position: fixed style.

```
<a href="#" rel="tooltip" data-tooltip-position="fixed" title="Another tooltip"></a>
```
