### PR TITLE
New insert strategy for tooltip breaks tooltips/popovers

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -123,23 +123,21 @@
           .css({ top: 0, left: 0, display: 'block' })
 
 
-	      switch (this.options.container||'parent') {
-		      case "parent":
-			      $tip.insertAfter(this.$element);
-			      break;
-		      case "body":
-			      console.log("body")
-			      $tip.appendTo(document.body);
-			      break;
-		      default :
-			      var container = $(this.options.container);
-			      if (container.length){
-				      console.log("container: "+ this.options.container)
-				      $tip.appendTo(container);
-			      } else {
-				      $tip.insertAfter(this.$element);
-			      }
-	      }
+         switch (this.options.container||'parent') {
+          case "parent":
+            $tip.insertAfter(this.$element)
+            break;
+          case "body":
+            $tip.appendTo(document.body)
+            break;
+          default :
+            var container = $(this.options.container)
+            if (container.length){
+              $tip.appendTo(container)
+            } else {
+              $tip.insertAfter(this.$element)
+            }
+         }
 
 
         pos = this.getPosition(inside)

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -68,7 +68,7 @@
         }
       }
 
-      return options
+		return options
     }
 
   , enter: function (e) {
@@ -121,7 +121,26 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
+
+
+	      switch (this.options.container||'parent') {
+		      case "parent":
+			      $tip.insertAfter(this.$element);
+			      break;
+		      case "body":
+			      console.log("body")
+			      $tip.appendTo(document.body);
+			      break;
+		      default :
+			      var container = $(this.options.container);
+			      if (container.length){
+				      console.log("container: "+ this.options.container)
+				      $tip.appendTo(container);
+			      } else {
+				      $tip.insertAfter(this.$element);
+			      }
+	      }
+
 
         pos = this.getPosition(inside)
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -288,6 +288,7 @@
   , title: ''
   , delay: 0
   , html: false
+  , container: 'parent'
   }
 
 }(window.jQuery);

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -150,4 +150,34 @@ $(function () {
         div.find('a').trigger('click')
         ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
       })
+	test("should place tooltips inside the body", function () {
+		$.support.transition = false
+		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'body'}).tooltip('show')
+
+		ok($("body > .tooltip").length, 'inside the body')
+		ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
+		tooltip.tooltip('hide')
+	})
+
+	test("should place tooltips inside the parent", function () {
+		$.support.transition = false
+		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'parent'}).tooltip('show')
+
+		ok($("#qunit-fixture > .tooltip").length, 'inside the parent')
+		ok(!$("body > .tooltip").length, 'not found in body')
+		tooltip.tooltip('hide')
+	})
+	test("should place tooltips inside an element", function () {
+		$.support.transition = false
+		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a><div id="tooltiphere"></div>').appendTo('#qunit-fixture').tooltip({container:'#tooltiphere'}).tooltip('show')
+
+		ok($("#tooltiphere > .tooltip").length, 'inside the element')
+		ok(!$("body > .tooltip").length, 'not in the body')
+		ok(!$("#qunit-fixture > .tooltip").length, 'not in the parent')
+
+		tooltip.tooltip('hide')
+	})
+
+
+
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -150,33 +150,29 @@ $(function () {
         div.find('a').trigger('click')
         ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
       })
-	test("should place tooltips inside the body", function () {
-		$.support.transition = false
-		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'body'}).tooltip('show')
+      test("should place tooltips inside the body", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'body'}).tooltip('show')
+        ok($("body > .tooltip").length, 'inside the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
+        tooltip.tooltip('hide')
+      })
 
-		ok($("body > .tooltip").length, 'inside the body')
-		ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
-		tooltip.tooltip('hide')
-	})
-
-	test("should place tooltips inside the parent", function () {
-		$.support.transition = false
-		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'parent'}).tooltip('show')
-
-		ok($("#qunit-fixture > .tooltip").length, 'inside the parent')
-		ok(!$("body > .tooltip").length, 'not found in body')
-		tooltip.tooltip('hide')
-	})
-	test("should place tooltips inside an element", function () {
-		$.support.transition = false
-		var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a><div id="tooltiphere"></div>').appendTo('#qunit-fixture').tooltip({container:'#tooltiphere'}).tooltip('show')
-
-		ok($("#tooltiphere > .tooltip").length, 'inside the element')
-		ok(!$("body > .tooltip").length, 'not in the body')
-		ok(!$("#qunit-fixture > .tooltip").length, 'not in the parent')
-
-		tooltip.tooltip('hide')
-	})
+      test("should place tooltips inside the parent", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').appendTo('#qunit-fixture').tooltip({container:'parent'}).tooltip('show')
+        ok($("#qunit-fixture > .tooltip").length, 'inside the parent')
+        ok(!$("body > .tooltip").length, 'not found in body')
+        tooltip.tooltip('hide')
+      })
+      test("should place tooltips inside an element", function () {
+        $.support.transition = false
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a><div id="tooltiphere"></div>').appendTo('#qunit-fixture').tooltip({container:'#tooltiphere'}).tooltip('show')
+        ok($("#tooltiphere > .tooltip").length, 'inside the element')
+        ok(!$("body > .tooltip").length, 'not in the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not in the parent')
+        tooltip.tooltip('hide')
+      })
 
 
 


### PR DESCRIPTION
added a container option so either use the html data api

```
data-container="parent"
data-container="body"
data-container="#some_element"
```

or the javascript

```
{
container: "body"
}
```

added 3 tests to the tool tip aswell to test if the tooltip is being added to the right places

---

yes i just stole the title from the issue tracker... #5687
