### PR TITLE
Hide radio/checkboxes for btn-group-vertical [data-toggle="buttons"]

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -194,6 +194,8 @@
 
 // Checkbox and radio options
 .btn-group[data-toggle="buttons"] > .btn > input[type="radio"],
-.btn-group[data-toggle="buttons"] > .btn > input[type="checkbox"] {
+.btn-group[data-toggle="buttons"] > .btn > input[type="checkbox"],
+.btn-group-vertical[data-toggle="buttons"] > .btn > input[type="radio"],
+.btn-group-vertical[data-toggle="buttons"] > .btn > input[type="checkbox"] {
   display: none;
 }


### PR DESCRIPTION
Fix for vertical button group when used with buttons.js plugin
