### PR TITLE
Trigger the input event for typeAhead selection

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -48,6 +48,7 @@
       this.$element
         .val(this.updater(val))
         .change()
+        .trigger("input")
       return this.hide()
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -162,17 +162,20 @@ $(function () {
             })
           , typeahead = $input.data('typeahead')
           , changed = false
+          , inputFired = false
 
         $input.val('a')
         typeahead.lookup()
 
-        $input.change(function() { changed = true });
+        $input.change(function() { changed = true })
+        $input.bind('input', function() { inputFired = true })
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
         equals($input.val(), 'ac', 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
         ok(changed, 'a change event was fired')
+        ok(inputFired, 'an input event was fired')
 
         typeahead.$menu.remove()
       })


### PR DESCRIPTION
### Test Case

http://jsfiddle.net/sirhc/nJ6vX/
### Background

This is for scripts written to detect user input in modern browsers. Mainly, to support AngularJS.
https://developer.mozilla.org/en-US/docs/DOM/DOM_event_reference/input

Previous pull request that was closed without reason: #5225 .
