### PR TITLE
Fixes #6242: Can't disable the button immediately after the reset.

### DIFF
--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -47,6 +47,7 @@
       state == 'loadingText' ?
         $el.addClass(d).attr(d, d) :
         $el.removeClass(d).removeAttr(d)
+        $el.trigger('set:state:' + state)
     }, 0)
   }
 

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -47,7 +47,7 @@
       state == 'loadingText' ?
         $el.addClass(d).attr(d, d) :
         $el.removeClass(d).removeAttr(d)
-        $el.trigger('set:state:' + state)
+      $el.trigger('set:state:' + state)
     }, 0)
   }
 


### PR DESCRIPTION
Fixes #6242 - triggering a custom event to allow user to catch the moment when the button state is completely changed.
