### PR TITLE
Added short instruction for obtaining respond.js in example HTML code (see description).

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -112,7 +112,7 @@ bootstrap/
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="js/bootstrap.min.js"></script>
 
-    <!-- Optionally enable responsive features in IE8 -->
+    <!-- Optionally enable responsive features in IE8. Respond.js can be obtained from https://github.com/scottjehl/Respond -->
     <script src="js/respond.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The Getting-Started page only lists the actual instructions for respond.js (its purpose and source) _after_ listing a piece of example HTML code for the user to copy and paste (the _Basic Template_ seciont comes before the _Browser Compatibility_ section). 

It would probably be more clear if that piece of HTML code actually lists where the user can obtain respond.js. Otherwise the user has to scroll down and read 1 specific line on the rest of the page (under the 'IE 8 and 9' compatibility section), in order to know that respond.js can be obtained from a GitHub page (and that it is in fact NOT part of the downloadable Bootstrap file that's provided earlier on the page, even though the use of response.js in the example HTML code seems to suggest that it _is_ part of the Bootstrap download).

It's a minor issue but this fix should make it just a little bit more clear to a user how the example HTML code works (lest they copy/paste it and find out the browser can't find respond.js. Because not every user will go on to read more of the getting-started page once they see the shiny Basic Template that's up for grabs to test out their new toy: Bootstrap).
