### PR TITLE
title attr, not tag, in tooltip/popover docs

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -802,7 +802,7 @@ $('#example').tooltip(options)
            <td>title</td>
            <td>string | function</td>
            <td>''</td>
-           <td>default title value if <code>title</code> tag isn't present</td>
+           <td>default title value if <code>title</code> attribute isn't present</td>
          </tr>
          <tr>
            <td>trigger</td>

--- a/javascript.html
+++ b/javascript.html
@@ -262,7 +262,7 @@ $('#myModal').on('show.bs.modal', function (e) {
            <td>remote</td>
            <td>path</td>
            <td>false</td>
-           <td><p>If a remote URL is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> tag to specify the remote source. An example of this is shown below:</p>
+           <td><p>If a remote URL is provided, content will be loaded via jQuery's <code>load</code> method and injected into the <code>.modal-body</code>. If you're using the data api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
 {% highlight html %}
 <a data-toggle="modal" href="remote.html" data-target="#modal">Click me</a>
 {% endhighlight %}


### PR DESCRIPTION
I guess it should be 'attribute' instead of 'tag'.
