### PR TITLE
Multiple modals fix

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -90,13 +90,13 @@
 
         e = $.Event('hide')
 
-        this.$element.trigger(e)
+        if ($("div.modal.in").length <= 1) this.$element.trigger(e)
 
         if (!this.isShown || e.isDefaultPrevented()) return
 
         this.isShown = false
 
-        $('body').removeClass('modal-open')
+        if ($("div.modal.in").length <= 1) $('body').removeClass('modal-open')
 
         this.escape()
 


### PR DESCRIPTION
If you want to use a modal on another modal (I know that is a bit strange, but I needed it), when you close the second one, it removes modal-open class from body.
If you have a typeahead here on the first one, the dropdown will go behind the modal.

So I fixed this issue removing the class when there is one or less modal opened, with this check:

``` javascript
if ($("div.modal.in").length <= 1)
```

The close event on second modals doesn't works the first time, the row  93 generate an error:

Uncaught RangeError: Maximum call stack size exceeded

Function called: 

``` javascript
this.$element.trigger(e)
```

so I added the same check there too (I don't know if this could generate any other error, any suggest is welcome :) )

examples: 
error: http://jsfiddle.net/DtPY4/
fixed: http://jsfiddle.net/KQXqM/
