### PR TITLE
Make docs use site.url as base instead of static top-level domain, reference to both #7758 and #7767.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,4 +9,5 @@ permalink:    pretty
 source:       ./docs
 destination:  ./_gh_pages
 port:         9001
-url:          http://bootstrap.dev:9001
+url:          /
+baseurl:      /

--- a/docs/_includes/docs-nav.html
+++ b/docs/_includes/docs-nav.html
@@ -1,6 +1,6 @@
 <div class="bs-docs-sidebar">
   <ul class="nav bs-docs-sidenav">
-    <h3 class="bs-docs-sidenav-heading"><a href="/">Bootstrap</a></h3>
+    <h3 class="bs-docs-sidenav-heading"><a href="{{ site.url }}">Bootstrap</a></h3>
 
     <li><a href="#welcome">Welcome!</a></li>
     <li><a href="#getting-started">Getting started</a></li>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,25 +1,25 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="/assets/js/jquery.js"></script>
-<script src="/assets/js/bootstrap-transition.js"></script>
-<script src="/assets/js/bootstrap-alert.js"></script>
-<script src="/assets/js/bootstrap-modal.js"></script>
-<script src="/assets/js/bootstrap-dropdown.js"></script>
-<script src="/assets/js/bootstrap-scrollspy.js"></script>
-<script src="/assets/js/bootstrap-tab.js"></script>
-<script src="/assets/js/bootstrap-tooltip.js"></script>
-<script src="/assets/js/bootstrap-popover.js"></script>
-<script src="/assets/js/bootstrap-button.js"></script>
-<script src="/assets/js/bootstrap-collapse.js"></script>
-<script src="/assets/js/bootstrap-carousel.js"></script>
-<script src="/assets/js/bootstrap-typeahead.js"></script>
-<script src="/assets/js/bootstrap-affix.js"></script>
+<script src="{{ site.url }}assets/js/jquery.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-transition.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-alert.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-modal.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-dropdown.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-scrollspy.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-tab.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-tooltip.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-popover.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-button.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-collapse.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-carousel.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-typeahead.js"></script>
+<script src="{{ site.url }}assets/js/bootstrap-affix.js"></script>
 
 <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
-<script src="/assets/js/holder/holder.js"></script>
+<script src="{{ site.url }}assets/js/holder/holder.js"></script>
 
-<script src="/assets/js/application.js"></script>
+<script src="{{ site.url }}assets/js/application.js"></script>
 
 <!-- Analytics
 ================================================== -->

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -12,26 +12,26 @@
 </title>
 
 <!-- Bootstrap core CSS -->
-<link href="/assets/css/bootstrap.css" rel="stylesheet">
+<link href="{{ site.url }}assets/css/bootstrap.css" rel="stylesheet">
 
 {% if page.layout != "example" %}
 <!-- Documentation extras -->
-<link href="/assets/css/docs.css" rel="stylesheet">
-<link href="/assets/css/pygments-manni.css" rel="stylesheet">
+<link href="{{ site.url }}assets/css/docs.css" rel="stylesheet">
+<link href="{{ site.url }}assets/css/pygments-manni.css" rel="stylesheet">
 {% endif %}
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
-  <script src="/assets/js/html5shiv.js"></script>
-  <script src="/assets/js/respond/respond.min.js"></script>
+  <script src="{{ site.url }}assets/js/html5shiv.js"></script>
+  <script src="{{ site.url }}assets/js/respond/respond.min.js"></script>
 <![endif]-->
 
 <!-- Favicons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/ico/apple-touch-icon-144-precomposed.png">
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/ico/apple-touch-icon-114-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/ico/apple-touch-icon-72-precomposed.png">
-                <link rel="apple-touch-icon-precomposed" href="/assets/ico/apple-touch-icon-57-precomposed.png">
-                               <link rel="shortcut icon" href="/assets/ico/favicon.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.url }}assets/ico/apple-touch-icon-144-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.url }}assets/ico/apple-touch-icon-114-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.url }}assets/ico/apple-touch-icon-72-precomposed.png">
+                <link rel="apple-touch-icon-precomposed" href="{{ site.url }}assets/ico/apple-touch-icon-57-precomposed.png">
+                               <link rel="shortcut icon" href="{{ site.url }}assets/ico/favicon.png">
 
 <script type="text/javascript">
   var _gaq = _gaq || [];

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -22,7 +22,7 @@ title: Bootstrap Documentation
 
     <h3>Download compiled CSS and JS</h3>
     <p class="lead">The fastest way to get started is to get the compiled and minified versions of our CSS, JavaScript, and fonts. No documentation or original source files are included.</p>
-    <p><a class="btn btn-large btn-primary" href="assets/bootstrap.zip" onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download compiled']);">Download Bootstrap</a></p>
+    <p><a class="btn btn-large btn-primary" href="{{ site.url}}/assets/bootstrap.zip" onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download compiled']);">Download Bootstrap</a></p>
 
     <hr>
 
@@ -124,86 +124,86 @@ title: Bootstrap Documentation
     <h3>Examples</h3>
     <div class="row bs-docs-examples">
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/starter-template/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-starter.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/starter-template/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-starter.png" alt="">
         </a>
         <h4>Starter template</h4>
         <p>A barebones HTML page with Bootstrap's CSS and JavaScript included.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/grid/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-grid.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/grid/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-grid.png" alt="">
         </a>
         <h4>Basic grid layouts</h4>
         <p>Simple grid layouts to familiarize you with using the Bootstrap grid system.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/jumbotron/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-marketing.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/jumbotron/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-marketing.png" alt="">
         </a>
         <h4>Basic marketing site</h4>
         <p>Features a jumbotron for primary message and three supporting elements.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/jumbotron-narrow/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-jumbotron-narrow.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/jumbotron-narrow/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-jumbotron-narrow.png" alt="">
         </a>
         <h4>Narrow marketing</h4>
         <p>Slim, lightweight marketing template for small projects or teams.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/justified-nav/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-justified-nav.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/justified-nav/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-justified-nav.png" alt="">
         </a>
         <h4>Justified nav</h4>
         <p>Marketing page with equal-width navigation links in a modified navbar.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/signin/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-signin.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/signin/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-signin.png" alt="">
         </a>
         <h4>Sign in</h4>
         <p>Barebones sign in form with custom, larger form controls and a flexible layout.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/sticky-footer/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-sticky-footer.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/sticky-footer/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-sticky-footer.png" alt="">
         </a>
         <h4>Sticky footer</h4>
         <p>Pin a fixed-height footer to the bottom of the user's viewport.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/sticky-footer-navbar/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-sticky-footer-navbar.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/sticky-footer-navbar/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-sticky-footer-navbar.png" alt="">
         </a>
         <h4>Sticky footer w/ navbar</h4>
         <p>Add a fixed navbar to the default sticky footer template.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/carousel/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-carousel.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/carousel/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-carousel.png" alt="">
         </a>
         <h4>Carousel jumbotron</h4>
         <p>An interactive riff on the basic marketing site featuring a prominent carousel.</p>
       </div>
 
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/navbar/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-navbar.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/navbar/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-navbar.png" alt="">
         </a>
         <h4>Navbar</h4>
         <p>Basic template for showcasing how the navbar works.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/navbar-static-top/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-navbar-static-top.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/navbar-static-top/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-navbar-static-top.png" alt="">
         </a>
         <h4>Static top navbar</h4>
         <p>Basic template for showcasing the static navbar variation.</p>
       </div>
       <div class="col col-lg-4">
-        <a class="thumbnail" href="/examples/navbar-fixed-top/" target="_blank">
-          <img src="/assets/img/examples/bootstrap-example-navbar-fixed-top.png" alt="">
+        <a class="thumbnail" href="{{ site.url }}examples/navbar-fixed-top/" target="_blank">
+          <img src="{{ site.url }}assets/img/examples/bootstrap-example-navbar-fixed-top.png" alt="">
         </a>
         <h4>Fixed top navbar</h4>
         <p>Basic template for showcasing the fixed navbar variation.</p>
@@ -282,7 +282,7 @@ title: Bootstrap Documentation
     </div>
 
     <h3>Removing potential bloat</h3>
-    <p>Not all sites and applications need to make use of everything Bootstrap has to offer, especially in production environments where bandwidth literally becomes a financial issue. We encourage folks to remove whatever is unused with our <a href="./customizer/">Customizer</a>.</p>
+    <p>Not all sites and applications need to make use of everything Bootstrap has to offer, especially in production environments where bandwidth literally becomes a financial issue. We encourage folks to remove whatever is unused with our <a href="{{ site.url }}customizer/">Customizer</a>.</p>
     <p>Using the Customizer, simply uncheck any component, feature, or asset you don't need. Hit download and swap out the default Bootstrap files with these newly customized ones. You'll get vanilla Bootstrap, but without the features *you* deem unnecessary. All custom builds include compiled and minified versions, so use whichever works for you.</p>
 
   </div>
@@ -2679,7 +2679,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <div class="page-header">
       <h1>Dropdown menus</h1>
     </div>
-    <p class="lead">Toggleable, contextual menu for displaying lists of links. Made interactive with the <a href="./javascript.html#dropdowns">dropdown JavaScript plugin</a>.</p>
+    <p class="lead">Toggleable, contextual menu for displaying lists of links. Made interactive with the <a href="{{ site.url }}javascript.html#dropdowns">dropdown JavaScript plugin</a>.</p>
 
     <h3 id="dropdowns-example">Example</h3>
     <p>Wrap the dropdown's trigger and the dropdown menu within <code>.dropdown</code>, or another element that declares <code>position: relative;</code>. Then add the menu's HTML.</p>
@@ -2832,7 +2832,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <div class="page-header">
       <h1>Button groups</h1>
     </div>
-    <p class="lead">Group a series of buttons together on a single line with the button group. Add on optional JavaScript radio and checkbox style behavior with <a href="./javascript.html#buttons">our buttons plugin</a>.</p>
+    <p class="lead">Group a series of buttons together on a single line with the button group. Add on optional JavaScript radio and checkbox style behavior with <a href="{{ site.url }}javascript.html#buttons">our buttons plugin</a>.</p>
 
     <h3 id="btn-groups-single">Basic button group</h3>
     <p>Wrap a series of buttons with <code>.btn</code> in <code>.btn-group</code>.</p>
@@ -3331,7 +3331,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 
 
     <h2 id="nav-dropdowns">Dropdowns</h2>
-    <p>Add dropdown menus with a little extra HTML and the <a href="./javascript.html#dropdowns">dropdowns JavaScript plugin</a>.</p>
+    <p>Add dropdown menus with a little extra HTML and the <a href="{{ site.url }}javascript.html#dropdowns">dropdowns JavaScript plugin</a>.</p>
 
     <h3>Tabs with dropdowns</h3>
     <div class="bs-docs-example">
@@ -3831,7 +3831,7 @@ body {
     <div class="page-header">
       <h1>Pagination</h1>
     </div>
-    <p class="lead">Provide pagination links for your site or app with the multi-page pagination component, or the simpler <a href="./docs/#pagination-pager">pager alternative</a>.</p>
+    <p class="lead">Provide pagination links for your site or app with the multi-page pagination component, or the simpler <a href="{{ site.url }}docs/#pagination-pager">pager alternative</a>.</p>
 
     <h2 id="pagination-default">Standard pagination</h2>
     <p>Simple pagination inspired by Rdio, great for apps and search results. The large block is hard to miss, easily scalable, and provides large click areas.</p>
@@ -4147,7 +4147,7 @@ body {
     <div class="page-header">
       <h1>Thumbnails</h1>
     </div>
-    <p class="lead">Extend Bootstrap's <a href="./docs/#grid">grid system</a> with the thumbnail component to easily display grids of images, videos, text, and more.</p>
+    <p class="lead">Extend Bootstrap's <a href="{{ site.url }}docs/#grid">grid system</a> with the thumbnail component to easily display grids of images, videos, text, and more.</p>
 
     <h3>Default thumbnails</h3>
     <p>By default, Bootstrap's thumbnails are designed to showcase linked images with minimal required markup.</p>
@@ -4247,7 +4247,7 @@ body {
     <div class="page-header">
       <h1>Alerts</h1>
     </div>
-    <p class="lead">Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages. For inline dismissal, use the <a href="./docs/#js-alerts">alerts jQuery plugin</a>.</p>
+    <p class="lead">Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages. For inline dismissal, use the <a href="{{ site.url }}docs/#js-alerts">alerts jQuery plugin</a>.</p>
 
     <h3 id="alerts-default">Default alert</h3>
     <p>Wrap any text and an optional dismiss button in <code>.alert</code> for a basic warning alert message. <strong>To ensure proper behavior across all devices</strong>, be sure to use <code>&lt;button&gt;</code> element with the <code>data-dismiss="alert"</code> data attribute.</p>
@@ -4810,7 +4810,7 @@ body {
 {% endhighlight %}
 
     <h3 id="panels-list-group">With list groups</h3>
-    <p>Easily include full-width <a href="./docs/#list-group">list groups</a> within any panel.</p>
+    <p>Easily include full-width <a href="{{ site.url }}docs/#list-group">list groups</a> within any panel.</p>
     <div class="bs-docs-example">
       <div class="panel">
         <!-- Default panel contents -->

--- a/docs/examples/navbar-fixed-top.html
+++ b/docs/examples/navbar-fixed-top.html
@@ -45,9 +45,9 @@ title: Fixed navbar template
             </li>
           </ul>
           <ul class="nav navbar-nav pull-right">
-            <li><a href="/examples/navbar/">Default</a></li>
-            <li><a href="/examples/navbar-static-top/">Static top</a></li>
-            <li class="active"><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+            <li><a href="{{ site.url }}examples/navbar/">Default</a></li>
+            <li><a href="{{ site.url }}examples/navbar-static-top/">Static top</a></li>
+            <li class="active"><a href="{{ site.url }}examples/navbar-fixed-top/">Fixed top</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/docs/examples/navbar-static-top.html
+++ b/docs/examples/navbar-static-top.html
@@ -41,9 +41,9 @@ title: Static navbar template
         </li>
       </ul>
       <ul class="nav navbar-nav pull-right">
-        <li><a href="/examples/navbar/">Default</a></li>
-        <li class="active"><a href="/examples/navbar-static-top/">Static top</a></li>
-        <li><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+        <li><a href="{{ site.url }}examples/navbar/">Default</a></li>
+        <li class="active"><a href="{{ site.url }}examples/navbar-static-top/">Static top</a></li>
+        <li><a href="{{ site.url }}examples/navbar-fixed-top/">Fixed top</a></li>
       </ul>
     </div><!--/.nav-collapse -->
   </div>

--- a/docs/examples/navbar.html
+++ b/docs/examples/navbar.html
@@ -47,9 +47,9 @@ title: Navbar template
           </li>
         </ul>
         <ul class="nav navbar-nav pull-right">
-          <li class="active"><a href="/examples/navbar/">Default</a></li>
-          <li><a href="/examples/navbar-static-top/">Static top</a></li>
-          <li><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+          <li class="active"><a href="{{ site.url }}examples/navbar/">Default</a></li>
+          <li><a href="{{ site.url }}examples/navbar-static-top/">Static top</a></li>
+          <li><a href="{{ site.url }}examples/navbar-fixed-top/">Fixed top</a></li>
         </ul>
       </div><!--/.nav-collapse -->
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,8 +9,8 @@ title: Bootstrap
     <h1>Bootstrap</h1>
     <p class="lead">Sleek, intuitive, and powerful mobile-first front-end framework for faster and easier web development.</p>
     <p>
-      <a href="assets/bootstrap.zip" class="btn btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 3.0.0']);">Download Bootstrap</a>
-      <a href="./docs/" class="btn btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Docs', 'View docs']);">View docs</a>
+      <a href="{{ site.url }}assets/bootstrap.zip" class="btn btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 3.0.0']);">Download Bootstrap</a>
+      <a href="{{ site.url }}docs/" class="btn btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Docs', 'View docs']);">View docs</a>
     </p>
 
     <div class="bs-docs-social">
@@ -32,13 +32,13 @@ title: Bootstrap
 
     <ul class="masthead-links">
       <li>
-        <a href="./customize/" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Customize']);">Customize</a>
+        <a href="{{ site.url }}customize/" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Customize']);">Customize</a>
       </li>
       <li>
         <a href="http://github.com/twitter/bootstrap" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);">GitHub project</a>
       </li>
       <li>
-        <a href="./docs/#examples" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Examples']);">Examples</a>
+        <a href="{{ site.url }}docs/#examples" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Examples']);">Examples</a>
       </li>
       <li>
         <a href="http://expo.getbootstrap.com" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Expo']);">Bootstrap Expo</a>


### PR DESCRIPTION
This patch works for both following setting in `_config.yml`
- `url + baseurl = /`
  - http://127.0.0.1:9001/
  - http://getbootstrap.dev:9001/ (if I hard code `127.0.0.1 getbootstrap.dev` into hosts file)
- `url + baseurl = /bootstrap/`
  - http://127.0.0.1:9001/bootstrap/
  - http://getbootstrap.dev:9001/bootstrap/ (if I hard code `127.0.0.1 getbootstrap.dev` into hosts file)
  - http://username.github.io/bootstrap/ (github project page for review without local jekyll)

Which means no more hard coding to specific domain name nor folder structure setup in docs's HTML, marks both local jekyll, github project page, and final document site URL with http://getbootstrap.com/ friendly, too ;-)
