### PR TITLE
Do not toggle collapsed state on collapse clicked element if target is still animating

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -160,7 +160,7 @@
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
-    $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+    if ($(target).css("height") !== "auto") $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     $(target).collapse(option)
   })
 

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -97,6 +97,7 @@
         , complete = function () {
             if (startEvent.type == 'show') that.reset()
             that.transitioning = 0
+            that.$element.removeClass('transitioning');
             that.$element.trigger(completeEvent)
           }
 
@@ -105,6 +106,7 @@
       if (startEvent.isDefaultPrevented()) return
 
       this.transitioning = 1
+      this.$element.addClass('transitioning');
 
       this.$element[method]('in')
 
@@ -160,7 +162,7 @@
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
-    if ($(target).css("height") !== "auto") $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+    if (!$(target).hasClass('transitioning')) $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     $(target).collapse(option)
   })
 


### PR DESCRIPTION
Fix for issue #6691

Not sure if the check for the target's height is "proper", but since for every collapse event, a new Collapse is created with its own (unshared) 'transitioning' state, which the click target doesn't have access to, this was the only thing I could think of for now.
