### PR TITLE
Support multiple breadcrumb trails

### DIFF
--- a/less/breadcrumbs.less
+++ b/less/breadcrumbs.less
@@ -9,7 +9,12 @@
   list-style: none;
   background-color: @breadcrumb-bg;
   border-radius: @border-radius-base;
-  > li {
+  ol {
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+  }
+  li {
     display: inline-block;
     &+li:before {
       content: "@{breadcrumb-separator}\00a0"; // Unicode space added since inline-block means non-collapsing white-space
@@ -17,7 +22,7 @@
       color: @breadcrumb-color;
     }
   }
-  > .active {
+  .active {
     color: @breadcrumb-active-color;
   }
 }


### PR DESCRIPTION
As per Google guidance on [Rich Snippets — Breadcrumbs](https://support.google.com/webmasters/answer/185417?hl=en), Bootstrap currently does not support multiple breadcrumb trails.

I have modified the code to allow a `<div class="breadcrumb">` wrapper with multiple `<ol>` within.

So multiple breadcrumb trail support like:

```
<div class="breadcrumb">
    <ol>
        <li><a href="#">Home</a></li>
        <li><a href="#">Library</a></li>
        <li class="active">Data</li>
    </ol>
    <ol>
        <li><a href="#">Home</a></li>
        <li><a href="#">Library</a></li>
        <li class="active">Data</li>
    </ol>
</div>
```
