### PR TITLE
add comment regarding caveat of #6199 impl per discussion in/of 14844db862

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -331,6 +331,9 @@ textarea[class*="span"],
 // --------------
 
 // Disabled and read-only inputs
+// Note: HTML5 says that inputs under a fieldset > legend:first-child won't be
+//   disabled if the fieldset is disabled. Due to implementation difficulty,
+//   we don't honor that edge case; we style them as disabled anyway.
 input,
 select,
 textarea {


### PR DESCRIPTION
Adds a comment in the Less explaining that Bootstrap doesn't honor the crazy HTML5 semantics of `fieldset[disabled] > legend:first-child`.

Feel free to adjust the phrasing.

X-ref: #6199
