### PR TITLE
Clear timeout on destroy.

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -352,6 +352,7 @@
   }
 
   Tooltip.prototype.destroy = function () {
+    clearTimeout(this.timeout);
     this.hide().$element.off('.' + this.type).removeData('bs.' + this.type)
   }
 


### PR DESCRIPTION
Clears the internal timeout on destroy so that hanging timers are not fired after destruction.

@fat does this need tests?
