### PR TITLE
fix dropdown when into a collapsed navbar

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2722,7 +2722,7 @@ input[type="button"].btn-block {
 }
 
 .dropdown-menu {
-  position: absolute;
+  position: relative;
   top: 100%;
   left: 0;
   z-index: 1000;
@@ -2906,6 +2906,12 @@ input[type="button"].btn-block {
 
 .typeahead {
   z-index: 1051;
+}
+
+@media screen and (min-width: 768px) {
+  .dropdown-menu {
+    position: absolute;
+  }
 }
 
 .list-group {

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -20,7 +20,7 @@
 // The dropdown menu (ul)
 // ----------------------
 .dropdown-menu {
-  position: absolute;
+  position: relative;
   top: 100%;
   left: 0;
   z-index: @zindex-dropdown;
@@ -223,4 +223,15 @@
 // ---------------------------
 .typeahead {
   z-index: 1051;
+}
+
+// Change behaviour when navbar changes
+// ------------------------------------
+@media screen and (min-width: @grid-float-breakpoint) {
+
+  // The dropdown menu (ul)
+  // ----------------------
+  .dropdown-menu {
+    position: absolute;
+  }
 }


### PR DESCRIPTION
About https://github.com/twitter/bootstrap/pull/6342#issuecomment-19113335 

Dropdowns went under the bottom edge of a collapsed navbar, now they push down to make room for themselves.
