### PR TITLE
Fix prepended and appended inputs margin-bottom in navbar forms

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -128,6 +128,7 @@
   .input-append,
   .input-prepend {
     margin-top: 5px;
+    margin-bottom: 5px;
     white-space: nowrap; // preven two  items from separating within a .navbar-form that has .pull-left
     input {
       margin-top: 0; // remove the margin on top since it's on the parent


### PR DESCRIPTION
navbar's height change when using prepended and appended inputs in navbar forms.
Plunker showing the bug: http://plnkr.co/F5odYeM7v5d10nhkDpU3
