### PR TITLE
Spelling correction Javasript -> Javascript

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -114,7 +114,7 @@
             </div>
             <div class="span6">
               <h2>Download source</h2>
-              <p>Get the original files for all CSS and Javasript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
+              <p>Get the original files for all CSS and Javascript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
               <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" >Download Bootstrap source</a></p>
             </div>
           </div>


### PR DESCRIPTION
Just a typo fix in the getting started documentation.
