### PR TITLE
add Gemfile to project since jekyll gem is invoked by default grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ validation-report.json
 # Folders to ignore
 node_modules
 bower_components
+
+# Ruby Gems dependencies should be specified in Gemfile
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem 'jekyll', '~> 1.3'
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Bootstrap's documentation, included in this repo in the root directory, is built
 
 ### Running documentation locally
 
-1. If necessary, [install Jekyll](http://jekyllrb.com/docs/installation) (requires v1.x).
+1. From the root `/bootstrap` directory, run `bundle install` in the command line to install the Jekyll gem.
 2. From the root `/bootstrap` directory, run `jekyll serve` in the command line.
   - **Windows users:** run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors.
 3. Open <http://localhost:9001> in your browser, and voilà.


### PR DESCRIPTION
since we’re using jekyll to compile the github pages, let’s add
it as a tool in the listed dependencies so contributors don’t
have to guess.

the following is my terminal output before adding the Gemfile

$ grunt

Running "recess:bootstrap" (recess) task
File "dist/css/bootstrap.css" created.

Running "recess:min" (recess) task
File "dist/css/bootstrap.min.css" created.
Original: 125095 bytes.
Minified: 102472 bytes.

Running "recess:theme" (recess) task
File "dist/css/bootstrap-theme.css" created.

Running "recess:theme_min" (recess) task
File "dist/css/bootstrap-theme.min.css" created.
Original: 19464 bytes.
Minified: 17493 bytes.

Running "jshint:gruntfile" (jshint) task

> > 1 file lint free.

Running "jshint:src" (jshint) task

> > 12 files lint free.

Running "jshint:test" (jshint) task

> > 13 files lint free.

Running "qunit:files" (qunit) task
# Testing js/tests/index.html Starting test suite

✔ All tests passed in 'transition' module
✔ All tests passed in 'alert' module
✔ All tests passed in 'button' module
✔ All tests passed in 'carousel' module
✔ All tests passed in 'collapse' module
✔ All tests passed in 'dropdowns' module
✔ All tests passed in 'modal' module
✔ All tests passed in 'scrollspy' module
✔ All tests passed in 'tabs' module
✔ All tests passed in 'tooltip' module
✔ All tests passed in 'popover' module
✔ All tests passed in 'affix' module
# 

Tests completed in 2238 milliseconds
216 tests of 216 passed, 0 failed.
OK

> > 216 assertions passed (2238ms)

Running "jekyll:docs" (jekyll) task
`jekyll build` was initiated.

Jekyll output:
Warning: Command failed: rbenv: jekyll: command not found

The `jekyll' command exists in these Ruby versions:
  2.0.0-p247

 Use --force to continue.

Aborted due to warnings.
