### PR TITLE
list-group.less: use `overflow: hidden;`

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -21,6 +21,7 @@
   // Place the border on the list items and negative margin up for better styling
   margin-bottom: -1px;
   background-color: @list-group-bg;
+  overflow: hidden;
   border: 1px solid @list-group-border;
 
   // Round the first and last items


### PR DESCRIPTION
avoid very long text overflow the margin
