### PR TITLE
Remove redundant argument from $.each which throws error in IE8

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -86,7 +86,7 @@
 
       this._options && $.each(this._options, function (key, value) {
         if (defaults[key] != value) options[key] = value
-      }, this)
+      })
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
Simple fix. The same bug is actual for 3.0.0 so you may want to apply it to both versions.
