### PR TITLE
IE img bug fix for <img width=>

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -79,7 +79,10 @@ sub {
 img {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%; /* Part 1: Set a maxium relative to the parent */
-  width: auto\9; /* IE7-8 need help adjusting responsive images */
+  min-width: auto\9; /* IE7-8 need help adjusting responsive images */
+  &[width] {
+    min-width: 0; /* Overwrite min-width: auto when img width set IE9 fix */
+  }
   height: auto; /* Part 2: Scale the height according to the width, otherwise you get stretching */
 
   vertical-align: middle;


### PR DESCRIPTION
In IE 9 images a scaled to max width even when the width attr is set in <img>. This fix segregates the auto scaling of the with only when there is no width attr set.
