### PR TITLE
Carousel arrows not working on resizing the browser window for example template  "Carousel jumbotron". 

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -88,6 +88,7 @@
       text-shadow: 0 1px 1px rgba(0,0,0,.4);
       background-color: transparent;
       border: 0;
+      z-index: 10;
     }
 
     .carousel .item {


### PR DESCRIPTION
Corrected the carousel arrows to active on resizing the browser window of  [Carousel jumbotron](http://twitter.github.com/bootstrap/examples/carousel.html)  page..
