### PR TITLE
Only preventDefault on click on [data-toggle="modal"] when the element is a link

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -230,7 +230,7 @@
     var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
     var option  = $target.data('modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
-    e.preventDefault()
+    if ($this.is('a')) e.preventDefault()
 
     $target
       .modal(option, this)


### PR DESCRIPTION
In it's current state Bootstrap always prevents the default action for a click event on `[data-toggle="modal"]` elements (see https://github.com/twbs/bootstrap/blob/master/js/modal.js#L233). Instead this should only happen when the element is a link.

Why? I'm opening a modal when the user chooses a particular radio button. But with the current Bootstrap version the radio button won't get selected, but the modal opens. I think the only reason why `preventDefault` is needed is to prevent the hash from appearing in the URL (and thus the browser from jumping to the top or said hash).
