### PR TITLE
support multiple self contained carousels

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -167,7 +167,7 @@
 
   $(document).on('click.carousel.data-api', '[data-slide]', function (e) {
     var $this = $(this), href
-      , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+      , $target = , $target = $this.attr('data-parent') ? $this.parent('.carousel') : $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
       , options = $.extend({}, $target.data(), $this.data())
     $target.carousel(options)
     e.preventDefault()


### PR DESCRIPTION
if `data-parent` is set on the controls, we look for the carousel content via a `$.parent` lookup.
`.carousel` is hardcoded, maybe it should be configurable too?

It seems presently the workaround is to add unique ids for each carousel...
