### PR TITLE
rename .retina-image => .img-retina

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -331,7 +331,7 @@
 // --------------------------------------------------
 
 // Short retina mixin for setting background-image and -size
-.retina-image(@file-1x, @file-2x, @width-1x, @height-1x) {
+.img-retina(@file-1x, @file-2x, @width-1x, @height-1x) {
   background-image: url("@{file-1x}");
 
   @media


### PR DESCRIPTION
For greater consistency with `.img-responsive`, `.img-thumbnail`, etc.
