### PR TITLE
Make collapsible 'parent' option independent on '.accordion-group'

### DIFF
--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -56,7 +56,7 @@
 
       dimension = this.dimension()
       scroll = $.camelCase(['scroll', dimension].join('-'))
-      actives = this.$parent && this.$parent.find('> .accordion-group > .in')
+      actives = this.$parent && this.$parent.find('.collapse.in')
 
       if (actives && actives.length) {
         hasData = actives.data('collapse')


### PR DESCRIPTION
Currently `parent` option of collapsible plugin relies on `.accordion-group` class, which is quite unobvious and discouraging, because according to the [documentation](http://twitter.github.io/bootstrap/javascript.html#collapse) is should not.

> parent - type(selector) - default(false);  If selector then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior)

And this can't be known unless you browse through the source code.
In this pull request I propose a fix.
