### PR TITLE
Force alert colors

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -13,7 +13,7 @@
   background-color: @warningBackground;
   border: 1px solid @warningBorder;
   .border-radius(4px);
-  color: @warningText;
+  color: @warningText !important;
 }
 .alert h4 {
   margin: 0;
@@ -40,12 +40,12 @@
 .alert-error {
   background-color: @errorBackground;
   border-color: @errorBorder;
-  color: @errorText;
+  color: @errorText !important;
 }
 .alert-info {
   background-color: @infoBackground;
   border-color: @infoBorder;
-  color: @infoText;
+  color: @infoText !important;
 }
 
 

--- a/less/alerts.less
+++ b/less/alerts.less
@@ -14,9 +14,10 @@
   border: 1px solid @warningBorder;
   .border-radius(4px);
   color: @warningText !important;
-}
-.alert h4 {
-  margin: 0;
+  h1, h2, h3, h4, h5, h6, p {
+    color: @warningText !important;
+    margin: 0;
+  }
 }
 
 // Adjust close link position
@@ -35,17 +36,26 @@
   background-color: @successBackground;
   border-color: @successBorder;
   color: @successText;
+  h1, h2, h3, h4, h5, h6, p {
+    color: @successText !important;
+  }
 }
 .alert-danger,
 .alert-error {
   background-color: @errorBackground;
   border-color: @errorBorder;
   color: @errorText !important;
+  h1, h2, h3, h4, h5, h6, p {
+    color: @errorText !important;
+  }
 }
 .alert-info {
   background-color: @infoBackground;
   border-color: @infoBorder;
   color: @infoText !important;
+  h1, h2, h3, h4, h5, h6, p {
+    color: @infoText !important;
+  }
 }
 
 


### PR DESCRIPTION
Alerts should use the configured alert colors regardless of colors set on elements that enclose them.

Without !important alert colors are overridden by more specific selectors.  For and example of the issue check out this fiddle: http://jsfiddle.net/kylewest/SEntG/
