### PR TITLE
Fix docs.html Table Row Danger CSS Class

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1190,7 +1190,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
         </tr>
         <tr>
           <td>
-            <code>.error</code>
+            <code>.danger</code>
           </td>
           <td>Indicates a dangerous or potentially negative action.</td>
         </tr>
@@ -1225,7 +1225,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
             <td>01/04/2012</td>
             <td>Approved</td>
           </tr>
-          <tr class="error">
+          <tr class="danger">
             <td>2</td>
             <td>TB - Monthly</td>
             <td>02/04/2012</td>


### PR DESCRIPTION
'danger' is in with BS3 and 'error' is out :)
