### PR TITLE
Allow multiple colors in progress bars

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1815,33 +1815,41 @@
     <div class="span3">
       <h3>Additional colors</h3>
       <p>Progress bars use some of the same button and alert classes for consistent styles.</p>
-      <div class="progress progress-info" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 20%"></div>
+      <div class="progress" style="margin-bottom: 9px;">
+        <div class="bar-info" style="width: 20%"></div>
       </div>
-      <div class="progress progress-success" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 40%"></div>
+      <div class="progress" style="margin-bottom: 9px;">
+        <div class="bar-success" style="width: 40%"></div>
       </div>
-      <div class="progress progress-warning" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 60%"></div>
+      <div class="progress" style="margin-bottom: 9px;">
+        <div class="bar-warning" style="width: 60%"></div>
       </div>
-      <div class="progress progress-danger" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 80%"></div>
+      <div class="progress" style="margin-bottom: 9px;">
+        <div class="bar-danger" style="width: 80%"></div>
+      </div>
+      <div class="progress" style="margin-bottom: 9px;">
+        <div class="bar-danger" style="width: 20%"></div>
+        <div class="bar" style="width: 50%"></div>
       </div>
     </div>
      <div class="span3">
       <h3>Striped bars</h3>
       <p>Similar to the solid colors, we have varied striped progress bars.</p>
-      <div class="progress progress-info progress-striped" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 20%"></div>
+      <div class="progress progress-striped" style="margin-bottom: 9px;">
+        <div class="bar-info" style="width: 20%"></div>
       </div>
-      <div class="progress progress-success progress-striped" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 40%"></div>
+      <div class="progress progress-striped" style="margin-bottom: 9px;">
+        <div class="bar-success" style="width: 40%"></div>
       </div>
-      <div class="progress progress-warning progress-striped" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 60%"></div>
+      <div class="progress progress-striped" style="margin-bottom: 9px;">
+        <div class="bar-warning" style="width: 60%"></div>
       </div>
-      <div class="progress progress-danger progress-striped" style="margin-bottom: 9px;">
-        <div class="bar" style="width: 80%"></div>
+      <div class="progress progress-striped" style="margin-bottom: 9px;">
+        <div class="bar-danger" style="width: 80%"></div>
+      </div>
+      <div class="progress progress-striped" style="margin-bottom: 9px;">
+        <div class="bar-danger" style="width: 20%"></div>
+        <div class="bar" style="width: 50%"></div>
       </div>
     </div>
     <div class="span3">

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -53,6 +53,7 @@
 // Bar of progress
 .progress .bar {
   width: 0%;
+  float: left;
   height: 18px;
   color: @white;
   font-size: 12px;
@@ -85,33 +86,33 @@
 // ------
 
 // Danger (red)
-.progress-danger .bar {
+.progress .bar-danger {
   #gradient > .vertical(#ee5f5b, #c43c35);
 }
-.progress-danger.progress-striped .bar {
+.progress.progress-striped .bar-danger {
   #gradient > .striped(#ee5f5b);
 }
 
 // Success (green)
-.progress-success .bar {
+.progress .bar-success {
   #gradient > .vertical(#62c462, #57a957);
 }
-.progress-success.progress-striped .bar {
+.progress.progress-striped .bar-success {
   #gradient > .striped(#62c462);
 }
 
 // Info (teal)
-.progress-info .bar {
+.progress .bar-info {
   #gradient > .vertical(#5bc0de, #339bb9);
 }
-.progress-info.progress-striped .bar {
+.progress.progress-striped .bar-info {
   #gradient > .striped(#5bc0de);
 }
 
 // Warning (orange)
-.progress-warning .bar {
+.progress .bar-warning {
   #gradient > .vertical(lighten(@orange, 15%), @orange);
 }
-.progress-warning.progress-striped .bar {
+.progress.progress-striped .bar-warning {
   #gradient > .striped(lighten(@orange, 15%));
 }


### PR DESCRIPTION
Additional colors added on '.bar' instead of '.progress' allowing multiple colors inside.

Useful when an action is partially failed and in progress for instance.
