### PR TITLE
added  windows user instructions to Jekyll and Grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Bootstrap's documentation, included in this repo in the root directory, is built
 ### Running documentation locally
 
 1. If necessary, [install Jekyll](http://jekyllrb.com/docs/installation) (requires v1.x).
+  - **Windows users:** [install Jekyll](http://minimaldev.com/how-to-install-jekyll-on-windows/)
 2. From the root `/bootstrap` directory, run `jekyll serve` in the command line.
   - **Windows users:** run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors.
 3. Open [http://localhost:9001](http://localhost:9001) in your browser, and voilà.
@@ -50,6 +51,9 @@ Documentation for v2.3.2 has been made available for the time being at [http://g
 ## Compiling CSS and JavaScript
 
 Bootstrap uses [Grunt](http://gruntjs.com/) with convenient methods for working with the framework. It's how we compile our code, run tests, and more. To use it, install the required dependencies as directed and then run some Grunt commands.
+  - **Windows users:** 
+   1. Run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so `jekyll` and `validation` tasks without errors.
+   2. Change console font for 'Lucida Console' or 'Consolas'. 'Raster Fonts' not supported Unicode character.
 
 ### Install Grunt
 

--- a/css.html
+++ b/css.html
@@ -759,7 +759,7 @@ base_url: "../"
 {% endhighlight %}
     <div class="bs-callout bs-callout-info">
       <h4>Dealing with specificity</h4>
-      <p>Sometimes emphasis classes cannot be applied due to the specificity of another selector. In most cases a sufficient workaround is to wrap your text in a <code>&gt;span&lt;</code> with the class.</p>
+      <p>Sometimes emphasis classes cannot be applied due to the specificity of another selector. In most cases a sufficient workaround is to wrap your text in a <code>&lt;span&gt;</code> with the class.</p>
     </div>
 
 


### PR DESCRIPTION
Instructions for windows user
fixing `<` `>` in callout info span
