### PR TITLE
There were some stray characters in the css reset that I removed

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -79,7 +79,7 @@ sub {
 img {
   /* Responsive images (ensure images don't scale beyond their parents) */
   max-width: 100%; /* Part 1: Set a maxium relative to the parent */
-  width: auto\9; /* IE7-8 need help adjusting responsive images */
+  width: auto; /* IE7-8 need help adjusting responsive images */
   height: auto; /* Part 2: Scale the height according to the width, otherwise you get stretching */
 
   vertical-align: middle;


### PR DESCRIPTION
Specifically a "\9"

img {
...
width: auto\9; /\* IE7-8 need help adjusting responsive images */
...
}

which was affecting some images on my site.
