### PR TITLE
scrollSpy - add parent scrollTop to offset calculation

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -59,7 +59,7 @@
               , $href = /^#\w/.test(href) && $(href)
             return ( $href
               && $href.length
-              && [[ $href.position().top, href ]] ) || null
+              && [[ $href.position().top + self.$scrollElement.scrollTop(), href ]] ) || null
           })
           .sort(function (a, b) { return a[0] - b[0] })
           .each(function () {


### PR DESCRIPTION
Fix for Bootstrap issue #6013 "scrollSpy - offset calculation"
https://github.com/twitter/bootstrap/issues/6013

When using scrollspy on div inside a container.
- If the div is already scrolled, the offset calculated are incorrects, sometimes < 0.
  Adding the parents scrollTop value solves the issue.

Demo:
- http://jsfiddle.net/qu97u/35/
