### PR TITLE
allow empty query string with minLength = 0 in typeahead plugin

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -81,9 +81,9 @@
   , lookup: function (event) {
       var items
 
-      this.query = this.$element.val()
+      this.query = this.$element.val() || ''
 
-      if (!this.query || this.query.length < this.options.minLength) {
+      if (this.query.length < this.options.minLength) {
         return this.shown ? this.hide() : this
       }
 

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -56,6 +56,26 @@ $(function () {
         typeahead.$menu.remove()
       })
 
+      test("should show menu when query is empty und minLength is 0", function () {
+        var $input = $('<input />')
+            .appendTo('body')
+            .typeahead({
+              source: ['aa', 'ab', 'ac'],
+              minLength: 0
+            })
+          , typeahead = $input.data('typeahead')
+
+        $input.val('')
+        typeahead.lookup()
+
+        ok(typeahead.$menu.is(":visible"), 'typeahead is visible')
+        equals(typeahead.$menu.find('li').length, 3, 'has 3 items in menu')
+        equals(typeahead.$menu.find('.active').length, 1, 'one item is active')
+
+        $input.remove()
+        typeahead.$menu.remove()
+      })
+
       test("should accept data source via synchronous function", function () {
         var $input = $('<input />').typeahead({
               source: function () {


### PR DESCRIPTION
This patch allows an empty query string when using the typeahead plugin and setting minLength to zero. I added a unit test and it passed with chrome on mac osx 10.8
