### PR TITLE
Fixes #10076: Document hide text

### DIFF
--- a/_includes/nav-css.html
+++ b/_includes/nav-css.html
@@ -81,6 +81,7 @@
     <li><a href="#helper-classes-floats">Quick floats</a></li>
     <li><a href="#helper-classes-clearfix">Clearfix</a></li>
     <li><a href="#helper-classes-screen-readers">Screen reader content</a></li>
+    <li><a href="#helper-classes-image-replacement">Image replacement</a></li>
   </ul>
 </li>
 <li>

--- a/css.html
+++ b/css.html
@@ -2294,14 +2294,14 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 
 
     <h3 id="helper-classes-image-replacement">Image replacement</h3>
-    <p>Utilize the <code>.hide-text</code> mixin or <code>.text-hide</code> class to help replace an element's text content with a background image.</p>
+    <p>Utilize the <code>.text-hide</code> class or mixin to help replace an element's text content with a background image.</p>
 {% highlight html %}
 <h1 class="text-hide">Custom heading</h1>
 {% endhighlight %}
   {% highlight css %}
 // Usage as a Mixin
 .heading {
-  .hide-text();
+  .text-hide();
 }
 {% endhighlight %}
   </div>

--- a/css.html
+++ b/css.html
@@ -2292,6 +2292,18 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 }
 {% endhighlight %}
 
+
+    <h3 id="helper-classes-image-replacement">Image replacement</h3>
+    <p>Utilize the <code>.hide-text</code> mixin or <code>.text-hide</code> class to help replace an element's text content with a background image.</p>
+{% highlight html %}
+<h1 class="text-hide">Custom heading</h1>
+{% endhighlight %}
+  {% highlight css %}
+// Usage as a Mixin
+.heading {
+  .hide-text();
+}
+{% endhighlight %}
   </div>
 
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -72,11 +72,20 @@
 //
 // Heads up! v3 launched with with only `.hide-text()`, but per our pattern for
 // mixins being reused as classes with the same name, this doesn't hold up. As
-// of v3.0.1 we have added `.text-hide()` and deprecated `.hide-text()`.
+// of v3.0.1 we have added `.text-hide()` and deprecated `.hide-text()`. Note
+// that we cannot chain the mixins together in Less, so they are repeated.
 //
 // Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
 
-.hide-text(),
+// Deprecated as of v3.0.1 (will be removed in v4)
+.hide-text() {
+  font: ~"0/0" a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+// New mixin to use as of v3.0.1
 .text-hide() {
   font: ~"0/0" a;
   color: transparent;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -69,8 +69,15 @@
 }
 
 // CSS image replacement
+//
+// Heads up! v3 launched with with only `.hide-text()`, but per our pattern for
+// mixins being reused as classes with the same name, this doesn't hold up. As
+// of v3.0.1 we have added `.text-hide()` and deprecated `.hide-text()`.
+//
 // Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
-.hide-text() {
+
+.hide-text(),
+.text-hide() {
   font: ~"0/0" a;
   color: transparent;
   text-shadow: none;

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -30,7 +30,7 @@
   visibility: hidden;
 }
 .text-hide {
-  .hide-text();
+  .text-hide();
 }
 
 


### PR DESCRIPTION
Fixes #10076.
This adds a missing helper class and mixin to the **Helper classes** section of the CSS page in our docs. The kicker is that the class and mixin are not the same name, unlike our other classes and mixins in the section (e.g., `.pull-right` is first a class but also mixin-able). This is confusing and super lame, so I've opted to deprecate the mixin and push folks to use the single class name.

``` css
// CSS image replacement
// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
.hide-text(),
.text-hide() {
  font: ~"0/0" a;
  color: transparent;
  text-shadow: none;
  background-color: transparent;
  border: 0;
}

// Applying the mixin
.text-hide {
  .text-hide();
}
```

That look about right @cvrebert?
