### PR TITLE
Put a space before `{` due to code style

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -28,7 +28,7 @@
   line-height: 1;
   -webkit-font-smoothing: antialiased;
 
-  &:empty{
+  &:empty {
     width: 1em;
   }
 }


### PR DESCRIPTION
Just a little code style fix.
