### PR TITLE
Out of bounds content with .input-append

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -502,6 +502,11 @@ select:focus:invalid {
   .btn-group {
     margin-left: -1px;
   }
+  .add-on:first-child,
+  .btn:first-child,
+  .btn-group:first-child {
+    margin-left: 0;
+  }
   .add-on:last-child,
   .btn:last-child,
   .btn-group:last-child > .dropdown-toggle {


### PR DESCRIPTION
When using `.input-append` inside elements with `overflow: auto` or `overflow: hidden` (e.g. `.tab-content>.tab-pane`) part of content inside `div` with this class become overlapped or hidden:

http://jsfiddle.net/gqEth/1/
