### PR TITLE
Fixed background issue for default buttons when changing $btnBackgroundHighlight value

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -28,10 +28,7 @@
 
   // Hover state
   &:hover {
-    color: @grayDark;
     text-decoration: none;
-    background-color: darken(@white, 10%);
-    *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
     background-position: 0 -15px;
 
     // transition is only when going to hover, otherwise the background

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -503,7 +503,7 @@
   &:hover, &:active, &.active, &.disabled, &[disabled] {
     color: @textColor;
     background-color: @endColor;
-    *background-color: darken(@endColor, 5%);
+    *background-color: darken(@endColor, 5%); /* Buttons in IE7 don't get borders, so darken on hover */
   }
 
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves


### PR DESCRIPTION
Fixed default button background issue: you cannot change default button background to other than default just changing bootstrap variables values. 
It happens due to unwanted style overriding at `buttons.less` button style of `.btn:hover` state.

Also `buttons.less:31`, `buttons.less:33`, `buttons.less:34` lines don't respect button colors variables (for easy color scheme changes).
