### PR TITLE
Fix of overlaid modal window

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5211,7 +5211,7 @@ input[type="submit"].btn.btn-mini {
 }
 
 .modal.fade {
-  top: -25%;
+  top: -100%;
   -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
      -moz-transition: opacity 0.3s linear, top 0.3s ease-out;
        -o-transition: opacity 0.3s linear, top 0.3s ease-out;

--- a/less/modals.less
+++ b/less/modals.less
@@ -40,7 +40,7 @@
 
   &.fade {
     .transition(e('opacity .3s linear, top .3s ease-out'));
-    top: -25%;
+    top: -100%;
   }
   &.fade.in { top: 10%; }
 }


### PR DESCRIPTION
If top is set to 25% on some screens it overlays the page at the very top. As it hidden area - page become unclickable at top of page.

I'm prefer to set top: 100% to avoid this (see attached screenshot):

![Screen Shot 2013-04-28 at 3 17 03 AM](https://f.cloud.github.com/assets/1686778/435049/d5a773ea-af90-11e2-8a02-92559fff8cd1.png)
