### PR TITLE
dropdown events 'show' and 'hide'

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -30,6 +30,7 @@
     , Dropdown = function (element) {
         var $el = $(element).on('click.dropdown.data-api', this.toggle)
         $('html').on('click.dropdown.data-api', function () {
+          $el.parent().trigger('hide')
           $el.parent().removeClass('open')
         })
       }

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -53,6 +53,7 @@
 
       if (!isActive) {
         $parent.toggleClass('open')
+        $parent.trigger('show')
       }
 
       $this.focus()
@@ -105,7 +106,12 @@
 
   function clearMenus() {
     $(toggle).each(function () {
-      getParent($(this)).removeClass('open')
+      var $parent = getParent($(this))
+      var isActive = $parent.hasClass('open')
+      if (isActive) {
+        $parent.trigger('hide')
+      }
+      $parent.removeClass('open')
     })
   }
 

--- a/js/tests/unit/bootstrap-dropdown.js
+++ b/js/tests/unit/bootstrap-dropdown.js
@@ -148,4 +148,32 @@ $(function () {
         $("#qunit-fixture").html("")
       })
 
+      test("should fire show and hide event", function () {
+        var dropdownHTML = '<ul class="tabs">'
+          + '<li class="dropdown">'
+          + '<a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>'
+          + '<ul class="dropdown-menu">'
+          + '<li><a href="#">Secondary link</a></li>'
+          + '<li><a href="#">Something else here</a></li>'
+          + '<li class="divider"></li>'
+          + '<li><a href="#">Another link</a></li>'
+          + '</ul>'
+          + '</li>'
+          + '</ul>'
+          , dropdown = $(dropdownHTML)
+            .find('[data-toggle="dropdown"]')
+            .dropdown()
+
+        stop()
+
+        dropdown.parent('.dropdown').bind('show', function () {
+          ok(true, 'show was called')
+        }).bind('hide', function () {
+          ok(true, 'hide was called')
+          start()
+        })
+
+        dropdown.click()
+        $('body').click()
+      })
 })


### PR DESCRIPTION
Small patch that adds "show" and "hide" events on dropdowns. Useful for notification 
systems that track seen notifications. Related to issue #1343.

Usage:

``` js
$('#myDropdown").on('show', function () {
  // code
})

$('#myDropdown').on('hide', function () {
  // code
})
```

Tested with Firefox 14.0.4 and Google Chrome 21.0.1180.81 on Ubuntu 12.04 
