### PR TITLE
Lets users remove hover styles on touch devices with one variable and modernizr

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -26,7 +26,7 @@
 
 // Hover state, but only for links
 a.badge {
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @badge-link-hover-color;
     text-decoration: none;

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -43,7 +43,7 @@
     position: relative;
     float: left;
     // Bring the "active" button to the front
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus,
     &:active,
     &.active {

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -89,7 +89,7 @@
   }
 
   // Hover/focus state
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @carousel-control-color;
     text-decoration: none;

--- a/less/close.less
+++ b/less/close.less
@@ -12,7 +12,7 @@
   text-shadow: @close-text-shadow;
   .opacity(.2);
 
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @close-color;
     text-decoration: none;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -73,7 +73,7 @@
 
 // Hover/Focus state
 .dropdown-menu > li > a {
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     text-decoration: none;
     color: @dropdown-link-hover-color;
@@ -84,7 +84,7 @@
 // Active state
 .dropdown-menu > .active > a {
   &,
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @dropdown-link-active-color;
     text-decoration: none;
@@ -99,14 +99,14 @@
 
 .dropdown-menu > .disabled > a {
   &,
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @dropdown-link-disabled-color;
   }
 }
 // Nuke hover/focus effects
 .dropdown-menu > .disabled > a {
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     text-decoration: none;
     background-color: transparent;

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -129,7 +129,7 @@
     margin-left: -4px;
   }
   // Bring the "active" button to the front
-  &:hover,
+  @{hover-prefix} &:hover,
   &:active {
     z-index: 2;
   }

--- a/less/labels.less
+++ b/less/labels.less
@@ -16,7 +16,7 @@
 
   // Add hover effects, but only for links
   &[href] {
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       color: @label-link-hover-color;
       text-decoration: none;

--- a/less/list-group.less
+++ b/less/list-group.less
@@ -49,7 +49,7 @@
     }
 
     // Hover state
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       text-decoration: none;
       background-color: @list-group-hover-bg;
@@ -58,7 +58,7 @@
 
   // Active class on item itself, not parent
   &.active,
-  &.active:hover,
+  @{hover-prefix} &.active:hover,
   &.active:focus {
     z-index: 2; // Place active items above their siblings for proper border styling
     color: @list-group-active-color;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -438,10 +438,10 @@
   // Hover states for `.table-hover`
   // Note: this is not available for cells or rows within `thead` or `tfoot`.
   .table-hover > tbody > tr {
-    > td.@{state}:hover,
-    > th.@{state}:hover,
-    &.@{state}:hover > td,
-    &.@{state}:hover > th {
+    @{hover-prefix} > td.@{state}:hover,
+    @{hover-prefix} > th.@{state}:hover,
+    @{hover-prefix} &.@{state}:hover > td,
+    @{hover-prefix} &.@{state}:hover > th {
       background-color: darken(@background, 5%);
       border-color: darken(@border, 5%);
     }
@@ -457,7 +457,7 @@
   background-color: @background;
   border-color: @border;
 
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus,
   &:active,
   &.active,
@@ -475,7 +475,7 @@
   &[disabled],
   fieldset[disabled] & {
     &,
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus,
     &:active,
     &.active {
@@ -523,7 +523,7 @@
 .label-variant(@color) {
   background-color: @color;
   &[href] {
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       background-color: darken(@color, 10%);
     }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -152,7 +152,7 @@
   padding: @navbar-padding-vertical @navbar-padding-horizontal;
   font-size: @font-size-large;
   line-height: @line-height-computed;
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     text-decoration: none;
   }
@@ -227,7 +227,7 @@
       }
       > li > a {
         line-height: @line-height-computed;
-        &:hover,
+        @{hover-prefix} &:hover,
         &:focus {
           background-image: none;
         }
@@ -356,7 +356,7 @@
 
   .navbar-brand {
     color: @navbar-default-brand-color;
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       color: @navbar-default-brand-hover-color;
       background-color: @navbar-default-brand-hover-bg;
@@ -371,7 +371,7 @@
     > li > a {
       color: @navbar-default-link-color;
 
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-default-link-hover-color;
         background-color: @navbar-default-link-hover-bg;
@@ -379,7 +379,7 @@
     }
     > .active > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-default-link-active-color;
         background-color: @navbar-default-link-active-bg;
@@ -387,7 +387,7 @@
     }
     > .disabled > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-default-link-disabled-color;
         background-color: @navbar-default-link-disabled-bg;
@@ -397,7 +397,7 @@
 
   .navbar-toggle {
     border-color: @navbar-default-toggle-border-color;
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       background-color: @navbar-default-toggle-hover-bg;
     }
@@ -414,7 +414,7 @@
   // Dropdown menu items and carets
   .navbar-nav {
     // Caret should match text color on hover
-    > .dropdown > a:hover .caret,
+    @{hover-prefix} > .dropdown > a:hover .caret,
     > .dropdown > a:focus .caret {
       border-top-color: @navbar-default-link-hover-color;
       border-bottom-color: @navbar-default-link-hover-color;
@@ -423,7 +423,7 @@
     // Remove background color from open dropdown
     > .open > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         background-color: @navbar-default-link-active-bg;
         color: @navbar-default-link-active-color;
@@ -444,7 +444,7 @@
       .open .dropdown-menu {
         > li > a {
           color: @navbar-default-link-color;
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-default-link-hover-color;
             background-color: @navbar-default-link-hover-bg;
@@ -452,7 +452,7 @@
         }
         > .active > a {
           &,
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-default-link-active-color;
             background-color: @navbar-default-link-active-bg;
@@ -460,7 +460,7 @@
         }
         > .disabled > a {
           &,
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-default-link-disabled-color;
             background-color: @navbar-default-link-disabled-bg;
@@ -477,7 +477,7 @@
 
   .navbar-link {
     color: @navbar-default-link-color;
-    &:hover {
+    @{hover-prefix} &:hover {
       color: @navbar-default-link-hover-color;
     }
   }
@@ -492,7 +492,7 @@
 
   .navbar-brand {
     color: @navbar-inverse-brand-color;
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       color: @navbar-inverse-brand-hover-color;
       background-color: @navbar-inverse-brand-hover-bg;
@@ -507,7 +507,7 @@
     > li > a {
       color: @navbar-inverse-link-color;
 
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-inverse-link-hover-color;
         background-color: @navbar-inverse-link-hover-bg;
@@ -515,7 +515,7 @@
     }
     > .active > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-inverse-link-active-color;
         background-color: @navbar-inverse-link-active-bg;
@@ -523,7 +523,7 @@
     }
     > .disabled > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @navbar-inverse-link-disabled-color;
         background-color: @navbar-inverse-link-disabled-bg;
@@ -534,7 +534,7 @@
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: @navbar-inverse-toggle-border-color;
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       background-color: @navbar-inverse-toggle-hover-bg;
     }
@@ -552,7 +552,7 @@
   .navbar-nav {
     > .open > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         background-color: @navbar-inverse-link-active-bg;
         color: @navbar-inverse-link-active-color;
@@ -568,7 +568,7 @@
     }
     > .open > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         .caret {
           border-top-color: @navbar-inverse-link-active-color;
@@ -585,7 +585,7 @@
         }
         > li > a {
           color: @navbar-inverse-link-color;
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-inverse-link-hover-color;
             background-color: @navbar-inverse-link-hover-bg;
@@ -593,7 +593,7 @@
         }
         > .active > a {
           &,
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-inverse-link-active-color;
             background-color: @navbar-inverse-link-active-bg;
@@ -601,7 +601,7 @@
         }
         > .disabled > a {
           &,
-          &:hover,
+          @{hover-prefix} &:hover,
           &:focus {
             color: @navbar-inverse-link-disabled-color;
             background-color: @navbar-inverse-link-disabled-bg;
@@ -613,7 +613,7 @@
 
   .navbar-link {
     color: @navbar-inverse-link-color;
-    &:hover {
+    @{hover-prefix} &:hover {
       color: @navbar-inverse-link-hover-color;
     }
   }

--- a/less/navs.less
+++ b/less/navs.less
@@ -20,7 +20,7 @@
       position: relative;
       display: block;
       padding: @nav-link-padding;
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         text-decoration: none;
         background-color: @nav-link-hover-bg;
@@ -31,7 +31,7 @@
     &.disabled > a {
       color: @nav-disabled-link-color;
 
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @nav-disabled-link-hover-color;
         text-decoration: none;
@@ -44,7 +44,7 @@
   // Open dropdowns
   .open > a {
     &,
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       background-color: @nav-link-hover-bg;
       border-color: @link-color;
@@ -91,7 +91,7 @@
       line-height: @line-height-base;
       border: 1px solid transparent;
       border-radius: @border-radius-base @border-radius-base 0 0;
-      &:hover {
+      @{hover-prefix} &:hover {
         border-color: @nav-tabs-link-hover-border-color @nav-tabs-link-hover-border-color @nav-tabs-border-color;
       }
     }
@@ -99,7 +99,7 @@
     // Active state, and it's :hover to override normal :hover
     &.active > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @nav-tabs-active-link-hover-color;
         background-color: @nav-tabs-active-link-hover-bg;
@@ -134,7 +134,7 @@
     // Active state
     &.active > a {
       &,
-      &:hover,
+      @{hover-prefix} &:hover,
       &:focus {
         color: @nav-pills-active-link-hover-color;
         background-color: @nav-pills-active-link-hover-bg;
@@ -200,7 +200,7 @@
   }
 
   > .active > a,
-  > .active > a:hover,
+  @{hover-prefix} > .active > a:hover,
   > .active > a:focus {
     border: 1px solid @nav-tabs-justified-link-border-color;
   }
@@ -211,7 +211,7 @@
       border-radius: @border-radius-base @border-radius-base 0 0;
     }
     > .active > a,
-    > .active > a:hover,
+    @{hover-prefix} > .active > a:hover,
     > .active > a:focus {
       border-bottom-color: @nav-tabs-justified-active-link-border-color;
     }
@@ -249,7 +249,7 @@
   border-top-color: @link-color;
   border-bottom-color: @link-color;
 }
-.nav a:hover .caret {
+@{hover-prefix} .nav a:hover .caret {
   border-top-color: @link-hover-color;
   border-bottom-color: @link-hover-color;
 }

--- a/less/normalize.less
+++ b/less/normalize.less
@@ -102,7 +102,7 @@ a:focus {
 //
 
 a:active,
-a:hover {
+@{hover-prefix} a:hover {
   outline: 0;
 }
 

--- a/less/pager.less
+++ b/less/pager.less
@@ -21,7 +21,7 @@
     }
 
     > a:hover,
-    > a:focus {
+    @{hover-prefix} > a:focus {
       text-decoration: none;
       background-color: @pagination-hover-bg;
     }
@@ -43,7 +43,7 @@
 
   .disabled {
     > a,
-    > a:hover,
+    @{hover-prefix} > a:hover,
     > a:focus,
     > span {
       color: @pager-disabled-color;

--- a/less/pagination.less
+++ b/less/pagination.less
@@ -37,7 +37,7 @@
 
   > li > a,
   > li > span {
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       background-color: @pagination-hover-bg;
     }
@@ -46,7 +46,7 @@
   > .active > a,
   > .active > span {
     &,
-    &:hover,
+    @{hover-prefix} &:hover,
     &:focus {
       z-index: 2;
       color: @pagination-active-color;
@@ -58,10 +58,10 @@
 
   > .disabled {
     > span,
-    > span:hover,
+    @{hover-prefix} > span:hover,
     > span:focus,
     > a,
-    > a:hover,
+    @{hover-prefix} > a:hover,
     > a:focus {
       color: @pagination-disabled-color;
       background-color: @pagination-bg;

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -44,7 +44,7 @@ a {
   color: @link-color;
   text-decoration: none;
 
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus {
     color: @link-hover-color;
     text-decoration: underline;

--- a/less/tables.less
+++ b/less/tables.less
@@ -116,7 +116,7 @@ th {
 //
 // Placed here since it has to come after the potential zebra striping
 
-.table-hover > tbody > tr:hover {
+@{hover-prefix} .table-hover > tbody > tr:hover {
   > td,
   > th {
     background-color: @table-bg-hover;

--- a/less/theme.less
+++ b/less/theme.less
@@ -36,7 +36,7 @@
   background-repeat: repeat-x;
   border-color: darken(@btn-color, 14%);
 
-  &:hover,
+  @{hover-prefix} &:hover,
   &:focus  {
     background-color: darken(@btn-color, 12%);
     background-position: 0 -15px;
@@ -83,13 +83,13 @@
 // Dropdowns
 // --------------------------------------------------
 
-.dropdown-menu > li > a:hover,
+@{hover-prefix} .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   #gradient > .vertical(@start-color: @dropdown-link-hover-bg; @end-color: darken(@dropdown-link-hover-bg, 5%));
   background-color: darken(@dropdown-link-hover-bg, 5%);
 }
 .dropdown-menu > .active > a,
-.dropdown-menu > .active > a:hover,
+@{hover-prefix} .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus {
   #gradient > .vertical(@start-color: @dropdown-link-active-bg; @end-color: darken(@dropdown-link-active-bg, 5%));
   background-color: darken(@dropdown-link-active-bg, 5%);
@@ -199,7 +199,7 @@
   .box-shadow(0 1px 2px rgba(0,0,0,.075));
 }
 .list-group-item.active,
-.list-group-item.active:hover,
+@{hover-prefix} .list-group-item.active:hover,
 .list-group-item.active:focus {
   text-shadow: 0 -1px 0 darken(@list-group-active-bg, 10%);
   #gradient > .vertical(@start-color: @list-group-active-bg; @end-color: darken(@list-group-active-bg, 7.5%));

--- a/less/thumbnails.less
+++ b/less/thumbnails.less
@@ -16,7 +16,7 @@
 
 
 // Add a hover state for linked versions only
-a.thumbnail:hover,
+@{hover-prefix} a.thumbnail:hover,
 a.thumbnail:focus {
   border-color: @link-color;
 }

--- a/less/type.less
+++ b/less/type.less
@@ -37,31 +37,31 @@ cite    { font-style: normal; }
 }
 .text-primary {
   color: @brand-primary;
-  &:hover {
+  @{hover-prefix} &:hover {
     color: darken(@brand-primary, 10%);
   }
 }
 .text-warning {
   color: @state-warning-text;
-  &:hover {
+  @{hover-prefix} &:hover {
     color: darken(@state-warning-text, 10%);
   }
 }
 .text-danger {
   color: @state-danger-text;
-  &:hover {
+  @{hover-prefix} &:hover {
     color: darken(@state-danger-text, 10%);
   }
 }
 .text-success {
   color: @state-success-text;
-  &:hover {
+  @{hover-prefix} &:hover {
     color: darken(@state-success-text, 10%);
   }
 }
 .text-info {
   color: @state-info-text;
-  &:hover {
+  @{hover-prefix} &:hover {
     color: darken(@state-info-text, 10%);
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -635,3 +635,10 @@
 // Large screen / wide desktop
 @container-large-desktop:      ((1140px + @grid-gutter-width));
 @container-lg:                 @container-large-desktop;
+
+// Modernizr
+// --------------------------------------------------
+
+// Remove hover styles on touch devices
+@hover-prefix: ~''; // Example of enabled code: @hover-prefix: ~'.no-touch';
+


### PR DESCRIPTION
Let less users prefix hover states with .no-touch by adding it to @hover-prefix in variables.less which by default is just an empty string

This fixes unwanted hover states on touch devices (http://www.nczonline.net/blog/2012/07/05/ios-has-a-hover-problem/)

I did compile the less using grunt and it produces no changes unless you add .no-touch to @hover-prefix in variables, that isn't the default so there are no changes reflected in the compiled/minified css. 

Tested on ios 6 in Chrome & Safari.

Perhaps it should be an option in http://getbootstrap.com/customize/ ? 
