### PR TITLE
Center text in navbar with change to @baseLineHeight (18 -> 20px)

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -47,9 +47,7 @@
   float: left;
   display: block;
   // Vertically center the text given @navbarHeight
-  @elementHeight: 20px;
-  @heightDifference: @navbarHeight - @elementHeight;
-  padding: ((@heightDifference / 2) - 2) 20px ((@heightDifference / 2) + 2);
+  padding: ((@navbarHeight - @baseLineHeight) / 2) 20px ((@navbarHeight - @baseLineHeight) / 2);
   margin-left: -20px; // negative indent to left-align the text down the page
   font-size: 20px;
   font-weight: 200;
@@ -207,8 +205,7 @@
 .navbar .nav > li > a {
   float: none;
   // Vertically center the text given @navbarHeight
-  @elementHeight: 20px;
-  padding: ((@navbarHeight - @elementHeight) / 2) 15px ((@navbarHeight - @elementHeight) / 2);
+  padding: ((@navbarHeight - @baseLineHeight) / 2) 15px ((@navbarHeight - @baseLineHeight) / 2);
   color: @navbarLinkColor;
   text-decoration: none;
   text-shadow: 0 1px 0 @navbarBackgroundHighlight;


### PR DESCRIPTION
In 2.1.0, default font size is 14px and line height 20px instead of 13px and 18px in 2.0.

To recover my old visual, I changed my variables.less with:

```
@baseFontSize: 13px;
@baseLineHeight: 18px;
```

If I do that, the `.brand` and the `<a>` tags in navbar are not centered. Furthermore the height of the anchors are too short of 2px.
