### PR TITLE
simple .dissolve transition for carousel slides

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5658,6 +5658,21 @@ a.badge:hover {
   margin-bottom: 0;
 }
 
+.dissolve .item {
+  -webkit-transition: opacity 2s ease-in-out;
+     -moz-transition: opacity 2s ease-in-out;
+       -o-transition: opacity 2s ease-in-out;
+          transition: opacity 2s ease-in-out;
+}
+
+.dissolve .active.left,
+.dissolve .active.right {
+  left: 0;
+  z-index: 2;
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+
 .hero-unit {
   padding: 60px;
   margin-bottom: 30px;

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1421,6 +1421,16 @@ $('#myCollapsible').on('hidden', function () {
             </div>
 
 
+            <h4>Dissolve Transition</h4>
+            <p>Give your slides a dissolving effect by adding <code>.dissolve</code> to your carousel.</p>
+<pre class="prettyprint linenums">
+&lt;div id="myCarousel" class="carousel dissolve slide"&gt;
+  &lt;!-- Carousel items --&gt;
+&lt;/div&gt;
+</pre>
+
+
+
             <hr class="bs-docs-separator">
 
 

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1351,6 +1351,15 @@ $('#myCollapsible').on('hidden', function () {
             </div>
 
 
+            <h4>{{_i}}Dissolve Transition{{/_i}}</h4>
+            <p>{{_i}}Give your slides a dissolving effect by adding <code>.dissolve</code> to your carousel.{{/_i}}</p>
+<pre class="prettyprint linenums">
+&lt;div id="myCarousel" class="carousel dissolve slide"&gt;
+  &lt;!-- {{_i}}Carousel items --&gt;
+&lt;/div&gt;
+</pre>
+
+
             <hr class="bs-docs-separator">
 
 

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -129,3 +129,20 @@
 .carousel-caption p {
   margin-bottom: 0;
 }
+
+
+
+// Dissolve animation
+.dissolve {
+  .item {
+    .transition(opacity 2s ease-in-out); 
+  }
+  .active {
+    &.left,
+    &.right {
+      left: 0;
+      z-index: 2;
+      .opacity(0);
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new carousel slide transition, .dissolve.  Javascript docs (mustache/html) were updated with a brief mention of the effect, LESS and CSS were updated as well. 

The transition works fine as intended in webkit and moz, but in IE the dissolve effect is ignored and falls back to the normal slide transition.  

As a side note, I tried to find existing code in Bootstrap to do this transition, but was unsuccessful in getting the dissolve effect to work. Sorry if I missed something and there is already code to do this.
