### PR TITLE
Fixed left tooltip positioning

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -191,7 +191,10 @@
 
     if (placement == 'top' && actualHeight != height) {
       replace = true
-      offset.top  = offset.top + height - actualHeight
+      offset.top = offset.top + height - actualHeight
+    } else if (placement == 'left' && actualWidth != width) {
+      replace = true
+      offset.left = offset.left + width - actualWidth
     }
 
     if (placement == 'bottom' || placement == 'top') {


### PR DESCRIPTION
Hey @mdo, @fat,

I noticed a bug in left tooltips a few weeks ago:

![broked](http://i.imgur.com/5RXmTcn.png)

And poked around `tooltip.js`, resulting in the following:

![fixed](http://i.imgur.com/WeW21zC.png)

This patch gives left tooltips a similar treatment given to top tooltips: recalculating the left offset if the width changes after a class is applied.
