### PR TITLE
fix for #6691,#6692: overriding fixes for #5669,#5668,#5727

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -100,6 +100,13 @@
             that.$element.trigger(completeEvent)
           }
 
+      var $toggle = that.$element.parent().find('.accordion-toggle'),
+        $toggles = $toggle.closest('.accordion').find('.accordion-toggle')
+
+      $toggle[that.$element.hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+
+      if ($toggle.attr('data-parent')) $toggles.not($toggle).addClass('collapsed')
+
       this.$element.trigger(startEvent)
 
       if (startEvent.isDefaultPrevented()) return
@@ -160,7 +167,6 @@
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
       , option = $(target).data('collapse') ? 'toggle' : $this.data()
-    $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     $(target).collapse(option)
   })
 


### PR DESCRIPTION
Tested in Chrome, Firefox, Safari, IE - waits for transition to finish in collapse before other accordion panels are toggled
