### PR TITLE
Close modal when clicking on the background

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -162,11 +162,12 @@
           this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
             .appendTo(document.body)
 
-          this.$backdrop.click(
-            this.options.backdrop == 'static' ?
-              $.proxy(this.$element[0].focus, this.$element[0])
-            : $.proxy(this.hide, this)
-          )
+          this.$element.on('click', $.proxy(function(e) {
+            if (e.target !== e.currentTarget) return
+            this.options.backdrop == 'static' 
+              ? this.$element[0].focus.call(this.$element[0])
+              : this.hide.call(this)
+          }, this))
 
           if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
 

--- a/js/tests/unit/bootstrap-modal.js
+++ b/js/tests/unit/bootstrap-modal.js
@@ -134,4 +134,23 @@ $(function () {
           })
           .modal("show")
       })
+
+      test("should close modal when clicking outside of modal-content", function () {
+        stop()
+        $.support.transition = false
+        var div = $("<div id='modal-test'><div class='contents'></div></div>")
+        div
+          .bind("shown", function () {
+            ok($('#modal-test').length, 'modal insterted into dom')
+            $('.contents').click()
+            ok($('#modal-test').is(":visible"), 'modal visible')
+            $('#modal-test').click()
+          })
+          .bind("hidden", function() {
+            ok(!$('#modal-test').is(":visible"), 'modal hidden')
+            div.remove()
+            start()
+          })
+          .modal("show")
+      })
 })


### PR DESCRIPTION
Because `.modal` takes up the entire screen now, clicks won't reach the background div... This binds to the the `.modal` area, checking if `e.target === e.currentTarget`, which will only be the case if you're clicking outside of the `.modal-content` area.

Test included, semicolons excluded.
