### PR TITLE
Single quick fix in one of the example files

### DIFF
--- a/docs/examples/fluid.html
+++ b/docs/examples/fluid.html
@@ -18,7 +18,7 @@
         padding: 9px 0;
       }
 
-      @media (max-width: 980px) {
+      @media (max-width: 979px) {
         /* Enable use of floated navbar text */
         .navbar-text.pull-right {
           float: none;


### PR DESCRIPTION
The navbar class starts a pixel early at 980px, before the other
bootstrap and responsive css files do at 979px

Here is a shot of the bug that was fixed:
![Screen Shot 2013-02-21 at 12 53 43 PM](https://f.cloud.github.com/assets/1238994/181733/0aab6716-7c58-11e2-8dc7-86a6a4af73c8.png)
