### PR TITLE
Update scaffolding.mustache, Responsive utility classes

### DIFF
--- a/docs/templates/pages/scaffolding.mustache
+++ b/docs/templates/pages/scaffolding.mustache
@@ -411,7 +411,7 @@
               <tr>
                 <th>{{_i}}Class{{/i}}</th>
                 <th>{{_i}}Phones <small>767px and below</small>{{/i}}</th>
-                <th>{{_i}}Tablets <small>979px to 768px</small>{{/i}}</th>
+                <th>{{_i}}Tablets <small>768px to 979px</small>{{/i}}</th>
                 <th>{{_i}}Desktops <small>Default</small>{{/i}}</th>
               </tr>
             </thead>


### PR DESCRIPTION
Below title "Responsive utility classes" changed description in table head, "higher to lower px size" reversed to "lower to higher px size"
