### PR TITLE
Add event triggers

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -52,6 +52,10 @@
       clearMenus()
 
       if (!isActive) {
+        $this.trigger('dropmenu.dropdown', [{
+          parent: $parent,
+          trigger: $this
+        }])
         $parent.toggleClass('open')
       }
 


### PR DESCRIPTION
This is a silly pull request, but I wanted to open it anyway to start a discussion. I am currently in the need of tweaking the exact dynamic positioning of the dropdown menu—I want to set that programmatically.

We could of course
- write a wrapper function that toggles the dropdown as a side effect. You'd have to let go of the nice Bootstrap data-api, though;
- Reimplement the whole menu manually. Now who'd want to do that?

Another way this could be easily solved in general, is by having the Bootstrap JS components trigger a formal event on key UI events, like right before the dropdown will show up. This is exactly my patch. It's only a tiny addition, and probably of shitty quality, but I'm more interested to know whether you'd support this idea more than my actual implementation.

I'm currently adding this little line to our custom Bootstrap build, and put all our specific logic in an event handler that's managed in my own code base. This structure allows for very specific customizations, while not having to sacrifice all the niceties of Bootstrap.
