### PR TITLE
Apply gradient stripe @color parameter

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -496,7 +496,7 @@
 .progress-bar-variant(@color) {
   background-color: @color;
   .progress-striped & {
-    #gradient > .striped(@color);
+    #gradient > .striped();
   }
 }
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -276,11 +276,11 @@
     background-image: radial-gradient(circle, @inner-color, @outer-color);
     background-repeat: no-repeat;
   }
-  .striped(@color: #555; @angle: 45deg) {
-    background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, rgba(255,255,255,.15)), color-stop(.25, transparent), color-stop(.5, transparent), color-stop(.5, rgba(255,255,255,.15)), color-stop(.75, rgba(255,255,255,.15)), color-stop(.75, transparent), to(transparent));
-    background-image: -webkit-linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
-    background-image: -moz-linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(@angle, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
+  .striped(@color: rgba(255,255,255,.15); @angle: 45deg) {
+    background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, @color), color-stop(.25, transparent), color-stop(.5, transparent), color-stop(.5, @color), color-stop(.75, @color), color-stop(.75, transparent), to(transparent));
+    background-image: -webkit-linear-gradient(@angle, @color 25%, transparent 25%, transparent 50%, @color 50%, @color 75%, transparent 75%, transparent);
+    background-image: -moz-linear-gradient(@angle, @color 25%, transparent 25%, transparent 50%, @color 50%, @color 75%, transparent 75%, transparent);
+    background-image: linear-gradient(@angle, @color 25%, transparent 25%, transparent 50%, @color 50%, @color 75%, transparent 75%, transparent);
   }
 }
 

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -60,7 +60,7 @@
 
 // Striped bars
 .progress-striped .progress-bar {
-  #gradient > .striped(@progress-bar-bg);
+  #gradient > .striped();
   background-size: 40px 40px;
 }
 


### PR DESCRIPTION
The @color parameter for the #gradient > .striped() mixin is not being used. Currently, the striped color is hard coded  to be a transparent white and not the #555 color value set as the default @color parameter.
