### PR TITLE
2nd modal over a 1rst modal issue, fixed

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -175,6 +175,8 @@
 
           this.$backdrop.addClass('in')
 
+	  this.$backdrop.css('z-index',this.$element.css('z-index') - 1)
+
           doAnimate ?
             this.$backdrop.one($.support.transition.end, callback) :
             callback()

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -175,7 +175,7 @@
 
           this.$backdrop.addClass('in')
 
-	  this.$backdrop.css('z-index',this.$element.css('z-index') - 1)
+          this.$backdrop.css('z-index',this.$element.css('z-index') - 1)
 
           doAnimate ?
             this.$backdrop.one($.support.transition.end, callback) :


### PR DESCRIPTION
Displays a modal on top of a first modal problem is fixed with that changes. We only have to set the backdrop z-index 1 point lower than its modal div. Of course we must set the 2nd modal z-index 2 points higher than the first modal at least, because the 2nd modal backdrop z-index mustbe higher than the 1rst modal and lower than the 2nd.
