### PR TITLE
Allow dynamic target definition.

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -37,7 +37,7 @@
   , show: function () {
       var $this = this.element
         , $ul = $this.closest('ul:not(.dropdown-menu)')
-        , selector = $this.attr('data-target')
+        , selector = ($this.attr('data-target') || $this.data('target'))
         , previous
         , $target
         , e

--- a/js/tests/unit/bootstrap-tab.js
+++ b/js/tests/unit/bootstrap-tab.js
@@ -32,22 +32,17 @@ $(function () {
         equals($("#qunit-fixture").find('.active').attr('id'), "home")
       })
 
-      test("should activate element by tab id", function () {
-        var pillsHTML =
-            '<ul class="pills">'
-          + '<li><a href="#home">Home</a></li>'
-          + '<li><a href="#profile">Profile</a></li>'
-          + '</ul>'
+      test("should allow tab definition by data('target')", function () {
+        var $pill = $('<a href="#">Dummy</a>')
+          , $pane = $('<div>Some content</div>')
+          , $fixture = $('#qunit-fixture')
 
-        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-fixture")
+        $pill.data({target: $pane})
+        $fixture.append($pill).append($pane)
+        $pill.tab('show')
 
-        $(pillsHTML).find('li:last a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "profile")
-
-        $(pillsHTML).find('li:first a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "home")
+        equals($fixture.find('div.active').text(), 'Some content')
       })
-
 
       test("should not fire closed when close is prevented", function () {
         $.support.transition = false


### PR DESCRIPTION
Please merge this pull request to allow users to create tab pane systems where
pane selectors are unknown at tab creation time.

Currently tabs expect jquery selectors only for tab pane target
definition. This makes it difficult for dynamic tab construction where
ids and thus selectors cannot be reliably generated. Also from an
efficiency stand-point, repeated dom queries could be avoided where the
target can be computed in advance.

This commit allows a tab a have its target defined using the data api,
while giving precedence to the data-target element attribute for target
definition. This in no way conflicts with the current behaviour of tabs,
and opens up powerful avenues for extension with autogenerated tab
systems.

My use case is an embedded widget which constructs tab panes as part of a
dialogue process. As many widgets could be instantiated on each page, ids are not
feasible for me to implement without some system for generating globally unique
element ids. Simply using the data api is much simpler way of addressing this
issue in a backwards compatible fashion.

Tests are included in the bootstrap-tabs unit test section.

A duplicate test (probably a copy-paste error) was removed from the tabs unit
test.
