### PR TITLE
Fixed pull/push columns @ sm & lg sizes. Added collapsable & centered grid columns ...

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -10,6 +10,18 @@
 // Mobile-first defaults
 .row {
   .make-row();
+
+  // Collapsed grid columns (no padding)
+  &.collapse {
+    margin-left: 0;
+    margin-right: 0;
+    [class*="col-"],
+    [class*="col-lg-"],
+    [class*="col-sm-"] {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
 }
 
 // Common styles for small and large grid columns
@@ -55,6 +67,13 @@
   // Inner gutter via padding
   padding-left:  (@grid-gutter-width / 2);
   padding-right: (@grid-gutter-width / 2);
+
+  // Centered column
+  &.centered {
+    margin-left: auto;
+    margin-right: auto;
+    float: none !important;
+  }
 }
 
 
@@ -125,29 +144,31 @@
   .col-sm-12 { width: 100%; }
 
   // Push and pull columns for source order changes
-  .col-push-1  { left: percentage((1 / @grid-columns)); }
-  .col-push-2  { left: percentage((2 / @grid-columns)); }
-  .col-push-3  { left: percentage((3 / @grid-columns)); }
-  .col-push-4  { left: percentage((4 / @grid-columns)); }
-  .col-push-5  { left: percentage((5 / @grid-columns)); }
-  .col-push-6  { left: percentage((6 / @grid-columns)); }
-  .col-push-7  { left: percentage((7 / @grid-columns)); }
-  .col-push-8  { left: percentage((8 / @grid-columns)); }
-  .col-push-9  { left: percentage((9 / @grid-columns)); }
-  .col-push-10 { left: percentage((10/ @grid-columns)); }
-  .col-push-11 { left: percentage((11/ @grid-columns)); }
+  [class*="col-sm"] {
+    &.col-push-1  { left: percentage((1 / @grid-columns)); }
+    &.col-push-2  { left: percentage((2 / @grid-columns)); }
+    &.col-push-3  { left: percentage((3 / @grid-columns)); }
+    &.col-push-4  { left: percentage((4 / @grid-columns)); }
+    &.col-push-5  { left: percentage((5 / @grid-columns)); }
+    &.col-push-6  { left: percentage((6 / @grid-columns)); }
+    &.col-push-7  { left: percentage((7 / @grid-columns)); }
+    &.col-push-8  { left: percentage((8 / @grid-columns)); }
+    &.col-push-9  { left: percentage((9 / @grid-columns)); }
+    &.col-push-10 { left: percentage((10/ @grid-columns)); }
+    &.col-push-11 { left: percentage((11/ @grid-columns)); }
 
-  .col-pull-1  { right: percentage((1 / @grid-columns)); }
-  .col-pull-2  { right: percentage((2 / @grid-columns)); }
-  .col-pull-3  { right: percentage((3 / @grid-columns)); }
-  .col-pull-4  { right: percentage((4 / @grid-columns)); }
-  .col-pull-5  { right: percentage((5 / @grid-columns)); }
-  .col-pull-6  { right: percentage((6 / @grid-columns)); }
-  .col-pull-7  { right: percentage((7 / @grid-columns)); }
-  .col-pull-8  { right: percentage((8 / @grid-columns)); }
-  .col-pull-9  { right: percentage((9 / @grid-columns)); }
-  .col-pull-10 { right: percentage((10/ @grid-columns)); }
-  .col-pull-11 { right: percentage((11/ @grid-columns)); }
+    &.col-pull-1  { right: percentage((1 / @grid-columns)); }
+    &.col-pull-2  { right: percentage((2 / @grid-columns)); }
+    &.col-pull-3  { right: percentage((3 / @grid-columns)); }
+    &.col-pull-4  { right: percentage((4 / @grid-columns)); }
+    &.col-pull-5  { right: percentage((5 / @grid-columns)); }
+    &.col-pull-6  { right: percentage((6 / @grid-columns)); }
+    &.col-pull-7  { right: percentage((7 / @grid-columns)); }
+    &.col-pull-8  { right: percentage((8 / @grid-columns)); }
+    &.col-pull-9  { right: percentage((9 / @grid-columns)); }
+    &.col-pull-10 { right: percentage((10/ @grid-columns)); }
+    &.col-pull-11 { right: percentage((11/ @grid-columns)); }
+  }
 }
 
 // Medium and large device columns (desktop and up)
@@ -194,6 +215,32 @@
   .col-offset-9  { margin-left: percentage((9 / @grid-columns)); }
   .col-offset-10 { margin-left: percentage((10/ @grid-columns)); }
   .col-offset-11 { margin-left: percentage((11/ @grid-columns)); }
+
+  [class*="col-lg"] {
+    &.col-push-1  { left: percentage((1 / @grid-columns)); }
+    &.col-push-2  { left: percentage((2 / @grid-columns)); }
+    &.col-push-3  { left: percentage((3 / @grid-columns)); }
+    &.col-push-4  { left: percentage((4 / @grid-columns)); }
+    &.col-push-5  { left: percentage((5 / @grid-columns)); }
+    &.col-push-6  { left: percentage((6 / @grid-columns)); }
+    &.col-push-7  { left: percentage((7 / @grid-columns)); }
+    &.col-push-8  { left: percentage((8 / @grid-columns)); }
+    &.col-push-9  { left: percentage((9 / @grid-columns)); }
+    &.col-push-10 { left: percentage((10/ @grid-columns)); }
+    &.col-push-11 { left: percentage((11/ @grid-columns)); }
+
+    &.col-pull-1  { right: percentage((1 / @grid-columns)); }
+    &.col-pull-2  { right: percentage((2 / @grid-columns)); }
+    &.col-pull-3  { right: percentage((3 / @grid-columns)); }
+    &.col-pull-4  { right: percentage((4 / @grid-columns)); }
+    &.col-pull-5  { right: percentage((5 / @grid-columns)); }
+    &.col-pull-6  { right: percentage((6 / @grid-columns)); }
+    &.col-pull-7  { right: percentage((7 / @grid-columns)); }
+    &.col-pull-8  { right: percentage((8 / @grid-columns)); }
+    &.col-pull-9  { right: percentage((9 / @grid-columns)); }
+    &.col-pull-10 { right: percentage((10/ @grid-columns)); }
+    &.col-pull-11 { right: percentage((11/ @grid-columns)); }
+  }
 }
 
 // Large desktops and up


### PR DESCRIPTION
I've added a simple way of fixing push/pull cols for sm & lg columns simply by only applying the push/pull to the corresponding size for the corresponding media query.

Added .row.collapse to remove default padding from columns.

Added .centered to to column classes to remove float and center a (single) column.
