### PR TITLE
Remove backface-visibility from progress bars

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -4915,9 +4915,6 @@ a.list-group-item.active > .badge,
      -moz-transition: width 0.6s ease;
        -o-transition: width 0.6s ease;
           transition: width 0.6s ease;
-  -webkit-backface-visibility: hidden;
-     -moz-backface-visibility: hidden;
-          backface-visibility: hidden;
 }
 
 .progress-striped .progress-bar {

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -63,7 +63,6 @@
   background-color: @progress-bar-bg;
   .box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
   .transition(width .6s ease);
-  .backface-visibility(hidden);
 }
 
 // Striped bars


### PR DESCRIPTION
#7621 introduces a bug where the corners of the progress bars are no longer rounded because of the backface-visibilty rule.
