### PR TITLE
Allow state other than loading to disable button

### DIFF
--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -31,7 +31,7 @@
     this.options = $.extend({}, $.fn.button.defaults, options)
   }
 
-  Button.prototype.setState = function (state) {
+  Button.prototype.setState = function (state, setDisabled) {
     var d = 'disabled'
       , $el = this.$element
       , data = $el.data()
@@ -44,7 +44,7 @@
 
     // push to event loop to allow forms to submit
     setTimeout(function () {
-      state == 'loadingText' ?
+      state == 'loadingText' || setDisabled == d ?
         $el.addClass(d).attr(d, d) :
         $el.removeClass(d).removeAttr(d)
     }, 0)
@@ -64,14 +64,14 @@
  /* BUTTON PLUGIN DEFINITION
   * ======================== */
 
-  $.fn.button = function (option) {
+  $.fn.button = function (option, setDisabled) {
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('button')
         , options = typeof option == 'object' && option
       if (!data) $this.data('button', (data = new Button(this, options)))
       if (option == 'toggle') data.toggle()
-      else if (option) data.setState(option)
+      else if (option) data.setState(option, setDisabled)
     })
   }
 

--- a/js/tests/unit/bootstrap-button.js
+++ b/js/tests/unit/bootstrap-button.js
@@ -23,6 +23,19 @@ $(function () {
         }, 0)
       })
 
+      test("should return set state to complete and be disabled", function () {
+        var btn = $('<button class="btn" data-complete-text="done">mdo</button>')
+        equals(btn.html(), 'mdo', 'btn text equals mdo')
+        btn.button('complete', 'disabled')
+        equals(btn.html(), 'done', 'btn text equals done')
+        stop()
+        setTimeout(function () {
+          ok(btn.attr('disabled'), 'btn is disabled')
+          ok(btn.hasClass('disabled'), 'btn has disabled class')
+          start()
+        }, 0)
+      })
+
       test("should return reset state", function () {
         var btn = $('<button class="btn" data-loading-text="fat">mdo</button>')
         equals(btn.html(), 'mdo', 'btn text equals mdo')


### PR DESCRIPTION
When setting a button's state, other than loading, we might want the
button to be disabled. This is especially useful for buttons which
might go through several states (as progress indicators) or for
buttons which have a complete, and disabled, state.

E.G.

State initial : Reveal Code (enabled)

State loading : Revealing Code (disabled)

State complete : Reveaed Code (disabled)

Tested in : 
`Chrome v21.0.1180.89`
`Firefox v12.0`
