### PR TITLE
Add optional (opt-in) mixin to create an outline on popovers / tooltips 

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -483,33 +483,83 @@
     bottom: 0;
     left: 50%;
     margin-left: -@arrowWidth;
-    border-left: @arrowWidth solid transparent;
-    border-right: @arrowWidth solid transparent;
-    border-top: @arrowWidth solid @color;
+    margin-bottom: ceil( @arrowWidth * -1.5 + 3 );
+    border: solid transparent;
+    border-width: @arrowWidth;
+    border-top-color: @color;
   }
   .left(@arrowWidth: 5px, @color: @black) {
     top: 50%;
     right: 0;
     margin-top: -@arrowWidth;
-    border-top: @arrowWidth solid transparent;
-    border-bottom: @arrowWidth solid transparent;
-    border-left: @arrowWidth solid @color;
+    margin-right: ceil( @arrowWidth * -1.5 + 3 );
+    border: solid transparent;
+    border-width: @arrowWidth;
+    border-left-color: @color;
   }
   .bottom(@arrowWidth: 5px, @color: @black) {
     top: 0;
     left: 50%;
     margin-left: -@arrowWidth;
-    border-left: @arrowWidth solid transparent;
-    border-right: @arrowWidth solid transparent;
-    border-bottom: @arrowWidth solid @color;
+    margin-top: ceil( @arrowWidth * -1.5 + 3 );
+    border: solid transparent;
+    border-width: @arrowWidth;
+    border-bottom-color: @color;
   }
   .right(@arrowWidth: 5px, @color: @black) {
     top: 50%;
     left: 0;
     margin-top: -@arrowWidth;
-    border-top: @arrowWidth solid transparent;
-    border-bottom: @arrowWidth solid transparent;
-    border-right: @arrowWidth solid @color;
+    margin-left: ceil( @arrowWidth * -1.5 + 3 );
+    border: solid transparent;
+    border-width: @arrowWidth;
+    border-right-color: @color;
+  }
+  #outlinedArrow {
+    .inner-arrow-styles() {
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        z-index: 10;
+        border: solid transparent;
+    }
+    #top {
+      .inner-arrow( @mainArrowWidth: 5px, @outlineWidth: 1px, @color: @white ) {
+        .inner-arrow-styles();
+        border-width: @mainArrowWidth + @outlineWidth;
+        border-top-color: @color;
+        margin-left: -@mainArrowWidth - @outlineWidth;
+        margin-top: -@mainArrowWidth + -(@outlineWidth * 2)
+      }
+    }
+    #left {
+      .inner-arrow( @mainArrowWidth: 5px, @outlineWidth: 1px, @color: @white ) {
+        .inner-arrow-styles();
+        border-width: @mainArrowWidth + @outlineWidth;
+        border-left-color: @color;
+        margin-top: -@mainArrowWidth - @outlineWidth;
+        margin-left: -@mainArrowWidth + -(@outlineWidth * 2);
+      }
+    }
+    #bottom {
+      .inner-arrow( @mainArrowWidth: 5px, @outlineWidth: 1px, @color: @white ) {
+        .inner-arrow-styles();
+        border-width: @mainArrowWidth + @outlineWidth;
+        border-bottom-color: @color;
+        margin-left: -@mainArrowWidth - @outlineWidth;
+        margin-top: -@mainArrowWidth;
+      }
+    }
+    #right {
+      .inner-arrow( @mainArrowWidth: 5px, @outlineWidth: 1px, @color: @white ) {
+        .inner-arrow-styles();
+        border-width: @mainArrowWidth + @outlineWidth;
+        border-right-color: @color;
+        margin-top: -@mainArrowWidth - @outlineWidth;
+        margin-left: -@mainArrowWidth;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Assumes that users will append it to the `:after` pseudo class of `.arrow`.  Both the size of the outline (perceived thickness of faux outline) and also the color can accept parameters.  All math is handled dynamically.

Opting in would look like:  

```
&.top .arrow {
    #popoverArrow > .top( @arrowWidth, @black );
    &:after {
        #popoverArrow > #outlinedArrow > #top > .inner-arrow( @mainArrowWidth, @outlineWidth, @white );
    }
}
```

This pull request was originally made (by mistake) against master here: https://github.com/twitter/bootstrap/pull/4323

To answer @markdotto's question about -1.5 and 3 in the math, it's in order to preserve the intended result of the `arrowWidth` variable.  Based on the pythagorean theorem, despite the clipping effect being done by CSS (which doesn't effect the darker arrow which is behind the main popover bg in the DOM, the point of origin for the 0-width DOM element is technically inside of the main popover body.  As a result, calculating the y-axis width of the new element I'm creating would overlap the content of the tooltip if I used `*2` in my math.  The `-3px` in the math is just a shim - the best way I could come up with for ensuring that the integrity of the arrow size is maintained (according to the pythagorean theorem) without the arrow being  disconnected from the popover body.

Also, for what it's worth - if we didn't care about the passed var being an exact match for the y-axis width of the arrow, we could clean it up, and even with that limitation I'm sure @fat could do this better :)
