### PR TITLE
Incompatibility with GoogleCharts BarFormat

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -80,7 +80,7 @@ img {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%; /* Part 1: Set a maxium relative to the parent */
   width: auto\9; /* IE7-8 need help adjusting responsive images */
-  height: auto; /* Part 2: Scale the height according to the width, otherwise you get stretching */
+  height: auto\9; /* Part 2: Scale the height according to the width, otherwise you get stretching */
 
   vertical-align: middle;
   border: 0;


### PR DESCRIPTION
![69237-1222013112341pm](https://f.cloud.github.com/assets/633012/87986/18126c3c-64da-11e2-8b70-c7a55b96ff30.png)
With image height auto, we see some images being unnecessarily warped. You can see this problem if you set up a GoogleChart's BarFormat (https://developers.google.com/chart/interactive/docs/reference#barformatter)

Forcing children images to not be re-scaled past their parents imposes an unnecessary restriction on the developer.
