### PR TITLE
Store the typeahead data via $.data() instead of $.attr() to allow custom String objects to be stored.

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -44,7 +44,7 @@
     constructor: Typeahead
 
   , select: function () {
-      var val = this.$menu.find('.active').attr('data-value')
+      var val = this.$menu.find('.active').data('value')
       this.$element
         .val(this.updater(val))
         .change()
@@ -138,7 +138,7 @@
       var that = this
 
       items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
+        i = $(that.options.item).data('value', item)
         i.find('a').html(that.highlighter(item))
         return i[0]
       })


### PR DESCRIPTION
It looks like Bootstrap typeahead was removed in 3.0 in favor of Twitter's typeahead.

However, it'd be nice to have this functionality in the mean while.

Live example:
http://jsfiddle.net/JLnbc/3/
