### PR TITLE
Fixed carousel example navigation.

### DIFF
--- a/examples/carousel/carousel.css
+++ b/examples/carousel/carousel.css
@@ -38,6 +38,7 @@ body {
 /* Declare heights because of positioning of img element */
 .carousel .item {
   height: 500px;
+  background-color: #777;
 }
 .carousel-inner > .item > img {
   position: absolute;
@@ -93,7 +94,7 @@ body {
 
 @media (min-width: 768px) {
 
-  /* Remve the edge padding needed for mobile */
+  /* Remove the edge padding needed for mobile */
   .marketing {
     padding-left: 0;
     padding-right: 0;

--- a/examples/carousel/carousel.css
+++ b/examples/carousel/carousel.css
@@ -18,6 +18,12 @@ body {
   z-index: 15;
 }
 
+/* Vertically aligns left and right chevrons. */
+.carousel-control > .glyphicon-chevron-left, .carousel-control > .glyphicon-chevron-right {
+  position: absolute;
+  display: inline-block;
+  top: 50%;
+}
 
 
 /* CUSTOMIZE THE CAROUSEL


### PR DESCRIPTION
Set a background color for the carousel example so that white text is now legible.
Chevrons are also now vertically centered.

Also fixed typo on line 97.
