### PR TITLE
fix scrollspy for targets within tabs

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -96,7 +96,7 @@
     this.activeTarget = target
 
     $(this.selector)
-      .parents('.active')
+      .parentsUntil(this.options.target, '.active')
       .removeClass('active')
 
     var selector = this.selector

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -34,4 +34,41 @@ $(function () {
         ok($topbar.find('.active', true))
       })
 
+      test("should only switch active class on current target", function () {
+        var
+          sectionHTML = '<div id="root" class="active">'
+          + '<div class="topbar">'
+          + '<div class="topbar-inner">'
+          + '<div class="container" id="ss-target">'
+          + '<ul class="nav">'
+          + '<li><a href="#masthead">Overview</a></li>'
+          + '<li><a href="#detail">Detail</a></li>'
+          + '</ul>'
+          + '</div>'
+          + '</div>'
+          + '</div>'
+          + '<div id="scrollspy-example" style="height: 100px; overflow: auto;">'
+          + '<div style="height: 200px;">'
+          + '<h4 id="masthead">Overview</h4>'
+          + '<p style="height: 200px">'
+          + 'Ad leggings keytar, brunch id art party dolor labore.'
+          + '</p>'
+          + '</div>'
+          + '<div style="height: 200px;">'
+          + '<h4 id="detail">Detail</h4>'
+          + '<p style="height: 200px">'
+          + 'Veniam marfa mustache skateboard, adipisicing fugiat velit pitchfork beard.'
+          + '</p>'
+          + '</div>'
+          + '</div>'
+          + '</div>'
+          , $section = $(sectionHTML).appendTo("#qunit-fixture")        
+          , $scrollSpy = $section
+            .show()
+            .find("#scrollspy-example")
+            .scrollspy({target: "#ss-target"})
+
+        $scrollSpy.scrollTop(350);
+        ok($section.hasClass("active"), "Active class still on root node")
+      })
 })


### PR DESCRIPTION
Scrollspy target in tab content does not work properly. Calling .parents('.active') will return all parents with an active class (including the tab pane). Changing this line to .parentsUntil(this.options.target, '.active') should resolve the issue. This will scope the query to only search for active elements inside the scrollspy target. 

[Example of the issue](http://jsfiddle.net/NjJY9/). Scroll down on the home tab and you will see the tab pane disappear. 
