### PR TITLE
update carousel js docs to reflect leading .glyphicon

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1556,7 +1556,7 @@ $('#myCollapsible').on('hidden.bs.collapse', function () {
 {% endhighlight %}
 <div class="bs-callout bs-callout-info">
   <h4>Glyphicon Alternative</h4>
-  <p>With <a href="/css/#glyphicons">Glyphicons</a> available, you may choose to style the left and right toggle buttons with <code>.glyphicon-chevron-left</code> and <code>.glyphicon-chevron-right</code>.</p>
+  <p>With <a href="/css/#glyphicons">Glyphicons</a> available, you may choose to style the left and right toggle buttons with <code>.glyphicon .glyphicon-chevron-left</code> and <code>.glyphicon .glyphicon-chevron-right</code>.</p>
 </div>
 
             <h3>Optional captions</h3>


### PR DESCRIPTION
https://github.com/twitter/bootstrap/pull/6342 icons section mentions the change to using glyphicon base class. This mentions the leading glyphicon base class next to the carousel example. 
