### PR TITLE
Corrected 3.0 responsive utility class reference mapping when migrating ...

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -369,27 +369,27 @@ bootstrap/
           </tr>
           <tr>
             <td><code>.visible-phone</code></td>
-            <td><code>.visible-sm</code></td>
+            <td><code>.visible-xs</code></td>
           </tr>
           <tr>
             <td><code>.visible-tablet</code></td>
-            <td><code>.visible-md</code></td>
+            <td><code>.visible-sm</code></td>
           </tr>
           <tr>
             <td><code>.visible-desktop</code></td>
-            <td><code>.visible-lg</code></td>
+            <td><code>.visible-md</code></td>
           </tr>
           <tr>
             <td><code>.hidden-phone</code></td>
-            <td><code>.hidden-sm</code></td>
+            <td><code>.hidden-xs</code></td>
           </tr>
           <tr>
             <td><code>.hidden-tablet</code></td>
-            <td><code>.hidden-md</code></td>
+            <td><code>.hidden-sm</code></td>
           </tr>
           <tr>
             <td><code>.hidden-desktop</code></td>
-            <td><code>.hidden-lg</code></td>
+            <td><code>.hidden-md</code></td>
           </tr>
           <tr>
             <td><code>.input-small</code></td>
@@ -460,20 +460,24 @@ bootstrap/
             <td><code>.jumbotron</code></td>
           </tr>
           <tr>
-            <td>Tiny grid (&lt;768 px)</td>
+            <td>Tiny grid (&lt;768px)</td>
             <td><code>.col-xs-*</code></td>
           </tr>
           <tr>
-            <td>Small grid (&gt;768 px)</td>
+            <td>Small grid (&ge;768px)</td>
             <td><code>.col-sm-*</code></td>
           </tr>
           <tr>
-            <td>Medium grid (&gt;992 px)</td>
+            <td>Medium grid (&ge;992px)</td>
             <td><code>.col-md-*</code></td>
           </tr>
           <tr>
-            <td>Large grid (&gt;1200 px)</td>
+            <td>Large grid (&ge;1200px)</td>
             <td><code>.col-lg-*</code></td>
+          </tr>
+          <tr>
+            <td>Responsive utility classes (&ge;1200px)</td>
+            <td><code>.visible-lg</code> <code>.hidden-lg</code></td>
           </tr>
           <tr>
             <td>Offsets</td>


### PR DESCRIPTION
...from 2.x (now accounting for new Large device support.) Also synchronized breakpoint values from Grid options > Media queries, for clarity.
