### PR TITLE
Add well-border variable

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -1147,6 +1147,8 @@ base_url: "../"
     <h3>Wells</h3>
     <label>@well-bg</label>
     <input type="text" class="form-control" placeholder="#f5f5f5" data-var="@well-bg">
+    <label>@well-border</label>
+    <input type="text" class="form-control" placeholder="darken(@well-bg, 7%)" data-var="@well-border">
 
 
     <h2 id="variables-accordion">Accordion</h2>

--- a/less/variables.less
+++ b/less/variables.less
@@ -545,6 +545,7 @@
 // Wells
 // -------------------------
 @well-bg:                     #f5f5f5;
+@well-border:                 darken(@well-bg, 7%);
 
 
 // Badges

--- a/less/wells.less
+++ b/less/wells.less
@@ -9,7 +9,7 @@
   padding: 19px;
   margin-bottom: 20px;
   background-color: @well-bg;
-  border: 1px solid darken(@well-bg, 7%);
+  border: 1px solid @well-border;
   border-radius: @border-radius-base;
   .box-shadow(inset 0 1px 1px rgba(0,0,0,.05));
   blockquote {


### PR DESCRIPTION
Add a variable to allow the well border color to be specified.

The reason I'd like to see this included is that my companies styleguide
requires an explicit border color on well-like constructs. This variable
allows me to easily override the default to use that color.
