### PR TITLE
Added an express server to run the docs: run_docs.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     , "recess": "1.1.6"
     , "connect": "2.1.3"
     , "hogan.js": "2.0.0"
+    , "express": "3.0.x"
   }
 }

--- a/run_docs.js
+++ b/run_docs.js
@@ -1,0 +1,22 @@
+/**
+ * Simple static server for running Bootstrap:
+ * $ node run_docs  
+ * Go to http://localhost:3000
+ */
+var express = require('express')
+  , http = require('http')
+  , path = require('path');
+
+var app = express();
+
+app.configure(function(){
+  app.set('port', process.env.PORT || 3000);
+  app.use(express.favicon('/docs/assets/ico/favicon.ico'));
+  app.use(express.logger('dev'));
+  app.use(express.static(path.join(__dirname, '/docs')));
+  app.use(express.errorHandler());
+});
+
+http.createServer(app).listen(app.get('port'), function(){
+  console.log("Bootstrap up and running sir! Port: " + app.get('port'));
+});


### PR DESCRIPTION
Since we are installing via "npm install" now why not add a very small
server so once I clone Boostrap I can both build it _and_ run it
locally?  Only one more dependency in package.json and tiny express
server.  Cheers.
