### PR TITLE
Fixed the yellow square around active buttons in Chrome

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -17,7 +17,8 @@
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
-  outline-color: transparent;
+  outline: 0;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
   .buttonBackground(@btnBackground, @btnBackgroundHighlight, @grayDark, 0 1px 1px rgba(255,255,255,.75));
   border: 1px solid @btnBorder;
   *border: 0; // Remove the border to prevent IE7's black border on input:focus

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -17,8 +17,7 @@
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
-  outline: 0;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  outline-color: transparent;
   .buttonBackground(@btnBackground, @btnBackgroundHighlight, @grayDark, 0 1px 1px rgba(255,255,255,.75));
   border: 1px solid @btnBorder;
   *border: 0; // Remove the border to prevent IE7's black border on input:focus

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -17,6 +17,7 @@
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
+  outline-color: transparent;
   .buttonBackground(@btnBackground, @btnBackgroundHighlight, @grayDark, 0 1px 1px rgba(255,255,255,.75));
   border: 1px solid @btnBorder;
   *border: 0; // Remove the border to prevent IE7's black border on input:focus


### PR DESCRIPTION
Added outline-color: transparent; to buttons.less to fix the yellow border on buttons in Chrome 
![bootstrapButtonError](https://f.cloud.github.com/assets/798252/38662/edf30294-54f9-11e2-8ba1-83956e6fb69f.png)
