### PR TITLE
Update getting-started.html

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -699,8 +699,22 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
     </div>
     <p class="lead">While we don't officially support any third party plugins or add-ons, we do offer some useful advice to help avoid potential issues in your projects.</p>
 
+    <h3>Box-sizing</h3>
+    <p>Third party widgets which insert or display html to your document might not display well cause our use of <code>* { box-sizing: border-box; }</code>. Boostrap sets CSS's universal selector to set box-sizing (see: [box-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing)) to border-box. To prevent this wrap the third party output in a extra wrapper.</p>
+{% highlight css %}
+/* Fix Box-sizing
+ *
+ * Wrap your Google Maps embed in a `.thirdparty-html` to reset Bootstrap's
+ * global `box-sizing` changes. 
+ */    
+ 
+ .thirdparty-html,
+.thirdparty-html * { .box-sizing(content-box); }
+{% endhighlight %}
+
+
     <h3>Google Maps</h3>
-    <p>If you're using Google Maps on a Bootstrapped project, you might run into some display problems due to our use of <code>* { box-sizing: border-box; }</code>. Previously, you may have also ran into issues with the use of <code>max-width</code> on images. The following snippet should avoid all those problems.</p>
+    <p>If you're using Google Maps on a Bootstrapped project, you might also run into some display problems due to our use of <code>* { box-sizing: border-box; }</code>. Previously, you may have also ran into issues with the use of <code>max-width</code> on images. The following snippet should avoid all those problems.</p>
 {% highlight css %}
 /* Fix Google Maps canvas
  *


### PR DESCRIPTION
The box-sizing "problem" not only affects Google's maps. See also: http://stackoverflow.com/questions/17128730/right-border-of-the-addthis-counter-missing-with-twitters-bootstrap-3 and http://stackoverflow.com/questions/18165901/twitters-bootstrap-3-with-sharethis-widget
