### PR TITLE
Use node-supervisor instead of watchr for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ gh-pages: bootstrap docs
 #
 
 watch:
-	echo "Watching less and js files..."; \
+	@echo "Watching less and js files..."; \
 	supervisor -w less,js -n exit --quiet -e 'less|js' -x make --
 
 #
@@ -102,7 +102,7 @@ watch:
 #
 
 watch-less:
-	echo "Watching less files..."; \
+	@echo "Watching less files..."; \
 	supervisor -w less/ -n exit --quiet -e 'less' -x make --
 
 #
@@ -110,7 +110,7 @@ watch-less:
 #
 
 watch-js:
-	echo "Watching js files..."; \
+	@echo "Watching js files..."; \
 	supervisor -w js/ -n exit --quiet -e 'js' -x make --
 
 #

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,28 @@ gh-pages: bootstrap docs
 	cp -r docs/* ../bootstrap-gh-pages
 
 #
-# WATCH LESS FILES
+# WATCH FILES
 #
 
 watch:
+	echo "Watching less and js files..."; \
+	supervisor -w less,js -n exit --quiet -e 'less|js' -x make --
+
+#
+# WATCH LESS FILES
+#
+
+watch-less:
 	echo "Watching less files..."; \
-	watchr -e "watch('less/.*\.less') { system 'make' }"
+	supervisor -w less/ -n exit --quiet -e 'less' -x make --
+
+#
+# WATCH JS FILES
+#
+
+watch-js:
+	echo "Watching js files..."; \
+	supervisor -w js/ -n exit --quiet -e 'js' -x make --
 
 #
 # HAUNT GITHUB ISSUES 4 FAT & MDO ONLY (O_O  )

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     , "jshint": "0.6.1"
     , "recess": "1.0.3"
     , "connect": "2.1.3"
+    , "supervisor": "0.4.1"
   }
 }


### PR DESCRIPTION
Resolves #4321 and (kind of) #2549.

Utilizes [node-supervisor](https://github.com/isaacs/node-supervisor).

Updated `watch` rule to scan for changes to both `less` and `js` files. 

Added `watch-less` rule to watch for changes to `less` files only.

Added `watch-js` rule to watch for changes to `js` files only.
