### PR TITLE
Update forms.less

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -123,7 +123,7 @@ input[type="color"],
   .transition(~"border linear .2s, box-shadow linear .2s");
 
   // Focus state
-  &:focus {
+  &:focus, &.active {
     border-color: rgba(82,168,236,.8);
     outline: 0;
     outline: thin dotted \9; /* IE6-9 */


### PR DESCRIPTION
Allow .uneditable-input to be "focused" via javascript (useful when using uneditable-input as a container for another input control)
In my case, I'm using it as a re-sizable container that includes a border-less text input and multiple bootstrap labels. (i.e. a tag editor).
