### PR TITLE
CSS Grid old classes in use

### DIFF
--- a/css.html
+++ b/css.html
@@ -296,8 +296,8 @@ base_url: "../"
         <div class="col-xs-6 col-sm-4 col-md-4">.col-xs-6 .col-sm-4 .col-md-4</div>
       </div>
       <div class="row show-grid">
-        <div class="col-6 col-sm-6 col-md-6">.col-xs-6 .col-sm-6 .col-md-6</div>
-        <div class="col-6 col-sm-6 col-md-6">.col-xs-6 .col-sm-6 .col-md-6</div>
+        <div class="col-xs-6 col-sm-6 col-md-6">.col-xs-6 .col-sm-6 .col-md-6</div>
+        <div class="col-xs-6 col-sm-6 col-md-6">.col-xs-6 .col-sm-6 .col-md-6</div>
       </div>
     </div>
 {% highlight html %}


### PR DESCRIPTION
CSS example file uses col-6 when trying to show col-xs-6 example.
