### PR TITLE
Use ref instead of label when checking branches in issue-guidelines

### DIFF
--- a/.issue-guidelines.js
+++ b/.issue-guidelines.js
@@ -24,11 +24,11 @@ module.exports = {
     'pull-requests': {
 
         'should always be made against -wip branches': function (pull) {
-            assert.ok(/\-wip$/.test(pull.base.label))
+            assert.ok(/\-wip$/.test(pull.base.ref))
         },
 
         'should always be made from feature branches': function (pull) {
-            assert.ok(pull.head.label != 'master')
+            assert.notEqual(pull.head.ref, 'master')
         },
 
         'should always include a unit test if changing js files': function (pull) {
@@ -36,7 +36,7 @@ module.exports = {
             var hasTests = false
 
             pull.files.forEach(function (file) {
-                if (/^js\/[^./]+.js/.test(file.filename))            hasJS    = true
+                if (/^js\/[^./]+.js/.test(file.filename))             hasJS    = true
                 if (/^js\/tests\/unit\/[^.]+.js/.test(file.filename)) hasTests = true
             })
 


### PR DESCRIPTION
The `label` field of the github API contains `user:branch` eg, `fat:my-cool-feature`. It is better to haunt using the `ref` field which will only contain the branch name.
