### PR TITLE
Format multiple badges in list-group-item

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -37,6 +37,9 @@
     float: right;
     margin-right: -15px;
   }
+  > .badge + .badge {
+    margin-right: 0;
+  }
 }
 
 // Custom content options


### PR DESCRIPTION
Currently, multiple badges side by side in a `list-group-item` overlap. I'm not sure this is the best solution, but something like this would be an upgrade.
