### PR TITLE
changed attr('data-target') to data('target');

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -30,7 +30,7 @@
   Tab.prototype.show = function () {
     var $this    = this.element
     var $ul      = $this.closest('ul:not(.dropdown-menu)')
-    var selector = $this.attr('data-target')
+    var selector = $this.data('target')
 
     if (!selector) {
       selector = $this.attr('href')


### PR DESCRIPTION
this will extend js interface, to be possible to setup targets for tabs that setted like 

```
var content=$('<div class="tab-pane">',{text: 'content'});
var tab=('<li>',{html: $('<a>',{text: 'Main options'})}).addClass('active').data({target: $main,toggle: 'tab'}).appendTo(tabs);
```

or just selected to js variable. 
