### PR TITLE
Browserstack testing integration (rebased, squashed, tweaked)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - 0.8
 before_script:
   - npm install -g grunt-cli
+env:
+  global:
+  - secure: Besg41eyU+2mfxrywQ4ydOShMdc34ImaO0S0ENP+aCOBuyNBIgP59wy5tBMmyai2/8eInYeVps4Td96mWInMMxzTe3Bar7eTLG5tWVKRSr/wc4NBPZ/ppoPAmCEsz9Y+VptRH9/FO8n7hsL9EFZ+xBKbG+C0SccGoyBDpA5j7/w=
+  - secure: Ptiv7phCImFP3ALIz+sMQzrZg8k7C1gLZbFBhWxjnQr3g06wIfX3Ls5y9OHvxid+lOZZjISui3wzBVgpVHqwHUYf96+r0mo6/mJ+F4ffUmShZANVaIMD/JRTnXhUQJbvntGLvxn1EYWPdNM+2IHJrMipnjHxU9tkgAnlel4Zdew=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,10 +125,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-recess');
+  grunt.loadNpmTasks('browserstack-runner');
 
 
   // Test task.
-  grunt.registerTask('test', ['jshint', 'qunit']);
+  grunt.registerTask('test', ['jshint', 'qunit', 'browserstack_runner']);
 
   // JS distribution task.
   grunt.registerTask('dist-js', ['concat', 'uglify']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,11 @@ module.exports = function(grunt) {
 
 
   // Test task.
-  grunt.registerTask('test', ['jshint', 'qunit', 'browserstack_runner']);
+  var testSubtasks = ['jshint', 'qunit'];
+  if (process.env.TRAVIS) {
+    testSubtasks.push('browserstack_runner');
+  }
+  grunt.registerTask('test', testSubtasks);
 
   // JS distribution task.
   grunt.registerTask('dist-js', ['concat', 'uglify']);

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,0 +1,61 @@
+{
+  "username": "--secure--",
+  "key": "--secure--",
+  "test_path": "js/tests/index.html",
+  "browsers":  [
+    {
+      "browser": "firefox",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mountain Lion"
+    },
+    {
+      "browser": "safari",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mountain Lion"
+    },
+    {
+      "browser": "chrome",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mountain Lion"
+    },
+    {
+      "browser": "firefox",
+      "browser_version": "latest",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "chrome",
+      "browser_version": "latest",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "8.0",
+      "os": "Windows",
+      "os_version": "XP"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "9.0",
+      "os": "Windows",
+      "os_version": "7"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "10.0",
+      "os": "Windows",
+      "os_version": "8"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "11.0",
+      "os": "Windows",
+      "os_version": "7"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     , "grunt-contrib-qunit": "~0.2.2"
     , "grunt-contrib-watch": "~0.5.1"
     , "grunt-recess": "~0.3.3"
+    , "browserstack-runner": "~0.0.11"
   }
 }


### PR DESCRIPTION
Successor to #9039.
/cc @jonschlinkert, @seriema: Is there a less-hacky way to skip the browserstack test when people don't have it installed locally?
