### PR TITLE
Fix file input width issues

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -97,6 +97,10 @@ textarea {
 textarea {
   height: auto;
 }
+// Reset width since it can't be styled reliably on file inputs
+input[type="file"] {
+  width: auto;
+}
 // Everything else
 textarea,
 input[type="text"],


### PR DESCRIPTION
It's not possible to style a file input width reliably in a cross browser way. Was already reported in #1571 but was broken later on.
See [this fiddle](http://jsfiddle.net/QnTxN/).
