### PR TITLE
getting-started - Replace NetDNA.com with MaxCDN.com

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -37,7 +37,7 @@ base_url: "../"
     </div>
 
     <h3 id="download-cdn">Bootstrap CDN</h3>
-    <p>The folks over at <a href="https://www.netdna.com/">NetDNA</a> graciously provide CDN support for Bootstrap's CSS and JavaScript. Just use these <a href="http://www.bootstrapcdn.com/">Bootstrap CDN</a> links.</p>
+    <p>The folks over at <a href="http://www.maxcdn.com/">MaxCDN</a> graciously provide CDN support for Bootstrap's CSS and JavaScript. Just use these <a href="http://www.bootstrapcdn.com/">Bootstrap CDN</a> links.</p>
 {% highlight html %}
 <!-- Latest compiled and minified CSS -->
 <link rel="stylesheet" href="{{ site.cdn_css }}">


### PR DESCRIPTION
We are merging our brands (NetDNA/MaxCDN) into one.  CDN urls will not be affected.
