### PR TITLE
Small documentation fix.

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -233,7 +233,7 @@
           <h2 id="blockquotes">Blockquotes</h2>
           <p>For quoting blocks of content from another source within your document.</p>
 
-          <h3>Default blockqoute</h3>
+          <h3>Default blockquote</h3>
           <p>Wrap <code>&lt;blockquote&gt;</code> around any <abbr title="HyperText Markup Language">HTML</abbr> as the quote. For straight quotes we recommend a <code>&lt;p&gt;</code>.</p>
           <div class="bs-docs-example">
             <blockquote>


### PR DESCRIPTION
Small typo in documentation.
Replaced "blockqoute" for "blockquote".

Thanks
