### PR TITLE
Removing "strip for ie7" code from JavaScript

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -34,7 +34,6 @@
 
     if (!selector) {
       selector = $this.attr('href')
-      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
     var $parent = $(selector)

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -192,8 +192,8 @@
   // =================
 
   $(document).on('click.bs.carousel.data-api', '[data-slide], [data-slide-to]', function (e) {
-    var $this   = $(this), href
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')))
+    var $this   = $(this)
+    var $target = $($this.attr('data-target') || $this.attr('href'))
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')
     if (slideIndex) options.interval = false

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -193,7 +193,7 @@
 
   $(document).on('click.bs.carousel.data-api', '[data-slide], [data-slide-to]', function (e) {
     var $this   = $(this), href
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+    var $target = $($this.attr('data-target') || (href = $this.attr('href')))
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')
     if (slideIndex) options.interval = false

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -161,7 +161,7 @@
     var $this   = $(this), href
     var target  = $this.attr('data-target')
         || e.preventDefault()
-        || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+        || (href = $this.attr('href'))
     var $target = $(target)
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -158,10 +158,10 @@
   // =================
 
   $(document).on('click.bs.collapse.data-api', '[data-toggle=collapse]', function (e) {
-    var $this   = $(this), href
+    var $this   = $(this)
     var target  = $this.attr('data-target')
         || e.preventDefault()
-        || (href = $this.attr('href'))
+        || $this.attr('href')
     var $target = $(target)
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -106,7 +106,7 @@
 
     if (!selector) {
       selector = $this.attr('href')
-      selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      selector = /#/.test(selector) && selector
     }
 
     var $parent = selector && $(selector)

--- a/js/modal.js
+++ b/js/modal.js
@@ -227,7 +227,7 @@
   $(document).on('click.bs.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this   = $(this)
     var href    = $this.attr('href')
-    var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
+    var $target = $($this.attr('data-target') || href)
     var option  = $target.data('modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
     e.preventDefault()

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -32,7 +32,7 @@
     this.$scrollElement = this.$element.on('scroll.bs.scroll-spy.data-api', process)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
     this.selector       = (this.options.target
-      || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+      || (href = $(element).attr('href'))
       || '') + ' .nav li > a'
     this.offsets        = $([])
     this.targets        = $([])

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -24,7 +24,6 @@
   // ==========================
 
   function ScrollSpy(element, options) {
-    var href
     var process  = $.proxy(this.process, this)
 
     this.$element       = $(element).is('body') ? $(window) : $(element)
@@ -32,7 +31,7 @@
     this.$scrollElement = this.$element.on('scroll.bs.scroll-spy.data-api', process)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
     this.selector       = (this.options.target
-      || (href = $(element).attr('href'))
+      || $(element).attr('href')
       || '') + ' .nav li > a'
     this.offsets        = $([])
     this.targets        = $([])

--- a/js/tab.js
+++ b/js/tab.js
@@ -34,7 +34,6 @@
 
     if (!selector) {
       selector = $this.attr('href')
-      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
     if ($this.parent('li').hasClass('active')) return


### PR DESCRIPTION
I have removed all cases where selectors or targets are being "stripped for ie7" since ie7 is no longer supported.

This resolves #10441.
