### PR TITLE
Fixes issue of tips inheriting 'text-indent' from parent

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -11,6 +11,7 @@
   visibility: visible;
   font-size: @font-size-small;
   line-height: 1.4;
+  text-indent: 0px;
   .opacity(0);
 
   &.in     { .opacity(.9); }


### PR DESCRIPTION
Added property to '.tooltip':

```
   text-indent: 0px;
```

This solves issue of tips inheriting 'text-indent' from element it is called from

Issue recreated @ http://bootply.com/78857
