### PR TITLE
change extra small devices to >=480px in css.html doc

### DIFF
--- a/css.html
+++ b/css.html
@@ -2409,7 +2409,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
             <th></th>
             <th>
               Extra small devices
-              <small>Phones (&lt;768px)</small>
+              <small>Phones (&ge;480px)</small>
             </th>
             <th>
               Small devices


### PR DESCRIPTION
Hey,

I'm refering on this table: [http://getbootstrap.com/css/#responsive-utilities-classes](http://getbootstrap.com/css/#responsive-utilities-classes)

I think that is currently bad documentation since there is by default a media query breakpoint at 480px, which is not represented.

Maybe there should even be a 5th column in that table for all columns below 480px without a class.

What do you think?
