### PR TITLE
Update less/responsive-767px-max.less

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -58,7 +58,8 @@
   }
   // Make all grid-sized elements block level again
   [class*="span"],
-  .row-fluid [class*="span"] {
+  .row-fluid [class*="span"],
+  .row-fluid [class*="offset"]:first-child {
     float: none;
     display: block;
     width: 100%;


### PR DESCRIPTION
When using a `<div class="span* offset*">` in a `<div class="row-fluid">` it will flow out of the row on phones.

Adding a `.row-fluid [class*="offset"]:first-child` on line 62 will fix this problem.
