### PR TITLE
updated README to fix Bower's project page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Three quick start options are available:
 
 * [Download the latest release](https://github.com/twitter/bootstrap/zipball/master).
 * Clone the repo: `git clone git://github.com/twitter/bootstrap.git`.
-* Install with Twitter's [Bower](http://twitter.github.com/bower): `bower install bootstrap`.
+* Install with Twitter's [Bower](http://bower.io/): `bower install bootstrap`.
 
 
 


### PR DESCRIPTION
Noticed Bower's homepage moved and the current link was broken, so I updated the link to [http://bower.io/](http://bower.io/)
