### PR TITLE
install needed node modules before calling them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PATH := ./node_modules/.bin:$(PATH)
 # BUILD DOCS
 #
 
-build:
+build: node_modules
 	@echo "\n\n"
 	@echo "\033[36mBuilding Bootstrap...\033[39m"
 	@echo "${HR}"
@@ -37,6 +37,16 @@ build:
 	@echo "\033[36mSuccess!\n\033[39m"
 	@echo "\033[37mThanks for using Bootstrap,"
 	@echo "<3 @mdo and @fat\n\033[39m"
+
+#
+# INSTALL NEEDED NODE MODULES
+#
+
+node_modules:
+	@echo "\n\n"
+	@echo "\033[36mInstalling dependencies...\033[39m"
+	@echo "${HR}"
+	npm install
 
 #
 # RUN JSHINT & QUNIT TESTS IN PHANTOMJS
@@ -70,7 +80,7 @@ bootstrap: bootstrap-fonts bootstrap-css bootstrap-js
 #
 bootstrap-js: bootstrap/js/*.js
 
-bootstrap/js/*.js: js/*.js
+bootstrap/js/*.js: node_modules js/*.js
 	mkdir -p bootstrap/js
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
@@ -84,7 +94,7 @@ bootstrap/js/*.js: js/*.js
 
 bootstrap-css: bootstrap/css/*.css
 
-bootstrap/css/*.css: less/*.less
+bootstrap/css/*.css: node_modules less/*.less
 	mkdir -p bootstrap/css
 	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
 	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css


### PR DESCRIPTION
this prevents calling "make" as advised in the README and ending up
with a ton of error messages instead of a working build.
