### PR TITLE
2.1.1 wip

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -316,7 +316,7 @@ $('#myModal').on('show', function (e) {
                <td>remote</td>
                <td>path</td>
                <td>false</td>
-               <td><p>If a remote url is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> tag to specify the remote source. An example of this is shown below:</p>
+               <td><p>If a remote url is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
               <pre class="prettyprint linenums"><code>&lt;a data-toggle="modal" href="remote.html" data-target="#modal"&gt;click me&lt;/a&gt;</code></pre></td>
              </tr>
             </tbody>
@@ -1035,7 +1035,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
 
 
         <h2>Example alerts</h2>
-        <p>Add dismiss functionality to all alerge messages with this plugin.</p>
+        <p>Add dismiss functionality to all alerts messages with this plugin.</p>
         <div class="bs-docs-example">
           <div class="alert fade in">
             <button type="button" class="close" data-dismiss="alert">&times;</button>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -246,7 +246,7 @@ $('#myModal').on('show', function (e) {
                <td>{{_i}}remote{{/i}}</td>
                <td>{{_i}}path{{/i}}</td>
                <td>{{_i}}false{{/i}}</td>
-               <td><p>{{_i}}If a remote url is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> tag to specify the remote source. An example of this is shown below:{{/i}}</p>
+               <td><p>{{_i}}If a remote url is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:{{/i}}</p>
               <pre class="prettyprint linenums"><code>&lt;a data-toggle="modal" href="remote.html" data-target="#modal"&gt;click me&lt;/a&gt;</code></pre></td>
              </tr>
             </tbody>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -965,7 +965,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
 
 
         <h2>{{_i}}Example alerts{{/i}}</h2>
-        <p>{{_i}}Add dismiss functionality to all alerge messages with this plugin.{{/i}}</p>
+        <p>{{_i}}Add dismiss functionality to all alerts messages with this plugin.{{/i}}</p>
         <div class="bs-docs-example">
           <div class="alert fade in">
             <button type="button" class="close" data-dismiss="alert">&times;</button>


### PR DESCRIPTION
The text "Add dismiss functionality to all alerge messages with this plugin." at javascript docs page are spelled incorrectly, the correct is alert. Also the href atribute from link was referenced as a tag.
