### PR TITLE
Allow the shadow color of input elements to be configured

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -130,9 +130,9 @@ input[type="number"] {
   .transition(~"border-color ease-in-out .15s, box-shadow ease-in-out .15s");
 
   &:focus {
-    border-color: rgba(82,168,236,.8);
+    border-color: darken(@input-border-shadow, 20%);
     outline: 0;
-    .box-shadow(~"inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6)");
+    .box-shadow(~"inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px @input-border-shadow");
   }
 
   // Disabled and read-only inputs

--- a/less/variables.less
+++ b/less/variables.less
@@ -131,6 +131,7 @@
 
 @input-border:                   #ccc;
 @input-border-radius:            @border-radius-base;
+@input-border-shadow:            rgba(82,168,236,.6);
 
 @input-color-placeholder:        @gray-light;
 


### PR DESCRIPTION
Sometimes you do not want a blue shadow around input elements but use another color. Instead of overwriting it in a custom css it would be helpfull if the color would be adjustable via variables.less. This patch moves the hardcoded color of the input box shadow to the variables.less.
