### PR TITLE
Improve Helvetica Font Stack

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -39,7 +39,7 @@
 // Typography
 // -------------------------
 
-@font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
+@font-family-sans-serif:  "Helvetica Neue", Arial, sans-serif;
 @font-family-serif:       Georgia, "Times New Roman", Times, serif;
 @font-family-monospace:   Monaco, Menlo, Consolas, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;


### PR DESCRIPTION
Helvetica renders poorly on Windows machines. Arial renders much better. Since the two fonts are very similar, removing Helvetica is the best option. Then, you will get "Helvetica Neue" if you have it (macs) and arial if you don't (Windows). That will keep the font stack rendering well on both Mac and Windows.

Quora ran into this issue themselves and documented it.
https://www.quora.com/Quora-product/What-is-wrong-with-the-fonts-on-Quora

Also, Twitter don't have Helvetica in their font stack.
