### PR TITLE
fix for https://github.com/twitter/bootstrap/issues/531 under 3.0.0-wip

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -201,7 +201,7 @@
       var options = $.extend({}, Modal.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
       if (!data) $this.data('bs.modal', (data = new Modal(this, options)))
-	  else $.extend($this.data('bs.modal').options, option)
+      else $.extend($this.data('bs.modal').options, option)
       if (typeof option == 'string') data[option]()
       else if (options.show) data.show()
     })

--- a/js/modal.js
+++ b/js/modal.js
@@ -201,6 +201,7 @@
       var options = $.extend({}, Modal.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
       if (!data) $this.data('bs.modal', (data = new Modal(this, options)))
+	  else $.extend($this.data('bs.modal').options, option)
       if (typeof option == 'string') data[option]()
       else if (options.show) data.show()
     })


### PR DESCRIPTION
This allows users to have multiple hrefs and pass the current href data-\* fields to the modal dialog for 3.0.0-wip
