### PR TITLE
using @line-height-computed in .navbar-nav link

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -28,7 +28,7 @@
     padding-top: ((@navbar-height - @line-height-computed) / 2);
     padding-bottom: ((@navbar-height - @line-height-computed) / 2);
     color: @navbar-link-color;
-    line-height: 20px;
+    line-height: @line-height-computed;
     border-radius: @border-radius-base;
     &:hover,
     &:focus {


### PR DESCRIPTION
When a user changed the @line-height-base/@line-height-computed var, the nav-bar items would not scale appropriately.

Screenshots (using custom font, which triggered the issue)

Before:

![before](https://f.cloud.github.com/assets/89551/906128/38e89574-fc71-11e2-8e8b-3e5c76a97f3f.png)

After:

![after](https://f.cloud.github.com/assets/89551/906129/3cc669d2-fc71-11e2-8a6e-8398e14e2c73.png)
