### PR TITLE
Switching from $.fn.attr to $.fn.prop for checked attributes

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -29,7 +29,7 @@
     // add-ons
     $('.add-on :checkbox').on('click', function () {
       var $this = $(this)
-        , method = $this.attr('checked') ? 'addClass' : 'removeClass'
+        , method = $this.prop('checked') ? 'addClass' : 'removeClass'
       $(this).parents('.add-on')[method]('active')
     })
 
@@ -77,12 +77,12 @@
     // toggle all plugin checkboxes
     $('#components.download .toggle-all').on('click', function (e) {
       e.preventDefault()
-      inputsComponent.attr('checked', !inputsComponent.is(':checked'))
+      inputsComponent.prop('checked', !inputsComponent.is(':checked'))
     })
 
     $('#plugins.download .toggle-all').on('click', function (e) {
       e.preventDefault()
-      inputsPlugin.attr('checked', !inputsPlugin.is(':checked'))
+      inputsPlugin.prop('checked', !inputsPlugin.is(':checked'))
     })
 
     $('#variables.download .toggle-all').on('click', function (e) {


### PR DESCRIPTION
"Toggle all" buttons do not work as expected on the [customize.html page](http://twitter.github.com/bootstrap/customize.html). Clicking them only un-checks the boxes; subsequent clicks do not re-check them.

Using $.fn.attr only retrieves the actual content of the "checked" attribute, so it never registers as false if there is content in the string. JQuery advises now using $.fn.prop for the checked attribute, which returns the actual value.

See: http://api.jquery.com/prop/
