### PR TITLE
Tooltip: Options not propagated correctly

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,9 +84,7 @@
         , options = {}
         , self
 
-      this._options && $.each(this._options, function (key, value) {
-        if (defaults[key] != value) options[key] = value
-      }, this)
+      if (this._options) options = $.extend({}, defaults, this._options);
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,7 +84,7 @@
         , options = {}
         , self
 
-      if (this._options) options = $.extend({}, defaults, this._options);
+      if (this._options) options = $.extend({}, defaults, this._options, $(e.currentTarget).data());
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
Tooltip's `enter()` function is not propagating options correctly. In my case I'm using jQuery 1.9.1 while also trying to use the `container` option. However, when the tooltip is displayed the `container` option is lost (reset to the default `false`) resulting in an `insertAfter()` call in `show()` rather than `appendTo()`.

This is a fix that uses jQuery's `$.extend()` to propagate tooltip options.
