### PR TITLE
Added bower install to download/install options in getting started guide

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -52,6 +52,11 @@ description: Overview of the project, its contents, and how to get started with 
             <p>Get the original files for all CSS and JavaScript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
             <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);">Download Bootstrap source</a></p>
           </div>
+          <div class="span6">
+            <h2>Install source</h2>
+            <p>Install and manage the original files for all CSS and JavaScript, along with a local copy of the docs using <a href="http://twitter.github.com/bower">Bower</a>, a package-manager for the web.</p>
+            <p><pre>bower install bootstrap</pre></p>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
As requested by @mdo, I've updated this PR so that it's against the 3.0.0-wip branch rather than gh-pages directly. 

I hope everything is in order. I assume you guys deploy a built version of this to gh-pages, but if you still require a compile on my end, let me know :)
