### PR TITLE
removed color treatment of outline for easier integration

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -30,8 +30,8 @@
 // WebKit-style focus
 .tab-focus() {
   // Default
-  outline: thin dotted #333;
-  // WebKit
+  outline: thin dotted;
+  //Webkit
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }


### PR DESCRIPTION
- The default outline treatment of outline is `invert` which ensures that the outline colour will always have sufficient contrast from the background it is on.
- `.tab-focus()` mixin was styling the background colour to `#333` , this poses a bit of a restriction for implementers of twitter bootstrap since if the background is darker than white, there may not be enough contrast to see the outline, causing an accessibility issue.

Great work again TB team, looking forward to v3.0.3

/cc @mdo @cvrebert
