### PR TITLE
Make sure line-height is preserved for tooltips

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -28,6 +28,7 @@
   text-decoration: none;
   background-color: @tooltipBackground;
   .border-radius(@baseBorderRadius);
+  line-height: @baseLineHeight;
 }
 
 // Arrows


### PR DESCRIPTION
This change allows tooltips to be used inside h\* or any other tag
changing line height.
