### PR TITLE
Fix for Issue #7885

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -654,7 +654,7 @@ legend + .control-group {
     float: left;
     width: @horizontalComponentOffset - 20;
     padding-top: 5px;
-    text-align: right;
+    text-align: left;
   }
   // Move over all input controls and content
   .controls {


### PR DESCRIPTION
This fix aligns form labels left, instead of right.
