### PR TITLE
Insert into `.popover-content`, not `.popover-content p`

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -44,7 +44,7 @@
         , content = this.getContent()
 
       $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
-      $tip.find('.popover-content > *')[this.options.html ? 'html' : 'text'](content)
+      $tip.find('.popover-content')[this.options.html ? 'html' : 'text'](content)
 
       $tip.removeClass('fade top bottom left right in')
     }
@@ -97,7 +97,7 @@
     placement: 'right'
   , trigger: 'click'
   , content: ''
-  , template: '<div class="popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>'
+  , template: '<div class="popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"></div></div></div>'
   })
 
 }(window.jQuery);


### PR DESCRIPTION
Using the paragraph element as container for content will punish the developer for using anything other than inline html elements. Honestly I do not see any reason to use a paragraph inside the container. The 5px bottom margin on the paragraph could also be solved with additional padding, thoughts?
