### PR TITLE
Minor typo in typographyic

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -117,7 +117,7 @@
           <ul>
             <li>Remove <code>margin</code> on the body</li>
             <li>Set <code>background-color: white;</code> on the <code>body</code></li>
-            <li>Use the <code>@baseFontFamily</code>, <code>@baseFontSize</code>, and <code>@baseLineHeight</code> attributes as our typographyic base</li>
+            <li>Use the <code>@baseFontFamily</code>, <code>@baseFontSize</code>, and <code>@baseLineHeight</code> attributes as our typographic base</li>
             <li>Set the global link color via <code>@linkColor</code> and apply link underlines only on <code>:hover</code></li>
           </ul>
           <p>These styles can be found within <strong>scaffolding.less</strong>.</p>


### PR DESCRIPTION
You might actually have meant "typographyic", of course.
