### PR TITLE
Fixes #9920: Radio checked property is removed on second click with data-toggle="buttons"

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -57,12 +57,14 @@
 
     if ($parent.length) {
       var $input = this.$element.find('input')
-        .prop('checked', !this.$element.hasClass('active'))
-        .trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
+      this.$element.toggleClass('active')
+      $input
+        .prop('checked', this.$element.hasClass('active'))
+        .trigger('change')
+    } else {
+      this.$element.toggleClass('active')
     }
-
-    this.$element.toggleClass('active')
   }
 
 


### PR DESCRIPTION
The radio checked property is removed on second click with data-toggle="buttons" as stated in [issue #9920](https://github.com/twbs/bootstrap/issues/9920). Also in the change event the active class is still on the previous active label.

How it currently works: http://jsfiddle.net/mauvm/atuYM/ (see console)
The solution: http://jsfiddle.net/mauvm/f9dsS/
