### PR TITLE
Added accessibility items for dropdown & Carousel

### DIFF
--- a/js/bootstrap-carousel.js
+++ b/js/bootstrap-carousel.js
@@ -135,6 +135,8 @@
           that.sliding = false
           setTimeout(function () { that.$element.trigger('slid') }, 0)
         })
+        $active.removeAttr('aria-live aria-atomic')
+        $next.attr({'aria-live': 'polite', 'aria-atomic': 'true'})
       } else {
         this.$element.trigger(e)
         if (e.isDefaultPrevented()) return

--- a/js/bootstrap-dropdown.js
+++ b/js/bootstrap-dropdown.js
@@ -59,6 +59,8 @@
         $parent.toggleClass('open')
       }
 
+      $this.attr('aria-haspopup', !$parent.hasClass('open'))
+      $this.attr('aria-expanded', $parent.hasClass('open'))
       $this.focus()
 
       return false


### PR DESCRIPTION
- Added aria-live and aria-atomic toggles for accessibility
  in bootstrap dropdowns. Based on the state the values will
  be set.
- Added aria-live and aria-atomic toggles for accessibility in
  bootstrat carousel. The values of aria-live and aria-atomic
  be set for the active slide in the carousel.
