### PR TITLE
Fixed left margin on btn-group's buttons to avoid double borders

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -92,6 +92,9 @@
 .navbar .btn-group .btn {
   margin: 0; // then undo the margin here so we don't accidentally double it
 }
+.navbar .btn-group > .btn + .btn {
+  margin-left: -1px; // fix left margin in order to avoid double border
+}
 
 // Navbar forms
 .navbar-form {


### PR DESCRIPTION
Button groups in navbar show double border between buttons

Problem: http://jsfiddle.net/rubenrails/qUR76/3/
Fixed: http://jsfiddle.net/rubenrails/qUR76/4/

Fixes #4692
