### PR TITLE
Correct doc inconsistency

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -442,7 +442,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <!-- Dropdown menu links -->
+    ...
   </ul>
 </div>
 {% endhighlight %}


### PR DESCRIPTION
Most component examples use '...' to represent a placeholder for common markup. The Dropup buttons section was inconsistent with this pattern.
