### PR TITLE
Changed return false in Dropdown toggle.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -56,7 +56,7 @@
         $this.focus()
       }
 
-      return false
+      e.preventDefault()
     }
 
   , keydown: function (e) {


### PR DESCRIPTION
Changed return false to e.preventDefault() in the toggle function of Dropdown. This is preventing from binding any additional events to a dropdown button. 

In my case specifically, my application is highly dynamic so I want to rerender the dropdown list when the button is clicked. This was not possible due to the return false.
