### PR TITLE
jQuery selector for tooltip initialization

### DIFF
--- a/docs/assets/js/application.js
+++ b/docs/assets/js/application.js
@@ -34,7 +34,7 @@
     // add tipsies to grid for scaffolding
     if ($('#gridSystem').length) {
       $('#gridSystem').tooltip({
-          selector: '.show-grid > div'
+          selector: '.show-grid > div[class*="span"]'
         , title: function () { return $(this).width() + 'px' }
       })
     }


### PR DESCRIPTION
Tooltips should be initialized only for cells of the grip, not for all div, because tooltip is a div too.
