### PR TITLE
Makefile dependency tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore jshint build timestamp
+js/.lastbuilt
+
 # Ignore compiled docs
 _gh_pages
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ bootstrap/fonts/*: fonts/*
 # MAKE FOR GH-PAGES 4 FAT & MDO ONLY (O_O  )
 #
 
-gh-pages: bootstrap docs
+gh-pages: bootstrap
 	rm -f docs/assets/bootstrap.zip
 	zip -r docs/assets/bootstrap.zip bootstrap
 	rm -r bootstrap

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,10 @@ test:
 #
 
 clean:
+	-rm ${BOOTSTRAP}
 	-rm js/.lastbuilt
+	-rm ${DOCS_FONTS}
+	-rm ${DOCS_JS}
 	-rm -r bootstrap
 
 #

--- a/Makefile
+++ b/Makefile
@@ -121,4 +121,4 @@ watch:
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 
-.PHONY: docs watch gh-pages bootstrap-img bootstrap-css bootstrap-js
+.PHONY: build test clean bootstrap bootstrap-js bootstrap-css bootstrap-fonts gh-pages watch

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ gh-pages: bootstrap
 #
 
 watch:
-	echo "Watching less files..."; \
+	@echo "Watching less files..."; \
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ BOOTSTRAP_LESS = ./less/bootstrap.less
 DATE=$(shell date +%I:%M%p)
 CHECK=\033[32m✔ Done\033[39m
 HR=\033[37m--------------------------------------------------\033[39m
+BIN_PREFIX=./node_modules/.bin
+JSHINT_BIN=$(BIN_PREFIX)/jshint
+RECESS_BIN=$(BIN_PREFIX)/recess
+UGLIFYJS_BIN=$(BIN_PREFIX)/uglifyjs
 
 #
 # BUILD DOCS
@@ -12,17 +16,17 @@ build:
 	@echo "\n\n"
 	@echo "\033[36mBuilding Bootstrap...\033[39m"
 	@echo "${HR}"
-	@./node_modules/.bin/jshint js/*.js --config js/.jshintrc
-	@./node_modules/.bin/jshint js/tests/unit/*.js --config js/.jshintrc
+	@$(JSHINT_BIN) js/*.js --config js/.jshintrc
+	@$(JSHINT_BIN) js/tests/unit/*.js --config js/.jshintrc
 	@echo "Running JSHint on javascript...             ${CHECK}"
-	@./node_modules/.bin/recess --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
+	@$(RECESS_BIN) --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
 	@echo "Compiling LESS with Recess...               ${CHECK}"
 	@cp fonts/* docs/assets/fonts/
 	@cp js/*.js docs/assets/js/
 	@cp js/tests/vendor/jquery.js docs/assets/js/
 	@echo "Prepping fonts and JavaScript...            ${CHECK}"
 	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
-	@./node_modules/.bin/uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
+	@$(UGLIFYJS_BIN) -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
 	@echo "/**\n* Bootstrap.js v3.0.0 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
@@ -37,8 +41,8 @@ build:
 #
 
 test:
-	./node_modules/.bin/jshint js/*.js --config js/.jshintrc
-	./node_modules/.bin/jshint js/tests/unit/*.js --config js/.jshintrc
+	$(JSHINT_BIN) js/*.js --config js/.jshintrc
+	$(JSHINT_BIN) js/tests/unit/*.js --config js/.jshintrc
 	node js/tests/server.js &
 	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
 	kill -9 `cat js/tests/pid.txt`
@@ -67,7 +71,7 @@ bootstrap-js: bootstrap/js/*.js
 bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
-	./node_modules/.bin/uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
+	$(UGLIFYJS_BIN) -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
 	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
@@ -80,10 +84,10 @@ bootstrap-css: bootstrap/css/*.css
 
 bootstrap/css/*.css: less/*.less
 	mkdir -p bootstrap/css
-	./node_modules/.bin/recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
-	./node_modules/.bin/recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	./node_modules/.bin/recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-	./node_modules/.bin/recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
+	$(RECESS_BIN) --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
+	$(RECESS_BIN) --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
+	$(RECESS_BIN) --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
+	$(RECESS_BIN) --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
 
 #
 # FONTS

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ bootstrap/js/*.js: js/*.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
 
 #
-# CSS COMPLILE
+# CSS COMPILE
 #
 
 bootstrap-css: bootstrap/css/*.css

--- a/Makefile
+++ b/Makefile
@@ -12,21 +12,29 @@ UGLIFYJS_BIN=$(BIN_PREFIX)uglifyjs
 # BUILD DOCS
 #
 
-build: splash js/.lastbuilt ${BOOTSTRAP}
-	@cp fonts/* docs/assets/fonts/
-	@cp js/*.js docs/assets/js/
-	@cp js/tests/vendor/jquery.js docs/assets/js/
-	@echo "Prepping fonts and JavaScript...            ${CHECK}"
-	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
+FONTS=${wildcard fonts/*}
+DOCS_FONTS=${patsubst fonts/%,docs/assets/fonts/%,${FONTS}}
+JS=${wildcard js/*.js} js/tests/vendor/jquery.js
+DOCS_JS=${patsubst js/%,docs/assets/js/%,${wildcard js/*.js}} docs/assets/js/jquery.js
+
+build: splash js/.lastbuilt ${BOOTSTRAP} ${DOCS_FONTS} ${DOCS_JS} docs/assets/js/bootstrap.js docs/assets/js/bootstrap.min.js
+	@echo "${HR}"
+	@echo "\033[36mSuccess!\n\033[39m"
+	@echo "\033[37mThanks for using Bootstrap,"
+	@echo "<3 @mdo and @fat\n\033[39m"
+
+docs/assets/js/bootstrap.js docs/assets/js/bootstrap.min.js: ${JS}
+	@cat ${JS} > docs/assets/js/bootstrap.js
 	@$(UGLIFYJS_BIN) -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
 	@echo "/**\n* Bootstrap.js v3.0.0 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
 	@echo "Compiling and minifying javascript...       ${CHECK}"
-	@echo "${HR}"
-	@echo "\033[36mSuccess!\n\033[39m"
-	@echo "\033[37mThanks for using Bootstrap,"
-	@echo "<3 @mdo and @fat\n\033[39m"
+
+${DOCS_FONTS} ${DOCS_JS}: ${FONTS} ${JS}
+	@cp ${FONTS} docs/assets/fonts/
+	@cp ${JS} docs/assets/js/
+	@echo "Prepping fonts and JavaScript...            ${CHECK}"
 
 splash:
 	@echo "\n\n"

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ UGLIFYJS_BIN=$(BIN_PREFIX)uglifyjs
 # BUILD DOCS
 #
 
-	@$(RECESS_BIN) --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
-	@echo "Compiling LESS with Recess...               ${CHECK}"
-build: splash js/.lastbuilt
+build: splash js/.lastbuilt ${BOOTSTRAP}
 	@cp fonts/* docs/assets/fonts/
 	@cp js/*.js docs/assets/js/
 	@cp js/tests/vendor/jquery.js docs/assets/js/
@@ -40,6 +38,10 @@ js/.lastbuilt: js/*.js
 	@$(JSHINT_BIN) js/tests/unit/*.js --config js/.jshintrc
 	@touch js/.lastbuilt
 	@echo "Running JSHint on javascript...             ${CHECK}"
+
+${BOOTSTRAP}: ${BOOTSTRAP_LESS}
+	@$(RECESS_BIN) --compile $^ > $@
+	@echo "Compiling LESS with Recess...               ${CHECK}"
 #
 # RUN JSHINT & QUNIT TESTS IN PHANTOMJS
 #

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 #
 
 clean:
-	rm -r bootstrap
+	-rm -r bootstrap
 
 #
 # BUILD SIMPLE BOOTSTRAP DIRECTORY

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ build:
 	@echo "\n\n"
 	@echo "\033[36mBuilding Bootstrap...\033[39m"
 	@echo "${HR}"
-	@jshint js/*.js --config js/.jshintrc
-	@jshint js/tests/unit/*.js --config js/.jshintrc
+	@./node_modules/.bin/jshint js/*.js --config js/.jshintrc
+	@./node_modules/.bin/jshint js/tests/unit/*.js --config js/.jshintrc
 	@echo "Running JSHint on javascript...             ${CHECK}"
 	@./node_modules/.bin/recess --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
 	@echo "Compiling LESS with Recess...               ${CHECK}"

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,9 @@ UGLIFYJS_BIN=$(BIN_PREFIX)uglifyjs
 # BUILD DOCS
 #
 
-build:
-	@echo "\n\n"
-	@echo "\033[36mBuilding Bootstrap...\033[39m"
-	@echo "${HR}"
-	@$(JSHINT_BIN) js/*.js --config js/.jshintrc
-	@$(JSHINT_BIN) js/tests/unit/*.js --config js/.jshintrc
-	@echo "Running JSHint on javascript...             ${CHECK}"
 	@$(RECESS_BIN) --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
 	@echo "Compiling LESS with Recess...               ${CHECK}"
+build: splash js/.lastbuilt
 	@cp fonts/* docs/assets/fonts/
 	@cp js/*.js docs/assets/js/
 	@cp js/tests/vendor/jquery.js docs/assets/js/
@@ -36,6 +30,16 @@ build:
 	@echo "\033[37mThanks for using Bootstrap,"
 	@echo "<3 @mdo and @fat\n\033[39m"
 
+splash:
+	@echo "\n\n"
+	@echo "\033[36mBuilding Bootstrap...\033[39m"
+	@echo "${HR}"
+
+js/.lastbuilt: js/*.js
+	@$(JSHINT_BIN) js/*.js --config js/.jshintrc
+	@$(JSHINT_BIN) js/tests/unit/*.js --config js/.jshintrc
+	@touch js/.lastbuilt
+	@echo "Running JSHint on javascript...             ${CHECK}"
 #
 # RUN JSHINT & QUNIT TESTS IN PHANTOMJS
 #
@@ -53,6 +57,7 @@ test:
 #
 
 clean:
+	-rm js/.lastbuilt
 	-rm -r bootstrap
 
 #
@@ -121,4 +126,4 @@ watch:
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 
-.PHONY: build test clean bootstrap bootstrap-js bootstrap-css bootstrap-fonts gh-pages watch
+.PHONY: build test clean bootstrap bootstrap-js bootstrap-css bootstrap-fonts gh-pages watch splash

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ bootstrap-js: bootstrap/js/*.js
 
 bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
-	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
+	cat $^ > bootstrap/js/bootstrap.js
 	$(UGLIFYJS_BIN) -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
 	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ BOOTSTRAP_LESS = ./less/bootstrap.less
 DATE=$(shell date +%I:%M%p)
 CHECK=\033[32m✔ Done\033[39m
 HR=\033[37m--------------------------------------------------\033[39m
-BIN_PREFIX=./node_modules/.bin
-JSHINT_BIN=$(BIN_PREFIX)/jshint
-RECESS_BIN=$(BIN_PREFIX)/recess
-UGLIFYJS_BIN=$(BIN_PREFIX)/uglifyjs
+BIN_PREFIX=./node_modules/.bin/
+JSHINT_BIN=$(BIN_PREFIX)jshint
+RECESS_BIN=$(BIN_PREFIX)recess
+UGLIFYJS_BIN=$(BIN_PREFIX)uglifyjs
 
 #
 # BUILD DOCS


### PR DESCRIPTION
This expands on the patch in #7022, adding full dependency tracking for all targets. I don't regard it as finished, since this patch makes the build splash screen behave a bit confusingly when nothing is being built, but I haven't thought of a good solution for this yet. Ideas are welcome.
