### PR TITLE
Fix to make it work on iPad devices

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -140,7 +140,7 @@
 
   $(function () {
     $('html')
-      .on('click.dropdown.data-api touchstart.dropdown.data-api', clearMenus)
+      .on('click.dropdown.data-api', clearMenus) // touchstart.dropdown.data-api must be removed in order to make it work on ipad devices
     $('body')
       .on('click.dropdown touchstart.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
       .on('click.dropdown.data-api touchstart.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)


### PR DESCRIPTION
On line 143 I removed touchstart.dropdown.data-api in order to make the dropdown works on iPad devices.
