### PR TITLE
Fixed broken "browse the examples" link on docs index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@
     <hr class="soften">
 
     <h1>Built with Bootstrap.</h1>
-    <p class="marketing-byline">For even more sites built with Bootstrap, <a href="http://builtwithbootstrap.tumblr.com/" target="_blank">visit the unofficial Tumblr</a> or <a href="./examples.html">browse the examples</a>.</p>
+    <p class="marketing-byline">For even more sites built with Bootstrap, <a href="http://builtwithbootstrap.tumblr.com/" target="_blank">visit the unofficial Tumblr</a> or <a href="./getting-started.html#examples">browse the examples</a>.</p>
     <div class="row-fluid">
       <ul class="thumbnails example-sites">
         <li class="span3">

--- a/docs/templates/pages/index.mustache
+++ b/docs/templates/pages/index.mustache
@@ -58,7 +58,7 @@
     <hr class="soften">
 
     <h1>{{_i}}Built with Bootstrap.{{/i}}</h1>
-    <p class="marketing-byline">{{_i}}For even more sites built with Bootstrap, <a href="http://builtwithbootstrap.tumblr.com/" target="_blank">visit the unofficial Tumblr</a> or <a href="./examples.html">browse the examples</a>.{{/i}}</p>
+    <p class="marketing-byline">{{_i}}For even more sites built with Bootstrap, <a href="http://builtwithbootstrap.tumblr.com/" target="_blank">visit the unofficial Tumblr</a> or <a href="./getting-started.html#examples">browse the examples</a>.{{/i}}</p>
     <div class="row-fluid">
       <ul class="thumbnails example-sites">
         <li class="span3">


### PR DESCRIPTION
In 2.1 the examples are listed on the "Getting started" page instead.
