### PR TITLE
tooltip options never inherited bug

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -86,7 +86,7 @@
 
       this._options && $.each(this._options, function (key, value) {
         if (defaults[key] != value) options[key] = value
-      }, this)
+      });
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
Also, `$.each(obj, fn, args)` is undocumented api usage.
