### PR TITLE
Fix dropdown (and therefore typeahead) wrap

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -79,7 +79,7 @@
     font-weight: normal;
     line-height: @baseLineHeight;
     color: @dropdownLinkColor;
-    white-space: nowrap;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
I have recently been experimenting with a lot of Typeahead controls, and I ran into a situation where my Typeahead was too wide for my screen, particularly on mobile devices, and it was not wrapping as I had expected it to do.

http://jsfiddle.net/Mtxkn/4/

Changing the CSS for `.dropdown-menu > li > a` to `white-space: normal` causes it to wrap in every scenario that I have seen, whereas leaving it as `nowrap` never does what I want when the text is too long for a given item.

It's possible that this has ramifications for other dropdown menus, but honestly I expect that even those would prefer to wrap than to extend the screen horizontally.  If that is not the case, then it would work to change the typeahead version of this only:

``` css
.typeahead > li > a {
  white-space: normal;
}
```
