### PR TITLE
Modal backdrop shouldn't be removed if it doesn't exist.

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -142,13 +142,15 @@
         var that = this
         this.$element.hide()
         this.backdrop(function () {
-          that.removeBackdrop()
+          if (that.options.backdrop) {
+            that.removeBackdrop()
+          }
           that.$element.trigger('hidden')
         })
       }
 
     , removeBackdrop: function () {
-        this.$backdrop && this.$backdrop.remove()
+         this.$backdrop && this.$backdrop.remove()
         this.$backdrop = null
       }
 


### PR DESCRIPTION
Fixed modal backdrop bug that was introduced with

https://github.com/twitter/bootstrap/commit/366e1e0a6d1442b8cf8546a27bac44a841b892a2

Check to make sure backdrop is used before removing it.

https://github.com/twitter/bootstrap/issues/7124
