### PR TITLE
move the 'timeout' to the 'self' from the 'this'

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -72,11 +72,11 @@
   , enter: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      if(self.timeout) clearTimeout(self.timeout)
       if (!self.options.delay || !self.options.delay.show) return self.show()
 
-      clearTimeout(this.timeout)
       self.hoverState = 'in'
-      this.timeout = setTimeout(function() {
+      self.timeout = setTimeout(function() {
         if (self.hoverState == 'in') self.show()
       }, self.options.delay.show)
     }
@@ -84,11 +84,11 @@
   , leave: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
-      if (this.timeout) clearTimeout(this.timeout)
+      if (self.timeout) clearTimeout(self.timeout)
       if (!self.options.delay || !self.options.delay.hide) return self.hide()
 
       self.hoverState = 'out'
-      this.timeout = setTimeout(function() {
+      self.timeout = setTimeout(function() {
         if (self.hoverState == 'out') self.hide()
       }, self.options.delay.hide)
     }


### PR DESCRIPTION
The bug will appear if the mouse enters into other elements from the
former elements when the hiding-delay is not the 0s. At the same time,
the 'tooltip' of the former elements won't hide. That's why I move the
'timeout' to the 'self' from the 'this'.
