### PR TITLE
Fixed .spanX selector (*= instead of ^=)

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -25,7 +25,7 @@
     max-width: 728px;
   }
   // Generate the grid columns and offsets
-  [class^="span"] { float: left; }
+  [class*="span"] { float: left; }
   .generate-grid-columns(@grid-columns);
 }
 


### PR DESCRIPTION
`[class^="span"]` will only match elements with a class attribute that begins with "span", meaning it won't work if spanX isn't the first class. This caused me some confusion when I had an element with multiple classes and couldn't figure out why it wasn't floating left. Changing the selector to `[class*="span"]` will match any elements that have "span" in the class attribute.
