### PR TITLE
Use @navbarCollapseWidth instead of hard coded value for default desktop

### DIFF
--- a/less/responsive-navbar.less
+++ b/less/responsive-navbar.less
@@ -166,7 +166,7 @@
 // DEFAULT DESKTOP
 // ---------------
 
-@media (min-width: 980px) {
+@media (min-width: (@navbarCollapseWidth+1)) {
 
   // Required to make the collapsing navbar work on regular desktops
   .nav-collapse.collapse {


### PR DESCRIPTION
Use @navbarCollapseWidth instead of hard coded value for DEFAULT DESKTOP in case of customized @navbarCollapseWidth
