### PR TITLE
Use .triggerHandler() instead of .trigger() for custom events.

### DIFF
--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -47,7 +47,7 @@
 
     $parent.length || ($parent = $this.hasClass('alert') ? $this : $this.parent())
 
-    $parent.trigger(e = $.Event('close'))
+    $parent.triggerHandler(e = $.Event('close'))
 
     if (e.isDefaultPrevented()) return
 
@@ -55,7 +55,7 @@
 
     function removeElement() {
       $parent
-        .trigger('closed')
+        .triggerHandler('closed')
         .remove()
     }
 

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -107,7 +107,7 @@
       if ($next.hasClass('active')) return
 
       if ($.support.transition && this.$element.hasClass('slide')) {
-        this.$element.trigger(e)
+        this.$element.triggerHandler(e)
         if (e.isDefaultPrevented()) return
         $next.addClass(type)
         $next[0].offsetWidth // force reflow
@@ -117,15 +117,15 @@
           $next.removeClass([type, direction].join(' ')).addClass('active')
           $active.removeClass(['active', direction].join(' '))
           that.sliding = false
-          setTimeout(function () { that.$element.trigger('slid') }, 0)
+          setTimeout(function () { that.$element.triggerHandler('slid') }, 0)
         })
       } else {
-        this.$element.trigger(e)
+        this.$element.triggerHandler(e)
         if (e.isDefaultPrevented()) return
         $active.removeClass('active')
         $next.addClass('active')
         this.sliding = false
-        this.$element.trigger('slid')
+        this.$element.triggerHandler('slid')
       }
 
       isCycling && this.cycle()

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -97,10 +97,10 @@
         , complete = function () {
             if (startEvent.type == 'show') that.reset()
             that.transitioning = 0
-            that.$element.trigger(completeEvent)
+            that.$element.triggerHandler(completeEvent)
           }
 
-      this.$element.trigger(startEvent)
+      this.$element.triggerHandler(startEvent)
 
       if (startEvent.isDefaultPrevented()) return
 

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -45,7 +45,7 @@
         var that = this
           , e = $.Event('show')
 
-        this.$element.trigger(e)
+        this.$element.triggerHandler(e)
 
         if (this.isShown || e.isDefaultPrevented()) return
 
@@ -77,8 +77,8 @@
           that.enforceFocus()
 
           transition ?
-            that.$element.one($.support.transition.end, function () { that.$element.trigger('shown') }) :
-            that.$element.trigger('shown')
+            that.$element.one($.support.transition.end, function () { that.$element.triggerHandler('shown') }) :
+            that.$element.triggerHandler('shown')
 
         })
       }
@@ -90,7 +90,7 @@
 
         e = $.Event('hide')
 
-        this.$element.trigger(e)
+        this.$element.triggerHandler(e)
 
         if (!this.isShown || e.isDefaultPrevented()) return
 
@@ -147,7 +147,7 @@
     , hideModal: function (that) {
         this.$element
           .hide()
-          .trigger('hidden')
+          .triggerHandler('hidden')
 
         this.backdrop()
       }

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -112,7 +112,7 @@
           active = active.closest('li.dropdown').addClass('active')
         }
 
-        active.trigger('activate')
+        active.triggerHandler('activate')
       }
 
   }

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -55,7 +55,7 @@
         relatedTarget: previous
       })
 
-      $this.trigger(e)
+      $this.triggerHandler(e)
 
       if (e.isDefaultPrevented()) return
 
@@ -63,7 +63,7 @@
 
       this.activate($this.parent('li'), $ul)
       this.activate($target, $target.parent(), function () {
-        $this.trigger({
+        $this.triggerHandler({
           type: 'shown'
         , relatedTarget: previous
         })


### PR DESCRIPTION
For custom events (hide, show, closed, etc..) it is more desirable to not propagate the event by default. This causes many problems with nested components such as tabs within tabs or tabs within modals, etc. 

The reason this is problematic is if I am watching the shown event on a modal that has tabs inside, clicking on the inner tab will cause the modal to receive a shown event.  This [fiddle](http://jsfiddle.net/jschr/7vTVJ/2/) shows the issue. Opening up the console will show that clicking on a tab triggers the modal's shown event as well.

The solution is to call stopPropagation() on the event which could be done in the event handler itself but this can automatically be done with the [triggerHandler](http://api.jquery.com/triggerHandler/) function instead of trigger. I can't think of a good use case why you would want these events to propagate through the DOM as it will almost always cause undesired behaviour.

See this jquery issue as a reference: http://bugs.jquery.com/ticket/10699
