### PR TITLE
Zero the Top and Left CSS properties of tooltips to prevent runoff, esp. on mobile

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -142,6 +142,9 @@
             tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width}
             break
         }
+        
+        if (tp.top < 0) tp.top = 0
+        if (tp.left < 0) tp.left = 0
 
         $tip
           .css(tp)


### PR DESCRIPTION
Zero-ing CSS top and left properties for tooltips if they go negative, which can be the case for tooltips on mobile.
