### PR TITLE
Responsive utilities display fix

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5115,48 +5115,27 @@ a.list-group-item.active > .badge,
   visibility: hidden;
 }
 
-.visible-sm {
-  display: inherit !important;
-}
-
-.visible-md {
-  display: none !important;
-}
-
-.visible-lg {
-  display: none !important;
-}
-
-.hidden-sm {
-  display: none !important;
-}
-
-.hidden-md {
-  display: inherit !important;
-}
-
-.hidden-lg {
-  display: inherit !important;
+@media (max-width: 991px) {
+  .visible-md {
+    display: none !important;
+  }
+  .visible-lg {
+    display: none !important;
+  }
+  .hidden-sm {
+    display: none !important;
+  }
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
   .visible-sm {
     display: none !important;
   }
-  .visible-md {
-    display: inherit !important;
-  }
   .visible-lg {
     display: none !important;
   }
-  .hidden-sm {
-    display: inherit !important;
-  }
   .hidden-md {
     display: none !important;
-  }
-  .hidden-lg {
-    display: inherit !important;
   }
 }
 
@@ -5166,15 +5145,6 @@ a.list-group-item.active > .badge,
   }
   .visible-md {
     display: none !important;
-  }
-  .visible-lg {
-    display: inherit !important;
-  }
-  .hidden-sm {
-    display: inherit !important;
-  }
-  .hidden-md {
-    display: inherit !important;
   }
   .hidden-lg {
     display: none !important;

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -5115,7 +5115,7 @@ a.list-group-item.active > .badge,
   visibility: hidden;
 }
 
-@media (max-width: 991px) {
+@media (max-width: 767px) {
   .visible-md {
     display: none !important;
   }

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -36,12 +36,11 @@
 // Visibility utilities
 
 // For Phones
-@media (max-width: @screen-tablet-max) {
+@media (max-width: @screen-phone-max) {
   .visible-md   { display: none !important; }
   .visible-lg   { display: none !important; }
   .hidden-sm    { display: none !important; }
 }
-
 
 // Tablets & small desktops only
 @media (min-width: @screen-tablet) and (max-width: @screen-tablet-max) {

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -36,34 +36,24 @@
 // Visibility utilities
 
 // For Phones
-.visible-sm   { display: inherit !important; }
-.visible-md   { display: none !important; }
-.visible-lg   { display: none !important; }
-
-.hidden-sm    { display: none !important; }
-.hidden-md    { display: inherit !important; }
-.hidden-lg    { display: inherit !important; }
+@media (max-width: @screen-tablet-max) {
+  .visible-md   { display: none !important; }
+  .visible-lg   { display: none !important; }
+  .hidden-sm    { display: none !important; }
+}
 
 
 // Tablets & small desktops only
 @media (min-width: @screen-tablet) and (max-width: @screen-tablet-max) {
   .visible-sm   { display: none !important; }
-  .visible-md   { display: inherit !important; }
   .visible-lg   { display: none !important; }
-
-  .hidden-sm    { display: inherit !important; }
   .hidden-md    { display: none !important; }
-  .hidden-lg    { display: inherit !important; }
 }
 
 // For desktops
 @media (min-width: @screen-desktop) {
   .visible-sm   { display: none !important; }
   .visible-md   { display: none !important; }
-  .visible-lg   { display: inherit !important; }
-
-  .hidden-sm    { display: inherit !important; }
-  .hidden-md    { display: inherit !important; }
   .hidden-lg    { display: none !important; }
 }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -397,8 +397,8 @@
 @screen-desktop:             @screen-medium;
 
 // So media queries don't overlap when required, provide a maximum
-@screen-tiny-max:           (@screen-small - 1);
-@screen-phone-max:          @screen-tiny-max;
+@screen-tiny-max:            (@screen-small - 1);
+@screen-phone-max:           @screen-tiny-max;
 @screen-small-max:           (@screen-medium - 1);
 @screen-tablet-max:          @screen-small-max;
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -397,6 +397,8 @@
 @screen-desktop:             @screen-medium;
 
 // So media queries don't overlap when required, provide a maximum
+@screen-tiny-max:           (@screen-small - 1);
+@screen-phone-max:          @screen-tiny-max;
 @screen-small-max:           (@screen-medium - 1);
 @screen-tablet-max:          @screen-small-max;
 


### PR DESCRIPTION
Should fix a display inherit problem i stumbled on and which is also discussed here: https://github.com/twitter/bootstrap/pull/7490
I think we are currently not able to set the visible-\* and hidden-\* classes mobile first. We need rocket science here! Until we figured out how this rocket science could be done, this fix should help.
