### PR TITLE
Fix for bad Firefox positioning at bottom, fix for #10270

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -61,7 +61,7 @@
     if (typeof offsetBottom == 'function') offsetBottom = offset.bottom()
 
     var affix = this.unpin   != null && (scrollTop + this.unpin <= position.top) ? false :
-                offsetBottom != null && (position.top + this.$element.height() >= scrollHeight - offsetBottom) ? 'bottom' :
+                offsetBottom != null && (Math.ceil(position.top) + this.$element.height() >= scrollHeight - offsetBottom) ? 'bottom' :
                 offsetTop    != null && (scrollTop <= offsetTop) ? 'top' : false
 
     if (this.affixed === affix) return


### PR DESCRIPTION
Fixes issue #10270
Firefox sometimes erroneously reports a float instead of an int for position.top. Math.ceil rounds this up and corrects the calculation
