### PR TITLE
Use padding instead of #push with box-sizing: border-box

### DIFF
--- a/docs/examples/sticky-footer-navbar.html
+++ b/docs/examples/sticky-footer-navbar.html
@@ -22,14 +22,13 @@ title: Sticky footer with navbar template
     height: 100%;
     /* Negative indent footer by its height */
     margin: 0 auto -60px;
+    /* Pad bottom by footer height */
+    padding: 0 0 60px;
   }
 
   /* Set the fixed height of the footer here */
-  #push,
   #footer {
     height: 60px;
-  }
-  #footer {
     background-color: #f5f5f5;
   }
 
@@ -106,8 +105,6 @@ title: Sticky footer with navbar template
     <p class="lead">Pin a fixed-height footer to the bottom of the viewport in desktop browsers with this custom HTML and CSS. A fixed navbar has been added within <code>#wrap</code> with <code>padding-top: 60px;</code> on the <code>.container</code>.</p>
     <p>Back to <a href="../sticky-footer">the default sticky footer</a> minus the navbar.</p>
   </div>
-
-  <div id="push"></div>
 </div>
 
 <div id="footer">

--- a/docs/examples/sticky-footer.html
+++ b/docs/examples/sticky-footer.html
@@ -22,14 +22,13 @@ title: Sticky footer template
     height: 100%;
     /* Negative indent footer by its height */
     margin: 0 auto -60px;
+    /* Pad bottom by footer height */
+    padding: 0 0 60px;
   }
 
   /* Set the fixed height of the footer here */
-  #push,
   #footer {
     height: 60px;
-  }
-  #footer {
     background-color: #f5f5f5;
   }
 
@@ -71,8 +70,6 @@ title: Sticky footer template
     <p class="lead">Pin a fixed-height footer to the bottom of the viewport in desktop browsers with this custom HTML and CSS.</p>
     <p>Use <a href="../sticky-footer-navbar">the sticky footer with a fixed navbar</a> if need be, too.</p>
   </div>
-
-  <div id="push"></div>
 </div>
 
 <div id="footer">


### PR DESCRIPTION
Now that we're using `box-sizing: border-box` throughout, the sticky footer examples no longer require the additional `#push` markup and can be replaced by `padding` on the `#wrapper`.
