### PR TITLE
Solved bug in bootstrap tooltip when entering and leaving quickly

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -73,7 +73,8 @@
 
   , enter: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
-
+      
+      clearTimeout(this.removeTimeout)
       if (!self.options.delay || !self.options.delay.show) return self.show()
 
       clearTimeout(this.timeout)
@@ -165,12 +166,12 @@
       $tip.removeClass('in')
 
       function removeWithAnimation() {
-        var timeout = setTimeout(function () {
+        that.removeTimeout = setTimeout(function () {
           $tip.off($.support.transition.end).remove()
         }, 500)
 
         $tip.one($.support.transition.end, function () {
-          clearTimeout(timeout)
+          clearTimeout(that.removeTimeout)
           $tip.remove()
         })
       }

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -140,5 +140,26 @@ $(function () {
         ok(tooltip.data('events').click[0].namespace == 'foo', 'tooltip still has click.foo')
         ok(!tooltip.data('events').mouseover && !tooltip.data('events').mouseout, 'tooltip does not have any events')
       })
+      
+      test("should not hide tooltip if cursor is moved out and back in quickly", function() {
+        $(".tooltip").remove()
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip()
+        tooltip.trigger('mouseenter')
+        stop()
+        // Get the mouse out and back in
+        tooltip.trigger('mouseout')
+               
+        setTimeout(function () {
+          // Tooltip should still show
+          tooltip.trigger('mouseenter')
+          setTimeout(function () {
+            // Tooltip should still show even after 500 ms
+            ok($(".tooltip").length, 'tooltip is showing')
+            start()
+          }, 500)
+        }, 100)
+      })
 
 })


### PR DESCRIPTION
When entering and leaving quickly you might get into a state that the tooltip is not visible when the cursor is inside the element. This is caused since the timeout in removeWithAnimation is not cancelled on enter. so if you leave and enter in a timeframe of 500 ms, the tooltip will be destroyed even though the cursor is within the element.
