### PR TITLE
Disable pagination links bleed background colour

### DIFF
--- a/less/pagination.less
+++ b/less/pagination.less
@@ -37,18 +37,16 @@
 .pagination ul > .active > span {
   background-color: @paginationActiveBackground;
 }
+.pagination ul > .disabled > span,
+.pagination ul > .disabled > a,
 .pagination ul > .active > a,
 .pagination ul > .active > span {
   color: @grayLight;
   cursor: default;
 }
-.pagination ul > .disabled > span,
-.pagination ul > .disabled > a,
 .pagination ul > .disabled > a:hover,
 .pagination ul > .disabled > a:focus {
-  color: @grayLight;
-  background-color: transparent;
-  cursor: default;
+  background-color: @paginationBackground;
 }
 .pagination ul > li:first-child > a,
 .pagination ul > li:first-child > span {


### PR DESCRIPTION
Disabled items in a pagination list have a transparent background applied to them, so whatever the colour behind the pagination bleeds though.

http://jsfiddle.net/kpRGA/

The patch should set the background to the default for the pagination list and set the colour of the text to the disabled colour and remove the cursor.
