### PR TITLE
Revert "Outdent nav links a bit more so they line up in navbar"

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -3543,7 +3543,7 @@ button.close {
 }
 
 .navbar-nav {
-  margin: 10px -15px 0;
+  margin-top: 5px;
 }
 
 .navbar-nav > li > a {

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -20,8 +20,7 @@
 
 .navbar-nav {
   // Space out from .navbar .brand and .btn-navbar when stacked in mobile views
-  // and outdent nav links so text lines up with logo.
-  margin: 10px -15px 0;
+  margin-top: 5px;
 
   > li > a {
     padding-top: ((@navbar-height - @line-height-base) / 2);


### PR DESCRIPTION
This reverts commit f06294d80f7a8dd0752837aab3ed5fca17d3d9be.

Unless there are other pending requests, the patch reverted caused some alignment issues.

Original
![mobile_nav](https://f.cloud.github.com/assets/171054/478586/7c76d326-b7fe-11e2-8af7-7d63b12cb7ce.png)
Revert
![mobile_nav_revert](https://f.cloud.github.com/assets/171054/478588/8393d33e-b7fe-11e2-9b05-7cdcefc3ef1a.png)

Original
![nav_revert](https://f.cloud.github.com/assets/171054/478592/9253e080-b7fe-11e2-98e7-93de2d4195e0.png)
Revert
![nav](https://f.cloud.github.com/assets/171054/478589/8b24adc6-b7fe-11e2-8b75-adaf1999e7b7.png)
