### PR TITLE
Added events to affix to resolve issue #6421

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -26,42 +26,64 @@
  /* AFFIX CLASS DEFINITION
   * ====================== */
 
-  var Affix = function (element, options) {
-    this.options = $.extend({}, $.fn.affix.defaults, options)
-    this.$window = $(window)
-      .on('scroll.affix.data-api', $.proxy(this.checkPosition, this))
-      .on('click.affix.data-api',  $.proxy(function () { setTimeout($.proxy(this.checkPosition, this), 1) }, this))
-    this.$element = $(element)
-    this.checkPosition()
-  }
+  var reset = 'affix affix-top affix-bottom'
+    , Affix = function (element, options) {
+      this.options = $.extend({}, $.fn.affix.defaults, options)
+      this.$window = $(window)
+        .on('scroll.affix.data-api', $.proxy(this.checkPosition, this))
+        .on('click.affix.data-api',  $.proxy(function () { setTimeout($.proxy(this.checkPosition, this), 1) }, this))
+      this.$element = $(element)
+      this.checkPosition()
+    }
 
-  Affix.prototype.checkPosition = function () {
-    if (!this.$element.is(':visible')) return
+  Affix.prototype = {
 
-    var scrollHeight = $(document).height()
-      , scrollTop = this.$window.scrollTop()
-      , position = this.$element.offset()
-      , offset = this.options.offset
-      , offsetBottom = offset.bottom
-      , offsetTop = offset.top
-      , reset = 'affix affix-top affix-bottom'
-      , affix
+    constructor: Affix
 
-    if (typeof offset != 'object') offsetBottom = offsetTop = offset
-    if (typeof offsetTop == 'function') offsetTop = offset.top()
-    if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
+  , checkPosition: function () {
+      if (!this.$element.is(':visible')) return
 
-    affix = this.unpin != null && (scrollTop + this.unpin <= position.top) ?
-      false    : offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ?
-      'bottom' : offsetTop != null && scrollTop <= offsetTop ?
-      'top'    : false
+      var scrollHeight = $(document).height()
+        , scrollTop = this.$window.scrollTop()
+        , position = this.$element.offset()
+        , offset = this.options.offset
+        , offsetBottom = offset.bottom
+        , offsetTop = offset.top
+        , affix
 
-    if (this.affixed === affix) return
+      if (typeof offset != 'object') offsetBottom = offsetTop = offset
+      if (typeof offsetTop == 'function') offsetTop = offset.top()
+      if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
 
-    this.affixed = affix
-    this.unpin = affix == 'bottom' ? position.top - scrollTop : null
+      affix = this.unpinned != null && (scrollTop + this.unpinned <= position.top) ?
+        false    : offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ?
+        'bottom' : offsetTop != null && scrollTop <= offsetTop ?
+        'top'    : false
 
-    this.$element.removeClass(reset).addClass('affix' + (affix ? '-' + affix : ''))
+      if (this.affixed === affix) return
+
+      this.affixed = affix
+      this.unpinned = affix == 'bottom' ? position.top - scrollTop : null
+
+      this[affix? 'unpin': 'pin'].call(this, affix)
+    }
+
+  , pin: function () {
+      this.$element
+        .trigger('pin')
+        .removeClass(reset)
+        .addClass('affix')
+        .trigger('pinned')
+    }
+
+  , unpin: function (affix) {
+      this.$element
+        .trigger('unpin')
+        .removeClass(reset)
+        .addClass('affix-' + affix)
+        .trigger('unpinned')
+    }
+
   }
 
 

--- a/js/tests/unit/bootstrap-affix.js
+++ b/js/tests/unit/bootstrap-affix.js
@@ -22,4 +22,25 @@ $(function () {
         ok(!$affix.hasClass('affix'), 'affix class was not added')
       })
 
+      test('should fire pin events', function () {
+        $('<div />')
+          .affix()
+          .on({
+            pin: function() {
+              ok(true, 'pin was fired')
+            },
+            pinned: function() {
+              ok(true, 'pinned was fired')
+            },
+            unpin: function() {
+              ok(true, 'unpin was fired')
+            },
+            unpinned: function() {
+              ok(true, 'unpinned was fired')
+            }
+          })
+          .affix('pin')
+          .affix('unpin')
+      })
+
 })


### PR DESCRIPTION
Added 4 events, pin, pinned, unpin, and unpinned to resolve [#6421](https://github.com/twitter/bootstrap/issues/6421). Adding events to affix required extracting "affix" and "unaffix" into their own methods pin and unpin.

Should something like this be broken into multiple commits to make it easier to see changes? Sorry, still new to contributing with github.
