### PR TITLE
Add new autocomplete standard to docs & examples

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -952,7 +952,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
           <h3>Inline form</h3>
           <p>Add <code>.form-inline</code> for left-aligned labels and inline-block controls for a compact layout.</p>
           <form class="bs-docs-example form-inline">
-            <input type="text" class="input-small" placeholder="Email">
+            <input type="text" class="input-small" placeholder="Email" autocomplete="email">
             <input type="password" class="input-small" placeholder="Password">
             <label class="checkbox">
               <input type="checkbox"> Remember me
@@ -961,7 +961,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
           </form>
 <pre class="prettyprint linenums">
 &lt;form class="form-inline"&gt;
-  &lt;input type="text" class="input-small" placeholder="Email"&gt;
+  &lt;input type="text" class="input-small" placeholder="Email" autocomplete="email"&gt;
   &lt;input type="password" class="input-small" placeholder="Password"&gt;
   &lt;label class="checkbox"&gt;
     &lt;input type="checkbox"&gt; Remember me
@@ -982,7 +982,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
             <div class="control-group">
               <label class="control-label" for="inputEmail">Email</label>
               <div class="controls">
-                <input type="text" id="inputEmail" placeholder="Email">
+                <input type="text" id="inputEmail" placeholder="Email" autocomplete="email">
               </div>
             </div>
             <div class="control-group">
@@ -1005,7 +1005,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
   &lt;div class="control-group"&gt;
     &lt;label class="control-label" for="inputEmail"&gt;Email&lt;/label&gt;
     &lt;div class="controls"&gt;
-      &lt;input type="text" id="inputEmail" placeholder="Email"&gt;
+      &lt;input type="text" id="inputEmail" placeholder="Email" autocomplete="email"&gt;
     &lt;/div&gt;
   &lt;/div&gt;
   &lt;div class="control-group"&gt;
@@ -1587,7 +1587,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
           <h3>Invalid inputs</h3>
           <p>Style inputs via default browser functionality with <code>:invalid</code>. Specify a <code>type</code>, add the <code>required</code> attribute if the field is not optional, and (if applicable) specify a <code>pattern</code>.</p>
           <form class="bs-docs-example form-inline">
-            <input class="span3" type="email" placeholder="test@example.com" required>
+            <input class="span3" type="email" placeholder="test@example.com" autocomplete="email" required>
           </form>
 <pre class="prettyprint linenums">
 &lt;input class="span3" type="email" required&gt;
@@ -2138,7 +2138,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
               <label class="control-label" for="inputIcon">Email address</label>
               <div class="controls">
                 <div class="input-prepend">
-                  <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text">
+                  <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text" autocomplete="email">
                 </div>
               </div>
             </div>
@@ -2149,7 +2149,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
   &lt;div class="controls"&gt;
     &lt;div class="input-prepend"&gt;
       &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;
-      &lt;input class="span2" id="inputIcon" type="text"&gt;
+      &lt;input class="span2" id="inputIcon" type="text" autocomplete="email"&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/div&gt;

--- a/docs/examples/hero.html
+++ b/docs/examples/hero.html
@@ -60,7 +60,7 @@
               </li>
             </ul>
             <form class="navbar-form pull-right">
-              <input class="span2" type="text" placeholder="Email">
+              <input class="span2" type="text" placeholder="Email" autocomplete="email">
               <input class="span2" type="password" placeholder="Password">
               <button type="submit" class="btn">Sign in</button>
             </form>

--- a/docs/examples/signin.html
+++ b/docs/examples/signin.html
@@ -63,7 +63,7 @@
 
       <form class="form-signin">
         <h2 class="form-signin-heading">Please sign in</h2>
-        <input type="text" class="input-block-level" placeholder="Email address">
+        <input type="text" class="input-block-level" placeholder="Email address" autocomplete="email">
         <input type="password" class="input-block-level" placeholder="Password">
         <label class="checkbox">
           <input type="checkbox" value="remember-me"> Remember me

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -889,7 +889,7 @@
           <h3>{{_i}}Inline form{{/i}}</h3>
           <p>{{_i}}Add <code>.form-inline</code> for left-aligned labels and inline-block controls for a compact layout.{{/i}}</p>
           <form class="bs-docs-example form-inline">
-            <input type="text" class="input-small" placeholder="{{_i}}Email{{/i}}">
+            <input type="text" class="input-small" placeholder="{{_i}}Email{{/i}}" autocomplete="email">
             <input type="password" class="input-small" placeholder="{{_i}}Password{{/i}}">
             <label class="checkbox">
               <input type="checkbox"> {{_i}}Remember me{{/i}}
@@ -898,7 +898,7 @@
           </form>{{! /example }}
 <pre class="prettyprint linenums">
 &lt;form class="form-inline"&gt;
-  &lt;input type="text" class="input-small" placeholder="{{_i}}Email{{/i}}"&gt;
+  &lt;input type="text" class="input-small" placeholder="{{_i}}Email{{/i}}" autocomplete="email"&gt;
   &lt;input type="password" class="input-small" placeholder="{{_i}}Password{{/i}}"&gt;
   &lt;label class="checkbox"&gt;
     &lt;input type="checkbox"&gt; {{_i}}Remember me{{/i}}
@@ -919,7 +919,7 @@
             <div class="control-group">
               <label class="control-label" for="inputEmail">{{_i}}Email{{/i}}</label>
               <div class="controls">
-                <input type="text" id="inputEmail" placeholder="{{_i}}Email{{/i}}">
+                <input type="text" id="inputEmail" placeholder="{{_i}}Email{{/i}}" autocomplete="email">
               </div>
             </div>
             <div class="control-group">
@@ -942,7 +942,7 @@
   &lt;div class="control-group"&gt;
     &lt;label class="control-label" for="inputEmail"&gt;{{_i}}Email{{/i}}&lt;/label&gt;
     &lt;div class="controls"&gt;
-      &lt;input type="text" id="inputEmail" placeholder="{{_i}}Email{{/i}}"&gt;
+      &lt;input type="text" id="inputEmail" placeholder="{{_i}}Email{{/i}}" autocomplete="email"&gt;
     &lt;/div&gt;
   &lt;/div&gt;
   &lt;div class="control-group"&gt;
@@ -1524,10 +1524,10 @@
           <h3>{{_i}}Invalid inputs{{/i}}</h3>
           <p>{{_i}}Style inputs via default browser functionality with <code>:invalid</code>. Specify a <code>type</code>, add the <code>required</code> attribute if the field is not optional, and (if applicable) specify a <code>pattern</code>.{{/i}}</p>
           <form class="bs-docs-example form-inline">
-            <input class="span3" type="email" placeholder="test@example.com" required>
+            <input class="span3" type="email" placeholder="test@example.com" autocomplete="email" required>
           </form>
 <pre class="prettyprint linenums">
-&lt;input class="span3" type="email" required&gt;
+&lt;input class="span3" type="email" autocomplete="email" required&gt;
 </pre>
 
           <h3>{{_i}}Disabled inputs{{/i}}</h3>
@@ -2075,7 +2075,7 @@
               <label class="control-label" for="inputIcon">{{_i}}Email address{{/i}}</label>
               <div class="controls">
                 <div class="input-prepend">
-                  <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text">
+                  <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text" autocomplete="email">
                 </div>
               </div>
             </div>
@@ -2086,7 +2086,7 @@
   &lt;div class="controls"&gt;
     &lt;div class="input-prepend"&gt;
       &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;
-      &lt;input class="span2" id="inputIcon" type="text"&gt;
+      &lt;input class="span2" id="inputIcon" type="text" autocomplete="email"&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/div&gt;


### PR DESCRIPTION
This adds the new autocomplete attribute to Bootstrap.

Supported in Chrome stable, see:
http://blog.chromium.org/2012/11/a-web-developers-guide-to-latest-chrome.html

and

http://www.whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.html#autofilling-form-controls:-the-autocomplete-attribute

Since many sites are copying the Bootstrap examples & templates verbatim, it's seems like a good idea to encourage the standards, though totally understood if you don't think this fits in the project.
