### PR TITLE
There was a bug with 'fade in' modal: background was black

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -2372,7 +2372,7 @@ input[type="button"].btn-block {
           transition: opacity 0.15s linear;
 }
 
-.fade.in {
+.in {
   opacity: 1;
 }
 


### PR DESCRIPTION
There was a bug with 'fade in' modal: background was black. Overriding this properties doesn't helped.
