### PR TITLE
Add a migration tip for .label to .label-default

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -457,6 +457,10 @@ bootstrap/
             <td><code>.text-muted</code></td>
           </tr>
           <tr>
+            <td><code>.label</code></td>
+            <td><code>.label .label-default</code></td>
+          </tr>
+          <tr>
             <td><code>.text-error</code></td>
             <td><code>.text-danger</code></td>
           </tr>


### PR DESCRIPTION
When I was migrating a project from Bootstrap 2 to Bootstrap 3 I realized that I also needed to update my `span.label` elements to have the `label-default` css class.

http://getbootstrap.com/components/#labels

Thanks for this awesome project!
