### PR TITLE
added semicolon to tabs javascript usage in javascript.html doc.

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -697,8 +697,8 @@ $('#myScrollspy').on('activate.bs.scrollspy', function () {
     <p>Enable tabbable tabs via JavaScript (each tab needs to be activated individually):</p>
 {% highlight js %}
 $('#myTab a').click(function (e) {
-  e.preventDefault()
-  $(this).tab('show')
+  e.preventDefault();
+  $(this).tab('show');
 })
 {% endhighlight %}
 


### PR DESCRIPTION
While looking into bootstrap 3.0's javascript examples, saw this particular example that was lacking semicolons, so added it for better usage of the code.

For reference, the 2.3.2 doc contained semicolons:
http://getbootstrap.com/2.3.2/javascript.html#tabs

Also, I did not see any guidelines for contributing to the documentation, but I hope this is ok.
