### PR TITLE
Allow easier variables overwriting

### DIFF
--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -8,53 +8,11 @@
  * Designed and built with all the love in the world by @mdo and @fat.
  */
 
-// Core variables and mixins
-@import "variables.less"; // Modify this for custom colors, font-sizes, etc
-@import "mixins.less";
+// Core variables
+@import "variables.less";
 
-// Reset
-@import "normalize.less";
+// To customize colors, font sizes and other variables, copy this file and add 
+// here your customizations. Remember to update the @import paths too.
+// @font-size-base: 13px;
 
-// Core CSS
-@import "scaffolding.less";
-@import "type.less";
-@import "code.less";
-@import "grid.less";
-
-@import "tables.less";
-@import "forms.less";
-@import "buttons.less";
-
-// Components: common
-@import "component-animations.less";
-@import "glyphicons.less";
-@import "dropdowns.less";
-@import "wells.less";
-@import "close.less";
-
-// Components: Nav
-@import "navs.less";
-@import "navbar.less";
-@import "button-groups.less";
-@import "breadcrumbs.less";
-@import "pagination.less";
-@import "pager.less";
-
-// Components: Popovers
-@import "modals.less";
-@import "tooltip.less";
-@import "popovers.less";
-
-// Components: Misc
-@import "alerts.less";
-@import "thumbnails.less";
-@import "media.less";
-@import "counters.less";
-@import "progress-bars.less";
-@import "accordion.less";
-@import "carousel.less";
-@import "jumbotron.less";
-
-// Utility classes
-@import "utilities.less"; // Has to be last to override when necessary
-@import "responsive-utilities.less";
+@import "styles.less";

--- a/less/styles.less
+++ b/less/styles.less
@@ -1,0 +1,49 @@
+// Core mixins
+@import "mixins.less";
+
+// Reset
+@import "normalize.less";
+
+// Core CSS
+@import "scaffolding.less";
+@import "type.less";
+@import "code.less";
+@import "grid.less";
+
+@import "tables.less";
+@import "forms.less";
+@import "buttons.less";
+
+// Components: common
+@import "component-animations.less";
+@import "glyphicons.less";
+@import "dropdowns.less";
+@import "wells.less";
+@import "close.less";
+
+// Components: Nav
+@import "navs.less";
+@import "navbar.less";
+@import "button-groups.less";
+@import "breadcrumbs.less";
+@import "pagination.less";
+@import "pager.less";
+
+// Components: Popovers
+@import "modals.less";
+@import "tooltip.less";
+@import "popovers.less";
+
+// Components: Misc
+@import "alerts.less";
+@import "thumbnails.less";
+@import "media.less";
+@import "counters.less";
+@import "progress-bars.less";
+@import "accordion.less";
+@import "carousel.less";
+@import "jumbotron.less";
+
+// Utility classes
+@import "utilities.less"; // Has to be last to override when necessary
+@import "responsive-utilities.less";


### PR DESCRIPTION
Right now to customize LESS variables there are two options:
- Edit `less/bootstrap.less`. This forces the user to modify the Bootstrap source code, but this option is not always available (e.g. when Bootstrap is included through Bower or Composer). Also, changing third party code doesn't seem a very good practice.
- Copy and edit `less/bootstrap.less`. Here Bootstrap isn't touched but it requires copying all those imports (and updating their paths), this makes updating a little more painful.

With the proposed changes one can do this:

``` css
@import "components/bootstrap/less/variables.less";
@import "variables.less"; // Bootstrap variables overwritten here
@import "components/bootstrap/less/styles.less";
```

`less/bootstrap.less` is functionally equivalent to current implementation so it could also be backported to version 2.x.
