### PR TITLE
Relocated typeahead menu

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -56,12 +56,12 @@
     }
 
   , show: function () {
-      var pos = $.extend({}, this.$element.position(), {
+      var pos = $.extend({}, this.$element.offset(), {
         height: this.$element[0].offsetHeight
       })
 
       this.$menu
-        .insertAfter(this.$element)
+        .appendTo('body')
         .css({
           top: pos.top + pos.height
         , left: pos.left


### PR DESCRIPTION
Moved the typeahead menu to append to body instead of inserting after the affected element.
An issue I had with this is that the typeahead menu was partially hidden below the border of my div. This was because my div had overflow:hidden and a set height.
