### PR TITLE
Update code example for live demo

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -201,7 +201,7 @@ $('#myModal').on('show.bs.modal', function (e) {
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title">Modal title</h4>
+          <h4 class="modal-title" id="myModalLabel">Modal title</h4>
         </div>
         <div class="modal-body">
           ...


### PR DESCRIPTION
Added missing id attribute ( id="myModalLabel") to the <h4 element in code example block. 
