### PR TITLE
Added min-height to .modal-header

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -47,6 +47,7 @@
 .modal-header {
   padding: 9px 15px;
   border-bottom: 1px solid #eee;
+  min-height:20px;
   // Close icon
   .close { margin-top: 2px; }
   // Heading


### PR DESCRIPTION
You may not always want to add a title for your modal. This change will ensure your close button will not look off if you have no text in the header.

See: http://jsbin.com/ayoqad/1/edit for the effect of change
