### PR TITLE
Update docs to add warning about accessibility implications of using icons without any text

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -2561,6 +2561,11 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 </div>
 {% endhighlight %}
 
+    <p class="alert alert-info">
+      <strong>Heads up!</strong>
+      Using icons without any additional content means the icons are not represented to screen reader users.
+    </p>
+
     <h5>Dropdown in a button group</h5>
     <div class="bs-docs-example">
       <div class="btn-group">


### PR DESCRIPTION
Spotted that one of the icons examples would be inaccessible to screen reader users so added a "heads up" to warn future users. I guess for many this won't matter, but for some this may save them a headache when tested.
