### PR TITLE
hack for range input to fix chrome issue

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -152,6 +152,15 @@ output {
     cursor: not-allowed;
     background-color: @input-bg-disabled;
   }
+  
+  // Range
+  // Hack for Chrome 30.x 
+  // https://github.com/twbs/bootstrap/issues/11177
+  &[type="range"] {
+    .box-shadow(none);
+    padding-left: 0;
+    padding-right: 0;
+  }
 
   // Reset height for `textarea`s
   textarea& {
@@ -167,15 +176,6 @@ output {
 
 .form-group {
   margin-bottom: 15px;
-}
-
-// Range
-// Hack for Chrome 30.x 
-// https://github.com/twbs/bootstrap/issues/11177
-input[type="range"] {
-  .box-shadow(none);
-  padding-left: 0;
-  padding-right: 0;
 }
 
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -169,6 +169,15 @@ output {
   margin-bottom: 15px;
 }
 
+// Range
+// Hack for Chrome 30.x 
+// https://github.com/twbs/bootstrap/issues/11177
+input[type="range"] {
+  .box-shadow(none);
+  padding-left: 0;
+  padding-right: 0;
+}
+
 
 // Checkboxes and radios
 //


### PR DESCRIPTION
fix for the issue https://github.com/twbs/bootstrap/issues/11177
remove the box shadow from range input to avoid strange behaviour with chrome 30.x on OSX
