### PR TITLE
change version of recess to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "devDependencies": {
       "uglify-js": "1.3.4"
     , "jshint": "2.1.2"
-    , "recess": "1.1.6"
+    , "recess": "1.1.7"
     , "connect": "2.1.3"
   }
 }


### PR DESCRIPTION
I tried to compile the .less file, but the file generated by recess 1.1.6 is empty. I don't know why, but the latest version of recess(v 1.1.7) works fine.

Both of my computers have the same problem.
