### PR TITLE
Positioning tooltip on edge case

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -190,7 +190,7 @@
 
       if (offset.left < 0){
         delta = -offset.left * 2;
-        offset.left = 0.1;
+        offset.left = 0;
         $tip.offset(offset);
         actualWidth = $tip[0].offsetWidth;
         actualHeight = $tip[0].offsetHeight;

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -190,7 +190,7 @@
 
       if (offset.left < 0){
         delta = -offset.left * 2;
-        offset.left = 0;
+        offset.left = .1;
         $tip.offset(offset);
         actualWidth = $tip[0].offsetWidth;
         actualHeight = $tip[0].offsetHeight;

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -180,7 +180,7 @@
     actualWidth = $tip[0].offsetWidth;
     actualHeight = $tip[0].offsetHeight;
 
-    if (placement == "top" && actualHeight != actualWidth){
+    if (placement == "top" && actualHeight != height){
       offset.top = offset.top + height - actualHeight;
       replace = true;
     }
@@ -190,7 +190,7 @@
 
       if (offset.left < 0){
         delta = -offset.left * 2;
-        offset.left = .1;
+        offset.left = 0.1;
         $tip.offset(offset);
         actualWidth = $tip[0].offsetWidth;
         actualHeight = $tip[0].offsetHeight;

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -152,14 +152,67 @@
             break
         }
 
-        $tip
-          .offset(tp)
-          .addClass(placement)
-          .addClass('in')
+        this.applyPlacement(tp, placement);
 
         this.$element.trigger('shown')
       }
     }
+
+  , applyPlacement: function(offset, placement){
+    var $tip
+      , width
+      , height
+      , actualWidth
+      , actualHeight
+      , delta
+      , replace = false;
+
+    $tip = this.tip();
+
+    width = $tip[0].offsetWidth;
+    height = $tip[0].offsetHeight;
+
+    $tip
+          .offset(offset)
+          .addClass(placement)
+          .addClass('in');
+
+    actualWidth = $tip[0].offsetWidth;
+    actualHeight = $tip[0].offsetHeight;
+
+    if (placement == "top" && actualHeight != actualWidth){
+      offset.top = offset.top + height - actualHeight;
+      replace = true;
+    }
+
+    if (placement == "bottom" || placement == "top"){
+      delta = 0;
+
+      if (offset.left < 0){
+        delta = -offset.left * 2;
+        offset.left = 0;
+        $tip.offset(offset);
+        actualWidth = $tip[0].offsetWidth;
+        actualHeight = $tip[0].offsetHeight;
+      }
+
+      this.replaceArrow(delta - width + actualWidth, actualWidth, "left");
+    }else{
+      this.replaceArrow(actualHeight - height, actualHeight, "top");
+    }
+
+    if (replace) $tip.offset(offset);
+  }
+
+  , replaceArrow: function(delta, dimension, position){
+    var $arrow = this.arrow();
+
+    if (delta !== 0){
+      $arrow.css(position, 50 * (1 - delta / dimension) + "%");
+    }else{
+      $arrow.css(position, "");
+    }
+  }
 
   , setContent: function () {
       var $tip = this.tip()
@@ -232,6 +285,10 @@
   , tip: function () {
       return this.$tip = this.$tip || $(this.options.template)
     }
+
+  , arrow: function(){
+    return this.$arrow = this.$arrow || this.tip().find(".tooltip-arrow");
+  }
 
   , validate: function () {
       if (!this.$element[0].parentNode) {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -152,7 +152,7 @@
             break
         }
 
-        this.applyPlacement(tp, placement);
+        this.applyPlacement(tp, placement)
 
         this.$element.trigger('shown')
       }
@@ -165,52 +165,52 @@
       , actualWidth
       , actualHeight
       , delta
-      , replace = false;
+      , replace = false
 
-    $tip = this.tip();
+    $tip = this.tip()
 
-    width = $tip[0].offsetWidth;
-    height = $tip[0].offsetHeight;
+    width = $tip[0].offsetWidth
+    height = $tip[0].offsetHeight
 
     $tip
           .offset(offset)
           .addClass(placement)
-          .addClass('in');
+          .addClass('in')
 
-    actualWidth = $tip[0].offsetWidth;
-    actualHeight = $tip[0].offsetHeight;
+    actualWidth = $tip[0].offsetWidth
+    actualHeight = $tip[0].offsetHeight
 
     if (placement == "top" && actualHeight != height){
-      offset.top = offset.top + height - actualHeight;
-      replace = true;
+      offset.top = offset.top + height - actualHeight
+      replace = true
     }
 
     if (placement == "bottom" || placement == "top"){
-      delta = 0;
+      delta = 0
 
       if (offset.left < 0){
-        delta = -offset.left * 2;
-        offset.left = 0;
-        $tip.offset(offset);
-        actualWidth = $tip[0].offsetWidth;
-        actualHeight = $tip[0].offsetHeight;
+        delta = -offset.left * 2
+        offset.left = 0
+        $tip.offset(offset)
+        actualWidth = $tip[0].offsetWidth
+        actualHeight = $tip[0].offsetHeight
       }
 
-      this.replaceArrow(delta - width + actualWidth, actualWidth, "left");
+      this.replaceArrow(delta - width + actualWidth, actualWidth, "left")
     }else{
-      this.replaceArrow(actualHeight - height, actualHeight, "top");
+      this.replaceArrow(actualHeight - height, actualHeight, "top")
     }
 
-    if (replace) $tip.offset(offset);
+    if (replace) $tip.offset(offset)
   }
 
   , replaceArrow: function(delta, dimension, position){
-    var $arrow = this.arrow();
+    var $arrow = this.arrow()
 
     if (delta !== 0){
-      $arrow.css(position, 50 * (1 - delta / dimension) + "%");
+      $arrow.css(position, 50 * (1 - delta / dimension) + "%")
     }else{
-      $arrow.css(position, "");
+      $arrow.css(position, "")
     }
   }
 
@@ -287,7 +287,7 @@
     }
 
   , arrow: function(){
-    return this.$arrow = this.$arrow || this.tip().find(".tooltip-arrow");
+    return this.$arrow = this.$arrow || this.tip().find(".tooltip-arrow")
   }
 
   , validate: function () {

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -29,6 +29,9 @@
   <script src="../../js/bootstrap-typeahead.js"></script>
   <script src="../../js/bootstrap-affix.js"></script>
 
+  <!-- Needed for testing -->
+  <link rel="stylesheet" type="text/css" href="unit/bootstrap-tooltip.css" />
+
   <!-- unit tests -->
   <script src="unit/bootstrap-transition.js"></script>
   <script src="unit/bootstrap-alert.js"></script>

--- a/js/tests/unit/bootstrap-tooltip.css
+++ b/js/tests/unit/bootstrap-tooltip.css
@@ -1,0 +1,13 @@
+
+
+.tooltip{
+	position: absolute;
+}
+
+.tooltip-inner{
+	max-width: 200px;
+}
+
+.tooltip.top .tooltip-arrow{
+	position: absolute;
+}

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -253,11 +253,12 @@ $(function () {
       })
 
       test("should place tooltip inside window", function(){
-        $("#qunit-fixture").show();
-        var tooltip = $("<a href='#' title='Very very very very very very very very long tooltip'></a>")
+        var container = $("<div />").appendTo("body")
+            .css({position: "absolute", width: 200, height: 200, bottom: 0, left: 0})
+          , tooltip = $("<a href='#' title='Very very very very very very very very long tooltip'>Hover me</a>")
           .css({position: "absolute", top:0, left: 0})
-          .appendTo("#qunit-fixture")
-          .tooltip({placement: "top"})
+          .appendTo(container)
+          .tooltip({placement: "top", animate: false})
           .tooltip("show");
 
         stop();
@@ -266,7 +267,28 @@ $(function () {
           ok($(".tooltip").offset().left >= 0);
 
           start();
-          $("#qunit-fixture").hide();
-        }, 200)
+          container.remove();
+        }, 100)
       });
+
+      test("should place tooltip on top of element", function(){
+        var container = $("<div />").appendTo("body")
+              .css({position: "absolute", bottom: 0, left: 0, textAlign: "right", width: 300, height: 300})
+            , p = $("<p style='margin-top:200px' />").appendTo(container)
+            , tooltiped = $("<a href='#' title='very very very very very very very long tooltip'>Hover me</a>")
+              .css({marginTop: 200})
+              .appendTo(p)
+              .tooltip({placement: "top", animate: false})
+              .tooltip("show");
+
+        stop();
+
+        setTimeout(function(){
+          var tooltip = container.find(".tooltip");
+
+          start();
+          ok(tooltip.offset().top + tooltip.outerHeight() <= tooltiped.offset().top);
+          container.remove();
+        }, 100)
+      })
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -290,5 +290,26 @@ $(function () {
           ok(tooltip.offset().top + tooltip.outerHeight() <= tooltiped.offset().top);
           container.remove();
         }, 100)
-      })
+      });
+
+      test("arrow should point to element", function(){
+        var container = $("<div />").appendTo("body")
+            .css({position: "absolute", bottom: 0, left: 0, textAlign: "right", width: 300, height: 300})
+          , p = $("<p style='margin-top:200px' />").appendTo(container)
+          , tooltiped = $("<a href='#' title='very very very very very very very long tooltip'>Hover me</a>")
+            .css({marginTop: 200})
+            .appendTo(p)
+            .tooltip({placement: "top", animate: false})
+            .tooltip("show");
+
+        stop();
+
+        setTimeout(function(){
+          var arrow = container.find(".tooltip-arrow");
+
+          start();
+          ok(Math.abs(arrow.offset().left - tooltiped.offset().left - tooltiped.outerWidth()/2) <= 1);
+          container.remove();
+        }, 100);
+      });
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -251,4 +251,22 @@ $(function () {
         ok(!$("#qunit-fixture > .tooltip").length, 'not found in parent')
         tooltip.tooltip('hide')
       })
+
+      test("should place tooltip inside window", function(){
+        $("#qunit-fixture").show();
+        var tooltip = $("<a href='#' title='Very very very very very very very very long tooltip'></a>")
+          .css({position: "absolute", top:0, left: 0})
+          .appendTo("#qunit-fixture")
+          .tooltip({placement: "top"})
+          .tooltip("show");
+
+        stop();
+
+        setTimeout(function(){
+          ok($(".tooltip").offset().left >= 0);
+
+          start();
+          $("#qunit-fixture").hide();
+        }, 200)
+      });
 })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -259,17 +259,17 @@ $(function () {
           .css({position: "absolute", top:0, left: 0})
           .appendTo(container)
           .tooltip({placement: "top", animate: false})
-          .tooltip("show");
+          .tooltip("show")
 
-        stop();
+        stop()
 
         setTimeout(function(){
-          ok($(".tooltip").offset().left >= 0);
+          ok($(".tooltip").offset().left >= 0)
 
-          start();
-          container.remove();
+          start()
+          container.remove()
         }, 100)
-      });
+      })
 
       test("should place tooltip on top of element", function(){
         var container = $("<div />").appendTo("body")
@@ -279,18 +279,18 @@ $(function () {
               .css({marginTop: 200})
               .appendTo(p)
               .tooltip({placement: "top", animate: false})
-              .tooltip("show");
+              .tooltip("show")
 
-        stop();
+        stop()
 
         setTimeout(function(){
-          var tooltip = container.find(".tooltip");
+          var tooltip = container.find(".tooltip")
 
-          start();
-          ok(tooltip.offset().top + tooltip.outerHeight() <= tooltiped.offset().top);
-          container.remove();
+          start()
+          ok(tooltip.offset().top + tooltip.outerHeight() <= tooltiped.offset().top)
+          container.remove()
         }, 100)
-      });
+      })
 
       test("arrow should point to element", function(){
         var container = $("<div />").appendTo("body")
@@ -300,16 +300,16 @@ $(function () {
             .css({marginTop: 200})
             .appendTo(p)
             .tooltip({placement: "top", animate: false})
-            .tooltip("show");
+            .tooltip("show")
 
-        stop();
+        stop()
 
         setTimeout(function(){
-          var arrow = container.find(".tooltip-arrow");
+          var arrow = container.find(".tooltip-arrow")
 
-          start();
-          ok(Math.abs(arrow.offset().left - tooltiped.offset().left - tooltiped.outerWidth()/2) <= 1);
-          container.remove();
-        }, 100);
-      });
+          start()
+          ok(Math.abs(arrow.offset().left - tooltiped.offset().left - tooltiped.outerWidth()/2) <= 1)
+          container.remove()
+        }, 100)
+      })
 })

--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -9,15 +9,14 @@
   z-index: @zindexTooltip;
   display: block;
   visibility: visible;
-  padding: 5px;
   font-size: 11px;
   line-height: 1.4;
   .opacity(0);
   &.in     { .opacity(80); }
-  &.top    { margin-top:  -3px; }
-  &.right  { margin-left:  3px; }
-  &.bottom { margin-top:   3px; }
-  &.left   { margin-left: -3px; }
+  &.top    { margin-top:  -3px; padding: 5px 0;}
+  &.right  { margin-left:  3px; padding: 0 5px;}
+  &.bottom { margin-top:   3px; padding: 5px 0;}
+  &.left   { margin-left: -3px; padding: 0 5px;}
 }
 
 // Wrapper for the tooltip content


### PR DESCRIPTION
1) Position the arrow in front of tooltiped element
2) Move the tooltip according to its real size (when resized on display)
3) Move the tooltip inside window when possible.

Before:
![before](https://f.cloud.github.com/assets/527245/100248/69c1f056-67fb-11e2-8aa8-3ece6fc8fe4d.png)

After:
![after](https://f.cloud.github.com/assets/527245/100249/6d10a6b2-67fb-11e2-9256-c7ebb15adce6.png)
