### PR TITLE
Allow some useful styles to be 'mixable' and hence more reusable

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -82,10 +82,11 @@
   padding: @paddingLarge;
   font-size: @fontSizeLarge;
   .border-radius(@borderRadiusLarge);
-}
-.btn-large [class^="icon-"],
-.btn-large [class*=" icon-"] {
-  margin-top: 2px;
+
+  [class^="icon-"],
+  [class*=" icon-"] {
+    margin-top: 2px;
+  }
 }
 
 // Small
@@ -93,10 +94,11 @@
   padding: @paddingSmall;
   font-size: @fontSizeSmall;
   .border-radius(@borderRadiusSmall);
-}
-.btn-small [class^="icon-"],
-.btn-small [class*=" icon-"] {
-  margin-top: 0;
+
+  [class^="icon-"],
+  [class*=" icon-"] {
+    margin-top: 0;
+  }
 }
 
 // Mini

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -28,6 +28,9 @@
 
   // Hover state
   &:hover {
+    .hover;
+  }
+  .hover() {
     color: @grayDark;
     text-decoration: none;
     background-color: darken(@white, 10%);
@@ -41,6 +44,9 @@
 
   // Focus state for keyboard and accessibility
   &:focus {
+    .focus;
+  }
+  .focus() {
     .tab-focus();
   }
 

--- a/less/sprites.less
+++ b/less/sprites.less
@@ -16,6 +16,9 @@
 
 [class^="icon-"],
 [class*=" icon-"] {
+  .icon;
+}
+.icon() {
   display: inline-block;
   width: 14px;
   height: 14px;


### PR DESCRIPTION
Hi!

I've been working on a component that is based on bootstrap's buttons and I found that I really had a need to mixin the `.btn`'s hover style with my own styles. This small change makes this (among other mixins) possible.

Also, I am using `.btn-large` and `.btn-small` as mixins and found that the adjustment to the icons was missing. This request also wraps the icon adjustment, just as it should be.

The resulting CSS files are unaffected, this is purely a request for better reusable.

Cheers,
Corin.
