### PR TITLE
Suggest to include responsive css only for media=screen

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -386,7 +386,7 @@
           <p>Turn on responsive CSS in your project by including the proper meta tag and additional stylesheet within the <code>&lt;head&gt;</code> of your document. If you've compiled Bootstrap from the Customize page, you need only include the meta tag.</p>
 <pre class="prettyprint linenums">
 &lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;
-&lt;link href="assets/css/bootstrap-responsive.css" rel="stylesheet"&gt;
+&lt;link href="assets/css/bootstrap-responsive.css" rel="stylesheet" media="screen" &gt;
 </pre>
           <p><span class="label label-info">Heads up!</span>  Bootstrap doesn't include responsive features by default at this time as not everything needs to be responsive. Instead of encouraging developers to remove this feature, we figure it best to enable it as needed.</p>
 


### PR DESCRIPTION
Problems like this http://stackoverflow.com/questions/12246096/bootstrap-printing-width/12250808
could be avoided.

The responsive design really seems to make sense only in a screen device, not in printing.
