### PR TITLE
Fix jquery each error in tooltip.

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -86,7 +86,7 @@
 
       this._options && $.each(this._options, function (key, value) {
         if (defaults[key] != value) options[key] = value
-      }, this)
+      })
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
The default and override options aren't being propagated correctly.  This causes problems if you use custom options (such as selector) when using tooltips.

broken tooltip: http://jsfiddle.net/5h3gd/
fixed tooltip: http://jsfiddle.net/v4WrE/
