### PR TITLE
Update buttons.less to disable btn pointer events

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -42,6 +42,7 @@
   &[disabled],
   fieldset[disabled] & {
     cursor: default;
+    pointer-events: none;
     .opacity(.65);
     .box-shadow(none);
   }


### PR DESCRIPTION
Buttons that are disabled are still clickable and can still fire click events (such as hopping up to the top of the page if your anchor href points to "#"). Adding the `pointer-events: none` property will truly disable the button so situations like this don't happen. 
