### PR TITLE
Fix white icons usage in navs

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -30,8 +30,8 @@
 
 /* White icons with optional class, or on hover/active states of certain elements */
 .icon-white,
-.nav > .active > a > [class^="icon-"],
-.nav > .active > a > [class*=" icon-"],
+.navbar-inverse .nav > .active > a > [class^="icon-"],
+.navbar-inverse .nav > .active > a > [class*=" icon-"],
 .dropdown-menu > li > a:hover > [class^="icon-"],
 .dropdown-menu > li > a:hover > [class*=" icon-"],
 .dropdown-menu > .active > a > [class^="icon-"],


### PR DESCRIPTION
Since 2.1 release, icons used in `.nav` and white `.navbar` are white.
White Sprite should be only used in `.navbar-inverse` elements.

Before patch :

![Before patch](http://cl.ly/image/160t1e19352W/Screenshot-3.png)

After :
![After](http://cl.ly/Itfq/Screenshot-4.png)
