### PR TITLE
Remove white space bellow sticky footer @ x-small viewport.

### DIFF
--- a/examples/sticky-footer-navbar/sticky-footer-navbar.css
+++ b/examples/sticky-footer-navbar/sticky-footer-navbar.css
@@ -38,6 +38,7 @@ body {
 #footer > .container {
   padding-left: 15px;
   padding-right: 15px;
+  background-color: #f5f5f5;
 }
 
 code {


### PR DESCRIPTION
This is really tiny fix, but maybe it will help someone sometime in the future...

URL: http://getbootstrap.com/examples/sticky-footer-navbar/

[Before](https://drive.google.com/file/d/0B8QVS6XeOnwtQ2pWWnlONjE3eVE/edit?usp=sharing) and [After](https://drive.google.com/file/d/0B8QVS6XeOnwtdEVlWjlQMnFMRUU/edit?usp=sharing) the fix - sticky footer background color is bright so pay attention. :)

Screenshots taken on:
- Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36

Also tested on:
- Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:25.0) Gecko/20100101 Firefox/25.0
- Opera/9.80 (X11; Linux i686) Presto/2.12.388 Version/12.16
