### PR TITLE
Getter/setter methods for object data-source

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1577,7 +1577,7 @@ $('.carousel').carousel({
                  <td>source</td>
                  <td>array, function</td>
                  <td>[ ]</td>
-                 <td>The data source to query against. May be an array of strings or a function. The function is passed two arguments, the <code>query</code> value in the input field and the <code>process</code> callback. The function may be used synchronously by returning the data source directly or asynchronously via the <code>process</code> callback's single argument.</td>
+                 <td>The data source to query against. May be an array of strings, array of objects or a function. The function is passed two arguments, the <code>query</code> value in the input field and the <code>process</code> callback. The function may be used synchronously by returning the data source directly or asynchronously via the <code>process</code> callback's single argument.</td>
                </tr>
                <tr>
                  <td>items</td>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1577,7 +1577,7 @@ $('.carousel').carousel({
                  <td>source</td>
                  <td>array, function</td>
                  <td>[ ]</td>
-                 <td>The data source to query against. May be an array of strings, array of objects or a function. The function is passed two arguments, the <code>query</code> value in the input field and the <code>process</code> callback. The function may be used synchronously by returning the data source directly or asynchronously via the <code>process</code> callback's single argument.</td>
+                 <td>The data source to query against. May be an array of strings, array of objects (in this case you need to specify <code>getter</code> and <code>setter</code>) or a function. The function is passed two arguments, the <code>query</code> value in the input field and the <code>process</code> callback. The function may be used synchronously by returning the data source directly or asynchronously via the <code>process</code> callback's single argument.</td>
                </tr>
                <tr>
                  <td>items</td>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1609,6 +1609,18 @@ $('.carousel').carousel({
                  <td>highlights all default matches</td>
                  <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
                </tr>
+               <tr>
+                 <td>getter</td>
+                 <td>function</td>
+                 <td>returns item</td>
+                 <td>Method used to retrieve item from data source matching given identifier. Used when items are objects. Accepts a single argument <code>pk</code> (primary key) and has the scope of the typeahead instance. Should return item.</td>
+               </tr>
+               <tr>
+                 <td>setter</td>
+                 <td>function</td>
+                 <td>sets item</td>
+                 <td>Method used set item identifier to autocomplete results. Used when items are objects. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return item identifier (most likely <code>item.id</code>).</td>
+               </tr>
               </tbody>
             </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -33,6 +33,8 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
+    this.getter = this.options.getter || this.getter
+    this.setter = this.options.setter || this.setter
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false
@@ -44,16 +46,30 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').attr('data-value'),
+      item = this.getter(val)
+      
       this.$element
-        .val(this.updater(val))
-        .change()
+          .val(this.updater(item))
+          .change()
       return this.hide()
     }
 
   , updater: function (item) {
       return item
     }
+    
+  , getter: function (pk) {      
+      var source = $.isFunction(this.source) ? this.source() : this.source
+        
+      return $.grep(source, function(item){
+          return item == pk
+      })[0]
+  }
+  
+  , setter: function(item) {
+      return item;
+  }
 
   , show: function () {
       var pos = $.extend({}, this.$element.offset(), {
@@ -136,7 +152,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).attr('data-value', that.setter(item))
         i.find('a').html(that.highlighter(item))
         return i[0]
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -87,6 +87,61 @@ $(function () {
 
         typeahead.$menu.remove()
       })
+      
+      test("should accept collection of objects as data source", function () {
+        var $input = $('<input />').typeahead({
+              source: function () {
+                return [{'id': '1', 'name': 'aa'}, {'id': '2', 'name': 'ab'}, {'id': '3', 'name': 'ac'}]
+              },
+              matcher: function (item) {
+                return ~item.name.toLowerCase().indexOf(this.query.toLowerCase())
+              },
+              sorter: function (items) {
+                var beginswith = []
+                  , caseSensitive = []
+                  , caseInsensitive = []
+                  , item
+
+                while (item = items.shift()) { 
+                  if (!item.name.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item)
+                  else if (~item.name.indexOf(this.query)) caseSensitive.push(item)
+                  else caseInsensitive.push(item)
+                }
+
+                return beginswith.concat(caseSensitive, caseInsensitive)
+              },
+              highlighter: function (item) {
+                var query = this.query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
+                return item.name.replace(new RegExp('(' + query + ')', 'ig'), function ($1, match) {
+                    return '<strong>' + match + '</strong>'
+                })
+              },
+              getter: function(pk) {
+                var source = $.isFunction(this.source) ? this.source() : this.source
+                
+                return $.grep(source, function(item){
+                    return item.id == pk
+                })[0]
+              },
+              setter: function(item) {            
+                return item.id
+              },
+              updater: function (item) {
+                $input.data('value', item.id)
+                return item.name
+              }
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        typeahead.$menu.remove()
+      })
 
       test("should not explode when regex chars are entered", function () {
         var $input = $('<input />').typeahead({


### PR DESCRIPTION
BC break: no
Feature: yes
Documentation: yes

Setter method allows to customize what is set as `data-value`.

Previously the script would break if item was an object, becouse render method rendered `<li data-value="[object Object]">`.

This method allows you to specify which field should be used as identifier for your result (preferabely database entry ID, but it can be any unique field).

Getter method allows to customize how item is retrieved from data source.

Previously the script just passed `item` (which was sufficient for simple string).

This method is connected to setter method. If you set `data-value` as `item.id` then the getter method must look for `item.id == pk` (where pk is value of `data-value` passed to this function). Returns the object matching that identiefier.

Example on JSFiddle:

http://jsfiddle.net/ZAQ2S/12/

Update: rebaseing against w-i-p branch.
