### PR TITLE
Remove display: block from address

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -264,7 +264,6 @@ blockquote:after {
 
 // Addresses
 address {
-  display: block;
   margin-bottom: @line-height-computed;
   font-style: normal;
   line-height: @line-height-base;


### PR DESCRIPTION
<address> is already displayed as block in all browsers (UAs).
