### PR TITLE
Move tooltip positioning class to be added before positioning

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -129,6 +129,7 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
+          .addClass(placement)
 
         this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 
@@ -154,7 +155,6 @@
 
         $tip
           .offset(tp)
-          .addClass(placement)
           .addClass('in')
 
         this.$element.trigger('shown')


### PR DESCRIPTION
Tooltip will be positioned wrong when there are position-specific tooltip styles(`.tooltip.right`, `.tooltip.right .tooltip-inner` with styles that change the box-model size), because the offset is calculated before the position classes(right, top, bottom, left) were added.

As shown: http://jsbin.com/esuwuj/10/edit

Simply adding the position class before calculating offset solves this issue.
