### PR TITLE
Fix for animated fading issue

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -166,12 +166,16 @@
 
       function removeWithAnimation() {
         var timeout = setTimeout(function () {
-          $tip.off($.support.transition.end).remove()
+          if (!$tip.hasClass("in")) {
+            $tip.off($.support.transition.end).remove()
+          }
         }, 500)
 
         $tip.one($.support.transition.end, function () {
           clearTimeout(timeout)
-          $tip.remove()
+          if (!$tip.hasClass("in")) {
+            $tip.remove()
+          }
         })
       }
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -128,6 +128,22 @@ $(function () {
         }, 200)
       })
 
+      test("should show tooltip if 'in' class is present when delay expires", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({ delay: 150 })
+        stop()
+        tooltip.tooltip('show')
+        tooltip.trigger('mouseout')
+        setTimeout(function () {
+          tooltip.trigger('mouseenter')
+          setTimeout(function () {
+            ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
+            start()
+          }, 200)
+        }, 100)
+      })
+
       test("should destroy tooltip", function () {
         var tooltip = $('<div/>').tooltip().on('click.foo', function(){})
         ok(tooltip.data('tooltip'), 'tooltip has data')


### PR DESCRIPTION
Applied a check when the fade-out timer expires to ensure the 'in' class is not present before removing a tooltip. This prevents the tooltip disappearing if the user mouses out and then back in again before the tooltip has finished fading out.
