### PR TITLE
generic carousel control class

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -99,6 +99,8 @@
   // Toggles
   .icon-prev,
   .icon-next,
+  .carousel-control-left,
+  .carousel-control-right,
   .glyphicon-chevron-left,
   .glyphicon-chevron-right {
     position: absolute;
@@ -107,10 +109,12 @@
     display: inline-block;
   }
   .icon-prev,
+  .carousel-control-left,
   .glyphicon-chevron-left {
     left: 50%;
   }
   .icon-next,
+  .carousel-control-right,
   .glyphicon-chevron-right {
     right: 50%;
   }
@@ -205,6 +209,8 @@
 
   // Scale up the controls a smidge
   .carousel-control {
+    .carousel-control-left,
+    .carousel-control-right,
     .glyphicons-chevron-left,
     .glyphicons-chevron-right,
     .icon-prev,

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -99,8 +99,8 @@
   // Toggles
   .icon-prev,
   .icon-next,
-  .carousel-control-left,
-  .carousel-control-right,
+  .carousel-control-prev,
+  .carousel-control-next,
   .glyphicon-chevron-left,
   .glyphicon-chevron-right {
     position: absolute;
@@ -109,12 +109,12 @@
     display: inline-block;
   }
   .icon-prev,
-  .carousel-control-left,
+  .carousel-control-prev,
   .glyphicon-chevron-left {
     left: 50%;
   }
   .icon-next,
-  .carousel-control-right,
+  .carousel-control-next,
   .glyphicon-chevron-right {
     right: 50%;
   }
@@ -209,8 +209,8 @@
 
   // Scale up the controls a smidge
   .carousel-control {
-    .carousel-control-left,
-    .carousel-control-right,
+    .carousel-control-prev,
+    .carousel-control-next,
     .glyphicons-chevron-left,
     .glyphicons-chevron-right,
     .icon-prev,


### PR DESCRIPTION
carosuel should not rely on glyphicons and should allow other icon sets, so a generic left/right control class could help to automatically position icons belonging to other font family.
