### PR TITLE
fix .brand alignment in .navbar-fixed-* when using .container-fluid

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -181,6 +181,10 @@
   bottom: 0;
 }
 
+// Fixed navbar's brand needs no left margin, so that it aligns with text inside a .container-fluid
+.navbar-fixed-top, .navbar-fixed-bottom {
+  .brand { margin-left: 0; }
+}
 
 
 // NAVIGATION


### PR DESCRIPTION
when using .container-fluid, in a non-fixed navbar, the brand has a negative margin to align to text further down on the page, but in a fixed navbar this negative margin should be cleared so that the alignment is in place.
