### PR TITLE
Add test of $.support.transition in bootstrap-carousel

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -73,7 +73,7 @@
 
   , pause: function (e) {
       if (!e) this.paused = true
-      if (this.$element.find('.next, .prev').length && $.support.transition.end) {
+      if (this.$element.find('.next, .prev').length && $.support.transition $.support.transition.end) {
         this.$element.trigger($.support.transition.end)
         this.cycle(true)
       }

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -73,7 +73,7 @@
 
   , pause: function (e) {
       if (!e) this.paused = true
-      if (this.$element.find('.next, .prev').length && $.support.transition $.support.transition.end) {
+      if (this.$element.find('.next, .prev').length && $.support.transition && $.support.transition.end) {
         this.$element.trigger($.support.transition.end)
         this.cycle(true)
       }


### PR DESCRIPTION
JS Error detected on IE7 while carousel paused. Add check on $.support.transition before testing $.support.transition.end in the pause method fixed the problem.
