### PR TITLE
Fixed form inline button overlap in Safari (#8795)

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -188,6 +188,7 @@ input[type="number"] {
 .checkbox-inline input[type="checkbox"] {
   float: left;
   margin-left: -20px;
+  margin-right: 8px;
 }
 .radio + .radio,
 .checkbox + .checkbox {


### PR DESCRIPTION
#8795

Before:

![image](https://f.cloud.github.com/assets/56288/874065/b4cb1540-f884-11e2-9e03-a0081194e48e.png)

After:

![image](https://f.cloud.github.com/assets/56288/874052/91604c7e-f884-11e2-864d-91c5e976b5a2.png)
