### PR TITLE
Set focus back after clicking typeahead menu

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -263,6 +263,7 @@
       e.stopPropagation()
       e.preventDefault()
       this.select()
+      this.$element.focus()
     }
 
   , mouseenter: function (e) {

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -162,17 +162,22 @@ $(function () {
             })
           , typeahead = $input.data('typeahead')
           , changed = false
+          , focus = false
+          , blur = false
 
         $input.val('a')
         typeahead.lookup()
 
         $input.change(function() { changed = true });
+        $input.focus(function() { focus = true; blur = false });
+        $input.blur(function() { blur = true; focus = false });
 
         $(typeahead.$menu.find('li')[2]).mouseover().click()
 
         equals($input.val(), 'ac', 'input value was correctly set')
         ok(!typeahead.$menu.is(':visible'), 'the menu was hidden')
         ok(changed, 'a change event was fired')
+        ok(focus && !blur, 'focus is still set')
 
         typeahead.$menu.remove()
       })


### PR DESCRIPTION
Test 'focus is still set' added

Tested in Firefox 17.0, Chromium 23.0.1271.91 and Opera 12.11 on Linux

Fixes issue #5933
