### PR TITLE
Add Jekyll generated 'serve' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore compiled docs
 _gh_pages
 _site
+serve
 
 # Numerous always-ignore extensions
 *.diff


### PR DESCRIPTION
Ignore the Jekyll generated `serve` directory from the repo when running `jekyll serve`

https://github.com/twitter/bootstrap/issues/7930
https://github.com/twitter/bootstrap/pull/6342
