### PR TITLE
Correct "Aligninment" -> "Alignment" typo.

### DIFF
--- a/components.html
+++ b/components.html
@@ -289,7 +289,7 @@ base_url: "../"
 </div>
 {% endhighlight %}
 
-    <h3 id="dropdowns-alignment">Aligninment options</h3>
+    <h3 id="dropdowns-alignment">Alignment options</h3>
     <p>Add <code>.pull-right</code> to a <code>.dropdown-menu</code> to right align the dropdown menu.</p>
 {% highlight html %}
 <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dLabel">


### PR DESCRIPTION
Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
