### PR TITLE
Fix tooltip positioning for IE8 broken in 2.3.0

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -212,7 +212,7 @@
 
   , getPosition: function () {
       var el = this.$element[0]
-      return $.extend({}, el.getBoundingClientRect ? el.getBoundingClientRect() : {
+      return $.extend({}, (typeof el.getBoundingClientRect == 'function') ? el.getBoundingClientRect() : {
         width: el.offsetWidth
       , height: el.offsetHeight
       }, this.$element.offset())


### PR DESCRIPTION
IE8 defines a broken placeholder object getBoundingClientRect which breaks the new getPosition() method introduced in 2.3.0

As height and width are not defined in the getPosition() result, tooltips aren't positioned correctly.

This pull request fixes https://github.com/twitter/bootstrap/issues/6659 .
