### PR TITLE
(Docs) Fixed column ordering example breaking with small grid.

### DIFF
--- a/css.html
+++ b/css.html
@@ -329,14 +329,14 @@ base_url: "../"
     <h3 id="grid-column-ordering">Column ordering</h3>
     <p>Easily change the order of our built-in grid columns with <code>.col-push-*</code> and <code>.col-pull-*</code> modifier classes.</p>
     <div class="row show-grid">
-      <div class="col-lg-9 col-push-3">9</div>
-      <div class="col-lg-3 col-pull-9">3</div>
+      <div class="col-lg-9 col-sm-9 col-push-3">9</div>
+      <div class="col-lg-3 col-sm-3 col-pull-9">3</div>
     </div>
 
 {% highlight html %}
 <div class="row show-grid">
-  <div class="col-lg-9 col-push-3">9</div>
-  <div class="col-lg-3 col-pull-9">3</div>
+  <div class="col-lg-9 col-sm-9 col-push-3">9</div>
+  <div class="col-lg-3 col-sm-3 col-pull-9">3</div>
 </div>
 {% endhighlight %}
 


### PR DESCRIPTION
The current example for Column Ordering in the documentation is broken at sizes using the small grid.

This is because the columns become 100% width, but are still offset by +25% (in the case of col-push-3) and -75% (in the case of col-pull-9).

I've added classes to specify the column widths when using the small grid, and everything works fine :)
