### PR TITLE
add cross-reference to Input Groups in CSS Form docs; fixes #10792

### DIFF
--- a/css.html
+++ b/css.html
@@ -1661,6 +1661,10 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 {% highlight html %}
 <input type="text" class="form-control" placeholder="Text input">
 {% endhighlight %}
+    <div class="bs-callout bs-callout-info">
+      <h4>Input groups</h4>
+      <p>To add integrated text or buttons before and/or after any text-based <code>&lt;input&gt;</code>, <a href="../components/#input-groups">check out the input group component.</a></p>
+    </div>
 
     <h3>Textarea</h3>
     <p>Form control which supports multiple lines of text. Change <code>rows</code> attribute as necessary.</p>


### PR DESCRIPTION
Fixes #10792. Happy to change this to not be a callout if you want.
/cc @mdo
