### PR TITLE
When opening the dropdown, focus() the toggle BEFORE triggering 'shown' event

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -49,11 +49,11 @@
 
       if (e.isDefaultPrevented()) return
 
+      $this.focus()
+
       $parent
         .toggleClass('open')
         .trigger('shown.bs.dropdown')
-
-      $this.focus()
     }
 
     return false


### PR DESCRIPTION
This is as much a question as it is a pull request.  Is there a reason for calling $this.focus() AFTER triggering the 'shown' event?  I've come across this multiple times now where I bind to the 'shown' event and try to focus() into an text input when the dropdown is shown.  For example, if the dropdown menu has a text input in it.  I can get around it by setting a timeout, and that doesn't bother me too much, but if it's all the same to you, maybe we should just flip the order here?
