### PR TITLE
Fix typo in Javascript Carousel description

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1511,7 +1511,7 @@ $('#myCollapsible').on('hidden', function () {
             <pre class="prettyprint linenums">$('.carousel').carousel()</pre>
 
             <h3>Options</h3>
-            <p>Options can be passed via data attributes or JavaScriptz. For data attributes, append the option name to <code>data-</code>, as in <code>data-interval=""</code>.</p>
+            <p>Options can be passed via data attributes or JavaScript. For data attributes, append the option name to <code>data-</code>, as in <code>data-interval=""</code>.</p>
             <table class="table table-bordered table-striped">
               <thead>
                <tr>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1441,7 +1441,7 @@ $('#myCollapsible').on('hidden', function () {
             <pre class="prettyprint linenums">$('.carousel').carousel()</pre>
 
             <h3>{{_i}}Options{{/i}}</h3>
-            <p>{{_i}}Options can be passed via data attributes or JavaScriptz. For data attributes, append the option name to <code>data-</code>, as in <code>data-interval=""</code>.{{/i}}</p>
+            <p>{{_i}}Options can be passed via data attributes or JavaScript. For data attributes, append the option name to <code>data-</code>, as in <code>data-interval=""</code>.{{/i}}</p>
             <table class="table table-bordered table-striped">
               <thead>
                <tr>


### PR DESCRIPTION
Javascriptz -> Javascript

I submitted something before on this, then I read the contribution guidelines more carefully. Hooray for reading!
