### PR TITLE
Fixes an error in documentation

### DIFF
--- a/base-css.html
+++ b/base-css.html
@@ -1891,7 +1891,8 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
   &lt;label class="control-label" for="inputIcon"&gt;Email address&lt;/label&gt;
   &lt;div class="controls"&gt;
     &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;i&gt;&lt;span&gt;&lt;input class="span2" id="inputIcon" type="text"&gt;
+      &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" id="inputIcon" type="text"&gt;
+    &lt;/div&gt;
   &lt;/div&gt;
 &lt;/div&gt;
 </pre>


### PR DESCRIPTION
Icon form field example code was missing a closing div, and the closing slashes in the i and span elements.  Needless to say, the prior example code didn't work.
