### PR TITLE
Fix misplaced input segmented buttons in FF and IE and support for dropdowns positioning

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -691,8 +691,6 @@ pre {
   line-height: 1.428571429;
   word-break: break-all;
   word-wrap: break-word;
-  white-space: pre;
-  white-space: pre-wrap;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.15);
@@ -706,7 +704,6 @@ pre.prettyprint {
 pre code {
   padding: 0;
   color: inherit;
-  white-space: pre;
   white-space: pre-wrap;
   background-color: transparent;
   border: 0;
@@ -1540,7 +1537,7 @@ textarea::-webkit-input-placeholder {
 // Move the options list down to align with labels
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-  padding-top: 5px; // has to be padding because margin collaspes
+  padding-top: 5px; // has to be padding because margin collapses
 }
 */
 
@@ -1745,7 +1742,9 @@ input[type="color"].input-small {
 .input-group input:first-child,
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group > .btn,
 .input-group-btn:first-child > .dropdown-toggle,
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -1758,7 +1757,9 @@ input[type="color"].input-small {
 .input-group input:last-child,
 .input-group-addon:last-child,
 .input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group > .btn,
 .input-group-btn:last-child > .dropdown-toggle,
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn,
 .input-group-btn:first-child > .btn:not(:first-child) {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
@@ -1773,17 +1774,22 @@ input[type="color"].input-small {
   white-space: nowrap;
 }
 
-.input-group-btn > .btn {
+.input-group-btn > .btn,
+.input-group-btn > .btn-group {
   position: relative;
-  float: left;
 }
 
-.input-group-btn > .btn + .btn {
-  margin-left: -1px;
+.input-group-btn > .btn + .btn,
+.input-group-btn > .btn-group + .btn,
+.input-group-btn > .btn + .btn-group,
+.input-group-btn > .btn-group + .btn-group {
+  margin-left: -4px;
 }
 
 .input-group-btn > .btn:hover,
-.input-group-btn > .btn:active {
+.input-group-btn > .btn-group:hover,
+.input-group-btn > .btn:active,
+.input-group-btn > .btn-group:active {
   z-index: 2;
 }
 

--- a/docs/css.html
+++ b/docs/css.html
@@ -1670,16 +1670,19 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
       <div class="input-group col-lg-7">
         <div class="input-group-btn">
           <button type="button" class="btn btn-default" tabindex="-1">Action</button>
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
-            <li class="divider"></li>
-            <li><a href="#">Separated link</a></li>
-          </ul>
+
+          <div class="btn-group">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+            </ul>
+          </div>
         </div>
         <input type="text">
       </div>
@@ -1690,31 +1693,40 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
         <input type="text">
         <div class="input-group-btn">
           <button type="button" class="btn btn-default" tabindex="-1">Action</button>
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
-            <li class="divider"></li>
-            <li><a href="#">Separated link</a></li>
-          </ul>
+          <div class="btn-group">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" tabindex="-1">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu pull-right">
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+              <li><a href="#">Something else here</a></li>
+              <li class="divider"></li>
+              <li><a href="#">Separated link</a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </form>
 {% highlight html %}
 <div class="input-group col-lg-7">
   <div class="input-group-btn">
-    <!-- Button and dropdown menu -->
+    <button type="button" class="btn btn-default" tabindex="-1">Action</button>
+    <div class="btn-group">
+      <!-- Button and dropdown menu -->
+    </div>
   </div>
   <input type="text">
 </div>
 
 <div class="input-group col-lg-7">
   <input type="text">
-  <div class="input-group-btn btn-group">
-    <!-- Button and dropdown menu -->
+  <div class="input-group-btn">
+    <button type="button" class="btn btn-default" tabindex="-1">Action</button>
+    <!-- optional btn-group used to set dropdown positions -->
+    <div class="btn-group">
+      <!-- Button and dropdown menu -->
+    </div>
   </div>
 </div>
 {% endhighlight %}

--- a/less/forms.less
+++ b/less/forms.less
@@ -381,9 +381,8 @@ input[type="color"] {
 }
 .input-group-btn > .btn {
   position: relative;
-  float: left; // Collapse white-space
   + .btn {
-    margin-left: -1px;
+    margin-left: -4px;
   }
   // Bring the "active" button to the front
   &:hover,

--- a/less/forms.less
+++ b/less/forms.less
@@ -355,7 +355,9 @@ input[type="color"] {
 .input-group input:first-child,
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group > .btn,
 .input-group-btn:first-child > .dropdown-toggle,
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle) {
   .border-right-radius(0);
 }
@@ -365,7 +367,9 @@ input[type="color"] {
 .input-group input:last-child,
 .input-group-addon:last-child,
 .input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group > .btn,
 .input-group-btn:last-child > .dropdown-toggle,
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn,
 .input-group-btn:first-child > .btn:not(:first-child) {
   .border-left-radius(0);
 }
@@ -379,9 +383,10 @@ input[type="color"] {
   position: relative;
   white-space: nowrap;
 }
-.input-group-btn > .btn {
+.input-group-btn > .btn,
+.input-group-btn > .btn-group {
   position: relative;
-  + .btn {
+  + .btn, + .btn-group {
     margin-left: -4px;
   }
   // Bring the "active" button to the front
@@ -390,6 +395,7 @@ input[type="color"] {
     z-index: 2;
   }
 }
+
 
 
 // Inline forms


### PR DESCRIPTION
The float left used to collapse borders causes the IE and FF troubles, same can be achieved using the negative margin that already is being used.

btn-group can be used inside input-groups as well in order to place dropdowns

Tested in FF, Safari, Chrome, IE 10, 9, 8 in all media cases and with all possible combinations, with multiple drop downs, buttons mixed…

**Before**
![before](https://f.cloud.github.com/assets/38347/713145/e85df74c-debc-11e2-8f20-c52f567f1663.png)

**After**
![after](https://f.cloud.github.com/assets/38347/713147/ee9e3e5a-debc-11e2-91c7-377d26aa6fa8.png)
