### PR TITLE
Added Vagrant configuration file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,61 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Boostrap Script
+$script = <<SCRIPT
+apt-get update
+apt-get install -y python-software-properties python g++ make
+add-apt-repository ppa:chris-lea/node.js
+apt-get install -y nodejs rubygems
+gem install jekyll
+cd /vagrant/
+npm install
+make
+jekyll serve
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 9001, host: 9001 
+  
+  # The shell provisioner allows you to upload and execute a script as the root
+  # user within the guest machine.
+  config.vm.provision :shell, :inline => $script
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "256"]
+  end
+  
+end


### PR DESCRIPTION
This pull makes it possible for a user to set up a fully working development environment for compiling the Bootstrap source files – and serving the documentation locally over port 9001. The only requirement is a working installation of Vagrant; **all** other dependencies are installed automatically making Bootstrap development super easy!
- start: `vagrant up`
- access bootstrap documentation on http://localhost:9001/
- stop: `vagrant destroy`

Learn more about Vagrant on http://www.vagrantup.com/.
