### PR TITLE
Resolves #10607 Radio button change event was triggered even if it was already active

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -59,6 +59,7 @@
       var $input = this.$element.find('input')
         .prop('checked', !this.$element.hasClass('active'))
 
+      $input.triggerHandler("click")
       if (!this.$element.hasClass('active')) $input.trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
     }

--- a/js/button.js
+++ b/js/button.js
@@ -58,7 +58,8 @@
     if ($parent.length) {
       var $input = this.$element.find('input')
         .prop('checked', !this.$element.hasClass('active'))
-        .trigger('change')
+
+      if (!this.$element.hasClass('active')) $input.trigger('change')
       if ($input.prop('type') === 'radio') $parent.find('.active').removeClass('active')
     }
 


### PR DESCRIPTION
If the radiobutton is already active, it won't trigger the change event.

Tested on Firefox 24.0 and Chromium 28.0.1500.71

Edit : @clement911 suggested that radiobuttons could trigger the click event too. Now it has the same behaviour as input type radio.

Resolves #10607.
