### PR TITLE
Fix typo in Nesting Columns example code

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -224,7 +224,7 @@
     Level 1: 9 columns
     &lt;div class="row"&gt;
       &lt;div class="span6"&gt;Level 2: 6 columns&lt;/div&gt;
-      &lt;div class="span3"&gt;Level 2: 6 columns&lt;/div&gt;
+      &lt;div class="span6"&gt;Level 2: 6 columns&lt;/div&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/div&gt;


### PR DESCRIPTION
The example code under Nesting columns shows a Level 2 of 6 columns but the code itself says "div class=span3". Pointed out by @usaphp in #6608
