### PR TITLE
Remove unnecessary trailing comma in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,7 +127,7 @@ module.exports = function(grunt) {
 
     validation: {
       options: {
-        reset: true,
+        reset: true
       },
       files: {
         src: ["_gh_pages/**/*.html"]


### PR DESCRIPTION
```
validation: {
  options: {
    reset: true
  },
```
