### PR TITLE
add responsive CSS to hyperlinked images when thumbnail caption markup used

### DIFF
--- a/less/thumbnails.less
+++ b/less/thumbnails.less
@@ -9,7 +9,8 @@
   display: block; // Override the inline-block from `.img-thumbnail`
   margin-bottom: @line-height-computed;
 
-  > img {
+  > img,
+  a > img {
     .img-responsive();
   }
 }


### PR DESCRIPTION
When caption markup is used in thumbnails like here http://getbootstrap.com/components/#thumbnails-custom-content, non-hyperlinked images are properly responsive. If you hyperlink the image when using caption markup (like in the default thumbnail example), the image is not responsive because the .thumbnail selector is moved up one level and .thumbnail > img no longer applies to the image.

This fix adds a new selector for responsive images for the case when you wish to use a hyperlinked image followed by a caption.
