### PR TITLE
Small defect inside ccs file

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -339,7 +339,7 @@ only screen and (     -o-min-device-pixel-ratio: 2/1) {
   min-height: 40px;
   line-height: 40px;
 }
-.show-grid:hover [class*="span"] {
+.show-grid [class*="span"]:hover {
   background: #ddd;
 }
 .show-grid .show-grid {


### PR DESCRIPTION
Here is the small defect http://twitter.github.com/bootstrap/scaffolding.html when you hover any element inside live grid example - hovers all elements inside show-grid line. I think the idea is to hover just one element. 
Also you can check this request https://github.com/twitter/bootstrap/pull/6706, because of mistake on the same page
