### PR TITLE
Add `loaded` event to modals that use remote

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,7 +30,9 @@
     this.options = options
     this.$element = $(element)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-    this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
+    this.options.remote && this.$element.find('.modal-body').load(this.options.remote, $.proxy(function() {
+      this.$element.trigger('loaded')
+    }, this))
   }
 
   Modal.prototype = {


### PR DESCRIPTION
Fixes issue #5169. Uses the callback in jQuery's `.load()` to trigger a `loaded` event on the modal element.

I am resubmitting this. It was previously pull request #6175. Since that pull request was closed, a number of people have voiced support for the addition of a `loaded` event:
- [@jordanisip](https://github.com/twitter/bootstrap/pull/6119#issuecomment-11014365)
- [@rmm5t](https://github.com/twitter/bootstrap/pull/6175#issuecomment-11979098)
- [@cvn](https://github.com/twitter/bootstrap/pull/6175#issuecomment-12352770)
- [@Nerian](https://github.com/twitter/bootstrap/issues/5169#issuecomment-11708043)
- [@pixelcode](https://github.com/twitter/bootstrap/issues/5169#issuecomment-12963204)
- [@stylenclass](https://github.com/twitter/bootstrap/issues/5169#issuecomment-13074384)

Also, please see [my justification](https://github.com/twitter/bootstrap/issues/5169#issuecomment-11639499) for adding this single event.
