### PR TITLE
table contextual classes docs: .col-lg-* => .col-xs-*

### DIFF
--- a/css.html
+++ b/css.html
@@ -1260,8 +1260,8 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
     <div class="table-responsive">
       <table class="table table-bordered table-striped">
         <colgroup>
-          <col class="col-lg-1">
-          <col class="col-lg-7">
+          <col class="col-xs-1">
+          <col class="col-xs-7">
         </colgroup>
         <thead>
           <tr>


### PR DESCRIPTION
AFAIK, there doesn't seem to be a particular reason for this to use the large grid.
/cc @mdo
