### PR TITLE
Update install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We have included a makefile with convenience methods for working with the Bootst
 Our makefile depends on you having recess, connect, uglify.js, and jshint installed. To install, just run the following command in npm:
 
 ```
-$ npm install recess connect uglify-js jshint -g
+$ npm install recess connect uglify-js@1 jshint
 ```
 
 + **build** - `make`


### PR DESCRIPTION
- `make` looks inside the node_modules for the execs;
- uglify-js fails to parse `docs/assets/js/bootstrap.js` on its latest version. forcing v1.
