### PR TITLE
Check for the existence of $.support.transition before accessing $.support.transition.end in bootstrap-carousel.js

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -68,7 +68,7 @@
 
   , pause: function (e) {
       if (!e) this.paused = true
-      if (this.$element.find('.next, .prev').length && $.support.transition.end) {
+      if (this.$element.find('.next, .prev').length && $.support.transition && $.support.transition.end) {
         this.$element.trigger($.support.transition.end)
         this.cycle()
       }


### PR DESCRIPTION
I noticed that the rest of the carousel code checks for the existence of `$.support.transition`, but the affected line does not. This broke my (abuse) of the carousel by preemptively setting the `prev` and `next` CSS classes on slides involved in the transition process.
