### PR TITLE
code.less: also set default monospace font for `<kbd>` and `<samp>`

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -5,7 +5,9 @@
 
 // Inline and block code styles
 code,
-pre {
+kdb,
+pre,
+samp {
   font-family: @font-family-monospace;
 }
 


### PR DESCRIPTION
Right now the "default monospace" (as set in `variables.less`) font is only set on `code` and `pre` elements.

It should include at least `kbd` and `samp` as well (`command` is obsolete and `var` doesn't have to be monospace)

_Edit:_ Updated for clarity
