### PR TITLE
Fix for issue #4647 bootstrap-affix.js: using Chrome, affixed menu moves violently up and down each time one scrolls to the bottom of page

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -70,7 +70,7 @@
       var $this = $(this)
         , data = $this.data('affix')
         , options = typeof option == 'object' && option
-      if (!data) $this.data('affix', (data = new Affix(this, options)))
+      $this.data('affix', (data = new Affix(this, options)))
       if (typeof option == 'string') data[option]()
     })
   }

--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -36,8 +36,7 @@
   Affix.prototype.checkPosition = function () {
     if (!this.$element.is(':visible')) return
 
-    var scrollHeight = $(document).height()
-      , scrollTop = this.$window.scrollTop()
+    var scrollTop = this.$window.scrollTop()
       , position = this.$element.offset()
       , offset = this.options.offset
       , offsetBottom = offset.bottom
@@ -50,7 +49,7 @@
     if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
 
     affix = this.unpin != null && (scrollTop + this.unpin <= position.top) ?
-      false    : offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ?
+      false    : offsetBottom != null && (position.top + this.$element.outerHeight(true) >= offsetBottom) ?
       'bottom' : offsetTop != null && scrollTop <= offsetTop ?
       'top'    : false
 


### PR DESCRIPTION
https://github.com/twitter/bootstrap/issues/4647
