### PR TITLE
Fix bootstrap-tooltip events interfering with MooTools Element.Shortcuts

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -121,7 +121,7 @@
         , e = $.Event('show')
 
       if (this.hasContent() && this.enabled) {
-        this.$element.trigger(e)
+        this.$element.triggerHandler(e)
         if (e.isDefaultPrevented()) return
         $tip = this.tip()
         this.setContent()
@@ -161,7 +161,7 @@
         }
 
         this.applyPlacement(tp, placement)
-        this.$element.trigger('shown')
+        this.$element.triggerHandler('shown')
       }
     }
 
@@ -225,7 +225,7 @@
         , $tip = this.tip()
         , e = $.Event('hide')
 
-      this.$element.trigger(e)
+      this.$element.triggerHandler(e)
       if (e.isDefaultPrevented()) return
 
       $tip.removeClass('in')
@@ -245,7 +245,7 @@
         removeWithAnimation() :
         $tip.detach()
 
-      this.$element.trigger('hidden')
+      this.$element.triggerHandler('hidden')
 
       return this
     }


### PR DESCRIPTION
MooTools [Element.Shortcuts](http://mootools.net/docs/more/Element/Element.Shortcuts) extends DOM elements with .hide() and .show() methods.

Unfortunately, because of the way jQuery .trigger() will call any methods of the same name as the event on the evented object, every time a tooltip hides, it also causes the underlying DOM element it is attached to to have it's .hide() method called.

This is obviously not desirable. This commit changes all .trigger() calls in tooltip to .triggerHandler() calls, preventing the undesirable behavior.

All bootstrap tests still pass, and the events on tooltip can still be used as intended.

See Note just before Examples in [.trigger() | jQuery API Documentation](http://api.jquery.com/trigger/) for details.
