### PR TITLE
e.preventDefault() on tooltip/popover toggle

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -319,6 +319,7 @@
   Tooltip.prototype.toggle = function (e) {
     var self = e ? $(e.currentTarget)[this.type](this._options).data('bs.' + this.type) : this
     self.tip().hasClass('in') ? self.leave(self) : self.enter(self)
+    e.preventDefault();
   }
 
   Tooltip.prototype.destroy = function () {


### PR DESCRIPTION
When the tooltip is created on an anchor element with an href the default event is not prevented. This is annoying as i have quite a lot of popovers as progressive enhancement but if no javascript is present, the user is sent to the correct page. Now I am doing another 'click' listener which prevents the default behaviour and then fires the popover (much like the twitter bootrap demo page does) but I guess it would be nice to have that behaviour directly in the bootstrap js.
#6500 was submitted some time ago but was rejected for not working with the -wip branches
