### PR TITLE
Added the "target-dir" parameter to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,6 @@
   , "homepage": "http://twitter.github.com/bootstrap/"
   , "author": "Twitter Inc."
   , "license": "Apache-2.0"
+  , "target-dir": "twitter/bootstrap"
 
 }


### PR DESCRIPTION
I have re-added the target-dir parameter back to composer.json. For some reason it had been removed in 2.3.0. 
