### PR TITLE
Use data-position or options.position to handle tooltips/popovers related to fixed elements

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -201,7 +201,7 @@
     }
 
   , getPosition: function (inside) {
-      return $.extend({}, (inside ? {top: 0, left: 0} : this.$element.offset()), {
+      return $.extend({}, (inside ? this.$element.position() : this.$element.offset()), {
         width: this.$element[0].offsetWidth
       , height: this.$element[0].offsetHeight
       })

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -125,6 +125,13 @@
 
         pos = this.getPosition(inside)
 
+        if (this.options.position === 'fixed') {
+          pos.top -= $(window).scrollTop()
+          pos.left -= $(window).scrollLeft()
+
+          $tip.addClass('fixed')
+        }
+
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
 
@@ -264,6 +271,7 @@
   $.fn.tooltip.defaults = {
     animation: true
   , placement: 'top'
+  , position: 'fixed'
   , selector: false
   , template: '<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
   , trigger: 'hover'

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -59,6 +59,16 @@ $(function () {
         ok(!$(".tooltip").length, 'tooltip removed')
       })
 
+      test("should respect fixed tooltip position", function () {
+        var tooltip = $('<a href="#" rel="tooltip" data-tooltip-position="fixed" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip('show')
+
+        ok($('.tooltip').hasClass('tooltip-fixed'), 'tooltip-fixed class is present')
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
       test("should not show tooltip if leave event occurs before delay expires", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')

--- a/less/popovers.less
+++ b/less/popovers.less
@@ -20,12 +20,13 @@
   .border-radius(6px);
   .box-shadow(0 5px 10px rgba(0,0,0,.2));
 
+  &.fixed   { position: fixed; }
+
   // Offset the popover to account for the popover arrow
   &.top     { margin-bottom: 10px; }
   &.right   { margin-left: 10px; }
   &.bottom  { margin-top: 10px; }
   &.left    { margin-right: 10px; }
-
 }
 
 .popover-title {

--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -13,6 +13,7 @@
   font-size: 11px;
   .opacity(0);
   &.in     { .opacity(80); }
+  &.fixed  { position: fixed; }
   &.top    { margin-top:  -3px; }
   &.right  { margin-left:  3px; }
   &.bottom { margin-top:   3px; }


### PR DESCRIPTION
It's like one of pull-requests before: https://github.com/twitter/bootstrap/pull/4200
But with small differences. First of all, this fix respects options ( $().tooltip({position: 'fixed'}) ) and second thing, that this is support popovers.
I was have this problem with popovers and tried some fixes from google, but everything was wrong. Pull request by ericmatthys was good, but doesn't support popovers, so i decided slightly extend it.
