### PR TITLE
Affix no longer jumps when using sticky footer (fixes #7414).

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -73,7 +73,7 @@
     this.$element.removeClass(Affix.RESET).addClass('affix' + (affix ? '-' + affix : ''))
 
     if (affix == 'bottom') {
-      this.$element.offset({ top: document.body.offsetHeight - offsetBottom - this.$element.height() })
+      this.$element.offset({ top: scrollHeight - offsetBottom - this.$element.height() })
     }
   }
 


### PR DESCRIPTION
This doesn't fix the other jumping issue #4647.
