### PR TITLE
add show and hide events for tooltip

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -96,7 +96,9 @@
     }
 
   , show: function () {
-      var $tip
+      var that = this
+        , e = $.Event('show')
+        , $tip
         , inside
         , pos
         , actualWidth
@@ -106,6 +108,11 @@
 
       if (this.hasContent() && this.enabled) {
         $tip = this.tip()
+
+        this.$element.trigger(e)
+
+        if (e.isDefaultPrevented()) return
+
         this.setContent()
 
         if (this.options.animation) {
@@ -147,6 +154,10 @@
           .css(tp)
           .addClass(placement)
           .addClass('in')
+
+        $.support.transition && $tip.hasClass('fade') ?
+            $tip.one($.support.transition.end, function () { that.$element.trigger('shown') }) :
+            this.$element.trigger('shown')
       }
     }
 
@@ -160,9 +171,19 @@
 
   , hide: function () {
       var that = this
+        , e = $.Event('hide')
         , $tip = this.tip()
 
+      this.$element.trigger(e)
+
+      if (e.isDefaultPrevented()) return
+
       $tip.removeClass('in')
+
+      function remove() {
+        $tip.remove()
+        that.$element.trigger('hidden')
+      }
 
       function removeWithAnimation() {
         var timeout = setTimeout(function () {
@@ -171,13 +192,13 @@
 
         $tip.one($.support.transition.end, function () {
           clearTimeout(timeout)
-          $tip.remove()
+          remove()
         })
       }
 
       $.support.transition && this.$tip.hasClass('fade') ?
         removeWithAnimation() :
-        $tip.remove()
+        remove()
 
       return this
     }

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -128,6 +128,58 @@ $(function () {
         }, 200)
       })
 
+      test("should fire show and hide events", function () {
+        stop()
+        $.support.transition = false
+        $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .bind("show", function () {
+            ok(true, "show was called")
+          })
+          .bind("shown", function () {
+            ok(true, "shown was called")
+          })
+          .bind("hide", function () {
+            ok(true, "hide was called")
+          })
+          .bind("hidden", function () {
+            ok(true, "hidden was called")
+            $(this).remove()
+            start()
+          })
+          .tooltip("show")
+          .tooltip("hide")
+      })
+
+      test("should not fire shown when default prevented", function () {
+        stop()
+        $.support.transition = false
+        $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .bind("show", function (e) {
+            e.preventDefault()
+            ok(true, "show was called")
+            start()
+          })
+          .bind("shown", function () {
+            ok(false, "shown was called")
+          })
+          .tooltip("show")
+      })
+
+      test("should not fire hidden when default prevented", function () {
+        stop()
+        $.support.transition = false
+        $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .bind("hide", function (e) {
+            e.preventDefault()
+            ok(true, "hide was called")
+            start()
+          })
+          .bind("hidden", function () {
+            ok(false, "hidden was called")
+          })
+          .tooltip("hide")
+      })
+
       test("should destroy tooltip", function () {
         var tooltip = $('<div/>').tooltip().on('click.foo', function(){})
         ok(tooltip.data('tooltip'), 'tooltip has data')


### PR DESCRIPTION
Adding tooltip events (show, shown, hide, hidden) w/ unit tests.

Rebased on 2.1.2-wip.
