### PR TITLE
tooltip('toggle') fixed, also added container option for where the tooltip gets placed

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -103,6 +103,7 @@
         , actualHeight
         , placement
         , tp
+        , container
 
       if (this.hasContent() && this.enabled) {
         $tip = this.tip()
@@ -122,7 +123,7 @@
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
         
-        var container = $(this.options.container)
+        container = this.options.container == '' ? '' : $(this.options.container)
         container.length ? $tip.appendTo(container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition(inside)

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -236,7 +236,8 @@
     }
 
   , toggle: function (e) {
-      this.tip().hasClass('in') ? this.hide() : this.show()
+      var self = (e) ? $(e.currentTarget)[this.type](this._options).data(this.type) : this
+      self.tip().hasClass('in') ? self.hide() : self.show()
     }
 
   , destroy: function () {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -123,7 +123,7 @@
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
         
-        container = this.options.container == '' ? '' : $(this.options.container)
+        container = this.options.container === '' ? '' : $(this.options.container)
         container.length ? $tip.appendTo(container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition(inside)

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -236,8 +236,7 @@
     }
 
   , toggle: function (e) {
-      var self = $(e.currentTarget)[this.type](this._options).data(this.type)
-      self[self.tip().hasClass('in') ? 'hide' : 'show']()
+      this.tip().hasClass('in') ? this.hide() : this.show()
     }
 
   , destroy: function () {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -121,7 +121,9 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
+        
+        var container = $(this.options.container)
+        container.length ? $tip.appendTo(container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition(inside)
 
@@ -271,6 +273,7 @@
   , title: ''
   , delay: 0
   , html: false
+  , container: ''
   }
 
 }(window.jQuery);

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -150,4 +150,12 @@ $(function () {
         div.find('a').trigger('click')
         ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
       })
+      
+      test("should show tooltip when toggle is called", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="tooltip on toggle"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip()
+        tooltip.trigger('toggle')
+        ok(!$(".tooltip").is('.fade.in'), 'tooltip toggled in')
+      })
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -158,4 +158,29 @@ $(function () {
         tooltip.trigger('toggle')
         ok(!$(".tooltip").is('.fade.in'), 'tooltip toggled in')
       })
+
+      test("should place tooltips inside the body", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'body'}).tooltip('show')
+        ok($("body > .tooltip").length, 'inside the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
+        tooltip.tooltip('hide')
+      })
+
+      test("should place tooltips inside the parent", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'parent'}).tooltip('show')
+        ok($("#qunit-fixture > .tooltip").length, 'inside the parent')
+        ok(!$("body > .tooltip").length, 'not found in body')
+        tooltip.tooltip('hide')
+      })
+
+      test("should place tooltips inside an element", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a><div id="tooltiphere"></div>').appendTo('#qunit-fixture').tooltip({container:'#tooltiphere'}).tooltip('show')
+        ok($("#tooltiphere > .tooltip").length, 'inside the element')
+        ok(!$("body > .tooltip").length, 'not in the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not in the parent')
+        tooltip.tooltip('hide')
+      })
 })


### PR DESCRIPTION
## This is an old pull request

Both of these bugs have been fixed in 2.3.0

please refer to the following requests--
#6321 to fix the insert strategy and use a container option
#6176  fixes the tooltip('toggle') feature which is currently broken.

---

refer to #5753

.tooltip('toggle') and .popover('toggle') was broken, so heres the fix

took me forever to get this request to send right, but I think I got it this time

thanks to @demike for helping correct the problem

Also, within the pull request is an alternate way of doing the insertAfter or appendTo options noted within #5830 to fix the problems within #5687

I found out after I changed my -wip branch that it updates this pull requests with my changes, thats why they're in the same pull

How to use the new container option..
you can use html5 elements -- `data-container="body"` or with javascript - `$().tooltip({ container: 'body' })`
and the container value, can be any element on the page, and for tooltips within modals I've been using `container: '.modal'` or `'.modal-body'`
