### PR TITLE
 Fix Issue #8175 - .input-group-addon broken in Firefox

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -59,13 +59,11 @@
     padding: @padding-small-vertical @padding-small-horizontal;
     font-size: @font-size-small;
     border-radius: @border-radius-small;
-    line-height: @line-height-small;
   }
   &.input-lg {
     padding: @padding-large-vertical @padding-large-horizontal;
     font-size: @font-size-large;
     border-radius: @border-radius-large;
-    line-height: @line-height-large;
   }
 
   // Nuke default margins from checkboxes and radios to vertically center within.

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -48,7 +48,7 @@
   padding: @padding-base-vertical @padding-base-horizontal;
   font-size: @font-size-base;
   font-weight: normal;
-  line-height: @line-height-base;
+  line-height: 1;
   text-align: center;
   background-color: @gray-lighter;
   border: 1px solid @input-group-addon-border-color;


### PR DESCRIPTION
Setting **line-height: 1** on **.input-group-addon** seems to fix the misalignment on FF and doesn't seem to affect other browsers
