### PR TITLE
Fix flickering on progress bar width update

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5813,6 +5813,9 @@ a.badge:focus {
      -moz-transition: width 0.6s ease;
        -o-transition: width 0.6s ease;
           transition: width 0.6s ease;
+  -webkit-backface-visibility: hidden;
+     -moz-backface-visibility: hidden;
+          backface-visibility: hidden;
 }
 
 .progress .bar + .bar {

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -64,6 +64,7 @@
   .box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
   .box-sizing(border-box);
   .transition(width .6s ease);
+  .backface-visibility(hidden);
 }
 .progress .bar + .bar {
   .box-shadow(~"inset 1px 0 0 rgba(0,0,0,.15), inset 0 -1px 0 rgba(0,0,0,.15)");


### PR DESCRIPTION
Issue visible on lastest version of Chrome Browser (if you update progress bar width from 100% to 0%) -> flickering appears

Fixed with addition of .backface-visibility(hidden) mixins
