### PR TITLE
Fixes 10212 - Make custom max-width on row conform to Bootstrap convention

### DIFF
--- a/examples/offcanvas/offcanvas.css
+++ b/examples/offcanvas/offcanvas.css
@@ -2,6 +2,9 @@
  * Style tweaks
  * --------------------------------------------------
  */
+html {
+  overflow-x: hidden;
+}
 body {
   padding-top: 70px;
 }

--- a/examples/offcanvas/offcanvas.css
+++ b/examples/offcanvas/offcanvas.css
@@ -14,7 +14,7 @@ footer {
  * Off Canvas
  * --------------------------------------------------
  */
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 767px) {
   .row-offcanvas {
     position: relative;
     -webkit-transition: all 0.25s ease-out;


### PR DESCRIPTION
Bootstrap break point for tablet portrait 768 keeps the row intact, so it's not appropriate to have off-canvas elements at that width. Custom off-canvas.css should be breakpoint 767px

https://github.com/twbs/bootstrap/issues/10212
