### PR TITLE
fix: .icon-folder-close same width as icon-folder-open

### DIFF
--- a/less/sprites.less
+++ b/less/sprites.less
@@ -166,7 +166,7 @@
 .icon-chevron-down       { background-position: -313px -119px; } // 1px, 1px off
 .icon-retweet            { background-position: -336px -120px; }
 .icon-shopping-cart      { background-position: -360px -120px; }
-.icon-folder-close       { background-position: -384px -120px; }
+.icon-folder-close       { background-position: -384px -120px; width: 16px; }
 .icon-folder-open        { background-position: -408px -120px; width: 16px; }
 .icon-resize-vertical    { background-position: -432px -119px; } // 1px, 1px off
 .icon-resize-horizontal  { background-position: -456px -118px; } // 1px, 2px off


### PR DESCRIPTION
.icon-folder-close same width as icon-folder-open. this prevents
buttons from wobbling if the icon changes from closed folder
to open folder

Tests:
unfixed version: http://baslr.github.com/boostrapButtons.html
fixed version: http://baslr.github.com/boostrapButtonsFix.html
