### PR TITLE
Ajax Based DOM Replacement support

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -85,20 +85,22 @@
 
  /* AFFIX DATA-API
   * ============== */
-
-  $(window).on('load', function () {
+  function bootstrapInitAffix() {
     $('[data-spy="affix"]').each(function () {
-      var $spy = $(this)
-        , data = $spy.data()
+      var $spy = $(this),
+        data = $spy.data();
 
-      data.offset = data.offset || {}
+      data.offset = data.offset || {};
 
-      data.offsetBottom && (data.offset.bottom = data.offsetBottom)
-      data.offsetTop && (data.offset.top = data.offsetTop)
+      data.offsetBottom && (data.offset.bottom = data.offsetBottom);
+      data.offsetTop && (data.offset.top = data.offsetTop);
 
-      $spy.affix(data)
-    })
-  })
+      $spy.affix(data);
+    });
+  }
+
+  $(window).on('load', bootstrapInitAffix);
+  $(document).on('page:load',bootstrapInitAffix);
 
 
 }(window.jQuery);

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -83,8 +83,11 @@
  /* ALERT DATA-API
   * ============== */
 
-  $(function () {
-    $('body').on('click.alert.data-api', dismiss, Alert.prototype.close)
-  })
+  function bootstrapInitAlert() {
+    $('body').on('click.alert.data-api', dismiss, Alert.prototype.close);
+  }
+
+  $(bootstrapInitAlert);
+  $(document).on('page:load',bootstrapInitAlert);
 
 }(window.jQuery);

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -85,12 +85,15 @@
  /* BUTTON DATA-API
   * =============== */
 
-  $(function () {
+  function bootstrapInitButton() {
     $('body').on('click.button.data-api', '[data-toggle^=button]', function ( e ) {
-      var $btn = $(e.target)
-      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-      $btn.button('toggle')
-    })
-  })
+      var $btn = $(e.target);
+      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn');
+      $btn.button('toggle');
+    });
+  }
+
+  $(bootstrapInitButton);
+  $(document).on('page:load',bootstrapInitButton);
 
 }(window.jQuery);

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -163,14 +163,17 @@
  /* CAROUSEL DATA-API
   * ================= */
 
-  $(function () {
+  function bootstrapInitCarousel() {
     $('body').on('click.carousel.data-api', '[data-slide]', function ( e ) {
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
         , options = !$target.data('modal') && $.extend({}, $target.data(), $this.data())
-      $target.carousel(options)
-      e.preventDefault()
-    })
-  })
+      $target.carousel(options);
+      e.preventDefault();
+    });
+  }
+
+  $(bootstrapInitCarousel);
+  $(document).on('page:load',bootstrapInitCarousel);
 
 }(window.jQuery);

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -143,7 +143,7 @@
  /* COLLAPSIBLE DATA-API
   * ==================== */
 
-  $(function () {
+  function bootstrapInitCollapse() {
     $('body').on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
       var $this = $(this), href
         , target = $this.attr('data-target')
@@ -153,6 +153,8 @@
       $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
       $(target).collapse(option)
     })
-  })
+  }
+  $(bootstrapInitCollapse);
+  $(document).on('page:load',bootstrapInitCollapse);
 
 }(window.jQuery);

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -138,13 +138,15 @@
   /* APPLY TO STANDARD DROPDOWN ELEMENTS
    * =================================== */
 
-  $(function () {
+   function bootstrapInitDropdown() {
     $('html')
       .on('click.dropdown.data-api touchstart.dropdown.data-api', clearMenus)
     $('body')
       .on('click.dropdown touchstart.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
       .on('click.dropdown.data-api touchstart.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
       .on('keydown.dropdown.data-api touchstart.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
-  })
+   }
+  $(bootstrapInitDropdown);
+  $(document).on('page:load',bootstrapInitDropdown);
 
 }(window.jQuery);

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -219,7 +219,7 @@
  /* MODAL DATA-API
   * ============== */
 
-  $(function () {
+  function bootstrapInitModal() {
     $('body').on('click.modal.data-api', '[data-toggle="modal"]', function ( e ) {
       var $this = $(this)
         , href = $this.attr('href')
@@ -234,6 +234,9 @@
           $this.focus()
         })
     })
-  })
+  }
+
+  $(bootstrapInitModal);
+  $(document).bind('page:load',bootstrapInitModal);
 
 }(window.jQuery);

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -141,11 +141,13 @@
  /* SCROLLSPY DATA-API
   * ================== */
 
-  $(window).on('load', function () {
+  function initScrollSpy() {
     $('[data-spy="scroll"]').each(function () {
       var $spy = $(this)
       $spy.scrollspy($spy.data())
     })
-  })
+  }
+  $(window).on('load', initScrollSpy);
+  $(document).on('page:load',initScrollSpy);
 
 }(window.jQuery);

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -125,11 +125,14 @@
  /* TAB DATA-API
   * ============ */
 
-  $(function () {
+  function bootstrapInitTab() {
     $('body').on('click.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
-      e.preventDefault()
-      $(this).tab('show')
-    })
-  })
+      e.preventDefault();
+      $(this).tab('show');
+    });
+  }
+
+  $(bootstrapInitTab);
+  $(document).on('page:load',bootstrapInitTab);
 
 }(window.jQuery);

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -288,13 +288,16 @@
  /*   TYPEAHEAD DATA-API
   * ================== */
 
-  $(function () {
+  function bootstrapInitTypeAhead() {
     $('body').on('focus.typeahead.data-api', '[data-provide="typeahead"]', function (e) {
-      var $this = $(this)
-      if ($this.data('typeahead')) return
-      e.preventDefault()
-      $this.typeahead($this.data())
-    })
-  })
+      var $this = $(this);
+      if ($this.data('typeahead')) return;
+      e.preventDefault();
+      $this.typeahead($this.data());
+    });
+  }
+
+  $(bootstrapInitTypeAhead)
+  $(document).on('page:load',bootstrapInitTypeAhead);
 
 }(window.jQuery);


### PR DESCRIPTION
Currently, if the document body is replaced via ajax style websites, there is no way to reinitialize bootstrap js. This now monitors page:load which is also used by the new Rails turbolinks gem created by @dhh.

However, this fix may apply to more than just rails 4 turbolinks but rather any ajax based javascript framework could benefit.

Support Added for Turbolinks which will become  standard in rails 4: https://github.com/rails/turbolinks
