### PR TITLE
Disable selection of icons

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -35,6 +35,9 @@
   font-family: 'Glyphicons Halflings';
   font-style: normal;
   line-height: 1;
+  // Disable selecting of icons
+  -webkit-touch-callout: none;
+  .user-select(none);
 }
 
 // Individual icons

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -83,6 +83,15 @@
   border: 0;
 }
 
+// Set text selection
+.user-select(@select) {
+  -webkit-user-select: @select;
+   -khtml-user-select: @select;
+     -moz-user-select: @select;
+      -ms-user-select: @select;
+          user-select: @select;
+}
+
 
 // FONTS
 // --------------------------------------------------


### PR DESCRIPTION
When double clicking or trying to select text manually you might
accidentally select icons which might have a non desired character.

This commit disables such selections by using the non standard CSS
propery user-select:
https://developer.mozilla.org/en-US/docs/CSS/user-select
as well as -webkit-touch-callout:
http://css-infos.net/property/-webkit-touch-callout
