### PR TITLE
Changed CSS rules for outlines in active/focus states

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -24,11 +24,9 @@
 // Webkit-style focus
 // ------------------
 .tab-focus() {
-  // Default
-  outline: thin dotted #333;
-  // Webkit
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+    outline: 0;
+    -moz-outline-style: none
+
 }
 
 // Center-align a block level element

--- a/less/reset.less
+++ b/less/reset.less
@@ -41,17 +41,24 @@ audio:not([controls]) {
 
 html {
   font-size: 100%;
+  -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
 }
-// Focus states
-a:focus {
-  .tab-focus();
-}
-// Hover & Active
+// Active, Focus, & Hover states
+a:active,
 a:hover,
-a:active {
-  outline: 0;
+a:focus,
+a::-moz-focus-inner,
+button:active,
+button:hover,
+button:focus,
+button::-moz-focus-inner,
+input[type="button"]:active,
+input[type="button"]:hover,
+input[type="button"]:focus,
+input[type="button"]::-moz-focus-inner {
+  .tab-focus();
 }
 
 // Prevents sub and sup affecting line-height in all browsers


### PR DESCRIPTION
I have modified mixins.less to have the tab-focus() function remove dotted borders, not set them as a default style. Then I modified reset.less to apply that function with active, focus, hover, and -moz-inner-focus pseudo classes on anchor, button, and input[type="button"] elements.
