### PR TITLE
Documentation typo with closing div/body tags.

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1616,7 +1616,7 @@ $('.carousel').carousel({
             <h3>Via data attributes</h3>
             <p>To easily add affix behavior to any element, just add <code>data-spy="affix"</code> to the element you want to spy on. Then use offsets to define when to toggle the pinning of an element on and off.</p>
 
-            <pre class="prettyprint linenums">&lt;div data-spy="affix" data-offset-top="200"&gt;...&lt;/body&gt;</pre>
+            <pre class="prettyprint linenums">&lt;div data-spy="affix" data-offset-top="200"&gt;...&lt;/div&gt;</pre>
 
             <div class="alert alert-info">
               <strong>Heads up!</strong>


### PR DESCRIPTION
Line reads as 

```
<div data-spy="affix" data-offset-top="200">...</body>
```

Should be

```
<div data-spy="affix" data-offset-top="200">...</div>
```
