### PR TITLE
fix for scrollbar 'hop' on .modal-open

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -196,10 +196,7 @@
   }
 
   Modal.prototype.checkForScrollBar = function () {
-    if ( $(document.body).outerHeight() > $(window).height() ) {
-      return true
-    }
-    return false
+    return $(document.body).outerHeight() > $(window).height();
   }
 
   Modal.prototype.calculateScrollbarWidth = function () {

--- a/js/modal.js
+++ b/js/modal.js
@@ -196,16 +196,16 @@
   }
 
   Modal.prototype.checkForScrollBar = function () {
-    return $(document.body).outerHeight() > $(window).height();
+    return $(document.body).outerHeight() > $(window).height()
   }
 
   Modal.prototype.calculateScrollbarWidth = function () {
       if ($("#scrollbar-width").length > 0)
-        return;
+        return
       var a = $('<div class="modal-measure-scrollbar"/>').prependTo($("body")), 
           b = $('<div class="inner"/>').appendTo(a), 
           c = a.width() - b.width();
-      a.remove(), $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>');
+      a.remove(), $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>')
   }
 
   // MODAL PLUGIN DEFINITION

--- a/js/modal.js
+++ b/js/modal.js
@@ -143,7 +143,7 @@
     this.$element.hide()
     this.backdrop(function () {
       that.removeBackdrop()
-      that.$element.trigger('hidden.bs.modal', {openClasses: that.openClasses})
+      that.$element.trigger('hidden.bs.modal', [that.openClasses])
     })
   }
 
@@ -260,6 +260,6 @@
 
   $(document)
     .on('show.bs.modal',  '.modal', function (event) { $(document.body).addClass(event.openClasses) })
-    .on('hidden.bs.modal', '.modal', function (event) { $(document.body).removeClass(event.openClasses) })
+    .on('hidden.bs.modal', '.modal', function (event, openClasses) { $(document.body).removeClass(openClasses) })
 
 }(window.jQuery);

--- a/js/modal.js
+++ b/js/modal.js
@@ -28,7 +28,7 @@
     this.$element  = $(element)
     this.$backdrop =
     this.isShown   = null
-
+    this.openClasses = 'modal-open scrollbar'
     if (this.options.remote) this.$element.load(this.options.remote)
   }
 
@@ -44,7 +44,11 @@
 
   Modal.prototype.show = function (_relatedTarget) {
     var that = this
-    var e    = $.Event('show.bs.modal', { relatedTarget: _relatedTarget })
+    var e    = $.Event('show.bs.modal', { relatedTarget: _relatedTarget, openClasses: that.openClasses })
+
+    this.calculateScrollbarWidth()
+
+    this.openClasses = this.checkForScrollBar() ? 'modal-open scrollbar' : 'modal-open'
 
     this.$element.trigger(e)
 
@@ -75,7 +79,7 @@
 
       that.enforceFocus()
 
-      var e = $.Event('shown.bs.modal', { relatedTarget: _relatedTarget })
+      var e = $.Event('shown.bs.modal', { relatedTarget: _relatedTarget, openClasses: that.openClasses })
 
       transition ?
         that.$element.find('.modal-dialog') // wait for modal to slide in
@@ -139,7 +143,7 @@
     this.$element.hide()
     this.backdrop(function () {
       that.removeBackdrop()
-      that.$element.trigger('hidden.bs.modal')
+      that.$element.trigger('hidden.bs.modal', {openClasses: that.openClasses})
     })
   }
 
@@ -191,6 +195,21 @@
     }
   }
 
+  Modal.prototype.checkForScrollBar = function () {
+    if ( $(document.body).outerHeight() > $(window).height() ) {
+      return true
+    }
+    return false
+  }
+
+  Modal.prototype.calculateScrollbarWidth = function () {
+      if ($("#scrollbar-width").length > 0)
+        return;
+      var a = $('<div class="modal-measure-scrollbar"/>').prependTo($("body")), 
+          b = $('<div class="inner"/>').appendTo(a), 
+          c = a.width() - b.width();
+      a.remove(), $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>');
+  }
 
   // MODAL PLUGIN DEFINITION
   // =======================
@@ -240,7 +259,7 @@
   })
 
   $(document)
-    .on('show.bs.modal',  '.modal', function () { $(document.body).addClass('modal-open') })
-    .on('hidden.bs.modal', '.modal', function () { $(document.body).removeClass('modal-open') })
+    .on('show.bs.modal',  '.modal', function (event) { debugger;$(document.body).addClass(event.openClasses) })
+    .on('hidden.bs.modal', '.modal', function (event) { $(document.body).removeClass(event.openClasses) })
 
 }(window.jQuery);

--- a/js/modal.js
+++ b/js/modal.js
@@ -259,7 +259,7 @@
   })
 
   $(document)
-    .on('show.bs.modal',  '.modal', function (event) { debugger;$(document.body).addClass(event.openClasses) })
+    .on('show.bs.modal',  '.modal', function (event) { $(document.body).addClass(event.openClasses) })
     .on('hidden.bs.modal', '.modal', function (event) { $(document.body).removeClass(event.openClasses) })
 
 }(window.jQuery);

--- a/js/modal.js
+++ b/js/modal.js
@@ -204,8 +204,9 @@
         return
       var a = $('<div class="modal-measure-scrollbar"/>').prependTo($("body")), 
           b = $('<div class="inner"/>').appendTo(a), 
-          c = a.width() - b.width();
-      a.remove(), $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>')
+          c = a.width() - b.width()
+      a.remove()
+      $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>')
   }
 
   // MODAL PLUGIN DEFINITION

--- a/js/modal.js
+++ b/js/modal.js
@@ -48,7 +48,7 @@
 
     this.calculateScrollbarWidth()
 
-    this.openClasses = this.checkForScrollBar() ? 'modal-open scrollbar' : 'modal-open'
+    this.openClasses = this.hasScrollbar() ? 'modal-open scrollbar' : 'modal-open'
 
     this.$element.trigger(e)
 
@@ -195,18 +195,18 @@
     }
   }
 
-  Modal.prototype.checkForScrollBar = function () {
+  Modal.prototype.hasScrollbar = function () {
     return $(document.body).outerHeight() > $(window).height()
   }
 
   Modal.prototype.calculateScrollbarWidth = function () {
-      if ($("#scrollbar-width").length > 0)
+      if ($("#bs-scrollbar-width").length > 0)
         return
       var a = $('<div class="modal-measure-scrollbar"/>').prependTo($("body")), 
           b = $('<div class="inner"/>').appendTo(a), 
           c = a.width() - b.width()
       a.remove()
-      $("head").append('<style id="scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>')
+      $("head").append('<style id="bs-scrollbar-width">.modal-open.scrollbar { margin-right: ' + c + 'px }</style>')
   }
 
   // MODAL PLUGIN DEFINITION

--- a/less/modals.less
+++ b/less/modals.less
@@ -124,6 +124,17 @@
   }
 }
 
+.modal-measure-scrollbar{
+  position:absolute;
+  height:100px;
+  width:100px;
+  top:-300px;
+  left:-300px;
+  overflow:scroll;
+  overflow-y:scroll;
+  .inner{ height:200px }
+}
+
 // Scale up the modal
 @media screen and (min-width: @screen-sm-min) {
 

--- a/less/modals.less
+++ b/less/modals.less
@@ -124,15 +124,15 @@
   }
 }
 
-.modal-measure-scrollbar{
-  position:absolute;
-  height:100px;
-  width:100px;
-  top:-300px;
-  left:-300px;
-  overflow:scroll;
-  overflow-y:scroll;
-  .inner{ height:200px }
+.modal-measure-scrollbar {
+  position: absolute;
+  height: 100px;
+  width: 100px;
+  top: -300px;
+  left: -300px;
+  overflow: scroll;
+  overflow-y: scroll;
+  .inner{ height: 200px; }
 }
 
 // Scale up the modal

--- a/less/modals.less
+++ b/less/modals.less
@@ -124,6 +124,7 @@
   }
 }
 
+// Used by Modal.prototype.calculateScrollbarWidth() to measure browsers' scrollbar width
 .modal-measure-scrollbar {
   position: absolute;
   height: 100px;
@@ -132,7 +133,7 @@
   left: -300px;
   overflow: scroll;
   overflow-y: scroll;
-  .inner{ height: 200px; }
+  .inner { height: 200px; }
 }
 
 // Scale up the modal


### PR DESCRIPTION
this fixes #9855.

It uses the same technique that Twitter uses on their own modals: 

create two empty divs, one scrolling within the other. The difference in widths is the offset needed to stop the body from shifting when its scrollbar is hidden.
