### PR TITLE
Speedier jQuery and Twitter widgets.js

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="{{ page.base_url }}dist/js/bootstrap.js"></script>
 
 <script src="http://platform.twitter.com/widgets.js"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="{{ page.base_url }}dist/js/bootstrap.js"></script>
 
 <script src="{{ page.base_url }}docs-assets/js/holder.js"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,11 +20,13 @@
 {% comment %}
   Inject Twitter widgets asynchronously. Snippet snipped from Twitter's
   JS interface site: https://dev.twitter.com/docs/tfw-javascript
+
+  * "js.async=1;" added to add async attribute to the generated script tag.
 {% endcomment %}
 <script>
   window.twttr = (function (d,s,id) {
     var t, js, fjs = d.getElementsByTagName(s)[0];
-    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id;
+    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id; js.async=1;
     js.src="https://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs);
     return window.twttr || (t = { _e: [], ready: function(f){ t._e.push(f) } });
   }(document, "script", "twitter-wjs"));

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,6 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="{{ page.base_url }}dist/js/bootstrap.js"></script>
 
-<script src="http://platform.twitter.com/widgets.js"></script>
 <script src="{{ page.base_url }}docs-assets/js/holder.js"></script>
 
 <script src="{{ page.base_url }}docs-assets/js/application.js"></script>
@@ -17,6 +16,19 @@
 <script src="{{ page.base_url }}docs-assets/js/raw-files.js"></script>
 <script src="{{ page.base_url }}docs-assets/js/customizer.js"></script>
 {% endif %}
+
+{% comment %}
+  Inject Twitter widgets asynchronously. Snippet snipped from Twitter's
+  JS interface site: https://dev.twitter.com/docs/tfw-javascript
+{% endcomment %}
+<script>
+  window.twttr = (function (d,s,id) {
+    var t, js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id;
+    js.src="https://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs);
+    return window.twttr || (t = { _e: [], ready: function(f){ t._e.push(f) } });
+  }(document, "script", "twitter-wjs"));
+</script>
 
 <!-- Analytics
 ================================================== -->


### PR DESCRIPTION
jquery.com uses Google Analytics and so sets a cookie when you visit
the site. When you request jquery.js from its CDN, code.jquery.com,
you take a hit from sending your previous GA cookie in the request.

Google's CDN, googleapis.com, never set cookies and so doesn't add
overhead. It also is faster in my unscientific testing of a billion
Command + Shift + R's.

Twitter's widget library has an async snippet to load the JS rather
than a synchronous script tag. widgets.js was before other, important JS
and slowed down document ready occasionally even on a decent connection.
