### PR TITLE
Docs: Fix broken links to navbar component in examples pages

### DIFF
--- a/docs/examples/navbar-fixed-top.html
+++ b/docs/examples/navbar-fixed-top.html
@@ -60,7 +60,7 @@ title: Fixed navbar template
         <h1>Navbar example</h1>
         <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
         <p>
-          <a class="btn btn-large btn-primary" href="../../docs/#navbar">View navbar docs &raquo;</a>
+          <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
         </p>
       </div>
 

--- a/docs/examples/navbar-static-top.html
+++ b/docs/examples/navbar-static-top.html
@@ -57,7 +57,7 @@ title: Static navbar template
     <h1>Navbar example</h1>
     <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
     <p>
-      <a class="btn btn-large btn-primary" href="../../docs/#navbar">View navbar docs &raquo;</a>
+      <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
     </p>
   </div>
 

--- a/docs/examples/navbar.html
+++ b/docs/examples/navbar.html
@@ -60,7 +60,7 @@ title: Navbar template
     <h1>Navbar example</h1>
     <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
     <p>
-      <a class="btn btn-large btn-primary" href="../../docs/#navbar">View navbar docs &raquo;</a>
+      <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
     </p>
   </div>
 


### PR DESCRIPTION
A couple of links were broken in the move from Mustache to Jekyll. This change updates old `../../` links to the new Jekyll format, and makes them no longer broken. Like a fucking boss.
