### PR TITLE
Deactivate active nav when scroll above anchors

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -88,6 +88,11 @@
             && (!offsets[i + 1] || scrollTop <= offsets[i + 1])
             && this.activate( targets[i] )
         }
+        
+        if (scrollTop < offsets[0]) {
+          this.activeTarget = false
+          $(this.selector).parent().removeClass('active')
+        }
       }
 
     , activate: function (target) {


### PR DESCRIPTION
If you have content that is above the first resolvable anchor item, currently with bootstrap, if you scroll up, beyond that anchor, the first nav item will remain highlighted, even though you're not anywhere near it. This pull request will deactivate that nav item.
