### PR TITLE
Fix Qunit.done use to support grunt-contrib-qunit

### DIFF
--- a/js/tests/unit/bootstrap-phantom.js
+++ b/js/tests/unit/bootstrap-phantom.js
@@ -14,8 +14,8 @@ QUnit.moduleDone = function (opts) {
   }
 }
 
-QUnit.done = function (opts) {
+QUnit.done(function (opts) {
   console.log("\n================================================")
   console.log("Tests completed in " + opts.runtime + " milliseconds")
   console.log(opts.passed + " tests of " + opts.total + " passed, " + opts.failed + " failed.")
-}
+})


### PR DESCRIPTION
It was overriding Qunit.done, but that doesn't appear to be necessary and it causes a PhantomJS timeout when using grunt-contrib-qunit. They must be using done() also.
Instead we can just pass the function as an arg as intended.
http://api.qunitjs.com/QUnit.done/

Not really a problem unless you switch to grunt some day.
