### PR TITLE
Fix code block white-space breaks within pre tags.

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -993,6 +993,8 @@ pre.prettyprint {
 pre code {
   padding: 0;
   color: inherit;
+  white-space: pre;
+  white-space: pre-wrap;
   background-color: transparent;
   border: 0;
 }

--- a/less/code.less
+++ b/less/code.less
@@ -47,6 +47,8 @@ pre {
   code {
     padding: 0;
     color: inherit;
+    white-space: pre;
+    white-space: pre-wrap;
     background-color: transparent;
     border: 0;
   }


### PR DESCRIPTION
In #5662, the fix describes a possible problem with using nowrap on code blocks:

> It could cause a problem, however. If you were to have a long string of code inside an inline code element with white-space: nowrap enabled: it could break the bounds of the containing element and make things look ugly. This could easily be resolved by using a code block with pre tags surrounding it. I would argue this 'workaround' is actually a best practice anyway.

However, the "workaround" doesn't actually work as shown here:
http://jsbin.com/opuhev/1/edit

The practice of using code tags within pre tags is very common with Markdown parsers and Jekyll-powered sites.

This change re-applies pre-wrap styles to code tags within pre tags so the workaround actually works as described:
http://jsbin.com/opuhev/2/edit
