### PR TITLE
fixes #5494: style invalid fields as invalid regardless of required-ness

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1588,16 +1588,16 @@ input[type="checkbox"][readonly] {
   border-color: #3a87ad;
 }
 
-input:focus:required:invalid,
-textarea:focus:required:invalid,
-select:focus:required:invalid {
+input:focus:invalid,
+textarea:focus:invalid,
+select:focus:invalid {
   color: #b94a48;
   border-color: #ee5f5b;
 }
 
-input:focus:required:invalid:focus,
-textarea:focus:required:invalid:focus,
-select:focus:required:invalid:focus {
+input:focus:invalid:focus,
+textarea:focus:invalid:focus,
+select:focus:invalid:focus {
   border-color: #e9322d;
   -webkit-box-shadow: 0 0 6px #f8b9b7;
      -moz-box-shadow: 0 0 6px #f8b9b7;

--- a/less/forms.less
+++ b/less/forms.less
@@ -366,9 +366,9 @@ input[type="checkbox"][readonly] {
 
 // HTML5 invalid states
 // Shares styles with the .control-group.error above
-input:focus:required:invalid,
-textarea:focus:required:invalid,
-select:focus:required:invalid {
+input:focus:invalid,
+textarea:focus:invalid,
+select:focus:invalid {
   color: #b94a48;
   border-color: #ee5f5b;
   &:focus {


### PR DESCRIPTION
The obvious, simple fix for #5494. Removes the `:required` selectors from the `:invalid` styles so that optional fields with invalid values also get styled.

The commit which originally introduced these styles (1209a375) does not explain the inclusion of the `required`s, nor does the blog post to which it links (said post instead justifies the `:focus`es), so the exclusion of optional fields doesn't seem to have been deliberate / explicitly-intended.
