### PR TITLE
use separate `form-group`s in horiz form example for greater generality

### DIFF
--- a/css.html
+++ b/css.html
@@ -1302,11 +1302,19 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
         <label for="inputPassword" class="col-lg-2 control-label">Password</label>
         <div class="col-lg-10">
           <input type="password" class="form-control" id="inputPassword" placeholder="Password">
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-offset-2 col-lg-10">
           <div class="checkbox">
             <label>
               <input type="checkbox"> Remember me
             </label>
           </div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-offset-2 col-lg-10">
           <button type="submit" class="btn btn-default">Sign in</button>
         </div>
       </div>
@@ -1323,11 +1331,19 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <label for="inputPassword" class="col-lg-2 control-label">Password</label>
     <div class="col-lg-10">
       <input type="password" class="form-control" id="inputPassword" placeholder="Password">
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-offset-2 col-lg-10">
       <div class="checkbox">
         <label>
           <input type="checkbox"> Remember me
         </label>
       </div>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-offset-2 col-lg-10">
       <button type="submit" class="btn btn-default">Sign in</button>
     </div>
   </div>


### PR DESCRIPTION
Fixes #8925.
This does cause some excess spacing on the checkbox; arguably the checkbox CSS should be tweaked.
/cc @mdo
