### PR TITLE
Get rid of -o prefixes, since Opera uses -webkit

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -111,19 +111,16 @@
 .transition(@transition) {
   -webkit-transition: @transition;
      -moz-transition: @transition;
-       -o-transition: @transition;
           transition: @transition;
 }
 .transition-delay(@transition-delay) {
   -webkit-transition-delay: @transition-delay;
      -moz-transition-delay: @transition-delay;
-       -o-transition-delay: @transition-delay;
           transition-delay: @transition-delay;
 }
 .transition-duration(@transition-duration) {
   -webkit-transition-duration: @transition-duration;
      -moz-transition-duration: @transition-duration;
-       -o-transition-duration: @transition-duration;
           transition-duration: @transition-duration;
 }
 
@@ -132,34 +129,29 @@
   -webkit-transform: rotate(@degrees);
      -moz-transform: rotate(@degrees);
       -ms-transform: rotate(@degrees);
-       -o-transform: rotate(@degrees);
           transform: rotate(@degrees);
 }
 .scale(@ratio) {
   -webkit-transform: scale(@ratio);
      -moz-transform: scale(@ratio);
       -ms-transform: scale(@ratio);
-       -o-transform: scale(@ratio);
           transform: scale(@ratio);
 }
 .translate(@x, @y) {
   -webkit-transform: translate(@x, @y);
      -moz-transform: translate(@x, @y);
       -ms-transform: translate(@x, @y);
-       -o-transform: translate(@x, @y);
           transform: translate(@x, @y);
 }
 .skew(@x, @y) {
   -webkit-transform: skew(@x, @y);
      -moz-transform: skew(@x, @y);
       -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twitter/bootstrap/issues/4885
-       -o-transform: skew(@x, @y);
           transform: skew(@x, @y);
 }
 .translate3d(@x, @y, @z) {
   -webkit-transform: translate3d(@x, @y, @z);
      -moz-transform: translate3d(@x, @y, @z);
-       -o-transform: translate3d(@x, @y, @z);
           transform: translate3d(@x, @y, @z);
 }
 
@@ -184,7 +176,6 @@
 .background-size(@size) {
   -webkit-background-size: @size;
      -moz-background-size: @size;
-       -o-background-size: @size;
           background-size: @size;
 }
 
@@ -201,7 +192,6 @@
   -webkit-user-select: @select;
      -moz-user-select: @select;
       -ms-user-select: @select;
-       -o-user-select: @select;
           user-select: @select;
 }
 
@@ -227,7 +217,6 @@
   -webkit-hyphens: @mode;
      -moz-hyphens: @mode;
       -ms-hyphens: @mode;
-       -o-hyphens: @mode;
           hyphens: @mode;
 }
 

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -24,12 +24,6 @@
   to    { background-position: 0 0; }
 }
 
-// Opera
-@-o-keyframes progress-bar-stripes {
-  from  { background-position: 0 0; }
-  to    { background-position: 40px 0; }
-}
-
 // Spec
 @keyframes progress-bar-stripes {
   from  { background-position: 40px 0; }


### PR DESCRIPTION
Opera uses `-webkit-` or bare css3 selectors now, rather than `-o-`, for most uses. This gets rid of the extra `-o-` selectors. (See http://www.opera.com/docs/specs/presto2.12/css/aliases/ for more information.)
