### PR TITLE
Fix for popovers in table or collapsable

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -346,7 +346,7 @@
   , title: ''
   , delay: 0
   , html: false
-  , container: false
+  , container: 'body'
   }
 
 


### PR DESCRIPTION
With this fix I have improved the bootstrap behaviour in two situations: first when rendered inside a table element, such as a <td>, the popover adds a block level element that screws up the layout. 
The other situation is when the popover is displayed in a collpsable element, and it gets trimmed if it is too close to the edges of the element. 
(here is the fiddle for both: http://jsfiddle.net/5vPJm/1/ )
I had a situation with a table in a collapsable element, and I found the fix for both the issues is to set the container in the tooltip to the body by default. I haven't experienced issues because of this change.
