### PR TITLE
Fixes affix plugin to allow a function for offset.

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1895,7 +1895,7 @@ $('#myCarousel').on('slide.bs.carousel', function () {
            <td>offset</td>
            <td>number | function | object</td>
            <td>10</td>
-           <td>Pixels to offset from screen when calculating position of scroll. If a single number is provided, the offset will be applied in both top and left directions. To provide a unique, bottom and top offset just provide an object <code>offset: { top: 10 }</code> or <code>offset: { top: 10, bottom: 5 }</code>. Use a function when you need to dynamically calculate an offset.</td>
+           <td>Pixels to offset from screen when calculating position of scroll. If a single number is provided, the offset will be applied in both top and bottom directions. To provide a unique bottom and top offset, just provide an object <code>offset: { top: 10 }</code> or <code>offset: { top: 10, bottom: 5 }</code>. Use a function when you need to dynamically calculate an offset. The function should return a number to use for both offsets or an object with top and/or bottom offsets.</td>
          </tr>
         </tbody>
       </table>

--- a/js/affix.js
+++ b/js/affix.js
@@ -56,6 +56,9 @@
     var offsetTop    = offset.top
     var offsetBottom = offset.bottom
 
+    if (typeof offset == 'function') {
+      offset = offset()
+    }
     if (typeof offset != 'object')         offsetBottom = offsetTop = offset
     if (typeof offsetTop == 'function')    offsetTop    = offset.top()
     if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()


### PR DESCRIPTION
The current affix plugin allows for a function in the top or bottom options:

``` javascript
$el.affix({
  offset: {
    top: function() {/* Some function */},
    bottom: function() {/* Some function */}
  }
});
```

but not as a single parameter for both top **and** bottom:

``` javascript
$el.affix({
  offset: function() {/* Some function */}
});
```

This PR evaluates `offset()` first if it's a function (and updates the docs to match).
