### PR TITLE
Modal "loaded" event

### DIFF
--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -30,7 +30,10 @@
     this.options = options
     this.$element = $(element)
       .delegate('[data-dismiss="modal"]', 'click.dismiss.modal', $.proxy(this.hide, this))
-    this.options.remote && this.$element.find('.modal-body').load(this.options.remote)
+    this.options.remote && this.$element.find('.modal-body').load(this.options.remote, function () {
+      var e = $.Event('loaded')
+      $(element).trigger(e)
+    } )
   }
 
   Modal.prototype = {


### PR DESCRIPTION
The event is triggered after ajax load complete.
Is very useful when need to change modal buttons actions according to loaded content.
