### PR TITLE
Add loaded event to modals that use remote

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,7 +30,9 @@
     this.options = options
     this.$element = $(element)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-    this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
+    this.options.remote && this.$element.find('.modal-body').load(this.options.remote, $.proxy(function() {
+      this.$element.trigger('loaded')
+    }, this))
   }
 
   Modal.prototype = {


### PR DESCRIPTION
Fixes issue #5169. Uses the callback in jQuery's .load() to trigger a loaded event on the modal element.
