### PR TITLE
fix for Issue #6303

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -27,8 +27,8 @@
  /* TOOLTIP PUBLIC CLASS DEFINITION
   * =============================== */
 
-  var toolTipType = 'tooltip',
-      Tooltip = function (element, options) {
+  var toolTipType = 'tooltip'
+    , Tooltip = function (element, options) {
     this.init(toolTipType, element, options)
   }
 
@@ -291,7 +291,7 @@
     //set the toolTipType var for future calls to init.
     toolTipType = newFuncName
     $.fn.tooltip = old
-    //return this for backwards compatibillity with original, even though I don't think original could possibly have
+    //return this for backwards compatibility with v2.2.2, even though I don't think original could possibly have
     //worked considering the way Tooltip.getOptions expected defaults to be a member of $.fn.tooltip, which may not exist
     //after running this.
     return this

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -27,8 +27,9 @@
  /* TOOLTIP PUBLIC CLASS DEFINITION
   * =============================== */
 
-  var Tooltip = function (element, options) {
-    this.init('tooltip', element, options)
+  var toolTipType = 'tooltip',
+      Tooltip = function (element, options) {
+    this.init(toolTipType, element, options)
   }
 
   Tooltip.prototype = {
@@ -45,12 +46,12 @@
       this.enabled = true
 
       if (this.options.trigger == 'click') {
-        this.$element.on('click.' + this.type, this.options.selector, $.proxy(this.toggle, this))
+        this.$element.on('click.tooltip', this.options.selector, $.proxy(this.toggle, this))
       } else if (this.options.trigger != 'manual') {
         eventIn = this.options.trigger == 'hover' ? 'mouseenter' : 'focus'
         eventOut = this.options.trigger == 'hover' ? 'mouseleave' : 'blur'
-        this.$element.on(eventIn + '.' + this.type, this.options.selector, $.proxy(this.enter, this))
-        this.$element.on(eventOut + '.' + this.type, this.options.selector, $.proxy(this.leave, this))
+        this.$element.on(eventIn + '.tooltip' , this.options.selector, $.proxy(this.enter, this))
+        this.$element.on(eventOut + '.tooltip' , this.options.selector, $.proxy(this.leave, this))
       }
 
       this.options.selector ?
@@ -241,7 +242,7 @@
     }
 
   , destroy: function () {
-      this.hide().$element.off('.' + this.type).removeData(this.type)
+      this.hide().$element.off('.tooltip').removeData(this.type)
     }
 
   }
@@ -255,9 +256,9 @@
   $.fn.tooltip = function ( option ) {
     return this.each(function () {
       var $this = $(this)
-        , data = $this.data('tooltip')
+        , data = $this.data(toolTipType)
         , options = typeof option == 'object' && option
-      if (!data) $this.data('tooltip', (data = new Tooltip(this, options)))
+      if (!data) $this.data(toolTipType, (data = new Tooltip(this, options)))
       if (typeof option == 'string') data[option]()
     })
   }
@@ -279,8 +280,20 @@
  /* TOOLTIP NO CONFLICT
   * =================== */
 
-  $.fn.tooltip.noConflict = function () {
+  $.fn.tooltip.noConflict = function (newFuncName) {
+    if(!/^[a-zA-Z]+/.test(newFuncName)){
+        throw 'tooltip.noConflict requires the newFuncName to be alpha letters only'
+        return false
+    }
+    //set the new name into the $.fn array, since the Tooltip object looks for things tied to it.
+    $.fn[newFuncName] = this
+    Tooltip.type = newFuncName
+    //set the toolTipType var for future calls to init.
+    toolTipType = newFuncName
     $.fn.tooltip = old
+    //return this for backwards compatibillity with original, even though I don't think original could possibly have
+    //worked considering the way Tooltip.getOptions expected defaults to be a member of $.fn.tooltip, which may not exist
+    //after running this.
     return this
   }
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -3,8 +3,10 @@ $(function () {
     module("bootstrap-tooltip")
 
       test("should provide no conflict", function () {
-        var tooltip = $.fn.tooltip.noConflict()
+        var tooltip = $.fn.tooltip.noConflict('newToolTipName')
         ok(!$.fn.tooltip, 'tooltip was set back to undefined (org value)')
+        ok($.fn.newToolTipName, 'tooltip was moved to newToolTipName as expected')
+        ok($.fn.newToolTipName.defaults, 'and defaults exists for newToolTipName as expected')
         $.fn.tooltip = tooltip
       })
 


### PR DESCRIPTION
I'm submitting an update to the noConflict method in bootstrap-tooltip.js.  It required a bit of reworking the Tooltip object since 'tooltip' was hardcoded in the init.  I have tested that it fixes issue #6303 for me in Chrome 24.0.1312.52 and Firefox 18.0 for Mac. And IE 9 for windows.
