### PR TITLE
Add new callouts to docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -51,7 +51,7 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
 
     <div class="bs-callout" id="callout-less-compilation">
       <h4>LESS compilation</h4>
-      <p>If you download the original source files, you need to compile Bootstrap's LESS files into usable CSS. While there are various LESS compilers available, Bootstrap only supports the latest stable version of <a href="http://lesscss.org/">less.js</a>.</p>
+      <p>If you download the original files, you need to compile Bootstrap's LESS files into usable CSS. To do that, Bootstrap only officially supports <a href="http://twitter.github.io/recess/">Recess</a>, Twitter's CSS hinter built on top of <a href="http://lesscss.org">less.js</a>.</p>
     </div>
   </div>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -48,6 +48,11 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
 <!-- Latest compiled and minified JavaScript -->
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 {% endhighlight %}
+
+    <div class="bs-callout">
+      <h4>LESS compilation</h4>
+      <p>If you download the original source files, you need to compile Bootstrap's LESS files into usable CSS. While there are various LESS compilers available, Bootstrap only supports the latest stable version of <a href="http://lesscss.org/">less.js</a>.</p>
+    </div>
   </div>
 
   <!-- File structure

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -49,7 +49,7 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 {% endhighlight %}
 
-    <div class="bs-callout">
+    <div class="bs-callout" id="callout-less-compilation">
       <h4>LESS compilation</h4>
       <p>If you download the original source files, you need to compile Bootstrap's LESS files into usable CSS. While there are various LESS compilers available, Bootstrap only supports the latest stable version of <a href="http://lesscss.org/">less.js</a>.</p>
     </div>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -67,7 +67,7 @@ $('#myModal').on('show.bs.modal', function (e) {
 
     <div class="bs-callout">
       <h4>Third-party libraries</h4>
-      <p><strong>Bootstrap does not support third-party JavaScript libraries</strong> like Prototype or jQuery UI. Despite <code>.noConflict</code> and namespaced events, there may be compatibility problems that you need to fix on your own.</p>
+      <p><strong>Bootstrap does not support third-party JavaScript libraries</strong> like Prototype or jQuery UI. Despite <code>.noConflict</code> and namespaced events, there may be compatibility problems that you need to fix on your own. Ask on the <a href="http://groups.google.com/group/twitter-bootstrap">mailing list</a> if you need help.</p>
     </div>
   </div>
 

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -64,6 +64,11 @@ $('#myModal').on('show.bs.modal', function (e) {
   if (!data) return e.preventDefault() // stops modal from being shown
 })
 {% endhighlight %}
+
+    <div class="bs-callout">
+      <h4>Third-party libraries</h4>
+      <p><strong>Bootstrap does not support third-party JavaScript libraries</strong> like Prototype or jQuery UI. Despite <code>.noConflict</code> and namespaced events, there may be compatibility problems that you need to fix on your own.</p>
+    </div>
   </div>
 
 

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -65,9 +65,9 @@ $('#myModal').on('show.bs.modal', function (e) {
 })
 {% endhighlight %}
 
-    <div class="bs-callout">
+    <div class="bs-callout" id="callout-third-party-libs">
       <h4>Third-party libraries</h4>
-      <p><strong>Bootstrap does not support third-party JavaScript libraries</strong> like Prototype or jQuery UI. Despite <code>.noConflict</code> and namespaced events, there may be compatibility problems that you need to fix on your own. Ask on the <a href="http://groups.google.com/group/twitter-bootstrap">mailing list</a> if you need help.</p>
+      <p><strong>Bootstrap does not officially support third-party JavaScript libraries</strong> like Prototype or jQuery UI. Despite <code>.noConflict</code> and namespaced events, there may be compatibility problems that you need to fix on your own. Ask on the <a href="http://groups.google.com/group/twitter-bootstrap">mailing list</a> if you need help.</p>
     </div>
   </div>
 


### PR DESCRIPTION
Add callouts to the docs to make people aware that:
- Bootstrap does not support third-party JS libraries.
- Bootstrap only supports less.js for LESS compilation.

This pull request addresses #8288 and #8289.

@mdo I'm not sure if this is what you had in mind - wording is of course adjustable :).
