### PR TITLE
Add RTL (right to left) support

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -8,6 +8,9 @@
 
 .alert {
   padding: 8px 35px 8px 14px;
+  .rtl & {
+    padding: 8px 14px 8px 35px;
+  }
   margin-bottom: @baseLineHeight;
   text-shadow: 0 1px 0 rgba(255,255,255,.5);
   background-color: @warningBackground;
@@ -28,6 +31,10 @@
   position: relative;
   top: -2px;
   right: -21px;
+  .rtl & {
+    left: -21px;
+    right: auto;
+  }
   line-height: @baseLineHeight;
 }
 

--- a/less/close.less
+++ b/less/close.less
@@ -17,6 +17,9 @@
     cursor: pointer;
     .opacity(40);
   }
+  .rtl & {
+    float: left;
+  }
 }
 
 // Additional properties for button version

--- a/less/code.less
+++ b/less/code.less
@@ -11,6 +11,9 @@ pre {
   font-size: @baseFontSize - 2;
   color: @grayDark;
   .border-radius(3px);
+  .rtl & {
+    direction: ltr;
+  }
 }
 
 // Inline code

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -60,11 +60,19 @@
 
   &:first-child {
     *margin-left: 0;
+    .rtl & {
+      *margin-left: auto;
+      *margin-right: 0;
+    }
   }
 }
 
 .ie7-restore-right-whitespace() {
   *margin-right: .3em;
+  .rtl & {
+    *margin-left: .3em;
+    *margin-right: auto;
+  }
 }
 
 // Sizing shortcuts
@@ -538,17 +546,30 @@
   float: none; // undo default grid column styles
   width: ((@gridColumnWidth) * @columnSpan) + (@gridGutterWidth * (@columnSpan - 1)) - 16; // 16 is total padding on left and right of table cells
   margin-left: 0; // undo default grid column styles
+  .rtl & {
+    margin-left: auto;
+    margin-right: 0;
+  }
 }
 
 // Make a Grid
 // Use .makeRow and .makeColumn to assign semantic layouts grid system behavior
 .makeRow() {
   margin-left: @gridGutterWidth * -1;
+  .rtl & {
+    margin-left: auto;
+    margin-right: @gridGutterWidth * -1;
+  }
   .clearfix();
 }
 .makeColumn(@columns: 1, @offset: 0) {
   float: left;
   margin-left: (@gridColumnWidth * @offset) + (@gridGutterWidth * (@offset - 1)) + (@gridGutterWidth * 2);
+  .rtl & {
+    float: right;
+    margin-left: auto;
+    margin-right: (@gridColumnWidth * @offset) + (@gridGutterWidth * (@offset - 1)) + (@gridGutterWidth * 2);
+  }
   width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
 }
 
@@ -571,6 +592,10 @@
 
     .offset (@columns) {
       margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns + 1));
+      .rtl & {
+        margin-left: auto;
+        margin-right: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns + 1));
+      }
     }
 
     .span (@columns) {
@@ -579,6 +604,10 @@
 
     .row {
       margin-left: @gridGutterWidth * -1;
+      .rtl & {
+        margin-left: auto;
+        margin-right: @gridGutterWidth * -1;
+      }
       .clearfix();
     }
 
@@ -586,6 +615,11 @@
       float: left;
       min-height: 1px; // prevent collapsing columns
       margin-left: @gridGutterWidth;
+      .rtl & {
+        float: right;
+        margin-left: auto;
+        margin-right: @gridGutterWidth;
+      }
     }
 
     // Set the container width, and override it for fixed navbars in media queries
@@ -618,11 +652,23 @@
     .offset (@columns) {
       margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth*2);
   	  *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + (@fluidGridGutterWidth*2) - (.5 / @gridRowWidth * 100 * 1%);
+      .rtl & {
+        margin-left: auto;
+        *margin-left: auto;
+        margin-right: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth*2);
+        *margin-right: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + (@fluidGridGutterWidth*2) - (.5 / @gridRowWidth * 100 * 1%);
+      }
     }
 
     .offsetFirstChild (@columns) {
       margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth);
       *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+      .rtl & {
+        margin-left: auto;
+        *margin-left: auto;
+        margin-right: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth);
+        *margin-right: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+      }
     }
 
     .span (@columns) {
@@ -638,14 +684,29 @@
         float: left;
         margin-left: @fluidGridGutterWidth;
         *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+        .rtl & {
+          float: right;
+          margin-left: auto;
+          *margin-left: auto;
+          margin-right: @fluidGridGutterWidth;
+          *margin-right: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+        }
       }
       [class*="span"]:first-child {
         margin-left: 0;
+        .rtl & {
+          margin-left: auto;
+          margin-right: 0;
+        }
       }
 
       // Space grid-sized controls properly if multiple per line
       .controls-row [class*="span"] + [class*="span"] {
         margin-left: @fluidGridGutterWidth;
+        .rtl & {
+          margin-left: auto;
+          margin-right: @fluidGridGutterWidth;
+        }
       }
 
       // generate .spanX and .offsetX
@@ -676,6 +737,10 @@
     // Space grid-sized controls properly if multiple per line
     .controls-row [class*="span"] + [class*="span"] {
       margin-left: @gridGutterWidth;
+      .rtl & {
+        margin-left: auto;
+        margin-right: @gridGutterWidth;
+      }
     }
 
     // generate .spanX

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -13,8 +13,12 @@ body {
   line-height: @baseLineHeight;
   color: @textColor;
   background-color: @bodyBackground;
+  direction: ltr;
 }
 
+.rtl {
+  direction: rtl;
+}
 
 // Links
 // -------------------------


### PR DESCRIPTION
I have added right to left support by adding extra CSS rules inside `.rtl` classes. This method does not affect original functionality at all, does not need additional CSS file and will be easy maintainable.
Changes have been made inside elements in less files like the following sample block:

``` css
.sample {
  margin-left: 2px;
  .rtl & {
    margin-left: auto;
    margin-right: 2px;
  }
}
```

Also will supports dynamic layout change by adding or removing '.rtl' class from any container like body.
example:

``` javascript
function switchLayout() {
  var $body = $(document.body);
  if ($body.hasClass('rtl')) {
    $body.removeClass('rtl');
  } else {
    $body.addClass('rtl');
  }
}
```
