### PR TITLE
"Fix: This is a fix for Clicking anywhere generates JS warnings in Firefox if a dropdown menu is present Issue #7318

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -118,7 +118,11 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
-    $parent = selector && $(selector)
+    if (selector === "#"){
+      $parent = $("")
+    } else {
+      $parent = selector && $(selector)
+    }
 
     if (!$parent || !$parent.length) $parent = $this.parent()
 


### PR DESCRIPTION
When jQuery receives an empty id selector like this `$("#")` , it throws an error in firefox. This error is visible only in the web console provided by firefox. I was not able to see it in firebug console. I have just added a if statement as a workaround for it.

Here is the diff

```
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -118,7 +118,11 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //st
     }

-    $parent = selector && $(selector)
+    if (selector === "#"){
+      $parent = $("")
+    } else {
+      $parent = selector && $(selector)
+    }

 if (!$parent || !$parent.length) $parent = $this.parent()
```

This is my first pull request hope I have done it right
