### PR TITLE
don't open modal if the trigger link/button is disabled.

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -228,6 +228,8 @@
 
       e.preventDefault()
 
+      if ($this.is('.disabled, :disabled')) return
+
       $target
         .modal(option)        
         .one('hide', function () {

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -111,4 +111,16 @@ $(function () {
           })
           .modal("toggle")
       })
+
+      test("should not open modal if link or button is disabled", function () {
+        var div = $("<div class='modal hide' id='modal-test'>Modal</div>")
+          .appendTo($("#qunit-fixture"))
+        var link = $('<a href="#modal-test" class="disabled" data-toggle="modal">Go</a>')
+          .appendTo($("#qunit-fixture"))
+
+        link.click()
+
+        ok(!$('#modal-test').hasClass("in"), 'modal not opened')
+      })
+
 })


### PR DESCRIPTION
If a link or button with `data-toggle="modal"` is `disabled`, this prevents the associated modal dialog from being displayed. (Similar to how dropdowns already work.)
