### PR TITLE
Edit composer for dev can custom install path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
-    "name": "twitter/bootstrap"
-  , "description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development."
-  , "keywords": ["bootstrap", "css"]
-  , "homepage": "http://twitter.github.com/bootstrap/"
-  , "author": "Twitter Inc."
-  , "license": "Apache-2.0"
-
+    "name": "twitter/bootstrap",
+	"description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development.",
+	"type": "css",
+	"keywords": ["bootstrap", "css"],
+	"homepage": "http://twitter.github.com/bootstrap/",
+	"author": "Twitter Inc.",
+	"license": "Apache-2.0",
+	"require": {
+		"composer/installers": "~1.0"
+	}
 }


### PR DESCRIPTION
Due this faq. https://github.com/composer/composer/blob/master/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md

Add composer/installers in require scope so dev who require bootstrap can config path to this package to store.
