### PR TITLE
Calling pause should never unpause. Fixes #7100

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -75,7 +75,7 @@
       if (!e) this.paused = true
       if (this.$element.find('.next, .prev').length && $.support.transition.end) {
         this.$element.trigger($.support.transition.end)
-        this.cycle()
+        this.cycle({})
       }
       clearInterval(this.interval)
       this.interval = null


### PR DESCRIPTION
Calling pause should never result in this.pause being set to false. Which is what happens if this.cycle is called with no arguments.
