### PR TITLE
Add 'bootstrap' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nbproject
 .idea
 node_modules
 dist
+bootstrap


### PR DESCRIPTION
Ignores the "bootstrap" directory that is created when you "make bootstrap". No
need to track these files since they're generated. conzett's commit to "Add
'dist' directory to .gitignore" (https://github.com/twitter/bootstrap/pull/4229)
is the same idea but for Bootstrap, the generated files are place in a
"bootstrap" directory by default, not a "dist" directory (like jQuery). Left
the "dist" directory in the .gitignore since it may be a convention others are
using already.

(Is this line "If modifying the .less files, always recompile and commit the compiled files bootstrap.css and bootstrap.min.css" in CONTRIBUTING.md supposed to be there? Assume that refers to "make bootstrap" not "make build"?)
