### PR TITLE
Pass $element to offset top/bottom calc funcs

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -57,8 +57,8 @@
     var offsetBottom = offset.bottom
 
     if (typeof offset != 'object')         offsetBottom = offsetTop = offset
-    if (typeof offsetTop == 'function')    offsetTop    = offset.top()
-    if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
+    if (typeof offsetTop == 'function')    offsetTop    = offset.top(this.$element)
+    if (typeof offsetBottom == 'function') offsetBottom = offset.bottom(this.$element)
 
     var affix = this.unpin   != null && (scrollTop + this.unpin <= position.top) ? false :
                 offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ? 'bottom' :


### PR DESCRIPTION
At the moment to make dynamic top offset calculator on multiple elements, one would write:

``` javascript
$('.my-affix').each(function () {
  var $el = $(this);
  $el.affix({
    offset: {
      top: function () { return $el.offset().top; }
    }
  });
})
```

This patch will allow to:

``` javascript
$('.my-affix').affix({
  offset: {
    top: function ($el) { return $el.offset().top; }
  }
});
```
