### PR TITLE
Added preventDefault to example links in the documentation

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -16,7 +16,8 @@
       offset: navHeight
     })
 
-    $('.bs-docs-container [href=#]').click(function (e) {
+    // Disable example links in the documentation
+    $('.bs-docs-container [href=#], .bs-example [href^=#]').click(function (e) {
       e.preventDefault()
     })
 


### PR DESCRIPTION
Fixes #8990 -- the old CSS selector assigned to hashtag links in the documentation did not cover all cases that required the preventDefault method. I expanded this to cover .bs-example hashtag links as well, which fixes the reported Scrollspy issue.
