### PR TITLE
Update less/dropdowns.less

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -39,6 +39,7 @@
 // The dropdown menu (ul)
 // ----------------------
 .dropdown-menu {
+  font-size: @baseFontSize
   position: absolute;
   top: 100%;
   left: 0;


### PR DESCRIPTION
Adding font-size to .dropdown-menu to account for .input-append setting font-size to 0.

This issue is run into when a search form has .input-append for an appended button and the button is of dropdown type. The font-size 0 causes the drop down options to inherit that property.
