### PR TITLE
Added delay option to typeahead

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1545,6 +1545,12 @@ $('.carousel').carousel({
                  <td>The minimum character length needed before triggering autocomplete suggestions</td>
                </tr>
                <tr>
+                 <td>delay</td>
+                 <td>number</td>
+                 <td>0</td>
+                 <td>The duration in milliseconds between when a keystroke occurs and when a source lookup is performed.</td>
+               </tr>
+               <tr>
                  <td>matcher</td>
                  <td>function</td>
                  <td>case insensitive</td>

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -99,7 +99,9 @@
       }
 
       this.lookupTimer = setTimeout($.proxy(this.lookup, this), this.options.delay)
-  }
+      
+      return this
+    }
 
   , process: function (items) {
       var that = this

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -92,7 +92,7 @@
         clearTimeout(this.timer)
       }
       
-      if(this.options.delay != 0) {
+      if(this.options.delay !== 0) {
         this.timer = setTimeout($.proxy(this.delayedLookup, this), this.options.delay)
       }
       else {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -36,6 +36,7 @@
     this.source = this.options.source
     this.$menu = $(this.options.menu)
     this.shown = false
+    this.timer
     this.listen()
   }
 
@@ -86,10 +87,34 @@
       if (!this.query || this.query.length < this.options.minLength) {
         return this.shown ? this.hide() : this
       }
+      
+      if(this.timer) {
+        clearTimeout(this.timer)
+      }
+      
+      if(this.options.delay != 0) {
+        this.timer = setTimeout($.proxy(this.delayedLookup, this), this.options.delay)
+      }
+      else {
+        items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
 
+        return items ? this.process(items) : this
+      }
+      
+      return this
+    }
+    
+  , delayedLookup: function() {
+      var items
+    
+      clearTimeout(this.timer)
+      
       items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
-
-      return items ? this.process(items) : this
+      
+      if(items) {
+        this.process(items)
+      }
+      
     }
 
   , process: function (items) {
@@ -296,6 +321,7 @@
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
   , minLength: 1
+  , delay: 0
   }
 
   $.fn.typeahead.Constructor = Typeahead

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -36,7 +36,7 @@
     this.source = this.options.source
     this.$menu = $(this.options.menu)
     this.shown = false
-    this.timer
+    this.lookupTimer
     this.listen()
   }
 
@@ -87,33 +87,19 @@
       if (!this.query || this.query.length < this.options.minLength) {
         return this.shown ? this.hide() : this
       }
-      
-      if(this.timer) {
-        clearTimeout(this.timer)
-      }
-      
-      if(this.options.delay !== 0) {
-        this.timer = setTimeout($.proxy(this.delayedLookup, this), this.options.delay)
-      }
-      else {
-        items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
-      }
-      
+
+      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+
       return items ? this.process(items) : this
     }
     
-  , delayedLookup: function() {
-      var items
-    
-      clearTimeout(this.timer)
-      
-      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
-      
-      if(items) {
-        this.process(items)
+  , debounceLookup: function(event) {
+      if(this.lookupTimer) {
+        clearTimeout(this.lookupTimer)
       }
-      
-    }
+
+      this.lookupTimer = setTimeout($.proxy(this.lookup, this), this.options.delay)
+  }
 
   , process: function (items) {
       var that = this
@@ -272,7 +258,7 @@
           break
 
         default:
-          this.lookup()
+          this.options.delay <= 0 ? this.lookup() : this.debounceLookup()
       }
 
       e.stopPropagation()

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -97,11 +97,9 @@
       }
       else {
         items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
-
-        return items ? this.process(items) : this
       }
       
-      return this
+      return items ? this.process(items) : this
     }
     
   , delayedLookup: function() {

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -277,7 +277,7 @@ $(function () {
         stop()
         expect(1)
         
-        // "a" pressed once
+        // 1st "a" keystroke
         $input.trigger({
           type: 'keydown'
         , keyCode: 65
@@ -291,7 +291,7 @@ $(function () {
         , keyCode: 65
         })
         
-        // "a" pressed twice
+        // 2nd "a" keystroke
         $input.trigger({
           type: 'keydown'
         , keyCode: 65

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -236,8 +236,20 @@ $(function () {
             }).appendTo('body')
           , typeahead = $input.data('typeahead')
         
+        //simulate "a" pressed
         $input.val('a')
-        typeahead.lookup()
+        $input.trigger({
+          type: 'keydown'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keypress'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keyup'
+        , keyCode: 65
+        })
         
         equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
         
@@ -251,23 +263,49 @@ $(function () {
         typeahead.$menu.remove()
       })
       
-      test("should prevent multiple lookups", function() {
+      test("should debounce keyups", function() {
         var $input = $('<input />').typeahead({
               source: ['aa', 'ab', 'ac'],
               delay:50
             }).appendTo('body')
           , typeahead = $input.data('typeahead')
         
-        //timer that will explode
-        var timer = setTimeout(function() {ok(false, "This should never get called")}, 50)
-        typeahead.timer = timer
-        
-        $input.val('a')
-        typeahead.lookup()
+        typeahead.lookup = function() {
+          ok(true)
+        }
         
         stop()
+        expect(1)
+        
+        // "a" pressed once
+        $input.trigger({
+          type: 'keydown'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keypress'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keyup'
+        , keyCode: 65
+        })
+        
+        // "a" pressed twice
+        $input.trigger({
+          type: 'keydown'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keypress'
+        , keyCode: 65
+        })
+        .trigger({
+          type: 'keyup'
+        , keyCode: 65
+        })
+        
         setTimeout(function () {
-          equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
           start()
         }, 51)
         

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -228,4 +228,50 @@ $(function () {
         $input.remove()
         typeahead.$menu.remove()
       })
+      
+      test("should delay lookup", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac'],
+              delay:50
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+        
+        $input.val('a')
+        typeahead.lookup()
+        
+        equals(typeahead.$menu.find('li').length, 0, 'has 0 items in menu')
+        
+        stop()
+        setTimeout(function () {
+          equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+          start()
+        }, 51)
+        
+        $input.remove()
+        typeahead.$menu.remove()
+      })
+      
+      test("should prevent multiple lookups", function() {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac'],
+              delay:50
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+        
+        //timer that will explode
+        var timer = setTimeout(function() {ok(false, "This should never get called")}, 50)
+        typeahead.timer = timer
+        
+        $input.val('a')
+        typeahead.lookup()
+        
+        stop()
+        setTimeout(function () {
+          equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+          start()
+        }, 51)
+        
+        $input.remove()
+        typeahead.$menu.remove()
+      })
 })


### PR DESCRIPTION
Introduces a delay option that defines the duration in milliseconds between when a keystroke occurs and when a source lookup is performed.

This also debounces source lookups. So, if multiple keystrokes occur, and the elapsed time between each consecutive keystroke is less than your delay, only the last keystroke will fire a source lookup.
