### PR TITLE
Remove invalid JSHint options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 	@echo "            ${CHECK}"
 	@printf "Compiling and minifying JavaScript..."
 	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
-	@uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
+	@uglifyjs docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
 	@echo "/**\n* Bootstrap.js v3.0.0 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js

--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* AFFIX CLASS DEFINITION

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* ALERT CLASS DEFINITION

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* BUTTON PUBLIC CLASS DEFINITION

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* CAROUSEL CLASS DEFINITION

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* COLLAPSE PUBLIC CLASS DEFINITION

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* DROPDOWN CLASS DEFINITION

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* MODAL CLASS DEFINITION

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* POPOVER PUBLIC CLASS DEFINITION

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* SCROLLSPY CLASS DEFINITION

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* TAB CLASS DEFINITION

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -21,7 +21,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* TOOLTIP PUBLIC CLASS DEFINITION

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -20,7 +20,7 @@
 
 !function ($) {
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
   /* CSS TRANSITION SUPPORT (http://www.modernizr.com/)

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -20,7 +20,7 @@
 
 !function($){
 
-  "use strict"; // jshint ;_;
+  "use strict";
 
 
  /* TYPEAHEAD PUBLIC CLASS DEFINITION


### PR DESCRIPTION
JSHint has, for some reason, decided that the `;_;` (which is, I think, meant to be an emote, in this case) that was lurking at the end of these lines is actually an option, but doesn't know what to do with it, and thus promptly breaks. I opted to remove the entire comment.
