### PR TITLE
affix positioning and this.unpin update

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -51,8 +51,8 @@
     if (typeof offsetTop == 'function') offsetTop = offset.top()
     if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
 
-    affix = this.unpin != null && (scrollTop + this.unpin <= position.top) ?
-      false    : offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ?
+    affix = scrollTop !== 0 && this.unpin != null && (scrollTop + this.unpin <= position.top) ?
+      false    : offsetBottom != null && (scrollTop + this.$element.height() >= scrollHeight - offsetBottom) ?
       'bottom' : offsetTop != null && scrollTop <= offsetTop ?
       'top'    : false
 
@@ -60,7 +60,7 @@
 
     this.affixed = affix
     this.unpin = affix == 'bottom' ? position.top - scrollTop : null
-
+    if (this.unpin < 0) this.unpin = 0
     this.$element.removeClass(reset).addClass('affix' + (affix ? '-' + affix : ''))
   }
 


### PR DESCRIPTION
Fix for "affix bottom" and  "affix key up,down,pageup, pagedown" issues.

How to reproduce a problem on the twitter site:
- navigate to http://twitter.github.io/bootstrap/javascript.html 
- left menu must be higher then visible part of the container (so u can't see all links of the "nav nav-list bs-docs-sidenav" element)
- it's visible on lower resolutions or when you reduce height of a viewport/browser window
- you can even open the dev tools and dock it horizontally
- press a key: end or pgdn a few times and the sidebar should float over the footer

in chrome/ff u should see the problem while pressing the pgdn key, in IE while pressing home etc

There is an another problem with affix position. When you scrolldown to the bottom of the page and refresh a page(F5), sidebar will float over footer.

If you can reproduce the problem with the above description you can verify commit in the chrome dev tools: ctrl+shift+f type in affix and click on bootstrap-affix.js content. Ctrl+a  and delete the content. Then paste in https://raw.github.com/buberdds/bootstrap/3.0.0-wip-affix-fix/js/bootstrap-affix.js and hit ctrl+s.
