### PR TITLE
Use floats instead of font-size:0 hack to accommodate nested content

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1660,7 +1660,6 @@ select:focus:invalid:focus {
 .input-prepend {
   display: inline-block;
   margin-bottom: 10px;
-  font-size: 0;
   white-space: nowrap;
   vertical-align: middle;
 }
@@ -1671,11 +1670,23 @@ select:focus:invalid:focus {
 .input-prepend select,
 .input-append .uneditable-input,
 .input-prepend .uneditable-input,
-.input-append .dropdown-menu,
-.input-prepend .dropdown-menu,
-.input-append .popover,
-.input-prepend .popover {
-  font-size: 14px;
+.input-append .add-on,
+.input-prepend .add-on,
+.input-append .btn,
+.input-prepend .btn,
+.input-append .btn-group,
+.input-prepend .btn-group {
+  float: left;
+}
+
+.input-append:after,
+.input-prepend:after {
+  display: block;
+  height: 0;
+  overflow: hidden;
+  clear: both;
+  font: 0/0;
+  content: ".";
 }
 
 .input-append input,
@@ -1709,7 +1720,6 @@ select:focus:invalid:focus {
   height: 20px;
   min-width: 16px;
   padding: 4px 5px;
-  font-size: 14px;
   font-weight: normal;
   line-height: 20px;
   text-align: center;

--- a/less/forms.less
+++ b/less/forms.less
@@ -425,16 +425,26 @@ select:focus:invalid {
   display: inline-block;
   margin-bottom: @baseLineHeight / 2;
   vertical-align: middle;
-  font-size: 0; // white space collapse hack
   white-space: nowrap; // Prevent span and input from separating
 
-  // Reset the white space collapse hack
+  // Float inputs nested content
   input,
   select,
   .uneditable-input,
-  .dropdown-menu,
-  .popover {
-    font-size: @baseFontSize;
+  .add-on,
+  .btn,
+  .btn-group {
+    float: left;
+  }
+
+  // Clear the floats
+  &:after {
+    content: ".";
+    display: block;
+    clear: both;
+    height: 0;
+    overflow: hidden;
+    font: 0/0;
   }
 
   input,
@@ -456,7 +466,6 @@ select:focus:invalid {
     height: @baseLineHeight;
     min-width: 16px;
     padding: 4px 5px;
-    font-size: @baseFontSize;
     font-weight: normal;
     line-height: @baseLineHeight;
     text-align: center;


### PR DESCRIPTION
This allows for nested content such as validation tooltips (both Bootstrap and third-party). Closes #6236. See further details in [my comment on the issue](https://github.com/twitter/bootstrap/issues/6236#issuecomment-12361151).
