### PR TITLE
fixes issue #7086

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -62,7 +62,7 @@
       }
 
       this.options.selector ?
-        (this._options = $.extend({}, this.options, { trigger: 'manual', selector: '' })) :
+        (this._options = $.extend({}, options, { trigger: 'manual', selector: '' })) :
         this.fixTitle()
     }
 


### PR DESCRIPTION
Default options are no longer merged with the _options property on tooltip when using the selector option. This allows data attributes on tooltips and popovers to work when using data-api.
