### PR TITLE
Fix of overlaid modal window

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4261,7 +4261,7 @@ button.close {
 }
 
 .modal.fade {
-  top: -25%;
+  top: -100%;
   -webkit-transition: opacity 0.3s linear, top 0.3s ease-out;
      -moz-transition: opacity 0.3s linear, top 0.3s ease-out;
        -o-transition: opacity 0.3s linear, top 0.3s ease-out;

--- a/less/modals.less
+++ b/less/modals.less
@@ -27,7 +27,7 @@
 
   // When fading in the modal, animate it to slide down
   &.fade {
-    top: -25%;
+    top: -100%;
     .transition(~"opacity 0.3s linear, top 0.3s ease-out");
   }
   &.fade.in { top: 0; }


### PR DESCRIPTION
If top is set to 25% on some screens it overlays the page at the very
top. As it hidden area - page become unclickable at top of page.

I'm prefer to set top: 100% to avoid this (please find attached screenshot):

![Screen Shot 2013-04-28 at 3 17 03 AM](https://f.cloud.github.com/assets/1686778/435611/c622c1dc-afee-11e2-96f3-d68d5c036952.png)

Send to 3.0.0-wip in correspond of #7708 issue
