### PR TITLE
Double border with table-bordered within a panel

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -62,6 +62,23 @@
   > .panel-body + .table {
     border-top: 1px solid @table-border-color;
   }
+  > .table-bordered {
+    border: none;
+    > thead,
+    > tbody,
+    > tfoot {
+      > tr {
+        > th:first-child,
+        > td:first-child {
+          border-left: none;
+        }
+        > th:last-child,
+        > td:last-child {
+          border-right: none;
+        }
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
There was a small styling issue if you decided you wanted a table with table-bordered in a panel. Because the panel provides a border around the left and right sides of the table, the table-bordered class added another one on top of that. This results in the border on the left and right sides of the table being double the size of the border.

This merge should resolve this.
