### PR TITLE
Renamed input-mini class to input-xsmall for consistency

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1259,23 +1259,23 @@ input[type="color"].input-small,
   border-radius: 3px;
 }
 
-select.input-mini,
-textarea.input-mini,
-input[type="text"].input-mini,
-input[type="password"].input-mini,
-input[type="datetime"].input-mini,
-input[type="datetime-local"].input-mini,
-input[type="date"].input-mini,
-input[type="month"].input-mini,
-input[type="time"].input-mini,
-input[type="week"].input-mini,
-input[type="number"].input-mini,
-input[type="email"].input-mini,
-input[type="url"].input-mini,
-input[type="search"].input-mini,
-input[type="tel"].input-mini,
-input[type="color"].input-mini,
-.uneditable-input.input-mini {
+select.input-xsmall,
+textarea.input-xsmall,
+input[type="text"].input-xsmall,
+input[type="password"].input-xsmall,
+input[type="datetime"].input-xsmall,
+input[type="datetime-local"].input-xsmall,
+input[type="date"].input-xsmall,
+input[type="month"].input-xsmall,
+input[type="time"].input-xsmall,
+input[type="week"].input-xsmall,
+input[type="number"].input-xsmall,
+input[type="email"].input-xsmall,
+input[type="url"].input-xsmall,
+input[type="search"].input-xsmall,
+input[type="tel"].input-xsmall,
+input[type="color"].input-xsmall,
+.uneditable-input.input-xsmall {
   padding: 0 6px;
   font-size: 10.5px;
   border-radius: 3px;

--- a/docs/css.html
+++ b/docs/css.html
@@ -1459,13 +1459,13 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
             <div class="controls docs-input-sizes">
               <input class="input-large" type="text" placeholder=".input-large">
               <input class="input-small" type="text" placeholder=".input-small">
-              <input class="input-mini" type="text" placeholder=".input-mini">
+              <input class="input-xsmall" type="text" placeholder=".input-xsmall">
             </div>
           </form>
 <pre class="prettyprint linenums">
 &lt;input class="input-large" type="text" placeholder=".input-large"&gt;
 &lt;input class="input-small" type="text" placeholder=".input-small"&gt;
-&lt;input class="input-mini" type="text" placeholder=".input-mini"&gt;
+&lt;input class="input-xsmall" type="text" placeholder=".input-xsmall"&gt;
 </pre>
 
           <h4>Column sizing</h4>

--- a/docs/templates/pages/css.mustache
+++ b/docs/templates/pages/css.mustache
@@ -1398,13 +1398,13 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
             <div class="controls docs-input-sizes">
               <input class="input-large" type="text" placeholder=".input-large">
               <input class="input-small" type="text" placeholder=".input-small">
-              <input class="input-mini" type="text" placeholder=".input-mini">
+              <input class="input-xsmall" type="text" placeholder=".input-xsmall">
             </div>
           </form>
 <pre class="prettyprint linenums">
 &lt;input class="input-large" type="text" placeholder=".input-large"&gt;
 &lt;input class="input-small" type="text" placeholder=".input-small"&gt;
-&lt;input class="input-mini" type="text" placeholder=".input-mini"&gt;
+&lt;input class="input-xsmall" type="text" placeholder=".input-xsmall"&gt;
 </pre>
 
           <h4>Column sizing</h4>

--- a/less/forms.less
+++ b/less/forms.less
@@ -281,7 +281,7 @@ input[type="color"],
     font-size: @font-size-small;
     border-radius: @border-radius-small;
   }
-  &.input-mini {
+  &.input-xsmall {
     padding: @padding-mini;
     font-size: @font-size-mini;
     border-radius: @border-radius-small;


### PR DESCRIPTION
This was originally reported in issue #2084.
