### PR TITLE
Update Gruntfile.js fixing undefined jQuery check

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
               '*\n' +
               '* Designed and built with all the love in the world by @mdo and @fat.\n' +
               '*/\n',
-    jqueryCheck: 'if (!jQuery) { throw new Error(\"Bootstrap requires jQuery\") }\n\n',
+    jqueryCheck: 'if (typeof jQuery === "undefined") { throw new Error(\"Bootstrap requires jQuery\") }\n\n',
 
     // Task configuration.
     clean: {


### PR DESCRIPTION
The check to see if jQuery was defined as incorrect causing the "Bootstrap requires jQuery" message to only be displayed if jQuery is defined and has a value which equates to `false`.
