### PR TITLE
Add 'dist' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nbproject
 .CVS
 .idea
 node_modules
+dist


### PR DESCRIPTION
Allows you to keep a 'dist' directory in the repository as a target build location.
This can be useful if you have bootstrap as a submodule in a project and want to build it,
but still keep it self-contained. Similar to how jQuery does their default builds:
https://github.com/jquery/jquery/#how-to-build-your-own-jquery
