### PR TITLE
component.json -> bower.json; adjust jquery to >=1.8.0 <2.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "2.3.2",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": ">=1.8.0 <2.1.0"
   }
 }


### PR DESCRIPTION
Fixes #6857.
Backports #8050 (`component.json` → `bower.json`) to BS v2.3.x.
Follow-up to #6593 (jQuery 1.9 compatibility confirmation) & #7627 (jQuery 2.0 compatibility confirmation).
Still allows jQuery 1.8 per mdo's comment: https://github.com/twitter/bootstrap/pull/8518#issuecomment-21214011
