### PR TITLE
Refactoring the paragraph describing the 'Examples' section.

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -135,7 +135,7 @@ bootstrap/
     <div class="page-header">
       <h1 id="examples">Examples</h1>
     </div>
-    <p class="lead">Build on the basic template above with Bootstrap's many components. Check out some of the more advanced tips for how to customize and build on top of them.</p>
+    <p class="lead">Build on the basic template above with Bootstrap's many components. See also <a href="#customizing">Customizing Bootstrap</a> for tips on maintaining your own Bootstrap variants.</p>
 
     <div class="row bs-examples">
       <div class="col-xs-6 col-md-4">


### PR DESCRIPTION
Quick edit to the Examples section in "Getting Started".  Here we provide a link to 'Customizing Bootstrap" instead of colloquially saying "Check out some of the more advanced tips..." with no link.

Here's how this pull request looks visually:

<img src="http://sbc.io/i/2013-09-02_15-21-39.jpg">
