### PR TITLE
Fix horizontal-three-colors to a horizontal filter gradient

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -283,7 +283,7 @@
     background-image: -o-linear-gradient(left, @startColor, @midColor @colorStop, @endColor);
     background-image: linear-gradient(to right, @startColor, @midColor @colorStop, @endColor);
     background-repeat: no-repeat;
-    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
+    filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",argb(@startColor),argb(@endColor))); // IE9 and down, gets no color-stop at all for proper fallback
   }
 
   .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {


### PR DESCRIPTION
While playing with a preview Sass conversion of 3 I noticed that both horizontal-three-colors and vertical-three-colors had the same filter type. This fixes horizontal-three-colors so that a horizontal gradient is rendered in IE9 and below.
