### PR TITLE
Button that triggered the modal is now passed to 'shown' event.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -363,7 +363,7 @@ $('#myModal').modal({
              </tr>
              <tr>
                <td>shown</td>
-               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).</td>
+               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the second parameter to the event call.</td>
              </tr>
              <tr>
                <td>hide</td>
@@ -378,6 +378,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // do something…
+})
+$('#myModal').on('shown', function (e, source) {
+  // source is the element that triggered the modal
 })
 </pre>
         </section>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -293,7 +293,7 @@ $('#myModal').modal({
              </tr>
              <tr>
                <td>{{_i}}shown{{/i}}</td>
-               <td>{{_i}}This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).{{/i}}</td>
+               <td>{{_i}}This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the second parameter to the event call.{{/i}}</td>
              </tr>
              <tr>
                <td>{{_i}}hide{{/i}}</td>
@@ -308,6 +308,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // {{_i}}do something…{{/i}}
+})
+$('#myModal').on('shown', function (e, source) {
+  // {{_i}}source is the element that triggered the modal{{/i}}
 })
 </pre>
         </section>

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -41,7 +41,7 @@
         return this[!this.isShown ? 'show' : 'hide']()
       }
 
-    , show: function () {
+    , show: function (source) {
         var that = this
           , e = $.Event('show')
 
@@ -74,8 +74,8 @@
           that.enforceFocus()
 
           transition ?
-            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger('shown') }) :
-            that.$element.focus().trigger('shown')
+            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger('shown', source) }) :
+            that.$element.focus().trigger('shown', source)
 
         })
       }
@@ -195,14 +195,14 @@
 
   var old = $.fn.modal
 
-  $.fn.modal = function (option) {
+  $.fn.modal = function (option, source) {
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('modal')
         , options = $.extend({}, $.fn.modal.defaults, $this.data(), typeof option == 'object' && option)
       if (!data) $this.data('modal', (data = new Modal(this, options)))
       if (typeof option == 'string') data[option]()
-      else if (options.show) data.show()
+      else if (options.show) data.show(source)
     })
   }
 
@@ -232,11 +232,12 @@
       , href = $this.attr('href')
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $target.data(), $this.data())
+      , source = e.target
 
     e.preventDefault()
 
     $target
-      .modal(option)
+      .modal(option, source)
       .one('hide', function () {
         $this.focus()
       })


### PR DESCRIPTION
When a modal is triggered by a button, the button is now passed as a parameter to the 'shown' event as mentioned in #6159.

Ex:

``` Javascript
$('#myModal').on('shown', function (e, source) {
  // source is the element that triggered the modal
})
```

Tested on IE9, Firefox 14, and Chrome 23.
