### PR TITLE
Bump jQuery dependency to ~1.9.0

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
   "version": "2.3.2",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": "~1.9.0"
   }
 }


### PR DESCRIPTION
Per:

http://blog.getbootstrap.com/2013/02/07/bootstrap-2-3-released/

jQuery version should be 1.9
