### PR TITLE
Fix all submenus expanded recursively in dropdown

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -172,7 +172,7 @@
      -moz-border-radius: 0 6px 6px 6px;
           border-radius: 0 6px 6px 6px;
 }
-.dropdown-submenu:hover .dropdown-menu {
+.dropdown-submenu:hover > .dropdown-menu {
   display: block;
 }
 


### PR DESCRIPTION
The problem was that the CSS selector made _all_ of a submenu's nested menus visible. Fixed by applying the selector to the immediate nested menu only.
