### PR TITLE
Update affix.js

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -65,7 +65,11 @@
                 offsetTop    != null && (scrollTop <= offsetTop) ? 'top' : false
 
     if (this.affixed === affix) return
-    if (this.unpin) this.$element.css('top', '')
+    if (this.unpin) 
+    {
+	  this.$element.css('top', '')	
+    this.$element.css('position', '')
+    } 
 
     this.affixed = affix
     this.unpin   = affix == 'bottom' ? position.top - scrollTop : null

--- a/js/affix.js
+++ b/js/affix.js
@@ -67,7 +67,7 @@
     if (this.affixed === affix) return
     if (this.unpin) 
     {
-	  this.$element.css('top', '')	
+    this.$element.css('top', '')	
     this.$element.css('position', '')
     } 
 


### PR DESCRIPTION
When the affix is bottom is applied the element offset adds a `top..` and a `position:relative` to the affixed element. When unpin the top is reset but the position not. This position:relative overrules the css position fixed.
