### PR TITLE
Fix column offsets from being improperly labeled #8310

### DIFF
--- a/css.html
+++ b/css.html
@@ -303,27 +303,27 @@ base_url: "../"
     <div class="bs-docs-grid">
       <div class="row show-grid">
         <div class="col-lg-4">4</div>
-        <div class="col-lg-4 col-lg-offset-4">4 offset 4</div>
+        <div class="col-lg-4 col-offset-4">4 offset 4</div>
       </div><!-- /row -->
       <div class="row show-grid">
-        <div class="col-lg-3 col-lg-offset-3">3 offset 3</div>
-        <div class="col-lg-3 col-lg-offset-3">3 offset 3</div>
+        <div class="col-lg-3 col-offset-3">3 offset 3</div>
+        <div class="col-lg-3 col-offset-3">3 offset 3</div>
       </div><!-- /row -->
       <div class="row show-grid">
-        <div class="col-lg-6 col-lg-offset-3">6 offset 3</div>
+        <div class="col-lg-6 col-offset-3">6 offset 3</div>
       </div><!-- /row -->
     </div>
 {% highlight html %}
 <div class="row">
   <div class="col-lg-4">...</div>
-  <div class="col-lg-4 col-lg-offset-4">...</div>
+  <div class="col-lg-4 col-offset-4">...</div>
 </div>
 <div class="row">
-  <div class="col-lg-3 col-lg-offset-3">3 offset 3</div>
-  <div class="col-lg-3 col-lg-offset-3">3 offset 3</div>
+  <div class="col-lg-3 col-offset-3">3 offset 3</div>
+  <div class="col-lg-3 col-offset-3">3 offset 3</div>
 </div>
 <div class="row">
-  <div class="col-lg-6 col-lg-offset-3">...</div>
+  <div class="col-lg-6 col-offset-3">...</div>
 </div>
 {% endhighlight %}
 


### PR DESCRIPTION
Using these classes doesn't work.  Not really a surprise when looking at the Bootstrap CSS.  In issue #8310 @mdo clearly said no to doing this.  This brings the documentation in line with what is actually part of the code.
