### PR TITLE
correct enable selector for button usage in docs

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1358,7 +1358,7 @@ $('#my-alert').bind('closed.bs.alert', function () {
     <h2 id="buttons-usage">Usage</h2>
     <p>Enable buttons via JavaScript:</p>
 {% highlight js %}
-$('.nav-tabs').button()
+$('.btn-group').button()
 {% endhighlight %}
 
     <h3>Markup</h3>


### PR DESCRIPTION
following the given examples the correct selector to enable the buttons with javascript is ".btn-group".
