### PR TITLE
Enable multiple lists to be updated by scrollspy

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -96,13 +96,13 @@
 
         this.activeTarget = target
 
-        $(this.selector)
-          .parent('.active')
-          .removeClass('active')
-
         selector = this.selector
           + '[data-target="' + target + '"],'
           + this.selector + '[href="' + target + '"]'
+
+        $(selector).parent()
+                   .siblings('.active')
+                   .removeClass('active')
 
         active = $(selector)
           .parent('li')


### PR DESCRIPTION
Changed scrollspy's behaviour to not remove all possible active classes and only remove the relevant list's active state, allowing for multiple lists in a single page.

Example:
http://codepen.io/BellendSebastian/pen/cfkDF
