### PR TITLE
Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
   , "description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development."
   , "keywords": ["bootstrap", "css"]
   , "homepage": "http://twitter.github.com/bootstrap/"
-  , "author": "Twitter Inc."
+  , "authors": [{
+      "name": "Twitter Inc."
+    }]
   , "license": "Apache-2.0"
 
 }


### PR DESCRIPTION
Composer return a validation error because the "author" attribute is not defined.

It should be called "authors" and be an array of objects as is defined in the res/composer-schema.json file.

https://github.com/composer/composer/blob/master/res/composer-schema.json  
