### PR TITLE
Fix for tooltip disappearance

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -224,12 +224,12 @@
 
       function removeWithAnimation() {
         var timeout = setTimeout(function () {
-          $tip.off($.support.transition.end).detach()
+          $tip.filter(':not(.in)').off($.support.transition.end).detach()
         }, 500)
 
         $tip.one($.support.transition.end, function () {
           clearTimeout(timeout)
-          $tip.detach()
+          $tip.filter(':not(.in)').detach()
         })
       }
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -82,9 +82,9 @@
   , enter: function (e) {
       var self = $(e.currentTarget)[this.type](this._options).data(this.type)
 
+      clearTimeout(this.timeout)
       if (!self.options.delay || !self.options.delay.show) return self.show()
 
-      clearTimeout(this.timeout)
       self.hoverState = 'in'
       this.timeout = setTimeout(function() {
         if (self.hoverState == 'in') self.show()


### PR DESCRIPTION
The bug occurs when using tooltip with hide delay that is longer than show delay, for example:

``` js
delay: {
  show: 0,
  hide: 200
}
```

If we quickly do mouse enter, leave and enter again our tooltip will get instantly showed but then hidden because the hide timeout is not cleared.
