### PR TITLE
Span selector is too loose

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -267,29 +267,47 @@ textarea {
 .input-xxlarge    { width: 530px; }
 
 // Grid style input sizes
-input[class*="span"],
-select[class*="span"],
-textarea[class*="span"],
-.uneditable-input[class*="span"],
+input[class^="span"],
+input[class*=" span"],
+select[class^="span"],
+select[class*=" span"],
+textarea[class^="span"],
+textarea[class*=" span"],
+.uneditable-input[class^="span"],
+.uneditable-input[class*=" span"],
 // Redeclare since the fluid row class is more specific
-.row-fluid input[class*="span"],
-.row-fluid select[class*="span"],
-.row-fluid textarea[class*="span"],
-.row-fluid .uneditable-input[class*="span"] {
+.row-fluid input[class^="span"],
+.row-fluid input[class*=" span"],
+.row-fluid select[class^="span"],
+.row-fluid select[class*=" span"],
+.row-fluid textarea[class^="span"],
+.row-fluid textarea[class*=" span"],
+.row-fluid .uneditable-input[class^="span"],
+.row-fluid .uneditable-input[class*=" span"] {
   float: none;
   margin-left: 0;
 }
 // Ensure input-prepend/append never wraps
-.input-append input[class*="span"],
-.input-append .uneditable-input[class*="span"],
-.input-prepend input[class*="span"],
-.input-prepend .uneditable-input[class*="span"],
-.row-fluid input[class*="span"],
-.row-fluid select[class*="span"],
-.row-fluid textarea[class*="span"],
-.row-fluid .uneditable-input[class*="span"],
-.row-fluid .input-prepend [class*="span"],
-.row-fluid .input-append [class*="span"] {
+.input-append input[class^="span"],
+.input-append input[class*=" span"],
+.input-append .uneditable-input[class^="span"],
+.input-append .uneditable-input[class*=" span"],
+.input-prepend input[class^="span"],
+.input-prepend input[class*=" span"],
+.input-prepend .uneditable-input[class^="span"],
+.input-prepend .uneditable-input[class*=" span"],
+.row-fluid input[class^="span"],
+.row-fluid input[class*=" span"],
+.row-fluid select[class^="span"],
+.row-fluid select[class*=" span"],
+.row-fluid textarea[class^="span"],
+.row-fluid textarea[class*=" span"],
+.row-fluid .uneditable-input[class^="span"],
+.row-fluid .uneditable-input[class*=" span"],
+.row-fluid .input-prepend [class^="span"],
+.row-fluid .input-prepend [class*=" span"],
+.row-fluid .input-append [class^="span"],
+.row-fluid .input-append [class*=" span"] {
   display: inline-block;
 }
 
@@ -307,14 +325,18 @@ textarea[class*="span"],
 }
 
 // Float to collapse white-space for proper grid alignment
-.controls-row [class*="span"],
+.controls-row [class^="span"],
+.controls-row [class*=" span"],
 // Redeclare the fluid grid collapse since we undo the float for inputs
-.row-fluid .controls-row [class*="span"] {
+.row-fluid .controls-row [class^="span"],
+.row-fluid .controls-row [class*=" span"] {
   float: left;
 }
 // Explicity set top padding on all checkboxes/radios, not just first-child
-.controls-row .checkbox[class*="span"],
-.controls-row .radio[class*="span"] {
+.controls-row .checkbox[class^="span"],
+.controls-row .checkbox[class*=" span"],
+.controls-row .radio[class^="span"],
+.controls-row .radio[class*=" span"] {
   padding-top: 5px;
 }
 

--- a/less/grid.less
+++ b/less/grid.less
@@ -10,12 +10,16 @@
 #grid > .fluid(@fluidGridColumnWidth, @fluidGridGutterWidth);
 
 // Reset utility classes due to specificity
-[class*="span"].hide,
-.row-fluid [class*="span"].hide {
+[class^="span"].hide,
+[class*=" span"].hide,
+.row-fluid [class^="span"].hide,
+.row-fluid [class*=" span"].hide {
   display: none;
 }
 
-[class*="span"].pull-right,
-.row-fluid [class*="span"].pull-right {
+[class^="span"].pull-right,
+[class*=" span"].pull-right,
+.row-fluid [class^="span"].pull-right,
+.row-fluid [class*=" span"].pull-right {
   float: right;
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -582,7 +582,7 @@
       .clearfix();
     }
 
-    [class*="span"] {
+    [class^="span"], [class*=" span"] {
       float: left;
       min-height: 1px; // prevent collapsing columns
       margin-left: @gridGutterWidth;
@@ -633,18 +633,21 @@
     .row-fluid {
       width: 100%;
       .clearfix();
-      [class*="span"] {
+      [class^="span"], [class*=" span"] {
         .input-block-level();
         float: left;
         margin-left: @fluidGridGutterWidth;
         *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
       }
-      [class*="span"]:first-child {
+      [class^="span"]:first-child, [class*=" span"]:first-child {
         margin-left: 0;
       }
 
       // Space grid-sized controls properly if multiple per line
-      .controls-row [class*="span"] + [class*="span"] {
+      .controls-row [class^="span"] + [class^="span"],
+      .controls-row [class*=" span"] + [class*=" span"],
+      .controls-row [class^="span"] + [class*=" span"],
+      .controls-row [class*=" span"] + [class^="span"] {
         margin-left: @fluidGridGutterWidth;
       }
 
@@ -674,7 +677,10 @@
     }
 
     // Space grid-sized controls properly if multiple per line
-    .controls-row [class*="span"] + [class*="span"] {
+    .controls-row [class*=" span"] + [class*=" span"],
+    .controls-row [class^="span"] + [class^="span"],
+    .controls-row [class^="span"] + [class*=" span"],
+    .controls-row [class*=" span"] + [class^="span"] {
       margin-left: @gridGutterWidth;
     }
 

--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -57,9 +57,12 @@
     margin-left: 0; // Reset the default margin for all li elements when no .span* classes are present
   }
   // Make all grid-sized elements block level again
-  [class*="span"],
-  .uneditable-input[class*="span"], // Makes uneditable inputs full-width when using grid sizing
-  .row-fluid [class*="span"] {
+  [class^="span"],
+  [class*=" span"],
+  .uneditable-input[class^="span"], // Makes uneditable inputs full-width when using grid sizing
+  .uneditable-input[class*=" span"],
+  .row-fluid [class^="span"],
+  .row-fluid [class*=" span"] {
     float: none;
     display: block;
     width: 100%;
@@ -81,21 +84,29 @@
   .input-large,
   .input-xlarge,
   .input-xxlarge,
-  input[class*="span"],
-  select[class*="span"],
-  textarea[class*="span"],
+  input[class^="span"],
+  input[class*=" span"],
+  select[class^="span"],
+  select[class*=" span"],
+  textarea[class^="span"],
+  textarea[class*=" span"],
   .uneditable-input {
     .input-block-level();
   }
   // But don't let it screw up prepend/append inputs
   .input-prepend input,
   .input-append input,
-  .input-prepend input[class*="span"],
-  .input-append input[class*="span"] {
+  .input-prepend input[class^="span"],
+  .input-prepend input[class*=" span"],
+  .input-append input[class^="span"],
+  .input-append input[class*=" span"] {
     display: inline-block; // redeclare so they don't wrap to new lines
     width: auto;
   }
-  .controls-row [class*="span"] + [class*="span"] {
+  .controls-row [class*=" span"] + [class*=" span"],
+  .controls-row [class^="span"] + [class^="span"],
+  .controls-row [class^="span"] + [class*=" span"],
+  .controls-row [class*=" span"] + [class^="span"] {
     margin-left: 0;
   }
 

--- a/less/tables.less
+++ b/less/tables.less
@@ -172,10 +172,14 @@ table {
 // -----------------
 
 // Reset default grid behavior
-table td[class*="span"],
-table th[class*="span"],
-.row-fluid table td[class*="span"],
-.row-fluid table th[class*="span"] {
+table td[class^="span"],
+table td[class*=" span"],
+table th[class^="span"],
+table th[class*=" span"],
+.row-fluid table td[class^="span"],
+.row-fluid table td[class*=" span"],
+.row-fluid table th[class^="span"],
+.row-fluid table th[class*=" span"] {
   display: table-cell;
   float: none; // undo default grid column styles
   margin-left: 0; // undo default grid column styles


### PR DESCRIPTION
The selector `[class*="span"]` seems to be too loose. While it matches `class="span1"` and `class="span2"`, it also matches `class="espanol"` or `class="wingspan"`.

It may be helpful to have a selector be slightly more specific and only match if the class name _begins_ with `span`
