### PR TITLE
Change "left" to "right" in offset documentation

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -176,7 +176,7 @@
           <p>Given this example, we have <code>.span4</code> and <code>.span8</code>, making for 12 total columns and a complete row.</p>
 
           <h2>Offsetting columns</h2>
-          <p>Move columns to the left using <code>.offset*</code> classes. Each class increases the left margin of a column by a whole column. For example, <code>.offset4</code> moves <code>.span4</code> over four columns.</p>
+          <p>Move columns to the right using <code>.offset*</code> classes. Each class increases the left margin of a column by a whole column. For example, <code>.offset4</code> moves <code>.span4</code> over four columns.</p>
           <div class="bs-docs-grid">
             <div class="row show-grid">
               <div class="span4">4</div>


### PR DESCRIPTION
Applying an offset moves a column to the right, not the left.
