### PR TITLE
Replace position() with offset() in scrollspy.js

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -60,7 +60,7 @@
 
         return ($href
           && $href.length
-          && [[ $href.position().top + (!$.isWindow(self.$scrollElement.get(0)) && self.$scrollElement.scrollTop()), href ]]) || null
+          && [[ $href.offset().top + (!$.isWindow(self.$scrollElement.get(0)) && self.$scrollElement.scrollTop()), href ]]) || null
       })
       .sort(function (a, b) { return a[0] - b[0] })
       .each(function () {


### PR DESCRIPTION
Regarding #7615: Chrome measured wrong positions when using position() - Using offset() instead fixes the issue.
