### PR TITLE
Implemented shownOnDisabled disabling the tooltip if the element is disabled.

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -434,4 +434,61 @@ $(function () {
         ttContainer.remove()
       })
 
+      test("tooltips should not be placed on disabled elements if showOnDisabled is set to false", function () {
+        var tooltipWithAttr = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;" disabled></button>')
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+            , showOnDisabled: false
+          })
+          .tooltip('show')
+
+        var tooltipWithProp = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></button>')
+          .prop('disabled', true)
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+            , showOnDisabled: false
+          })
+          .tooltip('show')
+        equal($('.tooltip').length, 0, 'tooltips with `disabled` property are not shown')
+      })
+
+      test("tooltips should not be placed on disabled elements if showOnDisabled is set to true", function () {
+        var tooltipWithAttr = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;" disabled></button>')
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+            , showOnDisabled: true
+          })
+          .tooltip('show')
+
+        var tooltipWithProp = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></button>')
+          .prop('disabled', true)
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+            , showOnDisabled: true
+          })
+          .tooltip('show')
+        equal($('.tooltip').length, 2, 'tooltips with `disabled` property are shown')
+      })
+
+      test("tooltips should not be placed on disabled elements if showOnDisabled is not set", function () {
+        var tooltipWithAttr = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;" disabled></button>')
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+          })
+          .tooltip('show')
+
+        var tooltipWithProp = $('<button href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></button>')
+          .prop('disabled', true)
+          .appendTo('#qunit-fixture')
+          .tooltip({
+            title: 'This is a tooltip with some content'
+          })
+          .tooltip('show')
+        equal($('.tooltip').length, 2, 'tooltips with `disabled` property are shown')
+      })
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -45,6 +45,7 @@
   , delay: 0
   , html: false
   , container: false
+  , showOnDisabled: true
   }
 
   Tooltip.prototype.init = function (type, element, options) {
@@ -133,6 +134,11 @@
   }
 
   Tooltip.prototype.show = function () {
+    // Disable tooltip on a disabled element
+    if (!this.options.showOnDisabled && (this.$element.prop('disabled') || this.$element.attr('disabled'))) {
+      return;
+    }
+
     var e = $.Event('show.bs.'+ this.type)
 
     if (this.hasContent() && this.enabled) {


### PR DESCRIPTION
In our app we had to hack bootstrap to be able to hide elements based on if they're disabled. This pull request implements an option to enable such behavior while leaving the default as it is.
