### PR TITLE
Fixes #11669 - Adds smooth modal scrolling on iOS by default

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -23,7 +23,8 @@
   bottom: 0;
   left: 0;
   z-index: @zindex-modal-background;
-
+  -webkit-overflow-scrolling: touch;
+  
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {
     .translate(0, -25%);


### PR DESCRIPTION
I think it is worth the tradeoff that @mdo mentioned in #11669. Still to be done would be to create a user-changeable variable that turns this on and off like @mmilo suggested.
