### PR TITLE
Fixed nav menu bug in IE7 and IE8 caused by fe3ed43

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -43,6 +43,10 @@
   height: auto;
 }
 
+// Fixes IE7 and IE8 hidden menu
+.nav-collapse {
+  overflow: visible;
+}
 
 // Brand: website or project name
 // -------------------------


### PR DESCRIPTION
Fixed bug in v2.1.1 Navbar. Menu is hidden in IE8 and IE7. 

This was caused by removing
`overflow: visible \9;`
for the collapse class from less/component-animations.less in commit fe3ed43 

The commit(fe3ed43) removed a nasty hack for IE7 and IE8 that broke collapsables, but had an unintended side effect on navbar menus.
