### PR TITLE
Prevent from modal unexpected padding in Chrome

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -36,7 +36,6 @@
   top: 50%;
   left: 50%;
   z-index: @zindexModal;
-  overflow: auto;
   width: 560px;
   margin: -250px 0 0 -280px;
   background-color: @white;


### PR DESCRIPTION
Sometimes, but quiet often I'm facing problem like this:

![bug example](http://s13.postimage.org/44vds9oqv/bootstrap_modal_break.png)

By removing modal's overflow:auto property, the problem disappears.

Even if this is not the case, overflow:hidden is more appropriate for .modal as the only possible overflow-able element is the .modal-body which already has the overflow-y: auto property.
