### PR TITLE
carousel: correctly reset when the slide event is prevented

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -111,13 +111,15 @@
       $next = this.$element.find('.item')[fallback]()
     }
 
+    if ($next.hasClass('active')) return
+
+    var e = $.Event('slide.bs.carousel', { relatedTarget: $next[0], direction: direction })
+    this.$element.trigger(e)
+    if (e.isDefaultPrevented()) return
+
     this.sliding = true
 
     isCycling && this.pause()
-
-    var e = $.Event('slide.bs.carousel', { relatedTarget: $next[0], direction: direction })
-
-    if ($next.hasClass('active')) return
 
     if (this.$indicators.length) {
       this.$indicators.find('.active').removeClass('active')
@@ -128,8 +130,6 @@
     }
 
     if ($.support.transition && this.$element.hasClass('slide')) {
-      this.$element.trigger(e)
-      if (e.isDefaultPrevented()) return
       $next.addClass(type)
       $next[0].offsetWidth // force reflow
       $active.addClass(direction)
@@ -143,8 +143,6 @@
         })
         .emulateTransitionEnd(600)
     } else {
-      this.$element.trigger(e)
-      if (e.isDefaultPrevented()) return
       $active.removeClass('active')
       $next.addClass('active')
       this.sliding = false

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -16,7 +16,7 @@ $(function () {
         ok($(document.body).carousel()[0] == document.body, 'document.body returned')
       })
 
-      test("should not fire sliden when slide is prevented", function () {
+      test("should not fire slid when slide is prevented", function () {
         $.support.transition = false
         stop()
         $('<div class="carousel"/>')
@@ -29,6 +29,29 @@ $(function () {
             ok(false);
           })
           .carousel('next')
+      })
+
+      test("should reset when slide is prevented", function () {
+        var template = '<div id="carousel-example-generic" class="carousel slide"><ol class="carousel-indicators"><li data-target="#carousel-example-generic" data-slide-to="0" class="active"></li><li data-target="#carousel-example-generic" data-slide-to="1"></li><li data-target="#carousel-example-generic" data-slide-to="2"></li></ol><div class="carousel-inner"><div class="item active"><div class="carousel-caption"></div></div><div class="item"><div class="carousel-caption"></div></div><div class="item"><div class="carousel-caption"></div></div></div><a class="left carousel-control" href="#carousel-example-generic" data-slide="prev"></a><a class="right carousel-control" href="#carousel-example-generic" data-slide="next"></a></div>'
+        var $carousel = $(template)
+        $.support.transition = false
+        stop()
+        $carousel.one('slide.bs.carousel', function (e) {
+          e.preventDefault()
+          setTimeout(function () {
+            ok($carousel.find('.item:eq(0)').is('.active'))
+            ok($carousel.find('.carousel-indicators li:eq(0)').is('.active'))
+            $carousel.carousel('next')
+          }, 1);
+        })
+        $carousel.one('slid.bs.carousel', function () {
+          setTimeout(function () {
+            ok($carousel.find('.item:eq(1)').is('.active'))
+            ok($carousel.find('.carousel-indicators li:eq(1)').is('.active'))
+            start()
+          }, 1);
+        })
+        $carousel.carousel('next')
       })
 
       test("should fire slide event with direction", function () {


### PR DESCRIPTION
This fixes a bug where carousel isn't correctly reset when the slide event is prevented. Which results in the carousel thinking that it was constantly sliding, making it impossible to slide.
