### PR TITLE
delete typeahead style

### DIFF
--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -2305,10 +2305,6 @@ input[type="button"].btn-block {
   padding-left: 20px;
 }
 
-.typeahead {
-  z-index: 1051;
-}
-
 .list-group {
   padding-left: 0;
   margin-bottom: 20px;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -158,9 +158,3 @@
   padding-left: 20px;
   padding-right: 20px;
 }
-
-// Typeahead
-// ---------------------------
-.typeahead {
-  z-index: 1051;
-}


### PR DESCRIPTION
Since typeahead has been deprecated (check [here](https://github.com/twitter/bootstrap/issues/7805)), and I don't see any other element is using this .typeahead

So I think it is reasonable to delete this.
