### PR TITLE
Fixes typo on border radius fix for tables

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -133,7 +133,7 @@ table {
   colgroup + tbody tr:first-child td:last-child {
     -webkit-border-top-right-radius: 4px;
             border-top-right-radius: 4px;
-          -moz-border-right-topleft: 4px;
+          -moz-border-right-topright: 4px;
   }
 
 }


### PR DESCRIPTION
The fix for tables has a typo for the Mozilla vendor prefix for border radius. Both webkit and the generic border radius change the top right radius while mozilla is using top left(probably just some copy-pasta typo)
