### PR TITLE
Scrollspy acting up when targets are hidden

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -62,6 +62,7 @@
 
         return ($href
           && $href.length
+          && $href.is(':visible')
           && [[ $href[offsetMethod]().top + (!$.isWindow(self.$scrollElement.get(0)) && self.$scrollElement.scrollTop()), href ]]) || null
       })
       .sort(function (a, b) { return a[0] - b[0] })


### PR DESCRIPTION
If elements are hidden using `display: none;` which are targets mapped by scrollspy, the plugin might select an incorrect or no menu item.

Checking if the target is visible solved this.
