### PR TITLE
Proposal - Fixed width for glypicons

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -27,10 +27,10 @@
   font-weight: normal;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
-}
 
-.glyphicon-block{
-  width: 1em;
+  &:empty{
+    width: 1em;
+  }
 }
 
 // Individual icons

--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -29,6 +29,10 @@
   -webkit-font-smoothing: antialiased;
 }
 
+.glyphicon-block{
+  width: 1em;
+}
+
 // Individual icons
 .glyphicon-asterisk               { &:before { content: "\2a"; } }
 .glyphicon-plus                   { &:before { content: "\2b"; } }


### PR DESCRIPTION
The problem…
Before the Glyphicon font file has loaded elements using glypicons have no width defined. Then once the font loads the elements grow and move other items around the page.
This issue is exacerbated when after the elements grow they cause text to go onto new lines.

The proposed fix - Add a defined width of 1em to all :empty glyphicons

Demo of the problem http://9a6c381b6ab68b16ed63-5b5693321d576aeab3f1767c0caf2c60.r44.cf3.rackcdn.com/
Demo of the proposed fix http://9a6c381b6ab68b16ed63-5b5693321d576aeab3f1767c0caf2c60.r44.cf3.rackcdn.com/fix.html
