### PR TITLE
Fix carousel this.sliding not getting reset if $next.hasClass('active')

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -117,7 +117,10 @@
 
     var e = $.Event('slide.bs.carousel', { relatedTarget: $next[0], direction: direction })
 
-    if ($next.hasClass('active')) return
+    if ($next.hasClass('active')) {
+      this.sliding = false
+      return
+    }
 
     if (this.$indicators.length) {
       this.$indicators.find('.active').removeClass('active')


### PR DESCRIPTION
Not resetting `this.sliding = false` before returning from `Carousel.slide` causes the carousel to stop working. This is an issue when `slide()` is trigger on a one-item carousel, and then a second item is later added but the carousel is stuck in a `this.sliding = true` state.
