### PR TITLE
Added permalink functionality to modals

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -234,6 +234,12 @@
           $this.focus()
         })
     })
+    
+    $('.modal').each(function () {
+      if(window.location.href.indexOf($(this).attr("id")) != -1) {
+        $(this).modal('show');
+      }
+    })
   })
 
 }(window.jQuery);


### PR DESCRIPTION
Added the ability to permalink to modal dialogs. When visiting a page with the modal's id appended to the url (ex: http://www.website.com/page.html#myModal) the page will load with the modal displayed open.
