### PR TITLE
Updated CSS Docs Grid Demos 

### DIFF
--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -315,7 +315,8 @@ body {
 .show-grid {
   margin-bottom: 15px;
 }
-.show-grid [class^="col-"] {
+.show-grid [class^="col-"] .show-bg {
+  text-align:center;
   padding-top: 10px;
   padding-bottom: 10px;
   background-color: #eee;
@@ -323,7 +324,6 @@ body {
   background-color: rgba(86,61,124,.15);
   border: 1px solid rgba(86,61,124,.2);
 }
-
 
 
 /* Bootstrap code examples

--- a/css.html
+++ b/css.html
@@ -164,31 +164,31 @@ base_url: "../"
     <p>Using a single set of grid classes, you can create a basic grid system that starts out stacked on mobile and tablet devices before becoming horizontal on desktop devices.</p>
     <div class="bs-docs-grid">
       <div class="row show-grid">
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
-        <div class="col-lg-1">1</div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
+        <div class="col-lg-1"><div class="show-bg">1</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-lg-8">8</div>
-        <div class="col-lg-4">4</div>
+        <div class="col-lg-8"><div class="show-bg">8</div></div>
+        <div class="col-lg-4"><div class="show-bg">8</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-lg-4">4</div>
-        <div class="col-lg-4">4</div>
-        <div class="col-lg-4">4</div>
+        <div class="col-lg-4"><div class="show-bg">4</div></div>
+        <div class="col-lg-4"><div class="show-bg">4</div></div>
+        <div class="col-lg-4"><div class="show-bg">4</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-lg-6">6</div>
-        <div class="col-lg-6">6</div>
+        <div class="col-lg-6"><div class="show-bg">6</div></div>
+        <div class="col-lg-6"><div class="show-bg">6</div></div>
       </div>
     </div>
 {% highlight html %}
@@ -225,17 +225,17 @@ base_url: "../"
     <p>Don't want your columns to simply stack in smaller devices? Use the small device grid system by adding <code>.col-*</code> classes to the existing <code>.col-lg-*</code> ones. See the example below for a better idea of how it all works.</p>
     <div class="bs-docs-grid">
       <div class="row show-grid">
-        <div class="col-12 col-lg-8">8</div>
-        <div class="col-6 col-lg-4">4</div>
+        <div class="col-12 col-lg-8"><div class="show-bg">8</div></div>
+        <div class="col-6 col-lg-4"><div class="show-bg">4</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-6 col-lg-4">4</div>
-        <div class="col-6 col-lg-4">4</div>
-        <div class="col-6 col-lg-4">4</div>
+        <div class="col-6 col-lg-4"><div class="show-bg">4</div></div>
+        <div class="col-6 col-lg-4"><div class="show-bg">4</div></div>
+        <div class="col-6 col-lg-4"><div class="show-bg">4</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-6 col-lg-6">6</div>
-        <div class="col-6 col-lg-6">6</div>
+        <div class="col-6 col-lg-6"><div class="show-bg">6</div></div>
+        <div class="col-6 col-lg-6"><div class="show-bg">6</div></div>
       </div>
     </div>
 {% highlight html %}
@@ -263,17 +263,17 @@ base_url: "../"
     <p>Build on the previous example by creating even more dynamic and powerful layouts with tablet <code>.col-sm-*</code> classes.</p>
     <div class="bs-docs-grid">
       <div class="row show-grid">
-        <div class="col-12 col-sm-8 col-lg-8">.col-12 .col-lg-8</div>
-        <div class="col-6 col-sm-4 col-lg-4">.col-6 .col-lg-4</div>
+        <div class="col-12 col-sm-8 col-lg-8"><div class="show-bg">.col-12 .col-lg-8</div></div>
+        <div class="col-6 col-sm-4 col-lg-4"><div class="show-bg">.col-6 .col-lg-4</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-6 col-sm-4 col-lg-4">.col-6 .col-lg-4</div>
-        <div class="col-6 col-sm-4 col-lg-4">.col-6 .col-lg-4</div>
-        <div class="col-6 col-sm-4 col-lg-4">.col-6 .col-lg-4</div>
+        <div class="col-6 col-sm-4 col-lg-4"><div class="show-bg">.col-6 .col-lg-4</div></div>
+        <div class="col-6 col-sm-4 col-lg-4"><div class="show-bg">.col-6 .col-lg-4</div></div>
+        <div class="col-6 col-sm-4 col-lg-4"><div class="show-bg">.col-6 .col-lg-4</div></div>
       </div>
       <div class="row show-grid">
-        <div class="col-6 col-sm-6 col-lg-6">.col-6 .col-lg-6</div>
-        <div class="col-6 col-sm-6 col-lg-6">.col-6 .col-lg-6</div>
+        <div class="col-6 col-sm-6 col-lg-6"><div class="show-bg">.col-6 .col-lg-6</div></div>
+        <div class="col-6 col-sm-6 col-lg-6"><div class="show-bg">.col-6 .col-lg-6</div></div>
       </div>
     </div>
 {% highlight html %}
@@ -302,15 +302,15 @@ base_url: "../"
     <p>Move columns to the right using <code>.col-offset-*</code> classes. These classes increase the left margin of a column by <code>*</code> columns. For example, <code>.col-offset-4</code> moves <code>.col-lg-4</code> over four columns.</p>
     <div class="bs-docs-grid">
       <div class="row show-grid">
-        <div class="col-lg-4">4</div>
-        <div class="col-lg-4 col-offset-4">4 offset 4</div>
+        <div class="col-lg-4"><div class="show-bg">4</div></div>
+        <div class="col-lg-4 col-offset-4"><div class="show-bg">4 offset 4</div></div>
       </div><!-- /row -->
       <div class="row show-grid">
-        <div class="col-lg-3 col-offset-3">3 offset 3</div>
-        <div class="col-lg-3 col-offset-3">3 offset 3</div>
+        <div class="col-lg-3 col-offset-3"><div class="show-bg">3 offset 3</div></div>
+        <div class="col-lg-3 col-offset-3"><div class="show-bg">3 offset 3</div></div>
       </div><!-- /row -->
       <div class="row show-grid">
-        <div class="col-lg-6 col-offset-3">6 offset 3</div>
+        <div class="col-lg-6 col-offset-3"><div class="show-bg">6 offset 3</div></div>
       </div><!-- /row -->
     </div>
 {% highlight html %}
@@ -332,13 +332,13 @@ base_url: "../"
     <p>To nest your content with the default grid, add a new <code>.row</code> and set of <code>.col-lg-*</code> columns within an existing <code>.col-lg-*</code> column. Nested rows should include a set of columns that add up to 12.</p>
     <div class="row show-grid">
       <div class="col-lg-9">
-        Level 1: 9 columns
+        <div class="show-bg">Level 1: 9 columns</div>
         <div class="row show-grid">
           <div class="col-lg-6">
-            Level 2: 6 columns
+            <div class="show-bg">Level 2: 6 columns</div>
           </div>
           <div class="col-lg-6">
-            Level 2: 6 columns
+            <div class="show-bg">Level 2: 6 columns</div>
           </div>
         </div>
       </div>
@@ -362,8 +362,8 @@ base_url: "../"
     <h3 id="grid-column-ordering">Column ordering</h3>
     <p>Easily change the order of our built-in grid columns with <code>.col-push-*</code> and <code>.col-pull-*</code> modifier classes.</p>
     <div class="row show-grid">
-      <div class="col-lg-9 col-push-3">9</div>
-      <div class="col-lg-3 col-pull-9">3</div>
+      <div class="col-lg-9 col-push-3"><div class="show-bg">9</div></div>
+      <div class="col-lg-3 col-pull-9"><div class="show-bg">3</div></div>
     </div>
 
 {% highlight html %}


### PR DESCRIPTION
Added divs with class "show-bg" within the scaffolding divs in the Grid CSS demos, so that the background color and border are within the intended grid, and not bleeding over.

Issue
#8927
