### PR TITLE
fix #10767; current .img-thumbnail is equivalent to old .img-polaroid

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -414,7 +414,7 @@ bootstrap/
             <td><code>.input-group-addon</code></td>
           </tr>
           <tr>
-            <td><code>.thumbnail</code></td>
+            <td><code>.img-polaroid</code></td>
             <td><code>.img-thumbnail</code></td>
           </tr>
           <tr>


### PR DESCRIPTION
Fixes #10767.
/cc @mdo
