### PR TITLE
streamlined tooltip and popover. Fixed .arrow() using the new 'arrow' option

### DIFF
--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -738,6 +738,18 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
             </thead>
             <tbody>
              <tr>
+               <td>{{_i}}template{{/i}}</td>
+               <td>{{_i}}string{{/i}}</td>
+               <td>'&lt;div class="tooltip"&gt;&lt;div class="tooltip-inner"&gt;&lt;/div&gt;&lt;/div&gt;'</td>
+               <td>{{_i}}the HTML template used to create the tooltip{{/i}}</td>
+             </tr>
+             <tr>
+               <td>{{_i}}arrow{{/i}}</td>
+               <td>{{_i}}string | false{{/i}}</td>
+               <td>'tooltip-arrow'</td>
+               <td>{{_i}}if set to false, no tooltip-arrow is shown. If set (default), it is the name of the class used for the arrow element that will be created on the fly. If you add a customized arrow in your template, please always add the default class name too.{{/i}}</td>
+             </tr>
+             <tr>
                <td>{{_i}}animation{{/i}}</td>
                <td>{{_i}}boolean{{/i}}</td>
                <td>true</td>
@@ -905,10 +917,22 @@ $('a[data-toggle="tab"]').on('shown', function (e) {
           </thead>
           <tbody>
            <tr>
+             <td>{{_i}}template{{/i}}</td>
+             <td>{{_i}}string{{/i}}</td>
+             <td>'&lt;div class="popover"&gt;&lt;h3 class="popover-title"&gt;&lt;/h3&gt;&lt;div class="popover-content"&gt;&lt;/div&gt;&lt;/div&gt;'</td>
+             <td>{{_i}}the HTML template used to create the popover{{/i}}</td>
+           </tr>
+           <tr>
+             <td>{{_i}}arrow{{/i}}</td>
+             <td>{{_i}}string | false{{/i}}</td>
+             <td>'popover-arrow'</td>
+             <td>{{_i}}if set to false, no popover-arrow is shown. If set (default), it is the name of the class used for the arrow element that will be created on the fly. If you add a customized arrow in your template, please always add the default class name too.{{/i}}</td>
+           </tr>
+           <tr>
              <td>{{_i}}animation{{/i}}</td>
              <td>{{_i}}boolean{{/i}}</td>
              <td>true</td>
-             <td>{{_i}}apply a css fade transition to the tooltip{{/i}}</td>
+             <td>{{_i}}apply a css fade transition to the popover{{/i}}</td>
            </tr>
            <tr>
              <td>{{_i}}html{{/i}}</td>

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -45,8 +45,6 @@
 
       $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
       $tip.find('.popover-content')[this.options.html ? 'html' : 'text'](content)
-
-      $tip.removeClass('fade top bottom left right in')
     }
 
   , hasContent: function () {
@@ -62,17 +60,6 @@
         || $e.attr('data-content')
 
       return content
-    }
-
-  , tip: function () {
-      if (!this.$tip) {
-        this.$tip = $(this.options.template)
-      }
-      return this.$tip
-    }
-
-  , destroy: function () {
-      this.hide().$element.off('.' + this.type).removeData(this.type)
     }
 
   })
@@ -99,7 +86,8 @@
     placement: 'right'
   , trigger: 'click'
   , content: ''
-  , template: '<div class="popover"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+  , template: '<div class="popover"><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+  , arrow: 'popover-arrow'
   })
 
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -126,10 +126,6 @@
         $tip = this.tip()
         this.setContent()
 
-        if (this.options.animation) {
-          $tip.addClass('fade')
-        }
-
         placement = typeof this.options.placement == 'function' ?
           this.options.placement.call(this, $tip[0], this.$element[0]) :
           this.options.placement
@@ -217,7 +213,6 @@
         , title = this.getTitle()
 
       $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
-      $tip.removeClass('fade in top bottom left right')
     }
 
   , hide: function () {
@@ -281,11 +276,30 @@
     }
 
   , tip: function () {
-      return this.$tip = this.$tip || $(this.options.template)
+      return this.$tip = this.$tip || this.createTipFromTemplate(this.options.template)
+    }
+
+  , createTipFromTemplate: function(template) {
+        var $tip = $(template);
+
+        if (this.options.animation) {
+          $tip.addClass('fade')
+        }
+
+        if (this.options.arrow) {
+          if (!$tip.children('.' + this.getOptions({}).arrow)) {
+              $tip.prepend('<div class="' + this.options.arrow + '"></div>');
+          }
+        } else {
+          $tip.find('.' + this.getOptions({}).arrow).remove();
+          $tip.find('.arrow').remove();
+        }
+
+        return $tip;
     }
 
   , arrow: function(){
-      return this.$arrow = this.$arrow || this.tip().find(".tooltip-arrow")
+      return this.$arrow = this.$arrow || this.tip().find(this.options.arrow ? "." + this.options.arrow : "")
     }
 
   , validate: function () {
@@ -341,7 +355,8 @@
     animation: true
   , placement: 'top'
   , selector: false
-  , template: '<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+  , template: '<div class="tooltip"><div class="tooltip-inner"></div></div>'
+  , arrow: 'tooltip-arrow'
   , trigger: 'hover focus'
   , title: ''
   , delay: 0

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -287,7 +287,7 @@
         }
 
         if (this.options.arrow) {
-          if (!$tip.children('.' + this.getOptions({}).arrow)) {
+          if ($tip.children('.' + this.getOptions({}).arrow).length === 0) {
               $tip.prepend('<div class="' + this.options.arrow + '"></div>');
           }
         } else {

--- a/js/tests/unit/bootstrap-popover.js
+++ b/js/tests/unit/bootstrap-popover.js
@@ -103,7 +103,7 @@ $(function () {
           .popover()
           .popover('show')
 
-        ok($('.popover').children('.popover-arrow'), 'arrow is present')
+        equal($('.popover').children('.popover-arrow').length, 1, 'arrow is present')
         popover.popover('hide')
         ok(!$(".popover").length, 'popover removed')
       })

--- a/js/tests/unit/bootstrap-popover.js
+++ b/js/tests/unit/bootstrap-popover.js
@@ -84,7 +84,7 @@ $(function () {
           .popover({
             title: 'Test'
           , content: 'Test'
-          , template: '<div class="popover foobar"><div class="arrow"></div><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div></div>'
+          , template: '<div class="popover foobar"><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div></div>'
           })
 
         popover.popover('show')
@@ -95,6 +95,56 @@ $(function () {
         popover.popover('hide')
         ok(!$('.popover').length, 'popover was removed')
         $('#qunit-fixture').empty()
+      })
+
+      test("should have get an arrow per default", function () {
+        var popover = $('<a href="#" rel="popover" title="Simple popover"></a>')
+          .appendTo('#qunit-fixture')
+          .popover()
+          .popover('show')
+
+        ok($('.popover').children('.popover-arrow'), 'arrow is present')
+        popover.popover('hide')
+        ok(!$(".popover").length, 'popover removed')
+      })
+
+      test("should not get an arrow if option set to false", function () {
+        var popover = $('<a href="#" rel="popover" title="Simple popover without an arrow"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({ arrow: false })
+          .popover('show')
+
+        ok(!$('.popover').children('.popover-arrow').length, 'arrow isn\'t present')
+        popover.popover('hide')
+        ok(!$(".popover").length, 'popover removed')
+      })
+
+      test("should not have arrow, even if customized", function () {
+        var popover = $('<a href="#" rel="popover" title="Simple popover with an custom arrow"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({
+            template: '<div class="popover foobar"><div class="popover-arrow customized"/><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div></div>',
+            arrow: false
+          })
+          .popover('show')
+
+        ok(!$('.popover').children('.popover-arrow').length, 'arrow isn\'t present')
+        popover.popover('hide')
+        ok(!$(".popover").length, 'popover removed')
+      })
+
+      test("should have not have doubled arrow if customized", function () {
+        var popover = $('<a href="#" rel="popover" title="Customized popover"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({
+            template: '<div class="popover foobar"><div class="popover-arrow customized"/><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div></div>'
+          })
+          .popover('show')
+
+        ok($('.popover').children('.popover-arrow').hasClass('customized'), 'customized arrow is present')
+        equal($(".popover").children('.popover-arrow').length, 1, 'no additional arrow present')
+        popover.popover('hide')
+        ok(!$(".popover").length, 'popover removed')
       })
 
       test("should destroy popover", function () {

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -108,7 +108,7 @@ $(function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Customized tooltip"></a>')
           .appendTo('#qunit-fixture')
           .tooltip({
-            template: '<div class="tooltip some-class"><div class="tooltip-arrow customized"/><div class="tooltip-inner"/></div>',
+            template: '<div class="tooltip some-class"><div class="tooltip-arrow customized"/><div class="tooltip-inner"/></div>'
           })
           .tooltip('show')
 

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -72,7 +72,7 @@ $(function () {
           .tooltip()
           .tooltip('show')
 
-        ok($('.tooltip').children('.tooltip-arrow'), '.tooltip-arrow is present')
+        equal($('.tooltip').children('.tooltip-arrow').length, 1, '.tooltip-arrow is present')
         tooltip.tooltip('hide')
         ok(!$(".tooltip").length, 'tooltip removed')
       })

--- a/js/tests/unit/bootstrap-tooltip.js
+++ b/js/tests/unit/bootstrap-tooltip.js
@@ -39,7 +39,7 @@ $(function () {
           .tooltip({placement: 'bottom'})
           .tooltip('show')
 
-        ok($(".tooltip").is('.fade.bottom.in'), 'has correct classes applied')
+        ok($(".tooltip").is('.fade.bottom.in'), 'has correct classes applied. Expected `.tooltip.fade.bottom.in`, got: ' + $(".tooltip").attr('class'))
         tooltip.tooltip('hide')
       })
 
@@ -58,10 +58,62 @@ $(function () {
       test("should respect custom classes", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
           .appendTo('#qunit-fixture')
-          .tooltip({ template: '<div class="tooltip some-class"><div class="tooltip-arrow"/><div class="tooltip-inner"/></div>'})
+          .tooltip({ template: '<div class="tooltip some-class"><div class="tooltip-inner"/></div>'})
           .tooltip('show')
 
         ok($('.tooltip').hasClass('some-class'), 'custom class is present')
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
+      test("should have get an arrow per default", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Simple tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip()
+          .tooltip('show')
+
+        ok($('.tooltip').children('.tooltip-arrow'), '.tooltip-arrow is present')
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
+      test("should not get an arrow if option set to false", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Simple tooltip without an arrow"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({ arrow: false })
+          .tooltip('show')
+
+        ok(!$('.tooltip').children('.tooltip-arrow').length, '.tooltip-arrow isn\'t present')
+
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
+      test("should not have arrow, even if customized", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Simple tooltip with an custom arrow"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            template: '<div class="tooltip some-class"><div class="tooltip-arrow customized"/><div class="tooltip-inner"/></div>',
+            arrow: false
+          })
+          .tooltip('show')
+
+        ok(!$('.tooltip').children('.tooltip-arrow').length, '.tooltip-arrow isn\'t present')
+
+        tooltip.tooltip('hide')
+        ok(!$(".tooltip").length, 'tooltip removed')
+      })
+
+      test("should have not have doubled arrow if customized", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Customized tooltip"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            template: '<div class="tooltip some-class"><div class="tooltip-arrow customized"/><div class="tooltip-inner"/></div>',
+          })
+          .tooltip('show')
+
+        ok($('.tooltip').children('.tooltip-arrow').hasClass('customized'), 'customized arrow is present')
+        equal($(".tooltip").children('.tooltip-arrow').length, 1, 'no additional arrow present')
         tooltip.tooltip('hide')
         ok(!$(".tooltip").length, 'tooltip removed')
       })

--- a/less/popovers.less
+++ b/less/popovers.less
@@ -54,8 +54,8 @@
 //
 // .arrow is outer, .arrow:after is inner
 
-.popover .arrow,
-.popover .arrow:after {
+.popover .popover-arrow,
+.popover .popover-arrow:after {
   position: absolute;
   display: block;
   width: 0;
@@ -63,16 +63,16 @@
   border-color: transparent;
   border-style: solid;
 }
-.popover .arrow {
+.popover .popover-arrow {
   border-width: @popoverArrowOuterWidth;
 }
-.popover .arrow:after {
+.popover .popover-arrow:after {
   border-width: @popoverArrowWidth;
   content: "";
 }
 
 .popover {
-  &.top .arrow {
+  &.top .popover-arrow {
     left: 50%;
     margin-left: -@popoverArrowOuterWidth;
     border-bottom-width: 0;
@@ -86,7 +86,7 @@
       border-top-color: @popoverArrowColor;
     }
   }
-  &.right .arrow {
+  &.right .popover-arrow {
     top: 50%;
     left: -@popoverArrowOuterWidth;
     margin-top: -@popoverArrowOuterWidth;
@@ -100,7 +100,7 @@
       border-right-color: @popoverArrowColor;
     }
   }
-  &.bottom .arrow {
+  &.bottom .popover-arrow {
     left: 50%;
     margin-left: -@popoverArrowOuterWidth;
     border-top-width: 0;
@@ -115,7 +115,7 @@
     }
   }
 
-  &.left .arrow {
+  &.left .popover-arrow {
     top: 50%;
     right: -@popoverArrowOuterWidth;
     margin-top: -@popoverArrowOuterWidth;


### PR DESCRIPTION
refactoring fix for #7771 supersedes #7772 on 2.3.1 / 2.x

this will add a new option 'arrow' in tooltip making this more flexible, even allow it to disable
