### PR TITLE
Remove old accordion remnant

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -516,11 +516,6 @@
 @well-bg:                     #f5f5f5;
 
 
-// Accordion
-// -------------------------
-@accordion-border-color:      #e5e5e5;
-
-
 // Badges
 // -------------------------
 @badge-color:                 #fff;


### PR DESCRIPTION
The variable <code>@accordion-border-color</code> is no longer used since the accordion was merged into the panel and can therefore be removed.
