### PR TITLE
Implemented `.font-face` and cache busting support.

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2001,8 +2001,10 @@ input[type="button"].btn-block {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphiconshalflings-regular.eot');
-  src: url('../fonts/glyphiconshalflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphiconshalflings-regular.woff') format('woff'), url('../fonts/glyphiconshalflings-regular.ttf') format('truetype'), url('../fonts/glyphiconshalflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  font-style: normal;
+  font-weight: normal;
+  src: url('../fonts/glyphiconshalflings-regular.eot?2990');
+  src: url('../fonts/glyphiconshalflings-regular.eot?8538#iefix') format('embedded-opentype'), url('../fonts/glyphiconshalflings-regular.svg?5493#glyphiconshalflings-regular') format('svg'), url('../fonts/glyphiconshalflings-regular.woff?3727') format('woff'), url('../fonts/glyphiconshalflings-regular.ttf?1302') format('truetype');
 }
 
 .glyphicon:before {

--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -19,14 +19,7 @@
 
 
 // Import the fonts
-@font-face {
-  font-family: 'Glyphicons Halflings';
-  src: url('@{glyphicons-font-path}/glyphiconshalflings-regular.eot');
-  src: url('@{glyphicons-font-path}/glyphiconshalflings-regular.eot?#iefix') format('embedded-opentype'),
-       url('@{glyphicons-font-path}/glyphiconshalflings-regular.woff') format('woff'),
-       url('@{glyphicons-font-path}/glyphiconshalflings-regular.ttf') format('truetype'),
-       url('@{glyphicons-font-path}/glyphiconshalflings-regular.svg#glyphicons_halflingsregular') format('svg');
-}
+.font-face(e('Glyphicons Halflings'), glyphiconshalflings-regular, e('@{glyphicons-font-path}/'));
 
 // Catchall baseclass
 .glyphicon:before {

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -540,3 +540,23 @@
     }
   }
 }
+
+// Generate font-face declarations
+.font-face(@family, @filename, @filepath, @weight: normal, @style: normal) {
+  @font-eot:    e(%("%d%d.eot%d", @filepath, @filename, @cacheBuster));
+  @font-eot-ie: e(%("%d%d.eot%d#iefix", @filepath, @filename, @cacheBuster));
+  @font-woff:   e(%("%d%d.woff%d", @filepath, @filename, @cacheBuster));
+  @font-ttf:    e(%("%d%d.ttf%d", @filepath, @filename, @cacheBuster));
+  @font-svg:    e(%("%d%d.svg%d#%d", @filepath, @filename, @cacheBuster, @filename));
+
+  @font-face {
+    font-family: '@{family}';
+    src: url('@{font-eot}');
+    src: url('@{font-eot-ie}') format('embedded-opentype'),
+         url('@{font-svg}') format('svg'),
+         url('@{font-woff}') format('woff'),
+         url('@{font-ttf}') format('truetype');
+    font-weight:  @weight;
+    font-style:   @style;
+  }
+}

--- a/less/variables.less
+++ b/less/variables.less
@@ -5,6 +5,7 @@
 
 // Global values
 // --------------------------------------------------
+@cacheBuster:            ~`"?" + Math.floor(Math.random() * 10000)`;
 
 
 // Grays


### PR DESCRIPTION
I added a font-face mixin which is usefull for implementing web fonts. I use this on multiple projects and i tested it on: Firefox, Chrome, Safari, IE8+

Example usage:

```
.font-face(Font, font-regular, e('path/to/font/'), normal, normal);
.font-face(Font, font-italic, e('path/to/font/'), normal, italic);
.font-face(Font, font-bold, e('path/to/font/'), bold, normal);
.font-face(Font, font-bolditalic, e('path/to/font/'), bold, italic);
```

Usage for the bold-italic variation of the font in CSS would look like:

```
font-family: 'Font';
font-style: italic;
font-weight: bold;
```
