### PR TITLE
Use NPM version of grunt-html-validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     , "grunt-contrib-uglify": "~0.2.2"
     , "grunt-contrib-qunit": "~0.2.2"
     , "grunt-contrib-watch": "~0.5.1"
-    , "grunt-html-validation": "git://github.com/praveenvijayan/grunt-html-validation.git"
+    , "grunt-html-validation": "~0.1.4"
     , "grunt-jekyll": "~0.3.8"
     , "grunt-recess": "~0.3.3"
     , "browserstack-runner": "~0.0.11"


### PR DESCRIPTION
The package is now published, so the direct git url is no longer required
