### PR TITLE
Removed reference to gradient on button that no longer has a gradient :)

### DIFF
--- a/css.html
+++ b/css.html
@@ -1972,7 +1972,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
       <button type="button" class="btn btn-link">Link</button>
     </div>
 {% highlight html %}
-<!-- Standard gray button with gradient -->
+<!-- Standard button with default colouring -->
 <button type="button" class="btn btn-default">Default</button>
 
 <!-- Provides extra visual weight and identifies the primary action in a set of buttons -->


### PR DESCRIPTION
There was a HTML "comment" in the sample HTML for button styling, that referred to the default button as being grey with a gradient. I guess it was left over from the old docs. I've removed the mention of grey and gradients in that HTML comment and just said it had "default colouring".
