### PR TITLE
Decouple small tag styling from HTML

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -25,7 +25,6 @@ p {
 // -------------------------
 
 // Ex: 14px base font * 85% = about 12px
-small,
 .small  { font-size: 85%; }
 
 // Undo browser default styling
@@ -82,7 +81,7 @@ h1, h2, h3, h4, h5, h6,
   line-height: @headings-line-height;
   color: @headings-color;
 
-  small {
+  .small {
     font-weight: normal;
     line-height: 1;
     color: @headings-small-color;
@@ -95,7 +94,7 @@ h3 {
   margin-top: @line-height-computed;
   margin-bottom: (@line-height-computed / 2);
 
-  small {
+  .small {
     font-size: 65%;
   }
 }
@@ -105,7 +104,7 @@ h6 {
   margin-top: (@line-height-computed / 2);
   margin-bottom: (@line-height-computed / 2);
 
-  small {
+  .small {
     font-size: 75%;
   }
 }
@@ -224,7 +223,7 @@ blockquote {
   p:last-child {
     margin-bottom: 0;
   }
-  small {
+  .small {
     display: block;
     line-height: @line-height-base;
     color: @blockquote-small-color;
@@ -240,10 +239,10 @@ blockquote {
     border-right: 5px solid @blockquote-border-color;
     border-left: 0;
     p,
-    small {
+    .small {
       text-align: right;
     }
-    small {
+    .small {
       &:before {
         content: '';
       }


### PR DESCRIPTION
Visual CSS should never be applied directly to HTML elements. All styling should be applied with class names.

Wrapping content in small tags does not always mean you want to change the appearance of that content. Small tags are for ranking the importance/relevance of content, not for styling content. That's what class names are for.
