### PR TITLE
Update translation sites URL

### DIFF
--- a/about.html
+++ b/about.html
@@ -86,8 +86,8 @@ base_url: "../"
   <p class="lead">Community members have translated Bootstrap's documentation into various langauges. None are officially supported and may not always be up to date.</p>
   <ul>
     <li><a href="http://v3.bootcss.com/">Bootstrap 中文文档 (Chinese)</a></li>
-    <li><a href="http://bootstrap.oneskyapp.net/ru">Bootstrap по-русски (Russian)</a></li>
-    <li><a href="http://bootstrap.oneskyapp.net/es">Bootstrap en Español (Spanish)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/ru">Bootstrap по-русски (Russian)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/es">Bootstrap en Español (Spanish)</a></li>
   </ul>
   <p>Have another language to add, or perhaps a different or better translation? Let us know by <a href="https://github.com/twbs/bootstrap/issues/new">opening an issue</a>.</p>
 </div>


### PR DESCRIPTION
Previous links were pointed to our testing servers. The new ones are hosted on our production servers. Thanks.

Vincent from OneSky
