### PR TITLE
fix multiple dropdown clearMenus behavior, now all menus are hidden

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -99,9 +99,10 @@
 
   }
 
-  function clearMenus() {
-    getParent($(toggle))
-      .removeClass('open')
+  function clearMenus() { 
+    $(toggle).each(function () { 
+      getParent($(this))
+        .removeClass("open") })
   }
 
   function getParent($this) {


### PR DESCRIPTION
when a multiple dropdown exists, just first are hidden on clearMenus.
