### PR TITLE
Dropdowns update - keyboard, touch and submenus

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -60,12 +60,6 @@
      -moz-background-clip: padding;
           background-clip: padding-box;
 
-  // Aligns the dropdown menu to right
-  &.pull-right {
-    right: 0;
-    left: auto;
-  }
-
   // Dividers (basically an hr) within the dropdown
   .divider {
     .nav-divider(@dropdownDividerTop, @dropdownDividerBottom);
@@ -133,6 +127,7 @@
 
 // Right aligned dropdowns
 // ---------------------------
+.dropdown-menu.pull-right,
 .pull-right > .dropdown-menu {
   right: 0;
   left: auto;
@@ -176,12 +171,31 @@
 }
 
 // Dropups
+.dropdown-submenu.dropup > .dropdown-menu,
 .dropup .dropdown-submenu > .dropdown-menu {
   top: auto;
   bottom: 0;
   margin-top: 0;
   margin-bottom: -2px;
+<<<<<<< HEAD
   .border-radius(5px 5px 5px 0);
+=======
+  -webkit-border-radius: 6px 6px 6px 0;
+     -moz-border-radius: 6px 6px 6px 0;
+          border-radius: 6px 6px 6px 0;
+}
+
+// Override the .dropup class with a .dropdown
+.dropdown-submenu.dropdown > .dropdown-menu,
+.dropdown .dropdown-submenu > .dropdown-menu {
+  top: 0;
+  bottom: auto;
+  margin-top: -6px;
+  margin-bottom: 0;
+  -webkit-border-radius: 0 6px 6px 6px;
+     -moz-border-radius: 0 6px 6px 6px;
+          border-radius: 0 6px 6px 6px;
+>>>>>>> afc5647... Updating jQuery dropdown plugin with full keyboard navigation (takes into account .pull-left, .dropup, .dropdown modifier classes). Takes into account whether we entered the menu using up or down. Behaves much like a standard dropdown menu on Mac, minus the submenu showing on focus. As a result of this - .pull-left will cause navigation to the submenu to be the left arrow v right normally. Use opposite direction to go up a level. Use [esc] will bring you back to the initial button focused. Reenables and adds touch support to menus and submenu items.
 }
 
 // Caret to indicate there is a submenu
@@ -210,8 +224,10 @@
 
   // Positioning the submenu
   > .dropdown-menu {
-    left: -100%;
-    margin-left: 10px;
+    left: auto;
+    right: 100%;
+    margin-left: 0;
+    margin-right: -1px;
     .border-radius(6px 0 6px 6px);
   }
 }


### PR DESCRIPTION
Fixes:
- Keyboard navigation using submenus (acts similar to right-click in Mac, going up first starts to top of list, bottom the bottom - moves from there, etc. Only difference is that the submenus display on item focus)
- Takes into account the `.dropup`, `.dropdown` and `.pull-left` modifier classes. E.g. If it's pull-left the left and right arrows switch around, if it's a dropup submenu - we start by focusing the last item vs the first which is at the top.
- Touch navigation now works prevents the default click events from happening with the delay
- [esc] key will bring you back in focus with the initial button no matter where in the dropdown you are
- Adds a item visibility selector to only navigate through visible items
