### PR TITLE
make indicators easier to click in IE9+

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -153,6 +153,7 @@
     border: 1px solid @carousel-indicator-border-color;
     border-radius: 10px;
     cursor: pointer;
+    background-color: rgba(0, 0, 0, 0);
   }
   .active {
     margin: 0;


### PR DESCRIPTION
inactive indicators are near impossible to click in IE9+ because the only hot spot is the 1px border. adding an invisible background seems to fix it
