### PR TITLE
Making modal work with max width 767px - fixes #4860

### DIFF
--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -872,8 +872,11 @@
     width: auto;
     margin: 0;
   }
+  .modal.fade {
+    top: -100px;
+  }
   .modal.fade.in {
-    top: auto;
+    top: 20px;
   }
 }
 

--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -107,7 +107,8 @@
     right: 20px;
     width: auto;
     margin: 0;
-    &.fade.in { top: auto; }
+    &.fade  { top: -100px; }
+    &.fade.in { top: 20px; }
   }
 
 }


### PR DESCRIPTION
Issue: #4860  (modals are disappearing on screens with less than 767px of width)
Jsfiddle:  This issue is not possible to reproduce in jsfiddle due to the nature of modals and the way jsfiddle handles modals and overlays.

Reproduce: 
Go to http://twitter.github.com/bootstrap/javascript.html#modals  
Click Launch modal
Resize window
See how modal disapears in when going under 767

Tested browsers: 
os x: chrome, firefox, safari
iOS: chrome, safari
