### PR TITLE
Thumbnails in responsive designs

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -53,6 +53,7 @@
   }
   .thumbnails > li {
     float: none;
+    margin-left: 0;
   }
   // Make all grid-sized elements block level again
   [class*="span"],


### PR DESCRIPTION
When having the mobile (768px max) view the thumbnails preserved their margin-left which looked a bit ugly.
