### PR TITLE
BS 2.3.3: Bower, Recess, and v3 RC1 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3 (July 26, 2013)
+
+Patch to update jQuery in Bower and bump Recess to 1.1.9
+
 ## 2.3.2 (May 17, 2013)
 - Fix dropdown for firefox (middleclick) and mobile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ Minor release to add carousel indicators, improve tooltips, improve dev setup, a
   - **Added carousel indicators!** Add the HTML and it automagically works.
   - **Added `container` option to tooltips.** The default option is still `insertAfter`, but now you may specify where to insert tooltips (and by extension, popovers) with the optional container parameter.
   - Improved popovers now utilize `max-width` instead of `width`, have been widened from 240px to 280px, and will automatically hide the title if one has not been set via CSS `:empty` selector.
-  - Improved tooltip alignment on edges with [#6713](https://github.com/twitter/bootstrap/pull/6713).
-  - **Improved accessibility for links in all components.** After merging [#6441](https://github.com/twitter/bootstrap/pull/6441), link hover states now apply to the `:focus` state as well. This goes for basic `<a>` tags, as well as buttons, navs, dropdowns, and more.
+  - Improved tooltip alignment on edges with [#6713](https://github.com/twbs/bootstrap/pull/6713).
+  - **Improved accessibility for links in all components.** After merging [#6441](https://github.com/twbs/bootstrap/pull/6441), link hover states now apply to the `:focus` state as well. This goes for basic `<a>` tags, as well as buttons, navs, dropdowns, and more.
   - Added print utility classes to show and hide content between `screen` and `print` via CSS.
   - Updated input groups to make them behave more like default form controls. Added `display: inline-block;`, increased `margin-bottom`, and added `vertical-align: middle;`  to match `<input>` styles.
   - Added `.horizontal-three-colors()` gradient mixin (with example in the CSS tests file).
@@ -34,7 +34,7 @@ Minor release to add carousel indicators, improve tooltips, improve dev setup, a
   - Added [new justified navigation example](https://f.cloud.github.com/assets/98681/25869/5e2f812c-4afa-11e2-9293-501cd689232d.png).
   - Added sticky footer with fixed navbar example.
 
-See more on the [2.3.0 pull request](https://github.com/twitter/bootstrap/pull/6346).
+See more on the [2.3.0 pull request](https://github.com/twbs/bootstrap/pull/6346).
 
 
 ## 2.2.2 (December 8, 2012)
@@ -49,14 +49,14 @@ Bugfix release addressing docs, CSS, and some JavaScript issues. Key changes inc
   - No longer inherits `font-size: 0;` when placed in button groups.
   - Arrows refactored to work in IE8, and use less code.
   - Plugin no longer inserts popover content into a `<p>`, but rather directly into `.popover-content`.
-- **Labels and badges:** Now [automatically collapse](https://github.com/twitter/bootstrap/commit/ead5dbeba5cd7acfa560bfb353f5e7c4f4a19256) if they have no content.
+- **Labels and badges:** Now [automatically collapse](https://github.com/twbs/bootstrap/commit/ead5dbeba5cd7acfa560bfb353f5e7c4f4a19256) if they have no content.
 - **Tables:** Nesting support with `.table-bordered` and `.table-striped` greatly improved.
 - **Typeahead:**
-  - Now [inserts dropdown menu after the input](https://github.com/twitter/bootstrap/commit/1747caf19d59cad7fdc90ae56a00e0e2849f95f4) instead of at the close of the document.
+  - Now [inserts dropdown menu after the input](https://github.com/twbs/bootstrap/commit/1747caf19d59cad7fdc90ae56a00e0e2849f95f4) instead of at the close of the document.
   - Hitting escape will place focus back on the `<input>`.
 - Print styles, from HTML5 Boilerplate, have been added.
 
-See more on the [2.2.2 milestone](https://github.com/twitter/bootstrap/issues?milestone=17&state=closed).
+See more on the [2.2.2 milestone](https://github.com/twbs/bootstrap/issues?milestone=17&state=closed).
 
 
 ## 2.2.1 (October 30, 2012)
@@ -68,7 +68,7 @@ Hotfix release to address the carousel bug reports.
 
 ### tl;dr
 
-2.1.2 is now 2.2.0: four new example templates, added media component, new typographic scale, fixed that box-shadow mixin bug, fixed z-index issues, and [more](https://github.com/twitter/bootstrap/issues?milestone=15&page=1&state=closed).
+2.1.2 is now 2.2.0: four new example templates, added media component, new typographic scale, fixed that box-shadow mixin bug, fixed z-index issues, and [more](https://github.com/twbs/bootstrap/issues?milestone=15&page=1&state=closed).
 
 ### Highlights
 
@@ -86,13 +86,13 @@ Hotfix release to address the carousel bug reports.
 - Miscellaneous variable improvements across the board.
 - Miscellaneous documentation typos fixed.
 
-For the full list of issues included in this release, visit the [2.2.0 milestone on GitHub](https://github.com/twitter/bootstrap/issues?milestone=15&page=1&state=closed)
+For the full list of issues included in this release, visit the [2.2.0 milestone on GitHub](https://github.com/twbs/bootstrap/issues?milestone=15&page=1&state=closed)
 
 
 
 ## 2.1.1 (September 4, 2012)
 
-* New feature: alert text. We documented these new classes, like `.text-success`, at the bottom of the [Typography section](http://twitter.github.com/bootstrap/base-css.html#typography) along with the long undocumented `.muted`.
+* New feature: alert text. We documented these new classes, like `.text-success`, at the bottom of the [Typography section](http://twbs.github.com/bootstrap/base-css.html#typography) along with the long undocumented `.muted`.
 * Fixed a lot of typos in the docs. Spelling is hard.
 * Made the `.box-shadow()` mixin more durable. It no longer requires escaping for multiple shadows, meaning you can easily use variables and functions in them once again.
 * Widened `.dl-horizontal dt` and `.horizontal-form .control-group` to better handle the increased font-size.
@@ -103,7 +103,7 @@ For the full list of issues included in this release, visit the [2.2.0 milestone
 * Fixed the vertical three color gradient in latest Firefox.
 * Reordered some variables that caused errors in certain Less compilers.
 
-View all closed issues on the [2.1.1 milestone](https://github.com/twitter/bootstrap/issues?milestone=14&state=closed).
+View all closed issues on the [2.1.1 milestone](https://github.com/twbs/bootstrap/issues?milestone=14&state=closed).
 
 
 ## 2.1.0 (August 20, 2012)
@@ -123,7 +123,7 @@ View all closed issues on the [2.1.1 milestone](https://github.com/twitter/boots
 * Fluid grid system variables are no longer fixed percentages
 * Removed LESS docs page
 
-For full set of changes, see the completed milestone: https://github.com/twitter/bootstrap/issues?milestone=7&page=1&state=closed
+For full set of changes, see the completed milestone: https://github.com/twbs/bootstrap/issues?milestone=7&page=1&state=closed
 
 ## 2.0.4 (June 1, 2012)
 
@@ -280,7 +280,7 @@ Overview of docs changes, bugfixes, and new features.
 - Added `.disabled` class support to the pager component (also added a mention of this to the docs)
 - Added `.well-large` and `.well-small` classes for extending the well component
 
-For a full issue-by-issue rundown of the release, check out the now closed [2.0.2 milestone on GitHub](https://github.com/twitter/bootstrap/issues?sort=created&direction=desc&state=closed&page=1&milestone=9)
+For a full issue-by-issue rundown of the release, check out the now closed [2.0.2 milestone on GitHub](https://github.com/twbs/bootstrap/issues?sort=created&direction=desc&state=closed&page=1&milestone=9)
 
 ## v2.0.1 (February 17, 2012)
 
@@ -296,10 +296,10 @@ Overview of changes:
 - Rearranged Scaffolding docs page to split fixed and fluid grid systems.
 - Tons of docs updates for typos and language changes.
 
-For full list of changes, see the now closed [v2.0.1 milestone](https://github.com/twitter/bootstrap/issues?milestone=8&state=closed).
+For full list of changes, see the now closed [v2.0.1 milestone](https://github.com/twbs/bootstrap/issues?milestone=8&state=closed).
 
 ## v2.0.0 (January 28, 2012)
-Complete rewrite of the library. For full details, head to the upgrading doc at http://twitter.github.com/bootstrap/upgrading.html.
+Complete rewrite of the library. For full details, head to the upgrading doc at http://twbs.github.com/bootstrap/upgrading.html.
 
 ## v1.4.0
 ### Key bug fixes and changes
@@ -308,7 +308,7 @@ Complete rewrite of the library. For full details, head to the upgrading doc at 
 - New javascript plugin for button states
 - Switched to strict mode for Javascript plugins
 - Added more data attribute controls to our plugins
-- Full list of 25+ issues fixed: https://github.com/twitter/bootstrap/issues?milestone=6&state=closed
+- Full list of 25+ issues fixed: https://github.com/twbs/bootstrap/issues?milestone=6&state=closed
 
 ## v1.3.0
 ### New features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,4 +72,4 @@ As of v2.0.0, Bootstrap's documentation is powered by Mustache templates and bui
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/twitter/bootstrap/blob/master/LICENSE
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/twbs/bootstrap/blob/master/LICENSE

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 	@echo "Compiling documentation...                  ${CHECK} Done"
 	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
 	@./node_modules/.bin/uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
-	@echo "/**\n* Bootstrap.js v2.3.2 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
+	@echo "/**\n* Bootstrap.js v2.3.2 by @fat & @mdo\n* Copyright 2013 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
 	@echo "Compiling and minifying javascript...       ${CHECK} Done"
@@ -74,7 +74,7 @@ bootstrap/js/*.js: js/*.js
 	mkdir -p bootstrap/js
 	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
 	./node_modules/.bin/uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
-	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
+	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2013 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
 	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
 	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 	@echo "Compiling documentation...                  ${CHECK} Done"
 	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
 	@./node_modules/.bin/uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
-	@echo "/**\n* Bootstrap.js v2.3.2 by @fat & @mdo\n* Copyright 2013 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
+	@echo "/**\n* Bootstrap.js v2.3.3 by @fat & @mdo\n* Copyright 2013 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
 	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
 	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
 	@echo "Compiling and minifying javascript...       ${CHECK} Done"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Bootstrap v2.3.2](http://twitter.github.com/bootstrap) [![Build Status](https://secure.travis-ci.org/twitter/bootstrap.png)](http://travis-ci.org/twitter/bootstrap)
+# [Bootstrap v2.3.2](http://twbs.github.com/bootstrap) [![Build Status](https://secure.travis-ci.org/twbs/bootstrap.png)](http://travis-ci.org/twbs/bootstrap)
 
 Bootstrap is a sleek, intuitive, and powerful front-end framework for faster and easier web development, created and maintained by [Mark Otto](http://twitter.com/mdo) and [Jacob Thornton](http://twitter.com/fat).
 
@@ -10,8 +10,8 @@ To get started, checkout [http://getbootstrap.com](http://getbootstrap.com)!
 
 Three quick start options are available:
 
-* [Download the latest release](https://github.com/twitter/bootstrap/zipball/master).
-* Clone the repo: `git clone git://github.com/twitter/bootstrap.git`.
+* [Download the latest release](https://github.com/twbs/bootstrap/zipball/master).
+* Clone the repo: `git clone git://github.com/twbs/bootstrap.git`.
 * Install with Twitter's [Bower](http://bower.io): `bower install bootstrap`.
 
 
@@ -36,7 +36,7 @@ For more information on SemVer, please visit [http://semver.org/](http://semver.
 
 ## Bug tracker
 
-Have a bug or a feature request? [Please open a new issue](https://github.com/twitter/bootstrap/issues). Before opening any issue, please search for existing issues and read the [Issue Guidelines](https://github.com/necolas/issue-guidelines), written by [Nicolas Gallagher](https://github.com/necolas/).
+Have a bug or a feature request? [Please open a new issue](https://github.com/twbs/bootstrap/issues). Before opening any issue, please search for existing issues and read the [Issue Guidelines](https://github.com/necolas/issue-guidelines), written by [Nicolas Gallagher](https://github.com/necolas/).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Bootstrap v2.3.2](http://twbs.github.com/bootstrap) [![Build Status](https://secure.travis-ci.org/twbs/bootstrap.png)](http://travis-ci.org/twbs/bootstrap)
+# [Bootstrap v2.3.3](http://twbs.github.com/bootstrap) [![Build Status](https://secure.travis-ci.org/twbs/bootstrap.png)](http://travis-ci.org/twbs/bootstrap)
 
 Bootstrap is a sleek, intuitive, and powerful front-end framework for faster and easier web development, created and maintained by [Mark Otto](http://twitter.com/mdo) and [Jacob Thornton](http://twitter.com/fat).
 

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "2.3.2",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": ">=1.8.0 <2.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
   "dependencies": {
     "jquery": ">=1.8.0 <2.1.0"

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "twitter/bootstrap"
+    "name": "twbs/bootstrap"
   , "description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development."
   , "keywords": ["bootstrap", "css"]
-  , "homepage": "http://twitter.github.com/bootstrap/"
+  , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."
   , "license": "Apache-2.0"
 

--- a/docs/assets/css/bootstrap-responsive.css
+++ b/docs/assets/css/bootstrap-responsive.css
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap Responsive v2.3.2
+ * Bootstrap Responsive v2.3.3
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/docs/assets/css/bootstrap.css
+++ b/docs/assets/css/bootstrap.css
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap v2.3.2
+ * Bootstrap v2.3.3
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/docs/assets/js/bootstrap-affix.js
+++ b/docs/assets/js/bootstrap-affix.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-affix.js v2.3.2
+ * bootstrap-affix.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-affix.js
+++ b/docs/assets/js/bootstrap-affix.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#affix
+ * http://twbs.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-alert.js
+++ b/docs/assets/js/bootstrap-alert.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-alert.js v2.3.2
+ * bootstrap-alert.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-alert.js
+++ b/docs/assets/js/bootstrap-alert.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * http://twbs.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-button.js
+++ b/docs/assets/js/bootstrap-button.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#buttons
+ * http://twbs.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-button.js
+++ b/docs/assets/js/bootstrap-button.js
@@ -1,5 +1,5 @@
 /* ============================================================
- * bootstrap-button.js v2.3.2
+ * bootstrap-button.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#carousel
+ * http://twbs.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-carousel.js
+++ b/docs/assets/js/bootstrap-carousel.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-carousel.js v2.3.2
+ * bootstrap-carousel.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-collapse.js
+++ b/docs/assets/js/bootstrap-collapse.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-collapse.js v2.3.2
+ * bootstrap-collapse.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-collapse.js
+++ b/docs/assets/js/bootstrap-collapse.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#collapse
+ * http://twbs.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-dropdown.js
+++ b/docs/assets/js/bootstrap-dropdown.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#dropdowns
+ * http://twbs.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-dropdown.js
+++ b/docs/assets/js/bootstrap-dropdown.js
@@ -1,5 +1,5 @@
 /* ============================================================
- * bootstrap-dropdown.js v2.3.2
+ * bootstrap-dropdown.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-modal.js
+++ b/docs/assets/js/bootstrap-modal.js
@@ -1,6 +1,6 @@
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#modals
+ * http://twbs.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-modal.js
+++ b/docs/assets/js/bootstrap-modal.js
@@ -1,5 +1,5 @@
 /* =========================================================
- * bootstrap-modal.js v2.3.2
+ * bootstrap-modal.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-popover.js
+++ b/docs/assets/js/bootstrap-popover.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * bootstrap-popover.js v2.3.2
+ * bootstrap-popover.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-popover.js
+++ b/docs/assets/js/bootstrap-popover.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#popovers
+ * http://twbs.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-scrollspy.js
+++ b/docs/assets/js/bootstrap-scrollspy.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
+ * http://twbs.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-scrollspy.js
+++ b/docs/assets/js/bootstrap-scrollspy.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-scrollspy.js v2.3.2
+ * bootstrap-scrollspy.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-tab.js
+++ b/docs/assets/js/bootstrap-tab.js
@@ -1,5 +1,5 @@
 /* ========================================================
- * bootstrap-tab.js v2.3.2
+ * bootstrap-tab.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-tab.js
+++ b/docs/assets/js/bootstrap-tab.js
@@ -1,6 +1,6 @@
 /* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * http://twbs.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-tooltip.js
+++ b/docs/assets/js/bootstrap-tooltip.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * bootstrap-tooltip.js v2.3.2
+ * bootstrap-tooltip.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================

--- a/docs/assets/js/bootstrap-tooltip.js
+++ b/docs/assets/js/bootstrap-tooltip.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tooltips
+ * http://twbs.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-transition.js
+++ b/docs/assets/js/bootstrap-transition.js
@@ -1,5 +1,5 @@
 /* ===================================================
- * bootstrap-transition.js v2.3.2
+ * bootstrap-transition.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap-transition.js
+++ b/docs/assets/js/bootstrap-transition.js
@@ -1,6 +1,6 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#transitions
+ * http://twbs.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * http://twbs.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap-typeahead.js
+++ b/docs/assets/js/bootstrap-typeahead.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-typeahead.js v2.3.2
+ * bootstrap-typeahead.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap.js
+++ b/docs/assets/js/bootstrap.js
@@ -1,5 +1,5 @@
 /* ===================================================
- * bootstrap-transition.js v2.3.2
+ * bootstrap-transition.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
@@ -58,7 +58,7 @@
   })
 
 }(window.jQuery);/* ==========================================================
- * bootstrap-alert.js v2.3.2
+ * bootstrap-alert.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
@@ -156,7 +156,7 @@
   $(document).on('click.alert.data-api', dismiss, Alert.prototype.close)
 
 }(window.jQuery);/* ============================================================
- * bootstrap-button.js v2.3.2
+ * bootstrap-button.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
@@ -260,7 +260,7 @@
   })
 
 }(window.jQuery);/* ==========================================================
- * bootstrap-carousel.js v2.3.2
+ * bootstrap-carousel.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
@@ -466,7 +466,7 @@
   })
 
 }(window.jQuery);/* =============================================================
- * bootstrap-collapse.js v2.3.2
+ * bootstrap-collapse.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
@@ -632,7 +632,7 @@
   })
 
 }(window.jQuery);/* ============================================================
- * bootstrap-dropdown.js v2.3.2
+ * bootstrap-dropdown.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
@@ -801,7 +801,7 @@
 
 }(window.jQuery);
 /* =========================================================
- * bootstrap-modal.js v2.3.2
+ * bootstrap-modal.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
@@ -1048,7 +1048,7 @@
 
 }(window.jQuery);
 /* ===========================================================
- * bootstrap-tooltip.js v2.3.2
+ * bootstrap-tooltip.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
@@ -1409,7 +1409,7 @@
 
 }(window.jQuery);
 /* ===========================================================
- * bootstrap-popover.js v2.3.2
+ * bootstrap-popover.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
@@ -1523,7 +1523,7 @@
 
 }(window.jQuery);
 /* =============================================================
- * bootstrap-scrollspy.js v2.3.2
+ * bootstrap-scrollspy.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
@@ -1684,7 +1684,7 @@
   })
 
 }(window.jQuery);/* ========================================================
- * bootstrap-tab.js v2.3.2
+ * bootstrap-tab.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
@@ -1827,7 +1827,7 @@
   })
 
 }(window.jQuery);/* =============================================================
- * bootstrap-typeahead.js v2.3.2
+ * bootstrap-typeahead.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
@@ -2162,7 +2162,7 @@
 
 }(window.jQuery);
 /* ==========================================================
- * bootstrap-affix.js v2.3.2
+ * bootstrap-affix.js v2.3.3
  * http://twbs.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.

--- a/docs/assets/js/bootstrap.js
+++ b/docs/assets/js/bootstrap.js
@@ -1,6 +1,6 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#transitions
+ * http://twbs.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -59,7 +59,7 @@
 
 }(window.jQuery);/* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * http://twbs.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -157,7 +157,7 @@
 
 }(window.jQuery);/* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#buttons
+ * http://twbs.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -261,7 +261,7 @@
 
 }(window.jQuery);/* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#carousel
+ * http://twbs.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -467,7 +467,7 @@
 
 }(window.jQuery);/* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#collapse
+ * http://twbs.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -633,7 +633,7 @@
 
 }(window.jQuery);/* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#dropdowns
+ * http://twbs.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -802,7 +802,7 @@
 }(window.jQuery);
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#modals
+ * http://twbs.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1049,7 +1049,7 @@
 }(window.jQuery);
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tooltips
+ * http://twbs.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
@@ -1410,7 +1410,7 @@
 }(window.jQuery);
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#popovers
+ * http://twbs.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1524,7 +1524,7 @@
 }(window.jQuery);
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
+ * http://twbs.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1685,7 +1685,7 @@
 
 }(window.jQuery);/* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * http://twbs.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -1828,7 +1828,7 @@
 
 }(window.jQuery);/* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * http://twbs.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *
@@ -2163,7 +2163,7 @@
 }(window.jQuery);
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#affix
+ * http://twbs.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/docs/assets/js/bootstrap.min.js
+++ b/docs/assets/js/bootstrap.min.js
@@ -1,5 +1,5 @@
 /**
-* Bootstrap.js v2.3.2 by @fat & @mdo
+* Bootstrap.js v2.3.3 by @fat & @mdo
 * Copyright 2012 Twitter, Inc.
 * http://www.apache.org/licenses/LICENSE-2.0.txt
 */

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -2186,9 +2186,9 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/base-css.html
+++ b/docs/base-css.html
@@ -2188,7 +2188,7 @@ For example, &lt;code&gt;&amp;lt;section&amp;gt;&lt;/code&gt; should be wrapped 
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/components.html
+++ b/docs/components.html
@@ -2599,7 +2599,7 @@ class="clearfix"
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/components.html
+++ b/docs/components.html
@@ -2597,9 +2597,9 @@ class="clearfix"
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/customize.html
+++ b/docs/customize.html
@@ -84,7 +84,7 @@
 <header class="jumbotron subhead" id="overview">
   <div class="container">
     <h1>Customize and download</h1>
-    <p class="lead"><a href="https://github.com/twitter/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.</p>
+    <p class="lead"><a href="https://github.com/twbs/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.</p>
   </div>
 </header>
 
@@ -485,9 +485,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/customize.html
+++ b/docs/customize.html
@@ -84,7 +84,7 @@
 <header class="jumbotron subhead" id="overview">
   <div class="container">
     <h1>Customize and download</h1>
-    <p class="lead"><a href="https://github.com/twbs/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.</p>
+    <p class="lead"><a href="https://github.com/twitter/bootstrap/archive/v2.3.3.zip">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.</p>
   </div>
 </header>
 
@@ -487,7 +487,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/examples/carousel.html
+++ b/docs/examples/carousel.html
@@ -291,7 +291,7 @@
                 <li class="active"><a href="#">Home</a></li>
                 <li><a href="#about">About</a></li>
                 <li><a href="#contact">Contact</a></li>
-                <!-- Read about Bootstrap dropdowns at http://twitter.github.com/bootstrap/javascript.html#dropdowns -->
+                <!-- Read about Bootstrap dropdowns at http://twbs.github.com/bootstrap/javascript.html#dropdowns -->
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
                   <ul class="dropdown-menu">

--- a/docs/extend.html
+++ b/docs/extend.html
@@ -147,7 +147,7 @@
           <h2>Tools for compiling</h2>
 
           <h3>Command line</h3>
-          <p>Follow <a href="https://github.com/twitter/bootstrap#developers">the instructions in the project readme</a> on GitHub for compiling via command line.</p>
+          <p>Follow <a href="https://github.com/twbs/bootstrap#developers">the instructions in the project readme</a> on GitHub for compiling via command line.</p>
 
           <h3>JavaScript</h3>
           <p><a href="http://lesscss.org/">Download the latest Less.js</a> and include the path to it (and Bootstrap) in the <code>&lt;head&gt;</code>.</p>
@@ -253,9 +253,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/extend.html
+++ b/docs/extend.html
@@ -255,7 +255,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -125,7 +125,7 @@
             <div class="span6">
               <h2>Download source</h2>
               <p>Get the original files for all CSS and JavaScript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
-              <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);">Download Bootstrap source</a></p>
+              <p><a class="btn btn-large" href="https://github.com/twbs/bootstrap/zipball/master" >Download Bootstrap source</a></p>
             </div>
           </div>
         </section>
@@ -167,13 +167,13 @@
           <p class="lead">Bootstrap comes equipped with HTML, CSS, and JS for all sorts of things, but they can be summarized with a handful of categories visible at the top of the <a href="http://getbootstrap.com">Bootstrap documentation</a>.</p>
 
           <h2>Docs sections</h2>
-          <h4><a href="http://twitter.github.com/bootstrap/scaffolding.html">Scaffolding</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/scaffolding.html">Scaffolding</a></h4>
           <p>Global styles for the body to reset type and background, link styles, grid system, and two simple layouts.</p>
-          <h4><a href="http://twitter.github.com/bootstrap/base-css.html">Base CSS</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/base-css.html">Base CSS</a></h4>
           <p>Styles for common HTML elements like typography, code, tables, forms, and buttons. Also includes <a href="http://glyphicons.com">Glyphicons</a>, a great little icon set.</p>
-          <h4><a href="http://twitter.github.com/bootstrap/components.html">Components</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/components.html">Components</a></h4>
           <p>Basic styles for common interface components like tabs and pills, navbar, alerts, page headers, and more.</p>
-          <h4><a href="http://twitter.github.com/bootstrap/javascript.html">JavaScript plugins</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/javascript.html">JavaScript plugins</a></h4>
           <p>Similar to Components, these JavaScript plugins are interactive components for things like tooltips, popovers, modals, and more.</p>
 
           <h2>List of components</h2>
@@ -348,9 +348,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -350,7 +350,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
     <h1>Bootstrap</h1>
     <p>Sleek, intuitive, and powerful front-end framework for faster and easier web development.</p>
     <p>
-      <a href="assets/bootstrap.zip" class="btn btn-primary btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.2']);">Download Bootstrap</a>
+      <a href="assets/bootstrap.zip" class="btn btn-primary btn-large" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.3']);">Download Bootstrap</a>
     </p>
     <ul class="masthead-links">
       <li>
@@ -97,7 +97,7 @@
         <a href="./extend.html" onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Extend']);">Extend</a>
       </li>
       <li>
-        Version 2.3.2
+        Version 2.3.3
       </li>
     </ul>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,16 +107,16 @@
   <div class="container">
     <ul class="bs-docs-social-buttons">
       <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
       </li>
       <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
       </li>
       <li class="follow-btn">
         <a href="https://twitter.com/twbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @twbootstrap</a>
       </li>
       <li class="tweet-btn">
-        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twitter.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twbs.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
       </li>
     </ul>
   </div>
@@ -192,9 +192,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -194,7 +194,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1238,7 +1238,7 @@ $('#my-alert').bind('closed', function () {
             <pre class="prettyprint linenums">&lt;button type="button" class="btn" data-loading-text="loading stuff..." &gt;...&lt;/button&gt;</pre>
             <div class="alert alert-info">
               <strong>Heads up!</strong>
-              <a href="https://github.com/twitter/bootstrap/issues/793">Firefox persists the disabled state across page loads</a>. A workaround for this is to use <code>autocomplete="off"</code>.
+              <a href="https://github.com/twbs/bootstrap/issues/793">Firefox persists the disabled state across page loads</a>. A workaround for this is to use <code>autocomplete="off"</code>.
             </div>
             <h4>$().button('reset')</h4>
             <p>Resets button state - swaps text to original text.</p>
@@ -1751,9 +1751,9 @@ $('.carousel').carousel({
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -448,7 +448,7 @@ $('#myModal').on('hidden', function () {
                 </div>
               </div>
             </div> <!-- /navbar-example -->
-          </div> 
+          </div>
 
           <h3>Within tabs</h3>
           <div class="bs-docs-example">
@@ -485,7 +485,7 @@ $('#myModal').on('hidden', function () {
                 </ul>
               </li>
             </ul> <!-- /tabs -->
-          </div> 
+          </div>
 
 
           <hr class="bs-docs-separator">
@@ -1753,7 +1753,7 @@ $('.carousel').carousel({
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -573,9 +573,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Blog</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/scaffolding.html
+++ b/docs/scaffolding.html
@@ -575,7 +575,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Issues</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">Changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/templates/layout.mustache
+++ b/docs/templates/layout.mustache
@@ -95,9 +95,9 @@
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">{{_i}}Blog{{/i}}</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">{{_i}}Issues{{/i}}</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">{{_i}}Issues{{/i}}</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twitter/bootstrap/blob/master/CHANGELOG.md">{{_i}}Changelog{{/i}}</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">{{_i}}Changelog{{/i}}</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/templates/layout.mustache
+++ b/docs/templates/layout.mustache
@@ -97,7 +97,7 @@
           <li class="muted">&middot;</li>
           <li><a href="https://github.com/twbs/bootstrap/issues?state=open">{{_i}}Issues{{/i}}</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md">{{_i}}Changelog{{/i}}</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/releases">{{_i}}Changelog{{/i}}</a></li>
         </ul>
       </div>
     </footer>

--- a/docs/templates/pages/customize.mustache
+++ b/docs/templates/pages/customize.mustache
@@ -3,7 +3,7 @@
 <header class="jumbotron subhead" id="overview">
   <div class="container">
     <h1>{{_i}}Customize and download{{/i}}</h1>
-    <p class="lead">{{_i}}<a href="https://github.com/twitter/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.{{/i}}</p>
+    <p class="lead">{{_i}}<a href="https://github.com/twbs/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.{{/i}}</p>
   </div>
 </header>
 

--- a/docs/templates/pages/customize.mustache
+++ b/docs/templates/pages/customize.mustache
@@ -3,7 +3,7 @@
 <header class="jumbotron subhead" id="overview">
   <div class="container">
     <h1>{{_i}}Customize and download{{/i}}</h1>
-    <p class="lead">{{_i}}<a href="https://github.com/twbs/bootstrap/zipball/master">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.{{/i}}</p>
+    <p class="lead">{{_i}}<a href="https://github.com/twbs/bootstrap/archive/v2.3.3.zip">Download Bootstrap</a> or customize variables, components, JavaScript plugins, and more.{{/i}}</p>
   </div>
 </header>
 

--- a/docs/templates/pages/extend.mustache
+++ b/docs/templates/pages/extend.mustache
@@ -66,7 +66,7 @@
           <h2>{{_i}}Tools for compiling{{/i}}</h2>
 
           <h3>{{_i}}Command line{{/i}}</h3>
-          <p>{{_i}}Follow <a href="https://github.com/twitter/bootstrap#developers">the instructions in the project readme</a> on GitHub for compiling via command line.{{/i}}</p>
+          <p>{{_i}}Follow <a href="https://github.com/twbs/bootstrap#developers">the instructions in the project readme</a> on GitHub for compiling via command line.{{/i}}</p>
 
           <h3>{{_i}}JavaScript{{/i}}</h3>
           <p>{{_i}}<a href="http://lesscss.org/">Download the latest Less.js</a> and include the path to it (and Bootstrap) in the <code>&lt;head&gt;</code>.{{/i}}</p>

--- a/docs/templates/pages/getting-started.mustache
+++ b/docs/templates/pages/getting-started.mustache
@@ -44,7 +44,7 @@
             <div class="span6">
               <h2>Download source</h2>
               <p>Get the original files for all CSS and JavaScript, along with a local copy of the docs by downloading the latest version directly from GitHub.</p>
-              <p><a class="btn btn-large" href="https://github.com/twitter/bootstrap/zipball/master" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);"{{/production}}>{{_i}}Download Bootstrap source{{/i}}</a></p>
+              <p><a class="btn btn-large" href="https://github.com/twbs/bootstrap/zipball/master" {{#production}}onclick="_gaq.push(['_trackEvent', 'Getting started', 'Download', 'Download source']);"{{/production}}>{{_i}}Download Bootstrap source{{/i}}</a></p>
             </div>
           </div>
         </section>
@@ -86,13 +86,13 @@
           <p class="lead">{{_i}}Bootstrap comes equipped with HTML, CSS, and JS for all sorts of things, but they can be summarized with a handful of categories visible at the top of the <a href="http://getbootstrap.com">Bootstrap documentation</a>.{{/i}}</p>
 
           <h2>{{_i}}Docs sections{{/i}}</h2>
-          <h4><a href="http://twitter.github.com/bootstrap/scaffolding.html">{{_i}}Scaffolding{{/i}}</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/scaffolding.html">{{_i}}Scaffolding{{/i}}</a></h4>
           <p>{{_i}}Global styles for the body to reset type and background, link styles, grid system, and two simple layouts.{{/i}}</p>
-          <h4><a href="http://twitter.github.com/bootstrap/base-css.html">{{_i}}Base CSS{{/i}}</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/base-css.html">{{_i}}Base CSS{{/i}}</a></h4>
           <p>{{_i}}Styles for common HTML elements like typography, code, tables, forms, and buttons. Also includes <a href="http://glyphicons.com">Glyphicons</a>, a great little icon set.{{/i}}</p>
-          <h4><a href="http://twitter.github.com/bootstrap/components.html">{{_i}}Components{{/i}}</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/components.html">{{_i}}Components{{/i}}</a></h4>
           <p>{{_i}}Basic styles for common interface components like tabs and pills, navbar, alerts, page headers, and more.{{/i}}</p>
-          <h4><a href="http://twitter.github.com/bootstrap/javascript.html">{{_i}}JavaScript plugins{{/i}}</a></h4>
+          <h4><a href="http://twbs.github.com/bootstrap/javascript.html">{{_i}}JavaScript plugins{{/i}}</a></h4>
           <p>{{_i}}Similar to Components, these JavaScript plugins are interactive components for things like tooltips, popovers, modals, and more.{{/i}}</p>
 
           <h2>{{_i}}List of components{{/i}}</h2>

--- a/docs/templates/pages/index.mustache
+++ b/docs/templates/pages/index.mustache
@@ -3,7 +3,7 @@
     <h1>{{_i}}Bootstrap{{/i}}</h1>
     <p>{{_i}}Sleek, intuitive, and powerful front-end framework for faster and easier web development.{{/i}}</p>
     <p>
-      <a href="assets/bootstrap.zip" class="btn btn-primary btn-large" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.3']);"{{/production}}>{{_i}}Download Bootstrap{{/i}}</a>
+      <a href="https://github.com/twbs/bootstrap/archive/v2.3.3.zip" class="btn btn-primary btn-large" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.3']);"{{/production}}>{{_i}}Download Bootstrap{{/i}}</a>
     </p>
     <ul class="masthead-links">
       <li>
@@ -35,7 +35,7 @@
         <a href="https://twitter.com/twbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">{{_i}}Follow @twbootstrap{{/i}}</a>
       </li>
       <li class="tweet-btn">
-        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twbs.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://getbootstrap.com" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Bootstrap">Tweet</a>
       </li>
     </ul>
   </div>

--- a/docs/templates/pages/index.mustache
+++ b/docs/templates/pages/index.mustache
@@ -3,7 +3,7 @@
     <h1>{{_i}}Bootstrap{{/i}}</h1>
     <p>{{_i}}Sleek, intuitive, and powerful front-end framework for faster and easier web development.{{/i}}</p>
     <p>
-      <a href="assets/bootstrap.zip" class="btn btn-primary btn-large" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.2']);"{{/production}}>{{_i}}Download Bootstrap{{/i}}</a>
+      <a href="assets/bootstrap.zip" class="btn btn-primary btn-large" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Download', 'Download 2.3.3']);"{{/production}}>{{_i}}Download Bootstrap{{/i}}</a>
     </p>
     <ul class="masthead-links">
       <li>
@@ -16,7 +16,7 @@
         <a href="./extend.html" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Extend']);"{{/production}}>{{_i}}Extend{{/i}}</a>
       </li>
       <li>
-        {{_i}}Version 2.3.2{{/i}}
+        {{_i}}Version 2.3.3{{/i}}
       </li>
     </ul>
   </div>

--- a/docs/templates/pages/index.mustache
+++ b/docs/templates/pages/index.mustache
@@ -7,7 +7,7 @@
     </p>
     <ul class="masthead-links">
       <li>
-        <a href="http://github.com/twitter/bootstrap" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);"{{/production}}>{{_i}}GitHub project{{/i}}</a>
+        <a href="http://github.com/twbs/bootstrap" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);"{{/production}}>{{_i}}GitHub project{{/i}}</a>
       </li>
       <li>
         <a href="./getting-started.html#examples" {{#production}}onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Examples']);"{{/production}}>{{_i}}Examples{{/i}}</a>
@@ -26,16 +26,16 @@
   <div class="container">
     <ul class="bs-docs-social-buttons">
       <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
       </li>
       <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&repo=bootstrap&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
       </li>
       <li class="follow-btn">
         <a href="https://twitter.com/twbootstrap" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">{{_i}}Follow @twbootstrap{{/i}}</a>
       </li>
       <li class="tweet-btn">
-        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twitter.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://twbs.github.com/bootstrap/" data-count="horizontal" data-via="twbootstrap" data-related="mdo:Creator of Twitter Bootstrap">Tweet</a>
       </li>
     </ul>
   </div>

--- a/docs/templates/pages/javascript.mustache
+++ b/docs/templates/pages/javascript.mustache
@@ -1158,7 +1158,7 @@ $('#my-alert').bind('closed', function () {
             <pre class="prettyprint linenums">&lt;button type="button" class="btn" data-loading-text="loading stuff..." &gt;...&lt;/button&gt;</pre>
             <div class="alert alert-info">
               <strong>{{_i}}Heads up!{{/i}}</strong>
-              {{_i}}<a href="https://github.com/twitter/bootstrap/issues/793">Firefox persists the disabled state across page loads</a>. A workaround for this is to use <code>autocomplete="off"</code>.{{/i}}
+              {{_i}}<a href="https://github.com/twbs/bootstrap/issues/793">Firefox persists the disabled state across page loads</a>. A workaround for this is to use <code>autocomplete="off"</code>.{{/i}}
             </div>
             <h4>$().button('reset')</h4>
             <p>{{_i}}Resets button state - swaps text to original text.{{/i}}</p>

--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -1,8 +1,8 @@
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#affix
+ * http://getbootstrap.com/2.3.3/javascript.html#affix
  * ==========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#affix
+ * http://twbs.github.com/bootstrap/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-affix.js
+++ b/js/bootstrap-affix.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-affix.js v2.3.2
+ * bootstrap-affix.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#affix
  * ==========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -1,8 +1,8 @@
 /* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#alerts
+ * http://getbootstrap.com/2.3.3/javascript.html#alerts
  * ==========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * http://twbs.github.com/bootstrap/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-alert.js
+++ b/js/bootstrap-alert.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-alert.js v2.3.2
+ * bootstrap-alert.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#alerts
  * ==========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -1,8 +1,8 @@
 /* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#buttons
+ * http://getbootstrap.com/2.3.3/javascript.html#buttons
  * ============================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#buttons
+ * http://twbs.github.com/bootstrap/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-button.js
+++ b/js/bootstrap-button.js
@@ -1,5 +1,5 @@
 /* ============================================================
- * bootstrap-button.js v2.3.2
+ * bootstrap-button.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#buttons
  * ============================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#carousel
+ * http://twbs.github.com/bootstrap/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -1,5 +1,5 @@
 /* ==========================================================
- * bootstrap-carousel.js v2.3.2
+ * bootstrap-carousel.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#carousel
  * ==========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -1,8 +1,8 @@
 /* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#carousel
+ * http://getbootstrap.com/2.3.3/javascript.html#carousel
  * ==========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#collapse
+ * http://twbs.github.com/bootstrap/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -1,8 +1,8 @@
 /* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#collapse
+ * http://getbootstrap.com/2.3.3/javascript.html#collapse
  * =============================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-collapse.js
+++ b/js/bootstrap-collapse.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-collapse.js v2.3.2
+ * bootstrap-collapse.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#collapse
  * =============================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -1,5 +1,5 @@
 /* ============================================================
- * bootstrap-dropdown.js v2.3.2
+ * bootstrap-dropdown.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#dropdowns
  * ============================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#dropdowns
+ * http://twbs.github.com/bootstrap/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -1,8 +1,8 @@
 /* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#dropdowns
+ * http://getbootstrap.com/2.3.3/javascript.html#dropdowns
  * ============================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -1,6 +1,6 @@
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#modals
+ * http://twbs.github.com/bootstrap/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -1,5 +1,5 @@
 /* =========================================================
- * bootstrap-modal.js v2.3.2
+ * bootstrap-modal.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#modals
  * =========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-modal.js
+++ b/js/bootstrap-modal.js
@@ -1,8 +1,8 @@
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#modals
+ * http://getbootstrap.com/2.3.3/javascript.html#modals
  * =========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -1,8 +1,8 @@
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#popovers
+ * http://getbootstrap.com/2.3.3/javascript.html#popovers
  * ===========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * bootstrap-popover.js v2.3.2
+ * bootstrap-popover.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#popovers
  * ===========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-popover.js
+++ b/js/bootstrap-popover.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#popovers
+ * http://twbs.github.com/bootstrap/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -1,8 +1,8 @@
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#scrollspy
+ * http://getbootstrap.com/2.3.3/javascript.html#scrollspy
  * =============================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-scrollspy.js v2.3.2
+ * bootstrap-scrollspy.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#scrollspy
  * =============================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-scrollspy.js
+++ b/js/bootstrap-scrollspy.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
+ * http://twbs.github.com/bootstrap/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -1,5 +1,5 @@
 /* ========================================================
- * bootstrap-tab.js v2.3.2
+ * bootstrap-tab.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#tabs
  * ========================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -1,8 +1,8 @@
 /* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#tabs
+ * http://getbootstrap.com/2.3.3/javascript.html#tabs
  * ========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-tab.js
+++ b/js/bootstrap-tab.js
@@ -1,6 +1,6 @@
 /* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * http://twbs.github.com/bootstrap/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * bootstrap-tooltip.js v2.3.2
+ * bootstrap-tooltip.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tooltips
+ * http://twbs.github.com/bootstrap/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
  * Copyright 2012 Twitter, Inc.

--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -1,9 +1,9 @@
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#tooltips
+ * http://getbootstrap.com/2.3.3/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -1,8 +1,8 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#transitions
+ * http://getbootstrap.com/2.3.3/javascript.html#transitions
  * ===================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -1,6 +1,6 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#transitions
+ * http://twbs.github.com/bootstrap/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-transition.js
+++ b/js/bootstrap-transition.js
@@ -1,5 +1,5 @@
 /* ===================================================
- * bootstrap-transition.js v2.3.2
+ * bootstrap-transition.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#transitions
  * ===================================================
  * Copyright 2013 Twitter, Inc.

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * http://twbs.github.com/bootstrap/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -1,8 +1,8 @@
 /* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twbs.github.com/bootstrap/javascript.html#typeahead
+ * http://getbootstrap.com/2.3.3/javascript.html#typeahead
  * =============================================================
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2013 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -1,5 +1,5 @@
 /* =============================================================
- * bootstrap-typeahead.js v2.3.2
+ * bootstrap-typeahead.js v2.3.3
  * http://getbootstrap.com/2.3.3/javascript.html#typeahead
  * =============================================================
  * Copyright 2013 Twitter, Inc.

--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -1,11 +1,11 @@
 /*!
  * Bootstrap v2.3.2
  *
- * Copyright 2012 Twitter, Inc
+ * Copyright 2013 Twitter, Inc
  * Licensed under the Apache License v2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ * Designed and built with all the love in the world by @mdo and @fat.
  */
 
 // Core variables and mixins

--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap v2.3.2
+ * Bootstrap v2.3.3
  *
  * Copyright 2013 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -300,10 +300,10 @@
 .skew(@x, @y) {
   -webkit-transform: skew(@x, @y);
      -moz-transform: skew(@x, @y);
-      -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twitter/bootstrap/issues/4885
+      -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twbs/bootstrap/issues/4885
        -o-transform: skew(@x, @y);
           transform: skew(@x, @y);
-  -webkit-backface-visibility: hidden; // See https://github.com/twitter/bootstrap/issues/5319
+  -webkit-backface-visibility: hidden; // See https://github.com/twbs/bootstrap/issues/5319
 }
 .translate3d(@x, @y, @z) {
   -webkit-transform: translate3d(@x, @y, @z);

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap Responsive v2.3.2
+ * Bootstrap Responsive v2.3.3
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/less/responsive.less
+++ b/less/responsive.less
@@ -1,11 +1,11 @@
 /*!
  * Bootstrap Responsive v2.3.3
  *
- * Copyright 2012 Twitter, Inc
+ * Copyright 2013 Twitter, Inc
  * Licensed under the Apache License v2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ * Designed and built with all the love in the world by @mdo and @fat.
  */
 
 

--- a/less/tests/css-tests.html
+++ b/less/tests/css-tests.html
@@ -1365,8 +1365,8 @@
         <p>Icons from <a href="http://glyphicons.com">Glyphicons Free</a>, licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
         <ul class="footer-links">
           <li><a href="http://blog.getbootstrap.com">Read the blog</a></li>
-          <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Submit issues</a></li>
-          <li><a href="https://github.com/twitter/bootstrap/wiki">Roadmap and changelog</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Submit issues</a></li>
+          <li><a href="https://github.com/twbs/bootstrap/wiki">Roadmap and changelog</a></li>
         </ul>
       </div>
     </footer>

--- a/less/type.less
+++ b/less/type.less
@@ -178,7 +178,7 @@ hr {
 
 // Abbreviations and acronyms
 abbr[title],
-// Added data-* attribute to help out our tooltip plugin, per https://github.com/twitter/bootstrap/issues/5257
+// Added data-* attribute to help out our tooltip plugin, per https://github.com/twbs/bootstrap/issues/5257
 abbr[data-original-title] {
   cursor: help;
   border-bottom: 1px dotted @grayLight;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bootstrap"
   , "description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development."
-  , "version": "2.3.2"
+  , "version": "2.3.3"
   , "keywords": ["bootstrap", "css"]
   , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "devDependencies": {
       "uglify-js": "1.3.4"
     , "jshint": "0.9.1"
-    , "recess": "1.1.8"
+    , "recess": "1.1.9"
     , "connect": "2.1.3"
     , "hogan.js": "2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   , "description": "Sleek, intuitive, and powerful front-end framework for faster and easier web development."
   , "version": "2.3.2"
   , "keywords": ["bootstrap", "css"]
-  , "homepage": "http://twitter.github.com/bootstrap/"
+  , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."
   , "scripts": { "test": "make test" }
   , "repository": {
       "type": "git"
-    , "url": "https://github.com/twitter/bootstrap.git"
+    , "url": "https://github.com/twbs/bootstrap.git"
   }
   , "licenses": [
     {


### PR DESCRIPTION
This is just a quick release before v3 RC1 to address three things"
- [x] Update jQuery dependencies for Bower to avoid some bugs
- [x] Bump to Recess 1.1.9
- [x] Update all links to point to @twbs org and new getbootstrap.com
- [x] Bump version numbers to `2.3.3`
- [x] Point download URLs to the release tag instead of a local ZIP
- [x] Bump copyright all over

/cc @cvrebert 
