### PR TITLE
Fixes IE8 complaining about $.support.transition.end (#7295)

### DIFF
--- a/js/transition.js
+++ b/js/transition.js
@@ -38,6 +38,7 @@
         return { end: transEndEventNames[name] }
       }
     }
+    return false
   }
 
   // http://blog.alexmaccaw.com/css-transitions


### PR DESCRIPTION
I found that while Issue #7295 about IE8 bugging when $.support.transition.end is called was marked as Fixed, the error was still occuring. Adding return false resolves the issue when no transitionEnd event is found (as is the case for IE8).
