### PR TITLE
Remove `text-rendering`

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -62,7 +62,6 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: @headingsFontWeight;
   line-height: @baseLineHeight;
   color: @headingsColor;
-  text-rendering: optimizelegibility; // Fix the character spacing for headings
   small {
     font-weight: normal;
     line-height: 1;


### PR DESCRIPTION
`text-rendering` is causing some pretty bad issue on Windows Chrome. Some special UTF-8 characters won't be shown and some text section can change font-face.

I created a reduced test case here: http://jsbin.com/uqisib/8/edit
- First title is the default Boostrap breaking an UTF-8 char
- Second use _impact_ font-face to clearly mark the bug (utf-8 special char and font-face)
- Third title just remove the `text-rendering` property to show the bug is resolved and is not related to the font-face

I guess right now the best solution is only to remove this property until better browser support.

_This issue only affects Windows Chrome ATM (Firefox, Safari are good and other browser don't implement this property). As Browsers seems to only implement this property on Windows, I don't think it should change anything on Mac and Ubuntu._
