### PR TITLE
bootstrap-modal.js "loaded" event

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,7 +30,10 @@
     this.options = options
     this.$element = $(element)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-    this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
+    var that = this
+    this.options.remote && this.$element.find('.modal-body').load(this.options.remote, function(){
+      that.$element.trigger('loaded')
+    });
   }
 
   Modal.prototype = {


### PR DESCRIPTION
Added an event on modals triggered when remote content has finished loading. Useful when you need to continue to manipulate the contents of a modal that contains remote content. Figured using the event interface was be more desired than passing an explicit onload callback.
