### PR TITLE
Makefile misses a 'clean' directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,13 @@ test:
 	rm js/tests/pid.txt
 
 #
+# CLEANS THE ROOT DIRECTORY OF PRIOR BUILDS
+#
+
+clean:
+	rm -r bootstrap
+
+#
 # BUILD SIMPLE BOOTSTRAP DIRECTORY
 # recess & uglifyjs are required
 #


### PR DESCRIPTION
I was missing a _"clean"_ directive for make so I just added it.

It should be a rather non-intrusive addition as it just deletes the _boostrap_  built directory.

You'd invoke it like this `make clean`
