### PR TITLE
3.0.0-wip: Apply table cell styles in tfoot not just thead & tbody.

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -20,6 +20,7 @@ th {
   margin-bottom: @line-height-computed;
   // Cells
   thead,
+  tfoot,
   tbody {
     > tr {
       > th,


### PR DESCRIPTION
This is a regression from 2.3 as the 2.3 styling didn't scope the `th` and `td` styles to anything other than that they were inside a tag with `.table`. In 3.0 they're now scoped to `thead` and `tbody`, but `tfoot` isn't currently included.
