### PR TITLE
remove clause that Opera doesn't support CSS Animations. closes #4460

### DIFF
--- a/docs/templates/pages/components.mustache
+++ b/docs/templates/pages/components.mustache
@@ -2070,7 +2070,7 @@
 
           <h2>{{_i}}Browser support{{/i}}</h2>
           <p>{{_i}}Progress bars use CSS3 gradients, transitions, and animations to achieve all their effects. These features are not supported in IE7-9 or older versions of Firefox.{{/i}}</p>
-          <p>{{_i}}Opera and IE do not support animations at this time.{{/i}}</p>
+          <p>{{_i}}IE does not support animations at this time.{{/i}}</p>
 
         </section>
 


### PR DESCRIPTION
closes #4460
