### PR TITLE
Popovers: Remove h3.popover-title if title is not set or empty

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -43,8 +43,14 @@
         , title = this.getTitle()
         , content = this.getContent()
 
-      $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
+  	  if (title.length < 1) {
+  	  	$tip.find('.popover-title').remove();
+  	  } else {
+      	$tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
+  	  }
       $tip.find('.popover-content')[this.options.html ? 'html' : 'text'](content)
+
+	  
 
       $tip.removeClass('fade top bottom left right in')
     }


### PR DESCRIPTION
Currently the h3-tag is always shown in popovers, even if the title-tag is empty or not set.
