### PR TITLE
IE8 requires width to be specified for box sizing to work correctly.

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -116,7 +116,7 @@
 
 @media (min-width: @screen-sm) {
   .container {
-    max-width: @container-sm;
+    width: @container-sm;
   }
 
   .col-sm-1,
@@ -194,7 +194,7 @@
 
 @media (min-width: @screen-md) {
   .container {
-    max-width: @container-md;
+    width: @container-md;
   }
   .col-md-1,
   .col-md-2,
@@ -274,7 +274,7 @@
 
 @media (min-width: @screen-lg-min) {
   .container {
-    max-width: @container-lg;
+    width: @container-lg;
   }
 
   .col-lg-1,


### PR DESCRIPTION
For box-sizing to work properly in IE8, ".container" needs to have the CSS width property specified. Property "max-width" has no effect.

fixes #10406
