### PR TITLE
Fixed a typo in prettify.css (bootstrap gh-pages)

### DIFF
--- a/assets/js/google-code-prettify/prettify.css
+++ b/assets/js/google-code-prettify/prettify.css
@@ -3,7 +3,7 @@
 .pun, .opn, .clo { color: #93a1a1; }
 .fun { color: #dc322f; }
 .str, .atv { color: #D14; }
-.kwd, .linenums .tag { color: #1e347b; }
+.kwd, .linenums, .tag { color: #1e347b; }
 .typ, .atn, .dec, .var { color: teal; }
 .pln { color: #48484c; }
 

--- a/assets/js/google-code-prettify/prettify.css
+++ b/assets/js/google-code-prettify/prettify.css
@@ -3,7 +3,7 @@
 .pun, .opn, .clo { color: #93a1a1; }
 .fun { color: #dc322f; }
 .str, .atv { color: #D14; }
-.kwd, .linenums, .tag { color: #1e347b; }
+.kwd, .tag { color: #1e347b; }
 .typ, .atn, .dec, .var { color: teal; }
 .pln { color: #48484c; }
 


### PR DESCRIPTION
I've downloaded prettify.css/prettify.js code from bootstrap repository for my project and I realized that it doesn't highlight my xml/html code w/o linenums class. 

I thinik, Its more easy to download google-prettify code from bootstrap repo (not from official site) because its already stylized to main bootstrap theme. I guess loads of users do that (not only me) and they can find this issue in their projects.

So, in case if user decided to prettify his html/xml code w/o "linenums" class, he wouldn't get any highlight from prettify.js due to forgotten comma betwen "linenums" and "tag" classes in css.
