### PR TITLE
Corrected typo in carousel.html

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -350,7 +350,7 @@ body {
 
   <div class="featurette">
     <img class="featurette-image img-circle pull-right" data-src="holder.js/512x512">
-    <h2 class="featurette-heading">First featurette headling. <span class="text-muted">It'll blow your mind.</span></h2>
+    <h2 class="featurette-heading">First featurette heading. <span class="text-muted">It'll blow your mind.</span></h2>
     <p class="lead">Donec ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur. Fusce dapibus, tellus ac cursus commodo.</p>
   </div>
 


### PR DESCRIPTION
Changed text from "First featurette headling" to "First featurette heading" in the first `h2.featurette-heading` tag.
