### PR TITLE
Fix live validation for unrequired fields

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1500,16 +1500,18 @@ input[type="checkbox"][readonly] {
   border-color: #3a87ad;
 }
 
-input:focus:required:invalid,
-textarea:focus:required:invalid,
-select:focus:required:invalid {
+input:required,
+textarea:required,
+select:required,
+input:invalid,
+textarea:invalid,
+select:invalid {
   color: #b94a48;
   border-color: #ee5f5b;
 }
-
-input:focus:required:invalid:focus,
-textarea:focus:required:invalid:focus,
-select:focus:required:invalid:focus {
+input:focus,
+textarea:focus,
+select:focus {
   border-color: #e9322d;
   -webkit-box-shadow: 0 0 6px #f8b9b7;
      -moz-box-shadow: 0 0 6px #f8b9b7;

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1500,18 +1500,15 @@ input[type="checkbox"][readonly] {
   border-color: #3a87ad;
 }
 
-input:required,
-textarea:required,
-select:required,
 input:invalid,
 textarea:invalid,
 select:invalid {
   color: #b94a48;
   border-color: #ee5f5b;
 }
-input:focus,
-textarea:focus,
-select:focus {
+input:invalid:focus,
+textarea:invalid:focus,
+select:invalid:focus {
   border-color: #e9322d;
   -webkit-box-shadow: 0 0 6px #f8b9b7;
      -moz-box-shadow: 0 0 6px #f8b9b7;

--- a/less/forms.less
+++ b/less/forms.less
@@ -364,15 +364,14 @@ input[type="checkbox"][readonly] {
 input,
 textarea,
 select {
-  &:required,
   &:invalid {
     color: #b94a48;
     border-color: #ee5f5b;
-  }
-  &:focus {
-    border-color: darken(#ee5f5b, 10%);
-    @shadow: 0 0 6px lighten(#ee5f5b, 20%);
-    .box-shadow(@shadow);
+    &:focus {
+      border-color: darken(#ee5f5b, 10%);
+      @shadow: 0 0 6px lighten(#ee5f5b, 20%);
+      .box-shadow(@shadow);
+    }
   }
 }
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -361,11 +361,14 @@ input[type="checkbox"][readonly] {
 
 // HTML5 invalid states
 // Shares styles with the .control-group.error above
-input:focus:required:invalid,
-textarea:focus:required:invalid,
-select:focus:required:invalid {
-  color: #b94a48;
-  border-color: #ee5f5b;
+input,
+textarea,
+select {
+  &:required,
+  &:invalid {
+    color: #b94a48;
+    border-color: #ee5f5b;
+  }
   &:focus {
     border-color: darken(#ee5f5b, 10%);
     @shadow: 0 0 6px lighten(#ee5f5b, 20%);


### PR DESCRIPTION
Currently with Bootstrap if you set a field as `required="true"`, Bootstrap applies live control-group states if the browser set the field as `:invalid`.
More clearly that means that if you assign a `pattern="[some regex]"` attribute on a field, and then type something that doesn't match that pattern, the field turns red. Which is good ! That's perfect, the problem is, that live validation _only_ works when the field is also set to required. This is due to the following bit of CSS :

``` css
// HTML5 invalid states
// Shares styles with the .control-group.error above
input:focus:required:invalid,
textarea:focus:required:invalid,
select:focus:required:invalid {
  color: #b94a48;
  border-color: #ee5f5b;
  &:focus {
    border-color: darken(#ee5f5b, 10%);
    @shadow: 0 0 6px lighten(#ee5f5b, 20%);
    .box-shadow(@shadow);
  }
}
```

The live validation is only active when the field has the `:required` state which limits things. Second of all, the whole bit of code doesn't make that much sense since we start from the principle that all fields are set to `:focus` and then afterwards we apply a **second** `:focus` on them.

This pull request fixes that and allows all invalid to turn red, whether they are required or not. Tested on a project and all is working good.
