### PR TITLE
Update CSS selector to remove horizontal labels

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -128,7 +128,7 @@
   }
 
   // Remove the horizontal form styles
-  .form-horizontal .control-group > label {
+  .form-horizontal .control-label {
     float: none;
     width: auto;
     padding-top: 0;


### PR DESCRIPTION
The CSS selector to float the labels left in horizontal forms is `.form-horizontal .control-label` (https://github.com/twitter/bootstrap/blob/master/less/forms.less#L608) but the selector to remove this float on small screens is `.form-horizontal .control-group > label`.

This can lead to a display error on small screens when using the class `control-label` on elements different than labels:

``` html
<div class="control-group">
  <p class="control-label">Text input</p>
  <div class="controls">
    <p class="help-inline">Inline help text with no input</p>
  </div>
</div>
```
