### PR TITLE
Bower: Ignore development and documentation files on bower.json. Fix #10313

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "ignore": [
     "**/.*",
     "_*",
-    "assets",
+    "docs-assets",
     "examples",
     "/fonts",
     "js/tests",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,19 @@
   "version": "3.0.0",
   "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css", "./dist/fonts/*"],
   "ignore": [
-      "**/.*"
+    "**/.*",
+    "_*",
+    "assets",
+    "examples",
+    "/fonts",
+    "js/tests",
+    "CNAME",
+    "CONTRIBUTING.md",
+    "Gruntfile.js",
+    "browserstack.json",
+    "composer.json",
+    "package.json",
+    "*.html"
   ],
   "dependencies": {
     "jquery": ">= 1.9.0"


### PR DESCRIPTION
Fixes #10313.

I've kept only the files I consider relevant to bower installation:
- Files in dist directory;
- Files in js directory;
- Files in less directory;
- bower.json file;
- README.md file;
- LICENSE file.
