### PR TITLE
Remove -webkit-backface-visibility on skew mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -212,7 +212,6 @@
       -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twitter/bootstrap/issues/4885
        -o-transform: skew(@x, @y);
           transform: skew(@x, @y);
-  -webkit-backface-visibility: hidden; // See https://github.com/twitter/bootstrap/issues/5319
 }
 .translate3d(@x, @y, @z) {
   -webkit-transform: translate3d(@x, @y, @z);


### PR DESCRIPTION
This rule is causing pixelated edges on iOS, even though that's what it was supposed to fix (#5319). Removing it makes everything smooth across all OS's, browsers, and devices.

Before:

![before](https://f.cloud.github.com/assets/115911/218052/902aa40c-84fe-11e2-9245-494c9d3e0567.png)

After:

![after](https://f.cloud.github.com/assets/115911/218054/951dc26e-84fe-11e2-9fd0-df3a9014e8ea.png)
