### PR TITLE
Fixed handling error when jQuery is missing

### DIFF
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -5,7 +5,7 @@
 *
 * Designed and built with all the love in the world by @mdo and @fat.
 */
-if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
+if (!window.jQuery) { throw new Error("Bootstrap requires jQuery") }
 
 /* ========================================================================
  * Bootstrap: transition.js v3.0.0


### PR DESCRIPTION
!jQuery throws error in IE when jQuery is not defined.
Do you want to debug?... Instead of showing your error message
