### PR TITLE
added support for customizing an item in the dropdown results

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1640,6 +1640,12 @@ $('.carousel').carousel({
                  <td>highlights all default matches</td>
                  <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
                </tr>
+               <tr>
+                 <td>itemPostRender</td>
+                 <td>function</td>
+                 <td>returns originally generated HTML for item</td>
+                 <td>Method for customizing item in dropdown. Accepts three arguments: the <code>item</code>, the item's <code>index</code> in the dropdown, and the rendered html. Should return html. </td>
+                </tr>
               </tbody>
             </table>
 

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1573,6 +1573,12 @@ $('.carousel').carousel({
                  <td>highlights all default matches</td>
                  <td>Method used to highlight autocomplete results. Accepts a single argument <code>item</code> and has the scope of the typeahead instance. Should return html.</td>
                </tr>
+               <tr>
+                 <td>itemPostRender</td>
+                 <td>function</td>
+                 <td>returns originally generated HTML for item</td>
+                 <td>Method for customizing item in dropdown. Accepts three arguments: the <code>item</code>, the item's <code>index</code> in the dropdown, and the rendered html. Should return html. </td>
+                </tr>
               </tbody>
             </table>
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -32,6 +32,7 @@
     this.matcher = this.options.matcher || this.matcher
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
+    this.itemPostRender = this.options.itemPostRender || this.itemPostRender
     this.updater = this.options.updater || this.updater
     this.source = this.options.source
     this.$menu = $(this.options.menu)
@@ -105,7 +106,7 @@
         return this.shown ? this.hide() : this
       }
 
-      return this.render(items.slice(0, this.options.items)).show()
+      return this.render(items.slice(0, this.options.items))
     }
 
   , matcher: function (item) {
@@ -138,14 +139,19 @@
       var that = this
 
       items = $(items).map(function (i, item) {
+        var index = i
         i = $(that.options.item).attr('data-value', item)
         i.find('a').html(that.highlighter(item))
-        return i[0]
+        return that.itemPostRender(item, i[0], index);
       })
+
+      if (!items.length) {
+        return this.shown ? this.hide() : this
+      }
 
       items.first().addClass('active')
       this.$menu.html(items)
-      return this
+      return this.show()
     }
 
   , next: function (event) {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -154,6 +154,10 @@
       return this.show()
     }
 
+  , itemPostRender: function (item, itemHTML, position) {
+      return itemHTML
+    }
+
   , next: function (event) {
       var active = this.$menu.find('.active').removeClass('active')
         , next = active.next()


### PR DESCRIPTION
I added an additional function <code>itemPostRender</code> to allow developers to customize particular dropdown results. By default, this just returns the HTML that was originally rendered. In the screenshots, I show some examples of how I leveraged this functionality to add a dividing line and loading indicator. 

I additionally added logic into <code>render</code> to check that the <code>items</code> list is not empty. This is a safeguard, to handle the case where a user potentially returns <code>null</code> for all items' HTML. 

Tested browsers:
Safari 6.0.2
Chrome 23.0.1271.101

![Screen Shot 2013-01-02 at 8 49 42 AM](https://f.cloud.github.com/assets/1937659/38735/de92a2b0-54fd-11e2-8ad9-037fe7ea6ff7.png)
![Screen Shot 2013-01-02 at 8 47 39 AM](https://f.cloud.github.com/assets/1937659/38736/df06f818-54fd-11e2-9ff6-6b0e9e682db1.png)
