### PR TITLE
Update package.json to current Recess version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "devDependencies": {
       "uglify-js": "1.3.4"
     , "jshint": "0.9.1"
-    , "recess": "1.0.3"
+    , "recess": "1.1.6"
     , "connect": "2.1.3"
     , "hogan.js": "2.0.0"
   }


### PR DESCRIPTION
The makefile gives me the message:

```
path.existsSync is now called `fs.existsSync`
```

with Recess 1.0.3

The message stopped showing up as of 1.1.3 but the project is now at 1.1.6
