### PR TITLE
Fix typo to make dropdown active link show icon-white

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -32,7 +32,7 @@
 .nav > .active > a > [class^="icon-"],
 .nav > .active > a > [class*=" icon-"],
 .dropdown-menu > li > a:hover > [class^="icon-"],
-.dropdown-menu > li > a:hover > [class*=" icon-"]
+.dropdown-menu > li > a:hover > [class*=" icon-"],
 .dropdown-menu > .active > a > [class^="icon-"],
 .dropdown-menu > .active > a > [class*=" icon-"] {
   background-image: url("@{iconWhiteSpritePath}");


### PR DESCRIPTION
This fixes a missing comma in `sprites.less`. Fixes #4413.
