### PR TITLE
fix .btn-group .btn border-radius in .input-append

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1440,7 +1440,10 @@ select:focus:invalid:focus {
 
 .input-append input + .btn-group .btn,
 .input-append select + .btn-group .btn,
-.input-append .uneditable-input + .btn-group .btn,
+.input-append .uneditable-input + .btn-group .btn {
+  border-radius: 0;
+}
+
 .input-append input + .btn-group .btn:last-child,
 .input-append select + .btn-group .btn:last-child,
 .input-append .uneditable-input + .btn-group .btn:last-child {

--- a/less/forms.less
+++ b/less/forms.less
@@ -501,7 +501,9 @@ select:focus:invalid {
   select,
   .uneditable-input {
     border-radius: @input-border-radius 0 0 @input-border-radius;
-    + .btn-group .btn,
+    + .btn-group .btn {
+      border-radius: 0;
+    }
     + .btn-group .btn:last-child {
       border-radius: 0 @input-border-radius @input-border-radius 0;
     }


### PR DESCRIPTION
The .input-append button in the segmented dropdown groups should not have border-radius.

![segmented-dropdown-groups](https://f.cloud.github.com/assets/4609/22431/68e6f102-49fd-11e2-834c-fb38a24f0907.png)
