### PR TITLE
Alter wording of example Skip Nav link to improve pronunciation

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -867,7 +867,7 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
     <p>If your navigation contains many links and comes before the main content in the DOM, add a <code>Skip to content</code> link immediately after your opening <code>&lt;body&gt;</code> tag. <a href="http://a11yproject.com/posts/skip-nav-links/">(read why)</a></p>
 {% highlight html %}
 <body>
-  <a href="#content" class="sr-only">Skip to content</a>
+  <a href="#content" class="sr-only">Skip to main content</a>
   <div class="container" id="content">
     The main page content.
   </div>


### PR DESCRIPTION
Screen reading applications, including Apple's VoiceOver, improperly pronounce the word "content" in "Skip to content" as an adjective rather than a noun because of insufficient context. "Skip to main content" is pronounced correctly. 

See 6 and Guideline 10 at the following site for more information:
http://redish.net/content/papers/interactions.htmlAlter wording of example Skip Nav link to improve pronunciation
