### PR TITLE
Use relative font sizes for headers

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -67,17 +67,17 @@ h1, h2, h3, h4, h5, h6 {
     color: @grayLight;
   }
 }
-h1 { font-size: 36px; line-height: 40px; }
-h2 { font-size: 30px; line-height: 40px; }
-h3 { font-size: 24px; line-height: 40px; }
-h4 { font-size: 18px; line-height: 20px; }
-h5 { font-size: 14px; line-height: 20px; }
-h6 { font-size: 12px; line-height: 20px; }
+h1 { font-size: @baseFontSize + 22; line-height: @baseLineHeight * 2; }
+h2 { font-size: @baseFontSize + 16; line-height: @baseLineHeight * 2; }
+h3 { font-size: @baseFontSize + 10; line-height: @baseLineHeight * 2; }
+h4 { font-size: @baseFontSize + 4;  line-height: @baseLineHeight; }
+h5 { font-size: @baseFontSize;      line-height: @baseLineHeight; }
+h6 { font-size: @baseFontSize - 2;  line-height: @baseLineHeight; }
 
-h1 small { font-size: 24px; }
-h2 small { font-size: 18px; }
-h3 small { font-size: 14px; }
-h4 small { font-size: 14px; }
+h1 small { font-size: @baseFontSize + 10; }
+h2 small { font-size: @baseFontSize + 4; }
+h3 small { font-size: @baseFontSize; }
+h4 small { font-size: @baseFontSize; }
 
 
 // Page header


### PR DESCRIPTION
It has been discussed before but this pull simply sets heading font-size differences relative to `@baseFontSize`.
