### PR TITLE
Recommend only <div> (not <span>) for putting tooltips on disabled elements

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -843,7 +843,7 @@ $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
     </div>
     <div class="bs-callout bs-callout-info">
       <h4>Tooltips on disabled elements require wrapper elements</h4>
-      <p>To add a tooltip to a <code>disabled</code> or <code>.disabled</code> element, put the element inside of a <code>&lt;div&gt;</code> or <code>&lt;span&gt;</code>, and apply the tooltip to that element instead.</p>
+      <p>To add a tooltip to a <code>disabled</code> or <code>.disabled</code> element, put the element inside of a <code>&lt;div&gt;</code> and apply the tooltip to that <code>&lt;div&gt;</code> instead.</p>
     </div>
 
     <h2 id="tooltips-usage">Usage</h2>
@@ -1025,7 +1025,7 @@ $('#myTooltip').on('hidden.bs.tooltip', function () {
     </div>
     <div class="bs-callout bs-callout-info">
       <h4>Popovers on disabled elements require wrapper elements</h4>
-      <p>To add a popover to a <code>disabled</code> or <code>.disabled</code> element, put the element inside of a <code>&lt;div&gt;</code> or <code>&lt;span&gt;</code>, and apply the popover to that element instead.</p>
+      <p>To add a popover to a <code>disabled</code> or <code>.disabled</code> element, put the element inside of a <code>&lt;div&gt;</code> and apply the popover to that <code>&lt;div&gt;</code> instead.</p>
     </div>
 
     <h3>Static popover</h3>


### PR DESCRIPTION
Per issue comments, `display: inline` elements like `<span>` don't work for this.
Resolves #10049.
/cc @twbs/team for review; aiming to get this into v3.0.1.
