### PR TITLE
Docs "Customize and Download" button didn't send the correct parameters

### DIFF
--- a/docs/assets/js/application.js
+++ b/docs/assets/js/application.js
@@ -90,9 +90,10 @@
     })
 
     // request built javascript
-    $('.download-btn .btn').on('click', function () {
+    $('.bs-customize-download .btn').on('click', function (e) {
+      e.preventDefault()
 
-      var css = $("#components input:checked")
+      var css = $("#less input:checked")
             .map(function () { return this.value })
             .toArray()
         , js = $("#plugins input:checked")
@@ -101,14 +102,14 @@
         , vars = {}
         , img = ['glyphicons-halflings.png', 'glyphicons-halflings-white.png']
 
-    $("#variables input")
-      .each(function () {
-        $(this).val() && (vars[ $(this).prev().text() ] = $(this).val())
+      $("#less-variables input")
+        .each(function () {
+          $(this).val() && (vars[ $(this).prev().text() ] = $(this).val())
       })
 
       $.ajax({
         type: 'POST'
-      , url: /\?dev/.test(window.location) ? 'http://localhost:3000' : 'http://bootstrap.herokuapp.com'
+      , url: /localhost/.test(window.location) ? 'http://localhost:9001' : 'http://bootstrap.herokuapp.com'
       , dataType: 'jsonpi'
       , params: {
           js: js


### PR DESCRIPTION
The "Download and Customize" button was not working as expected the following problems were fixed:
- The click handler wasn't preventing default which caused the page to jump to the top
- The ajax post was ALWAYS go to the heroku app because the check for dev/prod was incorrect
- The post send empty arrays as parameters because it was not selecting the correct divs to gather the input values.
