### PR TITLE
Fix for ScrollSpy on pages with 100% body height

### DIFF
--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -69,8 +69,10 @@
       }
 
     , process: function () {
-        var scrollTop = this.$scrollElement.scrollTop() + this.options.offset
-          , scrollHeight = this.$scrollElement[0].scrollHeight || this.$body[0].scrollHeight
+        var body = document.body
+          , html = document.documentElement
+          , scrollTop = this.$scrollElement.scrollTop() + this.options.offset
+          , scrollHeight = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight )
           , maxScroll = scrollHeight - this.$scrollElement.height()
           , offsets = this.offsets
           , targets = this.targets


### PR DESCRIPTION
This fixes ScrollSpy behavior on pages with body { height: 100%; }

Thanks :)
