### PR TITLE
Do not stop propagation of all click events in the document.

### DIFF
--- a/docs/assets/js/bootstrap-dropdown.js
+++ b/docs/assets/js/bootstrap-dropdown.js
@@ -158,7 +158,7 @@
   $(document)
     .on('click.dropdown.data-api', clearMenus)
     .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-    .on('click.dropdown-menu', function (e) { e.stopPropagation() })
+    .on('click.dropdown-menu', '.dropdown-menu', function (e) { clearMenus(); e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
 

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -158,7 +158,7 @@
   $(document)
     .on('click.dropdown.data-api', clearMenus)
     .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-    .on('click.dropdown-menu', function (e) { e.stopPropagation() })
+    .on('click.dropdown-menu', '.dropdown-menu', function (e) { clearMenus(); e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
 


### PR DESCRIPTION
I think that this is a bug as propagation of all click events in the document is stopped - I don't see the purpose of such wide application of stopping propagation.

The unwanted effect of that is disabling the Command + Click behavior in Firefox that lots of users use. 

Simple repro scenario: 
1. Open Firefox
2. Go to http://twitter.github.io/bootstrap/
3. Try Command + Click on any of the link (normally is opens URL in the new tab).
