### PR TITLE
Added the support for <menu> elements for the Tab component.

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -42,6 +42,11 @@
         , $target
         , e
 
+      if ($ul.length === 0) {
+        // Looking for HTML5 <menu> elements instead of <ul> elements.
+        $ul = $this.closest('menu:not(.dropdown-menu)');
+      }
+
       if (!selector) {
         selector = $this.attr('href')
         selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7


### PR DESCRIPTION
In some applications, with the regard of HTML semantic quality, some may use the `<menu>` elements of type "list" (`<menu type="list"/>`) instead of the classic `<ul>` elements. The JavaScript for the Tab component currently doesn't know how to handle as it only expects for `<ul>` elements.

This PR will use the `<menu>` elements as a backup only when `<ul>` elements aren't found.
