### PR TITLE
Changed to a percentage to avoid magic number issues

### DIFF
--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -48,5 +48,5 @@ a:hover {
 
 // Perfect circle
 .img-circle {
-  .border-radius(500px); // crank the border-radius so it works with most reasonably sized images
+  .border-radius(51%); // 51% instead of 50% to fix avoid pixel rounding issues http://bit.ly/RfX4xV
 }

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -48,5 +48,5 @@ a:hover {
 
 // Perfect circle
 .img-circle {
-  .border-radius(51%); // 51% instead of 50% to fix avoid pixel rounding issues http://bit.ly/RfX4xV
+  .border-radius(51%); // 51% instead of 50% to avoid pixel rounding issues http://bit.ly/RfX4xV
 }


### PR DESCRIPTION
I changed the img circle class to a percentage to avoid some edge cases and, at least I think, make it a little faster so it doesn't compute extraneous pixels. 

What we lose in this bargain is [Safari 5.0 and back](http://muddledramblings.com/table-of-css3-border-radius-compliance/) but it will just default to a square at that point.  It really just treating old Safari like we treat sub-ie9. 

Thoughts?
