### PR TITLE
Fix ID of buttons section on javascript page

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1137,7 +1137,7 @@ $('#my-alert').bind('closed.bs.alert', function () {
 
           <!-- Buttons
           ================================================== -->
-          <div class="bs-docs-section" id="js-buttons">
+          <div class="bs-docs-section" id="buttons">
             <div class="page-header">
               <h1>Buttons <small>button.js</small></h1>
             </div>


### PR DESCRIPTION
The old ID caused the link on affix to not work.
