### PR TITLE
fix makefile task dependencies of gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ bootstrap:
 # MAKE FOR GH-PAGES 4 FAT & MDO ONLY (O_O  )
 #
 
-gh-pages: bootstrap docs
+gh-pages: bootstrap build
 	rm -f docs/assets/bootstrap.zip
 	zip -r docs/assets/bootstrap.zip bootstrap
 	rm -r bootstrap
@@ -105,4 +105,4 @@ haunt:
 	@haunt .issue-guidelines.js https://github.com/twitter/bootstrap
 
 
-.PHONY: docs watch gh-pages
+.PHONY: watch gh-pages


### PR DESCRIPTION
It seems like the task 'docs' was renamed to 'build' without renaming the
dependencies of gh-pages.
