### PR TITLE
Update .navbar-toggle to match other navbar elems

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -116,12 +116,12 @@
 
 // Collapsible navbar toggle
 .navbar-toggle {
-  position: absolute;
-  top: floor((@navbar-height - 32) / 2);
-  right: 10px;
+  position: relative;
+  float: right;
+  height: 34px;
   width: 48px;
-  height: 32px;
-  padding: 8px 12px;
+  .navbar-vertical-align(34px);
+  padding: @padding-base-vertical @padding-base-horizontal; 
   background-color: transparent;
   border: 1px solid @navbar-toggle-border-color;
   border-radius: @border-radius-base;


### PR DESCRIPTION
In place of commit #9040, fixes #8844
And sizing .navbar-toggle more like .btn elem
- change `position:absolute` to `position:relative`
- remove `right: 10px` in favor of `float:right`
- change to `height: 34px`
- remove `top:` in favor of `.navbar-vertical-align` basis new height
- change `padding:` to match `.btn` elem
