### PR TITLE
Fix links since the move to jekyll

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -14,19 +14,19 @@
           <a href="/">Home</a>
         </li>
         <li {% if page.title == "Getting started" %}class="active"{% endif %}>
-          <a href="/getting-started">Get started</a>
+          <a href="/getting-started.html">Get started</a>
         </li>
         <li {% if page.title == "CSS" %}class="active"{% endif %}>
-          <a href="/css">CSS</a>
+          <a href="/css.html">CSS</a>
         </li>
         <li {% if page.title == "Components" %}class="active"{% endif %}>
-          <a href="/components">Components</a>
+          <a href="/components.html">Components</a>
         </li>
         <li {% if page.title == "JavaScript plugins" %}class="active"{% endif %}>
-          <a href="/javascript">JavaScript</a>
+          <a href="/javascript.html">JavaScript</a>
         </li>
         <li {% if page.title == "Customize and download" %}class="active"{% endif %}>
-          <a href="/customize">Customize</a>
+          <a href="/customize.html">Customize</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The links in the compiled docs are broken if I serve them statically.
