### PR TITLE
rm fallback white-space for <code>

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -47,7 +47,6 @@ pre {
   code {
     padding: 0;
     color: inherit;
-    white-space: pre;
     white-space: pre-wrap;
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
If my analysis is right, this should be unnecessary.
`white-space: pre-wrap;` is set on the very next line, and that value seems to be supported by all relevant browser versions: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
