### PR TITLE
add missing collapsed class on accordion-toggle element when hiding actives ones

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -63,6 +63,8 @@
         if (hasData && hasData.transitioning) return
         actives.collapse('hide')
         hasData || actives.data('collapse', null)
+        
+        $(actives).parent('.accordion-group').find('.accordion-heading .accordion-toggle').addClass('collapsed')
       }
 
       this.$element[dimension](0)


### PR DESCRIPTION
We currently used accordion with background images showing the element as collapsed or active. We used the CSS expressions '.accordion-toggle' and '.accordion-toggle.collapsed' to display these background images but the second one was not created when clicking on not the same accordion toggle.

This is a reopen of https://github.com/twitter/bootstrap/pull/5667 on wip branch
