### PR TITLE
Prevent default event behavior on click [tip] 

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -238,6 +238,7 @@
   , toggle: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
       self[self.tip().hasClass('in') ? 'hide' : 'show']()
+      e.preventDefault()
     }
 
   , destroy: function () {


### PR DESCRIPTION
tooltip and popover plugins does not override the default click event behavior.
