### PR TITLE
Move includes into bootstrap-include.less, so this can more easily be included with a custom variables file.

### DIFF
--- a/less/bootstrap-include.less
+++ b/less/bootstrap-include.less
@@ -1,0 +1,55 @@
+//
+// Includes
+// --------------------------------------------------
+
+@import "mixins.less";
+
+// Reset
+@import "normalize.less";
+@import "print.less";
+
+// Core CSS
+@import "scaffolding.less";
+@import "type.less";
+@import "code.less";
+@import "grid.less";
+
+@import "tables.less";
+@import "forms.less";
+@import "buttons.less";
+
+// Components: common
+@import "component-animations.less";
+@import "input-groups.less";
+@import "dropdowns.less";
+@import "list-group.less";
+@import "panels.less";
+@import "wells.less";
+@import "close.less";
+
+// Components: Nav
+@import "navs.less";
+@import "navbar.less";
+@import "button-groups.less";
+@import "breadcrumbs.less";
+@import "pagination.less";
+@import "pager.less";
+
+// Components: Popovers
+@import "modals.less";
+@import "tooltip.less";
+@import "popovers.less";
+
+// Components: Misc
+@import "alerts.less";
+@import "thumbnails.less";
+@import "media.less";
+@import "labels.less";
+@import "badges.less";
+@import "progress-bars.less";
+@import "carousel.less";
+@import "jumbotron.less";
+
+// Utility classes
+@import "utilities.less"; // Has to be last to override when necessary
+@import "responsive-utilities.less";

--- a/less/bootstrap.less
+++ b/less/bootstrap.less
@@ -10,54 +10,6 @@
 
 // Core variables and mixins
 @import "variables.less";
-@import "mixins.less";
 
-// Reset
-@import "normalize.less";
-@import "print.less";
-
-// Core CSS
-@import "scaffolding.less";
-@import "type.less";
-@import "code.less";
-@import "grid.less";
-
-@import "tables.less";
-@import "forms.less";
-@import "buttons.less";
-
-// Components: common
-@import "component-animations.less";
-@import "input-groups.less";
-@import "dropdowns.less";
-@import "list-group.less";
-@import "panels.less";
-@import "wells.less";
-@import "close.less";
-
-// Components: Nav
-@import "navs.less";
-@import "navbar.less";
-@import "button-groups.less";
-@import "breadcrumbs.less";
-@import "pagination.less";
-@import "pager.less";
-
-// Components: Popovers
-@import "modals.less";
-@import "tooltip.less";
-@import "popovers.less";
-
-// Components: Misc
-@import "alerts.less";
-@import "thumbnails.less";
-@import "media.less";
-@import "labels.less";
-@import "badges.less";
-@import "progress-bars.less";
-@import "carousel.less";
-@import "jumbotron.less";
-
-// Utility classes
-@import "utilities.less"; // Has to be last to override when necessary
-@import "responsive-utilities.less";
+// Main includes
+@import "bootstrap-include.less";


### PR DESCRIPTION
At the moment I use Bootstrap by replacing `bootstrap.less` with my own file, in order to include my own variables without modifying the Bootstrap source. However I then have to copy and paste the long list of includes into my own version of `bootstrap.less`. I can't include `bootstrap.less` directly because if I put my own variables before I include they get overridden by the defaults, and if I put it after they get ignored.

This PR moves those includes into `bootstrap-include.less`. `bootstrap.less` then simply includes `variables.less` and `bootstrap-include.less`.

My site's Less file then becomes

```
@import "lib/bootstrap/less/variables.less";

// my tweaks to variables...

@import "lib/bootstrap/less/bootstrap-include.less";

// my tweaks to other stuff...
```

Or am I using Bootstrap incorrectly?
