### PR TITLE
Prefer to collapse siblings

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -161,7 +161,7 @@
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
     $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
-    if ($(this).parent().children(target))
+    if ($(this).parent().children(target).size() > 0)
       $(this).parent().children(target).collapse(option)
     else
       $(target).collapse(option)

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -161,7 +161,10 @@
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
     $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
-    $(target).collapse(option)
+    if ($(this).parent().children(target))
+      $(this).parent().children(target).collapse(option)
+    else
+      $(target).collapse(option)
   })
 
 }(window.jQuery);


### PR DESCRIPTION
I wasn't exactly sure what the preferred method for this fix would be, or if is even really considered an issue, so I put this together and figured it would be a good starting point.

At the heart of this pull request is when you collapse or un-collapse a navbar, if you have more than one of them, then all of the navbars will collapse. My change makes the code prefer siblings, and if no siblings exist, it will use the current implementation, e.g. collapse all.

JSFiddle's:
With Fix: http://jsfiddle.net/qW8zh/1/ 
Without Fix: http://jsfiddle.net/qW8zh/3/

Commit:
This fix is to prefer to collapse siblings instead of every target. The situation in which this is useful is when two collapsible navbars exist on one screen. The reasoning for the if block is simple, if we have a sibling, prefer that, if not, then do it the 'legacy' way, as I do not know what other dependencies their may be.
