### PR TITLE
Integrate testing with browserstack runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - npm install -g grunt-cli
 env:
   global:
-  - secure: bIqcPK0Rtlv3e8rM6SPDC780yXxGj8AWHxPgbRXz2Os1bRdR6YVJtHXGpDmviVYBwWto4Zevljo7puUUnZ9IXPB+whckSIjut5sUqgXmWy1sROE98oPYi5H46ddH2zjM85Uifr/deaFSDJ5byrh+6+dHpMhgNL0duGmodpXfL6o=
-  - secure: YE0/FYpsuDvCYmxRtOvdSpx6XNnC19rdxWGuAJXOHH6x0sB6HwsoFVH2EYa8WXNjri+A+8bH8AZX1vHoIY8gKZAARrLn9kN/sVpcT/Z7jpPTLVIyg9LD59wdCWh5vwKYiriyDES5vTtqk3JOd6xy1ci+Nckl6t9Khh6mJ5V4A98=
+  - secure: Besg41eyU+2mfxrywQ4ydOShMdc34ImaO0S0ENP+aCOBuyNBIgP59wy5tBMmyai2/8eInYeVps4Td96mWInMMxzTe3Bar7eTLG5tWVKRSr/wc4NBPZ/ppoPAmCEsz9Y+VptRH9/FO8n7hsL9EFZ+xBKbG+C0SccGoyBDpA5j7/w=
+  - secure: Ptiv7phCImFP3ALIz+sMQzrZg8k7C1gLZbFBhWxjnQr3g06wIfX3Ls5y9OHvxid+lOZZjISui3wzBVgpVHqwHUYf96+r0mo6/mJ+F4ffUmShZANVaIMD/JRTnXhUQJbvntGLvxn1EYWPdNM+2IHJrMipnjHxU9tkgAnlel4Zdew=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - 0.8
 before_script:
   - npm install -g grunt-cli
+env:
+  global:
+  - secure: bIqcPK0Rtlv3e8rM6SPDC780yXxGj8AWHxPgbRXz2Os1bRdR6YVJtHXGpDmviVYBwWto4Zevljo7puUUnZ9IXPB+whckSIjut5sUqgXmWy1sROE98oPYi5H46ddH2zjM85Uifr/deaFSDJ5byrh+6+dHpMhgNL0duGmodpXfL6o=
+  - secure: YE0/FYpsuDvCYmxRtOvdSpx6XNnC19rdxWGuAJXOHH6x0sB6HwsoFVH2EYa8WXNjri+A+8bH8AZX1vHoIY8gKZAARrLn9kN/sVpcT/Z7jpPTLVIyg9LD59wdCWh5vwKYiriyDES5vTtqk3JOd6xy1ci+Nckl6t9Khh6mJ5V4A98=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,10 +108,11 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-recess');
+    grunt.loadNpmTasks('browserstack-runner');
 
 
     // Test task.
-    grunt.registerTask('test', ['jshint', 'qunit']);
+    grunt.registerTask('test', ['jshint', 'qunit', 'browserstack_runner']);
 
     // JS distribution task.
     grunt.registerTask('dist-js', ['concat', 'uglify']);

--- a/browserstack.json
+++ b/browserstack.json
@@ -7,7 +7,7 @@
       "browser": "firefox",
       "browser_version": "latest",
       "os": "OS X",
-      "os_version": "Lion"
+      "os_version": "Mountain Lion"
     },
     {
       "browser": "safari",
@@ -32,6 +32,12 @@
       "browser_version": "latest",
       "os": "Windows",
       "os_version": "7"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "8.0",
+      "os": "Windows",
+      "os_version": "XP"
     },
     {
       "browser": "ie",

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,0 +1,55 @@
+{
+  "username": "--secure--",
+  "key": "--secure--",
+  "test_path": "js/tests/index.html",
+  "browsers":  [
+    {
+      "browser": "firefox",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Lion"
+    },
+    {
+      "browser": "safari",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mountain Lion"
+    },
+    {
+      "browser": "chrome",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mountain Lion"
+    },
+    {
+      "browser": "firefox",
+      "browser_version": "latest",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "chrome",
+      "browser_version": "latest",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "9.0",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "10.0",
+      "os": "Windows",
+      "os_version": "8"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "11.0",
+      "os": "Windows",
+      "os_version": "7"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     , "grunt-contrib-qunit": "~0.2.2"
     , "grunt-contrib-watch": "~0.5.1"
     , "grunt-recess": "~0.3.3"
-    , "browserstack-runner": "git://github.com/browserstack/browserstack-runner"
+    , "browserstack-runner": "~0.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "keywords": ["bootstrap", "css"]
   , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."
-  , "scripts": { "test": "grunt test" }
+  , "scripts": { "test": "grunt test && PATH=\"$PATH:$(npm bin)\" browserstack-runner" }
   , "repository": {
       "type": "git"
     , "url": "https://github.com/twbs/bootstrap.git"
@@ -26,5 +26,6 @@
     , "grunt-contrib-qunit": "~0.2.2"
     , "grunt-contrib-watch": "~0.5.1"
     , "grunt-recess": "~0.3.3"
+    , "browserstack-runner": "git://github.com/browserstack/browserstack-runner"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "keywords": ["bootstrap", "css"]
   , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."
-  , "scripts": { "test": "grunt test && PATH=\"$PATH:$(npm bin)\" browserstack-runner" }
+  , "scripts": { "test": "grunt test" }
   , "repository": {
       "type": "git"
     , "url": "https://github.com/twbs/bootstrap.git"


### PR DESCRIPTION
We are BrowserStack and have made a npm package https://github.com/browserstack/browserstack-runner to enable easy Cross Browser Testing of open source JS libraries. The idea is:
1. These JS libraries can be cross browser tested
2. Make it super easy to test cross browser compatibility. (for eg. all you need is to provide a config file with supported browsers, test files) 

This pull request enables browser testing for bootstrap (3.0.0-wip as of now). The current build can be seen here: https://travis-ci.org/browserstack/bootstrap

I will send more details over to @mdo
