### PR TITLE
Getter/setter methods for object data-source

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -33,6 +33,8 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
+    this.getter = this.options.getter || this.getter
+    this.setter = this.options.setter || this.setter
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
@@ -44,16 +46,30 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').attr('data-value'),
+      item = this.getter(val)
+      
       this.$element
-        .val(this.updater(val))
-        .change()
+          .val(this.updater(item))
+          .change()
       return this.hide()
     }
 
   , updater: function (item) {
       return item
     }
+    
+  , getter: function (pk) {      
+      var source = $.isFunction(this.source) ? this.source() : this.source
+        
+      return $.grep(source, function(item){
+          return item == pk
+      })[0]
+  }
+  
+  , setter: function(item) {
+      return item;
+  }
 
   , show: function () {
       var pos = $.extend({}, this.$element.offset(), {
@@ -136,7 +152,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).attr('data-value', that.setter(item))
         i.find('a').html(that.highlighter(item))
         return i[0]
       })


### PR DESCRIPTION
BC break: no
Feature: yes
Documentation: in PR description

Setter method allows to customize what is set as `data-value`.

Previously the script would break if item was an object, becouse render method rendered `<li data-value="[object Object]">`.

This method allows you to specify which field should be used as identifier for your result (preferabely database entry ID, but it can be any unique field).

Getter method allows to customize how item is retrieved from data source.

Previously the script just passed `item` (which was sufficient for simple string).

This method is connected to setter method. If you set `data-value` as `item.id` then the getter method must look for `item.id == pk` (where pk is value of `data-value` passed to this function). Returns the object matching that identiefier.

Example on JSFiddle:

http://jsfiddle.net/ZAQ2S/12/
