### PR TITLE
Do not force white icons in active tab links

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -30,8 +30,6 @@
 
 /* White icons with optional class, or on hover/active states of certain elements */
 .icon-white,
-.nav-tabs > .active > a > [class^="icon-"],
-.nav-tabs > .active > a > [class*=" icon-"],
 .nav-pills > .active > a > [class^="icon-"],
 .nav-pills > .active > a > [class*=" icon-"],
 .nav-list > .active > a > [class^="icon-"],


### PR DESCRIPTION
Active `.nav-tabs` elements are not blue (like pills),
so forcing a white icon there is not appropriate.
