### PR TITLE
Update docs to add warning about accessibility implications of using icons without any text

### DIFF
--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -2072,6 +2072,11 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
 &lt;/div&gt;
 </pre>
 
+        <p>
+            <span class="label label-info">Heads up!</span>
+            Using icons without any additional content means the icons are not represented to screen reader users.
+          </p>
+
           <h5>Dropdown in a button group</h5>
           <div class="bs-docs-example">
             <div class="btn-group">

--- a/docs/templates/pages/base-css.mustache
+++ b/docs/templates/pages/base-css.mustache
@@ -2008,6 +2008,10 @@
   &lt;/div&gt;
 &lt;/div&gt;
 </pre>
+          <p>
+            <span class="label label-info">Heads up!</span>
+            Using icons without any additional content means the icons are not represented to screen reader users.
+          </p>
 
           <h5>{{_i}}Dropdown in a button group{{/i}}</h5>
           <div class="bs-docs-example">


### PR DESCRIPTION
Spotted that one of the icons examples would be inaccessible to screen reader users so added a "heads up" to warn future users. I guess for many this won't matter, but for some this may save them a headache when tested.
