### PR TITLE
Parameterize @breadcrumb-separator

### DIFF
--- a/less/breadcrumbs.less
+++ b/less/breadcrumbs.less
@@ -12,7 +12,7 @@
   > li {
     display: inline-block;
     &+li:before {
-      content: "/\00a0"; // Unicode space added since inline-block means non-collapsing white-space
+      content: "@{breadcrumb-separator}\00a0"; // Unicode space added since inline-block means non-collapsing white-space
       padding: 0 5px;
       color: @breadcrumb-color;
     }

--- a/less/variables.less
+++ b/less/variables.less
@@ -561,6 +561,7 @@
 @breadcrumb-bg:               #f5f5f5;
 @breadcrumb-color:            #ccc;
 @breadcrumb-active-color:     @gray-light;
+@breadcrumb-separator:        "/";
 
 
 // Carousel


### PR DESCRIPTION
This puts the breadcrumb separator into a variable, making it easy to use any other separator besides the default / . The compiled CSS is not changed, so this does not cause any issues with the default value.
