### PR TITLE
Fixed glyphicons svg id.

### DIFF
--- a/fonts/glyphicons-halflings-regular.svg
+++ b/fonts/glyphicons-halflings-regular.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
-<font id="glyphicons_halflingsregular" horiz-adv-x="1200" >
+<font id="glyphicons-halflingsregular" horiz-adv-x="1200" >
 <font-face units-per-em="1200" ascent="960" descent="-240" />
 <missing-glyph horiz-adv-x="500" />
 <glyph />


### PR DESCRIPTION
In Chrome, glyphicons are broken because the SVG font file id is incorrect.
