### PR TITLE
Fix margin-left for block buttons in modal footer

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -95,4 +95,8 @@
   .btn-group .btn + .btn {
     margin-left: -1px;
   }
+  // and for block buttons
+  .btn + .btn.btn-block {
+    margin-left: 0px;
+}
 }


### PR DESCRIPTION
Block buttons supposed to be displayed in a column, but with current styles they have different left margins and that ruins the alignment.

This request is the correction for: https://github.com/twitter/bootstrap/pull/5559
