### PR TITLE
Support for left-opening dropdown submenus

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -163,7 +163,6 @@
 .dropdown-submenu {
   position: relative;
 }
-
 // Default dropdowns
 .dropdown-submenu > .dropdown-menu {
   top: 0;
@@ -207,6 +206,40 @@
   border-left-color: @dropdownLinkColorHover;
 }
 
+// Left-opening Sub menus
+// ---------------------------
+.dropdown-submenu-left {
+  position: relative;
+}
+.dropdown-submenu-left > .dropdown-menu {
+  top: 0;
+  left: -100%;
+  margin-top: -6px;
+  margin-left: -1px;
+  -webkit-border-radius: 6px 0px 6px 6px;
+     -moz-border-radius: 6px 0px 6px 6px;
+          border-radius: 6px 0px 6px 6px;
+}
+.dropdown-submenu-left:hover > .dropdown-menu {
+  display: block;
+}
+
+.dropdown-submenu-left > a:before {
+  display: block;
+  content: "  ";
+  float: left;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 5px 5px 5px 0px;
+  border-right-color: darken(@dropdownBackground, 20%);
+  margin-top: 5px;
+  margin-left: -10px;
+}
+.dropdown-submenu-left:hover > a:after {
+  border-right-color: @dropdownLinkColorHover;
+}
 
 // Tweak nav headers
 // -----------------


### PR DESCRIPTION
Adds a new class called .dropdown-submenu-left. It is useful when you
have a .pull-right DropDown that has submenus. Without this, the menu
opens left past the page boundary, which can trigger the scrollbars and
cause other nastiness.

Resubmitting per https://github.com/twitter/bootstrap/pull/5156
