### PR TITLE
Enable display of dropdown navbar links when @grid-float-breakpoint has been adjusted.

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -211,7 +211,7 @@
     line-height: @line-height-computed;
   }
 
-  @media (max-width: @screen-xs-max) {
+  @media (max-width: @grid-float-breakpoint) {
     // Dropdowns get custom display when collapsed
     .open .dropdown-menu {
       position: static;


### PR DESCRIPTION
After changing @grid-float-breakpoint to, say, @screen-md-min, the dropdown menus won't appear since the CSS which displays them is enclosed in

``` css
@media (max-width: @screen-xs-max) {
```

This pull request changes the media query to

``` css
@media (max-width: @grid-float-breakpoint) {
```

which fixes it.
