### PR TITLE
explicitly call out font files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,14 @@
 {
   "name": "bootstrap",
   "version": "3.0.2",
-  "main": ["./dist/js/bootstrap.js", "./dist/css/bootstrap.css", "./dist/fonts/*"],
+  "main": [
+    "./dist/js/bootstrap.js", 
+    "./dist/css/bootstrap.css", 
+    "./dist/fonts/glyphicons-halflings-regular.eot",
+    "./dist/fonts/glyphicons-halflings-regular.svg",
+    "./dist/fonts/glyphicons-halflings-regular.ttf",
+    "./dist/fonts/glyphicons-halflings-regular.woff"
+  ],
   "ignore": [
     "**/.*",
     "_*",


### PR DESCRIPTION
Addresses https://github.com/twbs/bootstrap/issues/11296

Using wildcards to specify fonts causes errors for other
npm modules, EG, https://github.com/blittle/bower-installer/issues/33.
Additionally, it’s better to lock down files included in a
library.
