### PR TITLE
Bind affix events to document without waiting for ready

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -88,18 +88,16 @@
  /* AFFIX DATA-API
   * ============== */
 
-  $(window).on('load', function () {
-    $('[data-spy="affix"]').each(function () {
-      var $spy = $(this)
-        , data = $spy.data()
+  $(document).on('[data-spy="affix"]', function () {
+    var $spy = $(this)
+      , data = $spy.data()
 
-      data.offset = data.offset || {}
+    data.offset = data.offset || {}
 
-      data.offsetBottom && (data.offset.bottom = data.offsetBottom)
-      data.offsetTop && (data.offset.top = data.offsetTop)
+    data.offsetBottom && (data.offset.bottom = data.offsetBottom)
+    data.offsetTop && (data.offset.top = data.offsetTop)
 
-      $spy.affix(data)
-    })
+    $spy.affix(data)
   })
 
 


### PR DESCRIPTION
By binding data-api events to document without relying on document ready, we can replace the body element without losing the bindings.

This is necessary to be compatible with https://github.com/rails/turbolinks and other javascript libraries that replace body.

See #5308, which made similar changes to other parts of the data-api.
