### PR TITLE
Inline Code Elements Should Use white-space: nowrap

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -19,6 +19,7 @@ code {
   color: #d14;
   background-color: #f7f7f9;
   border: 1px solid #e1e1e8;
+  white-space: nowrap;
 }
 
 // Blocks of code


### PR DESCRIPTION
Using `white-space: nowrap` on inline code elements makes code more readable in the normal case. It keeps the snippet of code together and does not force the user to mentally concatenate it.

It could cause a problem, however. If you were to have a long string of code inside an inline code element with white-space: nowrap enabled: it could break the bounds of the containing element and make things look ugly. This could easily be resolved by using a code block with `<pre>` tags surrounding it. I would argue this 'workaround' is actually a best practice anyway.

![Imgur](http://i.imgur.com/hl4go.png)

[See this example](http://jsbin.com/orazuk/1)

I've gone ahead and added a line to `code.less` which will fix this issue.
