### PR TITLE
make test cleans up regardless of error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test:
 	jshint js/*.js --config js/.jshintrc
 	jshint js/tests/unit/*.js --config js/.jshintrc
 	node js/tests/server.js &
-	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
+	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"; true
 	kill -9 `cat js/tests/pid.txt`
 	rm js/tests/pid.txt
 


### PR DESCRIPTION
If make test fails, it does not kill the pid and clean up after itself. This fixes it.
