### PR TITLE
[doc] fixed the horizontal form example

### DIFF
--- a/css.html
+++ b/css.html
@@ -1585,19 +1585,19 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <div class="bs-example">
       <form class="form-horizontal">
         <div class="form-group">
-          <label for="inputEmail1" class="col-lg-2 control-label">Email</label>
-          <div class="col-lg-10">
-            <input type="email" class="form-control" id="inputEmail1" placeholder="Email">
+          <label for="inputEmail3" class="col-sm-2 control-label">Email</label>
+          <div class="col-sm-10">
+            <input type="email" class="form-control" id="inputEmail3" placeholder="Email">
           </div>
         </div>
         <div class="form-group">
-          <label for="inputPassword1" class="col-lg-2 control-label">Password</label>
-          <div class="col-lg-10">
-            <input type="password" class="form-control" id="inputPassword1" placeholder="Password">
+          <label for="inputPassword3" class="col-sm-2 control-label">Password</label>
+          <div class="col-sm-10">
+            <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
           </div>
         </div>
         <div class="form-group">
-          <div class="col-lg-offset-2 col-lg-10">
+          <div class="col-sm-offset-2 col-sm-10">
             <div class="checkbox">
               <label>
                 <input type="checkbox"> Remember me
@@ -1606,7 +1606,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
           </div>
         </div>
         <div class="form-group">
-          <div class="col-lg-offset-2 col-lg-10">
+          <div class="col-sm-offset-2 col-sm-10">
             <button type="submit" class="btn btn-default">Sign in</button>
           </div>
         </div>
@@ -1615,19 +1615,19 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 {% highlight html %}
 <form class="form-horizontal" role="form">
   <div class="form-group">
-    <label for="inputEmail1" class="col-lg-2 control-label">Email</label>
-    <div class="col-lg-10">
-      <input type="email" class="form-control" id="inputEmail1" placeholder="Email">
+    <label for="inputEmail3" class="col-sm-2 control-label">Email</label>
+    <div class="col-sm-10">
+      <input type="email" class="form-control" id="inputEmail3" placeholder="Email">
     </div>
   </div>
   <div class="form-group">
-    <label for="inputPassword1" class="col-lg-2 control-label">Password</label>
-    <div class="col-lg-10">
-      <input type="password" class="form-control" id="inputPassword1" placeholder="Password">
+    <label for="inputPassword3" class="col-sm-2 control-label">Password</label>
+    <div class="col-sm-10">
+      <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
     </div>
   </div>
   <div class="form-group">
-    <div class="col-lg-offset-2 col-lg-10">
+    <div class="col-sm-offset-2 col-sm-10">
       <div class="checkbox">
         <label>
           <input type="checkbox"> Remember me
@@ -1636,7 +1636,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     </div>
   </div>
   <div class="form-group">
-    <div class="col-lg-offset-2 col-lg-10">
+    <div class="col-sm-offset-2 col-sm-10">
       <button type="submit" class="btn btn-default">Sign in</button>
     </div>
   </div>


### PR DESCRIPTION
The original _horizontal form_ example wasn't correctly displayed because it uses `.col-lg-` columns. Using `.col-sm-` columns fixes this problem:

![form-horizontal](https://f.cloud.github.com/assets/73419/1087216/a03d7b90-1611-11e3-8b8c-0e84b4779386.png)

In addition, the `id` attributes of the form controls have been fixed (`inputEmail3` instead of `inputEmail1`, etc.).
