### PR TITLE
Improved Makefile build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DATE=$(shell date +%I:%M%p)
 CHECK=\033[32m✔\033[39m
 HR=\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
 
+all: bootstrap
 
 #
 # BUILD DOCS
@@ -62,20 +63,53 @@ clean:
 # recess & uglifyjs are required
 #
 
-bootstrap:
-	mkdir -p bootstrap/img
-	mkdir -p bootstrap/css
+# bootstrap:
+# 	mkdir -p bootstrap/img
+# 	mkdir -p bootstrap/css
+# 	mkdir -p bootstrap/js
+# 	cp img/* bootstrap/img/
+# 	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
+# 	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
+# 	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
+# 	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
+# 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
+# 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
+# 	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
+# 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
+# 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
+
+bootstrap: bs-img bs-css bs-js
+
+### js
+
+bs-js: bootstrap/js/*.js
+
+bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
-	cp img/* bootstrap/img/
-	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
-	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
 	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
+
+### css
+
+bs-css: bootstrap/css/*.css
+
+bootstrap/css/*.css: less/*.less
+	mkdir -p bootstrap/css
+	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
+	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
+	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
+	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
+
+### images
+
+bs-img: bootstrap/img/*
+
+bootstrap/img/*: img/*
+	mkdir -p bootstrap/img
+	cp img/* bootstrap/img/
 
 #
 # MAKE FOR GH-PAGES 4 FAT & MDO ONLY (O_O  )
@@ -98,4 +132,4 @@ watch:
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 
-.PHONY: docs watch gh-pages
+.PHONY: docs watch gh-pages bs-img bs-css bs-js

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ DATE=$(shell date +%I:%M%p)
 CHECK=\033[32m✔\033[39m
 HR=\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
 
-all: bootstrap
 
 #
 # BUILD DOCS
@@ -63,26 +62,13 @@ clean:
 # recess & uglifyjs are required
 #
 
-# bootstrap:
-# 	mkdir -p bootstrap/img
-# 	mkdir -p bootstrap/css
-# 	mkdir -p bootstrap/js
-# 	cp img/* bootstrap/img/
-# 	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
-# 	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-# 	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-# 	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
-# 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
-# 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
-# 	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
-# 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
-# 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
+bootstrap: bootstrap-img bootstrap-css bootstrap-js
 
-bootstrap: bs-img bs-css bs-js
+#
+# JS
+#
 
-### js
-
-bs-js: bootstrap/js/*.js
+bootstrap-js: bootstrap/js/*.js
 
 bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
@@ -92,9 +78,11 @@ bootstrap/js/*.js: js/*.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
 
-### css
+#
+# CSS
+#
 
-bs-css: bootstrap/css/*.css
+bootstrap-css: bootstrap/css/*.css
 
 bootstrap/css/*.css: less/*.less
 	mkdir -p bootstrap/css
@@ -103,9 +91,11 @@ bootstrap/css/*.css: less/*.less
 	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
 	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
 
-### images
+#
+# IMAGES
+#
 
-bs-img: bootstrap/img/*
+bootstrap-img: bootstrap/img/*
 
 bootstrap/img/*: img/*
 	mkdir -p bootstrap/img
@@ -132,4 +122,4 @@ watch:
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 
-.PHONY: docs watch gh-pages bs-img bs-css bs-js
+.PHONY: docs watch gh-pages bootstrap-img bootstrap-css bootstrap-js


### PR DESCRIPTION
Currently `make bootstrap` recompiles all js, css, and img files into the bootstrap directory on every invocation. This is very costly when using Bootstrap as a submodule in another project during the compile phase. This update adds new Makefile targets which add file dependency for each asset type (css, js, img) which will only recompile the specific asset type if associated input sources are changed. This saves valuable time during recompiles (of Bootstrap itself and of super-projects).
