### PR TITLE
Elaborated on placeholder bundling issue

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -209,7 +209,7 @@ input[type="checkbox"]:focus {
 // Placeholder
 // -------------------------
 
-// Placeholder text gets special styles; can't be bundled together though for some reason
+// Placeholder text gets special styles; can't be bundled together because when a browser doesn’t understand a selector, it invalidates the entire line of selectors (except IE 7)
 input,
 textarea {
   .placeholder();


### PR DESCRIPTION
The placeholder text is styled using a mixin. There's a comment saying this is so because it can't be bundled together but we ~"don't know why". It now states the reason
