### PR TITLE
fix typo / doc components.html responsive menu dropdowns now have ref to...

### DIFF
--- a/components.html
+++ b/components.html
@@ -927,7 +927,7 @@ body { padding-bottom: 70px; }
                   <li><a href="#">Another action</a></li>
                   <li><a href="#">Something else here</a></li>
                   <li class="divider"></li>
-                  <li class="nav-header">Nav header</li>
+                  <li class="dropdown-header">Dropdown header</li>
                   <li><a href="#">Separated link</a></li>
                   <li><a href="#">One more separated link</a></li>
                 </ul>
@@ -1004,7 +1004,7 @@ body { padding-bottom: 70px; }
                   <li><a href="#">Another action</a></li>
                   <li><a href="#">Something else here</a></li>
                   <li class="divider"></li>
-                  <li class="nav-header">Nav header</li>
+                  <li class="dropdown-header">Dropdown header</li>
                   <li><a href="#">Separated link</a></li>
                   <li><a href="#">One more separated link</a></li>
                 </ul>


### PR DESCRIPTION
... .dropdown-header instead of .nav-header
