### PR TITLE
Update .navbar-toggle to match other `.navbar` el

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -117,11 +117,11 @@
 // Collapsible navbar toggle
 .navbar-toggle {
   position: absolute;
-  top: floor((@navbar-height - 32) / 2);
-  right: 10px;
+  top: floor((@navbar-height - 34) / 2);
+  right: @navbar-padding-horizontal;
   width: 48px;
-  height: 32px;
-  padding: 8px 12px;
+  height: 34px;
+  padding: @padding-base-vertical @padding-base-horizontal;
   background-color: transparent;
   border: 1px solid @navbar-toggle-border-color;
   border-radius: @border-radius-base;


### PR DESCRIPTION
Update `.navbar-toggle` styling to position dynamically within `.navbar` right padding, and to size/look more like a `.btn` element
- change `right: 10px` to `right: @navbar-padding-horizontal`
- change `height:` to 34px
- change `top:` to calc basis new height
- change `padding:` to match `.btn` el
- could add dynamic calc for height and in calc of top, but not in this PR
