### PR TITLE
Remove body padding-left, padding-right on tablet screens

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -5,11 +5,6 @@
 
 @media (max-width: 767px) {
 
-  // Padding to set content in a bit
-  body {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
   // Negative indent the now static "fixed" navbar
   .navbar-fixed-top,
   .navbar-fixed-bottom,


### PR DESCRIPTION
This commit removes the default padding-left and padding-right rules for
tablet-sized screens. Adding this padding results in broken full-page-width
banners, such as the .jumbotron on Bootstrap's own documentation site.

While it makes sense to attempt to ensure that `<body>` content does not touch
the edge of the screen on tablet devices, any content in the responsive
Bootstrap grid _already_ cannot touch the edge, because the .container's width
continues to shrink as the page decreases in size, effectively providing the
same padding.  Specifically, if the browser is 980px large, the .container will
be 940px, giving 20px of margin on either side and if the browser is 979px, the
.container will be 724px, giving between 127px and 22px of margin on either
side.

If content is in the grid, it cannot touch the edge. If content is not in the
grid, it's probably because the site designer wants it to be as wide as
possible. Removing this default allows for that situation.
