### PR TITLE
remove comma separating the color and the color-stop in -webkit-linear-gradient in the #gradient .vertical mixin.

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -287,7 +287,7 @@
   // Color stops are not available in IE9 and below.
   .vertical(@start-color: #555; @end-color: #333; @start-percent: 0%; @end-percent: 100%) {
     background-image: -webkit-gradient(linear, left @start-percent, left @end-percent, from(@start-color), to(@end-color)); // Safari 4+, Chrome 2+
-    background-image: -webkit-linear-gradient(top, @start-color, @start-percent, @end-color, @end-percent); // Safari 5.1+, Chrome 10+
+    background-image: -webkit-linear-gradient(top, @start-color @start-percent, @end-color @end-percent); // Safari 5.1+, Chrome 10+
     background-image:  -moz-linear-gradient(top, @start-color @start-percent, @end-color @end-percent); // FF 3.6+
     background-image: linear-gradient(to bottom, @start-color @start-percent, @end-color @end-percent); // Standard, IE10
     background-repeat: repeat-x;


### PR DESCRIPTION
Before this pull request Chrome reports an "Invalid property value" for the -webkit-linear-gradient property, but after this pull request there is no error reported.
