### PR TITLE
Popover customization enhanced

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -40,7 +40,7 @@
 
   , setContent: function () {
       var $tip = this.tip()
-        , title = this.getTitle()
+        , title = this.options.title ? this.options.title : this.getTitle()
         , content = this.getContent()
 
       $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)

--- a/js/tests/unit/bootstrap-popover.js
+++ b/js/tests/unit/bootstrap-popover.js
@@ -76,6 +76,26 @@ $(function () {
         ok(!$('.popover').length, 'popover was removed')
         $('#qunit-fixture').empty()
       })
+      
+      test("should get title from options if both set in options and attributes", function () {
+        $.support.transition = false
+        var popover = $('<a href="#" title="@fat">@fat</a>')
+          .appendTo('#qunit-fixture')
+          .popover({
+            title: function () {
+              return '@mdo'
+            }
+          })
+
+        popover.popover('show')
+
+        ok($('.popover').length, 'popover was inserted')
+        equals($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
+
+        popover.popover('hide')
+        ok(!$('.popover').length, 'popover was removed')
+        $('#qunit-fixture').empty()
+      })
 
       test("should respect custom classes", function() {
         $.support.transition = false


### PR DESCRIPTION
Allowing the popover title to be different than the title of the element showing the popover.
Useful when you need a different title text in popover title than the one in tooltip.
