### PR TITLE
Add data-random support to carousel

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -1757,7 +1757,7 @@ $('#myCollapsible').on('hidden.bs.collapse', function () {
     <h3>Via data attributes</h3>
     <p>Use data attributes to easily control the position of the carousel. <code>data-slide</code> accepts the keywords <code>prev</code> or <code>next</code>, which alters the slide position relative to its current position. Alternatively, use <code>data-slide-to</code> to pass a raw slide index to the carousel <code>data-slide-to="2"</code>, which shifts the slide position to a particular index beginning with <code>0</code>.</p>
     <p>The <code>data-ride="carousel"</code> attribute is used to mark a carousel as animating starting at page load.</p>
-
+    <p>The <code>data-random="1"</code> attribute has the carousel choose a random starting item from the set of items.</p>
     <h3>Via JavaScript</h3>
     <p>Call carousel manually with:</p>
 {% highlight js %}

--- a/javascript.html
+++ b/javascript.html
@@ -1757,7 +1757,7 @@ $('#myCollapsible').on('hidden.bs.collapse', function () {
     <h3>Via data attributes</h3>
     <p>Use data attributes to easily control the position of the carousel. <code>data-slide</code> accepts the keywords <code>prev</code> or <code>next</code>, which alters the slide position relative to its current position. Alternatively, use <code>data-slide-to</code> to pass a raw slide index to the carousel <code>data-slide-to="2"</code>, which shifts the slide position to a particular index beginning with <code>0</code>.</p>
     <p>The <code>data-ride="carousel"</code> attribute is used to mark a carousel as animating starting at page load.</p>
-    <p>The <code>data-random="1"</code> attribute has the carousel choose a random starting item from the set of items.</p>
+    <p>The <code>data-random="true"</code> attribute has the carousel choose a random starting item from the set of items.</p>
     <h3>Via JavaScript</h3>
     <p>Call carousel manually with:</p>
 {% highlight js %}

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -173,6 +173,13 @@
       if (typeof option == 'number') data.to(option)
       else if (action) data[action]()
       else if (options.interval) data.pause().cycle()
+
+      if (options.random) {
+        $this.find('.item.active').removeClass('active')
+        var $items = $this.find('.item')
+        var pos = Math.floor(Math.random() * $items.length)
+        $($items[pos]).addClass('active')
+      }
     })
   }
 


### PR DESCRIPTION
This new data attribute lets you specify that a carousel should start with a random active item instead of the one marked active in the page DOM.  With this, you don't even need to mark any item as active which actually improves the look, since nothing will show before the first random item is picked.

On my own site, I used this for a carousel of site sponsor logos, with the randomness meaning no sponsor always gets first billing.
