### PR TITLE
carousel, setting data-interval on html was not working

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -160,7 +160,7 @@
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('carousel')
-        , options = $.extend({}, $.fn.carousel.defaults, typeof option == 'object' && option)
+        , options = $.extend({}, $.fn.carousel.defaults, typeof option == 'object' && option, $this.data())
         , action = typeof option == 'string' ? option : options.slide
       if (!data) $this.data('carousel', (data = new Carousel(this, options)))
       if (typeof option == 'number') data.to(option)

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -160,7 +160,7 @@
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('carousel')
-        , options = $.extend({}, $.fn.carousel.defaults, typeof option == 'object' && option, $this.data())
+        , options = $.extend({}, $.fn.carousel.defaults, typeof option == 'object' && option)
         , action = typeof option == 'string' ? option : options.slide
       if (!data) $this.data('carousel', (data = new Carousel(this, options)))
       if (typeof option == 'number') data.to(option)

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -78,4 +78,13 @@ $(function () {
         ok($('#myCarousel').data('carousel').options.interval == 1814, "attributes should be read only on intitialization");
         $('#myCarousel').remove();
       })
+
+      test("should listen to interval from data attribute", function () {
+        var template = $('<div id="myCarousel" class="carousel slide" data-interval="2000"> <div class="carousel-inner"> <div class="item active"> <img alt=""> <div class="carousel-caption"> <h4>{{_i}}First Thumbnail label{{/i}}</h4> <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p> </div> </div> <div class="item"> <img alt=""> <div class="carousel-caption"> <h4>{{_i}}Second Thumbnail label{{/i}}</h4> <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p> </div> </div> <div class="item"> <img alt=""> <div class="carousel-caption"> <h4>{{_i}}Third Thumbnail label{{/i}}</h4> <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p> </div> </div> </div> <a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a> <a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a> </div>');
+
+        template.appendTo("body");
+        $('[data-slide]').first().click();
+        ok($('#myCarousel').data('carousel').options.interval == 2000);
+        $('#myCarousel').remove();
+      })
 })


### PR DESCRIPTION
Heres a fiddle with this bug - http://jsfiddle.net/yohn/vm9vX/12/ and it was first noted within #5279 

as you can see, data-interval was set on the carousel within the html source, but its not getting rendered, and instead using the default interval option 

this seemed like the simplest way to fix it
