### PR TITLE
docs/base-css: Remove "disabled" class from button

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -1787,7 +1787,7 @@ For example, &lt;code&gt;&lt;section&gt;&lt;/code&gt; should be wrapped as inlin
           <h3>Button element</h3>
           <p>Add the <code>disabled</code> attribute to <code>&lt;button&gt;</code> buttons.</p>
           <p class="bs-docs-example">
-            <button type="button" class="btn btn-large btn-primary disabled" disabled="disabled">Primary button</button>
+            <button type="button" class="btn btn-large btn-primary" disabled="disabled">Primary button</button>
             <button type="button" class="btn btn-large" disabled>Button</button>
           </p>
 <pre class="prettyprint linenums">


### PR DESCRIPTION
Buttons are disabled by their attribute, no need for the class.
