### PR TITLE
make tabs generate hide and hidden events

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -49,10 +49,15 @@
 
       if ( $this.parent('li').hasClass('active') ) return
 
-      previous = $ul.find('.active a').last()[0]
+      previous = $ul.find('.active a').last()
+
+      previous.trigger({
+        type: 'hide'
+      , relatedTarget: $this
+      })
 
       e = $.Event('show', {
-        relatedTarget: previous
+        relatedTarget: previous[0]
       })
 
       $this.trigger(e)
@@ -63,9 +68,13 @@
 
       this.activate($this.parent('li'), $ul)
       this.activate($target, $target.parent(), function () {
+        previous.trigger({
+          type: 'hidden'
+        , relatedTarget: $this
+        })
         $this.trigger({
           type: 'shown'
-        , relatedTarget: previous
+        , relatedTarget: previous[0]
         })
       })
     }

--- a/js/tests/unit/bootstrap-tab.js
+++ b/js/tests/unit/bootstrap-tab.js
@@ -58,4 +58,32 @@ $(function () {
           .tab('show')
       })
 
+      test("should fire all four events", function () {
+        stop()
+        $('#qunit-fixture').append(''
+          + "<ul class='nav nav-tabs'>"
+          +   "<li class='active'><a data-target='#info' data-toggle='tab'>Info</a></li>"
+          +   "<li><a data-target='#media' data-toggle='tab'>Media</a></li>"
+          + "</ul>"
+          + "<div class='tab-content'>"
+          +   "<div class='tab-pane active' id='info'>Info</div>"
+          +   "<div class='tab-pane' id='media'></div>"
+          + "</div>")
+
+        var events = '' // order matters so stop() and start() alone aren't sufficcient
+        $('#qunit-fixture').find("a[data-target='#info']")
+          .on('show', function(e) { ok(false) })
+          .on('hide', function(e) { events += 'hide#info' })
+          .on('shown', function(e) { ok(false) })
+          .on('hidden', function(e) { events += ' hidden#info' })
+
+        $('#qunit-fixture').find("a[data-target='#media']")
+          .on('show', function(e) { events += ' show#media' })
+          .on('hide', function(e) { ok(false) })
+          .on('shown', function(e) { events += ' shown#media'; start() })
+          .on('hidden', function(e) { ok(false) })
+
+        $('#qunit-fixture').find('li:last a').tab('show')
+        equal(events, 'hide#info show#media hidden#info shown#media')
+      })
 })


### PR DESCRIPTION
Seems only fair, and it cleans up some convoluted logic in my app (stopping video players and restoring CSS states).

(this replaces #4830 -- an identical patch, but mistakenly diffed against master.)
