### PR TITLE
Fix grunt jshint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,6 @@
+/* jshint node: true */
 module.exports = function(grunt) {
+    "use strict";
 
     // Project configuration.
     grunt.initConfig({

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,7 @@ module.exports = function(grunt) {
         },
         jshint: {
             options: {
+                ignores: [],// HACK: workaround https://github.com/gruntjs/grunt-contrib-jshint/issues/86
                 jshintrc: 'js/.jshintrc'
             },
             gruntfile: {


### PR DESCRIPTION
The Travis build currently errors out with the jshint grunt task itself crashing. This should get it running again, although the BS JS won't pass jshint (I think the `.jshintrc` needs some updating).
