### PR TITLE
Fix dropdown in IE8

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -41,6 +41,7 @@
 // Override the default collapsed state
 .nav-collapse.collapse {
   height: auto;
+  overflow: visible;
 }
 
 


### PR DESCRIPTION
navbar should be visible by default (without mediaqueries). Fixes #5166 / #5102
