### PR TITLE
Fix jquery 1.8.1 warning

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -113,7 +113,7 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
-    $parent = $(selector)
+    $parent = selector == '#' ? $() : $(selector)
     $parent.length || ($parent = $this.parent())
 
     return $parent

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -111,9 +111,11 @@
     if (!selector) {
       selector = $this.attr('href')
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      if (selector == '#')
+        selector = '';
     }
 
-    $parent = selector == '#' ? $() : $(selector)
+    $parent = $(selector)
     $parent.length || ($parent = $this.parent())
 
     return $parent


### PR DESCRIPTION
Problem:
Firefox & jquery 1.8.1 will issue a warning on every click event:
Warning: Empty string passed to getElementById().

Fix:
do not query with '#' selector.
