### PR TITLE
Add a panel-footer class

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2981,6 +2981,17 @@ a.list-group-item.active .list-group-item-text {
   border-top-left-radius: 3px;
 }
 
+.panel-footer {
+  padding: 10px 15px;
+  margin: 20px -15px -15px;
+  font-size: 17.5px;
+  font-weight: 500;
+  background-color: #f5f5f5;
+  border-top: 1px solid #dddddd;
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
 .panel-primary {
   border-color: #428bca;
 }

--- a/docs/components.html
+++ b/docs/components.html
@@ -2413,12 +2413,13 @@ body {
 </div>
 {% endhighlight %}
 
-    <h3 id="panels-heading">Panel with heading</h3>
-    <p>Easily add a heading to your panel with <code>.panel-heading</code>. Use it on a <code>&lt;div&gt;</code> or any heading element (e.g., <code>&lt;h3&gt;</code>).</p>
+    <h3 id="panels-heading">Panel with headings &amp; Footers</h3>
+    <p>Easily add a heading or a footer to your panel with <code>.panel-heading</code> or <code>.panel-footer</code> respectively. Use them on a <code>&lt;div&gt;</code> or any heading element (e.g., <code>&lt;h3&gt;</code>). Panel footers are handy for holding buttons.</p>
     <div class="bs-example">
       <div class="panel">
         <div class="panel-heading">Panel heading</div>
         Panel content
+        <div class="panel-footer">Panel footer</div>
       </div>
     </div>
 {% highlight html %}
@@ -2429,7 +2430,7 @@ body {
 {% endhighlight %}
 
     <h3 id="panels-alternatives">Contextual alternatives</h3>
-    <p>Like other components, easily make a panel more meaningful to a particular context by adding any of the contextual state classes.</p>
+    <p>Like other components, easily make a panel more meaningful to a particular context by adding any of the contextual state classes. Panel footers will stay neutral.</p>
     <div class="bs-example">
       <div class="panel panel-primary">
         <div class="panel-heading">Panel heading</div>

--- a/less/panels.less
+++ b/less/panels.less
@@ -25,6 +25,18 @@
   border-top-right-radius: (@panel-border-radius - 1);
 }
 
+// Optional footer
+.panel-footer {
+  margin: 20px -15px -15px;
+  padding: 10px 15px;
+  font-size: (@font-size-base * 1.25);
+  font-weight: 500;
+  background-color: @panel-heading-bg;
+  border-top: 1px solid @panel-border;
+  border-bottom-left-radius:  (@panel-border-radius - 1);
+  border-bottom-right-radius: (@panel-border-radius - 1);
+}
+
 // Contextual variations
 .panel-primary {
   border-color: @panel-primary-border;


### PR DESCRIPTION
Hi,

I've been using this in one of my work projects and thought that it might be useful to push upstream - it's a panel-footer class that acts much the same like the header, but just fits at the bottom. :)

The use case for such a class is somewhere to put buttons that is separate from the content. Here's an example signin box, using a panel, with a button that is pulled to the right:

![signinexample](https://f.cloud.github.com/assets/3307100/496455/e0e11d66-bbe2-11e2-962e-5040a1519c19.png)

The footer does not change depending on the panel style, as shown in the example below. I think it's better to keep it neutral.

![screenshot from 2013-05-13 23 37 26](https://f.cloud.github.com/assets/3307100/496468/4a528712-bbe3-11e2-83e3-c640750339c4.png)

I've tested it in latest Chrome and FF, and have no reason to believe it won't work in other supported browsers, since it's just a modification of footer-header.

Regards,
HawkOwl
