### PR TITLE
Fixes #9008: remove `alert-block` class from example

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1203,7 +1203,7 @@ $('#myPopover').on('hidden.bs.popover', function () {
     </div><!-- /example -->
 
     <div class="bs-example">
-      <div class="alert alert-block alert-danger fade in">
+      <div class="alert alert-danger fade in">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <h4>Oh snap! You got an error!</h4>
         <p>Change this and that and try again. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum.</p>


### PR DESCRIPTION
Not sure, but think this should be removed.
