### PR TITLE
Aria role search instead of form

### DIFF
--- a/components.html
+++ b/components.html
@@ -1285,8 +1285,8 @@ body { padding-bottom: 70px; }
                 </ul>
               </li>
             </ul>
-            <form class="navbar-form pull-left" action="" role="form">
-              <input type="text" class="form-control col-lg-8" placeholder="Search" role="search">
+            <form class="navbar-form pull-left" action="" role="search">
+              <input type="text" class="form-control col-lg-8" placeholder="Search">
             </form>
             <ul class="nav navbar-nav pull-right">
               <li><a href="#">Link</a></li>
@@ -1355,8 +1355,8 @@ body { padding-bottom: 70px; }
               <li><a href="#">Link</a></li>
               <li><a href="#">Link</a></li>
             </ul>
-            <form class="navbar-form pull-left" action="" role="form">
-              <input type="text" class="form-control col-lg-8" placeholder="Search" role="search">
+            <form class="navbar-form pull-left" action="" role="search">
+              <input type="text" class="form-control col-lg-8" placeholder="Search">
             </form>
           </div><!-- /.nav-collapse -->
         </div><!-- /.container -->
@@ -1405,8 +1405,8 @@ body { padding-bottom: 70px; }
                 </ul>
               </li>
             </ul>
-            <form class="navbar-form pull-left" action="" role="form">
-              <input type="text" class="form-control col-lg-8" placeholder="Search" role="search">
+            <form class="navbar-form pull-left" action="" role="search">
+              <input type="text" class="form-control col-lg-8" placeholder="Search">
             </form>
             <ul class="nav navbar-nav pull-right">
               <li><a href="#">Link</a></li>


### PR DESCRIPTION
Currently search forms have a <code>role="form"</code> and the input boxes have a <code>role="search"</code>.

The specs (http://www.w3.org/TR/wai-aria/roles#search) state:

> search (role)
> A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility

And (http://www.w3.org/TR/wai-aria/roles#form):

> form (role)
> ...
> For search facilities, authors SHOULD use the search role and not the generic form role.

Therefore we should drop the <code>role="form"</code> and move the <code>role="search"</code> to the <code>form</code> element on search related forms
