### PR TITLE
fix file structure in "What's included"

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -73,9 +73,9 @@ bootstrap/
 ├── css/
 │   ├── bootstrap.css
 │   ├── bootstrap.min.css
-├── js/
-│   ├── bootstrap.js
-│   ├── bootstrap.min.js
+└── js/
+    ├── bootstrap.js
+    └── bootstrap.min.js
 {% endhighlight %}
 
     <p>This is the most basic form of Bootstrap: compiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (<code>bootstrap.*</code>), as well as compiled and minified CSS and JS (<code>bootstrap.min.*</code>).</p>


### PR DESCRIPTION
old ascii file structure in Bootstrap 2.3.2
![screen shot 2013-08-18 at 10 28 23 pm](https://f.cloud.github.com/assets/1016365/984231/301c914a-0890-11e3-80a1-2f6db4c697e3.png)

current ascii file structure in Bootstrap 3.0 RC2
![screen shot 2013-08-18 at 10 28 18 pm](https://f.cloud.github.com/assets/1016365/984233/32fc0fd0-0890-11e3-99c0-610c8b413b7c.png)
