### PR TITLE
Automatically Colored wells

### DIFF
--- a/less/wells.less
+++ b/less/wells.less
@@ -27,3 +27,24 @@
   padding: 9px;
   .border-radius(3px);
 }
+
+.well.success,
+.success .well {
+  background-color: darken(spin(@successBackground, -10), 5%);
+  border: 1px solid darken(spin(@successBackground, -10), 20%);
+}
+.well.error,
+.error .well {
+  background-color: darken(spin(@errorBackground, -10), 5%);
+  border: 1px solid darken(spin(@errorBackground, -10), 20%);
+}
+.well.warning ,
+.warning .well {
+  background-color: darken(spin(@warningBackground, -10), 5%);
+  border: 1px solid darken(spin(@warningBackground, -10), 20%);
+}
+.well.info ,
+.info .well {
+  background-color: darken(spin(@infoBackground, -10), 5%);
+  border: 1px solid darken(spin(@infoBackground, -10), 20%);
+}


### PR DESCRIPTION
Sometimes you need `.well` right inside table `.success` or `.warning` row.
 It is just does not looks nice there. The grey on the green for example.

![ex2](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-09-24 at 7.15.02 PM.png)

Would be nice that if `.well` int those classes it automatically change color. To give color option also good.

This pull request offers solution. Few lines to stile wells in the colored elements and at the same time option to color well itself.

This a usage example

``` html
<div class="well info">
    <h4>This is the well</h4>
    <p>lorem ispus
</div>

<table class="table table-striped table-bordered">
    <tbody>
        <tr class="success">
            <TD>
                <div class="well">
                    <h4>This is the well</h4>
                    <p>lorem ispus
                </div>
            </TD>
            <TD>SDFSDF</TD>
        </tr>
    </tbody>
</table>
```

![ex](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-09-24 at 7.11.44 PM.png)
