### PR TITLE
Fixing bugs in the example templates for 3.0.0

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -263,7 +263,7 @@ body {
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="brand" href="#">Project name</a>
+        <a class="navbar-brand" href="#">Project name</a>
         <!-- Responsive Navbar Part 2: Place all navbar contents you want collapsed withing .navbar-collapse.collapse. -->
         <div class="nav-collapse collapse">
           <ul class="nav">

--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -56,7 +56,7 @@ body {
 }
 
 /* Offset the responsive button for proper vertical alignment */
-.navbar .btn-navbar {
+.navbar .navbar-toggle {
   margin-top: 10px;
 }
 
@@ -258,7 +258,7 @@ body {
     <div class="navbar navbar-inverse">
       <div class="navbar-inner">
         <!-- Responsive Navbar Part 1: Button for triggering responsive navbar (not covered in tutorial). Include responsive CSS to utilize. -->
-        <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>

--- a/docs/examples/jumbotron.html
+++ b/docs/examples/jumbotron.html
@@ -44,7 +44,7 @@ title: Jumbotron template
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </a>
-    <a class="brand" href="#">Project name</a>
+    <a class="navbar-brand" href="#">Project name</a>
     <div class="nav-collapse collapse">
       <ul class="nav">
         <li class="active"><a href="#">Home</a></li>

--- a/docs/examples/jumbotron.html
+++ b/docs/examples/jumbotron.html
@@ -39,7 +39,7 @@ title: Jumbotron template
 
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="container">
-    <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+    <a class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>

--- a/docs/examples/starter-template.html
+++ b/docs/examples/starter-template.html
@@ -23,7 +23,7 @@ title: Starter template
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="brand" href="#">Project name</a>
+      <a class="navbar-brand" href="#">Project name</a>
       <div class="nav-collapse collapse">
         <ul class="nav">
           <li class="active"><a href="#">Home</a></li>

--- a/docs/examples/starter-template.html
+++ b/docs/examples/starter-template.html
@@ -18,7 +18,7 @@ title: Starter template
 <div class="navbar navbar-inverse navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>

--- a/docs/examples/sticky-footer-navbar.html
+++ b/docs/examples/sticky-footer-navbar.html
@@ -75,7 +75,7 @@ title: Sticky footer with navbar template
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="brand" href="#">Project name</a>
+      <a class="navbar-brand" href="#">Project name</a>
       <div class="nav-collapse collapse">
         <ul class="nav">
           <li class="active"><a href="#">Home</a></li>

--- a/docs/examples/sticky-footer-navbar.html
+++ b/docs/examples/sticky-footer-navbar.html
@@ -70,7 +70,7 @@ title: Sticky footer with navbar template
   <!-- Fixed navbar -->
   <div class="navbar navbar-fixed-top">
     <div class="container">
-      <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -369,7 +369,7 @@ $('#myModal').on('hidden', function () {
             <div id="navbar-example" class="navbar navbar-static">
               <div class="navbar-inner">
                 <div class="container" style="width: auto;">
-                  <a class="brand" href="#">Project Name</a>
+                  <a class="navbar-brand" href="#">Project Name</a>
                   <ul class="nav" role="navigation">
                     <li class="dropdown">
                       <a id="drop1" href="#" role="button" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
@@ -504,7 +504,7 @@ $('.dropdown-toggle').dropdown()
             <div id="navbarExample" class="navbar navbar-static">
               <div class="navbar-inner">
                 <div class="container" style="width: auto;">
-                  <a class="brand" href="#">Project Name</a>
+                  <a class="navbar-brand" href="#">Project Name</a>
                   <ul class="nav">
                     <li><a href="#fat">@fat</a></li>
                     <li><a href="#mdo">@mdo</a></li>

--- a/less/tests/navbar-fixed-top.html
+++ b/less/tests/navbar-fixed-top.html
@@ -35,7 +35,7 @@
     <!-- Fixed navbar -->
     <div class="navbar navbar-fixed-top">
       <div class="container">
-        <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+        <a class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>

--- a/less/tests/navbar-static-top.html
+++ b/less/tests/navbar-static-top.html
@@ -37,7 +37,7 @@
     <!-- Static navbar -->
     <div class="navbar navbar-static-top">
       <div class="container">
-        <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+        <a class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>

--- a/less/tests/navbar.html
+++ b/less/tests/navbar.html
@@ -40,7 +40,7 @@
       <!-- Static navbar -->
       <div class="navbar">
         <div class="container">
-          <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+          <a class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>


### PR DESCRIPTION
Fixed the formatting of the `navbar-brand` and got the `navbar-toggle` to work in the example templates.
Before
![before](https://f.cloud.github.com/assets/1160240/300989/237edb9e-95b5-11e2-960e-75bf81a42bc0.png)

After
![after](https://f.cloud.github.com/assets/1160240/300994/445a175c-95b5-11e2-96d6-c63e03292fdd.png)
