### PR TITLE
remove .btn-group

### DIFF
--- a/components.html
+++ b/components.html
@@ -1163,7 +1163,7 @@ base_url: "../"
 
 <div class="input-group">
   <input type="text" class="form-control">
-  <div class="input-group-btn btn-group">
+  <div class="input-group-btn">
     <!-- Button and dropdown menu -->
   </div>
 </div>


### PR DESCRIPTION
Removing this class--it's not used in the example and using it causes "bad things to happen" in some cases, i.e. stacked buttons. 

http://jsfiddle.net/josephtate/Jn6H4/
