### PR TITLE
Pass current and previous slides to 'slid' event

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -111,7 +111,7 @@
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false
-          setTimeout(function () { that.$element.trigger('slid') }, 0)
+          setTimeout(function () { that.$element.trigger('slid', $next, $active) }, 0)
         })
       } else {
         this.$element.trigger(e)
@@ -119,7 +119,7 @@
         $active.removeClass('active')
         $next.addClass('active')
         this.sliding = false
-        this.$element.trigger('slid')
+        this.$element.trigger('slid', $next, $active)
       }
 
       isCycling && this.cycle()


### PR DESCRIPTION
Allows access to the previous slide (current is easily accessed using .active) from a 'slid' event handler.
