### PR TITLE
Semantic pull-* utilitie classes 

### DIFF
--- a/_includes/nav-main.html
+++ b/_includes/nav-main.html
@@ -25,7 +25,7 @@
         </li>
       </ul>
       {% if page.layout == "default" %}
-      <ul class="nav navbar-nav pull-right">
+      <ul class="nav navbar-nav pull-direction">
         <li>
           <a href="http://getbootstrap.com/2.3.2/">Looking for Bootstrap 2.3.2?</a>
         </li>

--- a/components.html
+++ b/components.html
@@ -41,9 +41,9 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
 {% endhighlight %}
 
     <h3 id="dropdowns-alignment">Aligning the menus</h3>
-    <p>Add <code>.pull-right</code> to a <code>.dropdown-menu</code> to right align the dropdown menu.</p>
+    <p>Add <code>.pull-direction</code> to a <code>.dropdown-menu</code> to right align the dropdown menu.</p>
 {% highlight html %}
-<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dLabel">
+<ul class="dropdown-menu pull-direction" role="menu" aria-labelledby="dLabel">
   ...
 </ul>
 {% endhighlight %}
@@ -450,7 +450,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
         <div class="btn-group dropup">
           <button type="button" class="btn btn-primary">Right dropup</button>
           <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
-          <ul class="dropdown-menu pull-right">
+          <ul class="dropdown-menu pull-direction">
             <li><a href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
@@ -583,7 +583,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
 
 
     <h3 id="nav-alignment">Component alignment</h3>
-    <p>To align nav links, use the <code>.pull-left</code> or <code>.pull-right</code> utility classes. Both classes will add a CSS float in the specified direction.</p>
+    <p>To align nav links, use the <code>.pull-origin</code> or <code>.pull-direction</code> utility classes. Both classes will add a CSS float in the specified direction.</p>
 
 
     <hr class="bs-docs-separator">
@@ -728,18 +728,18 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
 {% endhighlight %}
 
     <h3 id="navbar-forms">Forms</h3>
-    <p>To properly style and position a form within the navbar, add the appropriate classes as shown below. For a default form, include <code>.navbar-form</code> and either <code>.pull-left</code> or <code>.pull-right</code> to properly align it.</p>
+    <p>To properly style and position a form within the navbar, add the appropriate classes as shown below. For a default form, include <code>.navbar-form</code> and either <code>.pull-origin</code> or <code>.pull-direction</code> to properly align it.</p>
     <div class="bs-example">
 
       <div class="navbar">
-        <form class="navbar-form pull-left">
+        <form class="navbar-form pull-origin">
           <input type="text" style="width: 200px;">
           <button type="submit" class="btn btn-default">Submit</button>
         </form>
       </div>
 
       <div class="navbar">
-        <form class="navbar-form pull-left">
+        <form class="navbar-form pull-origin">
           <select name="" id="" style="width: 200px;">
             <option value="1">1</option>
             <option value="2">2</option>
@@ -751,7 +751,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
       </div>
 
       <div class="navbar">
-        <form class="navbar-form pull-left">
+        <form class="navbar-form pull-origin">
           <input type="text" style="width: 200px;">
           <input type="checkbox">
           <button type="submit" class="btn btn-default">Submit</button>
@@ -759,7 +759,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
       </div>
 
       <div class="navbar">
-        <form class="navbar-form pull-left">
+        <form class="navbar-form pull-origin">
           <input type="text" style="width: 200px;">
           <label class="checkbox-inline">
             <input type="checkbox"> Remember me
@@ -770,7 +770,7 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
 
     </div><!-- /example -->
 {% highlight html %}
-<form class="navbar-form pull-left">
+<form class="navbar-form pull-origin">
   <input type="text" style="width: 200px;">
   <button type="submit" class="btn btn-default">Submit</button>
 </form>
@@ -808,18 +808,18 @@ lead: "Dozens of reusable components built to provide iconography, dropdowns, na
     <div class="bs-example">
       <div class="navbar">
         <a href="#" class="navbar-brand">Brand</a>
-        <p class="navbar-text pull-right">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
+        <p class="navbar-text pull-direction">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
       </div>
     </div>
 {% highlight html %}
 <div class="navbar">
   <a href="#" class="navbar-brand">Brand</a>
-  <p class="navbar-text pull-right">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
+  <p class="navbar-text pull-direction">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
 </div>
 {% endhighlight %}
 
     <h3 id="navbar-component-alignment">Component alignment</h3>
-    <p>Align nav links, forms, buttons, or text, using the <code>.pull-left</code> or <code>.pull-right</code> utility classes. Both classes will add a CSS float in the specified direction. To align nav links, put them in a separate <code>&lt;ul&gt;</code> with the respective utility class applied.</p>
+    <p>Align nav links, forms, buttons, or text, using the <code>.pull-origin</code> or <code>.pull-direction</code> utility classes. Both classes will add a CSS float in the specified direction. To align nav links, put them in a separate <code>&lt;ul&gt;</code> with the respective utility class applied.</p>
 
 
     <h2>Optional display variations</h2>
@@ -933,10 +933,10 @@ body { padding-bottom: 70px; }
                 </ul>
               </li>
             </ul>
-            <form class="navbar-form pull-left" action="">
+            <form class="navbar-form pull-origin" action="">
               <input type="text" class="col-lg-8" placeholder="Search">
             </form>
-            <ul class="nav navbar-nav pull-right">
+            <ul class="nav navbar-nav pull-direction">
               <li><a href="#">Link</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
@@ -1010,10 +1010,10 @@ body { padding-bottom: 70px; }
                 </ul>
               </li>
             </ul>
-            <form class="navbar-form pull-left" action="">
+            <form class="navbar-form pull-origin" action="">
               <input type="text" class="col-lg-8" placeholder="Search">
             </form>
-            <ul class="nav navbar-nav pull-right">
+            <ul class="nav navbar-nav pull-direction">
               <li><a href="#">Link</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
@@ -1309,14 +1309,14 @@ body { padding-bottom: 70px; }
       <ul class="nav nav-pills nav-stacked" style="max-width: 260px;">
         <li class="active">
           <a href="#">
-            <span class="badge pull-right">42</span>
+            <span class="badge pull-direction">42</span>
             Home
           </a>
         </li>
         <li><a href="#">Profile</a></li>
         <li>
           <a href="#">
-            <span class="badge pull-right">3</span>
+            <span class="badge pull-direction">3</span>
             Messages
           </a>
         </li>
@@ -1326,7 +1326,7 @@ body { padding-bottom: 70px; }
 <ul class="nav nav-pills nav-stacked">
   <li class="active">
     <a href="#">
-      <span class="badge pull-right">42</span>
+      <span class="badge pull-direction">42</span>
       Home
     </a>
   </li>
@@ -1711,7 +1711,7 @@ body { padding-bottom: 70px; }
     <p>The default media allow to float a media object (images, video, audio) to the left or right of a content block.</p>
     <div class="bs-example">
       <div class="media">
-        <a class="pull-left" href="#">
+        <a class="pull-origin" href="#">
           <img class="media-object" data-src="holder.js/64x64">
         </a>
         <div class="media-body">
@@ -1720,14 +1720,14 @@ body { padding-bottom: 70px; }
         </div>
       </div>
       <div class="media">
-        <a class="pull-left" href="#">
+        <a class="pull-origin" href="#">
           <img class="media-object" data-src="holder.js/64x64">
         </a>
         <div class="media-body">
           <h4 class="media-heading">Media heading</h4>
           Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
           <div class="media">
-            <a class="pull-left" href="#">
+            <a class="pull-origin" href="#">
               <img class="media-object" data-src="holder.js/64x64">
             </a>
             <div class="media-body">
@@ -1740,7 +1740,7 @@ body { padding-bottom: 70px; }
     </div><!-- /.bs-example -->
 {% highlight html %}
 <div class="media">
-  <a class="pull-left" href="#">
+  <a class="pull-origin" href="#">
     <img class="media-object" src="...">
   </a>
   <div class="media-body">
@@ -1755,7 +1755,7 @@ body { padding-bottom: 70px; }
     <div class="bs-example">
       <ul class="media-list">
         <li class="media">
-          <a class="pull-left" href="#">
+          <a class="pull-origin" href="#">
             <img class="media-object" data-src="holder.js/64x64">
           </a>
           <div class="media-body">
@@ -1763,7 +1763,7 @@ body { padding-bottom: 70px; }
             <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.</p>
             <!-- Nested media object -->
             <div class="media">
-              <a class="pull-left" href="#">
+              <a class="pull-origin" href="#">
                 <img class="media-object" data-src="holder.js/64x64">
               </a>
               <div class="media-body">
@@ -1771,7 +1771,7 @@ body { padding-bottom: 70px; }
                 Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
                 <!-- Nested media object -->
                 <div class="media">
-                  <a class="pull-left" href="#">
+                  <a class="pull-origin" href="#">
                     <img class="media-object" data-src="holder.js/64x64">
                   </a>
                   <div class="media-body">
@@ -1783,7 +1783,7 @@ body { padding-bottom: 70px; }
             </div>
             <!-- Nested media object -->
             <div class="media">
-              <a class="pull-left" href="#">
+              <a class="pull-origin" href="#">
                 <img class="media-object" data-src="holder.js/64x64">
               </a>
               <div class="media-body">
@@ -1794,7 +1794,7 @@ body { padding-bottom: 70px; }
           </div>
         </li>
         <li class="media">
-          <a class="pull-right" href="#">
+          <a class="pull-direction" href="#">
             <img class="media-object" data-src="holder.js/64x64">
           </a>
           <div class="media-body">
@@ -1807,7 +1807,7 @@ body { padding-bottom: 70px; }
 {% highlight html %}
 <ul class="media-list">
   <li class="media">
-    <a class="pull-left" href="#">
+    <a class="pull-origin" href="#">
       <img class="media-object" src="...">
     </a>
     <div class="media-body">

--- a/css.html
+++ b/css.html
@@ -640,15 +640,15 @@ lead: "Global CSS settings, fundamental HTML elements styled and enhanced with e
 {% endhighlight %}
 
     <h4>Alternate displays</h4>
-    <p>Use <code>.pull-right</code> for a floated, right-aligned blockquote.</p>
+    <p>Use <code>.pull-direction</code> for a floated, right-aligned blockquote.</p>
     <div class="bs-example" style="overflow: hidden;">
-      <blockquote class="pull-right">
+      <blockquote class="pull-direction">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
         <small>Someone famous in <cite title="Source Title">Source Title</cite></small>
       </blockquote>
     </div>
 {% highlight html %}
-<blockquote class="pull-right">
+<blockquote class="pull-direction">
   ...
 </blockquote>
 {% endhighlight %}
@@ -2031,24 +2031,24 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 <button type="button" class="close">&times;</button>
 {% endhighlight %}
 
-    <h3>.pull-left</h3>
+    <h3>.pull-origin</h3>
     <p>Float an element left</p>
 {% highlight html %}
-<div class="pull-left">...</div>
+<div class="pull-origin">...</div>
 {% endhighlight %}
 {% highlight css %}
-.pull-left {
+.pull-origin {
   float: left;
 }
 {% endhighlight %}
 
-    <h3>.pull-right</h3>
+    <h3>.pull-direction</h3>
     <p>Float an element right</p>
 {% highlight html %}
-<div class="pull-right">...</div>
+<div class="pull-direction">...</div>
 {% endhighlight %}
 {% highlight css %}
-.pull-right {
+.pull-direction {
   float: right;
 }
 {% endhighlight %}

--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -641,7 +641,7 @@ blockquote small:before {
   content: '\2014 \00A0';
 }
 
-blockquote.pull-right {
+blockquote.pull-direction {
   float: right;
   padding-right: 15px;
   padding-left: 0;
@@ -649,16 +649,16 @@ blockquote.pull-right {
   border-left: 0;
 }
 
-blockquote.pull-right p,
-blockquote.pull-right small {
+blockquote.pull-direction p,
+blockquote.pull-direction small {
   text-align: right;
 }
 
-blockquote.pull-right small:before {
+blockquote.pull-direction small:before {
   content: '';
 }
 
-blockquote.pull-right small:after {
+blockquote.pull-direction small:after {
   content: '\00A0 \2014';
 }
 
@@ -2160,7 +2160,7 @@ input[type="button"].btn-block {
   background-clip: padding-box;
 }
 
-.dropdown-menu.pull-right {
+.dropdown-menu.pull-direction {
   right: 0;
   left: auto;
 }
@@ -2250,7 +2250,7 @@ input[type="button"].btn-block {
   z-index: 990;
 }
 
-.pull-right > .dropdown-menu {
+.pull-direction > .dropdown-menu {
   right: 0;
   left: auto;
 }
@@ -2563,7 +2563,7 @@ button.close {
   border-bottom-color: #fff;
 }
 
-.nav > .pull-right {
+.nav > .pull-direction {
   float: right;
 }
 
@@ -2794,7 +2794,7 @@ button.close {
   background-color: transparent;
 }
 
-.navbar-nav.pull-right {
+.navbar-nav.pull-direction {
   width: 100%;
 }
 
@@ -2924,8 +2924,8 @@ button.close {
   border-bottom-color: #777777;
 }
 
-.navbar-nav.pull-right > li > .dropdown-menu,
-.navbar-nav > li > .dropdown-menu.pull-right {
+.navbar-nav.pull-direction > li > .dropdown-menu,
+.navbar-nav > li > .dropdown-menu.pull-direction {
   right: 0;
   left: auto;
 }
@@ -3026,7 +3026,7 @@ button.close {
   .navbar-nav > li > a {
     border-radius: 0;
   }
-  .navbar-nav.pull-right {
+  .navbar-nav.pull-direction {
     float: right;
     width: auto;
   }
@@ -3963,11 +3963,11 @@ a.thumbnail:focus {
   margin: 0 0 5px;
 }
 
-.media > .pull-left {
+.media > .pull-origin {
   margin-right: 10px;
 }
 
-.media > .pull-right {
+.media > .pull-direction {
   margin-left: 10px;
 }
 
@@ -4472,11 +4472,11 @@ a.list-group-item.active > .badge,
   clear: both;
 }
 
-.pull-right {
+.pull-direction {
   float: right;
 }
 
-.pull-left {
+.pull-origin {
   float: left;
 }
 

--- a/javascript.html
+++ b/javascript.html
@@ -381,7 +381,7 @@ $('#myModal').on('hidden.bs.modal', function () {
                       </ul>
                     </li>
                   </ul>
-                  <ul class="nav navbar-nav pull-right">
+                  <ul class="nav navbar-nav pull-direction">
                     <li id="fat-menu" class="dropdown">
                       <a href="#" id="drop3" role="button" class="dropdown-toggle" data-toggle="dropdown">Dropdown 3 <b class="caret"></b></a>
                       <ul class="dropdown-menu" role="menu" aria-labelledby="drop3">

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -38,7 +38,7 @@
   .background-clip(padding-box);
 
   // Aligns the dropdown menu to right
-  &.pull-right {
+  &.pull-direction {
     right: 0;
     left: auto;
   }
@@ -145,7 +145,7 @@
 
 // Right aligned dropdowns
 // ---------------------------
-.pull-right > .dropdown-menu {
+.pull-direction > .dropdown-menu {
   right: 0;
   left: auto;
 }

--- a/less/media.less
+++ b/less/media.less
@@ -37,10 +37,10 @@
 // -------------------------
 
 .media {
-  > .pull-left {
+  > .pull-origin {
     margin-right: 10px;
   }
-  > .pull-right {
+  > .pull-direction {
     margin-left: 10px;
   }
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -55,7 +55,7 @@
 
   // Right aligned contents
   // Make them full width first so that they align properly on mobile
-  &.pull-right {
+  &.pull-direction {
     width: 100%;
   }
 }
@@ -193,8 +193,8 @@
 }
 
 // Right aligned menus need alt position
-.navbar-nav.pull-right > li > .dropdown-menu,
-.navbar-nav > li > .dropdown-menu.pull-right {
+.navbar-nav.pull-direction > li > .dropdown-menu,
+.navbar-nav > li > .dropdown-menu.pull-direction {
   left: auto;
   right: 0;
 }
@@ -316,7 +316,7 @@
       }
     }
 
-    &.pull-right {
+    &.pull-direction {
       float: right;
       width: auto;
     }

--- a/less/navs.less
+++ b/less/navs.less
@@ -63,7 +63,7 @@
 
   // Redeclare pull classes because of specificity
   // Todo: consider making these utilities !important to avoid this bullshit
-  > .pull-right {
+  > .pull-direction {
     float: right;
   }
 

--- a/less/type.less
+++ b/less/type.less
@@ -197,7 +197,7 @@ blockquote {
   }
 
   // Float right with text-align: right
-  &.pull-right {
+  &.pull-direction {
     float: right;
     padding-right: 15px;
     padding-left: 0;

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -9,10 +9,10 @@
 .clearfix {
   .clearfix();
 }
-.pull-right {
+.pull-direction {
   float: right;
 }
-.pull-left {
+.pull-origin {
   float: left;
 }
 


### PR DESCRIPTION
Currently, adding a pull-right/left class in a RTL layout does not have sens.

You have to do this :

``` css
.rtl {
  .pull-left {
    float: right;
  }
  .pull-right {
    float: left;
  }
}
```

So, by changing -right to -direction and -left by -origin, you don't have this problem

``` css

.pull-origin {
  float: left;
}
.pull-direction {
  float: right;
}
.rtl {
  .pull-origin {
    float: right;
  }
  .pull-direction {
    float: left;
  }
}
```
