### PR TITLE
fixes tooltip insert problems

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -849,6 +849,15 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                 <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
                </td>
              </tr>
+             <tr>
+               <td>container</td>
+               <td>string</td>
+               <td>''</td>
+               <td>
+                <p>Usefull if your tooltip is within a btn-group or modal</p>
+                <p>Appends the tooltip to a specific element <code>container: '#Modal'</code></p>
+               </td>
+             </tr>
             </tbody>
           </table>
           <div class="alert alert-info">

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -779,6 +779,15 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                 <p>{{_i}}Object structure is: <code>delay: { show: 500, hide: 100 }</code>{{/i}}</p>
                </td>
              </tr>
+             <tr>
+               <td>{{_i}}container{{/i}}</td>
+               <td>{{_i}}string{{/i}}</td>
+               <td>''</td>
+               <td>
+                <p>{{_i}}Usefull if your tooltip is within a btn-group or modal{{/i}}</p>
+                <p>{{_i}}Appends the tooltip to a specific element <code>container: '#Modal'</code>{{/i}}</p>
+               </td>
+             </tr>
             </tbody>
           </table>
           <div class="alert alert-info">

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -790,6 +790,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
              </tr>
             </tbody>
           </table>
+
           <div class="alert alert-info">
             <strong>{{_i}}Heads up!{{/i}}</strong>
             {{_i}}Options for individual tooltips can alternatively be specified through the use of data attributes.{{/i}}

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -121,9 +121,10 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
 
-        pos = this.getPosition(inside)
+        inside ? this.$element.append($tip) : this.options.container && $tip.appendTo(this.options.container).length || $tip.insertAfter(this.$element)
+
+        pos = this.getPosition(inside ? inside : '')
 
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
@@ -143,8 +144,8 @@
             break
         }
 
+        inside ? $tip.css(tp) : $tip.offset(tp)
         $tip
-          .offset(tp)
           .addClass(placement)
           .addClass('in')
       }
@@ -273,6 +274,7 @@
   , title: ''
   , delay: 0
   , html: false
+  , container: ''
   }
 
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -156,4 +156,23 @@ $(function () {
         div.find('a').trigger('click')
         ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
       })
+
+      test("should place tooltips inside the body", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({container:'body'})
+          .tooltip('show')
+        ok($("body > .tooltip").length, 'inside the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
+        tooltip.tooltip('hide')
+      })
+	  
+      test("should place tooltips inside the trigger element", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({placement: 'in right'})
+          .tooltip('show')
+        ok($("a[rel=tooltip] > .tooltip").length, 'inside the trigger element')
+        tooltip.tooltip('hide')
+      })
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -166,7 +166,7 @@ $(function () {
         ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
         tooltip.tooltip('hide')
       })
-	  
+ 
       test("should place tooltips inside the trigger element", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')


### PR DESCRIPTION
This adds a container option to the tooltip that can be called via html5 - `data-container="body"` or javascript - `$().tooltip({container: 'body'})`

if no container is given then it will get the default `insertAfter()` strategy 

This fixes a number of bugs that were introduced when we changed the `appendTo()` to `insertAfter()` including bringing back the option to use 'in' for the placement like so -- `placement: 'in right'` so it doesnt break current projects using this technique 

If the tooltips are within a modal, and are inheriting its parents styles, then use `$().tooltip({container: '#modalID'})`

Its recommended to use the container option rather than the 'in' placement as sometimes the position is a little off if its used within a modal.

heres a fiddle to show the changes - http://jsfiddle.net/yohn/R23KB/15/

thanks to @WilliamStam, @thelonecabbage, and @blakeembrey for helping with this solution

some issues that noticed this bug
#5687 #6254 #6314 #6306 #6283 #6275 #6250 #6240 #6236 along with a lot more..
