### PR TITLE
typo fixed: highligted source code of second radio button was missing

### DIFF
--- a/css.html
+++ b/css.html
@@ -1342,6 +1342,10 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
     Option one is this and that&mdash;be sure to include why it's great
   </label>
+  <label>
+    <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+    Option two can be something else and selecting it will deselect option one
+  </label>
 </div>
 {% endhighlight %}
 


### PR DESCRIPTION
typo fixed: highligted source code of second radio button was missing in css.html -> checkboxes & radios -> default section
