### PR TITLE
Add the .collapsed class to all collapsed elements in an accordion group.

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -146,10 +146,12 @@
   $(function () {
     $('body').on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
       var $this = $(this), href
-        , target = $this.attr('data-target')
-          || e.preventDefault()
-          || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
-        , option = $(target).data('collapse') ? 'toggle' : $this.data()
+        , target = $this.attr('data-target') 
+          || e.preventDefault() 
+      	  || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+        , parent = $this.attr('data-parent'),
+          option = $(target).data('collapse') ? 'toggle' : $this.data()
+      if (parent) $(parent).find('[data-toggle=collapse]').addClass('collapsed')
       $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
       $(target).collapse(option)
     })


### PR DESCRIPTION
Added a check to the COLLAPSIBLE DATA-API function to add the .collapsed class to all collapsed elements in an accordion group instead of just the element that has been click. This is so as to be able to style collapsed elements differently to open elements. e.g. showing an up or down arrow on the data-toggle=collapse element based on the .collapsed class.
