### PR TITLE
include jspm package configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,4 +37,15 @@
     , "grunt-sed": "~0.1.1"
     , "regexp-quote": "~0.0.0"
   }
+  , "jspm": {
+      "main": "js/bootstrap"
+    , "directories": { "lib": "dist" }
+    , "shim": {
+        "js/bootstrap": {
+            "imports": "jquery"
+          , "exports": "$"
+        }
+    }
+    , "buildConfig": { "uglify": true }
+  }
 }


### PR DESCRIPTION
With this configuration in the package.json, Bootstrap can be included in a page through jspm with:

http://jsbin.com/osIYuDOJ/1/edit

This includes minification with source maps, shimming the jquery dependency, setting the main entry point and loading resources from the "dist" folder.

For example, this approach is used by http://getkickstrap.com/, a Bootstrap framework.

Bootstrap itself isn't downloaded as a clone of the Github repo, rather the Github release is detected and used instead.

Questions welcome, I know package.json littering can be a contentious issue. There are other options as well so happy to discuss this.
