### PR TITLE
[v3] Drop the sizzle dependency to allow smaller builds targeting mobile devices

### DIFF
--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -49,7 +49,7 @@
 
       if ( $this.parent('li').hasClass('active') ) return
 
-      previous = $ul.find('.active:last a')[0]
+      previous = $ul.find('.active').last().find('a')[0]
 
       e = $.Event('show', {
         relatedTarget: previous
@@ -71,7 +71,7 @@
     }
 
   , activate: function ( element, container, callback) {
-      var $active = container.find('> .active')
+      var $active = container.children('.active')
         , transition = callback
             && $.support.transition
             && $active.hasClass('fade')
@@ -79,7 +79,7 @@
       function next() {
         $active
           .removeClass('active')
-          .find('> .dropdown-menu > .active')
+          .children('.dropdown-menu > .active')
           .removeClass('active')
 
         element.addClass('active')


### PR DESCRIPTION
It would be great if on the javascript side, for the 3.0 release, bootstrap could drop the `sizzle` dependency. We can now easily get custom smaller jQuery builds. It would make sense with being "mobile first" where KBs matter a lot.

I'm currently reviewing a custom jquery2+bootstrap build for [AngularStrap](http://mgcrea.github.io/angular-strap/) to pave the way for mobile apps there. Looks like most of bootstrap's javascript works with this custom build:

```
grunt custom:-ajax,-deprecated,-effects,-sizzle
```

This gives a 17KB file (min+gz) vs. 29KB, thus -42%. That's great and the jquery modularization/cleanup is only beginning.
## Impact

We would rely on [selector-native.js](https://github.com/jquery/jquery/blob/master/src/selector-native.js):

``` javascript
/*
 * Optional (non-Sizzle) selector module for custom builds.
 *
 * Note that this DOES NOT SUPPORT many documented jQuery
 * features in exchange for its smaller size:
 *
 * Attribute not equal selector
 * Positional selectors (:first; :eq(n); :odd; etc.)
 * Type selectors (:input; :checkbox; :button; etc.)
 * State-based selectors (:animated; :visible; :hidden; etc.)
 * :has(selector)
 * :not(complex selector)
 * custom selectors via Sizzle extensions
 * Leading combinators (e.g., $collection.find("> *"))
 * Reliable functionality on XML fragments
 * Requiring all parts of a selector to match elements under context
 *   (e.g., $div.find("div > *") now matches children of $div)
 * Matching against non-elements
 * Reliable sorting of disconnected nodes
 * querySelectorAll bug fixes (e.g., unreliable :focus on WebKit)
 *
 * If any of these are unacceptable tradeoffs, either use Sizzle or
 * customize this stub for the project's specific needs.
 */
```
## Refactor example

If we take a look at the current [`bootstrap-tab.js`](https://github.com/twitter/bootstrap/blob/v2.3.1/js/bootstrap-tab.js) implementation for the `v2.3.1` release, to make it work with a sizzle-free build, we have to:
1. replace `> .class` with `children()`: 

[bootstrap-tab.js l.82](https://github.com/twitter/bootstrap/blob/v2.3.1/js/bootstrap-tab.js#L82)

``` javascript
.find('> .dropdown-menu > .active') // unsupported without sizzle
```

could be replaced with:

``` javascript
.children('.dropdown-menu > .active')
```
1. find a sizzle-free alternative to some positional selectors, `:first` & `:last` (that do not behave like the css3 `:first-child`, etc.).

[bootstrap-tab.js l.52](https://github.com/twitter/bootstrap/blob/v2.3.1/js/bootstrap-tab.js#L52)

``` javascript
previous = $ul.find('.active:last a')[0] // unsupported without sizzle
```

could become:

``` javascript
previous = $ul.find('.active').last().find('a')[0]
```
## Performance analysis

jsperf regarding theses changes : http://jsperf.com/bootstrap-sizzle/2

sizzle-free version seems **4 times faster!**
