### PR TITLE
fix bug of issue 8134(Carousel sliding with data-interval="false")

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -160,7 +160,7 @@
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.carousel')
-      var options = $.extend({}, Carousel.DEFAULTS, typeof option == 'object' && option)
+      var options = $.extend({}, Carousel.DEFAULTS, $this.data(), typeof option == 'object' && option)
       var action  = typeof option == 'string' ? option : options.slide
 
       if (!data) $this.data('bs.carousel', (data = new Carousel(this, options)))


### PR DESCRIPTION
This bug is because when we call carousel like `$("#content").carousel()`, the `$.fn.carousel` function is called.

But this function does not check the option in HTML attributes, it only extend the option in arguments and the default option. Which means, if we set the `data-interval="false"`, and call `$("#content").carousel()`, the `interval` will be set to default value 5000, but not false.

I extend `$this.data()` to option object. The bug is fixed.
