### PR TITLE
Allows appending of styles to tooltips and popovers

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -161,6 +161,7 @@
         }
 
         this.applyPlacement(tp, placement)
+        $tip.addClass(this.options.class)
         this.$element.trigger('shown')
       }
     }
@@ -245,6 +246,7 @@
         removeWithAnimation() :
         $tip.detach()
 
+      $tip.removeClass(this.options.class)
       this.$element.trigger('hidden')
 
       return this


### PR DESCRIPTION
Since tooltips and popovers are added to the DOM with dynamic placement, it makes it difficult to add your own position style fixes. This allows styles to be added through existing "options".
