### PR TITLE
Warn about opening example HTML directly instead of viewing via HTTP

### DIFF
--- a/docs-assets/js/warn-if-using-file-protocol.js
+++ b/docs-assets/js/warn-if-using-file-protocol.js
@@ -1,0 +1,7 @@
+if (window.location.protocol === 'file:') {
+  window.alert("ERROR: This Bootstrap example won't work correctly\n" +
+    "because you've opened the HTML file directly\n" +
+    "instead of serving it via HTTP.\n" +
+    "Web browser security rules will prevent\n" +
+    "some of our resources from loading.  :-(")
+}

--- a/examples/carousel/index.html
+++ b/examples/carousel/index.html
@@ -13,6 +13,8 @@
     <!-- Bootstrap core CSS -->
     <link href="../../dist/css/bootstrap.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/grid/index.html
+++ b/examples/grid/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="grid.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/jumbotron-narrow/index.html
+++ b/examples/jumbotron-narrow/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="jumbotron-narrow.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/jumbotron/index.html
+++ b/examples/jumbotron/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="jumbotron.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/justified-nav/index.html
+++ b/examples/justified-nav/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="justified-nav.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/navbar-fixed-top/index.html
+++ b/examples/navbar-fixed-top/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="navbar-fixed-top.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/navbar-static-top/index.html
+++ b/examples/navbar-static-top/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="navbar-static-top.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/navbar/index.html
+++ b/examples/navbar/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="navbar.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/non-responsive/index.html
+++ b/examples/non-responsive/index.html
@@ -18,6 +18,8 @@
     <!-- Custom styles for this template -->
     <link href="non-responsive.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/offcanvas/index.html
+++ b/examples/offcanvas/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="offcanvas.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/signin/index.html
+++ b/examples/signin/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="signin.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/starter-template/index.html
+++ b/examples/starter-template/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="starter-template.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/sticky-footer-navbar/index.html
+++ b/examples/sticky-footer-navbar/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="sticky-footer-navbar.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/sticky-footer/index.html
+++ b/examples/sticky-footer/index.html
@@ -16,6 +16,8 @@
     <!-- Custom styles for this template -->
     <link href="sticky-footer.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/examples/theme/index.html
+++ b/examples/theme/index.html
@@ -18,6 +18,8 @@
     <!-- Custom styles for this template -->
     <link href="theme.css" rel="stylesheet">
 
+    <!-- Warn about common error people make when trying out this example -->
+    <script src="../../docs-assets/js/warn-if-using-file-protocol.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.6.2/html5shiv.js"></script>


### PR DESCRIPTION
Viewing our example HTML files directly in the browser can break Glyphicons (see #10965) and breaks CDN links.
This commit displays an alert box when people do this to warn them about the brokenness.
/to @twbs/team for review
