### PR TITLE
Add dynamic tooltip positioning

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -106,6 +106,13 @@
   , show: function () {
       var $tip
         , pos
+		, doc
+		, body
+		, top
+		, conPos
+		, conLeft
+		, conHeight
+		, conWidth
         , actualWidth
         , actualHeight
         , placement
@@ -133,9 +140,30 @@
         this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 
         pos = this.getPosition()
+		conPos = this.$element.parent().offset()
 
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
+		
+		if(this.options.dynamicPos){
+		
+          doc = document.documentElement, body = document.body;
+          top = (doc && doc.scrollTop  || body && body.scrollTop  || 0);
+		
+          conWidth = this.options.container == 'body' ? window.innerWidth : this.$element.parent().outerWidth();
+          conHeight = this.options.container == 'body' ? window.innerHeight : this.$element.parent().outerHeight();
+          conLeft = this.options.container == 'body' ? 0 : conPos.left;
+		
+          if(placement == 'right' && (pos.right + actualWidth > conWidth))
+            placement = 'left';
+          else if(placement == 'left' && (pos.left - actualWidth < conLeft))
+            placement = 'right';
+          else if(placement == 'bottom' && (pos.top + pos.height + actualHeight - top > conHeight))
+            placement = 'top';
+          else if(placement == 'top' && (pos.top - top - actualHeight < 0))
+            placement = 'bottom';
+		  
+	    }
 
         switch (placement) {
           case 'bottom':
@@ -292,6 +320,7 @@
   , delay: 0
   , html: false
   , container: false
+  , dynamicPos: false
   }
 
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -162,7 +162,7 @@
             placement = 'top';
           else if(placement == 'top' && (pos.top - top - actualHeight < 0))
             placement = 'bottom';
-		  
+
         }
 
         switch (placement) {

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -106,13 +106,13 @@
   , show: function () {
       var $tip
         , pos
-		, doc
-		, body
-		, top
-		, conPos
-		, conLeft
-		, conHeight
-		, conWidth
+        , doc
+        , body
+        , top
+        , conPos
+        , conLeft
+        , conHeight
+        , conWidth
         , actualWidth
         , actualHeight
         , placement
@@ -145,7 +145,7 @@
         actualWidth = $tip[0].offsetWidth
         actualHeight = $tip[0].offsetHeight
 		
-		if(this.options.dynamicPos){
+        if(this.options.dynamicPos){
 		
           doc = document.documentElement, body = document.body;
           top = (doc && doc.scrollTop  || body && body.scrollTop  || 0);
@@ -163,7 +163,7 @@
           else if(placement == 'top' && (pos.top - top - actualHeight < 0))
             placement = 'bottom';
 		  
-	    }
+        }
 
         switch (placement) {
           case 'bottom':


### PR DESCRIPTION
I have added an option to the tooltip plugin, for dynamic positioning. I was looking for this, and I noticed some other people thought that having this would be beneficial as well.

``` javascript
$('.tip').tooltip({
    dynamicPos: true
});
$('.pop').popover({
    dynamicPos: true
});
```

I have created a fiddle to show its usage: http://jsfiddle.net/U4384/1/
