### PR TITLE
A few fixes for being able to use complex typeahead menus

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -60,10 +60,10 @@
         height: this.$element[0].offsetHeight
       })
 
-      if (!this.$menu.parent())
+      if (!this.$menu.parent().length)
         this.$menu
           .insertAfter(this.$element)
-      
+
       this.$menu
         .css({
           top: pos.top + pos.height

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -150,7 +150,7 @@
 
       this.$menu
         .filter('.dropdown-menu')
-        .add(this.$menu.children('.dropdown-menu'))
+        .add(this.$menu.find('.dropdown-menu'))
         .html(items)
 
       return this

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -60,8 +60,11 @@
         height: this.$element[0].offsetHeight
       })
 
+      if (!this.$menu.parent())
+        this.$menu
+          .insertAfter(this.$element)
+      
       this.$menu
-        .insertAfter(this.$element)
         .css({
           top: pos.top + pos.height
         , left: pos.left
@@ -144,7 +147,12 @@
       })
 
       items.first().addClass('active')
-      this.$menu.html(items)
+
+      this.$menu
+        .filter('.dropdown-menu')
+        .add(this.$menu.children('.dropdown-menu'))
+        .html(items)
+
       return this
     }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -37,6 +37,38 @@ $(function () {
         ok($._data($menu[0], 'events').click, 'has a click')
       })
 
+      test("should not destroy inner content with complex menus", function () {
+        var $input = $('<input />')
+            .appendTo('body')
+            .typeahead({
+              source: ['aa', 'ab', 'ac'],
+              menu: '<div class="typeahead"><ul class="dropdown-menu"></ul></div>'
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        equals(typeahead.$menu.find('.dropdown-menu').length, 1, 'inner content is not destroyed')
+        equals(typeahead.$menu.find('.dropdown-menu li').length, 3, 'has 3 items in the dropdown menu')
+      })
+
+      test("should not change the position of the typeahead if it already has a parent", function () {
+        var $input = $('<input />')
+            .appendTo('body')
+            .typeahead({
+              source: ['aa', 'ab', 'ac'],
+              menu: $('<div class="typeahead"><ul class="dropdown-menu"></ul></div>')
+                .appendTo($('<div class="fixed-parent"></div>').appendTo('body'))
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        equals(typeahead.$menu.parent('.fixed-parent').length, 1, 'is still in the original parent')
+      })
+
       test("should show menu when query entered", function () {
         var $input = $('<input />')
             .appendTo('body')

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -227,6 +227,7 @@
 // Typeahead
 // ---------
 .typeahead {
+  position: absolute;
   display: none;
   z-index: 1051;
   margin-top: 2px; // give it some space to breathe

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -233,3 +233,7 @@
   margin-top: 2px; // give it some space to breathe
   .border-radius(@baseBorderRadius);
 }
+
+.typeahead .dropdown-menu {
+  position: static;
+}

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -227,6 +227,7 @@
 // Typeahead
 // ---------
 .typeahead {
+  display: none;
   z-index: 1051;
   margin-top: 2px; // give it some space to breathe
   .border-radius(@baseBorderRadius);


### PR DESCRIPTION
+Unit tests, because :heart: 

With this pull request, you can now make something like :

```
<input type="text" data-provide="typeahead" data-menu="#all-your-base-are-belong-to-me" />
<div id="all-your-base-are-belong-to-me" class="typeahead">
    <ul class="dropdown-menu" style="display: block;"></ul>
</div>
```

It wasn't possible before for technical reasons :
- The `<div>` element was overwrote (`.html()`)
- The typeahead was displayed before typing, because it is using the `display:none` of the `dropdown-menu` class. Moving this class downward in the html dom was breaking this.

It's a nice addition for a few use cases : )
