### PR TITLE
Fix glyphicon class name wrapping in IE

### DIFF
--- a/docs-assets/css/docs.css
+++ b/docs-assets/css/docs.css
@@ -1062,6 +1062,7 @@ h1[id] {
 .bs-glyphicons .glyphicon-class {
   display: block;
   text-align: center;
+  word-wrap: break-word;
 }
 .bs-glyphicons li:hover {
   background-color: rgba(86,61,124,.1);


### PR DESCRIPTION
Before
![before](https://f.cloud.github.com/assets/831974/1498798/edd8c206-4843-11e3-89bf-959898b65eae.png)

After
![after](https://f.cloud.github.com/assets/831974/1498799/ede1f9ac-4843-11e3-8c58-5eaf3e7c9d3d.png)
