### PR TITLE
Tooltip (3.0.0): Options not propagated correctly

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,9 +84,7 @@
         , options = {}
         , self
 
-      this._options && $.each(this._options, function (key, value) {
-        if (defaults[key] != value) options[key] = value
-      }, this)
+      if (this._options) options = $.extend({}, defaults, this._options);
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -84,7 +84,7 @@
         , options = {}
         , self
 
-      if (this._options) options = $.extend({}, defaults, this._options);
+      if (this._options) options = $.extend({}, defaults, this._options, $(e.currentTarget).data());
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
Analogous to #7138, this is the same fix for 3.0.0-wip.
