### PR TITLE
don't remove title attribute for tooltips for 2.3-wip

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -245,7 +245,7 @@
   , fixTitle: function () {
       var $e = this.$element
       if ($e.attr('title') || typeof($e.attr('data-original-title')) != 'string') {
-        $e.attr('data-original-title', $e.attr('title') || '').removeAttr('title')
+        $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
       }
     }
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -22,9 +22,9 @@ $(function () {
         ok(!!$.fn.tooltip.defaults, 'defaults is defined')
       })
 
-      test("should remove title attribute", function () {
+      test("should empty title attribute", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').tooltip()
-        ok(!tooltip.attr('title'), 'title tag was removed')
+        ok(tooltip.attr('title') === '', 'title attribute was emptied')
       })
 
       test("should add data attribute for referencing original title", function () {


### PR DESCRIPTION
The original pull request - #6481 got merged into master instead of the -wip branch
credit goes to @pseidemann for coming up with this solution
