### PR TITLE
Close tags properly in form add-on icon example

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1881,7 +1881,7 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
   &lt;label class="control-label" for="inputIcon"&gt;Email address&lt;/label&gt;
   &lt;div class="controls"&gt;
     &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;i&gt;&lt;span&gt;&lt;input class="span2" id="inputIcon" type="text"&gt;
+    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" id="inputIcon" type="text"&gt;
   &lt;/div&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
Both the `<i>` and `<span class="add-on">` were missing the `/` on their closing tags.
