### PR TITLE
Fix make output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,31 +11,31 @@ PATH := ./node_modules/.bin:$(PATH)
 #
 
 build:
-	@echo "\n\n"
-	@echo "\033[36mBuilding Bootstrap...\033[39m"
-	@echo "${HR}"
+	@echo -e "\n\n"
+	@echo -e "\033[36mBuilding Bootstrap...\033[39m"
+	@echo -e "${HR}"
 	@printf "Running JSHint on JavaScript..."
 	@jshint js/*.js --config js/.jshintrc
 	@jshint js/tests/unit/*.js --config js/.jshintrc
-	@echo "             ${CHECK}"
+	@echo -e "             ${CHECK}"
 	@printf "Compiling LESS with Recess..."
 	@recess --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
-	@echo "               ${CHECK}"
+	@echo -e "               ${CHECK}"
 	@printf "Prepping documentation assets..."
 	@cp fonts/* docs/assets/fonts/
 	@cp js/tests/vendor/jquery.js docs/assets/js/
-	@echo "            ${CHECK}"
+	@echo -e "            ${CHECK}"
 	@printf "Compiling and minifying JavaScript..."
 	@cat js/transition.js js/alert.js js/button.js js/carousel.js js/collapse.js js/dropdown.js js/modal.js js/tooltip.js js/popover.js js/scrollspy.js js/tab.js js/affix.js > docs/assets/js/bootstrap.js
 	@uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
-	@echo "/**\n* Bootstrap.js v3.0.0 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
+	@echo -e "/**\n* Bootstrap.js v3.0.0 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
-	@echo "       ${CHECK}"
-	@echo "${HR}"
-	@echo "\033[36mSuccess!\n\033[39m"
-	@echo "\033[37mThanks for using Bootstrap,"
-	@echo "<3 @mdo and @fat\n\033[39m"
+	@echo -e "       ${CHECK}"
+	@echo -e "${HR}"
+	@echo -e "\033[36mSuccess!\n\033[39m"
+	@echo -e "\033[37mThanks for using Bootstrap,"
+	@echo -e "<3 @mdo and @fat\n\033[39m"
 
 #
 # RUN JSHINT & QUNIT TESTS IN PHANTOMJS
@@ -73,7 +73,7 @@ bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
 	cat js/transition.js js/alert.js js/button.js js/carousel.js js/collapse.js js/dropdown.js js/modal.js js/tooltip.js js/popover.js js/scrollspy.js js/tab.js js/affix.js > bootstrap/js/bootstrap.js
 	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
-	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
+	echo -e "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
 
@@ -104,7 +104,7 @@ bootstrap/fonts/*: fonts/*
 #
 
 watch:
-	echo "Watching less files..."; \
+	echo -e "Watching less files..."; \
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
 #


### PR DESCRIPTION
On some terminals make output shows escape codes instead of colorizing output.

For Example on konsole,

```
[bhush@archbox bootstrap]$ make
\n\n
\033[36mBuilding Bootstrap...\033[39m
033[37m--------------------------------------------------033[39m
Running JSHint on JavaScript...             \033[32m✔ Done\033[39m
Compiling LESS with Recess...               \033[32m✔ Done\033[39m
Prepping documentation assets...            \033[32m✔ Done\033[39m
Compiling and minifying JavaScript...       \033[32m✔ Done\033[39m
\033[37m--------------------------------------------------\033[39m
\033[36mSuccess!\n\033[39m
\033[37mThanks for using Bootstrap,
<3 @mdo and @fat\n\033[39m
```
