### PR TITLE
Fixed path to bootstrap.css and bootstrap.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap",
   "version": "3.0.0",
-  "main": ["./docs/assets/js/bootstrap.js", "./docs/assets/css/bootstrap.css"],
+  "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css"],
   "ignore": [
       "**/.*"
   ],


### PR DESCRIPTION
With the current bower.json file it's not possible to install Boostrap 3 via Bower and using grunt-contrib-copy.
