### PR TITLE
Adding back the color variations for badges

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -49,3 +49,34 @@ a.list-group-item.active > .badge,
 .nav-pills > li > a > .badge {
   margin-left: 3px;
 }
+
+// Colors
+// Contextual variations (linked labels get darker on :hover)
+
+.badge-default {
+  .color-variant(@badge-default-bg);
+}
+
+.badge-primary {
+  .color-variant(@badge-primary-bg);
+}
+
+.badge-success {
+  .color-variant(@badge-success-bg);
+}
+
+.badge-info {
+  .color-variant(@badge-info-bg);
+}
+
+.badge-warning {
+  .color-variant(@badge-warning-bg);
+}
+
+.badge-danger {
+  .color-variant(@badge-danger-bg);
+}
+
+.badge-inverse {
+  .color-variant(@badge-inverse-bg);
+}

--- a/less/labels.less
+++ b/less/labels.less
@@ -34,25 +34,25 @@
 // Contextual variations (linked labels get darker on :hover)
 
 .label-default {
-  .label-variant(@label-default-bg);
+  .color-variant(@label-default-bg);
 }
 
 .label-primary {
-  .label-variant(@label-primary-bg);
+  .color-variant(@label-primary-bg);
 }
 
 .label-success {
-  .label-variant(@label-success-bg);
+  .color-variant(@label-success-bg);
 }
 
 .label-info {
-  .label-variant(@label-info-bg);
+  .color-variant(@label-info-bg);
 }
 
 .label-warning {
-  .label-variant(@label-warning-bg);
+  .color-variant(@label-warning-bg);
 }
 
 .label-danger {
-  .label-variant(@label-danger-bg);
+  .color-variant(@label-danger-bg);
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -491,9 +491,9 @@
   }
 }
 
-// Labels
+// Labels and Badges
 // -------------------------
-.label-variant(@color) {
+.color-variant(@color) {
   background-color: @color;
   &[href] {
     &:hover,

--- a/less/variables.less
+++ b/less/variables.less
@@ -544,6 +544,15 @@
 
 // Badges
 // -------------------------
+
+@badge-default-bg:            @gray-light;
+@badge-primary-bg:            @brand-primary;
+@badge-success-bg:            @brand-success;
+@badge-info-bg:               @brand-info;
+@badge-warning-bg:            @brand-warning;
+@badge-danger-bg:             @brand-danger;
+@badge-inverse-bg:            @gray-dark;
+
 @badge-color:                 #fff;
 @badge-link-hover-color:      #fff;
 @badge-bg:                    @gray-light;


### PR DESCRIPTION
Adding back the color variations for badges that were in the previous version of twitter bootstrap. Also made the mixin for color variations name more generic.
