### PR TITLE
Prevent input groups from inheriting border styles from table cells when placed within a table

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -322,6 +322,7 @@ select:focus:invalid {
 // -------------------------
 .input-group {
   display: table;
+  border-collapse: separate; // prevents not rounded border in table tag
 
   // Undo padding and float of grid classes
   &.col {


### PR DESCRIPTION
Prevent input groups from inheriting border styles from table cells when placed within a table.

Fixes rounded border when `.input-group > .input-group-addon` is placed in `<table>`
