### PR TITLE
Fixes #7328: popover text not showing inside .btn-toolbar

### DIFF
--- a/less/popovers.less
+++ b/less/popovers.less
@@ -48,6 +48,7 @@
 
 .popover-content {
   padding: 9px 14px;
+  font-size: 14px; // == to .popover-title ; force or it may disappear
 }
 
 // Arrows


### PR DESCRIPTION
Hi,

This is a proposed fix for issue #7328
