### PR TITLE
Allow ScrollSpy to match non-latin anchors

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -56,7 +56,7 @@
           .map(function () {
             var $el = $(this)
               , href = $el.data('target') || $el.attr('href')
-              , $href = /^#\w/.test(href) && $(href)
+              , $href = /^#.+/.test(href) && $(href)
             return ( $href
               && $href.length
               && [[ $href.position().top, href ]] ) || null


### PR DESCRIPTION
Currently it's using `\w` to test link validity. ScrollSpy shouldn't
be in the business of specifying which anchors are valid or not. In
this case anchors like `#^_^` or `#香港` will fail even though browser
recognizes them just fine.
