### PR TITLE
Changed the border-color of .navbar-form to @navbar-default-border

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -408,7 +408,7 @@
 
   .navbar-collapse,
   .navbar-form {
-    border-color: darken(@navbar-default-bg, 7%);
+    border-color: @navbar-default-border;
   }
 
   // Dropdown menu items and carets


### PR DESCRIPTION
The difference is 0.5% darkness since the old value was `darken(@navbar-default-bg, 7%)` and the value of `@navbar-default-border` is `darken(@navbar-default-bg, 6.5%)`

I hit on this one when I tried to change the color of the `navbar-default-bg` to `transparent` and after I fixed all the related ones in the `variables.less` there was a problem in the `navbar.less`.
