### PR TITLE
Fix #11353: Add v2 unsupported note

### DIFF
--- a/2.3.2/assets/css/docs.css
+++ b/2.3.2/assets/css/docs.css
@@ -564,6 +564,11 @@ h2 + .row {
   background-color: #fff;
 }
 
+/* Alert with link to latest version of the docs */
+.bs-alert-old-docs {
+  margin: 30px 0 0;
+}
+
 
 
 /* Bootstrap code examples

--- a/2.3.2/base-css.html
+++ b/2.3.2/base-css.html
@@ -92,6 +92,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">

--- a/2.3.2/components.html
+++ b/2.3.2/components.html
@@ -92,6 +92,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">

--- a/2.3.2/customize.html
+++ b/2.3.2/customize.html
@@ -92,6 +92,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> This customizer is for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">

--- a/2.3.2/extend.html
+++ b/2.3.2/extend.html
@@ -90,6 +90,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">

--- a/2.3.2/getting-started.html
+++ b/2.3.2/getting-started.html
@@ -92,6 +92,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">

--- a/2.3.2/index.html
+++ b/2.3.2/index.html
@@ -124,6 +124,10 @@
 
 <div class="container">
 
+  <div class="alert alert-danger bs-alert-old-docs">
+    <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+  </div>
+
   <div class="marketing">
 
     <h1>Introducing Bootstrap.</h1>

--- a/2.3.2/javascript.html
+++ b/2.3.2/javascript.html
@@ -91,6 +91,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">
@@ -113,7 +117,6 @@
         </ul>
       </div>
       <div class="span9">
-
 
         <!-- Overview
         ================================================== -->

--- a/2.3.2/scaffolding.html
+++ b/2.3.2/scaffolding.html
@@ -91,6 +91,10 @@
 
   <div class="container">
 
+    <div class="alert alert-danger bs-alert-old-docs">
+      <strong>Heads up!</strong> These docs are for v2.3.2, which is no longer officially supported. <a href="http://getbootstrap.com">Check out the latest version of Bootstrap!</a>
+    </div>
+
     <!-- Docs nav
     ================================================== -->
     <div class="row">


### PR DESCRIPTION
Fix issue #11353 by adding a note to the v2.3.2 docs saying that we no longer support this version of Bootstrap. Provides a link to the latest docs, i.e. our homepage.

/cc @cvrebert @ZDroid
