### PR TITLE
Using correct name for the <dl> element, the definition list

### DIFF
--- a/base-css.html
+++ b/base-css.html
@@ -386,12 +386,12 @@
 &lt;/ul&gt;
 </pre>
 
-        <h3>Description</h3>
+        <h3>Definition</h3>
         <p>A list of terms with their associated descriptions.</p>
         <div class="bs-docs-example">
           <dl>
-            <dt>Description lists</dt>
-            <dd>A description list is perfect for defining terms.</dd>
+            <dt>Definition lists</dt>
+            <dd>A definition list is perfect for defining terms.</dd>
             <dt>Euismod</dt>
             <dd>Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.</dd>
             <dd>Donec id elit non mi porta gravida at eget metus.</dd>
@@ -406,12 +406,12 @@
 &lt;/dl&gt;
 </pre>
 
-        <h4>Horizontal description</h4>
+        <h4>Horizontal definition</h4>
         <p>Make terms and descriptions in <code>&lt;dl&gt;</code> line up side-by-side.</p>
         <div class="bs-docs-example">
           <dl class="dl-horizontal">
-            <dt>Description lists</dt>
-            <dd>A description list is perfect for defining terms.</dd>
+            <dt>Definition lists</dt>
+            <dd>A definition list is perfect for defining terms.</dd>
             <dt>Euismod</dt>
             <dd>Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.</dd>
             <dd>Donec id elit non mi porta gravida at eget metus.</dd>
@@ -429,7 +429,7 @@
 </pre>
         <p>
           <span class="label label-info">Heads up!</span>
-          Horizontal description lists will truncate terms that are too long to fit in the left column fix <code>text-overflow</code>. In narrower viewports, they will change to the default stacked layout.
+          Horizontal defintion lists will truncate terms that are too long to fit in the left column fix <code>text-overflow</code>. In narrower viewports, they will change to the default stacked layout.
         </p>
       </section>
 


### PR DESCRIPTION
Minor correction to documetnation
The <dl> element is a _definition_ list, not a _description_ list as previously used in the documentation.
http://www.w3.org/TR/html401/struct/lists.html#h-10.3
