### PR TITLE
Adding media queries breakpoints variables

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5341,7 +5341,7 @@ a.list-group-item.active > .badge,
   display: inherit !important;
 }
 
-@media (min-width: 768px) and (max-width: 979px) {
+@media (min-width: 768px) and (max-width: 992px) {
   .visible-phone {
     display: none !important;
   }
@@ -5362,7 +5362,7 @@ a.list-group-item.active > .badge,
   }
 }
 
-@media (min-width: 980px) {
+@media (min-width: 992px) {
   .visible-phone {
     display: none !important;
   }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -170,8 +170,8 @@
 }
 
 
-// Scale up controls for >768px
-@media screen and (min-width: 768px) {
+// Scale up controls for tablets and up
+@media screen and (min-width: @screen-tablet) {
 
   // Scale up the controls a smidge
   .carousel-control .glyphicon {

--- a/less/forms.less
+++ b/less/forms.less
@@ -514,7 +514,7 @@ select:focus:invalid {
 // Horizontal forms
 // --------------------------------------------------
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: @screen-tablet) {
 
   .form-horizontal {
 

--- a/less/grid.less
+++ b/less/grid.less
@@ -26,7 +26,7 @@
 .generate-small-grid-columns(@grid-columns);
 
 // Responsive: Tablets and up
-@media screen and (min-width: 768px) {
+@media screen and (min-width: @screen-tablet) {
   .container {
     max-width: 728px;
   }
@@ -38,14 +38,14 @@
 }
 
 // Responsive: Desktops and up
-@media screen and (min-width: 992px) {
+@media screen and (min-width: @screen-desktop) {
   .container {
     max-width: 940px;
   }
 }
 
 // Responsive: Large desktops and up
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: @screen-large-desktop) {
   .container {
     max-width: 1170px;
   }

--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -20,7 +20,7 @@
   }
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: @screen-tablet) {
   .jumbotron {
     padding: 50px 60px;
     border-radius: @border-radius-large; // Only round corners at higher resolutions

--- a/less/modals.less
+++ b/less/modals.less
@@ -120,7 +120,7 @@
 }
 
 // Scale up the modal
-@media screen and (min-width: 768px) {
+@media screen and (min-width: @screen-tablet) {
 
   .modal-dialog {
     left: 50%;

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -269,7 +269,7 @@
 // Inverse navbar
 // --------------------------------------------------
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: @screen-tablet) {
   .navbar {
     padding-top: 0;
     padding-bottom: 0;

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -46,7 +46,7 @@
 
 
 // Tablets & small desktops only
-@media (min-width: 768px) and (max-width: 979px) {
+@media (min-width: @screen-tablet) and (max-width: @screen-desktop) {
   .visible-phone    { display: none !important; }
   .visible-tablet    { display: inherit !important; }
   .visible-desktop   { display: none !important; }
@@ -57,7 +57,7 @@
 }
 
 // For desktops
-@media (min-width: 980px) {
+@media (min-width: @screen-desktop) {
   .visible-phone     { display: none !important; }
   .visible-tablet    { display: none !important; }
   .visible-desktop   { display: inherit !important; }

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -22,7 +22,7 @@ html {
 }
 
 // Disable iOS/WinMobile font size changes
-@media screen and (max-device-width: 480px) {
+@media screen and (max-device-width: @screen-phone) {
   html {
     -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;

--- a/less/variables.less
+++ b/less/variables.less
@@ -369,6 +369,22 @@
 @component-offset-horizontal: 180px;
 
 
+// Media queries breakpoints
+// --------------------------------------------------
+
+// Tiny screen / phone
+@screen-tiny:                480px;
+@screen-phone:               @screen-tiny;
+// Small screen / tablet
+@screen-small:               768px;
+@screen-tablet:              @screen-small;
+// Medium screen / desktop
+@screen-medium:              992px;
+@screen-desktop:             @screen-medium;
+// Large screen / wide desktop
+@screen-large:               1200px;
+@screen-large-desktop:       @screen-large;
+
 
 // Grid system
 // --------------------------------------------------
@@ -378,4 +394,4 @@
 // Padding, to be divided by two and applied to the left and right of all columns
 @grid-gutter-width:         30px;
 // Point at which the navbar stops collapsing
-@grid-float-breakpoint:     768px;
+@grid-float-breakpoint:     @screen-tablet;


### PR DESCRIPTION
Previous note:
I've never made pull request on github, I'm not that confortable with them, I hope I haven't done something wrong. Just let me know :)

Edit: second attempt with pull request :P
## What?

I've added variables for all media queries breakpoints in variables.less and replaced the corresponding values in the less files. They are prefixed with 'screen-'
## Why?

_\- more semantic and easy to remember than plain values_

example in carousel.less:

```
// Scale up controls for tablets and up
@media screen and (min-width: @screen-tablet) 
```

compared to

```
@media screen and (min-width: 768px) 
```

_\- consequence of the previous point: you can't make mistake_

more than once I have seen things like that:

```
@media screen and (min-width: 479px)  //foo1.less

@media screen and (min-width: 480px)  //foo2.less
```

_\- customize for your needs_

I don't want to launch a debate about this but, I think people have taken the wrong habit to associate breakpoints with some devices. 

And I recently read that media queries should use em units.

The important thing to consider is that your breakpoints should depend on your design.

So, for everybody to be happy, people can override the variables. (And I've put the same values of the twitter guys by default so you can just forget about them if you want :))

And, to continue with the semantics, here is a thing:

@media (max-width: 768px), is assumed to be for phones and tablets... 
are you certain that it's a phone or a tablet and not a resized browser window?

so I've decided to add variables like the following too, since we are actually checking the screen size and not if it's a phone or a tablet:

@screen-tiny (same as @screen-phone by default)
@screen-small (same as @screen-tablet...)
@screen-medium (same as @screen-desktop...)
@screen-large (same as @screen-large-desktop...)

You can use whichever you prefer.

(the bootstrap.css in the docs has been updated too)

Let me know what you think ;)

Kevin/aodev
