### PR TITLE
fix faulty input-group-btn display in firefox

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -392,7 +392,6 @@ input[type="color"] {
 }
 .input-group-btn > .btn {
   position: relative;
-  float: left; // Collapse white-space
   + .btn {
     margin-left: -1px;
   }
@@ -403,6 +402,9 @@ input[type="color"] {
   }
 }
 
+.input-group-btn > .btn:first-child {
+  margin-right: -3px; // collapse whitespace
+}
 
 // Inline forms
 // --------------------------------------------------


### PR DESCRIPTION
Input Group Buttons do not display correctly in Firefox - see this issue for screenshot:

https://github.com/twitter/bootstrap/issues/8067

This fixes it.
