### PR TITLE
Confine Tooltip to Viewport

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -142,6 +142,9 @@
             tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width}
             break
         }
+        
+        if (tp.top < 0) tp.top = 0
+        if (tp.left < 0) tp.left = 0
 
         $tip
           .offset(tp)

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -118,8 +118,11 @@ $(function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')
           .tooltip({ delay: 150 })
+          
         stop()
+        
         tooltip.trigger('mouseenter')
+        
         setTimeout(function () {
           ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
         }, 100)
@@ -127,6 +130,22 @@ $(function () {
           ok($(".tooltip").is('.fade.in'), 'tooltip has faded in')
           start()
         }, 200)
+      })
+      
+      test("should show the entire tooltip within the bounds of the viewport", function () {
+        var tooltip = $('<a href="#" rel="tooltip" data-placement="left" title="Test tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .css({'position': 'absolute', 'top': '0', 'left': '0'})
+          .tooltip()
+          
+        stop()
+        
+        tooltip.trigger('mouseenter')
+        
+        setTimeout(function () {
+          ok($('.tooltip').css('top') === '0px' && $('.tooltip').css('left') === '0px', 'tooltip within viewport')
+          start()
+        }, 300 )
       })
 
       test("should destroy tooltip", function () {


### PR DESCRIPTION
This is to address issues with keeping the tooltip in bounds on mobile devices, so we zero the Top and Left CSS values of the tooltip just in case they become negative.
