### PR TITLE
Dropdowns won't close where the first dropdown has data-target attribute.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -100,7 +100,7 @@
   }
 
   function clearMenus() {
-    getParent($(toggle))
+    $(toggle).parent()
       .removeClass('open')
   }
 

--- a/js/tests/unit/bootstrap-dropdown.js
+++ b/js/tests/unit/bootstrap-dropdown.js
@@ -102,4 +102,37 @@ $(function () {
         dropdown.remove()
       })
 
+      test("should remove open class from second dropdown if body clicked", function () {
+        var dropdownHTML = '<ul class="tabs">'
+          + '<li class="dropdown" id="first">'
+          + '<a href="#" class="dropdown-toggle" data-toggle="dropdown" data-target="#first">Dropdown</a>'
+          + '<ul class="dropdown-menu">'
+          + '<li><a href="#">Secondary link</a></li>'
+          + '<li><a href="#">Something else here</a></li>'
+          + '<li class="divider"></li>'
+          + '<li><a href="#">Another link</a></li>'
+          + '</ul>'
+          + '</li>'
+          + '</ul>'
+          + '<ul class="tabs">'
+          + '<li class="dropdown" id="second">'
+          + '<a href="#" class="dropdown-toggle" data-toggle="dropdown" data-target="#second">Dropdown</a>'
+          + '<ul class="dropdown-menu">'
+          + '<li><a href="#">Secondary link</a></li>'
+          + '<li><a href="#">Something else here</a></li>'
+          + '<li class="divider"></li>'
+          + '<li><a href="#">Another link</a></li>'
+          + '</ul>'
+          + '</li>'
+          + '</ul>'
+          , dropdown = $(dropdownHTML)
+            .appendTo('#qunit-fixture')
+            .find('[data-target="#second"]')
+            .dropdown()
+            .click()
+        ok(dropdown.parent('.dropdown[id="second"]').hasClass('open'), 'open class added on click')
+        $('body').click()
+        ok(!dropdown.parent('.dropdown[id="second"]').hasClass('open'), 'open class removed')
+        dropdown.remove()
+      })
 })


### PR DESCRIPTION
Reopen of #4307:

When there are multiple dropdown menus in a page, and the first one link has data-target attribute, the other dropdown menus in the page won't close if ever opened.

To illustrate the problem:
- [jsfiddle with the current version](http://jsfiddle.net/6fAm3/2/)
- [jsfiddle with patched version](http://jsfiddle.net/fY849/2/)
