### PR TITLE
typo: match doc text and example

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -942,7 +942,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
       </ul>
     </div>
 {% highlight html %}
-<ul class="nav nav-tabs">
+<ul class="nav nav-pills">
   ...
   <li class="disabled"><a href="#">Disabled link</a></li>
   ...


### PR DESCRIPTION
nav disabled links example and example text now match up as .nav-pills
