### PR TITLE
rm pre{white-space:pre-wrap;} since redundant to Normalize

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -31,8 +31,6 @@ pre {
   line-height: @line-height-base;
   word-break: break-all;
   word-wrap: break-word;
-  white-space: pre;
-  white-space: pre-wrap;
   background-color: #f5f5f5;
   border: 1px solid #ccc; // IE8 fallback
   border: 1px solid rgba(0,0,0,.15);


### PR DESCRIPTION
Redundant to:
https://github.com/twitter/bootstrap/blob/3.0.0-wip/less/normalize.less#L174
And the `pre` fallback should be unnecessary if this compatibility table is accurate:
https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
