### PR TITLE
Added button-size mixin

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -121,17 +121,13 @@
 // --------------------------------------------------
 
 .btn-lg {
-  padding: @padding-large-vertical @padding-large-horizontal;
-  font-size: @font-size-large;
-  line-height: @line-height-large; // ensure even-numbered height of button next to large input
-  border-radius: @border-radius-large;
+  // line-height: ensure even-numbered height of button next to large input
+  .button-size(@padding-large-vertical; @padding-large-horizontal; @font-size-large; @line-height-large; @border-radius-large);
 }
 .btn-sm,
 .btn-xs {
-  padding: @padding-small-vertical @padding-small-horizontal;
-  font-size: @font-size-small;
-  line-height: @line-height-small; // ensure proper height of button next to small input
-  border-radius: @border-radius-small;
+  // line-height: ensure proper height of button next to small input
+  .button-size(@padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @border-radius-small);
 }
 .btn-xs {
   padding: 3px 5px;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -394,6 +394,15 @@
   }
 }
 
+// Button sizes
+// -------------------------
+.button-size(@padding-vertical; @padding-horizontal; @font-size; @line-height; @border-radius) {
+  padding: @padding-vertical @padding-horizontal;
+  font-size: @font-size;
+  line-height: @line-height;
+  border-radius: @border-radius;
+}
+
 // Labels
 // -------------------------
 .label-variant(@color) {


### PR DESCRIPTION
This mixin may seem a bit trivial, but given the concerns on the removal of the (finally restored) btn-mini (#7984, #8644, #8886), I propose this helper mixin that would be of help for new users that need different button sizes. Easier customization is always better.
