### PR TITLE
Correct grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Bootstrap's documentation, included in this repo in the root directory, is built
   - **Windows users:** run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors.
 3. Open [http://localhost:9001](http://localhost:9001) in your browser, and voilà.
 
-Learn more about using Jekyll by reading their [documentation](http://jekyllrb.com/docs/home/).
+Learn more about using Jekyll by reading its [documentation](http://jekyllrb.com/docs/home/).
 
 ### Documentation for previous releases
 


### PR DESCRIPTION
Jekyll is the third person singular (it), so it should be 'its documentation', not 'their documentation'.
