### PR TITLE
more nested less rules - pager component

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4242,7 +4242,7 @@ button.close {
 .pager .disabled > span {
   color: #999999;
   cursor: default;
-  background-color: #fff;
+  background-color: #ffffff;
 }
 
 .modal-open {

--- a/less/pager.less
+++ b/less/pager.less
@@ -46,7 +46,7 @@
     > a:focus,
     > span {
       color: @grayLight;
-      background-color: #fff;
+      background-color: @pagination-bg;
       cursor: default;
     }
   }

--- a/less/pager.less
+++ b/less/pager.less
@@ -8,36 +8,47 @@
   list-style: none;
   text-align: center;
   .clearfix();
-}
-.pager li {
-  display: inline;
-}
-.pager li > a,
-.pager li > span {
-  display: inline-block;
-  padding: 5px 14px;
-  background-color: @pagination-bg;
-  border: 1px solid @pagination-border;
-  border-radius: 15px;
-}
-.pager li > a:hover,
-.pager li > a:focus {
-  text-decoration: none;
-  background-color: @pagination-active-bg;
-}
-.pager .next > a,
-.pager .next > span {
-  float: right;
-}
-.pager .previous > a,
-.pager .previous > span {
-  float: left;
-}
-.pager .disabled > a,
-.pager .disabled > a:hover,
-.pager .disabled > a:focus,
-.pager .disabled > span {
-  color: @grayLight;
-  background-color: #fff;
-  cursor: default;
+  li {
+    display: inline;
+    > a,
+    > span {
+      display: inline-block;
+      padding: 5px 14px;
+      background-color: @pagination-bg;
+      border: 1px solid @pagination-border;
+      border-radius: 15px;
+    }
+
+    > a:hover,
+    > a:focus {
+      text-decoration: none;
+      background-color: @pagination-active-bg;
+    }
+  }
+
+  .next {
+    > a,
+    > span {
+      float: right;
+    }
+  }
+  
+  .previous {
+    > a,
+    > span {
+      float: left;
+    }
+  }
+
+  .disabled {
+    > a,
+    > a:hover,
+    > a:focus,
+    > span {
+      color: @grayLight;
+      background-color: #fff;
+      cursor: default;
+    }
+  }
+
 }


### PR DESCRIPTION
A more nested version of pager component

This is a continuation of #7590

Lets say that this time you have a section called #bottom and you have an unordered list in it. Next thing you would like to do is format this list from your LESS main stylesheet.

```
<section id="#bottom">
  <ul>
    <li><a href="#">&larr; Older</a></li>
    <li><a href="#">Newer &rarr;</a></li>
  </ul>
</section>
```

This is our base to mess with, open your LESS and put:

```
#bottom {
    ul {
        .pager;
    }
}
```

So that you'll get the same result as you would type class="pager" on that list.

```
#bottom {
    ul {
        .pager;
            li {
                &:first-child {
                  .previous;
                }
                &:last-child {
                  .next;
                }
            }
      }
}
```

Taking these steps will provide you same result for first and last list items. They will look exactly like they would have class="previous" and class="next" on the HTML side.

```
#bottom {
    ul {
        .pager;
            li {
                &:first-child {
                  .previous;
                  .disabled;
                }
                &:last-child {
                  .next;
                  .disabled;
                }
            }
      }
}
```

In this case both pager buttons will be disabled as they would be styled with "disabled" class.

Info for reviewer: There is no bootstrap.css to merge with docs because output of pager.less does not change a thing :)

Tested on: Firefox 20.0.1, Chrome 26.0.1410.64 m, Internet Explorer 10.0.9200.16521
