### PR TITLE
Remove prevention of default focus event

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -315,8 +315,7 @@
 
   $(document).on('focus.typeahead.data-api', '[data-provide="typeahead"]', function (e) {
     var $this = $(this)
-    if ($this.data('typeahead')) return
-    e.preventDefault()
+    if ($this.data('typeahead')) return true
     $this.typeahead($this.data())
   })
 


### PR DESCRIPTION
Not sure why default focus event was being prevented.  Perhaps there is a use case where default focus breaks the typeahead, I haven't seen it.
