### PR TITLE
Update README.md to remove the global install in npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We have included a makefile with convenience methods for working with the Bootst
 Our makefile depends on you having recess, connect, uglify.js, and jshint installed. To install, just run the following command in npm:
 
 ```
-$ npm install recess connect uglify-js jshint -g
+$ npm install recess connect uglify-js jshint
 ```
 
 + **build** - `make`


### PR DESCRIPTION
This will make the README compatible with the announcement about Bootstrap 2.3.

By the way, the Makefile in its current form **does not** accept local installs as claimed since only some commands have been prefixed with the local PATH.

A fix for this problem has already been implemented in #6576 and properly documented in the commit messages.
