### PR TITLE
Add rem as default unit for font-sizes, including fallback

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -248,6 +248,7 @@ select,
 textarea {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
+  font-size: 1.4rem;
   line-height: 20px;
 }
 
@@ -341,6 +342,7 @@ p {
 .lead {
   margin-bottom: 20px;
   font-size: 21px;
+  font-size: 2.1rem;
   font-weight: 200;
   line-height: 1.25;
 }
@@ -456,49 +458,53 @@ h6 {
 }
 
 h1 {
-  font-size: 38.5px;
-  font-size: 4rem;
+  font-size: 39px;
+  font-size: 3.85rem;
 }
 
 h2 {
-  font-size: 31.5px;
-  font-size: 3rem;
+  font-size: 32px;
+  font-size: 3.15rem;
 }
 
 h3 {
-  font-size: 24.5px;
-  font-size: 2.5rem;
+  font-size: 24px;
+  font-size: 2.45rem;
 }
 
 h4 {
-  font-size: 17.5px;
-  font-size: 2rem;
+  font-size: 18px;
+  font-size: 1.75rem;
 }
 
 h5 {
   font-size: 14px;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
 }
 
 h6 {
-  font-size: 11.9px;
-  font-size: 1.2rem;
+  font-size: 12px;
+  font-size: 1.19rem;
 }
 
 h1 small {
-  font-size: 24.5px;
+  font-size: 24px;
+  font-size: 2.45rem;
 }
 
 h2 small {
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
 }
 
 h3 small {
   font-size: 14px;
+  font-size: 1.4rem;
 }
 
 h4 small {
   font-size: 14px;
+  font-size: 1.4rem;
 }
 
 .page-header {
@@ -603,7 +609,8 @@ blockquote {
 
 blockquote p {
   margin-bottom: 0;
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
   font-weight: 300;
   line-height: 1.25;
 }
@@ -658,6 +665,7 @@ pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 12px;
+  font-size: 1.2rem;
   color: #333333;
   border-radius: 4px;
 }
@@ -675,6 +683,7 @@ pre {
   padding: 9.5px;
   margin: 0 0 10px;
   font-size: 13px;
+  font-size: 1.3rem;
   line-height: 20px;
   word-break: break-all;
   word-wrap: break-word;
@@ -1026,6 +1035,7 @@ legend {
   padding: 0;
   margin-bottom: 20px;
   font-size: 21px;
+  font-size: 2.1rem;
   line-height: 40px;
   color: #333333;
   border: 0;
@@ -1059,6 +1069,7 @@ input[type="color"],
   min-height: 34px;
   padding: 6px 9px;
   font-size: 14px;
+  font-size: 1.4rem;
   line-height: 20px;
   color: #555555;
   vertical-align: middle;
@@ -1259,7 +1270,8 @@ input[type="tel"].input-large,
 input[type="color"].input-large,
 .uneditable-input.input-large {
   padding: 11px 14px;
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
   border-radius: 6px;
 }
 
@@ -1282,7 +1294,8 @@ input[type="color"].input-small,
 .uneditable-input.input-small {
   min-height: 26px;
   padding: 2px 10px;
-  font-size: 11.9px;
+  font-size: 12px;
+  font-size: 1.19rem;
   border-radius: 3px;
 }
 
@@ -1478,6 +1491,7 @@ select:focus:invalid:focus {
 .input-group-addon {
   padding: 6px 8px;
   font-size: 14px;
+  font-size: 1.4rem;
   font-weight: normal;
   line-height: 20px;
   text-align: center;
@@ -1491,12 +1505,14 @@ select:focus:invalid:focus {
 
 .input-group-addon.input-small {
   padding: 2px 10px;
-  font-size: 11.9px;
+  font-size: 12px;
+  font-size: 1.19rem;
 }
 
 .input-group-addon.input-large {
   padding: 11px 14px;
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
 }
 
 .input-group input:first-child,
@@ -1641,7 +1657,8 @@ select:focus:invalid:focus {
   display: inline-block;
   padding: 6px 12px;
   margin-bottom: 0;
-  font-size: 14px;
+  font-size: 12px;
+  font-size: 1.2rem;
   font-weight: 500;
   line-height: 20px;
   text-align: center;
@@ -1682,13 +1699,15 @@ fieldset[disabled] .btn {
 
 .btn-large {
   padding: 11px 14px;
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
   border-radius: 6px;
 }
 
 .btn-small {
   padding: 2px 10px;
-  font-size: 11.9px;
+  font-size: 12px;
+  font-size: 1.19rem;
   border-radius: 3px;
 }
 
@@ -1699,7 +1718,8 @@ fieldset[disabled] .btn {
 
 .btn-mini {
   padding: 0 6px;
-  font-size: 10.5px;
+  font-size: 10px;
+  font-size: 1.05rem;
   border-radius: 3px;
 }
 
@@ -2782,6 +2802,7 @@ fieldset[disabled] .btn-link:hover {
 .close {
   float: right;
   font-size: 20px;
+  font-size: 2rem;
   font-weight: bold;
   line-height: 20px;
   color: #000;
@@ -2946,6 +2967,7 @@ button.close {
   display: block;
   padding: 3px 15px;
   font-size: 11px;
+  font-size: 1.1rem;
   font-weight: bold;
   line-height: 20px;
   color: #999999;
@@ -3119,7 +3141,8 @@ button.close {
 .navbar .brand {
   display: inline-block;
   padding: 7px 15px;
-  font-size: 18px;
+  font-size: 20px;
+  font-size: 2rem;
   font-weight: 500;
   line-height: 20px;
   color: #777777;
@@ -3596,7 +3619,8 @@ button.close {
 .pagination-large > li > a,
 .pagination-large > li > span {
   padding: 11px 14px;
-  font-size: 17.5px;
+  font-size: 18px;
+  font-size: 1.75rem;
 }
 
 .pagination-large > li:first-child > a,
@@ -3630,13 +3654,15 @@ button.close {
 .pagination-small > li > a,
 .pagination-small > li > span {
   padding: 2px 10px;
-  font-size: 11.9px;
+  font-size: 12px;
+  font-size: 1.19rem;
 }
 
 .pagination-mini > li > a,
 .pagination-mini > li > span {
   padding: 0 6px;
-  font-size: 10.5px;
+  font-size: 10px;
+  font-size: 1.05rem;
 }
 
 .pager {
@@ -3808,6 +3834,7 @@ button.close {
   display: block;
   padding: 5px;
   font-size: 11px;
+  font-size: 1.1rem;
   line-height: 1.4;
   opacity: 0;
   filter: alpha(opacity=0);
@@ -3926,6 +3953,7 @@ button.close {
   padding: 8px 14px;
   margin: 0;
   font-size: 14px;
+  font-size: 1.4rem;
   font-weight: normal;
   line-height: 18px;
   background-color: #f7f7f7;
@@ -4156,6 +4184,7 @@ a.thumbnail:hover {
   min-width: 10px;
   padding: 3px 7px;
   font-size: 12px;
+  font-size: 1.19rem;
   font-weight: bold;
   line-height: 1;
   color: #fff;
@@ -4255,6 +4284,7 @@ a.counter:hover {
   width: 0;
   height: 100%;
   font-size: 12px;
+  font-size: 1.2rem;
   color: #fff;
   text-align: center;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
@@ -4486,6 +4516,7 @@ a.counter:hover {
   margin-top: -35px;
   margin-left: 30px;
   font-size: 80px;
+  font-size: 8rem;
   font-weight: 100;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
@@ -4549,6 +4580,7 @@ a.counter:hover {
   padding: 30px;
   margin-bottom: 30px;
   font-size: 21px;
+  font-size: 2.1rem;
   font-weight: 200;
   line-height: 30px;
   color: inherit;
@@ -4571,6 +4603,7 @@ a.counter:hover {
   }
   .jumbotron h1 {
     font-size: 60px;
+    font-size: 6rem;
   }
 }
 

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -11,7 +11,6 @@
   display: inline-block;
   padding: 6px 12px;
   margin-bottom: 0; // For input.btn
-  font-size: @font-size-base;
   font-weight: 500;
   line-height: @line-height-base;
   text-align: center;
@@ -19,6 +18,7 @@
   cursor: pointer;
   border: 1px solid @btn-border;
   border-radius: @border-radius-base;
+  .rem-font-size(1.2); // ~12px
 
   &:focus {
     .tab-focus();
@@ -53,15 +53,15 @@
 // Large
 .btn-large {
   padding: @padding-large;
-  font-size: @font-size-large;
   border-radius: @border-radius-large;
+  .rem-font-size(@font-size-large);
 }
 
 // Small
 .btn-small {
   padding: @padding-small;
-  font-size: @font-size-small;
   border-radius: @border-radius-small;
+  .rem-font-size(@font-size-small);
 }
 .btn-mini [class^="icon-"],
 .btn-mini [class*=" icon-"] {
@@ -71,8 +71,8 @@
 // Mini
 .btn-mini {
   padding: @padding-mini;
-  font-size: @font-size-mini;
   border-radius: @border-radius-small;
+  .rem-font-size(@font-size-mini);
 }
 
 

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -109,10 +109,10 @@
     display: block;
     margin-top: -35px;
     margin-left: 30px;
-    font-size: 80px;
     font-weight: 100;
     color: #fff;
     text-shadow: 0 1px 2px rgba(0,0,0,.6);
+    .rem-font-size(8); // ~80px
   }
   &.right .control {
     margin-left: 70px;

--- a/less/close.less
+++ b/less/close.less
@@ -5,11 +5,11 @@
 
 .close {
   float: right;
-  font-size: 20px;
   font-weight: bold;
   line-height: @line-height-base;
   color: #000;
   text-shadow: 0 1px 0 rgba(255,255,255,1);
+  .rem-font-size(2); // ~20px
   .opacity(20);
   &:hover {
     color: #000;

--- a/less/code.less
+++ b/less/code.less
@@ -7,10 +7,10 @@
 code,
 pre {
   padding: 0 3px 2px;
-  #font > #family > .monospace;
-  font-size: @font-size-base - 2;
+  #font > #family > .monospace;;
   color: @grayDark;
   border-radius: 4px;
+  .rem-font-size(@font-size-base - 0.2); // ~12px
 }
 
 // Inline code
@@ -27,7 +27,7 @@ pre {
   display: block;
   padding: (@line-height-base - 1) / 2;
   margin: 0 0 @line-height-base / 2;
-  font-size: @font-size-base - 1; // 14px to 13px
+  .rem-font-size(@font-size-base - 0.1); // 14px to 13px
   line-height: @line-height-base;
   word-break: break-all;
   word-wrap: break-word;

--- a/less/counters.less
+++ b/less/counters.less
@@ -8,7 +8,6 @@
   display: inline-block;
   min-width: 10px;
   padding: 3px 7px;
-  font-size: 12px;
   font-weight: bold;
   color: #fff;
   line-height: 1;
@@ -17,6 +16,7 @@
   text-align: center;
   background-color: @grayLight;
   border-radius: 10px;
+  .rem-font-size(@font-size-base * 0.85);
 
   // Empty labels/badges collapse
   &:empty {

--- a/less/forms.less
+++ b/less/forms.less
@@ -21,11 +21,11 @@ legend {
   width: 100%;
   padding: 0;
   margin-bottom: @line-height-base;
-  font-size: @font-size-base * 1.5;
   line-height: @line-height-base * 2;
   color: @grayDark;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
+  .rem-font-size(@font-size-base * 1.5);
 }
 
 label {
@@ -60,7 +60,6 @@ input[type="color"],
   min-height: @input-height-base; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
   padding: 6px 9px;
   // margin-bottom: @line-height-base / 2;
-  font-size: @font-size-base;
   line-height: @line-height-base;
   color: @gray;
   vertical-align: middle;
@@ -69,6 +68,7 @@ input[type="color"],
   border-radius: @input-border-radius;
   .box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
   .transition(~"border linear .2s, box-shadow linear .2s");
+  .rem-font-size(@font-size-base);
 }
 
 // Reset appearance properties for textual inputs and textarea
@@ -271,14 +271,14 @@ input[type="color"],
 .uneditable-input {
   &.input-large {
     padding: @padding-large;
-    font-size: @font-size-large;
     border-radius: @border-radius-large;
+    .rem-font-size(@font-size-large);
   }
   &.input-small {
     min-height: @input-height-small;
     padding: @padding-small;
-    font-size: @font-size-small;
     border-radius: @border-radius-small;
+    .rem-font-size(@font-size-small);
   }
 }
 
@@ -460,22 +460,22 @@ select:focus:invalid {
 .input-group-addon {
   .box-sizing(border-box);
   padding: 6px 8px;
-  font-size: @font-size-base;
   font-weight: normal;
   line-height: @line-height-base;
   text-align: center;
   text-shadow: 0 1px 0 #fff;
   background-color: @grayLighter;
   border: 1px solid #ccc;
+  .rem-font-size(@font-size-base);
 
-	&.input-small {
-	  padding: @padding-small;
-	  font-size: @font-size-small;
+  &.input-small {
+    padding: @padding-small;
+    .rem-font-size(@font-size-small);
   }
-	&.input-large {
-		padding: @padding-large;
-		font-size: @font-size-large;
-	}
+  &.input-large {
+    padding: @padding-large;
+    .rem-font-size(@font-size-large);
+  }
 }
 
 // Reset rounded corners

--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -6,11 +6,12 @@
 .jumbotron {
   padding: 30px;
   margin-bottom: 30px;
-  font-size: 21px;
   font-weight: 200;
   line-height: @line-height-base * 1.5;
   color: @jumbotron-lead-color;
   background-color: @jumbotron-background;
+  .rem-font-size(2.1);
+
   h1 {
     line-height: 1;
     color: @jumbotron-heading-color;
@@ -26,7 +27,7 @@
     border-radius: 6px; // Only round corners at higher resolutions
 
     h1 {
-      font-size: 60px;
+      .rem-font-size(6); // ~60px
     }
   }
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -87,6 +87,15 @@
 // FONTS
 // --------------------------------------------------
 
+
+// Fallback for the rem unit
+.rem-font-size (@size) {
+  @px-fallback: round(@size * 10);
+  @rem-size: round(@size, 3);
+  font-size: ~"@{px-fallback}px";
+  font-size: ~"@{rem-size}rem";
+}
+
 #font {
   #family {
     .serif() {
@@ -100,7 +109,7 @@
     }
   }
   .shorthand(@size: @font-size-base, @weight: normal, @lineHeight: @line-height-base) {
-    font-size: @size;
+    .rem-font-size (@size);
     font-weight: @weight;
     line-height: @lineHeight;
   }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -71,10 +71,10 @@
 .navbar .brand {
   display: inline-block;
   padding: 7px 15px;
-  font-size: 18px;
   font-weight: 500;
   line-height: @line-height-base;
   color: @navbar-brand-color;
+  .rem-font-size(2); // ~20px
   &:hover {
     color: @navbar-brand-color-hover;
     text-decoration: none;

--- a/less/navs.less
+++ b/less/navs.less
@@ -162,12 +162,12 @@
 .nav-header {
   display: block;
   padding: 3px 15px;
-  font-size: 11px;
   font-weight: bold;
   line-height: @line-height-base;
   color: @grayLight;
   text-shadow: 0 1px 0 rgba(255,255,255,.5);
   text-transform: uppercase;
+  .rem-font-size(1.1); // ~11px;
 }
 // Space them out when they follow another list item (link)
 .nav li + .nav-header {

--- a/less/pagination.less
+++ b/less/pagination.less
@@ -55,7 +55,7 @@
   > li > a,
   > li > span {
     padding: @padding-large;
-    font-size: @font-size-large;
+    .rem-font-size(@font-size-large);
   }
   > li:first-child > a,
   > li:first-child > span {
@@ -85,7 +85,7 @@
   > li > a,
   > li > span {
     padding: @padding-small;
-    font-size: @font-size-small;
+    .rem-font-size(@font-size-small);
   }
 }
 // Mini
@@ -93,6 +93,6 @@
   > li > a,
   > li > span {
     padding: @padding-mini;
-    font-size: @font-size-mini;
+    .rem-font-size(@font-size-mini);
   }
 }

--- a/less/popovers.less
+++ b/less/popovers.less
@@ -34,12 +34,12 @@
 .popover-title {
   margin: 0; // reset heading margin
   padding: 8px 14px;
-  font-size: 14px;
   font-weight: normal;
   line-height: 18px;
   background-color: @popover-title-background;
   border-bottom: 1px solid darken(@popover-title-background, 5%);
   border-radius: 5px 5px 0 0;
+  .rem-font-size(1.4);
 
   &:empty {
     display: none;

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -56,11 +56,11 @@
   float: left;
   width: 0%;
   height: 100%;
-  font-size: 12px;
   color: #fff;
   text-align: center;
   text-shadow: 0 -1px 0 rgba(0,0,0,.25);
   background-color: @progress-bar-bg;
+  .rem-font-size(1.2);
   .box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
   .box-sizing(border-box);
   .transition(width .6s ease);

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -25,10 +25,9 @@ body {
   margin: 0;
   color: @text-color;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  font-size: 1.4rem;
   line-height: 1.5;
   background-color: @body-background;
+  .rem-font-size(1.4);
 }
 
 // Reset fonts for revelant elements
@@ -38,8 +37,8 @@ button,
 select,
 textarea {
   font-family: @font-family-base;
-  font-size: @font-size-base;
   line-height: @line-height-base;
+  .rem-font-size(@font-size-base);
 }
 
 

--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -10,8 +10,8 @@
   display: block;
   visibility: visible;
   padding: 5px;
-  font-size: 11px;
   line-height: 1.4;
+  .rem-font-size(1.1);
   .opacity(0);
   &.in     { .opacity(100); }
   &.top    { margin-top:  -3px; }

--- a/less/type.less
+++ b/less/type.less
@@ -11,7 +11,7 @@ p {
 }
 .lead {
   margin-bottom: @line-height-base;
-  font-size: @font-size-base * 1.5;
+  .rem-font-size(@font-size-base * 1.5);
   font-weight: 200;
   line-height: 1.25;
 }
@@ -78,17 +78,17 @@ h6 {
   margin-bottom: @line-height-base / 2;
 }
 
-h1 { font-size: @font-size-base * 2.75; font-size: 4rem; } // ~38px
-h2 { font-size: @font-size-base * 2.25; font-size: 3rem; } // ~32px
-h3 { font-size: @font-size-base * 1.75; font-size: 2.5rem; } // ~24px
-h4 { font-size: @font-size-base * 1.25; font-size: 2rem; } // ~18px
-h5 { font-size: @font-size-base; font-size: 1.6rem; }
-h6 { font-size: @font-size-base * 0.85; font-size: 1.2rem; } // ~12px
+h1 { .rem-font-size(@font-size-base * 2.75); } // ~38px
+h2 { .rem-font-size(@font-size-base * 2.25); } // ~32px
+h3 { .rem-font-size(@font-size-base * 1.75); } // ~24px
+h4 { .rem-font-size(@font-size-base * 1.25); } // ~18px
+h5 { .rem-font-size(@font-size-base); } // ~14px
+h6 { .rem-font-size(@font-size-base * 0.85); } // ~12px
 
-h1 small { font-size: @font-size-base * 1.75; } // ~24px
-h2 small { font-size: @font-size-base * 1.25; } // ~18px
-h3 small { font-size: @font-size-base; }
-h4 small { font-size: @font-size-base; }
+h1 small { .rem-font-size(@font-size-base * 1.75); } // ~24px
+h2 small { .rem-font-size(@font-size-base * 1.25); } // ~18px
+h3 small { .rem-font-size(@font-size-base); }
+h4 small { .rem-font-size(@font-size-base); }
 
 
 // Page header
@@ -195,7 +195,7 @@ blockquote {
   border-left: 5px solid @grayLighter;
   p {
     margin-bottom: 0;
-    font-size: @font-size-base * 1.25;
+    .rem-font-size(@font-size-base * 1.25);
     font-weight: 300;
     line-height: 1.25;
   }

--- a/less/variables.less
+++ b/less/variables.less
@@ -45,7 +45,7 @@
 @font-family-monospace:   Monaco, Menlo, Consolas, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;
 
-@font-size-base:          14px;
+@font-size-base:          unit(14px / 10);
 @font-size-large:         @font-size-base * 1.25; // ~18px
 @font-size-small:         @font-size-base * 0.85; // ~12px
 @font-size-mini:          @font-size-base * 0.75; // ~11px


### PR DESCRIPTION
This PR is against the 3.0.0-wip branch.

In #6342 one of the issues still open is the use of the CSS unit `rem`.
Using rem is supported in all relevant browsers except Internet Explorer 8 and below.

It is fairly easy to write a mixin which provides a pixel-based fallback for properties using `rem`. I [wrote about this](http://drublic.de/blog/rem-fallback-sass-less/) some weeks ago but the technique is not exactly new.

This commit adds a simple mixin which calculates a pixel based value for font-sizes based on a provided rem-value. As described in the post, it is possible to interpolate property names and write a rem-fallback for all properties but in this case I sticked to `font-size`.

Including the mixin in LESS works like this:

```
.rem-font-size(@size) // while @size is a unit-less number
```

The `@size`-variable is based on the root-font-size of the website – which is 10px in the case of Bootstrap (aka. 62.5%).

This commit also changes all font-sizes from px-based values to the usage of the rem-size fallback.

Later next month (aaaahm– year, decade… whatever) when Bootstrap will drop support for IE8 it is really easy to switch to a rem-only font-size by running a grep|sed with a regex and all.

The thing that bugs be a little about this PR is using of the `unit()`-function to calculate a proper base font-size for the main elements (which use `@font-size-base`).

To be honest I would consider rethinking the font-size situation and maybe build the rem values upon the default font-size of 14px (this would mean applying it to the root-element (which is `html`)).
An advantage at the moment is the calculating of rem-values (which is dividing the px-based font-size by 10). That could be a point against changing the root-font-size.

Well… This is open for discussion and I am willing to update the PR if necessary.
