### PR TITLE
Lint doc-assets like the customizer in testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,9 @@ module.exports = function(grunt) {
       },
       test: {
         src: ['js/tests/unit/*.js']
+      },
+      'docs-assets': {
+        src:['docs-assets/js/*.js','!docs-assets/js/*.min.js']
       }
     },
 


### PR DESCRIPTION
This should let Travis-CI catch bugs in pull requests to things like the customizer, like #10632 and #10633.

The new rule excludes minified scripts like Respond.js, which I imagine don't lint properly.
