### PR TITLE
Fix issue with double move event firing in typeahead.

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -217,7 +217,7 @@
     }
 
   , keydown: function (e) {
-      this.suppressKeyPressRepeat = !~$.inArray(e.keyCode, [40,38,9,13,27])
+      this.suppressKeyPressRepeat = ~$.inArray(e.keyCode, [40,38,9,13,27])
       this.move(e)
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -137,8 +137,17 @@ $(function () {
         equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
         ok(typeahead.$menu.find('li').first().hasClass('active'), "first item is active")
 
+        // simulate entire key pressing event
         $input.trigger({
           type: 'keydown'
+        , keyCode: 40
+        })
+        .trigger({
+          type: 'keypress'
+        , keyCode: 40
+        })
+        .trigger({
+          type: 'keyup'
         , keyCode: 40
         })
 
@@ -147,6 +156,14 @@ $(function () {
 
         $input.trigger({
           type: 'keydown'
+        , keyCode: 38
+        })
+        .trigger({
+          type: 'keypress'
+        , keyCode: 38
+        })
+        .trigger({
+          type: 'keyup'
         , keyCode: 38
         })
 


### PR DESCRIPTION
The test for keyboard nav with the arrow keys only fired
the keyup event. The issue was with the mechanism that
prevented double `move` method firing for keyup, keydown,
and keypress.

This adds a more complete triggering of a full key press
and fixes the issue with the double calls to `move`.
