### PR TITLE
Removing the space for multiple appended and prepended input buttons 

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -92,4 +92,12 @@
   .btn-block + .btn-block {
     margin-left: 0;
   }
+  // and appended inputs
+  .input-append .btn {
+    margin-left: 0;
+  }
+  // and prepended inputs
+  .input-prepend .btn {
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
When multiple buttons are appended to an input in the .modal-footer the 5px left-margin should not apply.

Before:

![screen shot 2013-07-22 at 10 37 45 pm](https://f.cloud.github.com/assets/965298/839838/2c925244-f35a-11e2-9b67-cff468c80e4d.png)

![screen shot 2013-07-22 at 10 35 30 pm](https://f.cloud.github.com/assets/965298/839835/1843048c-f35a-11e2-89c2-061e0d0056c0.png)

After:

![screen shot 2013-07-22 at 10 37 28 pm](https://f.cloud.github.com/assets/965298/839839/384ba48c-f35a-11e2-8a35-9ee71d921472.png)

![screen shot 2013-07-22 at 10 36 34 pm](https://f.cloud.github.com/assets/965298/839841/3c887b92-f35a-11e2-9fc7-2963c218b60b.png)
