### PR TITLE
Update modal.js

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -28,8 +28,6 @@
     this.$element  = $(element)
     this.$backdrop =
     this.isShown   = null
-
-    if (this.options.remote) this.$element.load(this.options.remote)
   }
 
   Modal.DEFAULTS = {
@@ -45,6 +43,8 @@
   Modal.prototype.show = function (_relatedTarget) {
     var that = this
     var e    = $.Event('show.bs.modal', { relatedTarget: _relatedTarget })
+
+    if (this.options.remote) this.$element.load(this.options.remote)
 
     this.$element.trigger(e)
 
@@ -204,6 +204,8 @@
       var options = $.extend({}, Modal.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
       if (!data) $this.data('bs.modal', (data = new Modal(this, options)))
+      else data.options = options
+      
       if (typeof option == 'string') data[option](_relatedTarget)
       else if (options.show) data.show(_relatedTarget)
     })


### PR DESCRIPTION
No buggy "cache" for modal with remote source.
There is a bug when show modal via data-api for different elements with different remote URLs:
modal "caches" content and shows content for the first clicked element (and first modal initialization).
