### PR TITLE
Correcting .brand alignment in navbar-fixed-* when used with .container-fluid

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -214,6 +214,14 @@
   }
 }
 
+// Fixed navbar's brand needs no left margin, so that it aligns with text inside a .container-fluid
+.navbar-fixed-top,
+.navbar-fixed-bottom {
+  .brand {
+    margin-left: 0;
+  }
+}
+
 
 
 // NAVIGATION


### PR DESCRIPTION
This is now I believe a correct pull request to the *-wip branch.

Tested on latest Safari and latest stable Chrome on OSX 10.8.

I did not commit compiled bootstrap.css as there isn't a separate css/ directory to store these, as it used to be (same for the minified version of the CSS file because it doesn't even exist in this repo). Guidelines mention to commit these, but I am not sure where would I place them.
