### PR TITLE
Fix broken link to alerts section of JS page.

### DIFF
--- a/components.html
+++ b/components.html
@@ -2209,7 +2209,7 @@ body { padding-bottom: 70px; }
     <div class="page-header">
       <h1 id="alerts">Alerts</h1>
     </div>
-    <p class="lead">Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages. For inline dismissal, use the <a href="../javascript/#js-alerts">alerts jQuery plugin</a>.</p>
+    <p class="lead">Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages. For inline dismissal, use the <a href="../javascript/#alerts">alerts jQuery plugin</a>.</p>
 
     <h2 id="alerts-examples">Examples</h2>
     <p>Wrap any text and an optional dismiss button in <code>.alert</code> and one of the four contextual classes (e.g., <code>.alert-success</code>) for basic alert messages.</p>


### PR DESCRIPTION
Link was pointing to #js-alerts, but that section of the page does not exist. Changed to #alerts instead.
