### PR TITLE
fixes tooltip('toggle')

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -236,8 +236,8 @@
     }
 
   , toggle: function (e) {
-      var self = $(e.currentTarget)[this.type](this._options).data(this.type)
-      self[self.tip().hasClass('in') ? 'hide' : 'show']()
+      var self = (e) ? $(e.currentTarget)[this.type](this._options).data(this.type) : this
+      self.tip().hasClass('in') ? self.hide() : self.show()
     }
 
   , destroy: function () {

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -156,4 +156,12 @@ $(function () {
         div.find('a').trigger('click')
         ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
       })
+      
+      test("should show tooltip when toggle is called", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="tooltip on toggle"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({trigger: 'manual'})
+          .tooltip('toggle')
+        ok($(".tooltip").is('.fade.in'), 'tooltip should be toggled in')
+      })
 })


### PR DESCRIPTION
this is part 1 of a previous pull request - #5768 that fixes the tooltip('toggle') functionality in issue #5753

Heres some fiddles to show an example 
Current Bootstrap package - http://jsfiddle.net/SqFbx/
Updated - http://jsfiddle.net/SqFbx/1/

Thanks to @demike for helping fix this.
