### PR TITLE
Rename responsive breakpoint variables

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -171,7 +171,7 @@
 
 
 // Scale up controls for tablets and up
-@media screen and (min-width: @screen-tablet) {
+@media screen and (min-width: @screen-md-min) {
 
   // Scale up the controls a smidge
   .carousel-control .glyphicon {

--- a/less/grid.less
+++ b/less/grid.less
@@ -82,9 +82,9 @@
 .col-12 { width: 100%; }
 
 // Small device columns (phones to tablets)
-@media (min-width: @screen-tablet) {
+@media (min-width: @screen-md-min) {
   .container {
-    max-width: @container-tablet;
+    max-width: @container-md;
   }
 
   .col-sm-1  { width: percentage((1 / @grid-columns)); }
@@ -140,9 +140,9 @@
 }
 
 // Medium and large device columns (desktop and up)
-@media (min-width: @screen-desktop) {
+@media (min-width: @screen-lg-min) {
   .container {
-    max-width: @container-desktop;
+    max-width: @container-lg;
   }
   .col-lg-1  { width: percentage((1 / @grid-columns)); }
   .col-lg-2  { width: percentage((2 / @grid-columns)); }
@@ -159,8 +159,8 @@
 }
 
 // Large desktops and up
-@media (min-width: @screen-large-desktop) {
+@media (min-width: @screen-xl-min) {
   .container {
-    max-width: @container-large-desktop;
+    max-width: @container-xl;
   }
 }

--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -20,7 +20,7 @@
   }
 }
 
-@media screen and (min-width: @screen-tablet) {
+@media screen and (min-width: @screen-md-min) {
   .jumbotron {
     padding: 50px 60px;
     border-radius: @border-radius-large; // Only round corners at higher resolutions

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -419,7 +419,7 @@
   // Then clear the floated columns
   .clearfix();
 
-  @media (min-width: @screen-small) {
+  @media (min-width: @screen-sm-max) {
     margin-left:  (@grid-gutter-width / -2);
     margin-right: (@grid-gutter-width / -2);
   }

--- a/less/modals.less
+++ b/less/modals.less
@@ -120,7 +120,7 @@
 }
 
 // Scale up the modal
-@media screen and (min-width: @screen-tablet) {
+@media screen and (min-width: @screen-md-min) {
 
   .modal-dialog {
     left: 50%;

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -42,12 +42,10 @@
 .visible-sm   { display: block !important; }
 .visible-md   { display: none !important; }
 .visible-lg   { display: none !important; }
-.visible-xl   { display: none !important; }
 
 .hidden-sm    { display: none !important; }
 .hidden-md    { display: block !important; }
 .hidden-lg    { display: block !important; }
-.hidden-xl    { display: block !important; }
 
 
 // Medium screen size
@@ -55,40 +53,22 @@
   .visible-sm   { display: none !important; }
   .visible-md   { display: block !important; }
   .visible-lg   { display: none !important; }
-  .visible-xl   { display: none !important; }
 
   .hidden-sm    { display: block !important; }
   .hidden-md    { display: none !important; }
   .hidden-lg    { display: block !important; }
-  .hidden-xl    { display: block !important; }
 }
 
 
-// Large screen size
-@media (min-width: @screen-lg-min) and (max-width: @screen-lg-max) {
+// Large (and XL) screen size
+@media (min-width: @screen-lg-min) {
   .visible-sm   { display: none !important; }
   .visible-md   { display: none !important; }
   .visible-lg   { display: block !important; }
-  .visible-xl   { display: none !important; }
   
   .hidden-sm    { display: block !important; }
   .hidden-md    { display: block !important; }
   .hidden-lg    { display: none !important; }
-  .hidden-xl    { display: block !important; }
-}
-
-
-// Extra large screen size
-@media (min-width: @screen-xl-min) {
-  .visible-sm   { display: none !important; }
-  .visible-md   { display: none !important; }
-  .visible-lg   { display: none !important; }
-  .visible-xl   { display: block !important; }
-  
-  .hidden-sm    { display: block !important; }
-  .hidden-md    { display: block !important; }
-  .hidden-lg    { display: block !important; }
-  .hidden-xl    { display: none !important; }
 }
 
 

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -33,39 +33,64 @@
   visibility: hidden;
 }
 
-// Visibility utilities
+// Visibility utility classes
+// Applying these classes hides or shows elements in specific size ranges.
 
-// For Phones
+
+// Small screen size
+// This is the default state
 .visible-sm   { display: block !important; }
 .visible-md   { display: none !important; }
 .visible-lg   { display: none !important; }
+.visible-xl   { display: none !important; }
 
 .hidden-sm    { display: none !important; }
 .hidden-md    { display: block !important; }
 .hidden-lg    { display: block !important; }
+.hidden-xl    { display: block !important; }
 
 
-// Tablets & small desktops only
-@media (min-width: @screen-tablet) and (max-width: @screen-tablet-max) {
+// Medium screen size
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
   .visible-sm   { display: none !important; }
   .visible-md   { display: block !important; }
   .visible-lg   { display: none !important; }
+  .visible-xl   { display: none !important; }
 
   .hidden-sm    { display: block !important; }
   .hidden-md    { display: none !important; }
   .hidden-lg    { display: block !important; }
+  .hidden-xl    { display: block !important; }
 }
 
-// For desktops
-@media (min-width: @screen-desktop) {
+
+// Large screen size
+@media (min-width: @screen-lg-min) and (max-width: @screen-lg-max) {
   .visible-sm   { display: none !important; }
   .visible-md   { display: none !important; }
   .visible-lg   { display: block !important; }
-
+  .visible-xl   { display: none !important; }
+  
   .hidden-sm    { display: block !important; }
   .hidden-md    { display: block !important; }
   .hidden-lg    { display: none !important; }
+  .hidden-xl    { display: block !important; }
 }
+
+
+// Extra large screen size
+@media (min-width: @screen-xl-min) {
+  .visible-sm   { display: none !important; }
+  .visible-md   { display: none !important; }
+  .visible-lg   { display: none !important; }
+  .visible-xl   { display: block !important; }
+  
+  .hidden-sm    { display: block !important; }
+  .hidden-md    { display: block !important; }
+  .hidden-lg    { display: block !important; }
+  .hidden-xl    { display: none !important; }
+}
+
 
 // Print utilities
 .visible-print  { display: none !important; }

--- a/less/variables.less
+++ b/less/variables.less
@@ -411,4 +411,4 @@
 @grid-gutter-width:         30px;
 
 // Point at which the navbar stops collapsing
-@grid-float-breakpoint:     @screen-sm-max;
+@grid-float-breakpoint:     @screen-md-min;

--- a/less/variables.less
+++ b/less/variables.less
@@ -382,38 +382,26 @@
 // Media queries breakpoints
 // --------------------------------------------------
 
-// Tiny screen / phone
-@screen-tiny:                480px;
-@screen-phone:               @screen-tiny;
+// Define screen size breakpoints by max for each category
+@screen-sm-max:             768px;            // Small screen upper bound
+@screen-md-max:             992px;            // Medium screen upper bound
+@screen-lg-max:            1200px;            // Large screen upper bound
 
-// Small screen / tablet
-@screen-small:               768px;
-@screen-tablet:              @screen-small;
-
-// Medium screen / desktop
-@screen-medium:              992px;
-@screen-desktop:             @screen-medium;
-
-// So media queries don't overlap when required, provide a maximum
-@screen-small-max:           (@screen-medium - 1);
-@screen-tablet-max:          @screen-small-max;
-
-// Large screen / wide desktop
-@screen-large:               1200px;
-@screen-large-desktop:       @screen-large;
-
+// Define minimum screen sizes
+@screen-md-min:         @screen-sm-max + 1;   // Medium screen lower bound
+@screen-lg-min:         @screen-md-max + 1;   // Large screen lower bound
+@screen-xl-min:         @screen-lg-max + 1;   // Extra-large screen lower bound
 
 // Container sizes
 // --------------------------------------------------
 
-// Small screen / tablet
-@container-tablet:          728px;
+@container-screen-diff:     40px;   // Sets the difference between the container size and the screen size
 
-// Medium screen / desktop
-@container-desktop:         940px;
+@container-sm:          @screen-sm-max - @container-screen-diff;  // Small screen
+@container-md:          @screen-md-min - @container-screen-diff;  // Medium screen
+@container-lg:          @screen-lg-min - @container-screen-diff;  // Large screen
+@container-xl:          @screen-xl-min - @container-screen-diff;  // XL Screen container
 
-// Large screen / wide desktop
-@container-large-desktop:   1170px;
 
 
 // Grid system
@@ -423,5 +411,6 @@
 @grid-columns:              12;
 // Padding, to be divided by two and applied to the left and right of all columns
 @grid-gutter-width:         30px;
+
 // Point at which the navbar stops collapsing
-@grid-float-breakpoint:     @screen-tablet;
+@grid-float-breakpoint:     @screen-sm-max;

--- a/less/variables.less
+++ b/less/variables.less
@@ -395,12 +395,10 @@
 // Container sizes
 // --------------------------------------------------
 
-@container-screen-diff:     40px;   // Sets the difference between the container size and the screen size
-
-@container-sm:          @screen-sm-max - @container-screen-diff;  // Small screen
-@container-md:          @screen-md-min - @container-screen-diff;  // Medium screen
-@container-lg:          @screen-lg-min - @container-screen-diff;  // Large screen
-@container-xl:          @screen-xl-min - @container-screen-diff;  // XL Screen container
+@container-sm:          440px;  // Small screen
+@container-md:          748px;  // Medium screen
+@container-lg:          940px;  // Large screen
+@container-xl:          1170px;  // XL Screen container
 
 
 


### PR DESCRIPTION
Rename the variables that set the responsive media-query breakpoints to use the v3 naming scheme (e.g. screen-sm, screen-md, etc) and remove redundant v2 names (e.g. screen-tablet).

Updates the breakpoint names in variables.less to make clear how the bounds for each screen size are being set.

(Makes no functional change to output.)
