### PR TITLE
Update to use @list-group-border-radius

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -25,11 +25,11 @@
 
   // Round the first and last items
   &:first-child {
-    .border-top-radius(@border-radius-base);
+    .border-top-radius(@list-group-border-radius);
   }
   &:last-child {
     margin-bottom: 0;
-    .border-bottom-radius(@border-radius-base);
+    .border-bottom-radius(@list-group-border-radius);
   }
 
   // Align badges within list items


### PR DESCRIPTION
A minor fix.  Corrected the use of variable **@list-group-border-radius** on list-groups. 
