### PR TITLE
Calculate position for Affix bottom

### DIFF
--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -44,12 +44,14 @@
       , offset = this.options.offset
       , offsetBottom = offset.bottom
       , offsetTop = offset.top
+      , cssPositionBottom = this.options.positionbottom || false
       , reset = 'affix affix-top affix-bottom'
       , affix
 
     if (typeof offset != 'object') offsetBottom = offsetTop = offset
     if (typeof offsetTop == 'function') offsetTop = offset.top()
     if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
+    if (typeof cssPositionBottom == 'function') cssPositionBottom = this.options.positionbottom()
 
     affix = this.unpin != null && (scrollTop + this.unpin <= position.top) ?
       false    : offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ?
@@ -62,6 +64,8 @@
     this.unpin = affix == 'bottom' ? position.top - scrollTop : null
 
     this.$element.removeClass(reset).addClass('affix' + (affix ? '-' + affix : ''))
+    this.$element.css('bottom',(affix == 'bottom' && cssPositionBottom)?cssPositionBottom:'');
+    
   }
 
 


### PR DESCRIPTION
added positionbottom as Option-Value for affix()

so it is possible to calculate the css-bottom-value.
Example:
    var $document = $(document);
    var $Affixparent = $("#ProductDetails");

```
// side bar
$('#affixtocart').affix({
  offset: {
    top: function() { return  $Affixparent.offset().top; },
    bottom: function() { return $Affixparent.offset().top + $Affixparent.height()/2; }
  },
    positionbottom : function() {
        return parseInt($document.height() - ($Affixparent.offset().top + $Affixparent.height())); 
    } 
  }
```

CSS:
body {position: relative}
.affix { position: fixed; top: 40px} 
.affix-bottom { position: absolute} 

other css-positions not needed
