### PR TITLE
Typeahead: only accept array return vals from source

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -87,7 +87,7 @@
 
       items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
 
-      return items ? this.process(items) : this
+      return $.isArray(items) ? this.process(items) : this
     }
 
   , process: function (items) {


### PR DESCRIPTION
Typeahead's source option can be an array that returns
a list of completions, but we should check to guarantee the
return value is actually an array before forwarding it.

---

This is particularly a problem for CoffeeScript users, who might write the following:

```
$('#user-input').typeahead
    source: (query, process) ->
        process [query + query]
```

Expected behavior: a user types "abc" and the typeahead popup shows "abcabc".  Actual behavior: the typeahead popup has nothing.

This is because CoffeeScript implicitly returns the last value (here an instance of `Typeahead`).  Unless that value is actually an array, we shouldn't try to use it.
