### PR TITLE
Add a create event to the carousel

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -166,6 +166,7 @@
       if (typeof option == 'number') data.to(option)
       else if (action) data[action]()
       else if (options.interval) data.pause().cycle()
+      $this.trigger('create.carousel');
     })
   }
 

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -16,6 +16,21 @@ $(function () {
         ok($(document.body).carousel()[0] == document.body, 'document.body returned')
       })
 
+      test("should fire create.carousel event when a carousel is initialised", 1, function () {
+        var template = '<div id="myCarousel" class="carousel slide"><div class="carousel-inner"><div class="item active"><img alt=""><div class="carousel-caption"><h4>{{_i}}First Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Second Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Third Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div></div><a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a><a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a></div>'
+        stop()
+        $(document.body)
+          .append(template)
+          .on('create.carousel', function () {
+            ok(true)
+            $(document.body).off('create.carousel')
+            $('#myCarousel').remove()
+            start()
+          })
+        $.support.transition = false
+        $('#myCarousel').carousel()
+      })
+
       test("should not fire sliden when slide is prevented", function () {
         $.support.transition = false
         stop()
@@ -77,19 +92,5 @@ $(function () {
         $('[data-slide]').first().click();
         ok($('#myCarousel').data('carousel').options.interval == 1814, "attributes should be read only on intitialization");
         $('#myCarousel').remove();
-      })
-
-      test("should fire create.carousel event when a carousel is initialised", 1, function () {
-        var template = '<div id="myCarousel" class="carousel slide"><div class="carousel-inner"><div class="item active"><img alt=""><div class="carousel-caption"><h4>{{_i}}First Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Second Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Third Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div></div><a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a><a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a></div>'
-        stop()
-        $(document.body)
-          .append(template)
-          .on('create.carousel', function () {
-            ok(true)
-            start()
-            $('#myCarousel').remove()
-          })
-        $.support.transition = false
-        $('#myCarousel').carousel()
       })
 })

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -16,19 +16,6 @@ $(function () {
         ok($(document.body).carousel()[0] == document.body, 'document.body returned')
       })
 
-      test("should fire create.carousel event when a carousel is initialised", 1, function () {
-        var template = '<div id="myCarousel" class="carousel slide"><div class="carousel-inner"><div class="item active"><img alt=""><div class="carousel-caption"><h4>{{_i}}First Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Second Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Third Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div></div><a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a><a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a></div>'
-        stop()
-        $(document.body)
-          .append(template)
-          .on('create.carousel', function () {
-            ok(true)
-            start()
-          })
-        $.support.transition = false
-        $('#myCarousel').carousel()
-      })
-
       test("should not fire sliden when slide is prevented", function () {
         $.support.transition = false
         stop()
@@ -90,5 +77,19 @@ $(function () {
         $('[data-slide]').first().click();
         ok($('#myCarousel').data('carousel').options.interval == 1814, "attributes should be read only on intitialization");
         $('#myCarousel').remove();
+      })
+
+      test("should fire create.carousel event when a carousel is initialised", 1, function () {
+        var template = '<div id="myCarousel" class="carousel slide"><div class="carousel-inner"><div class="item active"><img alt=""><div class="carousel-caption"><h4>{{_i}}First Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Second Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Third Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div></div><a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a><a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a></div>'
+        stop()
+        $(document.body)
+          .append(template)
+          .on('create.carousel', function () {
+            ok(true)
+            start()
+            $('#myCarousel').remove()
+          })
+        $.support.transition = false
+        $('#myCarousel').carousel()
       })
 })

--- a/js/tests/unit/bootstrap-carousel.js
+++ b/js/tests/unit/bootstrap-carousel.js
@@ -16,6 +16,19 @@ $(function () {
         ok($(document.body).carousel()[0] == document.body, 'document.body returned')
       })
 
+      test("should fire create.carousel event when a carousel is initialised", 1, function () {
+        var template = '<div id="myCarousel" class="carousel slide"><div class="carousel-inner"><div class="item active"><img alt=""><div class="carousel-caption"><h4>{{_i}}First Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Second Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div><div class="item"><img alt=""><div class="carousel-caption"><h4>{{_i}}Third Thumbnail label{{/i}}</h4><p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit.</p></div></div></div><a class="left carousel-control" href="#myCarousel" data-slide="prev">&lsaquo;</a><a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a></div>'
+        stop()
+        $(document.body)
+          .append(template)
+          .on('create.carousel', function () {
+            ok(true)
+            start()
+          })
+        $.support.transition = false
+        $('#myCarousel').carousel()
+      })
+
       test("should not fire sliden when slide is prevented", function () {
         $.support.transition = false
         stop()


### PR DESCRIPTION
Adds a `create.carousel` event which is fired after a carousel is initialised. It can be used to add custom functionality separate from the main plugin. For example, I'm using it to add touch swipe/tap support to the carousel.
