### PR TITLE
updates tasks for browser and tests 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,6 +117,7 @@ module.exports = function(grunt) {
 
 
   // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('browserstack-runner');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-connect');
@@ -125,15 +126,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-recess');
-  grunt.loadNpmTasks('browserstack-runner');
 
+  // Browser tests.
+  grunt.registerTask('browser', ['test', 'browserstack_runner']);
 
-  // Test task.
-  var testSubtasks = ['jshint', 'qunit'];
-  if (process.env.TRAVIS) {
-    testSubtasks.push('browserstack_runner');
-  }
-  grunt.registerTask('test', testSubtasks);
+  // Unit testing and linting.
+  grunt.registerTask('test', ['qunit', 'jshint']);
 
   // JS distribution task.
   grunt.registerTask('dist-js', ['concat', 'uglify']);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "keywords": ["bootstrap", "css"]
   , "homepage": "http://twbs.github.com/bootstrap/"
   , "author": "Twitter Inc."
-  , "scripts": { "test": "grunt test" }
+  , "scripts": { "test": "grunt browser" }
   , "repository": {
       "type": "git"
     , "url": "https://github.com/twbs/bootstrap.git"


### PR DESCRIPTION
Gruntfile and package.json have been modified so:
- Travis CI will run browserstack and qunit by default, 
- the `test` task just runs qunit and jshint

If a user has browserstack installed locally, they may run `grunt browser` manually. 

cc/ @cvrebert, per https://github.com/twbs/bootstrap/pull/9165
