### PR TITLE
Add "component/" prefix to jquery dep in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
   "version": "2.2.2",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "component/jquery": "~1.8.0"
   }
 }

--- a/component.json
+++ b/component.json
@@ -1,7 +1,10 @@
 {
   "name": "bootstrap",
   "version": "2.2.2",
-  "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
+  "scripts": [
+    "./docs/assets/js/bootstrap.js", 
+    "./docs/assets/css/bootstrap.css"
+  ],
   "dependencies": {
     "component/jquery": "~1.8.0"
   }

--- a/component.json
+++ b/component.json
@@ -2,7 +2,9 @@
   "name": "bootstrap",
   "version": "2.2.2",
   "scripts": [
-    "./docs/assets/js/bootstrap.js", 
+    "./docs/assets/js/bootstrap.js"
+  ],
+  "styles" : [
     "./docs/assets/css/bootstrap.css"
   ],
   "dependencies": {

--- a/component.json
+++ b/component.json
@@ -2,10 +2,10 @@
   "name": "bootstrap",
   "version": "2.2.2",
   "scripts": [
-    "./docs/assets/js/bootstrap.js"
+    "docs/assets/js/bootstrap.js"
   ],
   "styles" : [
-    "./docs/assets/css/bootstrap.css"
+    "docs/assets/css/bootstrap.css"
   ],
   "dependencies": {
     "component/jquery": "~1.8.0"


### PR DESCRIPTION
fixes invalid component name error when running

```
error : Error: invalid component name "jquery"
```

when running

```
component install twitter/bootsrap
```
