### PR TITLE
Fix issue with normalize.css setting content-box sizing on type="search"

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1226,6 +1226,12 @@ label {
   font-weight: bold;
 }
 
+input[type="search"] {
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+}
+
 select,
 textarea,
 input[type="text"],

--- a/less/forms.less
+++ b/less/forms.less
@@ -36,6 +36,10 @@ label {
 
 // Form controls
 // -------------------------
+// Override content-box in normalize
+input[type="search"] {
+  .box-sizing(border-box);
+}
 
 // Shared size and type resets
 select,


### PR DESCRIPTION
See this [JsFiddle](http://jsfiddle.net/paultyng/saXsx/) for visual demonstration.

Normalize overrides the \* rule and sets the `box-sizing` to `content-box` so overriding back to `border-box` in _forms.less_.  Not sure if you would just prefer the edit in the normalize file or not.
