### PR TITLE
Radio buttons and checkboxes styled for <input type="radio" /> and <input type="checkbox" />

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3248,6 +3248,28 @@ button.close {
           box-shadow: none;
 }
 
+input:checked + label.btn {
+  background-image: none;
+  outline: 0;
+  -webkit-box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+     -moz-box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+          box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+input[disabled] + label.btn {
+  cursor: default;
+  background-image: none;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+     -moz-box-shadow: none;
+          box-shadow: none;
+}
+
+.btn-group > input {
+  display: none;
+}
+
 .btn-large {
   padding: 11px 19px;
   font-size: 17.5px;
@@ -3628,7 +3650,8 @@ input[type="submit"].btn.btn-mini {
   font-size: 17.5px;
 }
 
-.btn-group > .btn:first-child {
+.btn-group > .btn:first-child,
+.btn-group input:first-child + .btn {
   margin-left: 0;
   -webkit-border-bottom-left-radius: 4px;
           border-bottom-left-radius: 4px;

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1171,6 +1171,27 @@ $('#my-alert').bind('closed', function () {
   &lt;button type="button" class="btn btn-primary"&gt;Right&lt;/button&gt;
 &lt;/div&gt;
 </pre>
+            <p>Checkbox with <code>&lt;input type="checkbox" /&gt;</code>.</p>
+            <div class="bs-docs-example" style="padding-bottom: 24px;">
+            <div class="btn-group">
+              <input type="checkbox" checked id="checkbox_1" value="1" />
+              <label class="btn btn-primary" for="checkbox_1">Checkbox one</label>
+              <input type="checkbox" id="checkbox_2" value="2" />
+              <label class="btn btn-primary" for="checkbox_2">Checkbox two</label>
+              <input type="checkbox" disabled id="checkbox_3" value="3" />
+              <label class="btn btn-primary" for="checkbox_3">Disabled checkbox three</label>
+            </div>
+            </div>
+<pre class="prettyprint linenums">
+&lt;div class="btn-group"&gt;
+  &lt;input type="checkbox" checked id="checkbox_1" value="1" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_1"&gt;Checkbox one&lt;/label&gt;
+  &lt;input type="checkbox" id="checkbox_2" value="2" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_2"&gt;Checkbox two&lt;/label&gt;
+  &lt;input type="checkbox" disabled id="checkbox_3" value="3" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_3"&gt;Disabled checkbox three&lt;/label&gt;
+&lt;/div&gt;
+</pre>
 
             <h4>Radio</h4>
             <p>Add <code>data-toggle="buttons-radio"</code> for radio style toggling on btn-group.</p>
@@ -1189,6 +1210,27 @@ $('#my-alert').bind('closed', function () {
 &lt;/div&gt;
 </pre>
 
+            <p>Radio button with <code>&lt;input type="radio" /&gt;</code>.</p>
+            <div class="bs-docs-example" style="padding-bottom: 24px;">
+              <div class="btn-group">
+                <input type="radio" name="radios" id="radio_1" checked />
+                <label class="btn btn-primary" for="radio_1">Radio one</label>
+                <input type="radio" name="radios" id="radio_2" />
+                <label class="btn btn-primary" for="radio_2">Radio two</label>
+                <input type="radio" name="radios" disabled id="radio_3" />
+                <label class="btn btn-primary" for="radio_3">Disabled radio three</label>
+              </div>
+            </div>
+<pre class="prettyprint linenums">
+&lt;div class="btn-group"&gt;
+  &lt;input type="radio" name="radios" id="radio_1" checked /&gt;
+  &lt;label class="btn btn-primary" for="radio_1"&gt;Radio one&lt;/label&gt;
+  &lt;input type="radio" name="radios" id="radio_2" /&gt;
+  &lt;label class="btn btn-primary" for="radio_2"&gt;Radio two&lt;/label&gt;
+  &lt;input type="radio" name="radios" disabled id="radio_3" /&gt;
+  &lt;label class="btn btn-primary" for="radio_3"&gt;Disabled radio three&lt;/label&gt;
+&lt;/div&gt;
+</pre>
 
             <hr class="bs-docs-separator">
 

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1101,6 +1101,27 @@ $('#my-alert').bind('closed', function () {
   &lt;button type="button" class="btn btn-primary"&gt;Right&lt;/button&gt;
 &lt;/div&gt;
 </pre>
+            <p>{{_i}}Checkbox with <code>&lt;input type="checkbox" /&gt;</code>.{{/i}}</p>
+            <div class="bs-docs-example" style="padding-bottom: 24px;">
+            <div class="btn-group">
+              <input type="checkbox" checked id="checkbox_1" value="1" />
+              <label class="btn btn-primary" for="checkbox_1">Checkbox one</label>
+              <input type="checkbox" id="checkbox_2" value="2" />
+              <label class="btn btn-primary" for="checkbox_2">Checkbox two</label>
+              <input type="checkbox" disabled id="checkbox_3" value="3" />
+              <label class="btn btn-primary" for="checkbox_3">Disabled checkbox three</label>
+            </div>
+            </div>{{! /example }}
+<pre class="prettyprint linenums">
+&lt;div class="btn-group"&gt;
+  &lt;input type="checkbox" checked id="checkbox_1" value="1" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_1"&gt;Checkbox one&lt;/label&gt;
+  &lt;input type="checkbox" id="checkbox_2" value="2" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_2"&gt;Checkbox two&lt;/label&gt;
+  &lt;input type="checkbox" disabled id="checkbox_3" value="3" /&gt;
+  &lt;label class="btn btn-primary" for="checkbox_3"&gt;Disabled checkbox three&lt;/label&gt;
+&lt;/div&gt;
+</pre>
 
             <h4>{{_i}}Radio{{/i}}</h4>
             <p>{{_i}}Add <code>data-toggle="buttons-radio"</code> for radio style toggling on btn-group.{{/i}}</p>
@@ -1119,6 +1140,27 @@ $('#my-alert').bind('closed', function () {
 &lt;/div&gt;
 </pre>
 
+            <p>{{_i}}Radio button with <code>&lt;input type="radio" /&gt;</code>.{{/i}}</p>
+            <div class="bs-docs-example" style="padding-bottom: 24px;">
+              <div class="btn-group">
+                <input type="radio" name="radios" id="radio_1" checked />
+                <label class="btn btn-primary" for="radio_1">Radio one</label>
+                <input type="radio" name="radios" id="radio_2" />
+                <label class="btn btn-primary" for="radio_2">Radio two</label>
+                <input type="radio" name="radios" disabled id="radio_3" />
+                <label class="btn btn-primary" for="radio_3">Disabled radio three</label>
+              </div>
+            </div>{{! /example }}
+<pre class="prettyprint linenums">
+&lt;div class="btn-group"&gt;
+  &lt;input type="radio" name="radios" id="radio_1" checked /&gt;
+  &lt;label class="btn btn-primary" for="radio_1"&gt;Radio one&lt;/label&gt;
+  &lt;input type="radio" name="radios" id="radio_2" /&gt;
+  &lt;label class="btn btn-primary" for="radio_2"&gt;Radio two&lt;/label&gt;
+  &lt;input type="radio" name="radios" disabled id="radio_3" /&gt;
+  &lt;label class="btn btn-primary" for="radio_3"&gt;Disabled radio three&lt;/label&gt;
+&lt;/div&gt;
+</pre>
 
             <hr class="bs-docs-separator">
 

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -57,7 +57,8 @@
 }
 
 // Set corners individual because sometimes a single button can be in a .btn-group and we need :first-child and :last-child to both match
-.btn-group > .btn:first-child {
+.btn-group > .btn:first-child,
+.btn-group input:first-child + .btn {
   margin-left: 0;
   .border-top-left-radius(@baseBorderRadius);
   .border-bottom-left-radius(@baseBorderRadius);

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -60,6 +60,23 @@
 
 }
 
+input:checked + label.btn {
+  background-image: none;
+  outline: 0;
+  .box-shadow(~"inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)");
+}
+
+input[disabled] + label.btn {
+  cursor: default;
+  background-image: none;
+  .opacity(65);
+  .box-shadow(none);
+}
+
+.btn-group > input {
+    display: none;
+}
+
 
 
 // Button Sizes

--- a/less/tests/buttons.html
+++ b/less/tests/buttons.html
@@ -113,6 +113,28 @@
             <li><a href="#">Separated link</a></li>
           </ul>
         </div><!-- /btn-group -->
+
+<input type="checkbox" class="hidden" id="single_checkbox" />
+<label class="btn" for="single_checkbox">Single</label>
+<br/><br/>
+<div class="btn-group">
+    <input type="checkbox" id="checkbox_1" />
+    <label class="btn" for="checkbox_1">Checkbox one</label>
+    <input type="checkbox" id="checkbox_2" />
+    <label class="btn" for="checkbox_2">Checkbox two</label>
+    <input type="checkbox" disabled id="checkbox_3" />
+    <label class="btn" for="checkbox_3">Disabled checkbox three</label>
+</div>
+<br/>
+<div class="btn-group">
+    <input type="radio" name="radios" id="radio_1" />
+    <label class="btn" for="radio_1">Radio one</label>
+    <input type="radio" name="radios" id="radio_2" />
+    <label class="btn" for="radio_2">Radio two</label>
+    <input type="radio" name="radios" id="radio_3" />
+    <label class="btn" for="radio_3">Disabled radio three</label>
+</div>
+
       </div><!-- /btn-toolbar -->
 
 

--- a/less/tests/buttons.html
+++ b/less/tests/buttons.html
@@ -113,28 +113,6 @@
             <li><a href="#">Separated link</a></li>
           </ul>
         </div><!-- /btn-group -->
-
-<input type="checkbox" class="hidden" id="single_checkbox" />
-<label class="btn" for="single_checkbox">Single</label>
-<br/><br/>
-<div class="btn-group">
-    <input type="checkbox" id="checkbox_1" />
-    <label class="btn" for="checkbox_1">Checkbox one</label>
-    <input type="checkbox" id="checkbox_2" />
-    <label class="btn" for="checkbox_2">Checkbox two</label>
-    <input type="checkbox" disabled id="checkbox_3" />
-    <label class="btn" for="checkbox_3">Disabled checkbox three</label>
-</div>
-<br/>
-<div class="btn-group">
-    <input type="radio" name="radios" id="radio_1" />
-    <label class="btn" for="radio_1">Radio one</label>
-    <input type="radio" name="radios" id="radio_2" />
-    <label class="btn" for="radio_2">Radio two</label>
-    <input type="radio" name="radios" id="radio_3" />
-    <label class="btn" for="radio_3">Disabled radio three</label>
-</div>
-
       </div><!-- /btn-toolbar -->
 
 


### PR DESCRIPTION
Radio buttons and checkboxes with <input type="radio" /> and <input type="checkbox" /> styled in the same way as the ones using <button /> markup.

Tested with:
- Chrome 23
- Firefox 18
- IE 9

Example:

``` html
<div class="btn-group">
  <input type="checkbox" checked id="checkbox_1" value="1" />
  <label class="btn btn-primary" for="checkbox_1">Checkbox one</label>
  <input type="checkbox" id="checkbox_2" value="2" />
  <label class="btn btn-primary" for="checkbox_2">Checkbox two</label>
  <input type="checkbox" disabled id="checkbox_3" value="3" />
  <label class="btn btn-primary" for="checkbox_3">Disabled checkbox three</label>
</div>
```
