### PR TITLE
change scrollspy documentation to clarify javascript usage

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -571,12 +571,12 @@ $('#myModal').on('hidden', function () {
           <h2>Usage</h2>
 
           <h3>Via data attributes</h3>
-          <p>To easily add scrollspy behavior to your topbar navigation, just add <code>data-spy="scroll"</code> to the element you want to spy on (most typically this would be the body) and <code>data-target=".navbar"</code> to select which nav to use. You'll want to use scrollspy with a <code>.nav</code> component.</p>
+          <p>To easily add scrollspy behavior to your topbar navigation, just add <code>data-spy="scroll"</code> to the element you want to spy on (most typically this would be the body) and <code>data-target=".navbar"</code> to select which nav to use. You'll need to use scrollspy with a <code>.nav</code> component.</p>
           <pre class="prettyprint linenums">&lt;body data-spy="scroll" data-target=".navbar"&gt;...&lt;/body&gt;</pre>
 
           <h3>Via JavaScript</h3>
           <p>Call the scrollspy via JavaScript:</p>
-          <pre class="prettyprint linenums">$('#navbar').scrollspy()</pre>
+          <pre class="prettyprint linenums">$('body').scrollspy(options)</pre>
 
           <div class="alert alert-info">
             <strong>Heads up!</strong>
@@ -604,6 +604,12 @@ $('[data-spy="scroll"]').each(function () {
              </tr>
             </thead>
             <tbody>
+             <tr>
+               <td>target</td>
+               <td>selector</td>
+               <td>'body'</td>
+               <td>Nav target to be updated on scroll. (Scrollspy looks for <code>.nav li > a</code> inside this target.)</td>
+             </tr>
              <tr>
                <td>offset</td>
                <td>number</td>


### PR DESCRIPTION
The scrollspy documentation suggests calling a scrollspy instance in JavaScript with the following code:

$('#navbar').scrollspy();

This is wrong unless #navbar is what's scrolling. Scrollspy is invoked on what's being spied, not on the target. What I think the author means to say is:

$('body').scrollspy({ target: '#navbar' });

I've changed the documentation to reflect this, and to state that the scrollspy script is specifically looking for .nav li > a, which may be confusing for folks who tweak the standard nav component.

Mentioned in this bug:
https://github.com/twitter/bootstrap/issues/5553

This is my first pull request; holler (nicely, please) if I've done something incorrectly. 
