### PR TITLE
typeahead support for items that are object

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('typeahead-item')
       this.$element
         .val(this.updater(val))
         .change()
@@ -138,7 +138,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('typeahead-item', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })


### PR DESCRIPTION
Currently objects can't be used as items because the item is stored on the element as an attribute rather than as data. This simple change fixes that.
