### PR TITLE
Remove color: inherit from headings

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -80,7 +80,6 @@ h1, h2, h3, h4, h5, h6,
   font-family: @headings-font-family;
   font-weight: @headings-font-weight;
   line-height: @headings-line-height;
-  color: @headings-color;
 
   small,
   .small {

--- a/less/variables.less
+++ b/less/variables.less
@@ -61,7 +61,6 @@
 @headings-font-family:    @font-family-base;
 @headings-font-weight:    500;
 @headings-line-height:    1.1;
-@headings-color:          inherit;
 
 
 // Iconography


### PR DESCRIPTION
Heading classes (`.h1`, `.h2`, etc.) override default color styling for anchor tags as well as other well-defined classes for color styling (`.text-success`, `.text-danger`, etc.).

The following code snippet when rendered would appear with `@text-color` (instead of `@link-color`) until hovered over at which point it would appear with `@link-hover-color` color.

```
<a href="#" class="h1">Heading 1</a>
```

It should be noted that this styling was correct shortly ago in BS 3.0.0.  I have included two examples to document the issue:

Bootstrap 3.0.0 (styled correctly): http://jsfiddle.net/MYrV4/3/
Bootstrap 3.0.2 (styled incorrectly): http://jsfiddle.net/5g7WH/2/

Heading classes (which are simply meant to emulate their respective heading sizes) should not affect the color of anchor elements nor elements with the .text-\* classes.

While related to Issue #10202, I view this to be a far more grievous issue than it as it is more far-reaching (affecting styling all the way down to basic anchor tag styling).
