### PR TITLE
Insert comma to fix validation warning

### DIFF
--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -114,6 +114,6 @@ hr {
   margin: -1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip: rect(0,0,0,0);
   border: 0;
 }


### PR DESCRIPTION
BS doesn't support IE6/IE7, so comma can be inserted.
