### PR TITLE
Base buttons should use background color variables for hover state

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -30,8 +30,8 @@
   &:hover {
     color: @grayDark;
     text-decoration: none;
-    background-color: darken(@white, 10%);
-    *background-color: darken(@white, 15%); /* Buttons in IE7 don't get borders, so darken on hover */
+    background-color: @btnBackgroundHighlight;
+    *background-color: darken(@btnBackgroundHighlight, 5%); /* Buttons in IE7 don't get borders, so darken on hover */
     background-position: 0 -15px;
 
     // transition is only when going to hover, otherwise the background


### PR DESCRIPTION
Color (darkened white) was hard-coded for .btn hover, while the buttonBackground mixin is called for specific button types and properly using their background variables.

With this change, even default button colors can be overridden by variable updates.
