### PR TITLE
Adds some extra space at the bottom of modals to make buttons in modal footer clickable

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -45,7 +45,7 @@
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  padding: 10px;
+  padding: 10px 10px 44px;
   z-index: (@zindex-modal-background + 10);
 }
 

--- a/less/modals.less
+++ b/less/modals.less
@@ -45,7 +45,7 @@
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  padding: 10px 10px 44px; // extra space at the bottom to make sure buttons in modal footer are clickable
+  padding: 10px 10px 44px; // extra space at the bottom to make sure buttons in modal footer are clickable in iOS 7
   z-index: (@zindex-modal-background + 10);
 }
 

--- a/less/modals.less
+++ b/less/modals.less
@@ -45,7 +45,7 @@
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  padding: 10px 10px 44px; // extra space at the bottom to make sure buttons in modal footer are clickable in iOS 7
+  padding: 10px 10px 40px; // extra space at the bottom to make sure buttons in modal footer are clickable in iOS 7
   z-index: (@zindex-modal-background + 10);
 }
 

--- a/less/modals.less
+++ b/less/modals.less
@@ -45,7 +45,7 @@
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  padding: 10px 10px 44px;
+  padding: 10px 10px 44px; // extra space at the bottom to make sure buttons in modal footer are clickable
   z-index: (@zindex-modal-background + 10);
 }
 


### PR DESCRIPTION
When I click Cancel:
![img_2628](https://f.cloud.github.com/assets/96356/1086443/f57b83fa-15fc-11e3-9e2a-b45845c10496.PNG)

Action bar appears:
![img_2629](https://f.cloud.github.com/assets/96356/1086484/e109ed34-15fd-11e3-9028-2ffebcabac52.PNG)

In iOS7, the action bar at the bottom of the screen hides automatically when the webpage scrolls down, when we wanna close an active modal, the system action bar can be accidentally triggered and the buttons in modal footer become hard to click.
