### PR TITLE
fixes carousel sliding issues

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -31,7 +31,7 @@
     this.$indicators = this.$element.find('.carousel-indicators')
     this.options = options
     this.options.pause == 'hover' && this.$element
-      .on('mouseenter', $.proxy(this.pause, this))
+      .on('mouseenter, mouseover', $.proxy(this.pause, this))
       .on('mouseleave', $.proxy(this.cycle, this))
   }
 
@@ -74,7 +74,6 @@
       if (!e) this.paused = true
       if (this.$element.find('.next, .prev').length && $.support.transition.end) {
         this.$element.trigger($.support.transition.end)
-        this.cycle()
       }
       clearInterval(this.interval)
       this.interval = null


### PR DESCRIPTION
Theres 2 slide fixes in the pull request..

First is when we click on the new indicators and stay hovered on the carousel it still cycles through the rest of the items, not pausing it as it should. to fix this, I added the `, mouseover` in the beginning of the plugin

The second refers to #5747 when the pausing feature stops working when you hover on the carousel while its in the middle of sliding. In that issue. @andreif pointed out that if we remove the this.cycle() from the pause function it works as expected..

I'm not sure how I would go about creating the tests for this, which is why I didnt include it.. is there a way to trigger the hover effect? I did update the carousel plugin on my local machine and ran the tests and it passed
