### PR TITLE
Change example email addresses to use RFC 2606 reserved example domain.

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -226,7 +226,7 @@
             </address>
             <address>
               <strong>Full Name</strong><br>
-              <a href="mailto:#">first.last@gmail.com</a>
+              <a href="mailto:#">first.last@example.com</a>
             </address>
           </div>
 <pre class="prettyprint linenums">
@@ -239,7 +239,7 @@
 
 &lt;address&gt;
   &lt;strong&gt;Full Name&lt;/strong&gt;&lt;br&gt;
-  &lt;a href="mailto:#"&gt;first.last@gmail.com&lt;/a&gt;
+  &lt;a href="mailto:#"&gt;first.last@example.com&lt;/a&gt;
 &lt;/address&gt;
 </pre>
 

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -162,7 +162,7 @@
             </address>
             <address>
               <strong>{{_i}}Full Name{{/i}}</strong><br>
-              <a href="mailto:#">{{_i}}first.last@gmail.com{{/i}}</a>
+              <a href="mailto:#">{{_i}}first.last@example.com{{/i}}</a>
             </address>
           </div>
 <pre class="prettyprint linenums">
@@ -175,7 +175,7 @@
 
 &lt;address&gt;
   &lt;strong&gt;{{_i}}Full Name{{/i}}&lt;/strong&gt;&lt;br&gt;
-  &lt;a href="mailto:#"&gt;{{_i}}first.last@gmail.com{{/i}}&lt;/a&gt;
+  &lt;a href="mailto:#"&gt;{{_i}}first.last@example.com{{/i}}&lt;/a&gt;
 &lt;/address&gt;
 </pre>
 


### PR DESCRIPTION
first.last@gmail.com could be someone's actually email address, so lets be good internet citizens and use an address we know doesn't belong to anyone.

Spec info: http://tools.ietf.org/html/rfc2606#page-3
