### PR TITLE
Fix double space in wells bottom.

### DIFF
--- a/less/wells.less
+++ b/less/wells.less
@@ -16,6 +16,9 @@
     border-color: #ddd;
     border-color: rgba(0,0,0,.15);
   }
+  >:last-child {
+    margin-bottom: 0;
+  }
 }
 
 // Sizes


### PR DESCRIPTION
If we have block-elements in well instead of text we will get a double space issue (well's padding and element's margin).

``` html
<div class="well">
  <table class="table">
    ...
  </table>
</div>
```
