### PR TITLE
Fluid responsive modals 2.2.2

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -96,42 +96,66 @@
 
 .modal.fluid {
 	position: fixed;
-	display: block;
 	top: 10%;
 	left: 10%;
 	bottom: 10%;
 	right: 10%;
-	overflow: hidden;
-	margin: 0 auto;  // override default positioning with negative margin
+
+	width: 80%;
+	height: 80%;
+	padding: 0px;
+	border: none;
+
 	max-width: 600px;
-	max-height: none;
+	max-height: 80%;
+	min-width: 100px;
 
-	.modal-header {
+	margin: 0 auto;  // override default positioning with negative margin
+	background: transparent;
+	border-radius: 0;
+	box-shadow: none;
+
+	.close {
+		margin-top: 5px;
+	}
+	.modal-content {
 		position: relative;
+		overflow: auto;
+		height: 70%;
+		padding: 0;
+		background-color: @white;
+		border-radius: 0;
+		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
 
-		a.close {
-			margin-top: 5px;
+		&:first-child {
+			border-top-left-radius: 6px;
+			border-top-right-radius: 6px;
+		}
+		&:last-child {
+			border-bottom-left-radius: 6px;
+			border-bottom-right-radius: 6px;
 		}
 	}
-	.modal-body {
-		position: absolute;
-		overflow-x: visible;
-		overflow-y: auto;
-		top: 49px;
+	.modal-header {
+		position: relative;
+		top: 0;
 		left: 0;
-		bottom: 64px;
 		right: 0;
-		width: auto;
-		margin: 0;
-		padding: 15px;
-		max-width: none !important;  // override modal JS stupidity
-		max-height: none;
+		background: @white;
+		border-top-left-radius: 6px;
+		border-top-right-radius: 6px;
+		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
+	}
+	.modal-body {
+		position: relative;
+		overflow: visible;
+		background-color: @white;
 	}
 	.modal-footer {
-		position: absolute;
+		position: relative;
 		left: 0;
 		bottom: 0;
 		right: 0;
-		padding: 15px;
+		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
 	}
-}
+}	

--- a/less/modals.less
+++ b/less/modals.less
@@ -118,24 +118,6 @@
 	.close {
 		margin-top: 5px;
 	}
-	.modal-content {
-		position: relative;
-		overflow: auto;
-		height: 70%;
-		padding: 0;
-		background-color: @white;
-		border-radius: 0;
-		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
-
-		&:first-child {
-			border-top-left-radius: 6px;
-			border-top-right-radius: 6px;
-		}
-		&:last-child {
-			border-bottom-left-radius: 6px;
-			border-bottom-right-radius: 6px;
-		}
-	}
 	.modal-header {
 		position: relative;
 		top: 0;
@@ -144,7 +126,7 @@
 		background: @white;
 		border-top-left-radius: 6px;
 		border-top-right-radius: 6px;
-		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
+		.box-shadow(0 3px 7px rgba(0,0,0,0.3));
 	}
 	.modal-body {
 		position: relative;
@@ -156,6 +138,25 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
-		box-shadow: rgba(0, 0, 0, 0.298039) 0px 3px 7px 0px;
+		.box-shadow(0 3px 7px rgba(0,0,0,0.3));
 	}
-}	
+	.modal-body {
+		position: relative;
+		overflow: auto;
+		height: auto;
+		max-height: 70%;
+		padding: 15px;
+		background-color: @white;
+		border-radius: 0;
+		.box-shadow(0 3px 7px rgba(0,0,0,0.3));
+
+		&:first-child {
+			border-top-left-radius: 6px;
+			border-top-right-radius: 6px;
+		}
+		&:last-child {
+			border-bottom-left-radius: 6px;
+			border-bottom-right-radius: 6px;
+		}
+	}
+}

--- a/less/modals.less
+++ b/less/modals.less
@@ -93,3 +93,45 @@
     margin-left: 0;
   }
 }
+
+.modal.fluid {
+	position: fixed;
+	display: block;
+	top: 10%;
+	left: 10%;
+	bottom: 10%;
+	right: 10%;
+	overflow: hidden;
+	margin: 0 auto;  // override default positioning with negative margin
+	max-width: 600px;
+	max-height: none;
+
+	.modal-header {
+		position: relative;
+
+		a.close {
+			margin-top: 5px;
+		}
+	}
+	.modal-body {
+		position: absolute;
+		overflow-x: visible;
+		overflow-y: auto;
+		top: 49px;
+		left: 0;
+		bottom: 64px;
+		right: 0;
+		width: auto;
+		margin: 0;
+		padding: 15px;
+		max-width: none !important;  // override modal JS stupidity
+		max-height: none;
+	}
+	.modal-footer {
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		padding: 15px;
+	}
+}


### PR DESCRIPTION
Hi!

I made styles for fluid modals that always fit small viewports (mobile devices).

The first commit 9ce48eb5417dd1d20edaece0231194c45a63c0ee shows the basic idea,
and two later ones fix the modal height when content is short and override some default styles and some polishing touches (rounded corners on body when header or footer is missing).

Media queries could also be used to overflowflow-wrap text on narrow viewports:

@media (max-width: 600px) {
    .row-fluid {
        overflow-wrap: break-word;
        word-wrap: break-word;  // IE
        hyphens: auto;
        -webkit-hyphens: auto;
    }
}

Media query styles could also be used for a "page like" view on mobile devices, to that the modal fits the whole screen. I may do this later.

A big problem with bootstrap modals is that the modal is fixed positioned and outside modal-backdrop. This would be much easier to achieve, if the modal HTML element would be inside fixed modal-backdrop and be absolutely positioned. However, I didn't want to touch the Javascript yet.

Btw, what's with the strange coding convention of not using any semicolons and putting commas at the start of the lines?
