### PR TITLE
Forward originalEvent to hide.bs.dropdown handlers

### DIFF
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -711,7 +711,7 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
     var $parent  = getParent($this)
     var isActive = $parent.hasClass('open')
     var evProps
-    if (e) evProps = { sourceEvent: e }
+    if (e) evProps = { originalEvent: e }
 
     clearMenus(e)
 
@@ -768,7 +768,7 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
 
   function clearMenus(ev) {
     var evProps
-    if (ev) evProps = { sourceEvent: ev }
+    if (ev) evProps = { originalEvent: ev }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))

--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -764,12 +764,14 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
     $items.eq(index).focus()
   }
 
-  function clearMenus() {
+  function clearMenus(ev) {
+    var evProps
+    if (ev && ev.originalEvent) evProps = { originalEvent: ev.originalEvent }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))
       if (!$parent.hasClass('open')) return
-      $parent.trigger(e = $.Event('hide.bs.dropdown'))
+      $parent.trigger(e = $.Event('hide.bs.dropdown', evProps))
       if (e.isDefaultPrevented()) return
       $parent.removeClass('open').trigger('hidden.bs.dropdown')
     })

--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -710,8 +710,10 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
 
     var $parent  = getParent($this)
     var isActive = $parent.hasClass('open')
+    var evProps
+    if (e) evProps = { sourceEvent: e }
 
-    clearMenus()
+    clearMenus(e)
 
     if (!isActive) {
       if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
@@ -719,13 +721,13 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
         $('<div class="dropdown-backdrop"/>').insertAfter($(this)).on('click', clearMenus)
       }
 
-      $parent.trigger(e = $.Event('show.bs.dropdown'))
+      $parent.trigger(e = $.Event('show.bs.dropdown', evProps))
 
       if (e.isDefaultPrevented()) return
 
       $parent
         .toggleClass('open')
-        .trigger('shown.bs.dropdown')
+        .trigger('shown.bs.dropdown', evProps)
 
       $this.focus()
     }
@@ -766,14 +768,14 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
 
   function clearMenus(ev) {
     var evProps
-    if (ev && ev.originalEvent) evProps = { originalEvent: ev.originalEvent }
+    if (ev) evProps = { sourceEvent: ev }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))
       if (!$parent.hasClass('open')) return
       $parent.trigger(e = $.Event('hide.bs.dropdown', evProps))
       if (e.isDefaultPrevented()) return
-      $parent.removeClass('open').trigger('hidden.bs.dropdown')
+      $parent.removeClass('open').trigger('hidden.bs.dropdown', evProps)
     })
   }
 

--- a/javascript.html
+++ b/javascript.html
@@ -522,9 +522,16 @@ $('.dropdown-toggle').dropdown()
         </tbody>
       </table>
     </div><!-- ./bs-table-responsive -->
+
 {% highlight js %}
-$('#myDropdown').on('show.bs.dropdown', function () {
-  // do something…
+$('#myDropdown').on('hide.bs.dropdown', function (ev) {
+  // If not triggered programmatically, all those events will have a `sourceEvent`
+  // additional key containing the event at the source of the trigger.
+  //
+  // Example:
+  if (ev.sourceEvent && $(ev.sourceEvent.target).is('[contenteditable]')) {
+    ev.preventDefault()
+  }
 })
 {% endhighlight %}
   </div>

--- a/javascript.html
+++ b/javascript.html
@@ -525,11 +525,11 @@ $('.dropdown-toggle').dropdown()
 
 {% highlight js %}
 $('#myDropdown').on('hide.bs.dropdown', function (ev) {
-  // If not triggered programmatically, all those events will have a `sourceEvent`
+  // If not triggered programmatically, all those events will have a `originalEvent`
   // additional key containing the event at the source of the trigger.
   //
   // Example:
-  if (ev.sourceEvent && $(ev.sourceEvent.target).is('[contenteditable]')) {
+  if (ev.originalEvent && $(ev.originalEvent.target).is('[contenteditable]')) {
     ev.preventDefault()
   }
 })

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -90,12 +90,14 @@
     $items.eq(index).focus()
   }
 
-  function clearMenus() {
+  function clearMenus(ev) {
+    var evProps
+    if (ev && ev.originalEvent) evProps = { originalEvent: ev.originalEvent }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))
       if (!$parent.hasClass('open')) return
-      $parent.trigger(e = $.Event('hide.bs.dropdown'))
+      $parent.trigger(e = $.Event('hide.bs.dropdown', evProps))
       if (e.isDefaultPrevented()) return
       $parent.removeClass('open').trigger('hidden.bs.dropdown')
     })

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -36,8 +36,10 @@
 
     var $parent  = getParent($this)
     var isActive = $parent.hasClass('open')
+    var evProps
+    if (e) evProps = { sourceEvent: e }
 
-    clearMenus()
+    clearMenus(e)
 
     if (!isActive) {
       if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
@@ -45,13 +47,13 @@
         $('<div class="dropdown-backdrop"/>').insertAfter($(this)).on('click', clearMenus)
       }
 
-      $parent.trigger(e = $.Event('show.bs.dropdown'))
+      $parent.trigger(e = $.Event('show.bs.dropdown', evProps))
 
       if (e.isDefaultPrevented()) return
 
       $parent
         .toggleClass('open')
-        .trigger('shown.bs.dropdown')
+        .trigger('shown.bs.dropdown', evProps)
 
       $this.focus()
     }
@@ -92,14 +94,14 @@
 
   function clearMenus(ev) {
     var evProps
-    if (ev && ev.originalEvent) evProps = { originalEvent: ev.originalEvent }
+    if (ev) evProps = { sourceEvent: ev }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))
       if (!$parent.hasClass('open')) return
       $parent.trigger(e = $.Event('hide.bs.dropdown', evProps))
       if (e.isDefaultPrevented()) return
-      $parent.removeClass('open').trigger('hidden.bs.dropdown')
+      $parent.removeClass('open').trigger('hidden.bs.dropdown', evProps)
     })
   }
 

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -37,7 +37,7 @@
     var $parent  = getParent($this)
     var isActive = $parent.hasClass('open')
     var evProps
-    if (e) evProps = { sourceEvent: e }
+    if (e) evProps = { originalEvent: e }
 
     clearMenus(e)
 
@@ -94,7 +94,7 @@
 
   function clearMenus(ev) {
     var evProps
-    if (ev) evProps = { sourceEvent: ev }
+    if (ev) evProps = { originalEvent: ev }
     $(backdrop).remove()
     $(toggle).each(function (e) {
       var $parent = getParent($(this))


### PR DESCRIPTION
One might be interested to check the original event that originally triggered the dropdown's custom event.

In my case I need the target of the original click event in order to decide if I preventDefault or not.
