### PR TITLE
Tooltips fires show, shown, hide, hidden events

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -110,10 +110,10 @@
         , actualHeight
         , placement
         , tp
-        , e
+        , e = $.Event('show')
 
       if (this.hasContent() && this.enabled) {
-        this.$element.trigger(e = $.Event('show'))
+        this.$element.trigger(e)
         if (e.isDefaultPrevented()) return
         $tip = this.tip()
         this.setContent()
@@ -171,9 +171,9 @@
   , hide: function () {
       var that = this
         , $tip = this.tip()
-        , e
+        , e = $.Event('hide')
 
-      this.$element.trigger(e = $.Event('hide'))
+      this.$element.trigger(e)
       if (e.isDefaultPrevented()) return
 
       $tip.removeClass('in')

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -110,8 +110,11 @@
         , actualHeight
         , placement
         , tp
+        , e
 
       if (this.hasContent() && this.enabled) {
+        this.$element.trigger(e = $.Event('show'))
+        if (e.isDefaultPrevented()) return
         $tip = this.tip()
         this.setContent()
 
@@ -152,6 +155,8 @@
           .offset(tp)
           .addClass(placement)
           .addClass('in')
+
+        this.$element.trigger('shown')
       }
     }
 
@@ -166,6 +171,10 @@
   , hide: function () {
       var that = this
         , $tip = this.tip()
+        , e
+
+      this.$element.trigger(e = $.Event('hide'))
+      if (e.isDefaultPrevented()) return
 
       $tip.removeClass('in')
 
@@ -183,6 +192,8 @@
       $.support.transition && this.$tip.hasClass('fade') ?
         removeWithAnimation() :
         $tip.detach()
+
+      this.$element.trigger('hidden')
 
       return this
     }

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -66,6 +66,83 @@ $(function () {
         ok(!$(".tooltip").length, 'tooltip removed')
       })
 
+      test("should fire show event", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("show", function() {
+            ok(true, "show was called")
+            start()
+          })
+          .tooltip('show')
+      })
+
+      test("should fire shown event", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("shown", function() {
+            ok(true, "shown was called")
+            start()
+          })
+          .tooltip('show')
+      })
+
+      test("should not fire shown event when default prevented", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("show", function(e) {
+            e.preventDefault()
+            ok(true, "show was called")
+            start()
+          })
+          .bind("shown", function() {
+            ok(false, "shown was called")
+          })
+          .tooltip('show')
+      })
+
+      test("should fire hide event", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("shown", function() {
+            $(this).tooltip('hide')
+          })
+          .bind("hide", function() {
+            ok(true, "hide was called")
+            start()
+          })
+          .tooltip('show')
+      })
+
+      test("should fire hidden event", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("shown", function() {
+            $(this).tooltip('hide')
+          })
+          .bind("hidden", function() {
+            ok(true, "hidden was called")
+            start()
+          })
+          .tooltip('show')
+      })
+
+      test("should not fire hidden event when default prevented", function () {
+        stop()
+        var tooltip = $('<div title="tooltip title"></div>')
+          .bind("shown", function() {
+            $(this).tooltip('hide')
+          })
+          .bind("hide", function(e) {
+            e.preventDefault()
+            ok(true, "hide was called")
+            start()
+          })
+          .bind("hidden", function() {
+            ok(false, "hidden was called")
+          })
+          .tooltip('show')
+      })
+
       test("should not show tooltip if leave event occurs before delay expires", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')


### PR DESCRIPTION
It is re-worked from #3691.
Cherry picked for 2.3.0-wip as requested in #6269.
