### PR TITLE
Add transitioning class to collapse while in progess

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -97,10 +97,10 @@
         , complete = function () {
             if (startEvent.type == 'show') that.reset()
             that.transitioning = 0
-            that.$element.trigger(completeEvent)
+            that.$element.trigger(completeEvent).removeClass("transitioning")
           }
 
-      this.$element.trigger(startEvent)
+      this.$element.trigger(startEvent).addClass("transitioning")
 
       if (startEvent.isDefaultPrevented()) return
 


### PR DESCRIPTION
The current implementation of collapse.js adds the class `in` to the expanding element as soon as the transition starts and removes it as soon as the collapse starts. 

In certain situations where the style needs to be different between collapsed and expanded mode the change has to happen only after the transition is complete.

To achieve this, the attached commit adds a class `transitioning` during the process of expanding/collapsing.
