### PR TITLE
Update README.md regarding downloading tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Learn more about using Jekyll by reading their [documentation](http://jekyllrb.c
 
 Documentation for v2.3.2 has been made available for the time being at [http://getbootstrap.com/2.3.2/docs](http://getbootstrap.com/2.3.2/docs) while folks transition to Bootstrap 3.
 
-For previous releases, documentation is available for [download via Git tags](https://github.com/twitter/bootstrap/tags).
+For previous releases, you can [download them via Git tags](https://github.com/twitter/bootstrap/tags).
 
 
 


### PR DESCRIPTION
Wording change. The link isn't to documentation (how-to) but instead is a link to the tags themselves.
