### PR TITLE
Conveniently use objects in Typeahead

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -56,7 +56,7 @@
       var activeIndex = this.getActiveIndex()
         , that = this
 
-      if (pos > (this.$items.length - 1) || pos < 0) return
+      if (pos > (this.$items.length - 1) || pos < 0) return this
 
       if (this.sliding) {
         return this.$element.one('slid', function () {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -69,6 +69,12 @@
     }
 
   , show: function () {
+      this.showMenu()
+      this.shown = true
+      return this
+    }
+
+  , showMenu: function () {
       var pos = $.extend({}, this.$element.position(), {
         height: this.$element[0].offsetHeight
       })
@@ -80,9 +86,6 @@
         , left: pos.left
         })
         .show()
-
-      this.shown = true
-      return this
     }
 
   , hide: function () {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -29,10 +29,23 @@
   var Typeahead = function (element, options) {
     this.$element = $(element)
     this.options = $.extend({}, $.fn.typeahead.defaults, options)
+    this.lookup = this.options.lookup || this.lookup
     this.matcher = this.options.matcher || this.matcher
     this.sorter = this.options.sorter || this.sorter
+    this.sortQuerySensitive = this.options.sortQuerySensitive || this.sortQuerySensitive
+    this.sortQueryInsensitive = this.options.sortQueryInsensitive || this.sortQueryInsensitive
+    this.sortBeginsWith = this.options.sortBeginsWith || this.sortBeginsWith
+    this.sortSensitive = this.options.sortSensitive || this.sortSensitive
+    this.sortInsensitive = this.options.sortInsensitive || this.sortInsensitive
+    this.sortAny = this.options.sortAny || this.sortAny
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
+    this.show = this.options.show || this.show
+    this.showMenu = this.options.showMenu || this.showMenu
+    this.hide = this.options.hide || this.hide
+    this.focus = this.options.focus || this.focus
+    this.blur = this.options.blur || this.blur
+    this.click = this.options.click || this.click
     this.source = this.options.source
     this.$menu = $(this.options.menu)
     this.shown = false
@@ -44,7 +57,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('value')
       this.$element
         .val(this.updater(val))
         .change()
@@ -113,18 +126,46 @@
     }
 
   , sorter: function (items) {
-      var beginswith = []
+      var beginsWith = []
         , caseSensitive = []
         , caseInsensitive = []
+        , any = []
+        , sensitive = this.querySensitive()
+        , insensitive = this.queryInsensitive()
         , item
 
       while (item = items.shift()) {
-        if (!item.toLowerCase().indexOf(this.query.toLowerCase())) beginswith.push(item)
-        else if (~item.indexOf(this.query)) caseSensitive.push(item)
-        else caseInsensitive.push(item)
+        if (this.sortBeginsWith(item, sensitive, insensitive)) beginsWith.push(item)
+        else if (this.sortSensitive(item, sensitive, insensitive)) caseSensitive.push(item)
+        else if (this.sortInsensitive(item, sensitive, insensitive)) caseInsensitive.push(item)
+        else if (this.sortAny(item, sensitive, insensitive)) any.push(item)
       }
 
-      return beginswith.concat(caseSensitive, caseInsensitive)
+      return beginsWith.concat(caseSensitive, caseInsensitive, any)
+    }
+  
+  , querySensitive: function () {
+      return this.query
+    }
+  
+  , queryInsensitive: function () {
+      return this.query.toLowerCase()
+    }
+
+  , sortBeginsWith: function (item, sensitive, insensitive) {
+      return !item.toLowerCase().indexOf(insensitive)
+    }
+
+  , sortSensitive: function (item, sensitive, insensitive) {
+      return ~item.indexOf(sensitive)
+    }
+
+  , sortInsensitive: function (item, sensitive, insensitive) {
+      return ~item.indexOf(insensitive)
+    }
+
+  , sortAny: function (item, sensitive, insensitive) {
+      return true
     }
 
   , highlighter: function (item) {
@@ -138,7 +179,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('value', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -161,7 +161,7 @@
     }
 
   , sortInsensitive: function (item, sensitive, insensitive) {
-      return ~item.indexOf(insensitive)
+      return ~item.toLowerCase().indexOf(insensitive)
     }
 
   , sortAny: function (item, sensitive, insensitive) {

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -32,8 +32,8 @@
     this.lookup = this.options.lookup || this.lookup
     this.matcher = this.options.matcher || this.matcher
     this.sorter = this.options.sorter || this.sorter
-    this.sortQuerySensitive = this.options.sortQuerySensitive || this.sortQuerySensitive
-    this.sortQueryInsensitive = this.options.sortQueryInsensitive || this.sortQueryInsensitive
+    this.querySensitive = this.options.querySensitive || this.querySensitive
+    this.queryInsensitive = this.options.queryInsensitive || this.queryInsensitive
     this.sortBeginsWith = this.options.sortBeginsWith || this.sortBeginsWith
     this.sortSensitive = this.options.sortSensitive || this.sortSensitive
     this.sortInsensitive = this.options.sortInsensitive || this.sortInsensitive

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -234,6 +234,21 @@ $(function () {
         typeahead.$menu.remove()
       })
 
+      test("should match item case insensitively anywhere in the string", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(typeahead.sortInsensitive('abcd', 'A', 'a'), "abcd contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'A', 'a'), "ABCD contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'C', 'c'), "ABCD contains c")
+        ok(!typeahead.sortInsensitive('bcde', 'A', 'a'), "bcde does not contain a")
+        ok(!typeahead.sortInsensitive('BCDE', 'A', 'a'), "BCDE does not contain a")
+
+        $input.remove()
+      })
+
       test("should match any item", function () {
         var $input = $('<input />').typeahead({
               source: []

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -234,17 +234,31 @@ $(function () {
         typeahead.$menu.remove()
       })
 
-      test("should match item case insensitively anywhere in the string", function () {
+      test("should match beginning of item case insensitively", function () {
         var $input = $('<input />').typeahead({
               source: []
             }).appendTo('body')
           , typeahead = $input.data('typeahead')
 
-        ok(typeahead.sortInsensitive('abcd', 'A', 'a'), "abcd contains a")
-        ok(typeahead.sortInsensitive('ABCD', 'A', 'a'), "ABCD contains a")
-        ok(typeahead.sortInsensitive('ABCD', 'C', 'c'), "ABCD contains c")
-        ok(!typeahead.sortInsensitive('bcde', 'A', 'a'), "bcde does not contain a")
-        ok(!typeahead.sortInsensitive('BCDE', 'A', 'a'), "BCDE does not contain a")
+        ok(typeahead.sortBeginsWith('abcd', 'A', 'a'), "abcd begins with a")
+        ok(typeahead.sortBeginsWith('ABCD', 'A', 'a'), "ABCD begins with a")
+        ok(!typeahead.sortBeginsWith('bcde', 'A', 'a'), "bcde does not begin with a")
+        ok(!typeahead.sortBeginsWith('BCDE', 'A', 'a'), "BCDE does not begin with a")
+
+        $input.remove()
+      })
+
+      test("should match item case sensitively anywhere in the string", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(!typeahead.sortSensitive('abcd', 'A', 'a'), "abcd does not contain A")
+        equals(typeahead.sortSensitive('ABCD', 'A', 'a'), -1, "ABCD contains A")
+        equals(typeahead.sortSensitive('ABCD', 'C', 'c'), -3, "ABCD contains C")
+        ok(!typeahead.sortSensitive('bcde', 'A', 'a'), "bcde does not contain A")
+        ok(!typeahead.sortSensitive('BCDE', 'A', 'a'), "BCDE does not contain A")
 
         $input.remove()
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -234,50 +234,6 @@ $(function () {
         typeahead.$menu.remove()
       })
 
-      test("should match beginning of item case insensitively", function () {
-        var $input = $('<input />').typeahead({
-              source: []
-            }).appendTo('body')
-          , typeahead = $input.data('typeahead')
-
-        ok(typeahead.sortBeginsWith('abcd', 'A', 'a'), "abcd begins with a")
-        ok(typeahead.sortBeginsWith('ABCD', 'A', 'a'), "ABCD begins with a")
-        ok(!typeahead.sortBeginsWith('bcde', 'A', 'a'), "bcde does not begin with a")
-        ok(!typeahead.sortBeginsWith('BCDE', 'A', 'a'), "BCDE does not begin with a")
-
-        $input.remove()
-      })
-
-      test("should match item case sensitively anywhere in the string", function () {
-        var $input = $('<input />').typeahead({
-              source: []
-            }).appendTo('body')
-          , typeahead = $input.data('typeahead')
-
-        ok(!typeahead.sortSensitive('abcd', 'A', 'a'), "abcd does not contain A")
-        equals(typeahead.sortSensitive('ABCD', 'A', 'a'), -1, "ABCD contains A")
-        equals(typeahead.sortSensitive('ABCD', 'C', 'c'), -3, "ABCD contains C")
-        ok(!typeahead.sortSensitive('bcde', 'A', 'a'), "bcde does not contain A")
-        ok(!typeahead.sortSensitive('BCDE', 'A', 'a'), "BCDE does not contain A")
-
-        $input.remove()
-      })
-
-      test("should match item case insensitively anywhere in the string", function () {
-        var $input = $('<input />').typeahead({
-              source: []
-            }).appendTo('body')
-          , typeahead = $input.data('typeahead')
-
-        ok(typeahead.sortInsensitive('abcd', 'A', 'a'), "abcd contains a")
-        ok(typeahead.sortInsensitive('ABCD', 'A', 'a'), "ABCD contains a")
-        ok(typeahead.sortInsensitive('ABCD', 'C', 'c'), "ABCD contains c")
-        ok(!typeahead.sortInsensitive('bcde', 'A', 'a'), "bcde does not contain a")
-        ok(!typeahead.sortInsensitive('BCDE', 'A', 'a'), "BCDE does not contain a")
-
-        $input.remove()
-      })
-
       test("should match any item", function () {
         var $input = $('<input />').typeahead({
               source: []

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -233,4 +233,100 @@ $(function () {
         $input.remove()
         typeahead.$menu.remove()
       })
+
+      test("should match beginning of item case insensitively", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(typeahead.sortBeginsWith('abcd', 'A', 'a'), "abcd begins with a")
+        ok(typeahead.sortBeginsWith('ABCD', 'A', 'a'), "ABCD begins with a")
+        ok(!typeahead.sortBeginsWith('bcde', 'A', 'a'), "bcde does not begin with a")
+        ok(!typeahead.sortBeginsWith('BCDE', 'A', 'a'), "BCDE does not begin with a")
+
+        $input.remove()
+      })
+
+      test("should match item case sensitively anywhere in the string", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(!typeahead.sortSensitive('abcd', 'A', 'a'), "abcd does not contain A")
+        ok(typeahead.sortSensitive('ABCD', 'A', 'a'), "ABCD contains A")
+        ok(typeahead.sortSensitive('ABCD', 'C', 'c'), "ABCD contains C")
+        ok(!typeahead.sortSensitive('bcde', 'A', 'a'), "bcde does not contain A")
+        ok(!typeahead.sortSensitive('BCDE', 'A', 'a'), "BCDE does not contain A")
+
+        $input.remove()
+      })
+
+      test("should match item case insensitively anywhere in the string", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(typeahead.sortInsensitive('abcd', 'A', 'a'), "abcd contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'A', 'a'), "ABCD contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'C', 'c'), "ABCD contains c")
+        ok(!typeahead.sortInsensitive('bcde', 'A', 'a'), "bcde does not contain a")
+        ok(!typeahead.sortInsensitive('BCDE', 'A', 'a'), "BCDE does not contain a")
+
+        $input.remove()
+      })
+
+      test("should match any item", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(typeahead.sortAny(), "always returns true")
+
+        $input.remove()
+      })
+
+      test("sorter should only request query values once", function () {
+        var sensitive = 0
+          , insensitive = 10
+          , values = ['a', 'b']
+          , $input = $('<input />').typeahead({
+              source: [],
+              querySensitive: function() { 
+                return sensitive++
+              },
+              queryInsensitive: function() {
+                return insensitive++
+              },
+              sortBeginsWith: function(item, sensitive, insensitive) {
+                ok(sensitive == 0, "sensitive matches querySensitive")
+                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                return false
+              },
+              sortSensitive: function(item, sensitive, insensitive) {
+                ok(sensitive == 0, "sensitive matches querySensitive")
+                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                return false
+              },
+              sortInsensitive: function(item, sensitive, insensitive) {
+                ok(sensitive == 0, "sensitive matches querySensitive")
+                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                return false
+              },
+              sortAny: function(item, sensitive, insensitive) {
+                ok(sensitive == 0, "sensitive matches querySensitive")
+                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                return true
+              }
+            }).appendTo('body')
+          , sorted = $input.data('typeahead').sorter(values)
+
+        ok(sensitive == 1, "querySensitive only called once")
+        ok(insensitive == 11, "queryInsensitive only called once")
+
+        $input.remove()
+      })
 })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -255,8 +255,8 @@ $(function () {
           , typeahead = $input.data('typeahead')
 
         ok(!typeahead.sortSensitive('abcd', 'A', 'a'), "abcd does not contain A")
-        ok(typeahead.sortSensitive('ABCD', 'A', 'a'), "ABCD contains A")
-        ok(typeahead.sortSensitive('ABCD', 'C', 'c'), "ABCD contains C")
+        equals(typeahead.sortSensitive('ABCD', 'A', 'a'), -1, "ABCD contains A")
+        equals(typeahead.sortSensitive('ABCD', 'C', 'c'), -3, "ABCD contains C")
         ok(!typeahead.sortSensitive('bcde', 'A', 'a'), "bcde does not contain A")
         ok(!typeahead.sortSensitive('BCDE', 'A', 'a'), "BCDE does not contain A")
 
@@ -301,24 +301,24 @@ $(function () {
               queryInsensitive: function() {
                 return insensitive++
               },
-              sortBeginsWith: function(item, sensitive, insensitive) {
-                equals(sensitive, 0, "sensitive matches querySensitive")
-                equals(insensitive, 10, "insensitive matches queryInsensitive")
+              sortBeginsWith: function(item, cs, ci) {
+                equals(cs, 0, "sensitive matches querySensitive")
+                equals(ci, 10, "insensitive matches queryInsensitive")
                 return false
               },
-              sortSensitive: function(item, sensitive, insensitive) {
-                equals(sensitive, 0, "sensitive matches querySensitive")
-                equals(insensitive, 10, "insensitive matches queryInsensitive")
+              sortSensitive: function(item, cs, ci) {
+                equals(cs, 0, "sensitive matches querySensitive")
+                equals(ci, 10, "insensitive matches queryInsensitive")
                 return false
               },
-              sortInsensitive: function(item, sensitive, insensitive) {
-                equals(sensitive, 0, "sensitive matches querySensitive")
-                equals(insensitive, 10, "insensitive matches queryInsensitive")
+              sortInsensitive: function(item, cs, ci) {
+                equals(cs, 0, "sensitive matches querySensitive")
+                equals(ci, 10, "insensitive matches queryInsensitive")
                 return false
               },
-              sortAny: function(item, sensitive, insensitive) {
-                equals(sensitive, 0, "sensitive matches querySensitive")
-                equals(insensitive, 10, "insensitive matches queryInsensitive")
+              sortAny: function(item, cs, ci) {
+                equals(cs, 0, "sensitive matches querySensitive")
+                equals(ci, 10, "insensitive matches queryInsensitive")
                 return true
               }
             }).appendTo('body')
@@ -326,6 +326,7 @@ $(function () {
 
         equals(sensitive, 1, "querySensitive only called once")
         equals(insensitive, 11, "queryInsensitive only called once")
+        equals(sorted.length, 2, "both items appropriately returned")
 
         $input.remove()
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -302,30 +302,30 @@ $(function () {
                 return insensitive++
               },
               sortBeginsWith: function(item, sensitive, insensitive) {
-                ok(sensitive == 0, "sensitive matches querySensitive")
-                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                equals(sensitive, 0, "sensitive matches querySensitive")
+                equals(insensitive, 10, "insensitive matches queryInsensitive")
                 return false
               },
               sortSensitive: function(item, sensitive, insensitive) {
-                ok(sensitive == 0, "sensitive matches querySensitive")
-                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                equals(sensitive, 0, "sensitive matches querySensitive")
+                equals(insensitive, 10, "insensitive matches queryInsensitive")
                 return false
               },
               sortInsensitive: function(item, sensitive, insensitive) {
-                ok(sensitive == 0, "sensitive matches querySensitive")
-                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                equals(sensitive, 0, "sensitive matches querySensitive")
+                equals(insensitive, 10, "insensitive matches queryInsensitive")
                 return false
               },
               sortAny: function(item, sensitive, insensitive) {
-                ok(sensitive == 0, "sensitive matches querySensitive")
-                ok(insensitive == 10, "insensitive matches queryInsensitive")
+                equals(sensitive, 0, "sensitive matches querySensitive")
+                equals(insensitive, 10, "insensitive matches queryInsensitive")
                 return true
               }
             }).appendTo('body')
           , sorted = $input.data('typeahead').sorter(values)
 
-        ok(sensitive == 1, "querySensitive only called once")
-        ok(insensitive == 11, "queryInsensitive only called once")
+        equals(sensitive, 1, "querySensitive only called once")
+        equals(insensitive, 11, "queryInsensitive only called once")
 
         $input.remove()
       })

--- a/js/tests/unit/bootstrap-typeahead.js
+++ b/js/tests/unit/bootstrap-typeahead.js
@@ -262,6 +262,21 @@ $(function () {
 
         $input.remove()
       })
+      
+      test("should match item case insensitively anywhere in the string", function () {
+        var $input = $('<input />').typeahead({
+              source: []
+            }).appendTo('body')
+          , typeahead = $input.data('typeahead')
+
+        ok(typeahead.sortInsensitive('abcd', 'A', 'a'), "abcd contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'A', 'a'), "ABCD contains a")
+        ok(typeahead.sortInsensitive('ABCD', 'C', 'c'), "ABCD contains c")
+        ok(!typeahead.sortInsensitive('bcde', 'A', 'a'), "bcde does not contain a")
+        ok(!typeahead.sortInsensitive('BCDE', 'A', 'a'), "BCDE does not contain a")
+
+        $input.remove()
+      })
 
       test("should match any item", function () {
         var $input = $('<input />').typeahead({

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -71,7 +71,7 @@
     font-weight: normal;
     line-height: @line-height-base;
     color: @dropdown-link-color;
-    white-space: nowrap;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
http://jsfiddle.net/Mtxkn/15/

This adds the ability to conveniently override a lot more methods (ones that I arbitrarily identified as reasonable through my own usage), as well as providing an updated `sorter` method for interaction with objects.  Further, by exposing each internal sorting step as a method, as well as the query values, each piece can be overridden to enable Typeahead to work with arbitrary data.  With the changes, default behavior should remain unchanged.

The extra sorting option, `sortAny`, is added to support the case where the source gives results that may not match the actual query at all, such as through Ajax results that may have typo correction.  Such cases must also override `matcher`:

``` javascript
matcher: function() {
  return true
}
```

That can be done without changes, but the sorting would have to be completely overridden in its current form even for simple, arbitrary object sorting.  Allowing each step to be overridden enables arbitrary object support for both the `item` and the query due to the one-time expense of looking up the query in both normal and lowercase form; those methods could return anything relevant to the actual task at hand rather than a single string as well.

Overriding `highlighter` will always be necessary to support JSON objects, but that is already exposed.

Also attached are a few unit tests to test the minor added functions.

Finally, this is my first attempt at a multi-file pull request, and it's bringing across a CSS change that I referenced in a different pull request (dropdowns.less). I don't know how to remove that as part of the current request, so I apologize for the clutter.
