### PR TITLE
Button that triggered the modal is now passed to 'shown' and 'show' as event.relatedTarget

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -359,11 +359,11 @@ $('#myModal').modal({
             <tbody>
              <tr>
                <td>show</td>
-               <td>This event fires immediately when the <code>show</code> instance method is called.</td>
+               <td>This event fires immediately when the <code>show</code> instance method is called. If it was triggered by a button, the source button will be passed as the relatedTarget of the event.</td>
              </tr>
              <tr>
                <td>shown</td>
-               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).</td>
+               <td>This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the relatedTarget of the event.</td>
              </tr>
              <tr>
                <td>hide</td>
@@ -378,6 +378,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // do something…
+})
+$('#myModal').on('shown', function (e) {
+  // e.relatedTarget is the element that triggered the modal
 })
 </pre>
         </section>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -289,11 +289,11 @@ $('#myModal').modal({
             <tbody>
              <tr>
                <td>{{_i}}show{{/i}}</td>
-               <td>{{_i}}This event fires immediately when the <code>show</code> instance method is called.{{/i}}</td>
+               <td>{{_i}}This event fires immediately when the <code>show</code> instance method is called. If it was triggered by a button, the source button will be passed as the relatedTarget of the event.{{/i}}</td>
              </tr>
              <tr>
                <td>{{_i}}shown{{/i}}</td>
-               <td>{{_i}}This event is fired when the modal has been made visible to the user (will wait for css transitions to complete).{{/i}}</td>
+               <td>{{_i}}This event is fired when the modal has been made visible to the user (will wait for css transitions to complete). If it was triggered by a button, the source button will be passed as the relatedTarget of the event.{{/i}}</td>
              </tr>
              <tr>
                <td>{{_i}}hide{{/i}}</td>
@@ -308,6 +308,9 @@ $('#myModal').modal({
 <pre class="prettyprint linenums">
 $('#myModal').on('hidden', function () {
   // {{_i}}do something…{{/i}}
+})
+$('#myModal').on('shown', function (e) {
+  // {{_i}}e.relatedTarget is the element that triggered the modal{{/i}}
 })
 </pre>
         </section>

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -37,13 +37,15 @@
 
       constructor: Modal
 
-    , toggle: function () {
-        return this[!this.isShown ? 'show' : 'hide']()
+    , toggle: function (source) {
+        return this[!this.isShown ? 'show' : 'hide'](source)
       }
 
-    , show: function () {
+    , show: function (source) {
         var that = this
           , e = $.Event('show')
+
+        e.relatedTarget = source
 
         this.$element.trigger(e)
 
@@ -55,12 +57,15 @@
 
         this.backdrop(function () {
           var transition = $.support.transition && that.$element.hasClass('fade')
+            , e = $.Event('shown')
+
+          e.relatedTarget = source
 
           if (!that.$element.parent().length) {
             that.$element.appendTo(document.body) //don't move modals dom position
           }
 
-          that.$element.show()
+          that.$element.show(source)
 
           if (transition) {
             that.$element[0].offsetWidth // force reflow
@@ -73,8 +78,8 @@
           that.enforceFocus()
 
           transition ?
-            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger('shown') }) :
-            that.$element.focus().trigger('shown')
+            that.$element.one($.support.transition.end, function () { that.$element.focus().trigger(e) }) :
+            that.$element.focus().trigger(e)
 
         })
       }
@@ -194,14 +199,14 @@
 
   var old = $.fn.modal
 
-  $.fn.modal = function (option) {
+  $.fn.modal = function (option, source) {
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('modal')
         , options = $.extend({}, $.fn.modal.defaults, $this.data(), typeof option == 'object' && option)
       if (!data) $this.data('modal', (data = new Modal(this, options)))
-      if (typeof option == 'string') data[option]()
-      else if (options.show) data.show()
+      if (typeof option == 'string') data[option](source)
+      else if (options.show) data.show(source)
     })
   }
 
@@ -231,11 +236,12 @@
       , href = $this.attr('href')
       , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
       , option = $target.data('modal') ? 'toggle' : $.extend({ remote:!/#/.test(href) && href }, $target.data(), $this.data())
+      , source = e.target
 
     e.preventDefault()
 
     $target
-      .modal(option)
+      .modal(option, source)
       .one('hide', function () {
         $this.focus()
       })


### PR DESCRIPTION
When a modal is triggered by a button, the button is now passed as a relatedTarget to the 'shown' event as mentioned in #6159.

Also added show event as referenced in #6205

Ex:

``` Javascript
$('#myModal').on('shown', function (e) {
  // e.relatedTarget is the element that triggered the modal
})
```

Tested on IE9, Firefox 14, and Chrome 23.

Resubmit of #6173.  I took Fat's suggestion:  The source button is now passed through event.relatedTarget.  

Now it is a resubmit of #6425 against 2.3.0-wip as per Fat's suggestion.  If there is something I have done wrong or a different branch to commit to please let me know :)  Thanks!
