### PR TITLE
Fix navbar responsive width

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -695,7 +695,8 @@
   }
   .navbar-fixed-top .navbar-inner,
   .navbar-fixed-bottom .navbar-inner {
-    padding: 5px;
+    padding-right: 5px;
+    padding-left: 5px;
   }
   .navbar .container {
     width: auto;

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,10 +98,10 @@
     </ul>
     <ul class="quick-links">
       <li>
-        <iframe class="github-btn" src="http://markdotto.github.com/github-buttons/github-btn.html?user=twitter&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>
       </li>
       <li>
-        <iframe class="github-btn" src="http://markdotto.github.com/github-buttons/github-btn.html?user=twitter&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98px" height="20px"></iframe>
       </li>
       <li class="follow-btn">
         <a href="https://twitter.com/twbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @twbootstrap</a>

--- a/less/responsive-navbar.less
+++ b/less/responsive-navbar.less
@@ -21,7 +21,8 @@
   }
   .navbar-fixed-top .navbar-inner,
   .navbar-fixed-bottom .navbar-inner {
-    padding: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
   }
   .navbar .container {
     width: auto;


### PR DESCRIPTION
`responsive-navbar` was adding 5px padding to the top, bottom, left, and right of the navbar when < 979px.

This was causing the navbar to get "fatter" (taller) when resizing the window to a narrower width.

The fix: only add the padding to left and right.

P.S. I don't understand why the hotfix by @markdotto is included in this pull request. I branched off 2.1.0-wip as I should, but for some reason the hotfix commit shows up there anyway. :-(
