### PR TITLE
Prevent IE8 from misplacing imgs in navs

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -21,6 +21,11 @@
   background-color: @grayLighter;
 }
 
+// Prevent IE8 from misplacing imgs
+.nav > li > a > img {
+  max-width: none;
+}
+
 // Redeclare pull classes because of specifity
 .nav > .pull-right {
   float: right;


### PR DESCRIPTION
Fixed imgs in a nav that were misplaced on IE8.
