### PR TITLE
Typeahead no data attribute

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('value')
       this.$element
         .val(this.updater(val))
         .change()
@@ -138,7 +138,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('value', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -233,4 +233,34 @@ $(function () {
         $input.remove()
         typeahead.$menu.remove()
       })
+
+      test("should allow objects to be passed as items", function () {
+        var $input = $('<input />').typeahead({
+              source: function () {
+                return [{a: 'aa'}, {a: 'ab'}, {a: 'ac'}]
+              }
+            , matcher: function() { return true }
+            , sorter: function(items) { return items }
+            , updater: function(item) { return item.a }
+            , highlighter: function(item) { return item.a }
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        $input.val('a')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        equals(typeahead.$menu.find('.active').data('value').a, 'aa', 'item object has been stored')
+        equals(typeahead.$menu.find('.active').text(), 'aa', 'item object has been displayed correctly')
+
+        typeahead.select()
+
+        equals($input.val(), 'aa', 'input has been set correctly')
+
+        $input.remove()
+        typeahead.$menu.remove()
+      })
 })


### PR DESCRIPTION
By using a data-value attribute, each item is forcefully
converted into a string. If the items are not simple values,
the resulting retrieval is useless at select time. 

Storing it with the jQuery data function instead means the
object is stored without problems.

This is the same as #6741, rebased against the 2.3.0-wip branch
