### PR TITLE
fixes tooltip insert problems

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -849,6 +849,15 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                 <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
                </td>
              </tr>
+             <tr>
+               <td>container</td>
+               <td>string</td>
+               <td>''</td>
+               <td>
+                <p>Usefull if your tooltip is within a btn-group or modal</p>
+                <p>Appends the tooltip to a specific element <code>container: '#Modal'</code></p>
+               </td>
+             </tr>
             </tbody>
           </table>
           <div class="alert alert-info">

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -851,11 +851,10 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
              </tr>
              <tr>
                <td>container</td>
-               <td>string</td>
-               <td>''</td>
+               <td>string | false</td>
+               <td>false</td>
                <td>
-                <p>Usefull if your tooltip is within a btn-group or modal</p>
-                <p>Appends the tooltip to a specific element <code>container: '#Modal'</code></p>
+                <p>Appends the tooltip to a specific element <code>container: 'body'</code></p>
                </td>
              </tr>
             </tbody>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -779,6 +779,15 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
                 <p>{{_i}}Object structure is: <code>delay: { show: 500, hide: 100 }</code>{{/i}}</p>
                </td>
              </tr>
+             <tr>
+               <td>{{_i}}container{{/i}}</td>
+               <td>{{_i}}string{{/i}}</td>
+               <td>''</td>
+               <td>
+                <p>{{_i}}Usefull if your tooltip is within a btn-group or modal{{/i}}</p>
+                <p>{{_i}}Appends the tooltip to a specific element <code>container: '#Modal'</code>{{/i}}</p>
+               </td>
+             </tr>
             </tbody>
           </table>
           <div class="alert alert-info">

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -781,11 +781,10 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
              </tr>
              <tr>
                <td>{{_i}}container{{/i}}</td>
-               <td>{{_i}}string{{/i}}</td>
-               <td>''</td>
+               <td>{{_i}}string | false{{/i}}</td>
+               <td>{{_i}}false{{/i}}</td>
                <td>
-                <p>{{_i}}Usefull if your tooltip is within a btn-group or modal{{/i}}</p>
-                <p>{{_i}}Appends the tooltip to a specific element <code>container: '#Modal'</code>{{/i}}</p>
+                <p>{{_i}}Appends the tooltip to a specific element <code>container: 'body'</code>{{/i}}</p>
                </td>
              </tr>
             </tbody>

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -127,7 +127,7 @@
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
 
-        this.options.container && $tip.appendTo(this.options.container).length || $tip.insertAfter(this.$element)
+        this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition()
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -280,7 +280,7 @@
   , title: ''
   , delay: 0
   , html: false
-  , container: ''
+  , container: false
   }
 
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -126,7 +126,8 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
+
+        this.options.container && $tip.appendTo(this.options.container).length || $tip.insertAfter(this.$element)
 
         pos = this.getPosition()
 
@@ -279,6 +280,7 @@
   , title: ''
   , delay: 0
   , html: false
+  , container: ''
   }
 
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -164,4 +164,14 @@ $(function () {
           .tooltip('toggle')
         ok($(".tooltip").is('.fade.in'), 'tooltip should be toggled in')
       })
+
+      test("should place tooltips inside the body", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({container:'body'})
+          .tooltip('show')
+        ok($("body > .tooltip").length, 'inside the body')
+        ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
+        tooltip.tooltip('hide')
+      })
 })


### PR DESCRIPTION
This adds a container option to the tooltip that can be called via html5 - `data-container="body"` or javascript - `$().tooltip({container: 'body'})`

if no container is given then it will get the default `insertAfter()` strategy

This fixes a number of bugs that were introduced when we changed the `appendTo()` to `insertAfter()`

If the tooltips are within a modal, and are inheriting its parents styles, then use `$().tooltip({container: '#modalID'})`

thanks to @WilliamStam and @blakeembrey for helping with this solution

some issues that noticed this bug
#5687 #6254 #6314 #6283 #6275 #6250 #6240 #6236 along with a lot more..

this is another resubmit of this.. previous pull request - #6321 with some tweaks to work with the 2.3 branch.
