### PR TITLE
[docs] add github source links to javascript docs

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -168,7 +168,7 @@ $('#myModal').on('show', function (e) {
         ================================================== -->
         <section id="transitions">
           <div class="page-header">
-            <h1>Transitions <small>bootstrap-transition.js</small></h1>
+            <h1>Transitions <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-transition.js" target="_blank">bootstrap-transition.js</a></small></h1>
           </div>
           <h3>About transitions</h3>
           <p>For simple transition effects, include <strong>bootstrap-transition.js</strong> once alongside the other JS files. If you're using the compiled (or minified) <strong>bootstrap.js</strong>, there is no need to include this&mdash;it's already there.</p>
@@ -189,7 +189,7 @@ $('#myModal').on('show', function (e) {
         ================================================== -->
         <section id="modals">
           <div class="page-header">
-            <h1>Modals <small>bootstrap-modal.js</small></h1>
+            <h1>Modals <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-modal.js" target="_blank">bootstrap-modal.js</a></small></h1>
           </div>
 
 
@@ -398,7 +398,7 @@ $('#myModal').on('hidden', function () {
         ================================================== -->
         <section id="dropdowns">
           <div class="page-header">
-            <h1>Dropdowns <small>bootstrap-dropdown.js</small></h1>
+            <h1>Dropdowns <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-dropdown.js" target="_blank">bootstrap-dropdown.js</a></small></h1>
           </div>
 
 
@@ -448,7 +448,7 @@ $('#myModal').on('hidden', function () {
                 </div>
               </div>
             </div> <!-- /navbar-example -->
-          </div> 
+          </div>
 
           <h3>Within tabs</h3>
           <div class="bs-docs-example">
@@ -485,7 +485,7 @@ $('#myModal').on('hidden', function () {
                 </ul>
               </li>
             </ul> <!-- /tabs -->
-          </div> 
+          </div>
 
 
           <hr class="bs-docs-separator">
@@ -534,7 +534,7 @@ $('#myModal').on('hidden', function () {
         ================================================== -->
         <section id="scrollspy">
           <div class="page-header">
-            <h1>ScrollSpy <small>bootstrap-scrollspy.js</small></h1>
+            <h1>ScrollSpy <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-scrollspy.js" target="_blank">bootstrap-scrollspy.js</a></small></h1>
           </div>
 
 
@@ -649,7 +649,7 @@ $('[data-spy="scroll"]').each(function () {
         ================================================== -->
         <section id="tabs">
           <div class="page-header">
-            <h1>Togglable tabs <small>bootstrap-tab.js</small></h1>
+            <h1>Togglable tabs <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-tab.js" target="_blank">bootstrap-tab.js</a></small></h1>
           </div>
 
 
@@ -771,7 +771,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
         ================================================== -->
         <section id="tooltips">
           <div class="page-header">
-            <h1>Tooltips <small>bootstrap-tooltip.js</small></h1>
+            <h1>Tooltips <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-tooltip.js" target="_blank">bootstrap-tooltip.js</a></small></h1>
           </div>
 
 
@@ -904,7 +904,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
       ================================================== -->
       <section id="popovers">
         <div class="page-header">
-          <h1>Popovers <small>bootstrap-popover.js</small></h1>
+          <h1>Popovers <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-popover.js" target="_blank">bootstrap-popover.js</a></small></h1>
         </div>
 
         <h2>Examples</h2>
@@ -1077,7 +1077,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
       ================================================== -->
       <section id="alerts">
         <div class="page-header">
-          <h1>Alert messages <small>bootstrap-alert.js</small></h1>
+          <h1>Alert messages <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-alert.js" target="_blank">bootstrap-alert.js</a></small></h1>
         </div>
 
 
@@ -1154,7 +1154,7 @@ $('#my-alert').bind('closed', function () {
           ================================================== -->
           <section id="buttons">
             <div class="page-header">
-              <h1>Buttons <small>bootstrap-button.js</small></h1>
+              <h1>Buttons <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-button.js" target="_blank">bootstrap-button.js</a></small></h1>
             </div>
 
             <h2>Example uses</h2>
@@ -1257,7 +1257,7 @@ $('#my-alert').bind('closed', function () {
           ================================================== -->
           <section id="collapse">
             <div class="page-header">
-              <h1>Collapse <small>bootstrap-collapse.js</small></h1>
+              <h1>Collapse <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-collapse.js" target="_blank">bootstrap-collapse.js</a></small></h1>
             </div>
 
             <h3>About</h3>
@@ -1444,7 +1444,7 @@ $('#myCollapsible').on('hidden', function () {
           ================================================== -->
           <section id="carousel">
             <div class="page-header">
-              <h1>Carousel <small>bootstrap-carousel.js</small></h1>
+              <h1>Carousel <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-carousel.js" target="_blank">bootstrap-carousel.js</a></small></h1>
             </div>
 
             <h2>Example carousel</h2>
@@ -1594,7 +1594,7 @@ $('.carousel').carousel({
           ================================================== -->
           <section id="typeahead">
             <div class="page-header">
-              <h1>Typeahead <small>bootstrap-typeahead.js</small></h1>
+              <h1>Typeahead <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-typeahead.js" target="_blank">bootstrap-typeahead.js</a></small></h1>
             </div>
 
 
@@ -1686,7 +1686,7 @@ $('.carousel').carousel({
           ================================================== -->
           <section id="affix">
             <div class="page-header">
-              <h1>Affix <small>bootstrap-affix.js</small></h1>
+              <h1>Affix <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-affix.js" target="_blank">bootstrap-affix.js</a></small></h1>
             </div>
 
             <h2>Example</h2>

--- a/templates/pages/javascript.mustache
+++ b/templates/pages/javascript.mustache
@@ -87,7 +87,7 @@ $('#myModal').on('show', function (e) {
         ================================================== -->
         <section id="transitions">
           <div class="page-header">
-            <h1>{{_i}}Transitions{{/i}} <small>bootstrap-transition.js</small></h1>
+            <h1>{{_i}}Transitions{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-transition.js" target="_blank">bootstrap-transition.js</a></small></h1>
           </div>
           <h3>{{_i}}About transitions{{/i}}</h3>
           <p>{{_i}}For simple transition effects, include <strong>bootstrap-transition.js</strong> once alongside the other JS files. If you're using the compiled (or minified) <strong>bootstrap.js</strong>, there is no need to include this&mdash;it's already there.{{/i}}</p>
@@ -109,7 +109,7 @@ $('#myModal').on('show', function (e) {
         ================================================== -->
         <section id="modals">
           <div class="page-header">
-            <h1>{{_i}}Modals{{/i}} <small>bootstrap-modal.js</small></h1>
+            <h1>{{_i}}Modals{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-modal.js" target="_blank">bootstrap-modal.js</a></small></h1>
           </div>
 
 
@@ -318,7 +318,7 @@ $('#myModal').on('hidden', function () {
         ================================================== -->
         <section id="dropdowns">
           <div class="page-header">
-            <h1>{{_i}}Dropdowns{{/i}} <small>bootstrap-dropdown.js</small></h1>
+            <h1>{{_i}}Dropdowns{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-dropdown.js" target="_blank">bootstrap-dropdown.js</a></small></h1>
           </div>
 
 
@@ -454,7 +454,7 @@ $('#myModal').on('hidden', function () {
         ================================================== -->
         <section id="scrollspy">
           <div class="page-header">
-            <h1>{{_i}}ScrollSpy{{/i}} <small>bootstrap-scrollspy.js</small></h1>
+            <h1>{{_i}}ScrollSpy{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-scrollspy.js" target="_blank">bootstrap-scrollspy.js</a></small></h1>
           </div>
 
 
@@ -569,7 +569,7 @@ $('[data-spy="scroll"]').each(function () {
         ================================================== -->
         <section id="tabs">
           <div class="page-header">
-            <h1>{{_i}}Togglable tabs{{/i}} <small>bootstrap-tab.js</small></h1>
+            <h1>{{_i}}Togglable tabs{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-tab.js" target="_blank">bootstrap-tab.js</a></small></h1>
           </div>
 
 
@@ -691,7 +691,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
         ================================================== -->
         <section id="tooltips">
           <div class="page-header">
-            <h1>{{_i}}Tooltips{{/i}} <small>bootstrap-tooltip.js</small></h1>
+            <h1>{{_i}}Tooltips{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-tooltip.js" target="_blank">bootstrap-tooltip.js</a></small></h1>
           </div>
 
 
@@ -824,7 +824,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
       ================================================== -->
       <section id="popovers">
         <div class="page-header">
-          <h1>{{_i}}Popovers{{/i}} <small>bootstrap-popover.js</small></h1>
+          <h1>{{_i}}Popovers{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-popover.js" target="_blank">bootstrap-popover.js</a></small></h1>
         </div>
 
         <h2>{{_i}}Examples{{/i}}</h2>
@@ -997,7 +997,7 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
       ================================================== -->
       <section id="alerts">
         <div class="page-header">
-          <h1>{{_i}}Alert messages{{/i}} <small>bootstrap-alert.js</small></h1>
+          <h1>{{_i}}Alert messages{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-alert.js" target="_blank">bootstrap-alert.js</a></small></h1>
         </div>
 
 
@@ -1074,7 +1074,7 @@ $('#my-alert').bind('closed', function () {
           ================================================== -->
           <section id="buttons">
             <div class="page-header">
-              <h1>{{_i}}Buttons{{/i}} <small>bootstrap-button.js</small></h1>
+              <h1>{{_i}}Buttons{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-button.js" target="_blank">bootstrap-button.js</a></small></h1>
             </div>
 
             <h2>{{_i}}Example uses{{/i}}</h2>
@@ -1177,7 +1177,7 @@ $('#my-alert').bind('closed', function () {
           ================================================== -->
           <section id="collapse">
             <div class="page-header">
-              <h1>{{_i}}Collapse{{/i}} <small>bootstrap-collapse.js</small></h1>
+              <h1>{{_i}}Collapse{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-collapse.js" target="_blank">bootstrap-collapse.js</a></small></h1>
             </div>
 
             <h3>{{_i}}About{{/i}}</h3>
@@ -1364,7 +1364,7 @@ $('#myCollapsible').on('hidden', function () {
           ================================================== -->
           <section id="carousel">
             <div class="page-header">
-              <h1>{{_i}}Carousel{{/i}} <small>bootstrap-carousel.js</small></h1>
+              <h1>{{_i}}Carousel{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-carousel.js" target="_blank">bootstrap-carousel.js</a></small></h1>
             </div>
 
             <h2>{{_i}}Example carousel{{/i}}</h2>
@@ -1514,7 +1514,7 @@ $('.carousel').carousel({
           ================================================== -->
           <section id="typeahead">
             <div class="page-header">
-              <h1>{{_i}}Typeahead{{/i}} <small>bootstrap-typeahead.js</small></h1>
+              <h1>{{_i}}Typeahead{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-typeahead.js" target="_blank">bootstrap-typeahead.js</a></small></h1>
             </div>
 
 
@@ -1606,7 +1606,7 @@ $('.carousel').carousel({
           ================================================== -->
           <section id="affix">
             <div class="page-header">
-              <h1>{{_i}}Affix{{/i}} <small>bootstrap-affix.js</small></h1>
+              <h1>{{_i}}Affix{{/i}} <small><a class="muted" href="//github.com/twitter/bootstrap/blob/master/js/bootstrap-affix.js" target="_blank">bootstrap-affix.js</a></small></h1>
             </div>
 
             <h2>{{_i}}Example{{/i}}</h2>


### PR DESCRIPTION
Always thought that it was really frustrating not being able to click on the `<small>bootstrap-popover.js</small>` links to get a quick access to the github source.
