### PR TITLE
icons inside .btn-mini are misaligned by 1px

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -98,6 +98,9 @@
   font-size: @baseFontSize - 3px;
   line-height: @baseLineHeight - 4px;
 }
+.btn-mini [class^="icon-"] {
+  margin-top: -1px;
+}
 
 // Block button
 .btn-block {


### PR DESCRIPTION
This is a regression from #4409, adding css for giving the icons the right offset.
