### PR TITLE
Don't explicitly reference global jQuery

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -123,4 +123,4 @@
     })
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/alert.js
+++ b/js/alert.js
@@ -95,4 +95,4 @@
 
   $(document).on('click.bs.alert.data-api', dismiss, Alert.prototype.close)
 
-}(window.jQuery);
+}(jQuery);

--- a/js/button.js
+++ b/js/button.js
@@ -106,4 +106,4 @@
     e.preventDefault()
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -214,4 +214,4 @@
     })
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -176,4 +176,4 @@
     $target.collapse(option)
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -151,4 +151,4 @@
     .on('click.bs.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
 
-}(window.jQuery);
+}(jQuery);

--- a/js/modal.js
+++ b/js/modal.js
@@ -243,4 +243,4 @@
     .on('show.bs.modal',  '.modal', function () { $(document.body).addClass('modal-open') })
     .on('hidden.bs.modal', '.modal', function () { $(document.body).removeClass('modal-open') })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/popover.js
+++ b/js/popover.js
@@ -114,4 +114,4 @@
     return this
   }
 
-}(window.jQuery);
+}(jQuery);

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -155,4 +155,4 @@
     })
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/tab.js
+++ b/js/tab.js
@@ -132,4 +132,4 @@
     $(this).tab('show')
   })
 
-}(window.jQuery);
+}(jQuery);

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -383,4 +383,4 @@
     return this
   }
 
-}(window.jQuery);
+}(jQuery);

--- a/js/transition.js
+++ b/js/transition.js
@@ -53,4 +53,4 @@
     $.support.transition = transitionEnd()
   })
 
-}(window.jQuery);
+}(jQuery);


### PR DESCRIPTION
Removes `window.jQuery` in favor of `jQuery`, fixes #10038
