### PR TITLE
Always wrap words in tooltips

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -28,6 +28,8 @@
   text-decoration: none;
   background-color: @tooltipBackground;
   .border-radius(@baseBorderRadius);
+  // Always wrap words. When used in .btn-group wrapping is disabled
+  white-space: normal;
 }
 
 // Arrows


### PR DESCRIPTION
When using tooltips within .btn-group, white-space: nowrap; is inherited in tooltips. This always sets standard white-space: normal; 
