### PR TITLE
Allow placement styles on tooltips and popovers

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -161,6 +161,7 @@
         }
 
         this.applyPlacement(tp, placement)
+        if(this.options.fixclass != null) { $tip.addClass(this.options.fixclass) }
         this.$element.trigger('shown')
       }
     }
@@ -246,7 +247,8 @@
         $tip.detach()
 
       this.$element.trigger('hidden')
-
+      if(this.options.fixclass != null) { $tip.removeClass(this.options.fixclass) }
+      
       return this
     }
 


### PR DESCRIPTION
Through existing options using "fixclass"

JS Usage:

```
$('.bs-popover').popover({html:true, trigger:'click', fixclass:'popover-offset'})
```

CSS Usage:

```
.popover-offset { margin-left: -85px; }
```
