### PR TITLE
QUnit.equals() is deprecated; use QUnit.equal() instead

### DIFF
--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -18,9 +18,9 @@ $(function () {
 
       test("should return set state to loading", function () {
         var btn = $('<button class="btn" data-loading-text="fat">mdo</button>')
-        equals(btn.html(), 'mdo', 'btn text equals mdo')
+        equal(btn.html(), 'mdo', 'btn text equals mdo')
         btn.button('loading')
-        equals(btn.html(), 'fat', 'btn text equals fat')
+        equal(btn.html(), 'fat', 'btn text equals fat')
         stop()
         setTimeout(function () {
           ok(btn.attr('disabled'), 'btn is disabled')
@@ -31,9 +31,9 @@ $(function () {
 
       test("should return reset state", function () {
         var btn = $('<button class="btn" data-loading-text="fat">mdo</button>')
-        equals(btn.html(), 'mdo', 'btn text equals mdo')
+        equal(btn.html(), 'mdo', 'btn text equals mdo')
         btn.button('loading')
-        equals(btn.html(), 'fat', 'btn text equals fat')
+        equal(btn.html(), 'fat', 'btn text equals fat')
         stop()
         setTimeout(function () {
           ok(btn.attr('disabled'), 'btn is disabled')
@@ -41,7 +41,7 @@ $(function () {
           start()
           stop()
           btn.button('reset')
-          equals(btn.html(), 'mdo', 'btn text equals mdo')
+          equal(btn.html(), 'mdo', 'btn text equals mdo')
           setTimeout(function () {
             ok(!btn.attr('disabled'), 'btn is not disabled')
             ok(!btn.hasClass('disabled'), 'btn does not have disabled class')

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -53,8 +53,8 @@ $(function () {
         popover.popover('show')
 
         ok($('.popover').length, 'popover was inserted')
-        equals($('.popover .popover-title').text(), '@fat', 'title correctly inserted')
-        equals($('.popover .popover-content').text(), 'loves writing tests （╯°□°）╯︵ ┻━┻', 'content correctly inserted')
+        equal($('.popover .popover-title').text(), '@fat', 'title correctly inserted')
+        equal($('.popover .popover-content').text(), 'loves writing tests （╯°□°）╯︵ ┻━┻', 'content correctly inserted')
 
         popover.popover('hide')
         ok(!$('.popover').length, 'popover was removed')
@@ -69,8 +69,8 @@ $(function () {
           .popover('show')
 
         ok($('.popover').length, 'popover was inserted')
-        equals($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
-        equals($('.popover .popover-content').text(), "loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻", 'content correctly inserted')
+        equal($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
+        equal($('.popover .popover-content').text(), "loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻", 'content correctly inserted')
 
         popover.popover('hide')
         ok(!$('.popover').length, 'popover was removed')
@@ -89,8 +89,8 @@ $(function () {
           .popover('show')
 
         ok($('.popover').length, 'popover was inserted')
-        equals($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
-        equals($('.popover .popover-content').text(), "loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻", 'content correctly inserted')
+        equal($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
+        equal($('.popover .popover-content').text(), "loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻", 'content correctly inserted')
 
         popover.popover('hide')
         ok(!$('.popover').length, 'popover was removed')

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -26,10 +26,10 @@ $(function () {
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-fixture")
 
         $(tabsHTML).find('li:last a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "profile")
+        equal($("#qunit-fixture").find('.active').attr('id'), "profile")
 
         $(tabsHTML).find('li:first a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "home")
+        equal($("#qunit-fixture").find('.active').attr('id'), "home")
       })
 
       test("should activate element by tab id", function () {
@@ -42,10 +42,10 @@ $(function () {
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo("#qunit-fixture")
 
         $(pillsHTML).find('li:last a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "profile")
+        equal($("#qunit-fixture").find('.active').attr('id'), "profile")
 
         $(pillsHTML).find('li:first a').tab('show')
-        equals($("#qunit-fixture").find('.active').attr('id'), "home")
+        equal($("#qunit-fixture").find('.active').attr('id'), "home")
       })
 
 
@@ -77,9 +77,9 @@ $(function () {
 
         $(dropHTML).find('ul>li:first a').tab('show').end()
           .find('ul>li:last a').on('show', function(event){
-            equals(event.relatedTarget.hash, "#1-1")
+            equal(event.relatedTarget.hash, "#1-1")
           }).on('shown', function(event){
-            equals(event.relatedTarget.hash, "#1-1")
+            equal(event.relatedTarget.hash, "#1-1")
           }).tab('show')
       })
 

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -29,7 +29,7 @@ $(function () {
 
       test("should add data attribute for referencing original title", function () {
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').tooltip()
-        equals(tooltip.attr('data-original-title'), 'Another tooltip', 'original title preserved in data attribute')
+        equal(tooltip.attr('data-original-title'), 'Another tooltip', 'original title preserved in data attribute')
       })
 
       test("should place tooltips relative to placement option", function () {


### PR DESCRIPTION
When I attempted to update out copy of QUnit:

```
Message: QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead
```

Accordingly, this changes our tests to use `equal()` instead, which is still compatible with our current version of QUnit.
