### PR TITLE
fix position of focused search in inverse navbar

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -455,11 +455,9 @@
       // Focus states (we use .focused since IE7-8 and down doesn't support :focus)
       &:focus,
       &.focused {
-        padding: 5px 15px;
         color: @grayDark;
         text-shadow: 0 1px 0 @white;
         background-color: @navbarInverseSearchBackgroundFocus;
-        border: 0;
         .box-shadow(0 0 3px rgba(0,0,0,.15));
         outline: 0;
       }


### PR DESCRIPTION
When the search field in inverse navbar is focused, a small jump is size
is noticable. This is due to changing the border and padding which is
unnecessary.
