### PR TITLE
Fix sidebar links

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -22,8 +22,6 @@
     $(document.body).on('click', '.bs-sidenav [href^=#]', function (e) {
       var $target = $(this.getAttribute('href'))
 
-      e.preventDefault() // prevent browser scroll
-
       document.body.scrollTop =
         $target.offset().top -
         navHeight + 5 // offset scroll by nav


### PR DESCRIPTION
By preventing click events in the sidebar, the page does not scroll upon clicking a link in Firefox (Chrome scrolls anyway).
