### PR TITLE
Add support for custom icons.

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -14,18 +14,32 @@
 // For the white version of the icons, just add the .icon-white class:
 // <i class="icon-inbox icon-white"></i>
 
+// For custom icons, use the custom-icon- prefix:
+// <i class="custom-icon-object"></i>
+// and define the icon image and positioning in your stylesheet.
+// .custom-icon-object {
+//   background-image: ...;
+//   background-position: ...;
+// }
+
 [class^="icon-"],
-[class*=" icon-"] {
+[class*=" icon-"],
+[class^="custom-icon-"],
+[class*=" custom-icon-"]{
   display: inline-block;
   width: 14px;
   height: 14px;
   .ie7-restore-right-whitespace();
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url("@{iconSpritePath}");
   background-position: 14px 14px;
   background-repeat: no-repeat;
   margin-top: 1px;
+}
+
+[class^="icon-"],
+[class*=" icon-"] {
+  background-image: url("@{iconSpritePath}");
 }
 
 /* White icons with optional class, or on hover/active states of certain elements */


### PR DESCRIPTION
Ideally, a custom icon should be as easy to add as

```
.icon-[custom name] {
    background-image: ...;
    background-position: ...;
}
```

Apparently, this used to work in 2.0.4, but no longer works in 2.1.0 - someone reported this in the mailing group. The issue is that the bootstrap styles in many elements have more specificity now, such as 

```
.navbar-inverse .nav > .active > a > [class^="icon-"]
```

which makes the browser pick that particular background image (mentioned in the property). 

I have been thinking of some solutions and the best I could think of was to have a separate class prefix, like

```
.custom-icon-[custom name]
```

I have added support for using this approach in the commit.

Would love to hear/know about any alternate approaches possible. 
