### PR TITLE
Add ability for tooltip container to be a function

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -109,6 +109,7 @@
         , actualWidth
         , actualHeight
         , placement
+        , container
         , tp
         , e = $.Event('show')
 
@@ -130,7 +131,11 @@
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
 
-        this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+        container = typeof this.options.container == 'function' ?
+          this.options.container.call(this.$element[0], $tip[0], this.options) :
+          this.options.container
+
+        container ? $tip.appendTo(container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition()
 


### PR DESCRIPTION
Add a little snippet for the container for tooltips to be a function. This allows us to do more things with the container option if it's required. 

``` javascript
return $(this).closest('.modal')
```

Currently this is set to the DOM element, and it passes the tip and options as the first and second options respectively (not sure if even required). Was going to make it the same as the placement function ability - but I am not sure on the arguments or order for the function call there. Some clarity would be great, because passing the DOM element as `this` is generally how jQuery does it and seems confusing to pass it as an argument.
