### PR TITLE
Fixes #7521

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -240,7 +240,9 @@
     $target
       .modal(option)
       .one('hide', function () {
-        $this.focus()
+        try {
+          $this.focus()
+        } catch (error) {} // focus() may throw an error on IE8
       })
     })
 


### PR DESCRIPTION
https://github.com/twitter/bootstrap/issues/7521

This makes sure the IE8 error is caught when trying to focus () on an invisible element. 
When the element is invisible, I don't think it should be made visible for focusing.

I've only modified the source JS files, not the generated ones.
