### PR TITLE
Add an example of a nav-list with icons like there is in the 2.0 docs

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -843,6 +843,27 @@
 &lt;/ul&gt;
 </pre>
 
+        <h3>Icons</h3>
+        <p>Add icons to your nav list by including a <code><i></code> tag with a unique class, prefixed with a <code>icon-</code> cass on any item.
+          <p>Same example, but with <code><i></code> tags for icons</p>
+          <div class="bs-docs-example">
+            <div class="well" style="max-width: 340px; padding: 8px 0;">
+              <ul class="nav nav-list">
+                <li class="nav-header">List header</li>
+                <li class="active"><a href="#"><i class="icon-home icon-white"></i> Home</a></li>
+                <li><a href="#"><i class="icon-book"></i> Library</a></li>
+                <li><a href="#"><i class="icon-pencil"></i>Applications</a></li>
+              </ul>
+            </div> <!-- /well -->
+          </div>
+<pre class="prettyprint linenums">
+&lt;ul class="nav nav-list"&gt;
+  &lt;li class="nav-header"&gt;List header&lt;/li&gt;
+  &lt;li class="active"&gt;&lt;a href="#"&gt;&lt;i class="icon-home icon-white"&gt;&lt;/i&gt; Home&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href="#"&gt;&lt;i class="icon-pencil"&gt;&lt;/i&gt; Library&lt;/a&gt;&lt;/li&gt;
+  ...
+&lt;/ul&gt;
+</pre>
 
           <hr class="bs-docs-separator">
 


### PR DESCRIPTION
Missing this documentation showing that it's possible to use icon\* classes in the nav-lists.
