### PR TITLE
i18n tags missing in some strings at getting started download page

### DIFF
--- a/docs/templates/pages/getting-started.mustache
+++ b/docs/templates/pages/getting-started.mustache
@@ -37,14 +37,14 @@
 
           <div class="row-fluid">
             <div class="span6">
-              <h2>Download compiled</h2>
-              <p><strong>Fastest way to get started:</strong> get the compiled and minified versions of our CSS, JS, and images. No docs or original source files.</p>
-              <p><a class="btn btn-large btn-primary" href="assets/bootstrap.zip" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download compiled']);"{{/production}}>Download Bootstrap</a></p>
+              <h2>{{_i}}Download compiled{{/i}}</h2>
+              <p>{{_i}}<strong>Fastest way to get started:</strong> get the compiled and minified versions of our CSS, JS, and images. No docs or original source files.{{/i}}</p>
+              <p><a class="btn btn-large btn-primary" href="assets/bootstrap.zip" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download compiled']);"{{/production}}>{{_i}}Download Bootstrap{{/i}}</a></p>
             </div>
             <div class="span6">
               <h2>Download source</h2>
               <p>Get the original files for all CSS and JavaScript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
-              <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);"{{/production}}>Download Bootstrap source</a></p>
+              <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);"{{/production}}>{{_i}}Download Bootstrap source{{/i}}</a></p>
             </div>
           </div>
         </section>
@@ -204,9 +204,9 @@
           <div class="page-header">
             <h1>{{_i}}What next?{{/i}}</h1>
           </div>
-          <p class="lead">Head to the docs for information, examples, and code snippets, or take the next leap and customize Bootstrap for any upcoming project.</p>
-          <a class="btn btn-large btn-primary" href="./scaffolding.html" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Next steps', 'Visit docs']);"{{/production}}>Visit the Bootstrap docs</a>
-          <a class="btn btn-large" href="./customize.html" style="margin-left: 5px;" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Next steps', 'Customize']);"{{/production}}>Customize Bootstrap</a>
+          <p class="lead">{{_i}}Head to the docs for information, examples, and code snippets, or take the next leap and customize Bootstrap for any upcoming project.{{/i}}</p>
+          <a class="btn btn-large btn-primary" href="./scaffolding.html" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Next steps', 'Visit docs']);"{{/production}}>{{_i}}Visit the Bootstrap docs{{/i}}</a>
+          <a class="btn btn-large" href="./customize.html" style="margin-left: 5px;" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Next steps', 'Customize']);"{{/production}}>{{_i}}Customize Bootstrap{{/i}}</a>
         </section>
 
 


### PR DESCRIPTION
It's just a detail, but if we expect that the content be correctly translated we should wrap all strings with the tag i18n. I have a script to make a translation and just this part wasn't translated, so I changed it and wish to contribute.
