### PR TITLE
using screen-size variables for grids

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -39,21 +39,21 @@
 // Responsive: Tablets and up
 @media screen and (min-width: @screen-tablet) {
   .container {
-    max-width: (@screen-tablet - 40);
+    max-width: @container-tablet;
   }
 }
 
 // Responsive: Desktops and up
 @media screen and (min-width: @screen-desktop) {
   .container {
-    max-width: (@screen-desktop - 52);
+    max-width: @container-desktop;
   }
 }
 
 // Responsive: Large desktops and up
 @media screen and (min-width: @screen-large-desktop) {
   .container {
-    max-width: (@screen-large-desktop  - @grid-gutter-width);
+    max-width: @container-large-desktop;
   }
 }
 

--- a/less/grid.less
+++ b/less/grid.less
@@ -39,21 +39,21 @@
 // Responsive: Tablets and up
 @media screen and (min-width: @screen-tablet) {
   .container {
-    max-width: 728px;
+    max-width: (@screen-tablet - 40);
   }
 }
 
 // Responsive: Desktops and up
 @media screen and (min-width: @screen-desktop) {
   .container {
-    max-width: 940px;
+    max-width: (@screen-desktop - 52);
   }
 }
 
 // Responsive: Large desktops and up
 @media screen and (min-width: @screen-large-desktop) {
   .container {
-    max-width: 1170px;
+    max-width: (@screen-large-desktop  - @grid-gutter-width);
   }
 }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -405,6 +405,19 @@
 @screen-large-desktop:       @screen-large;
 
 
+// Container sizes
+// --------------------------------------------------
+
+// Small screen / tablet
+@container-tablet:          728px;
+
+// Medium screen / desktop
+@container-desktop:         940px;
+
+// Large screen / wide desktop
+@container-large-desktop:   1170px;
+
+
 // Grid system
 // --------------------------------------------------
 


### PR DESCRIPTION
Using screen-sizes in grids.less makes sense since this way we'll be able to alter the layout from the variables file.
What doesn't make complete sense right now is the relation of breakpoints to the individual grid sizes.
So for example on the desktop screens 940px = 992px - 52, but 52 seems like a number that can't be calculated easily from variables in a meaningful way.
On the other hand for large screens 1170px = 1200px - 30, where 30 is the grid gutter width so that makes perfect sense.
This is not perfect, but it is a first step.
