### PR TITLE
Prevent jekyll version mixup in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Bootstrap's documentation, included in this repo in the `/docs` directory, is bu
 
 1. If necessary, [install Jekyll](http://jekyllrb.com/docs/installation).
 2. From the `/bootstrap` directory, run `jekyll serve` in the command line.
-3. Open [http://getbootstrap.dev:9001](http://getbootstrap.dev:9001) in your browser, and voilà.
+3. Open [localhost:9001](localhost:9001) in your browser, and voilà.
+
+**Note:** These instructions are for Jekyll 1.0+. Older versions use the `jekyll --server` command and run on port 4000.
 
 Learn more about using Jekyll by reading their [documentation](http://jekyllrb.com/docs/home/).
 


### PR DESCRIPTION
The new docs do not publish to getbootstrap.dev:9001, they publish to localhost:9001. The "Customize and Download" button was fixed to handle this in [8158](https://github.com/twitter/bootstrap/pull/8158) but the docs were not updated.

There have been a number of comments (e.g. [8174](https://github.com/twitter/bootstrap/issues/8174)) where people are trying to use the new Jekyll 1.x syntax with the old version of the library. This updates the docs to explain that the instructions are for 1.x as well as changing the link to point to localhost
