### PR TITLE
Update readme npm instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,26 @@ Keep track of development and community news.
 
 
 
-## Developers
+## Compiling CSS and JavaScript
 
-We have included a makefile with convenience methods for working with the Bootstrap library.
-
-+ **dependencies**
-Our makefile depends on you having recess, connect, uglify.js, and jshint installed. To install, just run the following command in npm:
+Bootstrap includes a [makefile](Makefile) with convenient methods for working with the framework. Before getting started, be sure to install [the necessary local dependencies](package.json):
 
 ```
-$ npm install recess connect uglify-js jshint -g
+$ npm install
 ```
 
-+ **build** - `make`
-Runs the recess compiler to rebuild the `/less` files and compiles the docs pages. Requires recess and uglify-js. <a href="http://twitter.github.com/bootstrap/extend.html#compiling">Read more in our docs &raquo;</a>
+When completed, you'll be able to run the various make commands provided:
 
-+ **test** - `make test`
+#### build - `make`
+Runs the recess compiler to rebuild the `/less` files and compiles the docs. Requires recess and uglify-js.
+
+#### test - `make test`
 Runs jshint and qunit tests headlessly in [phantomjs](http://code.google.com/p/phantomjs/) (used for ci). Depends on having phantomjs installed.
 
-+ **watch** - `make watch`
+#### watch - `make watch`
 This is a convenience method for watching just Less files and automatically building them whenever you save. Requires the Watchr gem.
+
+Should you encounter problems with installing dependencies or running the makefile commands, be sure to first uninstall any previous versions (global and local) you may have installed, and then rerun `npm install`.
 
 
 


### PR DESCRIPTION
This is a quick fix that backports part of the readme updates we're making in v3 to address the current out of date npm installation process. With v2.3 we overhauled the makefile to only install dependencies locally, and thus we don't need to install them globally via `-g` anymore. Problem is we forgot to update the makefile before release.

From now on, just run `npm install`. If you run into problems, be sure to uninstall all the old versions and try again.

/cc @cvrebert 
