### PR TITLE
fix #6839 carousel example z-index for arrows

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -78,7 +78,7 @@
 
     .carousel .container {
       position: relative;
-      z-index: 9;
+      z-index: 8;
     }
 
     .carousel-control {
@@ -88,7 +88,7 @@
       text-shadow: 0 1px 1px rgba(0,0,0,.4);
       background-color: transparent;
       border: 0;
-      z-index: 10;
+      z-index: 9;
     }
 
     .carousel .item {


### PR DESCRIPTION
This fixes the z-index for the carousel controls in the [carousel example](http://twitter.github.com/bootstrap/examples/carousel.html#) per @pronoun's [suggestion](https://github.com/twitter/bootstrap/issues/6839#issuecomment-13457784)
