### PR TITLE
Add RTL (right to left) support to 3.0.0-wip

### DIFF
--- a/docs/assets/css/docs-rtl.css
+++ b/docs/assets/css/docs-rtl.css
@@ -1,0 +1,152 @@
+body.rtl  > .navbar .brand {
+  margin-left: auto;
+  margin-right: 20px;
+  float: left;
+}
+
+.rtl .bs-docs-separator {
+  margin: 40px 0 39px;
+}
+
+.rtl hr.soften {
+  margin: 70px 0;
+  background-image: -webkit-linear-gradient(right, rgba(0,0,0,0), rgba(0,0,0,.1), rgba(0,0,0,0));
+  background-image:    -moz-linear-gradient(right, rgba(0,0,0,0), rgba(0,0,0,.1), rgba(0,0,0,0));
+  background-image:     -ms-linear-gradient(right, rgba(0,0,0,0), rgba(0,0,0,.1), rgba(0,0,0,0));
+  background-image:      -o-linear-gradient(right, rgba(0,0,0,0), rgba(0,0,0,.1), rgba(0,0,0,0));
+}
+
+.rtl .bs-docs-jumbotron {
+  background: -webkit-gradient(linear, right bottom, left top, color-stop(0%,#020031), color-stop(100%,#6d3353)); /* Chrome,Safari4+ */
+}
+
+.rtl .masthead-links {
+  margin: 0;
+}
+
+.rtl .subhead {
+  text-align: right;
+}
+
+.rtl .footer-links li:first-child {
+  padding-right: 0;
+}
+
+.rtl .mini-layout.fluid .mini-layout-sidebar,
+.rtl .mini-layout.fluid .mini-layout-header,
+.rtl .mini-layout.fluid .mini-layout-body {
+  float: right;
+}
+
+.rtl .mini-layout.fluid .mini-layout-body {
+  margin-left: auto;
+  margin-right: 2.5%;
+}
+
+.rtl .download .checkbox {
+  padding: 6px 25px 6px 10px;
+}
+
+.rtl .example-sites {
+  xmargin-left: auto;
+  xmargin-right: 20px;
+}
+
+.rtl .the-icons {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+.rtl .the-icons li {
+  float: right;
+}
+
+.rtl .the-icons [class^="glyphicon-"] {
+  margin-left: 3px;
+  margin-right: auto;
+}
+
+.rtl .bs-docs-example:after {
+  left: auto;
+  right: -1px;
+  -webkit-border-radius: 0 4px 0 4px;
+     -moz-border-radius: 0 4px 0 4px;
+          border-radius: 0 4px 0 4px;
+}
+
+.rtl .bs-navbar-top-example {
+  -webkit-border-radius: 0 4px 4px 0;
+     -moz-border-radius: 0 4px 4px 0;
+          border-radius: 0 4px 4px 0;
+}
+
+.rtl .bs-navbar-top-example:after {
+  -webkit-border-radius: 4px 0 4px 0;
+     -moz-border-radius: 4px 0 4px 0;
+          border-radius: 4px 0 4px 0;
+}
+
+.rtl .bs-navbar-bottom-example {
+  -webkit-border-radius: 4px 0 0 4px;
+     -moz-border-radius: 4px 0 0 4px;
+          border-radius: 4px 0 0 4px;
+}
+
+.rtl .bs-docs-example-popover .popover {
+  float: right;
+}
+
+.rtl .bs-docs-example-submenus > .pull-left + .pull-left {
+  margin-left: auto;
+  margin-right: 20px;
+}
+
+.rtl .responsive-utilities-test {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+.rtl .responsive-utilities-test li {
+  float: right;
+}
+
+.rtl .responsive-utilities-test li + li {
+  margin-left: auto;
+  margin-right: 10px;
+}
+
+.rtl .bs-docs-sidenav {
+  margin: 30px 0 0;
+}
+
+.rtl .bs-docs-sidenav .glyphicon-chevron-right {
+  float: left;
+  margin-left: -6px;
+  margin-right: auto;
+}
+
+@media (max-width: 980px) {
+  body.rtl  > .navbar-fixed-top .brand {
+    float: right;
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .rtl .bs-docs-sidenav {
+    margin-left: 0;
+    margin-right: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .rtl .example-sites {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .rtl .bs-docs-example-submenus > .pull-left,
+  .rtl .bs-docs-example-submenus > .pull-left + .pull-left {
+    margin-left: auto;
+    margin-right: 0;
+  }
+}

--- a/docs/rtl.html
+++ b/docs/rtl.html
@@ -1,0 +1,205 @@
+﻿<!DOCTYPE html>
+<html lang="en" style="overflow-y: scroll">
+  <head>
+    <meta charset="utf-8">
+    <title>Bootstrap RTL demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <!-- Le styles -->
+    <script src="assets/js/jquery.js"></script>
+    <script src="build/node_modules/hogan.js/lib/template.js"></script>
+    <script src="build/node_modules/hogan.js/lib/compiler.js"></script>
+    <script src="http://cloud.github.com/downloads/cloudhead/less.js/less-1.3.1.min.js" type="text/javascript"></script>
+    <script>
+        $(document).ready(function () {
+            less.sheets.push({ href: '../less/rtl.less', rel: "stylesheet/less", type: "text/less" });
+            less.sheets.push({ href: 'assets/css/docs.css', rel: "stylesheet/less", type: "text/css" });
+            less.sheets.push({ href: 'assets/css/docs-rtl.css', rel: "stylesheet/less", type: "text/css" });
+            less.sheets.push({ href: 'assets/js/google-code-prettify/prettify.css', rel: "stylesheet/less", type: "text/css" });
+            less.refresh(true);
+
+            var $window = $(window), $body = $(document.body), $container = $('#page-container'), title = 'Bootstrap', prod = false, context = {};
+
+            context[name.replace(/\.mustache$/, '')] = 'active'
+            context._i = true;
+            context.production = prod;
+            context.title = name
+              .replace(/\.mustache/, '')
+              .replace(/\-.*/, '')
+              .replace(/(.)/, function ($1) { return $1.toUpperCase() })
+
+            if (context.title == 'Index') {
+                context.title = title
+            } else {
+                context.title += ' · ' + title
+            }
+
+            var options = { sectionTags: [{ o: '_i', c: 'i' }] };
+
+
+            $('a.doc-navigation').click(function () {
+                renderBody($(this).attr('href'));
+                return false;
+            });
+
+            $('.rtl-switch').click(function () {
+                $body.toggleClass('rtl');
+            });
+
+            $('.rtl-mirror').click(function () {
+                $body.toggleClass('mirror');
+            });
+
+            $(window).keydown(function (event) {
+                if (event.which == 113) { // F2
+                    $('.rtl-switch').click();
+                    return false;
+                }
+                else if (event.which == 114) { // F3
+                    $('.rtl-mirror').click();
+                    return false;
+                }
+            });
+
+            var appScript = ""
+            function renderBody(name) {
+                $.get('templates/pages/' + name + '.mustache', function (body) {
+                    body = Hogan.compile(body, options)
+                    body = body.render(context, {});
+
+                    $container.html('<header class="bs-docs-jumbotron subhead"><div class="container"><h1>Loading...</h1><p class="lead">' + name + '</p></div></header>');
+                    $body.animate({ scrollTop: 0 }, 'fast', function () {
+                        $container.html(body).ready(function () {
+                            $('[data-spy="scroll"]').each(function () {
+                                var $spy = $(this)
+                                $spy.scrollspy($spy.data())
+                            })
+                            eval(appScript)
+                            Holder.run()
+                            $body.scrollspy('refresh')
+                        });
+                    });
+                });
+            }
+            $.get('assets/js/application.js', function (app) {
+                appScript = app;
+                renderBody('index');
+            })
+        });
+
+    </script>
+
+    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+  </head>
+  <body data-spy="scroll" data-target=".bs-docs-sidebar" class="rtl mirror">
+  <!-- Navbar
+    ================================================== -->
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="container">
+        <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a href="index" class="doc-navigation brand">Bootstrap</a>
+        <div class="nav-collapse collapse">
+          <ul class="nav">
+            <li class="switches">
+              <button class="btn btn-mini btn-primary rtl-switch active" data-toggle="button">RTL</button>
+              <button class="btn btn-mini btn-primary rtl-mirror active" data-toggle="button">Mirror</button>
+            </li>
+            <li class="">
+              <a href="index" class="doc-navigation">Home</a>
+            </li>
+            <li class="">
+              <a href="getting-started" class="doc-navigation">Get started</a>
+            </li>
+            <li class="">
+              <a href="css" class="doc-navigation">Core CSS</a>
+            </li>
+            <li class="">
+              <a href="components" class="doc-navigation">Components</a>
+            </li>
+            <li class="">
+              <a href="javascript" class="doc-navigation">JavaScript</a>
+            </li>
+            <li class="">
+              <a href="customize" class="doc-navigation">Customize</a>
+            </li>
+            <li class="">
+              <a href="gallery" class="doc-navigation">Gallery</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div id="page-container">
+    </div>
+
+    <!-- Footer
+    ================================================== -->
+    <footer class="footer">
+      <div class="container">
+
+        <div class="bs-docs-social">
+          <ul class="bs-docs-social-buttons">
+            <li>
+              <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+            </li>
+            <li>
+              <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
+            </li>
+            <li class="follow-btn">
+              <a href="https://twitter.com/twbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @twbootstrap</a>
+            </li>
+            <li class="tweet-btn">
+              <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twitter.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+            </li>
+          </ul>
+        </div>
+
+
+        <p>Designed and built with all the love in the world by <a href="http://twitter.com/mdo" target="_blank">@mdo</a> and <a href="http://twitter.com/fat" target="_blank">@fat</a>.</p>
+        <p>Code licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License v2.0</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
+        <p><a href="http://glyphicons.com">Glyphicons Free</a> licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
+        <ul class="footer-links">
+          <li><a href="http://blog.getbootstrap.com">Blog</a></li>
+          <li class="muted">&middot;</li>
+          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li class="muted">&middot;</li>
+          <li><a href="https://github.com/twitter/bootstrap/wiki">Roadmap and changelog</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <!-- Le javascript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <!-- We are using script tag instead of sctipt, because the template itself is inside another script tag -->
+
+    <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
+    <script src="../js/bootstrap-transition.js"></script>
+    <script src="../js/bootstrap-alert.js"></script>
+    <script src="../js/bootstrap-modal.js"></script>
+    <script src="../js/bootstrap-dropdown.js"></script>
+    <script src="../js/bootstrap-scrollspy.js"></script>
+    <script src="../js/bootstrap-tab.js"></script>
+    <script src="../js/bootstrap-tooltip.js"></script>
+    <script src="../js/bootstrap-popover.js"></script>
+    <script src="../js/bootstrap-button.js"></script>
+    <script src="../js/bootstrap-collapse.js"></script>
+    <script src="../js/bootstrap-carousel.js"></script>
+    <script src="../js/bootstrap-typeahead.js"></script>
+    <script src="../js/bootstrap-affix.js"></script>
+
+    <script src="assets/js/holder/holder.js"></script>
+    <script src="assets/js/google-code-prettify/prettify.js"></script>
+
+  </body>  
+</html>

--- a/less/rtl.less
+++ b/less/rtl.less
@@ -1,0 +1,909 @@
+@import "bootstrap.less";
+
+.rtl {
+  direction: rtl;
+}
+
+//
+// variables.less RTL overrides
+// --------------------------------------------------
+
+//
+// mixins.less RTL overrides
+// --------------------------------------------------
+.formFieldState(@text-color: #555, @border-color: #ccc, @background-color: #f5f5f5) {
+  .input-with-feedback {
+    .rtl & {
+      padding-left: 32px;
+      padding-right: auto;
+    }
+  }
+}
+
+.makeRow() {
+  .rtl & {
+    margin-left: auto;
+    margin-right: @grid-gutter-width * -1;
+  }
+}
+
+.makeColumn(@columns: 1, @offset: 0) {
+  .rtl & {
+    float: left;
+    margin-left: auto;
+    margin-right: (@grid-column-width * @offset) + (@grid-gutter-width * (@offset - 1)) + (@grid-gutter-width * 2);
+  }
+}
+
+#grid {
+  .core(@grid-column-width, @grid-gutter-width, @grid-row-width) {
+    .rtl & {
+      .offsetX(@index) when (@index > 0) {
+        (~".offset@{index}") { .offset(@index); }
+        .offsetX(@index - 1);
+      }
+      .offsetX(0) {}
+
+      .offset(@columns) {
+        margin-left: auto;
+        margin-right: percentage(@columns / @grid-columns);
+      }
+
+      [class*="span"] {
+        float: right;
+      }
+
+      .offsetX(@grid-columns);
+    }
+  }
+
+  .input(@grid-column-width, @grid-gutter-width, @grid-row-width) {
+    .rtl & {
+      .offsetX(@index) when (@index > 0) {
+        (~"input.offset@{index}, textarea.offset@{index}, select.offset@{index}, uneditable-input.offset@{index}") { .offset(@index); }
+        .offsetX(@index - 1);
+      }
+      
+      .offsetX(0) {}
+    
+      .offset(@columns) {
+        margin-left: auto;
+        margin-right: percentage(@columns / @grid-columns) + percentage((@grid-gutter-width / 2) / @grid-row-width);
+      }
+
+      .offsetX(@grid-columns);
+    }
+  }
+}
+
+//
+// normalize.less RTL overrides
+// --------------------------------------------------
+
+//
+// scaffolding.less RTL overrides
+// --------------------------------------------------
+body {
+  direction: ltr;
+}
+
+//
+// grid.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  &.mirror {
+    [class*="span"].pull-right {
+      float: left;
+    }
+  }
+}
+
+//
+// type.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  ul, ol {
+    margin-left: 0;
+    margin-right: 25px;
+  }
+
+  .list-inline {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .list-unstyled,
+  .list-inline {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  
+  dd {
+    margin-left: auto;
+    margin-right: @line-height-base / 2;
+  }
+
+  .dl-horizontal {
+    dt {
+      float: right;
+      clear: right;
+      text-align: left;
+    }
+
+    dd {
+      margin-left: auto;
+      margin-right: @component-offset-horizontal;
+    }
+  }
+
+  blockquote {
+    padding: 0 15px 0 0;
+    border-left: 0;
+    border-right: 5px solid @grayLighter;
+
+    &.pull-right {
+      float: right;
+      padding-left: 15px;
+      padding-right: 0;
+      border-left: 5px solid @grayLighter;
+      border-right: 0;
+
+      p,
+      small {
+        text-align: left;
+      }
+    }
+  }
+}
+//
+// code.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  code,
+  pre {
+    direction: ltr;
+  }
+}
+
+//
+// forms.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .radio,
+  .checkbox {
+    padding-left: 0;
+    padding-right: 20px;
+  }
+  .radio input[type="radio"],
+  .checkbox input[type="checkbox"] {
+    float: right;
+    margin-left: auto;
+    margin-right: -20px;
+  }
+  .radio.inline + .radio.inline,
+  .checkbox.inline + .checkbox.inline {
+    margin-left: auto;
+    margin-right: 10px;
+  }
+
+  input[class*="span"],
+  select[class*="span"],
+  textarea[class*="span"],
+  .uneditable-input[class*="span"] {
+    float: none;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .help-inline {
+    padding-left: 0;
+    padding-right: 5px;
+  }
+
+  .input-group {
+    &[class*="span"] {
+      float: none;
+      padding: 0;
+    }
+  }
+
+  .input-group input:first-child,
+  .input-group .uneditable-input:first-child,
+  .input-group-addon:first-child {
+    .border-left-radius(0);
+    .border-right-radius(@border-radius-base);
+  }
+  .input-group-addon:first-child {
+    border: 1px solid #ccc;
+    border-left: 0;
+  }
+  .input-group input:last-child,
+  .input-group .uneditable-input:last-child,
+  .input-group-addon:last-child {
+    .border-left-radius(@border-radius-base);
+    .border-right-radius(0);
+  }
+  .input-group-addon:last-child {
+    border: 1px solid #ccc;
+    border-right: 0;
+  }
+
+  .input-group-btn > .btn {
+    float: right;
+    + .btn {
+      border-right: 0;
+    }
+  }
+
+  .input-group-btn {
+    &:first-child > .btn,
+    &.btn-group:first-child > .btn {
+      border: 1px solid #ccc;
+      border-left: 0;
+    }
+    &:first-child > .btn,
+    &.btn-group:first-child > .btn {
+      border-radius: 0 @border-radius-base @border-radius-base 0;
+    }
+  }
+
+  .input-group-btn {
+    &:last-child > .btn,
+    &.btn-group:last-child > .btn:first-child {
+      border: 1px solid #ccc;
+      border-right: 0;
+    }
+    &:last-child > .btn,
+    &.btn-group:last-child > .btn {
+      border-radius: @border-radius-base 0 0 @border-radius-base;
+    }
+  }
+
+  .form-horizontal {
+    .control-group > .control-label {
+      float: right;
+      text-align: left;
+    }
+    .control-group > .controls {
+      margin-left: 0;
+      margin-right: @component-offset-horizontal;
+    }
+  }
+}
+
+//
+// tables.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .table {
+    th,
+    td {
+      text-align: right;
+    }
+  }
+
+  .table-bordered {
+    border: 1px solid @table-border;
+    border-right: 0;
+
+    th,
+    td {
+      border-left: 0;
+      border-right: 1px solid @table-border;
+    }
+
+    // For first th or td in the first row in the first thead or tbody
+    thead:first-child tr:first-child > th:first-child,
+    tbody:first-child tr:first-child > td:first-child {
+      border-top-left-radius: 0;
+      border-top-right-radius: @border-radius-base;
+    }
+    thead:first-child tr:first-child > th:last-child,
+    tbody:first-child tr:first-child > td:last-child {
+      border-top-left-radius: @border-radius-base;
+      border-top-right-radius: 0;
+    }
+
+    // For first th or td in the last row in the last thead or tbody
+    thead:last-child tr:last-child > th:first-child,
+    tbody:last-child tr:last-child > td:first-child,
+    tfoot:last-child tr:last-child > td:first-child {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: @border-radius-base;
+    }
+    thead:last-child tr:last-child > th:last-child,
+    tbody:last-child tr:last-child > td:last-child,
+    tfoot:last-child tr:last-child > td:last-child {
+      border-bottom-left-radius: @border-radius-base;
+      border-bottom-right-radius: 0;
+    }
+
+    // Clear border-radius for first and last td in the last row in the last tbody for table with tfoot
+    tfoot + tbody:last-child tr:last-child > td:first-child {
+      border-bottom-right-radius: 0;
+    }
+    tfoot + tbody:last-child tr:last-child > td:last-child {
+      border-bottom-left-radius: 0;
+    }
+
+    // Special fixes to round the left border on the first td/th
+    caption + thead tr:first-child th:first-child,
+    caption + tbody tr:first-child td:first-child,
+    colgroup + thead tr:first-child th:first-child,
+    colgroup + tbody tr:first-child td:first-child {
+      border-top-left-radius: 0;
+      border-top-right-radius: @border-radius-base;
+    }
+    caption + thead tr:first-child th:last-child,
+    caption + tbody tr:first-child td:last-child,
+    colgroup + thead tr:first-child th:last-child,
+    colgroup + tbody tr:first-child td:last-child {
+      border-top-left-radius: @border-radius-base;
+      border-top-right-radius: 0;
+    }
+  }
+
+  table td[class*="span"],
+  table th[class*="span"] {
+    float: none;
+    margin-left: auto;
+    margin-right: 0;
+  }
+}
+
+//
+// glyphicons.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  &.mirror {
+    [class^="glyphicon-"]:before {
+      unicode-bidi: bidi-override;
+    }
+
+    .glyphicon-align-left:before              { content: "\e054"; }
+    .glyphicon-align-right:before             { content: "\e052"; }
+    .glyphicon-indent-left:before             { content: "\e058"; }
+    .glyphicon-indent-right:before            { content: "\e057"; }
+    .glyphicon-chevron-left:before            { content: "\e080"; }
+    .glyphicon-chevron-right:before           { content: "\e079"; }
+    .glyphicon-arrow-right:before             { content: "\e091"; }
+    .glyphicon-arrow-left:before              { content: "\e092"; }
+    .glyphicon-hand-left:before               { content: "\e127"; }
+    .glyphicon-hand-right:before              { content: "\e128"; }
+    .glyphicon-circle-arrow-left:before       { content: "\e131"; }
+    .glyphicon-circle-arrow-right:before      { content: "\e132"; }
+  }
+}
+
+//
+// dropdowns.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .dropdown .caret {
+    margin-left: auto;
+    margin-right: 2px;
+  }
+
+  .dropdown-menu {
+    left: auto;
+    right: 0;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+//
+// wells.less RTL overrides
+// --------------------------------------------------
+
+//
+// component-animations.less RTL overrides
+// --------------------------------------------------
+
+//
+// close.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .close {
+    float: left;
+  }
+}
+
+//
+// buttons.less RTL overrides
+// --------------------------------------------------
+
+//
+// button-groups.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .btn-group + .btn-group {
+    margin-left: auto;
+    margin-right: 5px;
+  }
+  .btn-toolbar {
+    > .btn + .btn,
+    > .btn-group + .btn,
+    > .btn + .btn-group {
+      margin-left: auto;
+      margin-right: 5px;
+    }
+  }
+  .btn-group > .btn + .btn {
+    margin-left: auto;
+    margin-right: -1px;
+  }
+  .btn-group > .btn {
+    border-radius: 0;
+  }
+  .btn-group > .btn:first-child {
+    margin-left: auto;
+    margin-right: 0;
+    border-top-right-radius: @border-radius-base;
+    border-bottom-right-radius: @border-radius-base;
+  }
+  .btn-group > .btn:last-child,
+  .btn-group > .dropdown-toggle {
+    border-top-left-radius: @border-radius-base;
+    border-bottom-left-radius: @border-radius-base;
+  }
+  .btn-group > .btn.large:first-child {
+    margin-left: auto;
+    margin-right: 0;
+    border-top-right-radius: @border-radius-large;
+    border-bottom-right-radius: @border-radius-large;
+  }
+  .btn-group > .btn.large:last-child,
+  .btn-group > .large.dropdown-toggle {
+    border-top-left-radius: @border-radius-large;
+    border-bottom-left-radius: @border-radius-large;
+  }
+  .btn .caret {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .btn-group-vertical > .btn {
+    float: none;
+  }
+  .btn-group-vertical > .btn + .btn {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .btn-group-vertical .btn:first-child {
+    border-radius: @border-radius-base @border-radius-base 0 0;
+  }
+  .btn-group-vertical .btn:last-child {
+    border-radius: 0 0 @border-radius-base @border-radius-base;
+  }
+  .btn-group-vertical .btn-large:first-child {
+    border-radius: @border-radius-large @border-radius-large 0 0;
+  }
+  .btn-group-vertical .btn-large:last-child {
+    border-radius: 0 0 @border-radius-large @border-radius-large;
+  }
+}
+
+//
+// alerts.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .alert {
+    padding-left: 35px;
+    padding-right: 14px;
+  }
+
+  .alert .close {
+    left: -21px;
+    right: auto;
+  }
+}
+
+
+//
+// navs.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .nav {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .nav > li {
+    float: right;
+  }
+  &.mirror  {
+    .nav > .pull-right {
+      float: left;
+    }
+  }
+  .nav-tabs > li > a {
+    margin-left: 2px;
+    margin-right: auto;
+  }
+  .nav-pills > li + li > a {
+    margin-left: auto;
+    margin-right: 2px;
+  }
+  .nav-stacked > li {
+    float: none;
+  }
+  .nav-stacked > li + li > a {
+    margin-left: 0;
+    margin-right: auto;
+  }
+  .nav-justified > li {
+    float: none;
+  }
+  .nav-list > li {
+    float: none;
+  }
+}
+
+//
+// navbar.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .navbar .brand {
+    float: right;
+    margin-left: auto;
+    margin-right: -20px;
+  }
+
+  .navbar .divider-vertical {
+    border-left: 1px solid @navbar-background-highlight;
+    border-right: 1px solid @navbar-background;
+  }
+
+  .navbar-search {
+    float: right;
+  }
+
+  .navbar .nav {
+    left: auto;
+    left: 0;
+    float: right;
+    margin-left: 10px;
+    margin-right: 0;
+  }
+
+  &.mirror {
+    .navbar .nav.pull-right {
+      float: left;
+      margin-left: 0;
+      margin-right: auto;
+    }
+  }
+  
+  .navbar .nav > li {
+    float: right;
+  }
+
+  .navbar .nav > li > a {
+    text-shadow: 0 @navbar-background-highlight 0 1px;
+  }
+
+  .navbar .btn-navbar {
+    float: left;
+  }
+
+  .navbar .nav > li > .dropdown-menu {
+    &:before {
+      left: auto;
+      right: 9px;
+    }
+
+    &:after {
+      left: auto;
+      right: 10px;
+    }
+  }
+
+  .navbar .pull-right > li > .dropdown-menu,
+  .navbar .nav > li > .dropdown-menu.pull-right {
+    right: auto;
+    left: 0;
+
+    &:before {
+      left: 12px;
+      right: auto;
+    }
+
+    &:after {
+      left: 13px;
+      right: auto;
+    }
+
+    .dropdown-menu {
+      left: 100%;
+      right: auto;
+      margin-left: -1px;
+      margin-right: 0;
+      border-radius: 6px 6px 6px 0;
+    }
+  }
+
+  &.mirror {
+    .navbar-inverse {
+      .divider-vertical {
+        border-left-color: @navbar-inverse-background-highlight;
+        border-right-color: @navbar-inverse-background;
+      }
+    }
+  }
+}
+
+//
+// breadcrumbs.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .breadcrumb {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+//
+// pagination.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .pagination ul {
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .pagination ul > li > a,
+  .pagination ul > li > span {
+    float: right;
+    border-left-width: 1px;
+    border-right-width: 0;
+  }
+  .pagination ul > li:first-child > a,
+  .pagination ul > li:first-child > span {
+    border-right-width: 1px;
+    .border-left-radius(0);
+    .border-right-radius(@border-radius-base);
+  }
+  .pagination ul > li:last-child > a,
+  .pagination ul > li:last-child > span {
+    .border-left-radius(@border-radius-base);
+    .border-right-radius(0);
+  }
+
+  &.mirror .pagination-right {
+    text-align: left;
+  }
+
+  .pagination-large {
+    ul > li:first-child > a,
+    ul > li:first-child > span {
+      .border-left-radius(0);
+      .border-right-radius(@border-radius-large);
+    }
+    ul > li:last-child > a,
+    ul > li:last-child > span {
+      .border-left-radius(@border-radius-large);
+      .border-right-radius(0);
+    }
+  }
+
+  .pagination-mini,
+  .pagination-small {
+    ul > li:first-child > a,
+    ul > li:first-child > span {
+      .border-left-radius(0);
+      .border-right-radius(@border-radius-small);
+    }
+    ul > li:last-child > a,
+    ul > li:last-child > span {
+      .border-left-radius(@border-radius-small);
+      .border-right-radius(0);
+    }
+  }
+}
+
+//
+// pager.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .pager .next > a,
+  .pager .next > span {
+    float: left;
+  }
+
+  .pager .previous > a,
+  .pager .previous > span {
+    float: right;
+  }
+}
+
+//
+// modals.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .modal {
+    left: auto;
+    right: 50%;
+    margin-left: auto;
+    margin-right: -280px;
+  }
+  .modal-footer {
+    text-align: left;
+    .btn + .btn {
+      margin-left: auto;
+      margin-right: 5px;
+    }
+    .btn-group .btn + .btn {
+      margin-left: auto;
+      margin-right: -1px;
+    }
+    .btn-block + .btn-block {
+      margin-left: auto;
+      margin-right: 0;
+    }
+  }
+}
+
+//
+// tooltip.less RTL overrides
+// --------------------------------------------------
+
+//
+// popovers.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .popover {
+    &.top .arrow,
+    &.bottom .arrow {
+      direction: ltr;
+    }
+  }
+}
+
+//
+// thumbnails.less RTL overrides
+// --------------------------------------------------
+
+//
+// media.less RTL overrides
+// --------------------------------------------------
+.rtl.mirror {
+  .media > .pull-left {
+    margin-left: 10px;
+    margin-right: auto;
+  }
+  .media > .pull-right {
+    margin-left: auto;
+    margin-right: 10px;
+  }
+  .media-list {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+}
+//
+// badges.less RTL overrides
+// --------------------------------------------------
+
+//
+// progress-bars.less RTL overrides
+// --------------------------------------------------
+.rtl .progress .bar {
+  float: right;
+}
+
+//
+// accordion.less RTL overrides
+// --------------------------------------------------
+
+//
+// carousel.less RTL overrides
+// --------------------------------------------------
+.rtl {
+  .carousel-inner {
+
+    > .item {
+      .transition(.6s ease-in-out right);
+    }
+
+    > .active {
+      left: auto;
+      right: 0;
+    }
+
+    > .next {
+      left: auto;
+      right: 100%;
+    }
+
+    > .prev {
+      left: auto;
+      right: -100%;
+    }
+
+    > .next.left,
+    > .prev.right {
+      left: auto;
+      right: 0;
+    }
+
+    > .active.left {
+      left: auto;
+      right: -100%;
+    }
+
+    > .active.right {
+      left: auto;
+      right: 100%;
+    }
+  }
+
+  .carousel-control {
+    left: auto;
+    right: 0;
+    &.left {
+      #gradient > .horizontal(rgba(0,0,0,.75), rgba(0,0,0,.001));
+      background-color: transparent;
+    }
+    &.right {
+      left: 0;
+      right: auto;
+      #gradient > .horizontal(rgba(0,0,0,.001), rgba(0,0,0,.75));
+      background-color: transparent;
+    }
+
+    .control {
+      margin-left: auto;
+      margin-right: 30px;
+    }
+    &.right .control {
+      margin-left: auto;
+      margin-right: 70px;
+    }
+  }
+
+  .carousel-indicators {
+    left: 15px;
+    right: auto;
+
+    li {
+      float: right;
+      margin-left: auto;
+      margin-right: 5px;
+    }
+  }
+}
+
+//
+// jumbotron.less RTL overrides
+// --------------------------------------------------
+
+//
+// utilities.less RTL overrides
+// --------------------------------------------------
+.rtl.mirror .pull-right {
+  float: left;
+}
+.rtl.mirror .pull-left {
+  float: right;
+}
+
+//
+// responsive-utilities.less RTL overrides
+// --------------------------------------------------
+
+//
+// responsive-1200px-min.less RTL overrides
+// --------------------------------------------------
+
+//
+// responsive-768px-979px.less RTL overrides
+// --------------------------------------------------
+
+//
+// responsive-767px-max.less RTL overrides
+// --------------------------------------------------
+
+//
+// responsive-navbar.less RTL overrides
+// --------------------------------------------------


### PR DESCRIPTION
As we discussed on pull request #6409, RTL added in a separate `rtl.less` file on branch 3.0.0-wip.
All components supported. The page `rtl.html`, loads Bootstrap documentation `.mustache` templates on the fly and renders RTL/LTR contents correctly without any modification.
Tested and worked with Chrome 23, FireFox 17 and IE10.

Developers can add RTL layout support to their current Bootstrap websites, simply by adding `.rtl` CSS class to any HTML element. e.g:

``` html
<body class="rtl">...</body>
```

or dynamically

``` javascript
function switchLayout() {
  $(document.body).toggleClass('rtl')
}
```

Another class, `.mirror` is useful to change direction of arrows and font icons. See its functionality in 'Icons by Glyphicons' section of the demo.

[Online Demo](http://malekpour.github.com/bootstrap/3.0.0-wip/docs/rtl.html) (buttons on navigation bar added to compare RTL/LTR layouts, F2 [RTL/LTR] and F3 [Mirror/Normal] keys also works and when modal popup is visible only hot keys will work)
