### PR TITLE
.dropdown & .dropup .caret selectors changing child carets unintentionally

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -31,7 +31,7 @@
 }
 
 // Place the caret
-.dropdown .caret {
+.dropdown > .caret {
   margin-top: 8px;
   margin-left: 2px;
 }

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -145,7 +145,7 @@
 .dropup,
 .navbar-fixed-bottom .dropdown {
   // Reverse the caret
-  .caret {
+  > .caret {
     border-top: 0;
     border-bottom: 4px solid @black;
     content: "\2191";


### PR DESCRIPTION
Made rules more specific to prevent this behavior.  The current rules would break this markup:

`<li class="dropdown"><span class="caret"></span><ul><li class="dropup"><span class="caret"></span></li></ul></li>`
