### PR TITLE
Use recess 1.1.8. Fixes: #8088

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "devDependencies": {
       "uglify-js": "1.3.4"
     , "jshint": "0.9.1"
-    , "recess": "1.1.6"
+    , "recess": "1.1.8"
     , "connect": "2.1.3"
     , "hogan.js": "2.0.0"
   }


### PR DESCRIPTION
Recess 1.1.8 switched back to less 1.3.x to prevent using 1.4.0 beta which was causing some issues. At the moment `make bootstrap` produces empty css files. This commit fixes that.
