### PR TITLE
Update css.html

### DIFF
--- a/css.html
+++ b/css.html
@@ -1649,10 +1649,10 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <p>Block level help text for form controls.</p>
     <form class="bs-example">
       <input type="text" class="form-control">
-      <span class="help-block">A longer block of help text that breaks onto a new line and may extend beyond one line.</span>
+      <span class="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
     </form>
 {% highlight html %}
-<span class="help-block">A longer block of help text that breaks onto a new line and may extend beyond one line.</span>
+<span class="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
 {% endhighlight %}
 
   </div>


### PR DESCRIPTION
`.help-block` talks about being 'longer', but with `.help-inline` gone, it's not longer than anything and the comparison is confusing.
