### PR TITLE
text-rendering: optimizelegibility causes problems in some languages

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -62,7 +62,7 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: @headingsFontWeight;
   line-height: @baseLineHeight;
   color: @headingsColor;
-  text-rendering: optimizelegibility; // Fix the character spacing for headings
+  //text-rendering: optimizelegibility; // Fix the character spacing for headings; unnecessary
   small {
     font-weight: normal;
     line-height: 1;


### PR DESCRIPTION
"text-rendering: optimizelegibility" style in type.less causes distortions in some languages with the current font.
Languages with 2-byte characters(Chinese, Korean, Japanese) seem to suffer from this.
I commented out optimizelegibility style that's applied in heading fonts to solve the problem.
After all, optimizelegibility does not seem necessary.
