### PR TITLE
documentation that multiple modals are not supported

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -104,6 +104,11 @@ $('#myModal').on('show.bs.modal', function (e) {
     <h2 id="modals-examples">Examples</h2>
     <p>Modals are streamlined, but flexible, dialog prompts with the minimum required functionality and smart defaults.</p>
 
+    <div class="bs-callout bs-callout-warning">
+      <h4>Overlapping modals not supported</h4>
+      <p>Be sure not to open a modal while another is still visible. Showing more than one modal at a time requires custom code.</p>
+    </div>
+
     <h3>Static example</h3>
     <p>A rendered modal with header, body, and set of actions in the footer.</p>
     <div class="bs-example bs-example-modal">


### PR DESCRIPTION
Resolves #11043.

I went with the term "overlapping" to avoid potential confusion about multiple (hidden) modals on a page not being supported.
