### PR TITLE
Escape example in documentation

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -453,7 +453,7 @@
   For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 </div>
 <pre class="prettyprint linenums">
-For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inline.
+For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped as inline.
 </pre>
 
           <h2>Basic block</h2>


### PR DESCRIPTION
[Inline section](http://twitter.github.com/bootstrap/base-css.html#code) example gives an impression that code tag escapes value by itself. Which is wrong
