### PR TITLE
ignore .files for bower packaging

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "bootstrap",
   "version": "3.0.0",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
+  "ignore": [
+      "**/.*"
+  ],
   "dependencies": {
     "jquery": ">= 1.9.0"
   }


### PR DESCRIPTION
Bootstrap's .gitignore file messes with my repositories' .gitignore when installed via bower (since bower copies the git repo into your projects).

This PR gets rid of all dotfiles, under the thought they may cause similar problems.

It would be really awesome to ignore everything not needed for a distribution, and to port this to the other tags for people on old versions, but I wasn't sure if that'd be acceptable. (Nor am I sure which files would qualify).
