### PR TITLE
Gitignore bootstrap and docs/_site generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ nbproject
 .idea
 node_modules
 dist
+bootstrap
+docs/_site


### PR DESCRIPTION
Added following generated directories to gitignore:
- bootstrap
- docs/_site
