### PR TITLE
Proposed fix for allowing Collapse events ('show'/'hide') to be cancelle...

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -61,21 +61,36 @@
       if (actives && actives.length) {
         hasData = actives.data('collapse')
         if (hasData && hasData.transitioning) return
-        actives.collapse('hide')
+        actives.collapse('hide', $.Event('show'))
+        if(hasData.defaultPrevented) {
+          hasData.defaultPrevented = 0
+          return
+        }
         hasData || actives.data('collapse', null)
       }
 
       this.$element[dimension](0)
       this.transition('addClass', $.Event('show'), 'shown')
+      if(this.defaultPrevented) {
+        this.$element[dimension]()
+        this.defaultPrevented = 0
+        return
+      }
       $.support.transition && this.$element[dimension](this.$element[0][scroll])
     }
 
-  , hide: function () {
+  , hide: function (isChained) {
       var dimension
-      if (this.transitioning || !this.$element.hasClass('in')) return
+      if (this.transitioning || !this.$element.hasClass('in') || this.defaultPrevented) return       
       dimension = this.dimension()
       this.reset(this.$element[dimension]())
       this.transition('removeClass', $.Event('hide'), 'hidden')
+      if(this.defaultPrevented) {
+        this.reset()
+        if(!event)
+          this.defaultPrevented = 0
+        return
+      }
       this.$element[dimension](0)
     }
 
@@ -102,7 +117,10 @@
 
       this.$element.trigger(startEvent)
 
-      if (startEvent.isDefaultPrevented()) return
+      if (startEvent.isDefaultPrevented()) {
+        this.defaultPrevented = 1
+        return
+      }    
 
       this.transitioning = 1
 
@@ -125,13 +143,13 @@
 
   var old = $.fn.collapse
 
-  $.fn.collapse = function (option) {
+  $.fn.collapse = function (option, isChained) {
     return this.each(function () {
       var $this = $(this)
         , data = $this.data('collapse')
         , options = $.extend({}, $.fn.collapse.defaults, $this.data(), typeof option == 'object' && option)
       if (!data) $this.data('collapse', (data = new Collapse(this, options)))
-      if (typeof option == 'string') data[option]()
+      if (typeof option == 'string') return data[option](isChained)
     })
   }
 


### PR DESCRIPTION
Proposed fix for issue #5973

Added tracking for if preventDefault has been called similar to how 'transitioning' is currently tracked. If that has occured, the elements are returned their previous states in show() and hide() respectively. The more complicated use case is for when a group of elements is being managed by a parent element, and calling show() triggers the other
elements to be hidden. I changed the plugin definition to take an argument (a boolean) to pass to hide() in this (and only this) case so that reseting this.defaultPrevented to 0 only happens in the originating show() function. The other way to go here so that the plugin definition is not changed is to call a different hide function (hideOpenSiblings()?) in show() to hide the other elements that never resets this.defaultPrevented to 0.
