### PR TITLE
Fix empty event.relatedTarget when carousel reaches bounds

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -94,15 +94,17 @@
         , direction = type == 'next' ? 'left' : 'right'
         , fallback  = type == 'next' ? 'first' : 'last'
         , that = this
-        , e = $.Event('slide', {
-            relatedTarget: $next[0]
-          })
+        , e
 
       this.sliding = true
 
       isCycling && this.pause()
 
       $next = $next.length ? $next : this.$element.find('.item')[fallback]()
+
+      e = $.Event('slide', {
+      	relatedTarget: $next[0]
+      })
 
       if ($next.hasClass('active')) return
 


### PR DESCRIPTION
When carousel reaches bounds (first or last carousel item), the event.relatedTarget is empty. Because of the event is initialized with an inconsistent $next element (that is fixed 3 lines after event initialization)
