### PR TITLE
Fix for #5362

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -49,7 +49,7 @@
 
       if ( $this.parent('li').hasClass('active') ) return
 
-      previous = $ul.find('.active a').last()[0]
+      previous = $ul.find('.active:last a')[0]
 
       e = $.Event('show', {
         relatedTarget: previous

--- a/js/tests/unit/bootstrap-tab.js
+++ b/js/tests/unit/bootstrap-tab.js
@@ -58,4 +58,23 @@ $(function () {
           .tab('show')
       })
 
+      test("show and shown events should reference correct relatedTarget", function () {
+        var dropHTML =
+            '<ul class="drop">'
+          + '<li class="dropdown"><a data-toggle="dropdown" href="#">1</a>'
+          + '<ul class="dropdown-menu">'
+          + '<li><a href="#1-1" data-toggle="tab">1-1</a></li>'
+          + '<li><a href="#1-2" data-toggle="tab">1-2</a></li>'
+          + '</ul>'
+          + '</li>'
+          + '</ul>'
+
+        $(dropHTML).find('ul>li:first a').tab('show').end()
+          .find('ul>li:last a').on('show', function(event){
+            equals(event.relatedTarget.hash, "#1-1")
+          }).on('shown', function(event){
+            equals(event.relatedTarget.hash, "#1-1")
+          }).tab('show')
+      })
+
 })


### PR DESCRIPTION
Fix for issue [5362](https://github.com/twitter/bootstrap/issues/5362) tab events fired on wrong dropdown anchor.
