### PR TITLE
trigger "hidden" event after backdrop was removed

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -140,11 +140,11 @@
       }
 
     , hideModal: function (that) {
+        this.backdrop()
+
         this.$element
           .hide()
           .trigger('hidden')
-
-        this.backdrop()
       }
 
     , removeBackdrop: function () {


### PR DESCRIPTION
In case the "hidden" event triggers the same modal to be opened again, the backdrop() function it then tries to add another backdrop instead of removing the old one. 
