### PR TITLE
Fix capitalization of “list groups” in middle of sentence

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -631,7 +631,7 @@ bootstrap/
           <tr>
             <td>Nav lists</td>
             <td><code>.nav-list</code> <code>.nav-header</code></td>
-            <td>No direct equivalent, but <a href="../components/#list-group">List groups</a> and <a href="../javascript/#collapse"><code>.panel-group</code>s</a> are similar.</td>
+            <td>No direct equivalent, but <a href="../components/#list-group">list groups</a> and <a href="../javascript/#collapse"><code>.panel-group</code>s</a> are similar.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
When “list groups” is used in the middle of a sentence in http://getbootstrap.com/components/#list-group-basic, it is not capitalized.

> The most basic list group is simply an unordered list with list items, and the proper classes.

Edits what was added in #10419.
