### PR TITLE
don't create new Tooltip/Popover objects just to destroy them immediately

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -96,6 +96,7 @@
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.popover')
+      if (!data && option === 'destroy') return
       var options = typeof option == 'object' && option
 
       if (!data) $this.data('bs.popover', (data = new Popover(this, options)))

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -365,6 +365,7 @@
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.tooltip')
+      if (!data && option === 'destroy') return
       var options = typeof option == 'object' && option
 
       if (!data) $this.data('bs.tooltip', (data = new Tooltip(this, options)))


### PR DESCRIPTION
Currently, when `tooltip('destroy')` is called on an element that does not have a tooltip, a Tooltip object is created only to be destroyed immediately afterward. I experience that behavior when creating the Tooltip on the `body` with a selector and destroying the potential targets in preparation of partial page update.
The same is true for the Popover component.
