### PR TITLE
Fix issue #4797 by double-applying CSS

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -118,6 +118,11 @@
 
         inside = /in/.test(placement)
 
+        /** @see https://github.com/twitter/bootstrap/issues/4797 */
+        $tip
+          .addClass("in")
+          .addClass(placement)
+
         $tip
           .remove()
           .css({ top: 0, left: 0, display: 'block' })


### PR DESCRIPTION
Apply the 'placement' once (to force the browser to pre-calculate the width of the target element correctly), calculate the CSS, and let the tooltip position be set again via CSS later.
