### PR TITLE
Fix for responsive controls-row misalignment

### DIFF
--- a/less/responsive-767px-max.less
+++ b/less/responsive-767px-max.less
@@ -95,7 +95,7 @@
     display: inline-block; // redeclare so they don't wrap to new lines
     width: auto;
   }
-  .controls-row [class*="span"] + [class*="span"] {
+  .controls-row [class*="span"] + [class*="span"], .row-fluid .controls-row [class*="span"] + [class*="span"] {
     margin-left: 0;
   }
 


### PR DESCRIPTION
The default style [here](https://github.com/twbs/bootstrap/blob/c9789f75153539a0ca0a2f31234716f527024333/docs/assets/css/bootstrap.css#L424) is taking precedence over the responsive style because it has the row-fluid class, so I'm adding the row-fluid class to the responsive style to compensate. I discovered the issue when working on [this bounty source bug](https://www.bountysource.com/issues/639345-bountybox-buttons-misaligned).
