### PR TITLE
remove .panel selector from collapse.js

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -48,7 +48,7 @@
     this.$element.trigger(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
-    var actives = this.$parent && this.$parent.find('> .panel > .in')
+    var actives = this.$parent && this.$parent.find('.in')
 
     if (actives && actives.length) {
       var hasData = actives.data('bs.collapse')


### PR DESCRIPTION
What is the purpose of using the ".panel" selector? It doesn't work for 

``` html
...
<li><a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#mainmenu" href="#collapseOne">label</a>
<ul class="list-unstyled collapse" id="collapseOne">
<li><a href="#">label</a></li>
</ul>
</li>
...
```
