### PR TITLE
Dropdown `dropdown-no-toggle` functionality

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -157,8 +157,8 @@
 
   $(document)
     .on('click.dropdown.data-api', clearMenus)
-    .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-    .on('click.dropdown.data-api', '.dropdown-no-toggle', function (e) { e.stopPropagation() })
+    .on('click.dropdown.data-api', '.dropdown form, .dropdown-no-toggle', function (e) { e.stopPropagation() })
+    .on('click.dropdown.data-api', function (e) { e.stopPropagation() })
     .on('click.dropdown-menu', function (e) { e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -158,6 +158,7 @@
   $(document)
     .on('click.dropdown.data-api', clearMenus)
     .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
+    .on('click.dropdown.data-api', '.dropdown-no-toggle', function (e) { e.stopPropagation() })
     .on('click.dropdown-menu', function (e) { e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)


### PR DESCRIPTION
When a element have a `dropdown-no-toggle` class, it doesn't toggle the dropdowns. Seems like pre-existing `.dropdown form` selector, but could be on any element with this class.
