### PR TITLE
Bower - Added fonts to "main" files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap",
   "version": "3.0.0",
-  "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css"],
+  "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css", "./dist/fonts/*"],
   "ignore": [
       "**/.*"
   ],


### PR DESCRIPTION
When using bower the "main" property is used to specify the files that should be consumed by applications including the package as a dependency.
Without including the fonts in this array the glyphicons do not work correctly as the relative font paths do not work after the "main" files are copied into my projects public dir using tools like https://github.com/yatskevich/grunt-bower-task

For now I have manually copied the fonts dir in the location needed for my project. But by accepting this pull request this will not be necessary for me or for other people that use bower.
