### PR TITLE
Positioned the .brand to the left

### DIFF
--- a/less/responsive-navbar.less
+++ b/less/responsive-navbar.less
@@ -38,6 +38,12 @@
     padding-right: 10px;
     margin: 0 0 0 -5px;
   }
+  
+  .btn-navbar[data-toggle=collapse] {
+    & ~ .brand {
+      float: left;
+    }
+  }
 
   // COLLAPSIBLE NAVBAR
   // ------------------


### PR DESCRIPTION
Set the float of the .brand class to left when preceded by the collapse toggle button in the responsive navbar. The button is defined with float=right so setting the float of the .brand to left makes it a bit more appealing.
