### PR TITLE
Update less/forms.less

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -79,7 +79,7 @@ input[type="tel"],
 input[type="color"],
 .uneditable-input {
   display: inline-block;
-  height: @baseLineHeight;
+  height: @baseLineHeight * 1.5;
   padding: 4px 6px;
   margin-bottom: 9px;
   font-size: @baseFontSize;


### PR DESCRIPTION
Fixed height for inputs.

The change to `@baseLineHeight` made text inputs too small vertically.

This is my first pull request on GitHub, albeit small. Hopefully this helps!
