### PR TITLE
make test waits for node to start before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test:
 	jshint js/*.js --config js/.jshintrc
 	jshint js/tests/unit/*.js --config js/.jshintrc
 	node js/tests/server.js &
+	while ! nc -vz localhost 3000; do sleep 1; done
 	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
 	kill -9 `cat js/tests/pid.txt`
 	rm js/tests/pid.txt


### PR DESCRIPTION
There's a race condition here. node starts in the background, and might not start listening to 3000 until after phantomjs attempts to hammer it. It fails not gracefully.
