### PR TITLE
Fix typo for Star glyphicon in css docs.

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -2170,10 +2170,10 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
 
           <h5>Large button</h5>
           <div class="bs-docs-example">
-            <a class="btn btn-large" href="#"><i class="icon-star"></i> Star</a>
+            <a class="btn btn-large" href="#"><i class="glyphicon-star"></i> Star</a>
           </div>
 <pre class="prettyprint linenums">
-&lt;a class="btn btn-large" href="#"&gt;&lt;i class="icon-star"&gt;&lt;/i&gt; Star&lt;/a&gt;
+&lt;a class="btn btn-large" href="#"&gt;&lt;i class="glyphicon-star"&gt;&lt;/i&gt; Star&lt;/a&gt;
 </pre>
 
           <h5>Small button</h5>

--- a/docs/templates/pages/css.mustache
+++ b/docs/templates/pages/css.mustache
@@ -2110,10 +2110,10 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
 
           <h5>Large button</h5>
           <div class="bs-docs-example">
-            <a class="btn btn-large" href="#"><i class="icon-star"></i> Star</a>
+            <a class="btn btn-large" href="#"><i class="glyphicon-star"></i> Star</a>
           </div>{{! /bs-docs-example }}
 <pre class="prettyprint linenums">
-&lt;a class="btn btn-large" href="#"&gt;&lt;i class="icon-star"&gt;&lt;/i&gt; Star&lt;/a&gt;
+&lt;a class="btn btn-large" href="#"&gt;&lt;i class="glyphicon-star"&gt;&lt;/i&gt; Star&lt;/a&gt;
 </pre>
 
           <h5>Small button</h5>


### PR DESCRIPTION
Fix a small typo for the Star glyphicon in the CSS docks.
