### PR TITLE
Adjacent Labels and Badges could use some spacing between them

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -18,6 +18,11 @@
   background-color: @badge-bg;
   border-radius: @badge-border-radius;
 
+  // for adjacent badges, some spacing is needed
+  + .badge {
+    margin-left: .2em;
+  }
+
   // Empty badges collapse automatically (not available in IE8)
   &:empty {
     display: none;

--- a/less/labels.less
+++ b/less/labels.less
@@ -14,6 +14,11 @@
   vertical-align: baseline;
   border-radius: .25em;
 
+  // for adjacent labels, some spacing is needed
+  + .label {
+    margin-left: .2em;
+  }
+
   // Add hover effects, but only for links
   &[href] {
     &:hover,


### PR DESCRIPTION
When using multiple adjacent labels (or badges) they bump right up next to each other. This uses the adjacent sibling selector (depending on the use-case, maybe the general sibling selector could be used instead?) to add some spacing.

I pretty much guessed at the margin size, feel free to suggest a better value.
