### PR TITLE
Update nav-main.html

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -9,19 +9,19 @@
     <div class="nav-collapse collapse bs-navbar-collapse">
       <ul class="nav navbar-nav">
         <li{% if page.slug == "getting-started" %} class="active"{% endif %}>
-          <a href="/getting-started">Getting started</a>
+          <a href="/getting-started.html">Getting started</a>
         </li>
         <li{% if page.slug == "css" %} class="active"{% endif %}>
-          <a href="/css">CSS</a>
+          <a href="/css.html">CSS</a>
         </li>
         <li{% if page.slug == "components" %} class="active"{% endif %}>
-          <a href="/components">Components</a>
+          <a href="/components.html">Components</a>
         </li>
         <li{% if page.slug == "js" %} class="active"{% endif %}>
-          <a href="/javascript">JavaScript</a>
+          <a href="/javascript.html">JavaScript</a>
         </li>
         <li{% if page.slug == "customize" %} class="active"{% endif %}>
-          <a href="/customize">Customize</a>
+          <a href="/customize.html">Customize</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
menu links are broken without .html (or should this be a jekyll setting / routing)
