### PR TITLE
Update justified-nav.css (Removed unnecessary ms-linear-gradient prefix)

### DIFF
--- a/examples/justified-nav/justified-nav.css
+++ b/examples/justified-nav/justified-nav.css
@@ -38,7 +38,6 @@ body {
   background-image: -moz-linear-gradient(top, #f5f5f5 0%, #e5e5e5 100%); /* FF3.6+ */
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f5f5f5), color-stop(100%,#e5e5e5)); /* Chrome,Safari4+ */
   background-image: -webkit-linear-gradient(top, #f5f5f5 0%,#e5e5e5 100%); /* Chrome 10+,Safari 5.1+ */
-  background-image: -ms-linear-gradient(top, #f5f5f5 0%,#e5e5e5 100%); /* IE10+ */
   background-image: -o-linear-gradient(top, #f5f5f5 0%,#e5e5e5 100%); /* Opera 11.10+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f5f5f5', endColorstr='#e5e5e5',GradientType=0 ); /* IE6-9 */
   background-image: linear-gradient(top, #f5f5f5 0%,#e5e5e5 100%); /* W3C */


### PR DESCRIPTION
Removed unnecessary ms-linear-gradient prefix. There was never a stable release of IE that supported -ms- prefixed gradients, those were only in preview versions (stable IE10 supports both prefixed and unprefixed gradients). (source: http://lea.verou.me/2013/04/can-we-get-rid-of-gradient-prefixes/)
