### PR TITLE
Typeahead: Allow function names passed as options

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -29,10 +29,10 @@
   var Typeahead = function (element, options) {
     this.$element = $(element)
     this.options = $.extend({}, $.fn.typeahead.defaults, options)
-    this.matcher = this.options.matcher || this.matcher
-    this.sorter = this.options.sorter || this.sorter
-    this.highlighter = this.options.highlighter || this.highlighter
-    this.updater = this.options.updater || this.updater
+    this.matcher = this.asFunction(this.options.matcher || this.matcher)
+    this.sorter = this.asFunction(this.options.sorter || this.sorter)
+    this.highlighter = this.asFunction(this.options.highlighter || this.highlighter)
+    this.updater = this.asFunction(this.options.updater || this.updater)
     this.source = this.asFunction(this.options.source)
     this.$menu = $(this.options.menu)
     this.shown = false

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -271,6 +271,29 @@
       this.$menu.find('.active').removeClass('active')
       $(e.currentTarget).addClass('active')
     }
+  , asFunction: function getFunction(arg) {
+      var curObj = window
+        , namespaces = typeof arg == "string" ? arg.split('.') : [null]
+        , result
+
+      // functions are of course functions...
+      if ($.isFunction(arg)) return arg
+
+      // Get named object
+      while (namespaces.length) {
+        curObj = curObj[namespaces.shift()]
+        if(!curObj) break
+      }
+
+      // If the current object is a function, return that
+      // If the current object is something else, return a function returning that
+      // Otherwise, return a function returning the passed argument
+      if ($.isFunction(curObj)) result = curObj
+      else if(typeof curObj !== 'undefined') result = function () { return curObj }
+      else result = function () { return arg }
+
+      return result
+    }
 
   }
 

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -33,7 +33,7 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
-    this.source = this.options.source
+    this.source = this.asFunction(this.options.source)
     this.$menu = $(this.options.menu)
     this.shown = false
     this.listen()
@@ -87,7 +87,7 @@
         return this.shown ? this.hide() : this
       }
 
-      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+      items = this.source(this.query, $.proxy(this.process, this))
 
       return items ? this.process(items) : this
     }

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -231,12 +231,28 @@ $(function () {
 
       test("should accept simple function names", function () {
         var $input = $('<input />').typeahead({
-              source: 'alert'
+              source: 'alert',
+              matcher: 'alert',
+              sorter: 'alert',
+              updater: 'alert',
+              highlighter: 'alert'
             }).appendTo('body')
           , typeahead = $input.data('typeahead')
 
         ok($.isFunction(typeahead.source), 'source is a function')
 		equals(typeahead.source, alert, 'source function is correctly set')
+
+        ok($.isFunction(typeahead.matcher), 'matcher is a function')
+		equals(typeahead.matcher, alert, 'matcher function is correctly set')
+
+        ok($.isFunction(typeahead.sorter), 'sorter is a function')
+		equals(typeahead.sorter, alert, 'sorter function is correctly set')
+
+        ok($.isFunction(typeahead.updater), 'updater is a function')
+		equals(typeahead.updater, alert, 'updater function is correctly set')
+
+        ok($.isFunction(typeahead.highlighter), 'highlighter is a function')
+		equals(typeahead.highlighter, alert, 'highlighter function is correctly set')
 
         $input.remove()
         typeahead.$menu.remove()
@@ -244,12 +260,28 @@ $(function () {
 
       test("should accept namespaced function names", function () {
         var $input = $('<input />').typeahead({
-              source: '$.isFunction'
+              source: '$.isFunction',
+              matcher: '$.isFunction',
+              sorter: '$.isFunction',
+              updater: '$.isFunction',
+              highlighter: '$.isFunction'
             }).appendTo('body')
           , typeahead = $input.data('typeahead')
 
         ok($.isFunction(typeahead.source), 'source is a function')
 		equals(typeahead.source, $.isFunction, 'source function is correctly set')
+
+        ok($.isFunction(typeahead.matcher), 'matcher is a function')
+		equals(typeahead.matcher, $.isFunction, 'matcher function is correctly set')
+
+        ok($.isFunction(typeahead.sorter), 'sorter is a function')
+		equals(typeahead.sorter, $.isFunction, 'sorter function is correctly set')
+
+        ok($.isFunction(typeahead.updater), 'updater is a function')
+		equals(typeahead.updater, $.isFunction, 'updater function is correctly set')
+
+        ok($.isFunction(typeahead.highlighter), 'highlighter is a function')
+		equals(typeahead.highlighter, $.isFunction, 'highlighter function is correctly set')
 
         $input.remove()
         typeahead.$menu.remove()

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -228,4 +228,31 @@ $(function () {
         $input.remove()
         typeahead.$menu.remove()
       })
+
+      test("should accept simple function names", function () {
+        var $input = $('<input />').typeahead({
+              source: 'alert'
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok($.isFunction(typeahead.source), 'source is a function')
+		equals(typeahead.source, alert, 'source function is correctly set')
+
+        $input.remove()
+        typeahead.$menu.remove()
+      })
+
+      test("should accept namespaced function names", function () {
+        var $input = $('<input />').typeahead({
+              source: '$.isFunction'
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok($.isFunction(typeahead.source), 'source is a function')
+		equals(typeahead.source, $.isFunction, 'source function is correctly set')
+
+        $input.remove()
+        typeahead.$menu.remove()
+      })
+
 })


### PR DESCRIPTION
Currently typeahead takes its options as-is. This is problematic for the data api since functions cannot be passed this way. Allow function names to be passed as functions, and look for them. If found, use that instead.
