### PR TITLE
Adding parenthesizes for the @navbarCollapseDesktopWidth variable declaration

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -178,7 +178,7 @@
 // Navbar
 // -------------------------
 @navbarCollapseWidth:             979px;
-@navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
+@navbarCollapseDesktopWidth:      (@navbarCollapseWidth + 1);
 
 @navbarHeight:                    40px;
 @navbarBackgroundHighlight:       #ffffff;


### PR DESCRIPTION
This commit forces the js Less script (less-1.4.1.min.js) to evaluate the expression in media selectors like "@media (max-width: @navbarCollapseDesktopWidth)".
Without the parenthesizes, this expression is evaluated as "@media (max-width: 979px + 1)" instead of "@media (max-width: 980px)".

Best regards
