### PR TITLE
Introduces config variables baseurl and static url in docs templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,7 @@ permalink:    pretty
 source:       ./docs
 destination:  ./_gh_pages
 port:         9001
+
+# Custom base urls
+baseurl:     /
+staticurl:   /assets/

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,13 +1,13 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="/assets/js/jquery.js"></script>
-<script src="/assets/js/bootstrap.js"></script>
+<script src="{{ site.staticurl }}js/jquery.js"></script>
+<script src="{{ site.staticurl }}js/bootstrap.js"></script>
 
 <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
-<script src="/assets/js/holder/holder.js"></script>
+<script src="{{ site.staticurl }}js/holder/holder.js"></script>
 
-<script src="/assets/js/application.js"></script>
+<script src="{{ site.staticurl }}js/application.js"></script>
 
 <!-- Analytics
 ================================================== -->

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -12,26 +12,26 @@
 </title>
 
 <!-- Bootstrap core CSS -->
-<link href="/assets/css/bootstrap.css" rel="stylesheet">
+<link href="{{ site.staticurl }}css/bootstrap.css" rel="stylesheet">
 
 {% if page.layout != "example" %}
 <!-- Documentation extras -->
-<link href="/assets/css/docs.css" rel="stylesheet">
-<link href="/assets/css/pygments-manni.css" rel="stylesheet">
+<link href="{{ site.staticurl }}css/docs.css" rel="stylesheet">
+<link href="{{ site.staticurl }}css/pygments-manni.css" rel="stylesheet">
 {% endif %}
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
-  <script src="/assets/js/html5shiv.js"></script>
-  <script src="/assets/js/respond/respond.min.js"></script>
+  <script src="{{ site.staticurl }}js/html5shiv.js"></script>
+  <script src="{{ site.staticurl }}js/respond/respond.min.js"></script>
 <![endif]-->
 
 <!-- Favicons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/ico/apple-touch-icon-144-precomposed.png">
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/ico/apple-touch-icon-114-precomposed.png">
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/ico/apple-touch-icon-72-precomposed.png">
-                <link rel="apple-touch-icon-precomposed" href="/assets/ico/apple-touch-icon-57-precomposed.png">
-                               <link rel="shortcut icon" href="/assets/ico/favicon.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.staticurl }}ico/apple-touch-icon-144-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.staticurl }}ico/apple-touch-icon-114-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.staticurl }}ico/apple-touch-icon-72-precomposed.png">
+                <link rel="apple-touch-icon-precomposed" href="{{ site.staticurl }}ico/apple-touch-icon-57-precomposed.png">
+                               <link rel="shortcut icon" href="{{ site.staticurl }}ico/favicon.png">
 
 <script type="text/javascript">
   var _gaq = _gaq || [];

--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -1,6 +1,6 @@
 <div class="navbar navbar-inverse navbar-fixed-top bs-docs-nav">
   <div class="container">
-    <a href="/" class="navbar-brand">Bootstrap</a>
+    <a href="{{ site.baseurl }}" class="navbar-brand">Bootstrap</a>
     <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
@@ -9,19 +9,19 @@
     <div class="nav-collapse collapse bs-navbar-collapse">
       <ul class="nav navbar-nav">
         <li{% if page.slug == "getting-started" %} class="active"{% endif %}>
-          <a href="/getting-started">Getting started</a>
+          <a href="{{ site.baseurl }}getting-started">Getting started</a>
         </li>
         <li{% if page.slug == "css" %} class="active"{% endif %}>
-          <a href="/css">CSS</a>
+          <a href="{{ site.baseurl }}css">CSS</a>
         </li>
         <li{% if page.slug == "components" %} class="active"{% endif %}>
-          <a href="/components">Components</a>
+          <a href="{{ site.baseurl }}components">Components</a>
         </li>
         <li{% if page.slug == "js" %} class="active"{% endif %}>
-          <a href="/javascript">JavaScript</a>
+          <a href="{{ site.baseurl }}javascript">JavaScript</a>
         </li>
         <li{% if page.slug == "customize" %} class="active"{% endif %}>
-          <a href="/customize">Customize</a>
+          <a href="{{ site.baseurl }}customize">Customize</a>
         </li>
       </ul>
     </div>

--- a/docs/customize.html
+++ b/docs/customize.html
@@ -13,7 +13,7 @@ lead: Customize Bootstrap's components, LESS variables, and jQuery plugins to ge
         <button class="btn btn-default toggle" type="button">Toggle all</button>
         <h1>LESS files</h1>
       </div>
-      <p class="lead">Choose which LESS files to compile into your custom build of Bootstrap. Not sure which files to use? Read through the <a href="/css/">CSS</a> and <a href="/components/">Components</a> pages in the docs</p>
+      <p class="lead">Choose which LESS files to compile into your custom build of Bootstrap. Not sure which files to use? Read through the <a href="{{ site.baseurl }}css/">CSS</a> and <a href="{{ site.baseurl }}components/">Components</a> pages in the docs</p>
 
       <h3>Basics</h3>
       <div class="row">
@@ -274,7 +274,7 @@ lead: Customize Bootstrap's components, LESS variables, and jQuery plugins to ge
         <button class="btn btn-default toggle" type="button">Toggle all</button>
         <h1>jQuery plugins</h1>
       </div>
-      <p class="lead">Choose which jQuery plugins should be included in your custom JavaScript files. Unsure what to include? Read the <a href="/javascript/">JavaScript</a> page in the docs.</p>
+      <p class="lead">Choose which jQuery plugins should be included in your custom JavaScript files. Unsure what to include? Read the <a href="{{ site.baseurl }}javascript/">JavaScript</a> page in the docs.</p>
       <div class="row">
         <div class="col-lg-6">
           <h4>Linked to components</h4>

--- a/docs/examples/navbar-fixed-top.html
+++ b/docs/examples/navbar-fixed-top.html
@@ -45,9 +45,9 @@ title: Fixed navbar template
             </li>
           </ul>
           <ul class="nav navbar-nav pull-right">
-            <li><a href="/examples/navbar/">Default</a></li>
-            <li><a href="/examples/navbar-static-top/">Static top</a></li>
-            <li class="active"><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+            <li><a href="{{ site.baseurl }}examples/navbar/">Default</a></li>
+            <li><a href="{{ site.baseurl }}examples/navbar-static-top/">Static top</a></li>
+            <li class="active"><a href="{{ site.baseurl }}examples/navbar-fixed-top/">Fixed top</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -60,7 +60,7 @@ title: Fixed navbar template
         <h1>Navbar example</h1>
         <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
         <p>
-          <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
+          <a class="btn btn-large btn-primary" href="{{ site.baseurl }}components/#navbar">View navbar docs &raquo;</a>
         </p>
       </div>
 

--- a/docs/examples/navbar-static-top.html
+++ b/docs/examples/navbar-static-top.html
@@ -41,9 +41,9 @@ title: Static navbar template
         </li>
       </ul>
       <ul class="nav navbar-nav pull-right">
-        <li><a href="/examples/navbar/">Default</a></li>
-        <li class="active"><a href="/examples/navbar-static-top/">Static top</a></li>
-        <li><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+        <li><a href="{{ site.baseurl }}examples/navbar/">Default</a></li>
+        <li class="active"><a href="{{ site.baseurl }}examples/navbar-static-top/">Static top</a></li>
+        <li><a href="{{ site.baseurl }}examples/navbar-fixed-top/">Fixed top</a></li>
       </ul>
     </div><!--/.nav-collapse -->
   </div>
@@ -57,7 +57,7 @@ title: Static navbar template
     <h1>Navbar example</h1>
     <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
     <p>
-      <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
+      <a class="btn btn-large btn-primary" href="{{ site.baseurl }}components/#navbar">View navbar docs &raquo;</a>
     </p>
   </div>
 

--- a/docs/examples/navbar.html
+++ b/docs/examples/navbar.html
@@ -47,9 +47,9 @@ title: Navbar template
           </li>
         </ul>
         <ul class="nav navbar-nav pull-right">
-          <li class="active"><a href="/examples/navbar/">Default</a></li>
-          <li><a href="/examples/navbar-static-top/">Static top</a></li>
-          <li><a href="/examples/navbar-fixed-top/">Fixed top</a></li>
+          <li class="active"><a href="{{ site.baseurl }}examples/navbar/">Default</a></li>
+          <li><a href="{{ site.baseurl }}examples/navbar-static-top/">Static top</a></li>
+          <li><a href="{{ site.baseurl }}examples/navbar-fixed-top/">Fixed top</a></li>
         </ul>
       </div><!--/.nav-collapse -->
     </div>
@@ -60,7 +60,7 @@ title: Navbar template
     <h1>Navbar example</h1>
     <p>This example is a quick exercise to illustrate how the default, static navbar and fixed to top navbar work. It includes the responsive CSS and HTML, so it also adapts to your viewport and device.</p>
     <p>
-      <a class="btn btn-large btn-primary" href="/components/#navbar">View navbar docs &raquo;</a>
+      <a class="btn btn-large btn-primary" href="{{ site.baseurl }}components/#navbar">View navbar docs &raquo;</a>
     </p>
   </div>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -43,10 +43,10 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
     <p>The folks over at <a href="https://www.netdna.com/">NetDNA</a> have graciously provided CDN support for Bootstrap's CSS and JavaScript. To use, swap your local instances for the <a href="http://www.bootstrapcdn.com/">Bootstrap CDN</a> links listed below.</p>
 {% highlight html linenos %}
 <!-- Latest compiled and minified CSS -->
-<link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
+<link href="{{ site.baseurl }}/netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
 
 <!-- Latest compiled and minified JavaScript -->
-<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+<script src="{{ site.baseurl }}/netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 {% endhighlight %}
 
     <div class="bs-callout" id="callout-less-compilation">
@@ -118,22 +118,22 @@ bootstrap/
     <div class="bs-examples">
       <div class="row">
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/starter-template/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-starter.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/starter-template/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-starter.png" alt="">
           </a>
           <h4>Starter template</h4>
           <p>A barebones HTML page with Bootstrap's CSS and JavaScript included.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/grid/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-grid.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/grid/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-grid.png" alt="">
           </a>
           <h4>Basic grid layouts</h4>
           <p>Simple grid layouts to familiarize you with using the Bootstrap grid system.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/jumbotron/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-marketing.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/jumbotron/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-marketing.png" alt="">
           </a>
           <h4>Basic marketing site</h4>
           <p>Features a jumbotron for primary message and three supporting elements.</p>
@@ -141,22 +141,22 @@ bootstrap/
       </div>
       <div class="row">
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/jumbotron-narrow/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-jumbotron-narrow.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/jumbotron-narrow/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-jumbotron-narrow.png" alt="">
           </a>
           <h4>Narrow marketing</h4>
           <p>Slim, lightweight marketing template for small projects or teams.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/justified-nav/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-justified-nav.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/justified-nav/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-justified-nav.png" alt="">
           </a>
           <h4>Justified nav</h4>
           <p>Marketing page with equal-width navigation links in a modified navbar.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/signin/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-signin.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/signin/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-signin.png" alt="">
           </a>
           <h4>Sign in</h4>
           <p>Barebones sign in form with custom, larger form controls and a flexible layout.</p>
@@ -164,22 +164,22 @@ bootstrap/
       </div>
       <div class="row">
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/sticky-footer/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-sticky-footer.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/sticky-footer/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-sticky-footer.png" alt="">
           </a>
           <h4>Sticky footer</h4>
           <p>Pin a fixed-height footer to the bottom of the user's viewport.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/sticky-footer-navbar/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-sticky-footer-navbar.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/sticky-footer-navbar/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-sticky-footer-navbar.png" alt="">
           </a>
           <h4>Sticky footer w/ navbar</h4>
           <p>Add a fixed navbar to the default sticky footer template.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/carousel/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-carousel.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/carousel/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-carousel.png" alt="">
           </a>
           <h4>Carousel jumbotron</h4>
           <p>An interactive riff on the basic marketing site featuring a prominent carousel.</p>
@@ -187,22 +187,22 @@ bootstrap/
       </div>
       <div class="row">
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/navbar/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-navbar.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/navbar/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-navbar.png" alt="">
           </a>
           <h4>Navbar</h4>
           <p>Basic template for showcasing how the navbar works.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/navbar-static-top/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-navbar-static-top.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/navbar-static-top/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-navbar-static-top.png" alt="">
           </a>
           <h4>Static top navbar</h4>
           <p>Basic template for showcasing the static navbar variation.</p>
         </div>
         <div class="col-lg-4">
-          <a class="thumbnail" href="/examples/navbar-fixed-top/" target="_blank">
-            <img src="/assets/img/examples/bootstrap-example-navbar-fixed-top.png" alt="">
+          <a class="thumbnail" href="{{ site.baseurl }}examples/navbar-fixed-top/" target="_blank">
+            <img src="{{ site.staticurl }}img/examples/bootstrap-example-navbar-fixed-top.png" alt="">
           </a>
           <h4>Fixed top navbar</h4>
           <p>Basic template for showcasing the fixed navbar variation.</p>
@@ -282,7 +282,7 @@ bootstrap/
     </div>
 
     <h3>Removing potential bloat</h3>
-    <p>Not all sites and applications need to make use of everything Bootstrap has to offer, especially in production environments where bandwidth literally becomes a financial issue. We encourage folks to remove whatever is unused with our <a href="/customize/">Customizer</a>.</p>
+    <p>Not all sites and applications need to make use of everything Bootstrap has to offer, especially in production environments where bandwidth literally becomes a financial issue. We encourage folks to remove whatever is unused with our <a href="{{ site.baseurl }}customize/">Customizer</a>.</p>
     <p>Using the Customizer, simply uncheck any component, feature, or asset you don't need. Hit download and swap out the default Bootstrap files with these newly customized ones. You'll get vanilla Bootstrap, but without the features *you* deem unnecessary. All custom builds include compiled and minified versions, so use whichever works for you.</p>
 
   </div>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -448,7 +448,7 @@ $('#myModal').on('hidden.bs.modal', function () {
           <p>To keep URLs intact, use the <code>data-target</code> attribute instead of <code>href="#"</code>.</p>
 {% highlight html %}
 <div class="dropdown">
-  <a class="dropdown-toggle" id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="/page.html">
+  <a class="dropdown-toggle" id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="{{ site.baseurl }}page.html">
     Dropdown <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">


### PR DESCRIPTION
This allows users to generate docs that can:
    - be served from a base url different of /
    - load assets from a url different of /assets/
These variables are stored in _config.yaml.
The defaults resolve to the same urls as previously.
