### PR TITLE
Ensure unix line end

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,10 @@
 module.exports = function(grunt) {
   "use strict";
 
+  // overwrite platform specific setting get always unix like line feed char
+  // https://github.com/gruntjs/grunt/blob/master/lib/grunt/util.js#L62
+  grunt.util.linefeed = '\n';
+
   RegExp.quote = require('regexp-quote')
   var btoa = require('btoa')
   // Project configuration.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
   "use strict";
 
   // overwrite platform specific setting get always unix like line feed char
-  // https://github.com/gruntjs/grunt/blob/master/lib/grunt/util.js#L62
+  // http://gruntjs.com/api/grunt.util#grunt.util.linefeed
   grunt.util.linefeed = '\n';
 
   RegExp.quote = require('regexp-quote')


### PR DESCRIPTION
To prevent changes in the dist files, that only are result of running build process on different platforms, I suggest to force the line feed char.

The option is documented here: http://gruntjs.com/api/grunt.util#grunt.util.linefeed
