### PR TITLE
Fix for Snap Mode on IE10 Metro in Windows 8

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -4,6 +4,9 @@
 
 
 @media (max-width: 767px) {
+  @-ms-viewport{
+    width: device-width;
+  }
 
   // Padding to set content in a bit
   body {

--- a/less/responsive-navbar.less
+++ b/less/responsive-navbar.less
@@ -11,7 +11,7 @@
   // ----------------
   // Remove any padding from the body
   body {
-    padding-top: 0;
+    padding-top: 0 !important;
   }
   // Unfix the navbars
   .navbar-fixed-top,


### PR DESCRIPTION
See http://timkadlec.com/2012/10/ie10-snap-mode-and-responsive-design/
for why this is necessary.
