### PR TITLE
Adding 'cursor:pointer' in navbar link

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -246,6 +246,7 @@
   color: @navbarLinkColor;
   text-decoration: none;
   text-shadow: 0 1px 0 @navbarBackgroundHighlight;
+  cursor:pointer;
 }
 .navbar .nav .dropdown-toggle .caret {
   margin-top: 8px;


### PR DESCRIPTION
I remove 'href' attribute in 'a' tag because href="#" manipulates location.hash, and router acts wrong. but 'a' tag is changed into normal cursor.
