### PR TITLE
Resolves #10607 Radiobutton change event triggers even if it's active

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -58,7 +58,7 @@
     if ($parent.length) {
       var $input = this.$element.find('input')
         .prop('checked', !this.$element.hasClass('active'))
-        .trigger('change')
+      if (!this.$element.hasClass('active')) this.$element.find('input').trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
     }
 

--- a/js/button.js
+++ b/js/button.js
@@ -58,6 +58,8 @@
     if ($parent.length) {
       var $input = this.$element.find('input')
         .prop('checked', !this.$element.hasClass('active'))
+
+      $input.triggerHandler("click")
       if (!this.$element.hasClass('active')) $input.trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
     }

--- a/js/button.js
+++ b/js/button.js
@@ -58,7 +58,7 @@
     if ($parent.length) {
       var $input = this.$element.find('input')
         .prop('checked', !this.$element.hasClass('active'))
-      if (!this.$element.hasClass('active')) this.$element.find('input').trigger('change')
+      if (!this.$element.hasClass('active')) $input.trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
     }
 


### PR DESCRIPTION
If the radiobutton is already active, it won't trigger change event

Tested on Firefox 24.0 and Chromium 28.0.1500.71

Resolves #10607.
