### PR TITLE
Add missing period on customize page.

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -13,7 +13,7 @@ base_url: "../"
       <button class="btn btn-default toggle" type="button">Toggle all</button>
       <h1 id="less">LESS files</h1>
     </div>
-    <p class="lead">Choose which LESS files to compile into your custom build of Bootstrap. Not sure which files to use? Read through the <a href="../css/">CSS</a> and <a href="../components/">Components</a> pages in the docs</p>
+    <p class="lead">Choose which LESS files to compile into your custom build of Bootstrap. Not sure which files to use? Read through the <a href="../css/">CSS</a> and <a href="../components/">Components</a> pages in the docs.</p>
 
     <div class="row">
       <div class="col-xs-6 col-sm-4">


### PR DESCRIPTION
All description texts have ending period at the end of sentence, but not on first one.
