### PR TITLE
Move mixins.less rules to a separate file

### DIFF
--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -11,6 +11,7 @@
 // Core variables and mixins
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "mixins.less";
+@import "common.less";
 
 // CSS Reset
 @import "reset.less";

--- a/less/common.less
+++ b/less/common.less
@@ -1,0 +1,36 @@
+// Clearfix
+// --------
+// For clearing floats like a boss h5bp.com/q
+.clearfix {
+  *zoom: 1;
+  &:before,
+  &:after {
+    display: table;
+    content: "";
+    // Fixes Opera/contenteditable bug:
+    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
+    line-height: 0;
+  }
+  &:after {
+    clear: both;
+  }
+}
+
+// CSS image replacement
+// -------------------------
+// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
+.hide-text {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+
+// Block level inputs
+.input-block-level {
+  display: block;
+  width: 100%;
+  min-height: @inputHeight; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
+  .box-sizing(border-box); // Makes inputs behave like true block-level elements
+}

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -6,24 +6,6 @@
 // UTILITY MIXINS
 // --------------------------------------------------
 
-// Clearfix
-// --------
-// For clearing floats like a boss h5bp.com/q
-.clearfix {
-  *zoom: 1;
-  &:before,
-  &:after {
-    display: table;
-    content: "";
-    // Fixes Opera/contenteditable bug:
-    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
-    line-height: 0;
-  }
-  &:after {
-    clear: both;
-  }
-}
-
 // Webkit-style focus
 // ------------------
 .tab-focus() {
@@ -100,17 +82,6 @@
   white-space: nowrap;
 }
 
-// CSS image replacement
-// -------------------------
-// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
-.hide-text {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
 
 // FONTS
 // --------------------------------------------------
@@ -149,16 +120,6 @@
 
 // FORMS
 // --------------------------------------------------
-
-// Block level inputs
-.input-block-level {
-  display: block;
-  width: 100%;
-  min-height: @inputHeight; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
-  .box-sizing(border-box); // Makes inputs behave like true block-level elements
-}
-
-
 
 // Mixin for form field states
 .formFieldState(@textColor: #555, @borderColor: #ccc, @backgroundColor: #f5f5f5) {

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -20,6 +20,7 @@
 
 @import "variables.less"; // Modify this for custom colors, font-sizes, etc
 @import "mixins.less";
+@import "common.less";
 
 
 // RESPONSIVE CLASSES


### PR DESCRIPTION
https://github.com/CamShaft/bootstrap-reset/issues/2 - Reason for the pull request

Rules don't belong in the mixins file and moving them into a separate file will make it easier to maintain components.

[Components](https://github.com/component/component/) of each component (sorry for the name collision) require these rules, and, when built, repeat them for each component added.  To prevent the repetition, simply move the rules to a new file. On each update of bootstrap, these component repos can be updated by updating and pre-processing instead of finding and replacing common rules manually. Plus it just makes sense to me.
