### PR TITLE
Modals loaded event implemented

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -295,6 +295,10 @@ $('#myModal').modal({
                <td>{{_i}}hidden{{/i}}</td>
                <td>{{_i}}This event is fired when the modal has finished being hidden from the user (will wait for css transitions to complete).{{/i}}</td>
              </tr>
+             <tr>
+               <td>{{_i}}loaded{{/i}}</td>
+               <td>{{_i}}This event is fired when the modal loaded its remote content and injected it into the <code>.modal-body</code>.{{/i}}</td>
+             </tr>
             </tbody>
           </table>
 <pre class="prettyprint linenums">

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,7 +30,9 @@
     this.options = options
     this.$element = $(element)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-    this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
+    this.options.remote && this.$element.find('.modal-body').load(this.options.remote, $.proxy(function() {
+      this.$element.trigger('loaded')
+    }, this))
   }
 
   Modal.prototype = {

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -111,4 +111,18 @@ $(function () {
           })
           .modal("toggle")
       })
+
+      test("should fire loaded event", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'><div class='modal-body'></div></div>")
+          .bind("loaded", function () {
+            ok(true, "loaded was called")
+            $(this).remove()
+            start()
+          })
+          .modal({ remote : 'http://example.com' })
+      })
+
+
 })


### PR DESCRIPTION
This pull request adds 'loaded' event to modals:

``` javascript
$('#myModal').modal({ remote : '/echo/html' }).on('loaded', function() {
  alert('Modal content loaded!')
})
```

Here's the demo http://jsfiddle.net/N96Ff/
Also tests & docs added.

It refers to issue #4735
