### PR TITLE
Navbar toggle is not vertically aligned (3.0.0-wip) with custom navbar height

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -117,7 +117,7 @@
 // Collapsible navbar toggle
 .navbar-toggle {
   position: absolute;
-  top: 10px;
+  top: floor((@navbar-height - 32) / 2);
   right: 10px;
   width: 48px;
   height: 32px;


### PR DESCRIPTION
When using navbars higher than the default one, the navbar-toggle button is not centered.

Fiddle demonstrating this issue (compiled with `@navbar-height: 60px;`): http://jsfiddle.net/tagliala/mRVMe/2/

Another fiddle with the proposed fix: http://jsfiddle.net/tagliala/mRVMe/3/
