### PR TITLE
Fixes #2043: allows minLength of zero to enable show all for typeahead

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -79,9 +79,9 @@
   , lookup: function (event) {
       var items
 
-      this.query = this.$element.val()
+      this.query = this.$element.val() || ''
 
-      if (!this.query || this.query.length < this.options.minLength) {
+      if (this.query.length < this.options.minLength) {
         return this.shown ? this.hide() : this
       }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -201,4 +201,22 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+
+      test("should allow a minLength of 0", function () {
+
+        var $input = $('<input />').typeahead({
+              source: ['aaaa', 'aaab', 'aaac'],
+              minLength: 0
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.typeahead.call($input, 'lookup')
+        
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        typeahead.$menu.remove()
+      })
+
 })


### PR DESCRIPTION
Allows you to set a minLength of 0 for typeahead, in order to show all items in the list.  For example, this allows you to show all items up front by binding to the focus of the control.  This seems simpler and more flexible than a new option such as `showAll` or `focusShow` as suggested in other tickets.

Specifically, this also enables the technique @fat suggested in #3941:

``` javascript
$input.on('focus', $input.typeahead.bind($input, 'lookup')));
```
