### PR TITLE
Add a migration tip for .label-important to .label-danger

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -461,6 +461,10 @@ bootstrap/
             <td><code>.label .label-default</code></td>
           </tr>
           <tr>
+            <td><code>.label .label-important</code></td>
+            <td><code>.label .label-danger</code></td>
+          </tr>
+          <tr>
             <td><code>.text-error</code></td>
             <td><code>.text-danger</code></td>
           </tr>


### PR DESCRIPTION
Found another small tip to add to the migration guide from Bootstrap 2 to Bootstrap 3.

http://getbootstrap.com/components/#labels
