### PR TITLE
Add default white background color to inputs to complement default gray foreground color - avoids unreadable text for users with dark themes.

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -60,6 +60,7 @@ input[type="color"] {
   font-size: @font-size-base;
   line-height: @line-height-base;
   color: @gray;
+  background-color: @white;
   vertical-align: middle;
   background-color: @input-bg;
   border: 1px solid @input-border;


### PR DESCRIPTION
Users on systems who chose a dark theme - for aesthetic preferences or because dark backgrounds aide their vision (ex. colorblind) - have inverted system default foreground and background colors. CSS designers often change just the foreground color, assuming the background will be white. This causes unreadable black/almost black text on a black background. Many many sites do this, including ones that should know better, for example:

![gmail](https://f.cloud.github.com/assets/439208/691809/51fadbc6-dbc9-11e2-81aa-66b804b771a0.png)

If one is going to set a foreground color, one should also set a complementary background color. If Bootstrap was diligent about this it would have a wide effect.
