### PR TITLE
Converted all font-size to rem units

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -11,7 +11,7 @@
   display: inline-block;
   padding: @padding-base-vertical @padding-base-horizontal;
   margin-bottom: 0; // For input.btn
-  font-size: @font-size-base;
+  font-size: 1rem;
   font-weight: @btn-font-weight;
   line-height: @line-height-base;
   text-align: center;

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -187,7 +187,7 @@
     height: 30px;
     margin-top: -15px;
     margin-left: -15px;
-    font-size: 30px;
+    font-size: 2.14rem;
   }
 
   // Show and left align the captions

--- a/less/close.less
+++ b/less/close.less
@@ -5,7 +5,7 @@
 
 .close {
   float: right;
-  font-size: (@font-size-base * 1.5);
+  font-size: 1.5rem;
   font-weight: @close-font-weight;
   line-height: 1;
   color: @close-color;

--- a/less/code.less
+++ b/less/code.less
@@ -12,7 +12,7 @@ pre {
 // Inline code
 code {
   padding: 2px 4px;
-  font-size: 90%;
+  font-size: 0.9rem;
   color: @code-color;
   background-color: @code-bg;
   white-space: nowrap;
@@ -24,7 +24,7 @@ pre {
   display: block;
   padding: ((@line-height-computed - 1) / 2);
   margin: 0 0 (@line-height-computed / 2);
-  font-size: (@font-size-base - 1); // 14px to 13px
+  font-size: 0.93rem; // 14px to 13px
   line-height: @line-height-base;
   word-break: break-all;
   word-wrap: break-word;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -33,7 +33,7 @@
   padding: 5px 0;
   margin: 2px 0 0; // override default ul
   list-style: none;
-  font-size: @font-size-base;
+  font-size: 1rem;
   background-color: @dropdown-bg;
   border: 1px solid @dropdown-fallback-border; // IE8 fallback
   border: 1px solid @dropdown-border;

--- a/less/forms.less
+++ b/less/forms.less
@@ -18,7 +18,7 @@ legend {
   width: 100%;
   padding: 0;
   margin-bottom: @line-height-computed;
-  font-size: (@font-size-base * 1.5);
+  font-size: 1.5rem;
   line-height: inherit;
   color: @legend-color;
   border: 0;
@@ -119,7 +119,7 @@ input[type="number"] {
   width: 100%;
   height: @input-height-base; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
   padding: @padding-base-vertical @padding-base-horizontal;
-  font-size: @font-size-base;
+  font-size: 1rem;
   line-height: @line-height-base;
   color: @input-color;
   vertical-align: middle;

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -58,7 +58,7 @@
 // -------------------------
 .input-group-addon {
   padding: @padding-base-vertical @padding-base-horizontal;
-  font-size: @font-size-base;
+  font-size: 1rem;
   font-weight: normal;
   line-height: 1;
   text-align: center;

--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -6,7 +6,7 @@
 .jumbotron {
   padding: 30px;
   margin-bottom: 30px;
-  font-size: (@font-size-base * 1.5);
+  font-size: 1.5rem;
   font-weight: 200;
   line-height: (@line-height-base * 1.5);
   color: @jumbotron-lead-color;
@@ -23,7 +23,7 @@
     padding: 50px 60px;
     border-radius: @border-radius-large; // Only round corners at higher resolutions
     h1 {
-      font-size: (@font-size-base * 4.5);
+      font-size: 4.5rem;
     }
   }
 }

--- a/less/labels.less
+++ b/less/labels.less
@@ -5,7 +5,7 @@
 .label {
   display: inline;
   padding: .25em .6em;
-  font-size: 75%;
+  font-size: 0.75rem;
   font-weight: bold;
   line-height: 1;
   color: @label-color;

--- a/less/normalize.less
+++ b/less/normalize.less
@@ -106,8 +106,8 @@ a:hover {
 //
 
 h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
+  font-size: 2rem;
+  margin: 0.67rem 0;
 }
 
 //
@@ -163,7 +163,7 @@ kbd,
 pre,
 samp {
   font-family: monospace, serif;
-  font-size: 1em;
+  font-size: 1rem;
 }
 
 //
@@ -187,7 +187,7 @@ q {
 //
 
 small {
-  font-size: 80%;
+  font-size: 0.8rem;
 }
 
 //
@@ -196,7 +196,7 @@ small {
 
 sub,
 sup {
-  font-size: 75%;
+  font-size: 0.75rem;
   line-height: 0;
   position: relative;
   vertical-align: baseline;
@@ -277,7 +277,7 @@ input,
 select,
 textarea {
   font-family: inherit; // 1
-  font-size: 100%; // 2
+  font-size: 1rem; // 2
   margin: 0; // 3
 }
 

--- a/less/panels.less
+++ b/less/panels.less
@@ -59,7 +59,7 @@
 .panel-title {
   margin-top: 0;
   margin-bottom: 0;
-  font-size: (@font-size-base * 1.25);
+  font-size: 1.25rem;
   > a {
     color: inherit;
   }

--- a/less/popovers.less
+++ b/less/popovers.less
@@ -32,7 +32,7 @@
 .popover-title {
   margin: 0; // reset heading margin
   padding: 8px 14px;
-  font-size: @font-size-base;
+  font-size: 1rem;
   font-weight: normal;
   line-height: 18px;
   background-color: @popover-title-bg;

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -17,14 +17,13 @@
 // -------------------------
 
 html {
-  font-size: 62.5%;
+  font-family: @font-family-base;
+  font-size: @font-size-base;
+  line-height: @line-height-base;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 body {
-  font-family: @font-family-base;
-  font-size: @font-size-base;
-  line-height: @line-height-base;
   color: @text-color;
   background-color: @body-bg;
 }

--- a/less/type.less
+++ b/less/type.less
@@ -11,12 +11,12 @@ p {
 }
 .lead {
   margin-bottom: @line-height-computed;
-  font-size: (@font-size-base * 1.15);
+  font-size: 1.15rem;
   font-weight: 200;
   line-height: 1.4;
 
   @media (min-width: 768px) {
-    font-size: (@font-size-base * 1.5);
+    font-size: 1.5rem;
   }
 }
 
@@ -25,7 +25,7 @@ p {
 // -------------------------
 
 // Ex: 14px base font * 85% = about 12px
-small   { font-size: 85%; }
+small   { font-size: 0.85rem; }
 
 // Undo browser default styling
 cite    { font-style: normal; }
@@ -72,17 +72,17 @@ h6 {
   margin-bottom: (@line-height-computed / 2);
 }
 
-h1, .h1 { font-size: ceil(@font-size-base * 2.70); } // ~38px
-h2, .h2 { font-size: ceil(@font-size-base * 2.25); } // ~32px
-h3, .h3 { font-size: ceil(@font-size-base * 1.70); } // ~24px
-h4, .h4 { font-size: ceil(@font-size-base * 1.25); } // ~18px
-h5, .h5 { font-size:  @font-size-base; }
-h6, .h6 { font-size: ceil(@font-size-base * 0.85); } // ~12px
+h1, .h1 { font-size: 2.70rem; } // ~38px
+h2, .h2 { font-size: 2.25rem; } // ~32px
+h3, .h3 { font-size: 1.70rem; } // ~24px
+h4, .h4 { font-size: 1.25rem; } // ~18px
+h5, .h5 { font-size: 1rem; }
+h6, .h6 { font-size: 0.85rem; } // ~12px
 
-h1 small, .h1 small { font-size: ceil(@font-size-base * 1.70); } // ~24px
-h2 small, .h2 small { font-size: ceil(@font-size-base * 1.25); } // ~18px
+h1 small, .h1 small { font-size: 1.70rem; } // ~24px
+h2 small, .h2 small { font-size: 1.25rem; } // ~18px
 h3 small, .h3 small,
-h4 small, .h4 small { font-size: @font-size-base; }
+h4 small, .h4 small { font-size: 1rem; }
 
 
 // Page header
@@ -174,7 +174,7 @@ abbr[data-original-title] {
   border-bottom: 1px dotted @abbr-border-color;
 }
 abbr.initialism {
-  font-size: 90%;
+  font-size: 0.9rem;
   text-transform: uppercase;
 }
 
@@ -184,7 +184,7 @@ blockquote {
   margin: 0 0 @line-height-computed;
   border-left: 5px solid @blockquote-border-color;
   p {
-    font-size: (@font-size-base * 1.25);
+    font-size: 1.25rem;
     font-weight: 300;
     line-height: 1.25;
   }

--- a/less/variables.less
+++ b/less/variables.less
@@ -45,8 +45,8 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          14px;
-@font-size-large:         ceil(@font-size-base * 1.25); // ~18px
-@font-size-small:         ceil(@font-size-base * 0.85); // ~12px
+@font-size-large:         1.25rem; // ~18px
+@font-size-small:         0.85rem; // ~12px
 
 @line-height-base:        1.428571429; // 20/14
 @line-height-computed:    floor(@font-size-base * @line-height-base); // ~20px
@@ -548,7 +548,7 @@
 @carousel-control-color:                      #fff;
 @carousel-control-width:                      15%;
 @carousel-control-opacity:                    .5;
-@carousel-control-font-size:                  20px;
+@carousel-control-font-size:                  1.43rem;
 
 @carousel-indicator-active-bg:                #fff;
 @carousel-indicator-border-color:             #fff;


### PR DESCRIPTION
This allows implementers to override all font sizes without the need to recompile and still be able to use the code from CDN. Implementers only need to add `body{font-size:...}` to their style sheets.

This also allows implementers that need to conform to WCAG 2.0 to comply with the previous line of code (it is a failure of WCAG 2.0 to use absolute units such as pixels).
