### PR TITLE
Button that triggered the modal is now passed to 'shown' event.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -348,11 +348,11 @@ $('#myModal').modal({
             <tbody>
              <tr>
                <td>show</td>
-               <td>This event fires immediately when the <code>show</code> instance method is called.</td>
+               <td>This event fires immediately when the <code>show</code> instance method is called. If it was triggered by a button, the source button will be passed as the second parameter to the event call.</td>
              </tr>
              <tr>
                <td>shown</td>
-               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).</td>
+               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the second parameter to the event call.</td>
              </tr>
              <tr>
                <td>hide</td>
@@ -367,6 +367,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // do something…
+})
+$('#myModal').on('shown', function (e, source) {
+  // source is the element that triggered the modal
 })
 </pre>
         </section>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -281,11 +281,11 @@ $('#myModal').modal({
             <tbody>
              <tr>
                <td>show</td>
-               <td>This event fires immediately when the <code>show</code> instance method is called.</td>
+               <td>This event fires immediately when the <code>show</code> instance method is called. If it was triggered by a button, the source button will be passed as the second parameter to the event call.</td>
              </tr>
              <tr>
                <td>shown</td>
-               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).</td>
+               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the second parameter to the event call.</td>
              </tr>
              <tr>
                <td>hide</td>
@@ -300,6 +300,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // do something…
+})
+$('#myModal').on('shown', function (e, source) {
+  // source is the element that triggered the modal
 })
 </pre>
         </section>

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -37,15 +37,15 @@
 
       constructor: Modal
 
-    , toggle: function () {
-        return this[!this.isShown ? 'show' : 'hide']()
+    , toggle: function (source) {
+        return this[!this.isShown ? 'show' : 'hide'](source)
       }
 
-    , show: function () {
+    , show: function (source) {
         var that = this
           , e = $.Event('show')
 
-        this.$element.trigger(e)
+        this.$element.trigger(e, source)
 
         if (this.isShown || e.isDefaultPrevented()) return
 
@@ -61,7 +61,7 @@
           }
 
           that.$element
-            .show()
+            .show(source)
 
           if (transition) {
             that.$element[0].offsetWidth // force reflow
@@ -74,8 +74,8 @@
           that.enforceFocus()
 
           transition ?
-            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger('shown') }) :
-            that.$element.focus().trigger('shown')
+            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger('shown', source) }) :
+            that.$element.focus().trigger('shown', source)
 
         })
       }
@@ -193,14 +193,14 @@
  /* MODAL PLUGIN DEFINITION
   * ======================= */
 
-  $.fn.modal = function (option) {
+  $.fn.modal = function (option, source) {
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('modal')
         , options = $.extend({}, $.fn.modal.defaults, $this.data(), typeof option == 'object' && option)
       if (!data) $this.data('modal', (data = new Modal(this, options)))
-      if (typeof option == 'string') data[option]()
-      else if (options.show) data.show()
+      if (typeof option == 'string') data[option](source)
+      else if (options.show) data.show(source)
     })
   }
 
@@ -221,11 +221,12 @@
       , href = $this.attr('href')
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $target.data(), $this.data())
+      , source = e.target
 
     e.preventDefault()
 
     $target
-      .modal(option)
+      .modal(option, source)
       .one('hide', function () {
         $this.focus()
       })


### PR DESCRIPTION
When a modal is triggered by a button, the button is now passed as a parameter to the 'shown' event as mentioned in #6159.

Ex:

``` Javascript
$('#myModal').on('shown', function (e, source) {
  // source is the element that triggered the modal
})
```

Tested on IE9, Firefox 14, and Chrome 23.

I'm resubmitting this because I think it was automatically closed due to 2.2.2-wip being deleted?  If there is something I have done wrong or a different branch to commit to please let me know :)
