### PR TITLE
Updated bootstrap-typeahead.js highlighter to apply `<strong>` not to the matched string, but instead to the remaining portion of the suggested item.

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -129,9 +129,10 @@
 
   , highlighter: function (item) {
       var query = this.query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&')
-      return item.replace(new RegExp('(' + query + ')', 'ig'), function ($1, match) {
-        return '<strong>' + match + '</strong>'
-      })
+      return ('<strong>' + 
+             item.replace(new RegExp('(' + query + ')', 'ig'), function ($1, match) {
+        return '</strong>' + match + '<strong>'
+      }) + "</strong>").replace("<strong></strong>","")
     }
 
   , render: function (items) {


### PR DESCRIPTION
Updated bootstrap-typeahead.js highlighter to apply `<strong>` not to the matched string, but instead to the remaining portion of the suggested item. Has the effect of highlighting what the UI widget is offering to type-ahead for you rather than what you've already typed.

e.g.
user typed: Jin
item: Jingle
suggestion appearance: Jin<strong>gle</strong>

user typed: gl
item: Jingle
suggestion appearance: <strong>Jin</strong>gl<strong>e</strong>
