### PR TITLE
reordered access of options in tooltip and popover

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -58,7 +58,7 @@
         , $e = this.$element
         , o = this.options
 
-      content = (typeof o.content == 'function' ? o.content.call($e[0]) :  o.content) ||
+      content = (typeof o.content == 'function' ? o.content.call($e[0]) :  o.content)
         || $e.attr('data-content')
 
       return content

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -58,8 +58,8 @@
         , $e = this.$element
         , o = this.options
 
-      content = $e.attr('data-content')
-        || (typeof o.content == 'function' ? o.content.call($e[0]) :  o.content)
+      content = (typeof o.content == 'function' ? o.content.call($e[0]) :  o.content) ||
+        || $e.attr('data-content')
 
       return content
     }

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -67,7 +67,7 @@
     }
 
   , getOptions: function (options) {
-      options = $.extend({}, $.fn[this.type].defaults, options, this.$element.data())
+      options = $.extend({}, $.fn[this.type].defaults, this.$element.data(), options)
 
       if (options.delay && typeof options.delay == 'number') {
         options.delay = {


### PR DESCRIPTION
Reordered access of options in tooltip and popover to allow overriding data attrs from js.

The current functionality gives higher precedence to the html, so that a call like 

``` js
$('#pop').popover({content:'overriding content'})
```

does not override the html attribute 'data-content' in

``` html
<div id="pop" class="btn" data-content="content" rel="popover">Button</div>
```
