### PR TITLE
Docs Customize toggle button used incorrect selectors

### DIFF
--- a/docs/assets/js/application.js
+++ b/docs/assets/js/application.js
@@ -71,10 +71,10 @@
     // javascript build logic
     var inputsComponent = $("#less input")
       , inputsPlugin = $("#plugins input")
-      , inputsVariables = $("#variables input")
+      , inputsVariables = $("#less-variables input")
 
     // toggle all plugin checkboxes
-    $('#components .toggle').on('click', function (e) {
+    $('#less .toggle').on('click', function (e) {
       e.preventDefault()
       inputsComponent.prop('checked', !inputsComponent.is(':checked'))
     })
@@ -84,7 +84,7 @@
       inputsPlugin.prop('checked', !inputsPlugin.is(':checked'))
     })
 
-    $('#variables .toggle').on('click', function (e) {
+    $('#less-variables .toggle').on('click', function (e) {
       e.preventDefault()
       inputsVariables.val('')
     })


### PR DESCRIPTION
The "Toggle All" buttons that allow customization of the bootstrap download were using the wrong selectors to attach events and were not working.
