### PR TITLE
Hide tooltip if parent element moved

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -111,6 +111,7 @@
         , placement
         , tp
         , e = $.Event('show')
+        , that = this
 
       if (this.hasContent() && this.enabled) {
         this.$element.trigger(e)
@@ -131,6 +132,15 @@
           .css({ top: 0, left: 0, display: 'block' })
 
         this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+
+        this.interval = setInterval(function() {
+          if (that.elementOffset
+            && (that.elementOffset.top != that.$element.offset().top
+            || that.elementOffset.left != that.$element.offset().left)) {
+            that.hide()
+          }
+          that.elementOffset = that.$element.offset()
+        }, 500)
 
         pos = this.getPosition()
 
@@ -238,6 +248,8 @@
         $tip.detach()
 
       this.$element.trigger('hidden')
+
+      clearInterval(this.interval)
 
       return this
     }

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -291,4 +291,26 @@ $(function () {
           container.remove()
         }, 100)
       })
+
+      test("should not show tooltip if parent element moves", function () {
+        var container = $("<div />").appendTo("body")
+            .css({position: "absolute", bottom: 0, left: 0, textAlign: "right", width: 300, height: 300})
+            .offset({ top: 100 })
+          , tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
+            .appendTo(container)
+            .tooltip()
+            .tooltip('show')
+
+        stop()
+
+        setTimeout(function(){
+          container.offset({ top: 200 })
+          ok($(".tooltip").is('.fade.in'), 'tooltip is faded in')
+          setTimeout(function(){
+            start()
+            ok(!$(".tooltip").is('.fade.in'), 'tooltip is not faded in')
+          }, 520)
+        }, 500)
+      })
+
 })


### PR DESCRIPTION
No mouseout event is triggered when the parent element of the tooltip
changes position, so the tooltip doesn't dissapear even if the cursor
isn't hover it anymore.

A check every 500 milliseconds has been added. It looks for the
position of the parent item and if it changed hides the tooltip.
