### PR TITLE
Added accessibility items for dropdown & Carousel

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -146,7 +146,8 @@
       this.sliding = false
       this.$element.trigger('slid')
     }
-
+    $active.removeAttr('aria-live aria-atomic')
+    $next.attr({'aria-live': 'polite', 'aria-atomic': 'true'})
     isCycling && this.cycle()
 
     return this

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -54,6 +54,8 @@
         .trigger('shown.bs.dropdown')
     }
 
+    $this.attr('aria-haspopup', !$parent.hasClass('open'))
+    $this.attr('aria-expanded', $parent.hasClass('open'))
     $this.focus()
 
     return false


### PR DESCRIPTION
- Added aria-live and aria-atomic toggles for accessibility
  in bootstrap dropdowns. Based on the state the values will
  be set.
- Added aria-live and aria-atomic toggles for accessibility in
  bootstrat carousel. The values of aria-live and aria-atomic
  be set for the active slide in the carousel.
