### PR TITLE
Add direction to the slide event of the Carousel plugin

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -95,7 +95,8 @@
         , fallback  = type == 'next' ? 'first' : 'last'
         , that = this
         , e = $.Event('slide', {
-            relatedTarget: $next[0]
+            relatedTarget: $next[0],
+            direction: direction
           })
 
       this.sliding = true


### PR DESCRIPTION
I found myself needing to know which direction the slide is occurring in. The use case is, when we are at the extreme ends (first item or last item). When going left at first item OR going right at last item the relatedTarget is null. There is no indication as to which of the two cases we are dealing with, so knowing the direction on top of the relatedTarget is necessary to distinguish the two cases. Use case is at http://tapangi.github.com (check out the discs - I will be using a patched version of bootstrap there )
