### PR TITLE
"Plasma TV first!"

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -740,7 +740,7 @@ pre code {
           box-sizing: border-box;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 48em) {
   .container {
     max-width: 728px;
   }
@@ -821,13 +821,13 @@ pre code {
   }
 }
 
-@media screen and (min-width: 992px) {
+@media screen and (min-width: 62em) {
   .container {
     max-width: 940px;
   }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 75em) {
   .container {
     max-width: 1170px;
   }

--- a/less/grid.less
+++ b/less/grid.less
@@ -24,8 +24,8 @@
           box-sizing: border-box;
 }
 
-// Responsive: Tablets and up
-@media screen and (min-width: 768px) {
+// Responsive: Tablets and up (48em ~ 768px)
+@media screen and (min-width: 48em) {
   .container {
     max-width: 728px;
   }
@@ -36,15 +36,15 @@
   #grid > .core(@grid-column-width, @grid-gutter-width);
 }
 
-// Responsive: Desktops and up
-@media screen and (min-width: 992px) {
+// Responsive: Desktops and up (62em ~ 992px)
+@media screen and (min-width: 62em) {
   .container {
     max-width: 940px;
   }
 }
 
-// Responsive: Large desktops and up
-@media screen and (min-width: 1200px) {
+// Responsive: Large desktops and up (75em ~ 1200px)
+@media screen and (min-width: 75em) {
   .container {
     max-width: 1170px;
   }


### PR DESCRIPTION
Switched from non-proportional media queries to proportional media queries. If you sit far away from a large screen and zoom into the page you will get the "mobile" layout (e.g. responsive design not just for small screens, but for all screens). If you don't zoom the media queries behave normally.
(Caveat: Due to a [webkit bug](https://bugs.webkit.org/show_bug.cgi?id=41063) you see the changes only after a refresh (Chrome, Safari). If you don't refresh the proportional media query behaves like a non-proportional media query, so this isn't a real problem. Nothing breaks - everything behaves like it behaves now. Within Firefox you see the changes immediately.)
