### PR TITLE
Add grunt-cli as NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     , "grunt-html-validation": "~0.1.5"
     , "grunt-jekyll": "~0.4.0"
     , "grunt-recess": "~0.4.0"
+    , "grunt-cli": "~0.1.9"
   }
 }


### PR DESCRIPTION
This will allow `npm test` to use the `grunt` command line binary without requiring a manual install first. This is because npm scripts get `node_modules/.bin` added to their `PATH` before executing.

This is really handy for new developers because it allows someone to just come in, make some changes, and run `npm install && npm test` without having to worry about what dependencies are required.
