### PR TITLE
Update Skip Nav Wording for pronunciation

### DIFF
--- a/css.html
+++ b/css.html
@@ -2361,7 +2361,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <h3 id="helper-classes-screen-readers">Screen reader content</h3>
     <p>Hide an element to all devices <strong>except screen readers</strong> with <code>.sr-only</code>. Necessary for following <a href="{{ page.base_url }}getting-started#accessibility">accessibility best practices</a>. Can also be used as a mixin.</p>
 {% highlight html %}
-<a class="sr-only" href="#content">Skip to content</a>
+<a class="sr-only" href="#content">Skip to main content</a>
 {% endhighlight %}
 {% highlight css %}
 // Usage as a Mixin


### PR DESCRIPTION
As I was reading the BS3 docs I stumbled upon another one of these "improperly" worded Skip Nav links. The addition of the word "main" gives screen readers sufficient context to pronounce the word "content" correctly.
