### PR TITLE
Updating docs -> popover to show container option

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1028,7 +1028,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
              <td>string | false</td>
              <td>false</td>
              <td>
-              <p>Appends the tooltip to a specific element <code>container: 'body'</code></p>
+              <p>Appends the popover to a specific element <code>container: 'body'</code></p>
              </td>
            </tr>
           </tbody>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1023,6 +1023,14 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
               <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
              </td>
            </tr>
+           <tr>
+             <td>container</td>
+             <td>string | false</td>
+             <td>false</td>
+             <td>
+              <p>Appends the tooltip to a specific element <code>container: 'body'</code></p>
+             </td>
+           </tr>
           </tbody>
         </table>
         <div class="alert alert-info">

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -958,7 +958,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
              <td>{{_i}}string | false{{/i}}</td>
              <td>{{_i}}false{{/i}}</td>
              <td>
-              <p>{{_i}}Appends the tooltip to a specific element <code>container: 'body'</code>{{/i}}</p>
+              <p>{{_i}}Appends the popover to a specific element <code>container: 'body'</code>{{/i}}</p>
              </td>
            </tr>
           </tbody>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -953,6 +953,14 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
               <p>{{_i}}Object structure is: <code>delay: { show: 500, hide: 100 }</code>{{/i}}</p>
              </td>
            </tr>
+           <tr>
+             <td>{{_i}}container{{/i}}</td>
+             <td>{{_i}}string | false{{/i}}</td>
+             <td>{{_i}}false{{/i}}</td>
+             <td>
+              <p>{{_i}}Appends the tooltip to a specific element <code>container: 'body'</code>{{/i}}</p>
+             </td>
+           </tr>
           </tbody>
         </table>
         <div class="alert alert-info">


### PR DESCRIPTION
I was checking out the updated docs pages and saw I didnt add the container option to the docs for the popovers, so I figured I would add that. 
