### PR TITLE
Fix vertical alignment of input-append button in nav-bar

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -95,11 +95,7 @@
 .navbar .btn-group {
   .navbarVerticalAlign(30px); // Vertically center in navbar
 }
-.navbar .btn-group .btn,
-.navbar .input-prepend .btn,
-.navbar .input-append .btn,
-.navbar .input-prepend .btn-group,
-.navbar .input-append .btn-group {
+.navbar .btn-group .btn {
   margin-top: 0; // then undo the margin here so we don't accidentally double it
 }
 


### PR DESCRIPTION
Fixes the vertical alignment of input-append buttons in nav-bar. Example of the wrong alignment here: http://jsfiddle.net/jendrik/LXLBJ/1/

This is a revert of the fix for bug #4680, which was an improper fix for the problem, now causing this bug. (The problem was properly fixed #4540 as far as I see).
