### PR TITLE
Add missing aria-hidden attribs to close buttons

### DIFF
--- a/components.html
+++ b/components.html
@@ -1917,13 +1917,13 @@ body { padding-bottom: 70px; }
     <p>Build on any alert by adding an optional <code>.alert-dismissable</code> and close button.</p>
     <div class="bs-example">
       <div class="alert alert-dismissable">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <strong>Warning!</strong> Best check yo self, you're not looking too good.
       </div>
     </div>
 {% highlight html %}
 <div class="alert alert-dismissable">
-  <button type="button" class="close" data-dismiss="alert">&times;</button>
+  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <strong>Warning!</strong> Best check yo self, you're not looking too good.
 </div>
 {% endhighlight %}

--- a/css.html
+++ b/css.html
@@ -2032,10 +2032,10 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <h3>Close icon</h3>
     <p>Use the generic close icon for dismissing content like modals and alerts.</p>
     <div class="bs-example">
-      <p><button type="button" class="close">&times;</button></p>
+      <p><button type="button" class="close" aria-hidden="true">&times;</button></p>
     </div>
 {% highlight html %}
-<button type="button" class="close">&times;</button>
+<button type="button" class="close" aria-hidden="true">&times;</button>
 {% endhighlight %}
 
     <h3>.pull-left</h3>

--- a/javascript.html
+++ b/javascript.html
@@ -1144,14 +1144,14 @@ $('#myPopover').on('hidden.bs.popover', function () {
     <p>Add dismiss functionality to all alert messages with this plugin.</p>
     <div class="bs-example">
       <div class="alert fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <strong>Holy guacamole!</strong> Best check yo self, you're not looking too good.
       </div>
     </div><!-- /example -->
 
     <div class="bs-example">
       <div class="alert alert-block alert-error fade in">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <h4>Oh snap! You got an error!</h4>
         <p>Change this and that and try again. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum.</p>
         <p>
@@ -1167,7 +1167,7 @@ $('#myPopover').on('hidden.bs.popover', function () {
 
     <h3>Markup</h3>
     <p>Just add <code>data-dismiss="alert"</code> to your close button to automatically give an alert close functionality.</p>
-    {% highlight html %}<a class="close" data-dismiss="alert" href="#">&times;</a>{% endhighlight %}
+    {% highlight html %}<a class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</a>{% endhighlight %}
 
     <h3>Methods</h3>
 


### PR DESCRIPTION
Currently not all close (&times;) buttons have an <code>aria-hidden="true"</code>. This adds the missing ones.
