### PR TITLE
Overloaded label-variant mixin for increased flexibility

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -396,12 +396,18 @@
 
 // Labels
 // -------------------------
-.label-variant(@color) {
-  background-color: @color;
+// Mixin overload to allow users to call it without providing the second parameter
+.label-variant(@background) {
+  @link-hover-color: darken(@background, 10%);
+  .label-variant(@background; @link-hover-color);
+}
+
+.label-variant(@background; @link-hover-color) {
+  background-color: @background;
   &[href] {
     &:hover,
     &:focus {
-      background-color: darken(@color, 10%);
+      background-color: @link-hover-color;
     }
   }
 }


### PR DESCRIPTION
For now, label-variant can only be called with the background-color parameter, that is darkened for the link hover state. I also wanted to allow the posibility to manually provide the hover color, but as an optional parameter, so I tried this:

I tried

```
.label-variant(@background; @link-hover-color: darken(@background, 10%)) { 
```

But it failed to compile, cause LESS tried to process the background parameter even after the mixin was called.

So I overloaded the mixin, creating one that receives only one parameter, and other that receives both. It could be done in other places as well.

I know is not as easily readable, but I think we can gain a lot of flexibility by doing this.
