### PR TITLE
Changing tooltip to prependto body instead of appending to element

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -121,7 +121,7 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
+          .prependTo('body')
 
         pos = this.getPosition(inside)
 


### PR DESCRIPTION
Even when using the absolute positioning, appending the tooltip div inline causes styling issues within tables (other table cells are shifted out of the way). Prepending the tooltip to the body element corrects this.

Has been tested within latest Firefox and Chrome browsers.
