### PR TITLE
Fixed issue where caret wouldn't inherit "active" li style on nav-pills

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -133,6 +133,11 @@
       &:focus {
         color: @nav-pills-active-link-hover-color;
         background-color: @nav-pills-active-link-hover-bg;
+
+        .caret {
+          border-top-color: @nav-pills-active-link-hover-color;
+          border-bottom-color: @nav-pills-active-link-hover-color;
+        }
       }
     }
   }

--- a/less/navs.less
+++ b/less/navs.less
@@ -48,6 +48,11 @@
     &:focus {
       background-color: @nav-link-hover-bg;
       border-color: @link-color;
+
+      .caret {
+        border-top-color: @link-hover-color;
+        border-bottom-color: @link-hover-color;
+      }
     }
   }
 


### PR DESCRIPTION
Hi,

I've fixed a couple of issues:
- Caret wouldn't inherit "active" li style on nav-pills, which caused the caret to stay @link-color
- Corrected caret colour to '@link-hover-color' when a nav dropdown is ".open"

Not sure if the code is in the right place as I saw there is a "// Dropdowns" section at the end. Let me know if it needs correction.
