### PR TITLE
Change input type for the email input examples

### DIFF
--- a/css.html
+++ b/css.html
@@ -1355,7 +1355,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
         <legend>Legend</legend>
         <div class="form-group">
           <label for="exampleInputEmail1">Email address</label>
-          <input type="text" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+          <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
         </div>
         <div class="form-group">
           <label for="exampleInputPassword1">Password</label>
@@ -1380,7 +1380,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <legend>Legend</legend>
     <div class="form-group">
       <label for="exampleInputEmail1">Email address</label>
-      <input type="text" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+      <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
     </div>
     <div class="form-group">
       <label for="exampleInputPassword1">Password</label>
@@ -1415,7 +1415,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <form class="bs-example form-inline" role="form">
       <div class="form-group">
         <label class="sr-only" for="exampleInputEmail2">Email address</label>
-        <input type="text" class="form-control" id="exampleInputEmail2" placeholder="Enter email">
+        <input type="email" class="form-control" id="exampleInputEmail2" placeholder="Enter email">
       </div>
       <div class="form-group">
         <label class="sr-only" for="exampleInputPassword2">Password</label>
@@ -1432,7 +1432,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 <form class="form-inline" role="form">
   <div class="form-group">
     <label class="sr-only" for="exampleInputEmail2">Email address</label>
-    <input type="text" class="form-control" id="exampleInputEmail2" placeholder="Enter email">
+    <input type="email" class="form-control" id="exampleInputEmail2" placeholder="Enter email">
   </div>
   <div class="form-group">
     <label class="sr-only" for="exampleInputPassword2">Password</label>
@@ -1453,7 +1453,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
       <div class="form-group">
         <label for="inputEmail1" class="col-lg-2 control-label">Email</label>
         <div class="col-lg-10">
-          <input type="text" class="form-control" id="inputEmail1" placeholder="Email">
+          <input type="email" class="form-control" id="inputEmail1" placeholder="Email">
         </div>
       </div>
       <div class="form-group">
@@ -1482,7 +1482,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
   <div class="form-group">
     <label for="inputEmail1" class="col-lg-2 control-label">Email</label>
     <div class="col-lg-10">
-      <input type="text" class="form-control" id="inputEmail1" placeholder="Email">
+      <input type="email" class="form-control" id="inputEmail1" placeholder="Email">
     </div>
   </div>
   <div class="form-group">


### PR DESCRIPTION
I know the form code are only examples, but it'd be good to encourage proper usage of the input type for the email inputs by changing the type from "text" to "email".
