### PR TITLE
Typo in attributes list of "container" in github page

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <button type="button"class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+          <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>


### PR DESCRIPTION
Simply noticed this one while looking at the example pages
