### PR TITLE
Add @inputHeight for non-block level inputs

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -277,6 +277,7 @@ textarea[class*="span"],
 .row-fluid .uneditable-input[class*="span"] {
   float: none;
   margin-left: 0;
+  min-height: @inputHeight;
 }
 // Ensure input-prepend/append never wraps
 .input-append input[class*="span"],


### PR DESCRIPTION
This is an additional fix for issue #5127, the non-block level inputs also needs a min-height from @inputHeight
