### PR TITLE
Fixed navbar-text issue

### DIFF
--- a/docs/examples/fluid.html
+++ b/docs/examples/fluid.html
@@ -45,14 +45,14 @@
           </a>
           <a class="brand" href="#">Project name</a>
           <div class="nav-collapse collapse">
-            <p class="navbar-text pull-right">
-              Logged in as <a href="#" class="navbar-link">Username</a>
-            </p>
             <ul class="nav">
               <li class="active"><a href="#">Home</a></li>
               <li><a href="#about">About</a></li>
               <li><a href="#contact">Contact</a></li>
             </ul>
+            <p class="navbar-text pull-right">
+              Logged in as <a href="#" class="navbar-link">Username</a>
+            </p>
           </div><!--/.nav-collapse -->
         </div>
       </div>


### PR DESCRIPTION
Found, that if `navbar-text` element is before `ul.nav` then it isn't visible in responsive. So moved around in docs, for it to work.
