### PR TITLE
getTitle and getContent of tooltip and popover are not acting the same way

### DIFF
--- a/js/tests/unit/bootstrap-popover.js
+++ b/js/tests/unit/bootstrap-popover.js
@@ -61,11 +61,30 @@ $(function () {
         $('#qunit-fixture').empty()
       })
 
-      test("should get title and content from attributes", function () {
+      test("should get title and content from attributes #1", function () {
         $.support.transition = false
         var popover = $('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>')
           .appendTo('#qunit-fixture')
           .popover()
+          .popover('show')
+
+        ok($('.popover').length, 'popover was inserted')
+        equals($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
+        equals($('.popover .popover-content').text(), "loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻", 'content correctly inserted')
+
+        popover.popover('hide')
+        ok(!$('.popover').length, 'popover was removed')
+        $('#qunit-fixture').empty()
+      })
+
+      test("should get title and content from attributes #2", function () {
+        $.support.transition = false
+        var popover = $('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>')
+          .appendTo('#qunit-fixture')
+          .popover({
+              title: 'ignored title option',
+              content: 'ignored content option'
+          })
           .popover('show')
 
         ok($('.popover').length, 'popover was inserted')


### PR DESCRIPTION
while getTitle() prefers the attribute of the anchor element instead of the passed option 'title' (see pull request #7775 ) the getContent() method for popovers is acting the other way round.

PLEASE streamline that behaviours of options. It's cruel to have look into the code evertime how this option works

THESE TESTS WILL FAIL UNLESS IT IS FIXED
