### PR TITLE
Move .affix from utilities.less; fixes #10766

### DIFF
--- a/less/is-utilities.less
+++ b/less/is-utilities.less
@@ -1,6 +1,9 @@
 //
-// Component animations
+// Javascript utilities
 // --------------------------------------------------
+
+// Component animations
+// -------------------------
 
 // Heads up!
 //
@@ -26,4 +29,11 @@
   height: 0;
   overflow: hidden;
   .transition(height .35s ease);
+}
+
+// For Affix plugin
+// -------------------------
+
+.affix {
+  position: fixed;
 }

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -46,11 +46,3 @@
   display: none !important;
   visibility: hidden !important;
 }
-
-
-// For Affix plugin
-// -------------------------
-
-.affix {
-  position: fixed;
-}


### PR DESCRIPTION
I moved `.affix` to another file — `is-utilities.less` (`is-` prefix per https://github.com/styleguide/css).

This pull request fixes #10766.
