### PR TITLE
Guarantee invokation of `complete()`

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -95,9 +95,11 @@
   , transition: function (method, startEvent, completeEvent) {
       var that = this
         , complete = function () {
-            if (startEvent.type == 'show') that.reset()
-            that.transitioning = 0
-            that.$element.trigger(completeEvent)
+            if (that.transitioning) {
+              if (startEvent.type == 'show') that.reset()
+              that.transitioning = 0
+              that.$element.trigger(completeEvent)
+            }
           }
 
       this.$element.trigger(startEvent)
@@ -106,11 +108,17 @@
 
       this.transitioning = 1
 
-      this.$element[method]('in')
-
-      $.support.transition && this.$element.hasClass('collapse') ?
-        this.$element.one($.support.transition.end, complete) :
+      if ($.support.transition && this.$element.hasClass('collapse')) {
+        // assign callback to transition end event, then start transition
+        this.$element.one($.support.transition.end, complete)
+        this.$element[method]('in')
+        // guarantee callback invokation
+        // timeout is equal to transition time from component-animations.less
+        setTimeout(complete, 350)
+      } else {
+        this.$element[method]('in')
         complete()
+      }
     }
 
   , toggle: function () {

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -94,11 +94,11 @@
 
   , transition: function (method, startEvent, completeEvent) {
       var that = this
-        , complete = function () {
-            if (that.transitioning) {
-              if (startEvent.type == 'show') that.reset()
-              that.transitioning = 0
-              that.$element.trigger(completeEvent)
+        , complete = function (startEvent, completeEvent) {
+            if (this.transitioning) {
+              if (startEvent.type == 'show') this.reset()
+              this.transitioning = 0
+              this.$element.trigger(completeEvent)
             }
           }
 
@@ -114,10 +114,12 @@
         this.$element[method]('in')
         // guarantee callback invokation
         // timeout is equal to transition time from component-animations.less
-        setTimeout(complete, 350)
+        setTimeout(function() {
+            complete.call(that, startEvent, completeEvent)
+        }, 350)
       } else {
         this.$element[method]('in')
-        complete()
+        complete.call(this, startEvent, completeEvent)
       }
     }
 


### PR DESCRIPTION
Transition end event isn't reliable (browser may not fire it, or delay its firing until next transition, in many circumstances, read more in related issue #5462 https://github.com/twitter/bootstrap/issues/5462).

In order to guarantee proper inner state of `Collapse` object (especially `Collapse#transitioning`, because its invalid state will block all successive transitions) additional callback invokation is added with `setTimeout()`.

Timeout value for `setTimeout()` should be equal to transition time from `component-animation.less` - I cannot find a better solution for now.
