### PR TITLE
auto-close collapsing navbar menu when menu item clicked

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -150,5 +150,10 @@
     .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
     .on('click.bs.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
+    // make the collapsing navbar close itself when a menu item is clicked
+    .on('click', '.navbar-collapse.in', function(e) {if($(e.target).is('a')){$(this).collapse('hide');}})
+    // make the collapsing navbar close itself when clicked outside
+    .on('blur', '.navbar', function(e) {$('.navbar-collapse.in').collapse('hide');})
+
 
 }(window.jQuery);

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -150,10 +150,7 @@
     .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
     .on('click.bs.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
     .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
-    // make the collapsing navbar close itself when a menu item is clicked
-    .on('click', '.navbar-collapse.in', function(e) {if($(e.target).is('a')){$(this).collapse('hide');}})
-    // make the collapsing navbar close itself when clicked outside
-    .on('blur', '.navbar', function(e) {$('.navbar-collapse.in').collapse('hide');})
-
+    // make the collapsing navbar close itself when a menu item is clicked (only if "auto" has been specified)
+    .on('click', '.navbar-collapse.auto.in', function(e) { if($(e.target).is('a')) { $(this).collapse('hide'); } })
 
 }(window.jQuery);


### PR DESCRIPTION
Added an optional event handler to auto-close the collapsing navbar menu when a menu selection is clicked (add "auto" to navbar-collapse, like `<div class="collapse navbar-collapse auto">`)
