### PR TITLE
lowered carousel beneath the nav (in carousel example)

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -78,7 +78,7 @@
 
     .carousel .container {
       position: relative;
-      z-index: 10;
+      z-index: 9;
     }
 
     .carousel-control {


### PR DESCRIPTION
The navbar is broken in the carousel example because it sits beneath the carousel and cannot be activated. This is just a tiny fix that resolves the issue. 
