### PR TITLE
insert missing i18n tag at customize and download string

### DIFF
--- a/docs/templates/pages/customize.mustache
+++ b/docs/templates/pages/customize.mustache
@@ -378,7 +378,7 @@
               </h1>
             </div>
             <div class="download-btn">
-              <a class="btn btn-primary" href="#" {{#production}}onclick="_gaq.push(['_trackEvent', 'Customize', 'Download', 'Customize and Download']);"{{/production}}>Customize and Download</a>
+              <a class="btn btn-primary" href="#" {{#production}}onclick="_gaq.push(['_trackEvent', 'Customize', 'Download', 'Customize and Download']);"{{/production}}>{{_i}}Customize and Download{{/i}}</a>
               <h4>{{_i}}What's included?{{/i}}</h4>
               <p>{{_i}}Downloads include compiled CSS, compiled and minified CSS, and compiled jQuery plugins, all nicely packed up into a zipball for your convenience.{{/i}}</p>
             </div>


### PR DESCRIPTION
Missing a i18n tag at "Customize and Download" button text in Customize page.
