### PR TITLE
fixes #5873: @navbarInverseBrandColor not used

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4678,6 +4678,10 @@ input[type="submit"].btn.btn-mini {
   color: #ffffff;
 }
 
+.navbar-inverse .brand {
+  color: #999999;
+}
+
 .navbar-inverse .navbar-text {
   color: #999999;
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -394,6 +394,10 @@
     }
   }
 
+  .brand {
+    color: @navbarInverseBrandColor;
+  }
+
   .navbar-text {
     color: @navbarInverseText;
   }


### PR DESCRIPTION
Tested by changing `@navbarinversebrand` in variables.less, recompiling, and viewing the result on the starter template example in the docs. Tested in Chrome 22.
