### PR TITLE
Allow buttons-radio options to be deselected

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1093,6 +1093,23 @@ $('#my-alert').bind('closed', function () {
 &lt;/div&gt;
 </pre>
 
+  <h4>{{_i}}Radio - Optional{{/i}}</h4>
+  <p>{{_i}}Add data-toggle="buttons-radio-optional" for radio style toggling on btn-group, where deselecting a choice is allowed.{{/i}}</p>
+  <div class="bs-docs-example" style="padding-bottom: 24px;">
+    <div class="btn-group" data-toggle="buttons-radio-optional">
+      <button class="btn btn-primary">{{_i}}Left{{/i}}</button>
+      <button class="btn btn-primary">{{_i}}Middle{{/i}}</button>
+      <button class="btn btn-primary">{{_i}}Right{{/i}}</button>
+    </div>
+  </div>{{! /example }}
+<pre class="prettyprint linenums">
+&lt;div class="btn-group" data-toggle="buttons-radio-optional"&gt;
+  &lt;button class="btn"&gt;Left&lt;/button&gt;
+  &lt;button class="btn"&gt;Middle&lt;/button&gt;
+  &lt;button class="btn"&gt;Right&lt;/button&gt;
+&lt;/div&gt;
+</pre>
+
 
             <hr class="bs-docs-separator">
 

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -51,7 +51,7 @@
   }
 
   Button.prototype.toggle = function () {
-    var $parent = this.$element.parent('[data-toggle="buttons-radio"], [data-toggle="buttons-radio-optional"]')
+    var $parent = this.$element.parent('[data-toggle^="buttons-radio"]')
 
     this.$element.toggleClass('active')
 

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -51,13 +51,21 @@
   }
 
   Button.prototype.toggle = function () {
-    var $parent = this.$element.parent('[data-toggle="buttons-radio"]')
-
-    $parent && $parent
-      .find('.active')
-      .removeClass('active')
+    var $parent = this.$element.parent('[data-toggle="buttons-radio"], [data-toggle="buttons-radio-optional"]')
 
     this.$element.toggleClass('active')
+
+    if ($parent && $parent.attr('data-toggle') == 'buttons-radio') {
+      $parent
+        .find('.active')
+        .removeClass('active');
+      this.$element.toggleClass('active')
+    } else if ($parent) {
+      $parent
+        .find('.active')
+        .not(this.$element)
+        .removeClass('active');
+    }
   }
 
 

--- a/js/tests/unit/bootstrap-button.js
+++ b/js/tests/unit/bootstrap-button.js
@@ -62,16 +62,54 @@ $(function () {
         ok(btn.hasClass('active'), 'btn has class active')
       })
 
-     test("should toggle active when btn children are clicked within btn-group", function () {
+     test("should toggle active when btn children are clicked within buttons-checkbox btn-group", function () {
         var btngroup = $('<div class="btn-group" data-toggle="buttons-checkbox"></div>')
           , btn = $('<button class="btn">fat</button>')
+          , btn2 = $('<button class="btn active">philfreo</button>')
           , inner = $('<i></i>')
         btngroup
           .append(btn.append(inner))
+          .append(btn2)
           .appendTo($('#qunit-fixture'))
         ok(!btn.hasClass('active'), 'btn does not have active class')
         inner.click()
         ok(btn.hasClass('active'), 'btn has class active')
+        ok(btn2.hasClass('active'), 'other btn still has class active')
+        inner.click()
+        ok(!btn.hasClass('active'), 'btn does not have active class')
       })
 
+     test("should toggle active when btn children are clicked within buttons-radio btn-group", function () {
+        var btngroup = $('<div class="btn-group" data-toggle="buttons-radio"></div>')
+          , btn = $('<button class="btn">fat</button>')
+          , btn2 = $('<button class="btn active">philfreo</button>')
+          , inner = $('<i></i>')
+        btngroup
+          .append(btn.append(inner))
+          .append(btn2)
+          .appendTo($('#qunit-fixture'))
+        ok(!btn.hasClass('active'), 'btn does not have active class')
+        inner.click()
+        ok(btn.hasClass('active'), 'btn has class active')
+        ok(!btn2.hasClass('active'), 'other btn no longer has class active')
+        inner.click()
+        ok(btn.hasClass('active'), 'btn still has active class')
+      })
+
+     test("should toggle active when btn children are clicked within buttons-radio-optional btn-group", function () {
+        var btngroup = $('<div class="btn-group" data-toggle="buttons-radio-optional"></div>')
+          , btn = $('<button class="btn">fat</button>')
+          , btn2 = $('<button class="btn active">philfreo</button>')
+          , inner = $('<i></i>')
+        btngroup
+          .append(btn.append(inner))
+          .append(btn2)
+          .appendTo($('#qunit-fixture'))
+        ok(!btn.hasClass('active'), 'btn does not have active class')
+        inner.click()
+        ok(btn.hasClass('active'), 'btn has class active')
+        ok(!btn2.hasClass('active'), 'other btn no longer has class active')
+        inner.click()
+        ok(!btn.hasClass('active'), 'btn does not have active class')
+      })
 })


### PR DESCRIPTION
Simple change: `buttons-radio-optional` behaves like `buttons-radio` except it allows the user to deselect a chosen button.

Basically, if you have two buttons in a `buttons-radio` group, by using `buttons-radio-optional` instead you could have a 3rd state of neither button selected.

(Reopening PR #3992 which @markdotto said was a good idea, but @fat said needed unit tests)
