### PR TITLE
Fix inline lists for IE7

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -835,8 +835,10 @@ ol.inline {
 ul.inline > li,
 ol.inline > li {
   display: inline-block;
+  *display: inline;
   padding-right: 5px;
   padding-left: 5px;
+  *zoom: 1;
 }
 
 dl {

--- a/less/type.less
+++ b/less/type.less
@@ -125,6 +125,7 @@ ol.inline {
   list-style: none;
   > li {
     display: inline-block;
+    .ie7-inline-block();
     padding-left: 5px;
     padding-right: 5px;
   }


### PR DESCRIPTION
Inline lists (`ul.inline` and `ol.inline`) do not show up as inline in IE7. We just need to add the `.ie7-inline-block` mixin to the `li` elements to fix this.
