### PR TITLE
Fixes Issue #9281: List group items within Panels should match padding

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -17,6 +17,7 @@
     margin: 15px -15px -15px;
 
     .list-group-item {
+      padding: 15px;
       border-width: 1px 0;
 
       // Remove border radius for top one


### PR DESCRIPTION
https://github.com/twbs/bootstrap/issues/9281

When list group is within a panel, it stretches to 100%, and that's OK. It would be nice to have padding the same for panel and list-group-item
