### PR TITLE
Fixed typo - <= 480px is portrait phone, not landscape

### DIFF
--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -476,7 +476,7 @@
 /* Landscape phone to portrait tablet */
 @media (max-width: 767px) { ... }
 
-/* Landscape phones and down */
+/* Portrait phones and down */
 @media (max-width: 480px) { ... }
 </pre>
 


### PR DESCRIPTION
In [this section](http://twitter.github.io/bootstrap/scaffolding.html#responsive) of the docs, when discussing resolutions, somebody mixed up portrait and landscape 
