### PR TITLE
Update alerts to hide the element instead of removing it - like modals

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -51,15 +51,15 @@
 
     $parent.removeClass('in')
 
-    function removeElement() {
-      $parent.trigger('closed.bs.alert').remove()
+    function hideElement() {
+      $parent.trigger('closed.bs.alert').hide()
     }
 
     $.support.transition && $parent.hasClass('fade') ?
       $parent
-        .one($.support.transition.end, removeElement)
+        .one($.support.transition.end, hideElement)
         .emulateTransitionEnd(150) :
-      removeElement()
+      hideElement()
   }
 
 

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -28,7 +28,7 @@ $(function () {
         ok(!alert.hasClass('in'), 'remove .in class on .close click')
       })
 
-      test("should remove element when clicking .close", function () {
+      test("should hide element when clicking .close", function () {
         $.support.transition = false
 
         var alertHTML = '<div class="alert-message warning fade in">'
@@ -41,7 +41,7 @@ $(function () {
 
         alert.find('.close').click()
 
-        ok(!$('#qunit-fixture').find('.alert-message').length, 'element removed from dom')
+        ok(!$('#qunit-fixture').find('.alert-message').is(':visible'), 'element hidden')
       })
 
       test("should not fire closed when close is prevented", function () {


### PR DESCRIPTION
This allows alerts to be re-usable and unifies the the Bootstrap API to respond the same way - improving code usability and expectations. (Make the same functions do the same things?  Why would we do that!)

This is a breaking API change.

This is a proper implementation of PR #1845, which has many +1's and has been ignored for about two years now.
