### PR TITLE
[example] fix sticky-footer-navbar example

### DIFF
--- a/docs/examples/sticky-footer-navbar.html
+++ b/docs/examples/sticky-footer-navbar.html
@@ -57,6 +57,11 @@
       #wrap > .container {
         padding-top: 60px;
       }
+      @media (max-width: 979px) {
+        #wrap > .container {
+          padding-top: 0;
+        }
+      }
       .container .credit {
         margin: 20px 0;
       }


### PR DESCRIPTION
[example] fix sticky-footer-navbar so container won't have excessive padding <979px
