### PR TITLE
Glyphicons copy to clipboard shortcut

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,6 +9,10 @@
 
 <script src="{{ page.base_url }}assets/js/application.js"></script>
 
+{% if page.slug == "components" %}
+<script src="{{ page.base_url }}assets/js/clipboard.js"></script>
+{% endif %}
+
 {% if page.slug == "customize" %}
 <script src="{{ page.base_url }}assets/js/less.js"></script>
 <script src="{{ page.base_url }}assets/js/jszip.js"></script>

--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -976,6 +976,21 @@ h1[id] {
   }
 }
 
+#glyphicon-clipboard-container {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 0;
+  height: 0;
+  z-index: 100;
+  display: none;
+  opacity: 0;
+}
+#glyphicon-clipboard {
+  width: 1px;
+  height: 1px;
+  padding: 0;
+}
 
 /*
  * Customizer

--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -1,0 +1,59 @@
+var TWBSClipboard
+
+TWBSClipboard = new ((function() {
+
+  function _Class() {
+    var _this = this
+    this.value = ""
+    $(document).keydown(function(e) {
+      var _ref, _ref1
+      if (!_this.value || !(e.ctrlKey || e.metaKey)) {
+        return
+      }
+      if ($(e.target).is("input:visible,textarea:visible")) {
+        return
+      }
+      if (typeof window.getSelection === "function" ? (_ref = window.getSelection()) != null ? _ref.toString() : void 0 : void 0) {
+        return
+      }
+      if ((_ref1 = document.selection) != null ? _ref1.createRange().text : void 0) {
+        return
+      }
+
+      var $clipboardContainer = $("#glyphicon-clipboard-container")
+      $clipboardContainer.empty().show()
+      return $("<textarea id='glyphicon-clipboard'></textarea>").val(_this.value).appendTo($clipboardContainer).focus().select()
+    })
+    $(document).keyup(function(e) {
+      if ($(e.target).is("#glyphicon-clipboard")) {
+        return $("#glyphicon-clipboard-container").empty().hide()
+      }
+    })
+  }
+
+  _Class.prototype.set = function(value) {
+    this.value = value
+  }
+
+  return _Class
+
+})())
+
+
+!function ($) {
+
+  $(function(){
+
+    var copyKey = navigator.platform.indexOf("Mac") != -1 ? "Cmd" : "Ctrl"
+
+    $(".bs-glyphicons li").mouseenter(function() {
+      var span = $(this).children("span").clone().wrap('<div>').parent().html()
+      TWBSClipboard.set(span)
+    }).tooltip({
+      title: copyKey+"+C to Copy",
+      delay: { show: 800, hide: 100 }
+    })
+
+  })
+
+}(window.jQuery)

--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -1,3 +1,10 @@
+// TWBSClipboard Class borrowed heavily from Trello style clipboard
+// http://stackoverflow.com/questions/17527870/how-does-trello-access-the-users-clipboard
+// Handles tooltip and action for copying glyphicon span while hovering
+//
+// Dave Gaeddert, 8/22/2013
+// ++++++++++++++++++++++++++++++++++++++++++
+
 var TWBSClipboard
 
 TWBSClipboard = new ((function() {
@@ -44,6 +51,7 @@ TWBSClipboard = new ((function() {
 
   $(function(){
 
+    // Change tooltip text based on OS
     var copyKey = navigator.platform.indexOf("Mac") != -1 ? "Cmd" : "Ctrl"
 
     $(".bs-glyphicons li").mouseenter(function() {

--- a/components.html
+++ b/components.html
@@ -219,6 +219,7 @@ base_url: "../"
       <li><span class="glyphicon glyphicon-zoom-out"></span> .glyphicon .glyphicon-zoom-out</li>
     </ul>
 
+    <div id="glyphicon-clipboard-container"><textarea id="glyphicon-clipboard"></textarea></div>
 
     <h2 id="glyphicons-how-to-use">How to use</h2>
     <p>For performance reasons, all icons require a base class and individual icon class. To use, place the following code just about anywhere. Be sure to leave a space between the icon and text for proper padding.</p>


### PR DESCRIPTION
This is a relatively simple feature addition for the ability to hover over a glyphicon in the docs and press Cmd/Ctrl+C to automatically copy the `<span>` element with the appropriate classes for the icon. It also includes a slightly delayed tooltip to let the user know about the action.

Based heavily on the idea from [Trello](http://stackoverflow.com/questions/17527870/how-does-trello-access-the-users-clipboard) using only JS (no flash) -- uses a hidden `textarea` to temporarily copy the contents into and select before the user hits C.

Tested in Chrome 28 for Mac & Windows, Safari 6.0.5 for Mac
