### PR TITLE
Do not show Modal if button is disabled

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -218,7 +218,10 @@
 
   $(document).on('click.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this = $(this)
-      , href = $this.attr('href')
+
+    if ($this.prop( "disabled" ) || $this.is( ".disabled" ) || $this.is( "[disabled]" )) return false
+
+    var href = $this.attr('href')
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $target.data(), $this.data())
 


### PR DESCRIPTION
Like the title says, the modal dialog shouldn't appear if the button is disabled like this:

``` html
<a class="btn disabled" disabled data-toggle="modal" href="#myModal" >Launch Modal</a>
```
