### PR TITLE
Fixed mixin btn-pseudo-state background for [disabled] buttons

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -366,6 +366,7 @@
   &.disabled,
   &[disabled],
   fieldset[disabled] & {
+    &,
     &:hover,
     &:focus,
     &:active,


### PR DESCRIPTION
Fixed mixin for 

``` html
<input type="submit" class="btn btn-primary" disabled="disabled">
```

when `.btn[disabled]` selector have higher priority than `.btn-primary` selector.

---

For this it works ok:

``` html
<input type="submit" class="btn btn-primary disabled">
```
