### PR TITLE
Add event triggers to the Affix plugin

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -56,6 +56,12 @@
 
     if (this.affixed === affix) return
 
+    if (affix) {
+      this.$element.trigger('unaffixed')
+    } else {
+      this.$element.trigger('affixed')
+    }
+
     this.affixed = affix
     this.unpin = affix == 'bottom' ? position.top - scrollTop : null
 


### PR DESCRIPTION
I added event triggers for when an item is affixed or unaffixed. In my case this was so I could have a default navbar and then when it becomes affixed add the "navbar-fixed-top" class for example:

<script type="text/javascript">
    $(function(){
        $('#navbar').on('affixed', function () {
            $('#navbar').addClass('navbar-fixed-top')
        });
        
        $('#navbar').on('unaffixed', function () {
            $('#navbar').removeClass('navbar-fixed-top')
        });
    });
</script>


Think it would be useful for any kind of style changes people want to make when an object is affixed.

Please feel free to make comments I can take constructive criticism :)
