### PR TITLE
Enabling Keyboard Navigation on Dropdown Lists with invisible items

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -82,7 +82,7 @@
 
       if (!isActive || (isActive && e.keyCode == 27)) return $this.click()
 
-      $items = $('[role=menu] li:not(.divider) a', $parent)
+      $items = $('[role=menu] li:not(.divider):visible a', $parent)
 
       if (!$items.length) return
 


### PR DESCRIPTION
There was a bug where the keyboard navigation inside a dropdown view was not working properly when single list items are not visible. So i’ve added the `:visible` filter to the `$items` selector.
