### PR TITLE
Fix for issue #8260 https://github.com/twitter/bootstrap/issues/8260 Popup overlay issue.

### DIFF
--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -100,6 +100,7 @@
   , trigger: 'click'
   , content: ''
   , template: '<div class="popover"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+  , locatorId:'tbpopup'
   })
 
 

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -179,6 +179,12 @@
         .addClass(placement)
         .addClass('in')
 
+      if (this.options.locatorId) {
+        $tip
+          .attr(this.options.locatorId, this.options.locatorId)
+          .css('z-index', $('.popover[' + this.options.locatorId + ']').length)
+      }
+
       actualWidth = $tip[0].offsetWidth
       actualHeight = $tip[0].offsetHeight
 


### PR DESCRIPTION
This fixes the problem of multiple popovers being in a fixed z index not according to click pattern. This puts the most recently clicked popover on top. This change may need some fixing or versioning changes and I would love to hear feedback thank you.

-Anthony Sierra
