### PR TITLE
Minify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,44 +2,6 @@
 _gh_pages
 _site
 
-# Numerous always-ignore extensions
-*.diff
-*.err
-*.orig
-*.log
-*.rej
-*.swo
-*.swp
-*.zip
-*.vi
-*~
-*.sass-cache
-*.ruby-version
-
-# OS or Editor folders
-.DS_Store
-._*
-Thumbs.db
-.cache
-.project
-.settings
-.tmproj
-*.esproj
-nbproject
-*.sublime-project
-*.sublime-workspace
-
-# Komodo
-*.komodoproject
-.komodotools
-
 # grunt-html-validation
 validation-status.json
 validation-report.json
-
-# Folders to ignore
-.hg
-.svn
-.CVS
-.idea
-node_modules


### PR DESCRIPTION
Gitignore is made to ignore **project-specific files**, not **always-ignore files**. Use core.excludesfile to ignore that. [Example](https://help.github.com/articles/ignoring-files).

Project-specific files in Bootstrap is just grunt-html-validation and jekyll & gh-pages builds.
