### PR TITLE
Save some traffic: round mantissa length of percentage values to two.

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -565,8 +565,8 @@
 }
 .makeColumn(@columns: 1, @offset: 0) {
   float: left;
-  margin-left: (@gridColumnWidth * @offset) + (@gridGutterWidth * (@offset - 1)) + (@gridGutterWidth * 2);
-  width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
+  margin-left: round((@gridColumnWidth * @offset) + (@gridGutterWidth * (@offset - 1)) + (@gridGutterWidth * 2), 2);
+  width: round((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)), 2);
 }
 
 // The Grid
@@ -587,11 +587,11 @@
     .offsetX (0) {}
 
     .offset (@columns) {
-      margin-left: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns + 1));
+      margin-left: round((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns + 1)), 2);
     }
 
     .span (@columns) {
-      width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
+      width: round((@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1)), 2);
     }
 
     .row {
@@ -602,7 +602,7 @@
     [class*="span"] {
       float: left;
       min-height: 1px; // prevent collapsing columns
-      margin-left: @gridGutterWidth;
+      margin-left: round(@gridGutterWidth, 2);
     }
 
     // Set the container width, and override it for fixed navbars in media queries
@@ -633,18 +633,18 @@
     .offsetX (0) {}
 
     .offset (@columns) {
-      margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth*2);
-  	  *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + (@fluidGridGutterWidth*2) - (.5 / @gridRowWidth * 100 * 1%);
+      margin-left: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth*2), 2);
+  	  *margin-left: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + (@fluidGridGutterWidth*2) - (.5 / @gridRowWidth * 100 * 1%), 2);
     }
 
     .offsetFirstChild (@columns) {
-      margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth);
-      *margin-left: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+      margin-left: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) + (@fluidGridGutterWidth), 2);
+      *margin-left: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%) + @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%), 2);
     }
 
     .span (@columns) {
-      width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1));
-      *width: (@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%);
+      width: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)), 2);
+      *width: round((@fluidGridColumnWidth * @columns) + (@fluidGridGutterWidth * (@columns - 1)) - (.5 / @gridRowWidth * 100 * 1%), 2);
     }
 
     .row-fluid {
@@ -653,8 +653,8 @@
       [class*="span"] {
         .input-block-level();
         float: left;
-        margin-left: @fluidGridGutterWidth;
-        *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+        margin-left: round(@fluidGridGutterWidth, 2);
+        *margin-left: round(@fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%), 2);
       }
       [class*="span"]:first-child {
         margin-left: 0;
@@ -662,7 +662,7 @@
 
       // Space grid-sized controls properly if multiple per line
       .controls-row [class*="span"] + [class*="span"] {
-        margin-left: @fluidGridGutterWidth;
+        margin-left: round(@fluidGridGutterWidth, 2);
       }
 
       // generate .spanX and .offsetX


### PR DESCRIPTION
The `bootstrap-responsive.css` from Bootstrap 2.3 contains several percentage numbers with unnecessarily high precision, such as

```
width:31.570740134569924%
```

There are 148 of those:

```
$ grep -Hno '\.[0-9]\{3,\}%' bootstrap/css/bootstrap-responsive.css | wc -l
148
```

By rounding all percentages in `bootstrap-responsive.min.css` to at maximum two digits after the decimal point, the size of the file is reduced by 11 %.

Regarding a percentage number, a mantissa length of two means that the absolute length given by that relative value is defined with a precision of the 10000th part of the absolute reference length. This is more than enough as long as screens do not have significantly more than 10000 pixels in either dimension.

I've created the patch in a rather ignorant fashion: added `round(number, 2)` function calls until all of these long numbers disappeared. I actually have never dealt with LESS and Bootstrap LESS files before, so this patch is required to be reviewed carefully.

I'm not sure if there will be another 2.X (bugfix) release, so maybe this patch does not make sense with respect to 2.X at all. I'll have a look if there is the same situation with Bootstrap 3.
