### PR TITLE
Allow hidden/visibility classes on <col>s & <table>s

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -506,9 +506,10 @@
 // More easily include all the states for responsive-utilities.less.
 .responsive-visibility() {
   display: block !important;
-  tr& { display: table-row !important; }
+  colgroup& { display: table-column !important; }
+  tr&       { display: table-row    !important; }
   th&,
-  td& { display: table-cell !important; }
+  td&       { display: table-cell   !important; }
 }
 
 .responsive-invisibility() {

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -515,9 +515,11 @@
 
 .responsive-invisibility() {
   display: none !important;
-  tr& { display: none !important; }
+  table&,
+  col&,
+  tr&,
   th&,
-  td& { display: none !important; }
+  td&       { display: none         !important; }
 }
 
 // Grid System

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -507,7 +507,7 @@
 .responsive-visibility() {
   display: block !important;
   table&    { display: table        !important; }
-  colgroup& { display: table-column !important; }
+  col&      { display: table-column !important; }
   tr&       { display: table-row    !important; }
   th&,
   td&       { display: table-cell   !important; }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -506,6 +506,7 @@
 // More easily include all the states for responsive-utilities.less.
 .responsive-visibility() {
   display: block !important;
+  table&    { display: table        !important; }
   colgroup& { display: table-column !important; }
   tr&       { display: table-row    !important; }
   th&,


### PR DESCRIPTION
Currently it is not possible to have the hidden-\* and visible-\* classes on colgroups because they need display of table-column, however they're very helpful when you would like to hide/show whole columns in a table.
