### PR TITLE
javascript.html: add data-ride note

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1756,6 +1756,7 @@ $('#myCollapsible').on('hidden.bs.collapse', function () {
 
     <h3>Via data attributes</h3>
     <p>Use data attributes to easily control the position of the carousel. <code>data-slide</code> accepts the keywords <code>prev</code> or <code>next</code>, which alters the slide position relative to its current position. Alternatively, use <code>data-slide-to</code> to pass a raw slide index to the carousel <code>data-slide-to="2"</code>, which shifts the slide position to a particular index beginning with <code>0</code>.</p>
+    <p>The <code>data-ride="carousel"</code> attribute is used to mark a carousel as animating starting at page load.</p>
 
     <h3>Via JavaScript</h3>
     <p>Call carousel manually with:</p>


### PR DESCRIPTION
carousel docs were missing mention of the data-ride attribute
used to automatically start the carousel at load time
