### PR TITLE
Reversed split button dropdown fix

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -90,7 +90,7 @@
 // Set corners individual because sometimes a single button can be in a .btn-group and we need :first-child and :last-child to both match
 .btn-group > .btn:first-child {
   margin-left: 0;
-  &:not(:last-child):not(.dropdown-toggle) {
+  &:not(:last-child) {
     .border-right-radius(0);
   }
 }


### PR DESCRIPTION
A bug(?)  when a reversed split button dropdown not rendered properly.
Illustrated in the following example http://jsfiddle.net/rBFW9/2/
