### PR TITLE
Adding an 'expanded' class to click target

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -150,6 +150,7 @@
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
     $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+    $this[$(target).hasClass('in') ? 'removeClass' : 'addClass']('expanded')
     $(target).collapse(option)
   })
 


### PR DESCRIPTION
To help with styling elements that are targets for the collapse plugin, we required a class when the element was in the expanded state. Because the default state was collapsed, there was no difference in class on the target element from the default state through the first click to expand.
