### PR TITLE
Do not alter the tooltip content on 'show' if it has already been rendered

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -222,8 +222,9 @@
   Tooltip.prototype.setContent = function () {
     var $tip  = this.tip()
     var title = this.getTitle()
+    var $el   = $tip.find('.tooltip-inner')
 
-    $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
+    if (!$el.html()) $el[this.options.html ? 'html' : 'text'](title)
     $tip.removeClass('fade in top bottom left right')
   }
 


### PR DESCRIPTION
- Create a tooltip
- Modify the tooltip content
- Hide it with `$el.tooltip('hide')`
- Show it again (`$el.tooltip('show')`)

The content of the tooltip is overwritten by the original content. I would be expecting this behavior if i had called `$el.tooltip('destroy')`, but not when calling 'hide'.

This pull request set the `.tooltip-inner` content only if it hasn't already been set which allow editing the tooltip content and not loosing the changes.

I need this because my tooltip is a bunch of `<i class="icon">` and i would like to toogle the `active` classes of theses icon and have those classes persist a `tooltip('hide')`/`tooltip('show')`.

Thanks!
Arthur
