### PR TITLE
Enable Close Dropdown on Toggle Click

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -37,8 +37,6 @@
     var $parent  = getParent($this)
     var isActive = $parent.hasClass('open')
 
-    clearMenus()
-
     if (!isActive) {
       if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
         // if mobile we we use a backdrop because click events don't delegate
@@ -50,12 +48,21 @@
       if (e.isDefaultPrevented()) return
 
       $parent
-        .toggleClass('open')
+        .addClass('open')
         .trigger('shown.bs.dropdown')
 
       $this.focus()
-    }
+    } else {
+      $parent.trigger($.Event("hide.bs.dropdown"))
 
+      if (e.isDefaultPrevented()) return
+
+      $parent
+        .removeClass("open")
+        .trigger("hidden.bs.dropdown")
+
+      $this.focus()
+    }
     return false
   }
 
@@ -90,7 +97,8 @@
     $items.eq(index).focus()
   }
 
-  function clearMenus() {
+  function clearMenus(event) {
+    if ($(event.target).is('.dropdown-toggle')) return
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -233,10 +233,13 @@
   width: 100%;
   table-layout: fixed;
   border-collapse: separate;
-  .btn {
-    float: none;
+  > * {
+    float: none !important;
     display: table-cell;
     width: 1%;
+    > * {
+      width: 100$;
+    }
   }
 }
 

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -6,8 +6,11 @@
 // Dropdown arrow/caret
 .caret {
   display: inline-block;
-  width: 0;
-  height: 0;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 8px;
+  height: 4px;
+  margin: 2px 0;
   margin-left: 2px;
   vertical-align: middle;
   border-top:   @caret-width-base solid @dropdown-caret-color;
@@ -16,6 +19,29 @@
   // Firefox fix for https://github.com/twbs/bootstrap/issues/9538. Once fixed,
   // we can just straight up remove this.
   border-bottom: 0 dotted;
+
+}
+
+// Dropdown arrow, pointing right
+.caret.caret-right {
+  border-left:4px solid;
+  border-top:4px solid transparent;
+  border-bottom:4px solid transparent;
+  border-right:0 dotted;
+  height:8px;
+  width:4px;
+  margin:0 2px;
+}
+
+// Dropdown arrow, pointing left
+.caret.caret-left {
+  border-right:4px solid;
+  border-top:4px solid transparent;
+  border-bottom:4px solid transparent;
+  border-left:0 dotted;
+  height:8px;
+  width:4px;
+  margin:0 2px;
 }
 
 // The dropdown wrapper (div)


### PR DESCRIPTION
In Chrome with Zepto, clicking on the dropdown toggle button when the dropdown was open would not close the dropdown. This appears to be because click.bs.dropdown.data-api fires on the document first to call clearMenus(), making Dropdown.prototype.toggle see a closed dropdown to open again.

This update replaces Dropdown.prototype.toggle's call to clearMenus with its own code. clearMenus also needs to be escaped if the event target is the dropdown toggle button.
