### PR TITLE
Improve user-select mixin in Firefox

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -349,6 +349,9 @@
        -o-user-select: @select;
           user-select: @select;
 }
+.user-select (@select) when (@select = none) {
+  -moz-user-select: -moz-none;
+}
 
 // Resize anything
 .resizable(@direction) {


### PR DESCRIPTION
"-moz-none" is marginally better than "none" on Firefox. "none" prevents you from styling sub-elements differently.

See MDN: https://developer.mozilla.org/en-US/docs/CSS/user-select
