### PR TITLE
transitionend do not fail when not supported

### DIFF
--- a/js/transition.js
+++ b/js/transition.js
@@ -42,9 +42,9 @@
 
   // http://blog.alexmaccaw.com/css-transitions
   $.fn.emulateTransitionEnd = function (duration) {
-    var called = false, $el    = this
-    $(this).one($.support.transition.end, function () { called = true })
-    var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
+    var called = false, $el = this, eventName = $.support.transition && $.support.transition.end || 'transitionend'
+    $(this).one(eventName, function () { called = true })
+    var callback = function () { if (!called) $($el).trigger(eventName) }
     setTimeout(callback, duration)
     return this
   }


### PR DESCRIPTION
If the browser doesn't support any form of transitionend, simply trigger a `'transitionend'` instead of failing
see previous change 270316f140e821d7ba9a5675def47086abe4fc39
