### PR TITLE
Small fix to justified button groups docs

### DIFF
--- a/components.html
+++ b/components.html
@@ -203,8 +203,8 @@ base_url: "../"
     <div class="bs-example">
       <div class="btn-group btn-group-justified">
         <a href="#" class="btn btn-default">Left</a>
-        <a href="#" class="btn btn-default">Right</a>
         <a href="#" class="btn btn-default">Middle</a>
+        <a href="#" class="btn btn-default">Right</a>
       </div>
     </div>
 {% highlight html %}


### PR DESCRIPTION
The order of the buttons in the justified button groups documentation was Left, Right, Middle. This is just a small fix to put them in the right order (Left, Middle, Right).
