### PR TITLE
[closed] - committed to wrong branch

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -19,3 +19,7 @@
 .row-fluid [class*="span"].pull-right {
   float: right;
 }
+
+.space {
+  margin-bottom: @gridGutterWidth;
+}

--- a/less/responsive-1200px-min.less
+++ b/less/responsive-1200px-min.less
@@ -24,5 +24,9 @@
   .row-fluid .thumbnails {
     margin-left: 0;
   }
+  
+  .space {
+    margin-bottom: @gridGutterWidth;
+  }  
 
 }

--- a/less/responsive-768px-979px.less
+++ b/less/responsive-768px-979px.less
@@ -13,6 +13,10 @@
 
   // Input grid
   #grid > .input(@gridColumnWidth768, @gridGutterWidth768);
+  
+  .space {
+    margin-bottom: @gridGutterWidth - 5;
+  }  
 
   // No need to reset .thumbnails here since it's the same @gridGutterWidth
 


### PR DESCRIPTION
When you markup a page, especialy a column it is ver often when you need to add a little space between to `<div>`. And you want this space be equal everywhere for everything looks aligned.

Right now I use `<br />` or simple add additional classes and add CSS instruction. But that would be nice to have horizontal spacer with would add the same space as we have width between span1-12.

This PR adds new class called `.space`. This class adds horizontal space equal to vertical space between span1-12

Here is the example of the usage.

``` html
<div class="container">
    <div class="row">
        <div class="span6">
            <div class="pull-right"><a class="btn">22</a></div>
            <div class="clearfix space"></div>
            <p>Col 1</p>
        </div>
        <div class="span6">Col 2</div>
    </div>
    <div class="space"></div>
    <div class="row space">Row 2</div>
    <div>Something</div>
</div>
```
