### PR TITLE
Remove invalid .on() from bootstrap-dropdown.js

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -158,7 +158,6 @@
   $(document)
     .on('click.dropdown.data-api', clearMenus)
     .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-    .on('.dropdown-menu', function (e) { e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
 


### PR DESCRIPTION
Fixes #6835

Remnant from [b5ad50686c](https://github.com/twitter/bootstrap/commit/b5ad50686c892c5fb8d0e58571b9dc0b77b4f0d2) (line 161) where first param was removed but not the whole line

---

For example, causes with aFarkas/webshim#211: [IE8](https://f.cloud.github.com/assets/79461/155581/6684a00c-7654-11e2-9184-15515d88e000.png), [IE9](https://f.cloud.github.com/assets/79461/155046/74d00c7e-7635-11e2-8165-5fa661db500b.png) and [IE10 Release Preview for Windows 7](https://f.cloud.github.com/assets/79461/155054/ba9c16e4-7635-11e2-8794-6b4ea2ce6861.png)
