### PR TITLE
js/bootstrap-collapse.js .collapsed missing

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -150,6 +150,7 @@
           || e.preventDefault()
           || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
         , option = $(target).data('collapse') ? 'toggle' : $this.data()
+      $('[data-toggle=collapse]').addClass('collapsed')
       $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
       $(target).collapse(option)
     })


### PR DESCRIPTION
Be sure to restore the .collapsed on .accordion-toggle :

Simply adding this to line 153 :

$('[data-toggle=collapse]').addClass('collapsed')
