### PR TITLE
Fixed misleading Nested Columns explanation in Docs.

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -200,7 +200,7 @@
           <h2>Nesting columns</h2>
           <p>To nest your content with the default grid, add a new <code>.row</code> and set of <code>.span*</code> columns within an existing <code>.span*</code> column. Nested rows should include a set of columns that add up to the number of columns of its parent.</p>
           <h3>Example</h3>
-          <p>Here two nested <code>.span4</code> columns are placed within a <code>.span8</code>.</p>
+          <p>Here a <code>.span6</code> and a <code>.span3</code> column are nested within a <code>.span9</code>.</p>
           <div class="row show-grid">
             <div class="span9">
               Level 1 of column


### PR DESCRIPTION
Original version did not match the actual and sample markup. Now it does.
