### PR TITLE
Deleted unnecessary ID from modals example

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1218,7 +1218,7 @@ $('#my-alert').bind('closed.bs.alert', function () {
       </button>
     </div><!-- /example -->
 {% highlight html %}
-<button type="button" id="fat-btn" data-loading-text="Loading..." class="btn btn-primary">
+<button type="button" data-loading-text="Loading..." class="btn btn-primary">
   Loading state
 </button>
 {% endhighlight %}


### PR DESCRIPTION
The ID is not necessary in the example. Also, I don't think the true button ID is necessary either (https://github.com/ggam/bootstrap/blob/3.0.0-wip/javascript.html#L1151), but I left it just in case.
