### PR TITLE
Fix document title for Getting Started docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Getting · Bootstrap</title>
+    <title>Getting Started · Bootstrap</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">


### PR DESCRIPTION
Title was "Getting · Bootstrap"
