### PR TITLE
When overriding grid-float-breakpoint to a larger size, dropdown menu still has desktop styling.

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -211,7 +211,7 @@
     line-height: @line-height-computed;
   }
 
-  @media (max-width: @screen-xs-max) {
+  @media (max-width: @grid-float-breakpoint-max) {
     // Dropdowns get custom display when collapsed
     .open .dropdown-menu {
       position: static;
@@ -282,7 +282,7 @@
   .form-inline();
 
   .form-group {
-    @media (max-width: @screen-xs-max) {
+    @media (max-width: @grid-float-breakpoint-max) {
       margin-bottom: 5px;
     }
   }
@@ -439,7 +439,7 @@
     }
 
 
-    @media (max-width: @screen-xs-max) {
+    @media (max-width: @grid-float-breakpoint-max) {
       // Dropdowns get custom display when collapsed
       .open .dropdown-menu {
         > li > a {
@@ -577,7 +577,7 @@
       }
     }
 
-    @media (max-width: @screen-xs-max) {
+    @media (max-width: @grid-float-breakpoint-max) {
       // Dropdowns get custom display
       .open .dropdown-menu {
         > .dropdown-header {

--- a/less/variables.less
+++ b/less/variables.less
@@ -248,6 +248,8 @@
 @grid-gutter-width:         30px;
 // Point at which the navbar stops collapsing
 @grid-float-breakpoint:     @screen-sm-min;
+// So media queries don't overlap when required, provide a maximum
+@grid-float-breakpoint-max: (@grid-float-breakpoint - 1);
 
 
 // Navbar


### PR DESCRIPTION
The docs say to customize the @grid-float-breakpoint variable for the point when the navbar collapses, however the dropdown menu styles use the @screen-xs-max which means that if for instance I set the grid-float-breakpoint to 1000px the dropdown menu will have the desktop styles after 767px. 

So I created a grid-float-breakpoint-max to use for the dropdown styles so it behaves more consistently when customizing the grid-float-breakpoint. I hope that makes sense.
