### PR TITLE
Add 'collapse' class back after expanding

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -69,7 +69,7 @@
     var complete = function () {
       this.$element
         .removeClass('collapsing')
-        .addClass('in')
+        .addClass('collapse in')
         [dimension]('auto')
       this.transitioning = 0
       this.$element.trigger('shown.bs.collapse')


### PR DESCRIPTION
The `collapse` class is replaced with the `collapsing` class while expanding, but it is never added back after the animation is complete. This functionality was changed for v3.0.0, but I think this detail was overlooked.

This breaks at least one third-party plugin: http://tarruda.github.io/bootstrap-datetimepicker/
