### PR TITLE
Removing the space for multiple appended and prepended input buttons

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -116,6 +116,14 @@
   .btn-block + .btn-block {
     margin-left: 0;
   }
+  // and appended inputs
+  .input-append .btn {
+     margin-left: 0;
+     }
+  // and prepended inputs
+  .input-prepend .btn {
+    margin-left: 0;
+    }
 }
 
 // Scale up the modal


### PR DESCRIPTION
When multiple buttons are appended to an input in the .modal-footer the 5px left-margin should not apply.

Before:
![screen shot 2013-07-22 at 10 37 45 pm](https://f.cloud.github.com/assets/965298/840139/ac4c8e9c-f368-11e2-9b5b-44b130ceccf2.png)
![screen shot 2013-07-22 at 10 35 30 pm](https://f.cloud.github.com/assets/965298/840141/b246b28c-f368-11e2-9bd2-c98728b48887.png)
After: 
![screen shot 2013-07-22 at 10 37 28 pm](https://f.cloud.github.com/assets/965298/840144/c0387c18-f368-11e2-8b13-8a7201ffd998.png)

![screen shot 2013-07-22 at 10 36 34 pm](https://f.cloud.github.com/assets/965298/840142/b8306d1e-f368-11e2-9751-277c4040835c.png)
