### PR TITLE
Wrong third argument for jQuery.extend breaks tooltips with "selector" option

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -86,7 +86,7 @@
 
       this._options && $.each(this._options, function (key, value) {
         if (defaults[key] != value) options[key] = value
-      }, this)
+      })
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
Third argument in jQuery.extend is not a context and is not documented.
As a result options for new tooltips does not correctly inherit from specified, when "selector" option is present. 

Also fixes #8308
