### PR TITLE
Fix carousel controls styling consistency cross-platform

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -74,9 +74,10 @@
   width: 40px;
   height: 40px;
   margin-top: -20px;
-  font-size: 60px;
+  font-family: Arial, sans-serif;
+  font-size: 36px;
   font-weight: 100;
-  line-height: 30px;
+  line-height: 34px;
   color: @white;
   text-align: center;
   background: @grayDarker;


### PR DESCRIPTION
Fix the size of the arrow in carousel controls on Windows being roughly double the size of the arrow on other platforms such as Mac because Helvetica is not installed by default on Windows. Usually falling back on Arial from Helvetica is fine, but the arrow's font-size is 60px and at that size the height of the font differs greatly.

By forcing the carousel controls to Arial at font-size 36px, we can have a consistent looking carousel control cross-platform.

Before commit: http://i.imgur.com/obRunh.jpg
After commit: http://i.imgur.com/dSqHIh.jpg
