### PR TITLE
Firefox placeholder text is faded out and not the full color. 

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -55,7 +55,7 @@
 // Placeholder text
 .placeholder(@color: @input-color-placeholder) {
   &:-moz-placeholder            { color: @color; } // Firefox 4-18
-  &::-moz-placeholder           { color: @color; } // Firefox 19+
+  &::-moz-placeholder           { color: @color; opacity:1; } // Firefox 19+
   &:-ms-input-placeholder       { color: @color; } // Internet Explorer 10+
   &::-webkit-input-placeholder  { color: @color; } // Safari and Chrome
 }


### PR DESCRIPTION
- Adding opacity:1 to it returns it to the proper color
- (this is a re-commit since I messed up my branch last time and failed the travis build)

---

My previous pull request I did wrong as I didn't make a new branch (first time doing that). This should not fail the build and make everything work properly. Sorry.
