### PR TITLE
Decouple type styling from html

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -110,12 +110,12 @@ h6 {
   }
 }
 
-.xl-heading { font-size: @font-size-h1; }
-.l-heading { font-size: @font-size-h2; }
-.df-heading { font-size: @font-size-h3; }
-.s-heading { font-size: @font-size-h4; }
-.xs-heading { font-size: @font-size-h5; }
-.xxs-heading { font-size: @font-size-h6; }
+.xl-heading { font-size: @font-size-xl; }
+.l-heading { font-size: @font-size-l; }
+.df-heading { font-size: @font-size-df; }
+.s-heading { font-size: @font-size-s; }
+.xs-heading { font-size: @font-size-xs; }
+.xxs-heading { font-size: @font-size-xxs; }
 
 
 // Page header

--- a/less/type.less
+++ b/less/type.less
@@ -110,12 +110,12 @@ h6 {
   }
 }
 
-h1, .h1 { font-size: @font-size-h1; }
-h2, .h2 { font-size: @font-size-h2; }
-h3, .h3 { font-size: @font-size-h3; }
-h4, .h4 { font-size: @font-size-h4; }
-h5, .h5 { font-size: @font-size-h5; }
-h6, .h6 { font-size: @font-size-h6; }
+.xl-heading { font-size: @font-size-h1; }
+.l-heading { font-size: @font-size-h2; }
+.df-heading { font-size: @font-size-h3; }
+.s-heading { font-size: @font-size-h4; }
+.xs-heading { font-size: @font-size-h5; }
+.xxs-heading { font-size: @font-size-h6; }
 
 
 // Page header

--- a/less/variables.less
+++ b/less/variables.less
@@ -48,12 +48,12 @@
 @font-size-large:         ceil(@font-size-base * 1.25); // ~18px
 @font-size-small:         ceil(@font-size-base * 0.85); // ~12px
 
-@font-size-h1:            floor(@font-size-base * 2.60); // ~36px
-@font-size-h2:            floor(@font-size-base * 2.15); // ~30px
-@font-size-h3:            ceil(@font-size-base * 1.70); // ~24px
-@font-size-h4:            ceil(@font-size-base * 1.25); // ~18px
-@font-size-h5:            @font-size-base;
-@font-size-h6:            ceil(@font-size-base * 0.85); // ~12px
+@font-size-xl:            floor(@font-size-base * 2.60); // ~36px
+@font-size-l:            floor(@font-size-base * 2.15); // ~30px
+@font-size-df:            ceil(@font-size-base * 1.70); // ~24px
+@font-size-s:            ceil(@font-size-base * 1.25); // ~18px
+@font-size-xs:            @font-size-base;
+@font-size-xxs:            ceil(@font-size-base * 0.85); // ~12px
 
 @line-height-base:        1.428571429; // 20/14
 @line-height-computed:    floor(@font-size-base * @line-height-base); // ~20px


### PR DESCRIPTION
Visual styles should never be applied directly to HTML elements. They should always be applied with class names. 

The size of my headings shouldn't be determined by which HTML element they use. I should be able to apply any heading size to any h tag.

This was possible by using classes .h1 through .h6 but those aren't semantic classes. Applying the .h2 class to a h6 tag suggests that I want my h6 heading to look like a h2 heading. But what should a h2 heading look like?

Using classes like .large, .medium, .small is much more semantic. Just like Bootstrap's buttons.
