### PR TITLE
Improve carousel example

### DIFF
--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -22,10 +22,7 @@ body {
 
 /* Special class on .container surrounding .navbar, used for positioning it into place. */
 .navbar-wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  position: relative;
   z-index: 10;
 }
 
@@ -37,6 +34,9 @@ body {
 /* Carousel base class */
 .carousel {
   margin-bottom: 60px;
+
+  /* Negative margin to pull up carousel. 90px is roughly margins and height of navbar. */
+  margin-top: -90px;
 }
 /* Since positioning the image, we need to help out the caption */
 .carousel-caption {
@@ -126,7 +126,6 @@ body {
   /* Navbar positioning foo */
   .navbar-wrapper {
     margin-top: 20px;
-    margin-bottom: -90px; /* Negative margin to pull up carousel. 90px is roughly margins and height of navbar. */
   }
   /* The navbar becomes detached from the top, so we round the corners */
   .navbar-wrapper .navbar {

--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -47,7 +47,7 @@ body {
 .carousel .item {
   height: 500px;
 }
-.carousel img {
+.carousel-inner > .item > img {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
I tried using the carousel example's CSS from the 2.3.x branch for a project and noticed that it didn't work well on pages without a carousel. This keeps the carousel example working the same and lets the floating navbar be used on pages without carousels.

**Specificity change:**

The specificity change was specific to the 3.x branch. Slides were not the height of the container: 
![screen shot 2013-07-13 at 12 45 49 pm](https://f.cloud.github.com/assets/29612/793300/e553ab64-ebf5-11e2-8a1e-525b946d88d3.png)

Matching specificity fixed it:
![screen shot 2013-07-13 at 12 45 13 pm](https://f.cloud.github.com/assets/29612/793303/f7a98e32-ebf5-11e2-8ee9-abec1c10df40.png)

**Navbar change:**

Hiding the carousel shows these styles don't work well without a carousel:
![screen shot 2013-07-13 at 12 48 51 pm](https://f.cloud.github.com/assets/29612/793306/10708f1a-ebf6-11e2-8715-5f693e216634.png)

Letting the navbar flow and moving the negative margin means the carousel still works, and the styles can be used on carousel-free pages:
![screen shot 2013-07-13 at 12 47 04 pm](https://f.cloud.github.com/assets/29612/793307/24a01708-ebf6-11e2-94e3-b52ef7483c7a.png)
