### PR TITLE
Fix Typeahead key navigation with Chrome + jQuery 1.8.0

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -174,7 +174,7 @@
         .on('keypress', $.proxy(this.keypress, this))
         .on('keyup',    $.proxy(this.keyup, this))
 
-      if ($.browser.webkit || $.browser.msie) {
+      if ($.browser.chrome || $.browser.webkit || $.browser.msie) {
         this.$element.on('keydown', $.proxy(this.keydown, this))
       }
 


### PR DESCRIPTION
In jQuery 1.8.0, Google Chrome no longer shows up as `$.browser.webkit`, but instead has its own `$.browser.chrome` flag. Because of this, `keydown` events were not being added.

[jsFiddle - typeahead key events not working (on Chrome)](http://jsfiddle.net/tdcWe/4/)
[jsFiddle - typeahead key events working with change](http://jsfiddle.net/tdcWe/7/)
