### PR TITLE
Fix tooltips on .add-on elements

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -12,6 +12,8 @@
   font-size: @font-size-small;
   line-height: 1.4;
   .opacity(0);
+  white-space: normal;
+  text-shadow: none;
 
   &.in     { .opacity(.9); }
   &.top    { margin-top:  -3px; padding: @tooltip-arrow-width 0; }


### PR DESCRIPTION
Fixes a bug where tooltips added to .add-on elements are forced onto one line and inherit a blurry text shadow.
