### PR TITLE
fixes #5683: use @btnBackgroundHighlight for button state backgrounds

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -30,8 +30,8 @@
   &:hover {
     color: @grayDark;
     text-decoration: none;
-    background-color: darken(@white, 10%);
-    *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
+    background-color: @btnBackgroundHighlight;
+    *background-color: darken(@btnBackgroundHighlight, 5%); /* Buttons in IE7 don't get borders, so darken on hover */
     background-position: 0 -15px;
 
     // transition is only when going to hover, otherwise the background
@@ -47,8 +47,8 @@
   // Active state
   &.active,
   &:active {
-    background-color: darken(@white, 10%);
-    background-color: darken(@white, 15%) e("\9");
+    background-color: @btnBackgroundHighlight;
+    background-color: darken(@btnBackgroundHighlight, 5%) e("\9");
     background-image: none;
     outline: 0;
     .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
@@ -58,7 +58,7 @@
   &.disabled,
   &[disabled] {
     cursor: default;
-    background-color: darken(@white, 10%);
+    background-color: @btnBackgroundHighlight;
     background-image: none;
     .opacity(65);
     .box-shadow(none);


### PR DESCRIPTION
Use `@btnBackgroundHighlight` var for hover/active/disabled button state backgrounds
