### PR TITLE
Update bootstrap-typeahead.js

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -59,11 +59,16 @@
       var pos = $.extend({}, this.$element.position(), {
         height: this.$element[0].offsetHeight
       })
+      , scrollHeight
+      
+      scrollHeight = typeof this.options.scrollHeight == 'function' ?
+          this.options.scrollHeight.call() :
+          this.options.scrollHeight
 
       this.$menu
         .insertAfter(this.$element)
         .css({
-          top: pos.top + pos.height
+          top: pos.top + pos.height + scrollHeight
         , left: pos.left
         })
         .show()
@@ -309,6 +314,7 @@
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
   , minLength: 1
+  , scrollHeight: 0
   }
 
   $.fn.typeahead.Constructor = Typeahead


### PR DESCRIPTION
When add a typehead to a scrollable element the placement (height) of the typeahead dropdown is calculated wrong, See: http://bootply.com/66845 (remove the javascript to see the problem)
The scrollHeight (int or function) option can be used to correct this problem.

Example for typeahead input in the Modal use:

```
 scrollHeight: function() { return $('.modal-body').scrollTop(); }
```
