### PR TITLE
fixes #5605; resubmission of #5875 against 3.0.0-wip

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1130,7 +1130,10 @@ select[disabled],
 textarea[disabled],
 input[readonly],
 select[readonly],
-textarea[readonly] {
+textarea[readonly],
+fieldset[disabled] input,
+fieldset[disabled] select,
+fieldset[disabled] textarea {
   cursor: not-allowed;
   background-color: #eeeeee;
 }
@@ -1138,7 +1141,9 @@ textarea[readonly] {
 input[type="radio"][disabled],
 input[type="checkbox"][disabled],
 input[type="radio"][readonly],
-input[type="checkbox"][readonly] {
+input[type="checkbox"][readonly],
+fieldset[disabled] input[type="radio"],
+fieldset[disabled] input[type="checkbox"] {
   background-color: transparent;
 }
 
@@ -2777,7 +2782,8 @@ button.close {
 .btn:active,
 .btn.active,
 .btn.disabled,
-.btn[disabled] {
+.btn[disabled],
+fieldset[disabled] .btn {
   color: #333333;
   background-color: #e6e6e6;
 }
@@ -2812,7 +2818,8 @@ button.close {
 }
 
 .btn.disabled,
-.btn[disabled] {
+.btn[disabled],
+fieldset[disabled] .btn {
   cursor: default;
   background-image: none;
   opacity: 0.65;
@@ -2907,7 +2914,8 @@ input[type="button"].btn-block {
 .btn-primary:active,
 .btn-primary.active,
 .btn-primary.disabled,
-.btn-primary[disabled] {
+.btn-primary[disabled],
+fieldset[disabled] .btn-primary {
   color: #ffffff;
   background-color: #0044cc;
 }
@@ -2937,7 +2945,8 @@ input[type="button"].btn-block {
 .btn-warning:active,
 .btn-warning.active,
 .btn-warning.disabled,
-.btn-warning[disabled] {
+.btn-warning[disabled],
+fieldset[disabled] .btn-warning {
   color: #ffffff;
   background-color: #f89406;
 }
@@ -2967,7 +2976,8 @@ input[type="button"].btn-block {
 .btn-danger:active,
 .btn-danger.active,
 .btn-danger.disabled,
-.btn-danger[disabled] {
+.btn-danger[disabled],
+fieldset[disabled] .btn-danger {
   color: #ffffff;
   background-color: #bd362f;
 }
@@ -2997,7 +3007,8 @@ input[type="button"].btn-block {
 .btn-success:active,
 .btn-success.active,
 .btn-success.disabled,
-.btn-success[disabled] {
+.btn-success[disabled],
+fieldset[disabled] .btn-success {
   color: #ffffff;
   background-color: #51a351;
 }
@@ -3027,7 +3038,8 @@ input[type="button"].btn-block {
 .btn-info:active,
 .btn-info.active,
 .btn-info.disabled,
-.btn-info[disabled] {
+.btn-info[disabled],
+fieldset[disabled] .btn-info {
   color: #ffffff;
   background-color: #2f96b4;
 }
@@ -3057,7 +3069,8 @@ input[type="button"].btn-block {
 .btn-inverse:active,
 .btn-inverse.active,
 .btn-inverse.disabled,
-.btn-inverse[disabled] {
+.btn-inverse[disabled],
+fieldset[disabled] .btn-inverse {
   color: #ffffff;
   background-color: #222222;
 }
@@ -3069,7 +3082,8 @@ input[type="button"].btn-block {
 
 .btn-link,
 .btn-link:active,
-.btn-link[disabled] {
+.btn-link[disabled],
+fieldset[disabled] .btn-link {
   background-color: transparent;
   background-image: none;
   -webkit-box-shadow: none;
@@ -3089,7 +3103,8 @@ input[type="button"].btn-block {
   background-color: transparent;
 }
 
-.btn-link[disabled]:hover {
+.btn-link[disabled]:hover,
+fieldset[disabled] .btn-link:hover {
   color: #333333;
   text-decoration: none;
 }
@@ -3883,7 +3898,8 @@ input[type="button"].btn-block {
 .navbar .btn-navbar:active,
 .navbar .btn-navbar.active,
 .navbar .btn-navbar.disabled,
-.navbar .btn-navbar[disabled] {
+.navbar .btn-navbar[disabled],
+fieldset[disabled] .navbar .btn-navbar {
   color: #ffffff;
   background-color: #e5e5e5;
 }
@@ -4133,7 +4149,8 @@ input[type="button"].btn-block {
 .navbar-inverse .btn-navbar:active,
 .navbar-inverse .btn-navbar.active,
 .navbar-inverse .btn-navbar.disabled,
-.navbar-inverse .btn-navbar[disabled] {
+.navbar-inverse .btn-navbar[disabled],
+fieldset[disabled] .navbar-inverse .btn-navbar {
   color: #ffffff;
   background-color: #040404;
 }

--- a/docs/css.html
+++ b/docs/css.html
@@ -1725,6 +1725,43 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
 &lt;input class="input-xlarge" id="disabledInput" type="text" placeholder="Disabled input here..." disabled&gt;
 </pre>
 
+          <h3>Disabled fieldsets</h3>
+          <p>Add the <code>disabled</code> attribute on a <code>fieldset</code> to disable all the controls within the fieldset at once.</p>
+          <form class="bs-docs-example form-inline">
+            <fieldset disabled>
+              <input type="text" class="span4" placeholder="These controls are all disabled just">
+              <select class="span4">
+                <option>by being under a disabled fieldset</option>
+              </select>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox"> Can't check this
+                </label>
+              </div>
+              <button type="submit" class="btn btn-primary">Submit</button>
+            </fieldset>
+          </form>
+<pre class="prettyprint linenums">
+&lt;form class="form-inline"&gt;
+  &lt;fieldset disabled&gt;
+    &lt;input type="text" class="span4" placeholder="These controls are all disabled just"&gt;
+    &lt;select class="span4"&gt;
+      &lt;option&gt;by being under a disabled fieldset&lt;/option&gt;
+    &lt;/select&gt;
+    &lt;div class="checkbox"&gt;
+      &lt;label&gt;
+        &lt;input type="checkbox"&gt; Can't check this
+      &lt;/label&gt;
+    &lt;/div&gt;
+    &lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+</pre>
+          <p>
+            <span class="label label-info">Heads up!</span>
+            <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
+          </p>
+
           <h3>Validation states</h3>
           <p>Bootstrap includes validation styles for error, warning, info, and success messages. To use, add the appropriate class to the surrounding <code>.control-group</code>.</p>
 

--- a/docs/css.html
+++ b/docs/css.html
@@ -1759,7 +1759,8 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
 </pre>
           <p>
             <span class="label label-info">Heads up!</span>
-            <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
+            Contrary to the HTML5 spec, form controls within a <code>fieldset</code>'s <code>legend</code> will also be disabled.<br>
+            Also, <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
           </p>
 
           <h3>Validation states</h3>

--- a/docs/templates/pages/css.mustache
+++ b/docs/templates/pages/css.mustache
@@ -1699,7 +1699,8 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
 </pre>
           <p>
             <span class="label label-info">Heads up!</span>
-            <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
+            Contrary to the HTML5 spec, form controls within a <code>fieldset</code>'s <code>legend</code> will also be disabled.<br>
+            Also, <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
           </p>
 
           <h3>Validation states</h3>

--- a/docs/templates/pages/css.mustache
+++ b/docs/templates/pages/css.mustache
@@ -1665,6 +1665,43 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
 &lt;input class="input-xlarge" id="disabledInput" type="text" placeholder="Disabled input here..." disabled&gt;
 </pre>
 
+          <h3>Disabled fieldsets</h3>
+          <p>Add the <code>disabled</code> attribute on a <code>fieldset</code> to disable all the controls within the fieldset at once.</p>
+          <form class="bs-docs-example form-inline">
+            <fieldset disabled>
+              <input type="text" class="span4" placeholder="These controls are all disabled just">
+              <select class="span4">
+                <option>by being under a disabled fieldset</option>
+              </select>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox"> Can't check this
+                </label>
+              </div>
+              <button type="submit" class="btn btn-primary">Submit</button>
+            </fieldset>
+          </form>
+<pre class="prettyprint linenums">
+&lt;form class="form-inline"&gt;
+  &lt;fieldset disabled&gt;
+    &lt;input type="text" class="span4" placeholder="These controls are all disabled just"&gt;
+    &lt;select class="span4"&gt;
+      &lt;option&gt;by being under a disabled fieldset&lt;/option&gt;
+    &lt;/select&gt;
+    &lt;div class="checkbox"&gt;
+      &lt;label&gt;
+        &lt;input type="checkbox"&gt; Can't check this
+      &lt;/label&gt;
+    &lt;/div&gt;
+    &lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+</pre>
+          <p>
+            <span class="label label-info">Heads up!</span>
+            <code>&lt;a&gt;</code> buttons within a <code>fieldset[disabled]</code> will be styled like they each had the <code>.disabled</code> class, but this only affects aesthetics; you must use custom JavaScript to actually make such links non-functional.
+          </p>
+
           <h3>Validation states</h3>
           <p>Bootstrap includes validation styles for error, warning, info, and success messages. To use, add the appropriate class to the surrounding <code>.control-group</code>.</p>
 

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -48,7 +48,8 @@
 
   // Disabled state
   &.disabled,
-  &[disabled] {
+  &[disabled],
+  fieldset[disabled] & {
     cursor: default;
     background-image: none;
     .opacity(65);
@@ -174,7 +175,8 @@ input[type="button"] {
 // Make a button look and behave like a link
 .btn-link,
 .btn-link:active,
-.btn-link[disabled] {
+.btn-link[disabled],
+fieldset[disabled] .btn-link {
   background-color: transparent;
   background-image: none;
   .box-shadow(none);
@@ -190,7 +192,12 @@ input[type="button"] {
   text-decoration: underline;
   background-color: transparent;
 }
-.btn-link[disabled]:hover {
-  color: @grayDark;
-  text-decoration: none;
+.btn-link {
+  &[disabled],
+  fieldset[disabled] & {
+    &:hover {
+      color: @grayDark;
+      text-decoration: none;
+    }
+  }
 }

--- a/less/forms.less
+++ b/less/forms.less
@@ -330,21 +330,24 @@ textarea[class*="span"],
 // --------------
 
 // Disabled and read-only inputs
-input[disabled],
-select[disabled],
-textarea[disabled],
-input[readonly],
-select[readonly],
-textarea[readonly] {
-  cursor: not-allowed;
-  background-color: @input-background-disabled;
+input,
+select,
+textarea {
+  &[disabled],
+  &[readonly],
+  fieldset[disabled] & {
+    cursor: not-allowed;
+    background-color: @input-background-disabled;
+  }
 }
 // Explicitly reset the colors here
-input[type="radio"][disabled],
-input[type="checkbox"][disabled],
-input[type="radio"][readonly],
-input[type="checkbox"][readonly] {
-  background-color: transparent;
+input[type="radio"],
+input[type="checkbox"] {
+  &[disabled],
+  &[readonly],
+  fieldset[disabled] & {
+    background-color: transparent;
+  }
 }
 
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -416,7 +416,7 @@
   .reset-filter();
 
   // in these cases the gradient won't cover the background, so we override
-  &:hover, &:active, &.active, &.disabled, &[disabled] {
+  &:hover, &:active, &.active, &.disabled, &[disabled], fieldset[disabled] & {
     color: @text-color;
     background-color: @endColor;
   }


### PR DESCRIPTION
Styles as disabled all form controls & btns under a `fieldset[disabled]`. See referenced issues for more info.
Fix for issue #5605.
Previous PR: #5875
