### PR TITLE
Update typo css.html move double class .form-control from label in examp...

### DIFF
--- a/css.html
+++ b/css.html
@@ -1278,9 +1278,9 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 {% highlight html %}
 <form class="form-horizontal">
   <div class="row">
-    <label for="inputEmail" class="form-control" class="col-lg-2 control-label">Email</label>
+    <label for="inputEmail" class="col-lg-2 control-label">Email</label>
     <div class="col-lg-10">
-      <input type="text" id="inputEmail" placeholder="Email">
+      <input type="text" class="form-control" id="inputEmail" placeholder="Email">
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
...le mark up to input

missed the double class in label in recent commit #8621
