### PR TITLE
removed mention of button gradient

### DIFF
--- a/css.html
+++ b/css.html
@@ -1972,7 +1972,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
       <button type="button" class="btn btn-link">Link</button>
     </div>
 {% highlight html %}
-<!-- Standard gray button with gradient -->
+<!-- Default button -->
 <button type="button" class="btn btn-default">Default</button>
 
 <!-- Provides extra visual weight and identifies the primary action in a set of buttons -->


### PR DESCRIPTION
The default button's description said it was grey with a gradient. I stripped down the wording, but I doubt this is the ideal description (it reads more like a non-description). Whatever the case, some new wording is likely needed to reflect the button's new look.
