### PR TITLE
Make better use of dropdown caret size variables

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -10,9 +10,9 @@
   height: 0;
   margin-left: 2px;
   vertical-align: middle;
-  border-top:   @caret-width-base solid @dropdown-caret-color;
-  border-right: @caret-width-base solid transparent;
-  border-left:  @caret-width-base solid transparent;
+  border-top:   @caret-width-large solid @dropdown-caret-color;
+  border-right: @caret-width-base/2 solid transparent;
+  border-left:  @caret-width-base/2 solid transparent;
   // Firefox fix for https://github.com/twbs/bootstrap/issues/9538. Once fixed,
   // we can just straight up remove this.
   border-bottom: 0 dotted;

--- a/less/variables.less
+++ b/less/variables.less
@@ -94,7 +94,7 @@
 @component-active-color:         #fff;
 @component-active-bg:            @brand-primary;
 
-@caret-width-base:               4px;
+@caret-width-base:               8px;
 @caret-width-large:              5px;
 
 // Tables


### PR DESCRIPTION
This is more a variable name concept fix rather than a bug fix.
- `@caret-width-large` was not being used for setting the height of the caret, now it is.
- Caret width was twice `@caret-width-base`, I doubled the value and make the caret width to correspond with it.
