### PR TITLE
Scrollspy target in tab content does not work properly

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -96,7 +96,7 @@
     this.activeTarget = target
 
     $(this.selector)
-      .parents('.active')
+      .parents('li.active')
       .removeClass('active')
 
     var selector = this.selector


### PR DESCRIPTION
When scrollspy's target is set in a tab content, the tab content is forced to be invisible.

``` html
<div class="tab-content">
  <div id="scroll-spy-target" class="tab-pane active">
    <ul class="nav">
      <li class="active">...</li>
      <li>...</li>
    </ul>
  </div>
  <div id="not-scroll-spy-target" class="tab-pane">
     ...
   </div>
</div>
```

In the example, the first tab pane is not visible.
