### PR TITLE
less: Move to new selector interpolation, supported from 1.3.1

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -575,13 +575,13 @@
   .core (@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~".offset@{index}") { .offset(@index); }
+      .offset@{index} { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -620,14 +620,14 @@
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}') { .offset(@index); }
-      (~'.offset@{index}:first-child') { .offsetFirstChild(@index); }
+      .offset@{index} { .offset(@index); }
+      .offset@{index}:first-child { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -675,7 +675,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
@@ -699,5 +699,4 @@
     .spanX (@gridColumns);
 
   }
-
 }


### PR DESCRIPTION
less introduced a better selector interpolation format in 1,3,1. It will remove the old (undocumented) format in 1.4.0.

This pull request updates you to be compatible with future versions of less.

I am one of the core mantainers of less.

(had this on master then read the guidelines and moved to 2.3.0-wip - is that right?)

p.s. I can also remove those ugly 

```
.spanX (0) {}
```

they are not needed in 1.3.3 but it depends what version of less you want to support.
