### PR TITLE
Docs 2.1- add class 'fade' to myModal

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -214,7 +214,7 @@ $('#myModal').on('show', function (e) {
           <h3>Live demo</h3>
           <p>Toggle a modal via JavaScript by clicking the button below. It will slide down and fade in from the top of the page.</p>
           <!-- sample modal content -->
-          <div id="myModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+          <div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
             <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
               <h3 id="myModalLabel">Modal Heading</h3>


### PR DESCRIPTION
The description says modal will fade and slide, but was missing 'fade' class as in 2.0.4 so it was just appearing.
Obviously not the place for suggestions, but I didn't want to noise up the issues list. It might be nice to have two classes, fade and slide.  Fade would transition the opacity, and slide would transition the 'top'.  Since some people might be interested in only the subtler fade effect, without going for the more drastic fade/slide combo.
