### PR TITLE
Add height to :empty glyphicon elements

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -30,6 +30,7 @@
 
   &:empty{
     width: 1em;
+    height: 1em;
   }
 }
 


### PR DESCRIPTION
Add height so that :empty elements with .glyphicon but no icon class name fill the same amount of space other glyphicons would see #10328
