### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap",
   "version": "3.0.0",
-  "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
+  "main": ["./dist/js/bootstrap.min.js", "./dist/js/bootstrap.js", "./dist/css/bootstrap.min.css", "./dist/css/bootstrap.css"],
   "ignore": [
       "**/.*"
   ],


### PR DESCRIPTION
Main files in bower.json are outdated, like so:

``` json
   "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
```

I think it should reference the dist files.
