### PR TITLE
Remove prevention of focus

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -315,8 +315,7 @@
 
   $(document).on('focus.typeahead.data-api', '[data-provide="typeahead"]', function (e) {
     var $this = $(this)
-    if ($this.data('typeahead')) return
-    e.preventDefault()
+    if ($this.data('typeahead')) return true
     $this.typeahead($this.data())
   })
 


### PR DESCRIPTION
Allows .focus() trigger to actually focus a typeahead input.  Tested no adverse effects Chrome 24, FF 18, IE9 (and 7/8 through browser mode) - all Windows 7.
