### PR TITLE
OL breadcrumbs

### DIFF
--- a/components.html
+++ b/components.html
@@ -1445,25 +1445,25 @@ body { padding-bottom: 70px; }
     <p class="lead">Indicate the current page's location within a navigational hierarchy.</p>
     <p>Separators are automatically added in CSS through <code>:before</code> and <code>content</code>.</p>
     <div class="bs-example">
-      <ul class="breadcrumb">
+      <ol class="breadcrumb">
         <li class="active">Home</li>
-      </ul>
-      <ul class="breadcrumb">
+      </ol>
+      <ol class="breadcrumb">
         <li><a href="#">Home</a></li>
         <li class="active">Library</li>
-      </ul>
-      <ul class="breadcrumb" style="margin-bottom: 5px;">
+      </ol>
+      <ol class="breadcrumb" style="margin-bottom: 5px;">
         <li><a href="#">Home</a></li>
         <li><a href="#">Library</a></li>
         <li class="active">Data</li>
-      </ul>
+      </ol>
     </div>
 {% highlight html %}
-<ul class="breadcrumb">
+<ol class="breadcrumb">
   <li><a href="#">Home</a></li>
   <li><a href="#">Library</a></li>
   <li class="active">Data</li>
-</ul>
+</ol>
 {% endhighlight %}
   </div>
 


### PR DESCRIPTION
The order of breadcrumbs is semantically relevant so it should be an <code>ol</code> instead of an <code>ul</code>
