### PR TITLE
Fixed mutiple modal-backdrop issue

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -159,8 +159,8 @@
         if (this.isShown && this.options.backdrop) {
           var doAnimate = $.support.transition && animate
 
-          this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-            .appendTo(document.body)
+          this.$backdrop = $('.modal-backdrop').length < 1 ? $('<div class="modal-backdrop ' + animate + '" />')
+            .appendTo(document.body) : $('.modal-backdrop:eq(0)')
 
           this.$backdrop.click(
             this.options.backdrop == 'static' ?


### PR DESCRIPTION
Changed line 162 in `js/boostrap-modal.js` to confirm that `.modal-backdrop` does not exist before injecting a new one.

Reference: Issue #6466
