### PR TITLE
Fix spacing after '=' in popover.js

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -81,7 +81,7 @@
             o.content)
   }
 
-  Popover.prototype.arrow =function () {
+  Popover.prototype.arrow = function () {
     return this.$arrow = this.$arrow || this.tip().find('.arrow')
   }
 


### PR DESCRIPTION
Just added a space after a function definition in popover.js to tidy up the code (even more than it already is).
