### PR TITLE
Fixed wrong char encoding for non-responsive.css

### DIFF
--- a/examples/non-responsive/non-responsive.css
+++ b/examples/non-responsive/non-responsive.css
@@ -1,4 +1,4 @@
-
+﻿
 /* Template-specific stuff
  *
  * Customizations just for the template—these are not necessary for anything


### PR DESCRIPTION
Saved file with 'UTF-8 with BOM' option so that the dash in the CSS comment can rendered in the browser.
For issue: https://github.com/twbs/bootstrap/issues/9924

Before fix:
![screen shot 2013-08-20 at 12 35 34 pm](https://f.cloud.github.com/assets/1811365/996438/de2626c6-09cf-11e3-8c65-2242cab58c76.png)

After:
![screen shot 2013-08-20 at 12 35 50 pm](https://f.cloud.github.com/assets/1811365/996439/e2de2d3a-09cf-11e3-9d0d-81cad8502165.png)
