### PR TITLE
Removed the ugly dotted border on controls in carousel for firefox

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -93,6 +93,7 @@
   &:focus {
     color: @carousel-control-color;
     text-decoration: none;
+    outline: none;
     .opacity(.9);
   }
 


### PR DESCRIPTION
I guess the firefox users enjoy the dotted border on focus but it looks very ugly in the carousel, so I think it's better off without it..

![screen shot 2013-09-18 at 1 39 54 pm](https://f.cloud.github.com/assets/125676/1164484/9f6301d0-2058-11e3-877e-d04ba5af792d.png)
