### PR TITLE
`.table` style is duplicate in `List groups in panels` and `Tables in panels`

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -25,9 +25,6 @@
 // any kind of custom content between the two.
 
 .panel {
-  > .table {
-    margin-bottom: 0;
-  }
   > .list-group {
     margin-bottom: 0;
 


### PR DESCRIPTION
`.table` style is duplicate in `List groups in panels` and `Tables in panels`
