### PR TITLE
Modal action sent with hide event

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -82,11 +82,12 @@
     , hide: function (e) {
         e && e.preventDefault()
 
-        var that = this
+        var that = this,
+            action = e && $(e.target).attr('data-action')
 
         e = $.Event('hide')
 
-        this.$element.trigger(e)
+        this.$element.trigger(e, action)
 
         if (!this.isShown || e.isDefaultPrevented()) return
 

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -117,4 +117,23 @@ $(function () {
           })
           .modal("toggle")
       })
+
+      test("should trigger hide event with action when clicking a button with data-dismiss and data-action attr set", function(){
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'><span class='save' data-dismiss='modal' data-action='save'></span></div>")
+        div
+            .bind("shown", function () {
+                div.find('.save').click()
+            })
+            .bind("hide", function(e, action) {
+                ok(action === 'save', 'action sent')
+            })
+            .bind("hidden", function () {
+                div.remove()
+                start()
+            })
+            .modal("toggle")
+      })
+
 })


### PR DESCRIPTION
Modal - if data-dismiss button also has a data-action attribute, send the action string with the hide event that is emitted from the hide method.
