### PR TITLE
Added in list elements for dividers

### DIFF
--- a/components.html
+++ b/components.html
@@ -1441,7 +1441,9 @@ base_url: "../"
                 <li><a href="#">Action</a></li>
                 <li><a href="#">Another action</a></li>
                 <li><a href="#">Something else here</a></li>
+                <li class="divider"></li>
                 <li><a href="#">Separated link</a></li>
+                <li class="divider"></li>
                 <li><a href="#">One more separated link</a></li>
               </ul>
             </li>
@@ -1460,6 +1462,7 @@ base_url: "../"
                 <li><a href="#">Action</a></li>
                 <li><a href="#">Another action</a></li>
                 <li><a href="#">Something else here</a></li>
+                <li class="divider"></li>
                 <li><a href="#">Separated link</a></li>
               </ul>
             </li>
@@ -1491,7 +1494,9 @@ base_url: "../"
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
+          <li class="divider"></li>
           <li><a href="#">Separated link</a></li>
+          <li class="divider"></li>
           <li><a href="#">One more separated link</a></li>
         </ul>
       </li>
@@ -1510,6 +1515,7 @@ base_url: "../"
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
+          <li class="divider"></li>
           <li><a href="#">Separated link</a></li>
         </ul>
       </li>


### PR DESCRIPTION
Noticed there were a few missing `<li class="divider"></li>` above/below the "Separated link" and "One more separated link" list elements.
