### PR TITLE
Make sure the typeahead item is a string

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -109,7 +109,8 @@
     }
 
   , matcher: function (item) {
-      return ~item.toLowerCase().indexOf(this.query.toLowerCase())
+      return typeof item == 'string' ?
+        ~item.toLowerCase().indexOf(this.query.toLowerCase()) : false
     }
 
   , sorter: function (items) {

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -111,6 +111,23 @@ $(function () {
         typeahead.$menu.remove()
       })
 
+      test("should not explode when non strings are entered", function () {
+        var $input = $('<input />').typeahead({
+              source: ['aa', 'ab', 'ac', null, undefined]
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 item in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        $input.remove()
+        typeahead.$menu.remove()
+      })
+
       test("should hide menu when query entered", function () {
         stop()
         var $input = $('<input />').typeahead({


### PR DESCRIPTION
Fixes #6410

Simple check to make sure the value of the item is a string before try to use the toLowerCase() method so we don't cause errors. Added a simple test case.
