### PR TITLE
Adjustment of position of icons.

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -967,7 +967,7 @@ For example, &lt;code&gt;section&lt;/code&gt; should be wrapped as inline.
 </pre>
 
           <h3>Textarea</h3>
-          <p>Form control which supports multiple lines of text. Change <code>row</code> attribute as necessary.</p>
+          <p>Form control which supports multiple lines of text. Change <code>rows</code> attribute as necessary.</p>
           <form class="bs-docs-example form-inline">
             <textarea rows="3"></textarea>
           </form>

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -79,7 +79,7 @@
   .border-radius(5px);
 }
 .btn-large [class^="icon-"] {
-  margin-top: 1px;
+  margin-top: 2px;
 }
 
 // Small
@@ -89,7 +89,7 @@
   line-height: @baseLineHeight - 2px;
 }
 .btn-small [class^="icon-"] {
-  margin-top: -1px;
+  margin-top: 0px;
 }
 
 // Mini

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -89,7 +89,7 @@
   line-height: @baseLineHeight - 2px;
 }
 .btn-small [class^="icon-"] {
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 // Mini

--- a/less/sprites.less
+++ b/less/sprites.less
@@ -25,6 +25,7 @@
   background-image: url("@{iconSpritePath}");
   background-position: 14px 14px;
   background-repeat: no-repeat;
+  margin-top: 1px;
 }
 
 /* White icons with optional class, or on hover/active states of certain elements */


### PR DESCRIPTION
I noticed that icons never seem to hit the center line of text when placed inline.  Specifically, I observed this not only on the official Twitter Bootstrap landing page (in the section when the icons are placed next to their class designation) but in my own site where the buttons are placed before the text in buttons.  I also observed this in the RC of Bootstrap 2.1 (rc.getbootstrap.com).  This was observed in Chrome 21, Firefox 10/14, and IE8.  My personal site is using Bootstrap 2.0.4.

The problem was obviously already looked at because there were overrides for when icons were placed under buttons marked .btn-large or .btn-small.  However, there seemed to be a constant error of the margin being 1px too high across the board.

I added 1px more of top margin to icons... thus, it ends up looking like:

.icon-\* -> margin-top: 1px
.btn-large .icon-\* -> margin-top: 2px
.btn-small .icon-\* -> margin-top: 0

(I tried to make another pull request for a simple spelling error fix that is apparently now in this pull request... not precisely sure how to back that out so I'm just leaving it in because it is literally a single character addition.)
