### PR TITLE
store typehead item value as a object not string

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('value')
       this.$element
         .val(this.updater(val))
         .change()
@@ -138,7 +138,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('value', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })


### PR DESCRIPTION
now the typehead control can only use string to build the list,we can't store more data in the items.

so i change the attr('data-value') to data('value') to get object value from the select, so we can extend the item object like this.

``` javascript
    var TypeHeadItem=function(item,value){
        this.item=item;
        this.value=value;
    };

    TypeHeadItem.prototype={
        toString: function() {
            return this.value;
        },
        toLowerCase:function(){
            return String.prototype.toLowerCase.apply(this.value);
        },
        indexOf:function(value){
            return String.prototype.indexOf.apply(this.value,arguments);
        },
        replace:function(){
            return String.prototype.replace.apply(this.value,arguments);
        }
    };

    TypeHeadItem.prototype.__defineGetter__('length',function(){return this.value.length;});
```

then we can get more information from the typehead selected item, so we don't need to use a cache to store the object which match to the key.It's useful when u have same keyword for different items.(although typehead is not desgined for this,but we use it)
