### PR TITLE
Fixed hidden navbar dropdowns on mobiles, corrected header.

### DIFF
--- a/less/component-animations.less
+++ b/less/component-animations.less
@@ -29,4 +29,5 @@
 }
 .collapse.in {
   height: auto;
+  overflow: visible; // Fix hidden (navbar) dropdown menus on mobiles
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -299,6 +299,8 @@
 
 }
 
+
+
 // Buttons in navbars
 //
 // Vertically center a button within a navbar (when *not* in a form).

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -262,7 +262,7 @@
 
 
 
-// Inverse navbar
+// Navbar styles for tablets and up
 // --------------------------------------------------
 
 @media screen and (min-width: @screen-tablet) {
@@ -298,8 +298,6 @@
   }
 
 }
-
-
 
 // Buttons in navbars
 //


### PR DESCRIPTION
Currently drowdowns are hidden/cut-off on mobile devices. This way they are shown. Save because only applied if the menu is actually open, in that stage there is no need for `overflow: hidden;`

Also there was a header text copy pasted that was wrong.

Before:
![bs_nav_cutoff](https://f.cloud.github.com/assets/1780826/462923/e193fb3c-b4f5-11e2-8ff4-5bc99733d9b5.png)

After:
![bs_nav_fixed](https://f.cloud.github.com/assets/1780826/462924/eaafdd3a-b4f5-11e2-83d8-9d777032584d.png)
