### PR TITLE
Changing out jQuery.delegate() for jQuery.on()

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -29,7 +29,7 @@
   var Modal = function (element, options) {
     this.options = options
     this.$element = $(element)
-      .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
+      .on('click.dismiss.modal', '[data-dismiss="modal"]', $.proxy(this.hide, this))
     this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
   }
 


### PR DESCRIPTION
As of jQuery 1.7, .delegate() has been superseded by the .on() method.
