### PR TITLE
update links to bower

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -31,9 +31,9 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
       </h4>
       <p>Clone the entire project or fork your own version of Bootstrap to make it your own by visiting us on GitHub.</p>
       <h4>
-        Install with <a href="http://twitter.github.com/bower">Bower</a>
+        Install with <a href="http://bower.io">Bower</a>
       </h4>
-      <p>Install and manage the original files for all CSS and JavaScript, along with a local copy of the docs, using <a href="http://twitter.github.com/bower">Bower</a>.</p>
+      <p>Install and manage the original files for all CSS and JavaScript, along with a local copy of the docs, using <a href="http://bower.io">Bower</a>.</p>
       {% highlight bash %}$ bower install bootstrap{% endhighlight %}
     </div>
 


### PR DESCRIPTION
I just noticed that the links to Bower were not working. The new url is http://bower.io.
