### PR TITLE
carousel-inner: added missing height=100%

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -12,6 +12,7 @@
 .carousel-inner {
   overflow: hidden;
   width: 100%;
+  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
I am not totally sure about it, but it seems to be a bug that the inner container has zero height
