### PR TITLE
updates mixins to consistently use semicolons as argument separator. 

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -52,11 +52,11 @@
 // -------------------------
 
 .alert-success {
-  .alert-variant(@alert-success-bg, @alert-success-border, @alert-success-text);
+  .alert-variant(@alert-success-bg; @alert-success-border; @alert-success-text);
 }
 .alert-danger {
-  .alert-variant(@alert-danger-bg, @alert-danger-border, @alert-danger-text);
+  .alert-variant(@alert-danger-bg; @alert-danger-border; @alert-danger-text);
 }
 .alert-info {
-  .alert-variant(@alert-info-bg, @alert-info-border, @alert-info-text);
+  .alert-variant(@alert-info-bg; @alert-info-border; @alert-info-text);
 }

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -54,26 +54,26 @@
 // --------------------------------------------------
 
 .btn-default {
-  .btn-pseudo-states(@btn-default-color, @btn-default-bg, @btn-default-border);
+  .btn-pseudo-states(@btn-default-color; @btn-default-bg; @btn-default-border);
 }
 .btn-primary {
-  .btn-pseudo-states(@btn-primary-color, @btn-primary-bg, @btn-primary-border);
+  .btn-pseudo-states(@btn-primary-color; @btn-primary-bg; @btn-primary-border);
 }
 // Warning appears as orange
 .btn-warning {
-  .btn-pseudo-states(@btn-warning-color, @btn-warning-bg, @btn-warning-border);
+  .btn-pseudo-states(@btn-warning-color; @btn-warning-bg; @btn-warning-border);
 }
 // Danger and error appear as red
 .btn-danger {
-  .btn-pseudo-states(@btn-danger-color, @btn-danger-bg, @btn-danger-border);
+  .btn-pseudo-states(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
 }
 // Success appears as green
 .btn-success {
-  .btn-pseudo-states(@btn-success-color, @btn-success-bg, @btn-success-border);
+  .btn-pseudo-states(@btn-success-color; @btn-success-bg; @btn-success-border);
 }
 // Info appears as blue-green
 .btn-info {
-  .btn-pseudo-states(@btn-info-color, @btn-info-bg, @btn-info-border);
+  .btn-pseudo-states(@btn-info-color; @btn-info-bg; @btn-info-border);
 }
 
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -255,15 +255,15 @@ textarea {
 
 // Warning
 .has-warning {
-  .form-control-validation(@state-warning-text, @state-warning-text, @state-warning-bg);
+  .form-control-validation(@state-warning-text; @state-warning-text; @state-warning-bg);
 }
 // Error
 .has-error {
-  .form-control-validation(@state-danger-text, @state-danger-text, @state-danger-bg);
+  .form-control-validation(@state-danger-text; @state-danger-text; @state-danger-bg);
 }
 // Success
 .has-success {
-  .form-control-validation(@state-success-text, @state-success-text, @state-success-bg);
+  .form-control-validation(@state-success-text; @state-success-text; @state-success-bg);
 }
 
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -44,12 +44,12 @@
 }
 
 // Sizing shortcuts
-.size(@width, @height) {
+.size(@width; @height) {
   width: @width;
   height: @height;
 }
 .square(@size) {
-  .size(@size, @size);
+  .size(@size; @size);
 }
 
 // Placeholder text
@@ -138,17 +138,17 @@
       -ms-transform: scale(@ratio);
           transform: scale(@ratio);
 }
-.translate(@x, @y) {
+.translate(@x; @y) {
   -webkit-transform: translate(@x, @y);
       -ms-transform: translate(@x, @y);
           transform: translate(@x, @y);
 }
-.skew(@x, @y) {
+.skew(@x; @y) {
   -webkit-transform: skew(@x, @y);
       -ms-transform: skewX(@x) skewY(@y); // See https://github.com/twbs/bootstrap/issues/4885
           transform: skew(@x, @y);
 }
-.translate3d(@x, @y, @z) {
+.translate3d(@x; @y; @z) {
   -webkit-transform: translate3d(@x, @y, @z);
           transform: translate3d(@x, @y, @z);
 }
@@ -197,7 +197,7 @@
 }
 
 // CSS3 Content Columns
-.content-columns(@column-count, @column-gap: @grid-gutter-width) {
+.content-columns(@column-count; @column-gap: @grid-gutter-width) {
   -webkit-column-count: @column-count;
      -moz-column-count: @column-count;
           column-count: @column-count;
@@ -259,14 +259,14 @@
     filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@start-color),argb(@end-color))); // IE9 and down
   }
 
-  .directional(@start-color: #555, @end-color: #333, @deg: 45deg) {
+  .directional(@start-color: #555; @end-color: #333; @deg: 45deg) {
     background-color: @end-color;
     background-repeat: repeat-x;
     background-image: -webkit-linear-gradient(@deg, @start-color, @end-color); // Safari 5.1+, Chrome 10+
     background-image: -moz-linear-gradient(@deg, @start-color, @end-color); // FF 3.6+
     background-image: linear-gradient(@deg, @start-color, @end-color); // Standard, IE10
   }
-  .horizontal-three-colors(@start-color: #00b3ee, @mid-color: #7a43b6, @color-stop: 50%, @end-color: #c3325f) {
+  .horizontal-three-colors(@start-color: #00b3ee; @mid-color: #7a43b6; @color-stop: 50%; @end-color: #c3325f) {
     background-color: mix(@mid-color, @end-color, 80%);
     background-image: -webkit-gradient(left, linear, 0 0, 0 100%, from(@start-color), color-stop(@color-stop, @mid-color), to(@end-color));
     background-image: -webkit-linear-gradient(left, @start-color, @mid-color @color-stop, @end-color);
@@ -276,7 +276,7 @@
     filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",argb(@start-color),argb(@end-color))); // IE9 and down, gets no color-stop at all for proper fallback
   }
 
-  .vertical-three-colors(@start-color: #00b3ee, @mid-color: #7a43b6, @color-stop: 50%, @end-color: #c3325f) {
+  .vertical-three-colors(@start-color: #00b3ee; @mid-color: #7a43b6; @color-stop: 50%; @end-color: #c3325f) {
     background-color: mix(@mid-color, @end-color, 80%);
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@start-color), color-stop(@color-stop, @mid-color), to(@end-color));
     background-image: -webkit-linear-gradient(@start-color, @mid-color @color-stop, @end-color);
@@ -285,7 +285,7 @@
     background-repeat: no-repeat;
     filter: e(%("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",argb(@start-color),argb(@end-color))); // IE9 and down, gets no color-stop at all for proper fallback
   }
-  .radial(@inner-color: #555, @outer-color: #333) {
+  .radial(@inner-color: #555; @outer-color: #333) {
     background-color: @outer-color;
     background-image: -webkit-gradient(radial, center center, 0, center center, 460, from(@inner-color), to(@outer-color));
     background-image: -webkit-radial-gradient(circle, @inner-color, @outer-color);
@@ -293,7 +293,7 @@
     background-image: radial-gradient(circle, @inner-color, @outer-color);
     background-repeat: no-repeat;
   }
-  .striped(@color: #555, @angle: 45deg) {
+  .striped(@color: #555; @angle: 45deg) {
     background-color: @color;
     background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, rgba(255,255,255,.15)), color-stop(.25, transparent), color-stop(.5, transparent), color-stop(.5, rgba(255,255,255,.15)), color-stop(.75, rgba(255,255,255,.15)), color-stop(.75, transparent), to(transparent));
     background-image: -webkit-linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
@@ -316,7 +316,7 @@
 // --------------------------------------------------
 
 // Short retina mixin for setting background-image and -size
-.img-retina(@file-1x, @file-2x, @width-1x, @height-1x) {
+.img-retina(@file-1x; @file-2x; @width-1x; @height-1x) {
   background-image: url("@{file-1x}");
 
   @media
@@ -347,7 +347,7 @@
 
 // Alerts
 // -------------------------
-.alert-variant(@background, @border, @text-color) {
+.alert-variant(@background; @border; @text-color) {
   background-color: @background;
   border-color: @border;
   color: @text-color;
@@ -363,7 +363,7 @@
 // -------------------------
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
-.btn-pseudo-states(@color, @background, @border) {
+.btn-pseudo-states(@color; @background; @border) {
   color: @color;
   background-color: @background;
   border-color: @border;
@@ -520,7 +520,7 @@
 // Used in forms.less to generate the form validation CSS for warnings, errors,
 // and successes.
 
-.form-control-validation(@text-color: #555, @border-color: #ccc, @background-color: #f5f5f5) {
+.form-control-validation(@text-color: #555; @border-color: #ccc; @background-color: #f5f5f5) {
   // Color the label and help text
   .help-block,
   .control-label {


### PR DESCRIPTION
Rebuild to confirm, no diff in compiled CSS.
Resolves https://github.com/twbs/bootstrap/issues/9014
