### PR TITLE
scrollSpy - only add parent scrollTop to offset if parent isn't the brow...

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -59,7 +59,7 @@
               , $href = /^#\w/.test(href) && $(href)
             return ( $href
               && $href.length
-              && [[ $href.position().top + self.$scrollElement.scrollTop(), href ]] ) || null
+              && [[ $href.position().top + (!$.isWindow(self.$scrollElement.get(0)) && self.$scrollElement.scrollTop()), href ]] ) || null
           })
           .sort(function (a, b) { return a[0] - b[0] })
           .each(function () {


### PR DESCRIPTION
This closed issue: https://github.com/twitter/bootstrap/issues/6013 resulted in this pull request: https://github.com/twitter/bootstrap/pull/6118 which has created the following new bug:

If scrollspy is invoked on the window (or &lt;body&gt;), but the page is already scrolled on load, the browser's scroll is added to the offset, which breaks the scrollspy behavior.

Demo:
http://jsfiddle.net/FH7Q3/8/
