### PR TITLE
Fix left-side-cutoff problem with prepended inputs in togglable tabs

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -523,6 +523,12 @@ input.search-query {
 }
 
 
+/* Prevent cutoff of left border in a togglable tab */
+
+.tab-content .input-prepend {
+  margin-left: 1px;
+}
+
 
 
 // HORIZONTAL & VERTICAL FORMS


### PR DESCRIPTION
When a prepended input is inside of a togglable tab, the left border gets cut off; see this fiddle:

http://jsfiddle.net/RyesV/

To fix it I simply (naively) added `1px` of margin to the left side of prepended inputs if they are inside a `.tab-content` element. Seems to work.
