### PR TITLE
Removing "target-dir" option to stop extra nesting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,5 @@
   , "homepage": "http://twitter.github.com/bootstrap/"
   , "author": "Twitter Inc."
   , "license": "Apache-2.0"
-  , "target-dir": "twitter/bootstrap"
 
 }


### PR DESCRIPTION
There is no valid reason to set this since it causes extra nesting: `./vendor/twitter/bootstrap/twitter/bootstrap/`

By default (i.e. without this option) bootstrap will be set up in: `./vendor/twitter/bootstrap/`

It's an optional field, and only really useful when dealing with a large library with multiple components in separate composer packages ([see the docs](http://getcomposer.org/doc/04-schema.md#target-dir)).
