### PR TITLE
Add border calc for @btn-default-border: darken(@btn-default-bg, 20%)

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -102,7 +102,7 @@
 
 @btn-default-color:              #333;
 @btn-default-bg:                 #fff;
-@btn-default-border:             #ccc;
+@btn-default-border:             darken(@btn-default-bg, 20%);
 
 @btn-primary-color:              #fff;
 @btn-primary-bg:                 @brand-primary;


### PR DESCRIPTION
The 20% should keep the #ccc border on the current #fff bg.

This change sets up easier for people to extend default button color - still they would have to specify a new bg and decide if they want a 20% or 5% darken on borders (other btn styles are 5%), but at least groundwork is there for uniform calculations.

That said, I cut-pasted the change in far less time than I wrote this so... it's never too big an issue. Relates to 01c46bf.
