### PR TITLE
Fix #10044

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -109,7 +109,7 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
-    var $parent = selector && $(selector)
+    var $parent = selector === '#' ? $('') : selector && $(selector)
 
     return $parent && $parent.length ? $parent : $this.parent()
   }


### PR DESCRIPTION
Fix #10044 Empty string passed to getElementById() in dropdown.js
