### PR TITLE
Fixed #9196 - malformed HTML in doc

### DIFF
--- a/css.html
+++ b/css.html
@@ -1257,7 +1257,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 {% endhighlight %}
 
 
-    <h3 id="forms-inline">Inline form</h2>
+    <h3 id="forms-inline">Inline form</h3>
     <p>Add <code>.form-inline</code> for left-aligned and inline-block controls for a compact layout.</p>
     <div class="bs-callout bs-callout-danger">
       <h4>Requires custom widths</h4>


### PR DESCRIPTION
Stray <h3> was being closed by an </h2>. Updated to valid HTML. Fixes #9196
