### PR TITLE
use .form-group in .form-horizontal for application of consistent vertical form spacing

### DIFF
--- a/css.html
+++ b/css.html
@@ -1254,13 +1254,13 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <h3 id="forms-horizontal">Horizontal form</h3>
     <p>Use Bootstrap's predefined grid classes to align labels and groups of form controls in a horizontal layout.</p>
     <form class="bs-example form-horizontal">
-      <div class="row">
+      <div class="row form-group">
         <label for="inputEmail" class="col-lg-2 control-label">Email</label>
         <div class="col-lg-10">
           <input type="text" class="form-control" id="inputEmail" placeholder="Email">
         </div>
       </div>
-      <div class="row">
+      <div class="row form-group">
         <label for="inputPassword" class="col-lg-2 control-label">Password</label>
         <div class="col-lg-10">
           <input type="password" class="form-control" id="inputPassword" placeholder="Password">
@@ -1277,13 +1277,13 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     </form>
 {% highlight html %}
 <form class="form-horizontal">
-  <div class="row">
+  <div class="row form-group">
     <label for="inputEmail" class="form-control" class="col-lg-2 control-label">Email</label>
     <div class="col-lg-10">
       <input type="text" id="inputEmail" placeholder="Email">
     </div>
   </div>
-  <div class="row">
+  <div class="row form-group">
     <label for="inputPassword" class="col-lg-2 control-label">Password</label>
     <div class="col-lg-10">
       <input type="password" class="form-control" id="inputPassword" placeholder="Password">

--- a/less/forms.less
+++ b/less/forms.less
@@ -422,13 +422,8 @@ select {
 // --------------------------------------------------
 // Horizontal forms are built on grid classes.
 
-.form-horizontal {
-  .row + .row {
-    margin-top: 15px;
-  }
-  .control-label {
+.form-horizontal .control-label {
     padding-top: 6px;
-  }
 }
 
 // Only right align form labels here when the columns stop stacking


### PR DESCRIPTION
Not totally sold myself on this but with .form-group having margin bottom, might be more consistent to use this in .form-horizontal instead of using .form-horizontal .row + .row. - here's jsfiddle but pretty clear http://jsfiddle.net/jholl/Qfv36/

Things I don't like:
- adds extra mark-up
- forces use of a margin at bottom of form or awkwardly drop class .form-group on final div...

Things I do like:
- all form vertical spacing can be controlled with .form-group
- feels more consistent application of .form-group for new users

@mdo, you decide.
