### PR TITLE
allow bower to install jquery 1.9.x

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
   "version": "2.3.0",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": ">=1.8.0"
   }
 }


### PR DESCRIPTION
This pull requests allows bower to install jquery 1.9.x. Previously it wasn't possible to install any version > 1.8.x.
