### PR TITLE
Update tables.less

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -137,14 +137,14 @@ th {
 //
 // Reset default table behavior
 
-table col[class^="col-"] {
+table col[class*="col-"] {
   float: none;
   display: table-column;
 }
 table {
   td,
   th {
-    &[class^="col-"] {
+    &[class*="col-"] {
       float: none;
       display: table-cell;
     }


### PR DESCRIPTION
Fixed table cell sizing with leading classes by using *= instead of ^=

The issue:
http://jsfiddle.net/XxrtB/8/

With fix:
http://jsfiddle.net/XxrtB/9/
