### PR TITLE
Fixed typo on JavaScript documentation

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -824,7 +824,7 @@ $('#example').tooltip(options)
                <td>trigger</td>
                <td>string</td>
                <td>'hover focus'</td>
-               <td>how tooltip is triggered - click | hover | focus | manual. Note you case pass trigger mutliple, space seperated, trigger types.</td>
+               <td>how tooltip is triggered - click | hover | focus | manual. Note you case pass trigger multiple, space seperated, trigger types.</td>
              </tr>
              <tr>
                <td>delay</td>


### PR DESCRIPTION
I've fixed a typo inside the tooltip's options table

![Screen Shot 2013-02-15 at 18 49 19 ](https://f.cloud.github.com/assets/226693/160260/63c28974-775d-11e2-8735-c87cb44189ba.png)
