### PR TITLE
Make icons antialiased on Webkit browsers

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2177,6 +2177,7 @@ input[type="button"].btn-block {
 
 .glyphicon:before {
   font-family: 'Glyphicons Halflings';
+  -webkit-font-smoothing: antialiased;
   font-style: normal;
   font-weight: normal;
   line-height: 1;

--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -34,6 +34,7 @@
   font-style: normal;
   font-weight: normal;
   line-height: 1;
+  -webkit-font-smoothing: antialiased;
 }
 
 // Individual icons


### PR DESCRIPTION
Removes the excess weight from the new icon font in Chrome.
