### PR TITLE
Fix nav-main and example links in docs

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -9,19 +9,19 @@
     <div class="nav-collapse collapse bs-navbar-collapse">
       <ul class="nav navbar-nav">
         <li{% if page.slug == "getting-started" %} class="active"{% endif %}>
-          <a href="/getting-started">Getting started</a>
+          <a href="/getting-started.html">Getting started</a>
         </li>
         <li{% if page.slug == "css" %} class="active"{% endif %}>
-          <a href="/css">CSS</a>
+          <a href="/css.html">CSS</a>
         </li>
         <li{% if page.slug == "components" %} class="active"{% endif %}>
-          <a href="/components">Components</a>
+          <a href="/components.html">Components</a>
         </li>
         <li{% if page.slug == "js" %} class="active"{% endif %}>
-          <a href="/javascript">JavaScript</a>
+          <a href="/javascript.html">JavaScript</a>
         </li>
         <li{% if page.slug == "customize" %} class="active"{% endif %}>
-          <a href="/customize">Customize</a>
+          <a href="/customize.html">Customize</a>
         </li>
       </ul>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,14 +16,13 @@ title: Bootstrap
 
     <ul class="bs-masthead-links">
       <li>
-        <a href="./customize/" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Customize']);">Customize</a>
+        <a href="./customize.html" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Customize']);">Customize</a>
       </li>
       <li>
         <a href="http://github.com/twitter/bootstrap" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);">GitHub project</a>
       </li>
       <li>
-        <a href="./getting-started/#examples" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Examples']);">Examples</a>
-      </li>
+        <a href="./getting-started.html/#examples" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Examples']);">Examples</a>
       <li>
         <a href="http://expo.getbootstrap.com" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Expo']);">Bootstrap Expo</a>
       </li>


### PR DESCRIPTION
Links to Jekyll templates were missing .html extensions. Fixed.
