### PR TITLE
Added min-height to modal-header for modals with no header text

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4302,6 +4302,7 @@ button.close {
 }
 
 .modal-header {
+  min-height: 40px;
   padding: 9px 15px;
   border-bottom: 1px solid #e5e5e5;
 }

--- a/less/modals.less
+++ b/less/modals.less
@@ -76,6 +76,7 @@
 .modal-header {
   padding: 9px 15px;
   border-bottom: 1px solid #e5e5e5;
+  min-height:40px;
 }
 // Close icon
 .modal-header .close {


### PR DESCRIPTION
Modals can be used for alerts which may or may not have a title. When you render a modal with no title the close button appears below the header border. I added a min-height to the modal-header to fix that.
