### PR TITLE
Fixes vertical-three-colors in Firefox

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -431,7 +431,7 @@
     background-color: mix(@midColor, @endColor, 80%);
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
     background-image: -webkit-linear-gradient(@startColor, @midColor @colorStop, @endColor);
-    background-image: -moz-linear-gradient(top, @startColor, @midColor @colorStop, @endColor);
+    background-image: -moz-linear-gradient(top, @startColor, @midColor @colorStop*100%, @endColor);
     background-image: -o-linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(@startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;


### PR DESCRIPTION
The less mixin for vertical-three-colors doesn't seem to work in Firefox 13.0.1. 
It just displays the default background-image option. It looks like Firefox want a percentage value.

I hope `*100%` works fine.

Old Request was #4055
