### PR TITLE
Avoid fancy characters

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -210,7 +210,7 @@ input[type="checkbox"]:focus {
 // Placeholder
 // -------------------------
 
-// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn’t understand a selector
+// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn't understand a selector
 input,
 textarea {
   .placeholder();


### PR DESCRIPTION
This makes my sass spit this error : Invalid US-ASCII character &quot;\xE2&quot;
(yeah, I'm using sass with this fork of twitter bootstrap: https://github.com/jlong/sass-twitter-bootstrap)
