### PR TITLE
Add Tooltip/Popover Support Inside SVGs

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -118,12 +118,24 @@
 
         inside = /in/.test(placement)
 
-        $tip
-          .detach()
-          .css({ top: 0, left: 0, display: 'block' })
-          .insertAfter(this.$element)
+        if($('#'+this.$element[0].id,$('svg')).length > 0){
+	        $tip
+		      .remove()
+		      .css({ top: 0, left: 0, display: 'block' })
+		      .prependTo(document.body)
 
-        pos = this.getPosition(inside)
+	        pos = $.extend({}, this.$element.offset(), {
+		      width: this.$element[0].getBoundingClientRect().width
+		      , height: this.$element[0].getBoundingClientRect().height
+	        })
+	    } else {
+		     $tip
+			     .detach()
+			     .css({ top: 0, left: 0, display: 'block' })
+			     .insertAfter(this.$element)
+
+		     pos = this.getPosition(inside)
+	    }
 
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight


### PR DESCRIPTION
This checks if the the element is part of an SVG and adds the tooltip/popup div to the body instead of inside the SVG. It also calculates the position for the SVG element. 

This is the result of the thread at http://stackoverflow.com/questions/13943582/why-doesnt-twitter-bootstrap-popover-work-with-svg-elements?lq=1
