### PR TITLE
Remove touchstart from bootstrap-dropdown.js.

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -156,10 +156,10 @@
    * =================================== */
 
   $(document)
-    .on('click.dropdown.data-api touchstart.dropdown.data-api', clearMenus)
-    .on('click.dropdown.data-api touchstart.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-    .on('touchstart.dropdown.data-api', '.dropdown-menu', function (e) { e.stopPropagation() })
-    .on('click.dropdown.data-api touchstart.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
-    .on('keydown.dropdown.data-api touchstart.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
+    .on('click.dropdown.data-api', clearMenus)
+    .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
+    .on('.dropdown-menu', function (e) { e.stopPropagation() })
+    .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
+    .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
 
 }(window.jQuery);


### PR DESCRIPTION
It would be great to remove listening to touchstart from the bootstrap dropdowns. This would make it consistent with the rest of the bootstrap components.

It seems like either all clickable elements should be listening for touchstart or none of them should be. I agree with the comment from https://github.com/twitter/bootstrap/issues/3772#issuecomment-11563061

FastClick works great with Bootstrap except for the bootstrap-dropdowns because they also listen for touchstart which then causes the dropdown to open and then immediately close. See https://github.com/ftlabs/fastclick/issues/48 for more info. Removing touchstart from bootstrap dropdowns would fix this issue and make all of the bootstrap controls behave the same.

Thanks!
