### PR TITLE
.input-block-level is a mixin, not a class.

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -152,7 +152,7 @@
 // --------------------------------------------------
 
 // Block level inputs
-.input-block-level {
+.input-block-level() {
   display: block;
   width: 100%;
   min-height: 28px;        // Make inputs at least the height of their button counterpart


### PR DESCRIPTION
I modified the definition of the `.input-block-level` mixin so that it won't create a `.input-block-level` class.
