### PR TITLE
[2.1.0-wip] Active link color for dropdownmenu in navbar

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -287,6 +287,10 @@
     top: -6px;
     left: 10px;
   }
+  .active > a,
+  .active > a:hover {
+      color: @dropdownLinkColorHover;
+  }
 }
 // Menu position and menu caret support for dropups via extra dropup class
 .navbar-fixed-bottom .nav > li > .dropdown-menu {


### PR DESCRIPTION
If we have a dropdown menu inside a navbar, the active link color for dropdown menu (in dropdown.less) is overwritten by the one from navbar.
