### PR TITLE
Add option to Modal to force refresh the content.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -263,6 +263,17 @@ $('#myModal').on('show.bs.modal', function (e) {
 {% highlight html %}
 <a data-toggle="modal" href="remote.html" data-target="#modal">Click me</a>
 {% endhighlight %}
+         </td>
+       </tr>
+       <tr>
+         <td>refresh</td>
+         <td>boolean</td>
+         <td>false</td>
+         <td><p>Force the modal content to be refreshed. If a remote url is provided, jQuery's <code>load</code> method will be used to load the content again. If using the data api, you may force the content to be refreshed every time the modal is opened. An example of this is shown below:</p>
+{% highlight html %}
+<a data-toggle="modal" href="dynamic-remote.php" data-target="#modal" data-refresh="true">click me</a>
+{% endhighlight %}
+         </td>
        </tr>
       </tbody>
     </table>
@@ -289,6 +300,10 @@ $('#myModal').modal({
     <p>Manually hides a modal.</p>
     {% highlight js %}$('#myModal').modal('hide'){% endhighlight %}
 
+    <h4>.modal('refresh')</h4>
+    <p>Manually refreshes a modal.</p>
+    {% highlight js %}$('#myModal').modal('refresh'){% endhighlight %}
+
     <h3>Events</h3>
     <p>Bootstrap's modal class exposes a few events for hooking into modal functionality.</p>
     <table class="table table-bordered table-striped">
@@ -314,6 +329,14 @@ $('#myModal').modal({
        <tr>
          <td>hidden</td>
          <td>This event is fired when the modal has finished being hidden from the user (will wait for css transitions to complete).</td>
+       </tr>
+       <tr>
+         <td>refresh</td>
+         <td>This event fires immediately when the <code>refresh</code> instance method is called.</td>
+       </tr>
+       <tr>
+         <td>refreshed</td>
+         <td>This event is fired when the modal content has been refreshed.</td>
        </tr>
       </tbody>
     </table>

--- a/js/tests/server.js
+++ b/js/tests/server.js
@@ -7,7 +7,20 @@ var connect = require('connect')
   , http = require('http')
   , fs   = require('fs')
   , app = connect()
-      .use(connect.static(__dirname + '/../../'));
+      .use(connect.static(__dirname + '/../../'))
+      .use(function(req, res){
+          if (req.url=='/modal/example1.html') {
+            var body = '<h1>Modal Example 1</h1>\n';
+            res.statusCode = 200;
+            res.setHeader('Content-Length', body.length);
+            res.end(body);
+          } else {
+            var body = '404 Not Found\n';
+            res.statusCode = 404;
+            res.setHeader('Content-Length', body.length);
+            res.end(body);
+          }
+      });
 
 http.createServer(app).listen(3000);
 

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -64,6 +64,77 @@ $(function () {
           .modal("show")
       })
 
+      test("should call shown and insert into dom when refresh method is called", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'></div>")
+          .on("shown.bs.modal", function () {
+            ok($('#modal-test').length, 'modal insterted into dom')
+            $(this).remove()
+            start()
+          })
+          .modal("refresh")
+      })
+
+      test("should fire refresh event", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'></div>")
+          .on("refresh.bs.modal", function () {
+            ok(true, "refresh was called")
+          })
+          .on("shown.bs.modal", function () {
+            $(this).remove()
+            start()
+          })
+          .modal("refresh")
+      })
+
+      test("should update content when refresh is called", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'><div class='modal-body'>content</div></div>")
+          .on('shown.bs.modal', function(){
+            ok($(this).find('.modal-body').html()=='<h1>Modal Example 1</h1>\n', 'content was updated')
+            $(this).remove()
+            start()
+          })
+          .modal({
+            show: true,
+            refresh: true,
+            remote: 'http://localhost:3000/modal/example1.html'
+          })
+      })
+
+      test("should not update content when refresh is called without a remote", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'>content</div>")
+          .on("shown.bs.modal", function () {
+            ok($('#modal-test').html()=='content', 'content was not updated')
+          })
+          .on("shown.bs.modal", function () {
+            $(this).remove()
+            start()
+          })
+          .modal("refresh")
+      })
+
+      test("should not fire refreshed when default prevented", function () {
+        stop()
+        $.support.transition = false
+        $("<div id='modal-test'></div>")
+          .on("refresh.bs.modal", function (e) {
+            e.preventDefault()
+            ok(true, "refresh was called")
+            start()
+          })
+          .on("refreshed.bs.modal", function () {
+            ok(false, "refreshed was called")
+          })
+          .modal("refresh")
+      })
+
       test("should hide modal when hide is called", function () {
         stop()
         $.support.transition = false


### PR DESCRIPTION
Add option to Modal to force refresh the content. This option allows modals to be dynamic and multipurpose. For example, you can use the same modal div for the following two links that request different content:

```
<a href="/api/pages/user/profile" data-toggle="modal" data-target="#myModal" data-refresh="true">My Profile</a>
<a href="/api/pages/user/settings" data-toggle="modal" data-target="#myModal" data-refresh="true">Account Settings</a>
```

This feature can be tested at http://jsfiddle.net/sCsB9/.

(This pull request deprecates pull request https://github.com/twitter/bootstrap/pull/6793.)
