### PR TITLE
Adds `-webkit-overflow-scrolling: touch;` fix for iOS bouncing scroll effect

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -31,6 +31,7 @@
   bottom: 0;
   left: 0;
   z-index: @zindex-modal-background;
+  -webkit-overflow-scrolling: touch;
 
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {


### PR DESCRIPTION
This can enable bouncing scroll effect for modal that longer than screen height.
