### PR TITLE
Set explicit font size of @baseFontSize in popovers.less...

### DIFF
--- a/less/popovers.less
+++ b/less/popovers.less
@@ -11,6 +11,7 @@
   display: none;
   max-width: 276px;
   padding: 1px;
+  font-size: @baseFontSize;
   text-align: left; // Reset given new insertion method
   background-color: @popoverBackground;
   -webkit-background-clip: padding-box;


### PR DESCRIPTION
...to prevent inheriting `font-size:0;` from `.input-append`.

The inheritance issue happens when a popover is triggered from an element that has the `input-append` class.
