### PR TITLE
Fixes #8647

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -111,4 +111,8 @@
   &:active {
     z-index: 2;
   }
+  &:focus {
+    // Remove focus outline when dropdown JS adds it after closing the menu
+    outline: none;
+  }
 }


### PR DESCRIPTION
Buttons had still focus in `input-group` in both chrome and firefox

Before: http://jsfiddle.net/tagliala/fKXKN
After: http://jsfiddle.net/tagliala/fKXKN/1/
