### PR TITLE
Fix wording in 'hidden on...' to be in line with 3.0 wording.

### DIFF
--- a/css.html
+++ b/css.html
@@ -1963,7 +1963,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
       </li>
       <li>
         <span class="visible-lg">Large</span>
-        <span class="hidden-lg">&#10004; Hidden on desktop</span>
+        <span class="hidden-lg">&#10004; Hidden on large</span>
       </li>
     </ul>
 


### PR DESCRIPTION
It seems the css page had an instance missed where 'desktop' was still being used rather than 'large'.
