### PR TITLE
removing bootstrap-fonts rule in Makefile for bootstrap rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean:
 # recess & uglifyjs are required
 #
 
-bootstrap: bootstrap-fonts bootstrap-css bootstrap-js
+bootstrap:  bootstrap-css bootstrap-js
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean:
 # recess & uglifyjs are required
 #
 
-bootstrap:  bootstrap-css bootstrap-js
+bootstrap: bootstrap-css bootstrap-js
 
 
 #


### PR DESCRIPTION
I tried to do a "make bootstrap" but it failed due to the non-existence of the bootstrap-fonts rule.

Are we going to move 3.0.0 to grunt for the build process? :)
