### PR TITLE
Unabbreviate JS and fix link to File structure anchor

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -109,7 +109,7 @@
           <div class="row-fluid">
             <div class="span6">
               <h2>Download compiled</h2>
-              <p><strong>Fastest way to get started:</strong> get the compiled and minified versions of our CSS, JS, and images. No docs or original source files.</p>
+              <p><strong>Fastest way to get started:</strong> get the compiled and minified versions of our CSS, JavaScript, and images. No docs or original source files.</p>
               <p><a class="btn btn-large btn-primary" href="assets/bootstrap.zip" >Download Bootstrap</a></p>
             </div>
             <div class="span6">
@@ -142,7 +142,7 @@
       ├── glyphicons-halflings.png
       └── glyphicons-halflings-white.png
 </pre>
-          <p>This is the most basic form of Bootstrap: compiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (<code>bootstrap.*</code>), as well as compiled and minified CSS and JS (<code>bootstrap.min.*</code>). The image files are compressed using <a href="http://imageoptim.com/">ImageOptim</a>, a Mac app for compressing PNGs.</p>
+          <p>This is the most basic form of Bootstrap: compiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JavaScript (<code>bootstrap.*</code>), as well as compiled and minified CSS and JavaScript (<code>bootstrap.min.*</code>). The image files are compressed using <a href="http://imageoptim.com/">ImageOptim</a>, a Mac app for compressing PNGs.</p>
           <p>Please note that all JavaScript plugins require jQuery to be included.</p>
         </section>
 
@@ -154,7 +154,7 @@
           <div class="page-header">
             <h1>3. What's included</h1>
           </div>
-          <p class="lead">Bootstrap comes equipped with HTML, CSS, and JS for all sorts of things, but they can be summarized with a handful of categories visible at the top of the <a href="http://getbootstrap.com">Bootstrap documentation</a>.</p>
+          <p class="lead">Bootstrap comes equipped with HTML, CSS, and JavaScript for all sorts of things, but they can be summarized with a handful of categories visible at the top of the <a href="http://getbootstrap.com">Bootstrap documentation</a>.</p>
 
           <h2>Docs sections</h2>
           <h4><a href="http://twitter.github.com/bootstrap/scaffolding.html">Scaffolding</a></h4>
@@ -198,7 +198,7 @@
           <div class="page-header">
             <h1>4. Basic HTML template</h1>
           </div>
-          <p class="lead">With a brief intro into the contents out of the way, we can focus on putting Bootstrap to use. To do that, we'll utilize a basic HTML template that includes everything we mentioned in the <a href="#file-structure">File structure</a>.</p>
+          <p class="lead">With a brief intro into the contents out of the way, we can focus on putting Bootstrap to use. To do that, we'll utilize a basic HTML template that includes everything we mentioned in the <a href="./getting-started.html#file-structure">File structure</a>.</p>
           <p>Now, here's a look at a <strong>typical HTML file</strong>:</p>
 <pre class="prettyprint linenums">
 &lt;!DOCTYPE html&gt;
@@ -212,7 +212,7 @@
   &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-          <p>To make this <strong>a Bootstrapped template</strong>, just include the appropriate CSS and JS files:</p>
+          <p>To make this <strong>a Bootstrapped template</strong>, just include the appropriate CSS and JavaScript files:</p>
 <pre class="prettyprint linenums">
 &lt;!DOCTYPE html&gt;
 &lt;html&gt;


### PR DESCRIPTION
Replaced all instances of the abbreviation "JS" with "JavaScript" for
more clarity and fixed the link under "Basic HTML Template" that linked
to the anchor for "File structure".
