### PR TITLE
Deleted "show-grid" class from examples

### DIFF
--- a/css.html
+++ b/css.html
@@ -178,7 +178,7 @@ base_url: "../"
   <div class="col-lg-1">1</div>
   <div class="col-lg-1">1</div>
 </div>
-<div class="row show-grid">
+<div class="row">
   <div class="col-lg-8">8</div>
   <div class="col-lg-4">4</div>
 </div>
@@ -334,7 +334,7 @@ base_url: "../"
     </div>
 
 {% highlight html %}
-<div class="row show-grid">
+<div class="row">
   <div class="col-lg-9 col-push-3">9</div>
   <div class="col-lg-3 col-pull-9">3</div>
 </div>


### PR DESCRIPTION
It's only part of the docs css.
