### PR TITLE
added missing class to doc example

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -177,7 +177,7 @@
 <pre class="prettyprint linenums">
 &lt;ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu"&gt;
   &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;Regular link&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;Disabled link&lt;/a&gt;&lt;/li&gt;
+  &lt;li class="disabled"&gt;&lt;a tabindex="-1" href="#"&gt;Disabled link&lt;/a&gt;&lt;/li&gt;
   &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;Another link&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 </pre>

--- a/docs/templates/pages/components.mustache
+++ b/docs/templates/pages/components.mustache
@@ -106,7 +106,7 @@
 <pre class="prettyprint linenums">
 &lt;ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu"&gt;
   &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;{{_i}}Regular link{{/i}}&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;{{_i}}Disabled link{{/i}}&lt;/a&gt;&lt;/li&gt;
+  &lt;li class="disabled"&gt;&lt;a tabindex="-1" href="#"&gt;{{_i}}Disabled link{{/i}}&lt;/a&gt;&lt;/li&gt;
   &lt;li&gt;&lt;a tabindex="-1" href="#"&gt;{{_i}}Another link{{/i}}&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 </pre>


### PR DESCRIPTION
via commit a7231854c91399aafb371ccdf2b930037a7ac5ed mark added an example of the disabled links in the dropdown menus, but missed the `class="disabled"` in the example code which might confuse some people
