### PR TITLE
Update js/bootstrap-tooltip.js

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -119,7 +119,7 @@
         inside = /in/.test(placement)
 
         $tip
-          .remove()
+          .detach()
           .css({ top: 0, left: 0, display: 'block' })
           .insertAfter(this.$element)
 


### PR DESCRIPTION
Avoid loosing events in popover content when adding jQuery content via function.
