### PR TITLE
Use document ready instead of window load for affix plugin data API

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -86,7 +86,7 @@
  /* AFFIX DATA-API
   * ============== */
 
-  $(window).on('load', function () {
+  $(function () {
     $('[data-spy="affix"]').each(function () {
       var $spy = $(this)
         , data = $spy.data()


### PR DESCRIPTION
Window load doesn't allow for use of the data API when  affix has been
loaded asynchronously, as it will have missed the window load event.
Also, this brings it in line with the rest of the bootstrap plugins.
