### PR TITLE
accordion's data-parent can't contain dots

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -169,7 +169,7 @@
     var $parent = parent && $(parent)
 
     if (!data || !data.transitioning) {
-      if ($parent) $parent.find('[data-toggle=collapse][data-parent=' + parent + ']').not($this).addClass('collapsed')
+      if ($parent) $parent.find('[data-toggle=collapse][data-parent="' + parent + '"]').not($this).addClass('collapsed')
       $this[$target.hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     }
 

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -126,4 +126,39 @@ $(function () {
         target3.click()
       })
 
+      test("should allow dots in data-parent", function () {
+        $.support.transition = false
+        stop()
+
+        var accordion = $('<div class="accordion"><div class="accordion-group"></div><div class="accordion-group"></div><div class="accordion-group"></div></div>')
+          .appendTo($('#qunit-fixture'))
+
+        var target1 = $('<a data-toggle="collapse" href="#body1" data-parent=".accordion"></a>')
+          .appendTo(accordion.find('.accordion-group').eq(0))
+
+        var collapsible1 = $('<div id="body1" class="in"></div>')
+          .appendTo(accordion.find('.accordion-group').eq(0))
+
+        var target2 = $('<a class="collapsed" data-toggle="collapse" href="#body2" data-parent=".accordion"></a>')
+          .appendTo(accordion.find('.accordion-group').eq(1))
+
+        var collapsible2 = $('<div id="body2"></div>')
+          .appendTo(accordion.find('.accordion-group').eq(1))
+
+        var target3 = $('<a class="collapsed" data-toggle="collapse" href="#body3" data-parent=".accordion"></a>')
+          .appendTo(accordion.find('.accordion-group').eq(2))
+
+        var collapsible3 = $('<div id="body3"></div>')
+          .appendTo(accordion.find('.accordion-group').eq(2))
+          .on('show.bs.collapse', function () {
+            ok(target1.hasClass('collapsed'))
+            ok(target2.hasClass('collapsed'))
+            ok(!target3.hasClass('collapsed'))
+
+            start()
+          })
+
+        target3.click()
+      })
+
 })


### PR DESCRIPTION
jQuery is throwing when it encounters "[data-parent=anything.with.a.dot]".

Failing fiddle (look in the console to see the error): http://jsfiddle.net/jdiamond/tqDZd/

The fix is to quote the value for data-parent when finding the elements to hide.

Pull request contains both a unit test and the fix.
