### PR TITLE
Switch from using watchr (Ruby) to supervisor (Node.js)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,28 @@ gh-pages: bootstrap docs
 	cp -r docs/* ../bootstrap-gh-pages
 
 #
-# WATCH LESS FILES
+# WATCH FILES
 #
 
 watch:
-	echo "Watching less files..."; \
-	watchr -e "watch('less/.*\.less') { system 'make' }"
+	@echo "Watching less and js files..."; \
+	supervisor -w less,js -n exit --quiet -e 'less|js' -x make --
+
+#
+# WATCH LESS FILES
+#
+
+watch-less:
+	@echo "Watching less files..."; \
+	supervisor -w less/ -n exit --quiet -e 'less' -x make --
+
+#
+# WATCH JS FILES
+#
+
+watch-js:
+	@echo "Watching js files..."; \
+	supervisor -w js/ -n exit --quiet -e 'js' -x make --
 
 #
 # HAUNT GITHUB ISSUES 4 FAT & MDO ONLY (O_O  )

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     , "jshint": "0.6.1"
     , "recess": "1.0.3"
     , "connect": "2.1.3"
+    , "supervisor": "0.4.1"
   }
 }


### PR DESCRIPTION
Resolves #4321, #2549, and #5284.

Utilizes [node-supervisor](https://github.com/isaacs/node-supervisor) to remove the dependency for Ruby.

This commit adds two new rules and changes the current watch rule.
- `make watch` watches for changes to both js and less files.
- `make watch-less` watches for changes to less files only.
- `make watch-js` watches for changes to js files only.
