### PR TITLE
Affix: use scrollHeight instead of offsetHeight

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -73,7 +73,7 @@
     this.$element.removeClass(Affix.RESET).addClass('affix' + (affix ? '-' + affix : ''))
 
     if (affix == 'bottom') {
-      this.$element.offset({ top: document.body.offsetHeight - offsetBottom - this.$element.height() })
+      this.$element.offset({ top: document.body.scrollHeight - offsetBottom - this.$element.height() })
     }
   }
 


### PR DESCRIPTION
`document.body.offsetHeight` returns "wrong" value when the following CSS is applied:

``` css
html, body {
  height: 100%;
}
```

A wrong (negative) `top` value is then calculated for `affix-bottom`.
