### PR TITLE
Fix Toggle all button on Customize page

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -77,12 +77,12 @@
     // toggle all plugin checkboxes
     $('#components.download .toggle-all').on('click', function (e) {
       e.preventDefault()
-      inputsComponent.attr('checked', !inputsComponent.is(':checked'))
+      inputsComponent.prop('checked', !inputsComponent.is(':checked'))
     })
 
     $('#plugins.download .toggle-all').on('click', function (e) {
       e.preventDefault()
-      inputsPlugin.attr('checked', !inputsPlugin.is(':checked'))
+      inputsPlugin.prop('checked', !inputsPlugin.is(':checked'))
     })
 
     $('#variables.download .toggle-all').on('click', function (e) {


### PR DESCRIPTION
Fix Toggle all button on [Customize page](http://twitter.github.com/bootstrap/customize.html):
after toggling the checkboxes with Toggle all button it's impossible
to ckeck them back with the same way - button doesn't work as expected.
