### PR TITLE
Use contrast function to make things readable on dark backgrounds

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -56,7 +56,7 @@ h1, h2, h3, h4, h5, h6 {
   small {
     font-weight: normal;
     line-height: 1;
-    color: @grayLight;
+    color: contrast(@body-background, @grayDark, @grayLight);
   }
 }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -20,14 +20,14 @@
 // -------------------------
 
 @body-background:         #fff;
-@text-color:              @grayDark;
+@text-color:              contrast(@body-background, @grayDark, @grayLighter);
 
 
 // Links
 // -------------------------
 
 @link-color:              #428bca;
-@link-color-hover:        darken(@link-color, 15%);
+@link-color-hover:        contrast(@body-background, darken(@link-color, 15%), lighten(@link-color, 15%));
 
 
 // Typography
@@ -66,10 +66,10 @@
 // -------------------------
 
 @table-background:                   transparent; // overall background-color
-@table-background-accent:            #f9f9f9; // for striping
-@table-background-hover:             #f5f5f5; // for hover
+@table-background-accent:            contrast(@body-background, #f9f9f9, #222); // for striping
+@table-background-hover:             contrast(@body-background, #f5f5f5, #333); // for hover
 
-@table-border:                       #ddd; // table and cell border
+@table-border:                       contrast(@body-background, #ddd, #333); // table and cell border
 
 
 // Buttons


### PR DESCRIPTION
If you change bootstrap's background color from light to dark, many things become unreadable, and there are lots of color values that need updating manually in order to make things usable. There's no reason this can't be done automatically since we've got all kinds of color processing functions on hand in less. This commit makes some attempt at doing this using less' `contrast` function (which I wrote specifically for this purpose!). It's not a complete translation, but if you think this is a good idea, I'll persevere.

This shows an example page with the default bootstrap styles after changing only `@body-background` to `#000`:

![Screen Shot 2013-01-18 at 10 10 15](https://f.cloud.github.com/assets/81561/77617/30926c5a-614f-11e2-9d3c-9b4905d2fc89.png)

and this is how it looks with this change applied:

![Screen Shot 2013-01-18 at 10 11 54](https://f.cloud.github.com/assets/81561/77619/3a16c4e2-614f-11e2-8f72-e8f81e77602b.png)

It strikes me that much of the inverse navbar could be achieved using a similar mechanism and far less markup.
