### PR TITLE
Position of the page doesn't change anymore when switching from a short to a long page

### DIFF
--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -29,6 +29,7 @@ body {
   font-size: 1.4rem;
   line-height: 1.5;
   background-color: @body-background;
+  overflow-y: scroll;
 }
 
 // Reset fonts for revelant elements


### PR DESCRIPTION
When switching from a page without a scrollbar to a page with one or vice versa, the centre of the page changes. This causes a slight move to left or right. This easy fix makes sure a vertical scrollbar is always visible, even when it's not needed. This way no centre change happens and the page doesn't move slightly.
