### PR TITLE
Adding force selection option to typeAhead (enhancement)

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -244,6 +244,22 @@
 
   , blur: function (e) {
       var that = this
+      , items
+      if(this.options.forceSelection){
+        this.query = this.$element.val()
+        if (!this.query || this.query.length < this.options.minLength) {
+          this.$element.val('')
+          return this.shown ? this.hide() : this
+        }
+          
+        items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+        items = $.grep(items, function (item) {
+          return that.matcher(item)
+        })
+        items = this.sorter(items)
+        
+        this.$element.val(!items.length ? '' : items[0]) 
+      }
       setTimeout(function () { that.hide() }, 150)
     }
 
@@ -280,6 +296,7 @@
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
   , minLength: 1
+  , forceSelection : false
   }
 
   $.fn.typeahead.Constructor = Typeahead

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -201,4 +201,58 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+      
+      test("should empty input value when no match is found in items when selection is forced", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aaaa', 'aaab', 'aaac'],
+              forceSelection: true
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('zzz')
+        $input.blur()
+
+        equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
+        equals($input.val().length, 0, 'input value is empty')
+
+        typeahead.$menu.remove()
+      })      
+
+      test("should set input value to first match in items when selection is forced", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aaaa', 'aaab', 'aaac'],
+              forceSelection: true
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('aa')
+        $input.blur()
+
+        equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
+        equals($input.val(), 'aaaa', 'input value was correctly set')
+
+        typeahead.$menu.remove()
+      })      
+
+      test("should not change input value when no selection is forced", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aaaa', 'aaab', 'aaac'],
+              forceSelection: false
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('aa')
+        $input.blur()
+
+        equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
+        equals($input.val(), 'aa', 'input value not changed')
+
+        $input.val('zz')
+        $input.blur()
+
+        equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
+        equals($input.val(), 'zz', 'input value not changed when no match found in items')
+        
+        typeahead.$menu.remove()
+      })          
 })


### PR DESCRIPTION
option: forceSelection (default value false)

When on blur event is triggered and no match is found in items input
is emptied, when one or more matches are found first value will
be set as input value.
