### PR TITLE
Remove non-mixins from mixins.less

### DIFF
--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -14,6 +14,7 @@
 // Core variables and mixins
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "mixins.less";
+@import "common.less";
 
 // Grid system and page structure
 @import "scaffolding.less";

--- a/less/common.less
+++ b/less/common.less
@@ -1,0 +1,36 @@
+// Clearfix
+// --------
+// For clearing floats like a boss h5bp.com/q
+.clearfix {
+  *zoom: 1;
+  &:before,
+  &:after {
+    display: table;
+    content: "";
+    // Fixes Opera/contenteditable bug:
+    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
+    line-height: 0;
+  }
+  &:after {
+    clear: both;
+  }
+}
+
+// CSS image replacement
+// -------------------------
+// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
+.hide-text {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+
+// Block level inputs
+.input-block-level {
+  display: block;
+  width: 100%;
+  min-height: @inputHeight; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
+  .box-sizing(border-box); // Makes inputs behave like true block-level elements
+}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -6,24 +6,6 @@
 // UTILITY MIXINS
 // --------------------------------------------------
 
-// Clearfix
-// --------
-// For clearing floats like a boss h5bp.com/q
-.clearfix {
-  *zoom: 1;
-  &:before,
-  &:after {
-    display: table;
-    content: "";
-    // Fixes Opera/contenteditable bug:
-    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
-    line-height: 0;
-  }
-  &:after {
-    clear: both;
-  }
-}
-
 // Webkit-style focus
 // ------------------
 .tab-focus() {
@@ -100,18 +82,6 @@
   white-space: nowrap;
 }
 
-// CSS image replacement
-// -------------------------
-// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
-.hide-text {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
-
 // FONTS
 // --------------------------------------------------
 
@@ -149,16 +119,6 @@
 
 // FORMS
 // --------------------------------------------------
-
-// Block level inputs
-.input-block-level {
-  display: block;
-  width: 100%;
-  min-height: @inputHeight; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
-  .box-sizing(border-box); // Makes inputs behave like true block-level elements
-}
-
-
 
 // Mixin for form field states
 .formFieldState(@textColor: #555, @borderColor: #ccc, @backgroundColor: #f5f5f5) {


### PR DESCRIPTION
I was importing mixins.less for some of my own projects to use some of the mixins available to extend some themes. I found that including mixins.less would also add some style definitions at the top of my compiled CSS file due to some of the definitions in mixins.less not actually being mixins but instead they are definitions in themselves.

This approach allows @import-ing mixins.less without the added definitions that would already be defined in bootstrap.css, assuming you're also including that on your website.
