### PR TITLE
Fix for licensing conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "uglify-js": "1.3.4"
     , "jshint": "0.9.1"
     , "recess": "1.1.6"
-    , "connect": "2.1.3"
+    , "connect": "2.7.6"
     , "hogan.js": "2.0.0"
   }
 }


### PR DESCRIPTION
Version 2.1.3 of [connect](https://github.com/senchalabs/connect) used [node-crc](https://github.com/alexgorbatchev/node-crc) as a dependency, which did not contain the proper licensing for legal reuse.  The latest version of connect removed this dependency and utilizes [buffer-crc32](https://github.com/brianloveswords/buffer-crc32) instead, which maintains a valid license.

See [PR from the connect repo](https://github.com/mdp/connect/commit/fe6ba40d7e309c2b613dbee72c1dcfb0f8afa58c) for more information.

This PR updates package.json to use the latest version of connect, which resolves any licensing conflict of using Bootstrap and all of it's dependencies.
