### PR TITLE
fixed mobile menu expansion with submenus

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -67,7 +67,7 @@
 
       this.$element[dimension](0)
       this.transition('addClass', $.Event('show'), 'shown')
-      $.support.transition && this.$element[dimension](this.$element[0][scroll])
+      $.support.transition && this.$element[dimension]('auto')
     }
 
   , hide: function () {


### PR DESCRIPTION
The first time expanding the mobile menu in bootstrap, submenus would not make the menu taller - this resulted in long menus losing entries.
This issue could be resolved by closing and opening the menu.
I found that changing the dimension on the initial open function to 'auto' fixed this issue, and didn't seem to have negative effects.
Tested in Chrome, Firefox, and Safari under OS X 10.8.2; tested in IE7, IE8, and IE9 under Windows 7.
