### PR TITLE
Fixed responsive navbar docs typo

### DIFF
--- a/components.html
+++ b/components.html
@@ -1312,7 +1312,7 @@ body { padding-bottom: 70px; }
     <!-- Be sure to leave the brand out there if you want it shown -->
     <a class="navbar-brand" href="#">Title</a>
 
-    <!-- Place everything within .navbar-collapse to hide it until above 768px -->
+    <!-- Place everything within .nav-collapse to hide it until above 768px -->
     <div class="nav-collapse collapse navbar-responsive-collapse">
       ...
     </div><!-- /.nav-collapse -->


### PR DESCRIPTION
The example given contradicts itself. The comments in the code claim `.navbar-collapse` will be hidden until 768px+ wide, but the line beneath uses `.nav-collapse`. The latter seems to actually work with the collapse plugin.
