### PR TITLE
Maths is required to be in parenthesis in variables.less

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -114,7 +114,7 @@
 @inputBorderRadius:             @baseBorderRadius;
 @inputDisabledBackground:       @grayLighter;
 @formActionsBackground:         #f5f5f5;
-@inputHeight:                   @baseLineHeight + 10px; // base line-height + 8px vertical padding + 2px top/bottom border
+@inputHeight:                   (@baseLineHeight + 10px); // base line-height + 8px vertical padding + 2px top/bottom border
 
 
 // Dropdowns


### PR DESCRIPTION
according less1.4.0 (currently 1.4.0 Beta)Maths is required to be in parenthesis.

in variables.less 

```
@inputHeight:                   @baseLineHeight + 10px;
```

in previous version of less will compiled to 

```
@inputHeight: 30px;
```

but in version 1.4+ it will compiled to 

```
@inputHeight : 20px +10px;
```

so I modified to 

```
@inputHeight:                   (@baseLineHeight + 10px);
```
