### PR TITLE
Changed the color of the .help-block the .form-field-validation() mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -486,4 +486,7 @@
       .box-shadow(@shadow);
     }
   }
+  .help-block {
+    color: @text-color;
+  }
 }


### PR DESCRIPTION
When a form `has-error` (or something) I think it's a good idea to also change the color of the `.help-block` to the relevant color to emphasize what has to be done there.
