### PR TITLE
Dropdown data-api vs js inconsistency fix

### DIFF
--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -27,7 +27,9 @@
   * ========================= */
 
   var toggle = '.dropdown-toggle'
-    , Dropdown = function (element) {}
+    , Dropdown = function (element) {
+        var $el = $(element).on('click.dropdown.data-api', this.toggle)
+      }
 
   Dropdown.prototype = {
 

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -26,13 +26,8 @@
  /* DROPDOWN CLASS DEFINITION
   * ========================= */
 
-  var toggle = '[data-toggle=dropdown]'
-    , Dropdown = function (element) {
-        var $el = $(element).on('click.dropdown.data-api', this.toggle)
-        $('html').on('click.dropdown.data-api', function () {
-          $el.parent().removeClass('open')
-        })
-      }
+  var toggle = '.dropdown-toggle'
+    , Dropdown = function (element) {}
 
   Dropdown.prototype = {
 


### PR DESCRIPTION
Changed selector for clearMenus() - "[data-toggle=dropdown]" was taking only data-api dropdowns into account, changed to ".dropdown-toggle" because its needed in all dropdowns for proper styling

Removed reduntant event hook in constructor (leaved empty constructor) - clearMenus runs on html so it clears all

Bug [#8104](https://github.com/twitter/bootstrap/issues/8104)
