### PR TITLE
Improved .box-shadow mixins

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -119,7 +119,7 @@
 .btn-group > .btn + .dropdown-toggle {
   padding-left: 8px;
   padding-right: 8px;
-  .box-shadow(~"inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
+  .box-shadow(inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05));
   *padding-top: 5px;
   *padding-bottom: 5px;
 }
@@ -146,7 +146,7 @@
   // Remove the gradient and set the same inset shadow as the :active state
   .dropdown-toggle {
     background-image: none;
-    .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
+    .box-shadow(inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05));
   }
 
   // Keep the hover's background when dropdown is open

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -24,7 +24,7 @@
   border-bottom-color: darken(@btnBorder, 10%);
   .border-radius(4px);
   .ie7-restore-left-whitespace(); // Give IE7 some love
-  .box-shadow(~"inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
+  .box-shadow(inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05));
 
   // Hover state
   &:hover {
@@ -51,7 +51,7 @@
     background-color: darken(@white, 15%) e("\9");
     background-image: none;
     outline: 0;
-    .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
+    .box-shadow(inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05));
   }
 
   // Disabled state

--- a/less/forms.less
+++ b/less/forms.less
@@ -125,7 +125,7 @@ input[type="color"],
     border-color: rgba(82,168,236,.8);
     outline: 0;
     outline: thin dotted \9; /* IE6-9 */
-    .box-shadow(~"inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6)");
+    .box-shadow(inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6));
   }
 }
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -253,6 +253,18 @@
           box-shadow: @shadow;
 }
 
+.box-shadow(@shadow1, @shadow2) {
+  -webkit-box-shadow: @shadow1, @shadow2;
+     -moz-box-shadow: @shadow1, @shadow2;
+          box-shadow: @shadow1, @shadow2;
+}
+
+.box-shadow(@shadow1, @shadow2, @shadow3) {
+  -webkit-box-shadow: @shadow1, @shadow2, @shadow3;
+     -moz-box-shadow: @shadow1, @shadow2, @shadow3;
+          box-shadow: @shadow1, @shadow2, @shadow3;
+}
+
 // Transitions
 .transition(@transition) {
   -webkit-transition: @transition;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -249,11 +249,10 @@
 // Drop shadows
 // Multiple shadow solution from www.toekneestuck.com/blog/2012/05/15/less-css-arguments-variable/
 .box-shadow(@shadowA, @shadowB:X, ...){
-    @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
-    -webkit-box-shadow: @props;
-       -moz-box-shadow: @props;
-         -o-box-shadow: @props;
-            box-shadow: @props;
+  @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+  -webkit-box-shadow: @props;
+     -moz-box-shadow: @props;
+          box-shadow: @props;
 }
 
 // Transitions

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -247,22 +247,13 @@
 }
 
 // Drop shadows
-.box-shadow(@shadow) {
-  -webkit-box-shadow: @shadow;
-     -moz-box-shadow: @shadow;
-          box-shadow: @shadow;
-}
-
-.box-shadow(@shadow1, @shadow2) {
-  -webkit-box-shadow: @shadow1, @shadow2;
-     -moz-box-shadow: @shadow1, @shadow2;
-          box-shadow: @shadow1, @shadow2;
-}
-
-.box-shadow(@shadow1, @shadow2, @shadow3) {
-  -webkit-box-shadow: @shadow1, @shadow2, @shadow3;
-     -moz-box-shadow: @shadow1, @shadow2, @shadow3;
-          box-shadow: @shadow1, @shadow2, @shadow3;
+// Multiple shadow solution from www.toekneestuck.com/blog/2012/05/15/less-css-arguments-variable/
+.box-shadow(@shadowA, @shadowB:X, ...){
+    @props: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+    -webkit-box-shadow: @props;
+       -moz-box-shadow: @props;
+         -o-box-shadow: @props;
+            box-shadow: @props;
 }
 
 // Transitions

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -195,7 +195,7 @@
 .navbar-fixed-top,
 .navbar-static-top {
   .navbar-inner {
-    .box-shadow(~"inset 0 -1px 0 rgba(0,0,0,.1), 0 1px 10px rgba(0,0,0,.1)");
+    .box-shadow(inset 0 -1px 0 rgba(0,0,0,.1), 0 1px 10px rgba(0,0,0,.1));
   }
 }
 
@@ -203,7 +203,7 @@
 .navbar-fixed-bottom {
   bottom: 0;
   .navbar-inner {
-    .box-shadow(~"inset 0 1px 0 rgba(0,0,0,.1), 0 -1px 10px rgba(0,0,0,.1)");
+    .box-shadow(inset 0 1px 0 rgba(0,0,0,.1), 0 -1px 10px rgba(0,0,0,.1));
   }
 }
 
@@ -268,7 +268,7 @@
   margin-left: 5px;
   margin-right: 5px;
   .buttonBackground(darken(@navbarBackgroundHighlight, 5%), darken(@navbarBackground, 5%));
-  .box-shadow(~"inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.075)");
+  .box-shadow(inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.075));
 }
 .navbar .btn-navbar .icon-bar {
   display: block;
@@ -440,7 +440,7 @@
       color: @white;
       background-color: @navbarInverseSearchBackground;
       border-color: @navbarInverseSearchBorder;
-      .box-shadow(~"inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0 rgba(255,255,255,.15)");
+      .box-shadow(inset 0 1px 2px rgba(0,0,0,.1), 0 1px 0 rgba(255,255,255,.15));
       .transition(none);
       .placeholder(@navbarInverseSearchPlaceholderColor);
 

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -66,7 +66,7 @@
   .transition(width .6s ease);
 }
 .progress .bar + .bar {
-  .box-shadow(~"inset 1px 0 0 rgba(0,0,0,.15), inset 0 -1px 0 rgba(0,0,0,.15)");
+  .box-shadow(inset 1px 0 0 rgba(0,0,0,.15), inset 0 -1px 0 rgba(0,0,0,.15));
 }
 
 // Striped bars

--- a/less/responsive-navbar.less
+++ b/less/responsive-navbar.less
@@ -123,7 +123,7 @@
     margin: (@baseLineHeight / 2) 0;
     border-top: 1px solid @navbarBackground;
     border-bottom: 1px solid @navbarBackground;
-    .box-shadow(~"inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1)");
+    .box-shadow(inset 0 1px 0 rgba(255,255,255,.1), 0 1px 0 rgba(255,255,255,.1));
   }
   // Pull right (secondary) nav content
   .navbar .nav-collapse .nav.pull-right {


### PR DESCRIPTION
Added .box-shadow mixins that take multiple arguments. This allows up to three comma delimited shadows to be defined without needing to escape the string with tilde and quotes. It allows variables to be within the box-shadow to be evaluated by LESS.

Before:
.box-shadow(~"inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");

After:
.box-shadow(inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05));
