### PR TITLE
Themeable/one off tooltips and popovers

### DIFF
--- a/javascript.html
+++ b/javascript.html
@@ -935,6 +935,14 @@ $('#example').tooltip(options)
             <p>Appends the tooltip to a specific element. Example: <code>container: 'body'</code></p>
            </td>
          </tr>
+          <tr>
+            <td>theme</td>
+            <td>string | function</td>
+            <td>''</td>
+            <td>
+              <p>Default theme if <code>data-theme</code> attribute isn't present. Should be a space separated list of class names to add to the tooltip. Example: <code>theme: 'fruit apple'</code>.</p>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div><!-- /.table-responsive -->
@@ -1170,6 +1178,14 @@ $('#myTooltip').on('hidden.bs.tooltip', function () {
             <td>false</td>
             <td>
              <p>Appends the popover to a specific element. Example: <code>container: 'body'</code>. This option is particularly useful in that it allows you to position the popover in the flow of the document near the triggering element - which will prevent the popover from floating away from the triggering element during a window resize.</p>
+            </td>
+          </tr>
+          <tr>
+            <td>theme</td>
+            <td>string | function</td>
+            <td>''</td>
+            <td>
+              <p>Default theme if <code>data-theme</code> attribute isn't present. Should be a space separated list of class names to add to the tooltip. Example: <code>theme: 'fruit apple'</code>.</p>
             </td>
           </tr>
         </tbody>

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -117,6 +117,16 @@ $(function () {
         $('#qunit-fixture').empty()
       })
 
+      test("should append the data-class to the popover for one-off themes", function () {
+        var popover = $('<a href="#" data-class="one two"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({ content: "Test" })
+          .popover('show')
+        ok($('.popover').hasClass('one'), 'one class is present')
+        ok($('.popover').hasClass('two'), 'two class is present')
+        $('#qunit-fixture').empty()
+      })
+
       test("should destroy popover", function () {
         var popover = $('<div/>').popover({trigger: 'hover'}).on('click.foo', function(){})
         ok(popover.data('bs.popover'), 'popover has data')

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -117,10 +117,30 @@ $(function () {
         $('#qunit-fixture').empty()
       })
 
-      test("should append the data-class to the popover for one-off themes", function () {
-        var popover = $('<a href="#" data-class="one two"></a>')
+      test("should append the data-theme to the popover for one-off themes", function () {
+        var popover = $('<a href="#" data-theme="one two"></a>')
           .appendTo('#qunit-fixture')
           .popover({ content: "Test" })
+          .popover('show')
+        ok($('.popover').hasClass('one'), 'one class is present')
+        ok($('.popover').hasClass('two'), 'two class is present')
+        $('#qunit-fixture').empty()
+      })
+
+      test("pull theme from the options", function () {
+        var popover = $('<a href="#"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({ content: "Test", theme: "one two" })
+          .popover('show')
+        ok($('.popover').hasClass('one'), 'one class is present')
+        ok($('.popover').hasClass('two'), 'two class is present')
+        $('#qunit-fixture').empty()
+      })
+
+      test("pull theme as a function from the options", function () {
+        var popover = $('<a href="#"></a>')
+          .appendTo('#qunit-fixture')
+          .popover({ content: "Test", theme: function (el) { return "one two" } })
           .popover('show')
         ok($('.popover').hasClass('one'), 'one class is present')
         ok($('.popover').hasClass('two'), 'two class is present')

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -66,10 +66,28 @@ $(function () {
         ok(!$(".tooltip").length, 'tooltip removed')
       })
 
-      test("should append the data-class to the tooltip for one-off themes", function () {
-        var tooltip = $('<a href="#" rel="tooltip" data-class="one two" title="One off tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
+      test("should append the data-theme to the tooltip for one-off themes", function () {
+        var tooltip = $('<a href="#" rel="tooltip" data-theme="one two" title="One off tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
           .appendTo('#qunit-fixture')
           .tooltip({})
+          .tooltip('show')
+        ok($('.tooltip').hasClass('one'), 'one class is present')
+        ok($('.tooltip').hasClass('two'), 'two class is present')
+      })
+
+      test("pull theme from the options", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="One off tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({ theme: "one two" })
+          .tooltip('show')
+        ok($('.tooltip').hasClass('one'), 'one class is present')
+        ok($('.tooltip').hasClass('two'), 'two class is present')
+      })
+
+      test("pull theme as a function from the options", function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="One off tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({ theme: function (el) { return "one two" } })
           .tooltip('show')
         ok($('.tooltip').hasClass('one'), 'one class is present')
         ok($('.tooltip').hasClass('two'), 'two class is present')

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -66,6 +66,15 @@ $(function () {
         ok(!$(".tooltip").length, 'tooltip removed')
       })
 
+      test("should append the data-class to the tooltip for one-off themes", function () {
+        var tooltip = $('<a href="#" rel="tooltip" data-class="one two" title="One off tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({})
+          .tooltip('show')
+        ok($('.tooltip').hasClass('one'), 'one class is present')
+        ok($('.tooltip').hasClass('two'), 'two class is present')
+      })
+
       test("should fire show event", function () {
         stop()
         var tooltip = $('<div title="tooltip title"></div>')

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -45,6 +45,7 @@
   , delay: 0
   , html: false
   , container: false
+  , theme: ''
   }
 
   Tooltip.prototype.init = function (type, element, options) {
@@ -158,7 +159,7 @@
         .detach()
         .css({ top: 0, left: 0, display: 'block' })
         .addClass(placement)
-        .addClass(this.getClass())
+        .addClass(this.getTheme())
 
       this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 
@@ -319,8 +320,15 @@
     return title
   }
 
-  Tooltip.prototype.getClass = function () {
-    return this.$element.attr('data-class') || ''
+  Tooltip.prototype.getTheme = function () {
+    var theme
+    var $e = this.$element
+    var o = this.options
+
+    theme = $.attr('data-theme')
+      || (typeof o.theme == 'function' ? o.theme.call($e[0]) : o.theme)
+
+    return theme
   }
 
   Tooltip.prototype.tip = function () {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -158,6 +158,7 @@
         .detach()
         .css({ top: 0, left: 0, display: 'block' })
         .addClass(placement)
+        .addClass(this.getClass())
 
       this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 
@@ -316,6 +317,10 @@
       || (typeof o.title == 'function' ? o.title.call($e[0]) :  o.title)
 
     return title
+  }
+
+  Tooltip.prototype.getClass = function () {
+    return this.$element.attr('data-class') || ''
   }
 
   Tooltip.prototype.tip = function () {


### PR DESCRIPTION
I know it is possible to use templates for custom themes, etc. However, I quickly needed to handle a few special cases within an app. Being able to specify a data-theme attribute allowed me to quickly solve the special cases without adding more JS and copying the template changes around multiple times just to change/add a class name.
