### PR TITLE
- Added a new mixin to create a column for the base mobile widths, which...

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -546,6 +546,16 @@
   }
 }
 
+// Generate a mixin for mobile full width columns, to maintain the same attributes
+.make-column(@gutter: @grid-gutter-width) {
+  position: relative;
+  // Prevent columns from collapsing when empty
+  min-height: 1px;
+  // Inner gutter via padding
+  padding-left:  (@gutter / 2);
+  padding-right: (@gutter / 2);
+}
+
 // Generate the extra small columns
 .make-xs-column(@columns; @gutter: @grid-gutter-width) {
   position: relative;


### PR DESCRIPTION
- Added a new mixin to create a column for the base mobile widths, which allows for a class to use a "make-column()" so classes that don't use column sizes still get the padding, position, min-height. When using HTML classes that rely on the mixins to generate the columns, if you have a class that generates columns with a standard .make-_-column(_) within a media query, there is nothing on the base class to tell it to grab the base styles, as referenced in the grid.less line 16 "// Common styles for small and large grid columns".

this make-column() mixin essentially says to make the class a column, but since it's for a mobile 100% width it doesn't need any column variable since if you did want a column at the smallest size, you would use make-xs-column(*).
