### PR TITLE
Dropping unused variable in dropdown.js

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -26,7 +26,7 @@
   var backdrop = '.dropdown-backdrop'
   var toggle   = '[data-toggle=dropdown]'
   var Dropdown = function (element) {
-    var $el = $(element).on('click.bs.dropdown', this.toggle)
+    $(element).on('click.bs.dropdown', this.toggle)
   }
 
   Dropdown.prototype.toggle = function (e) {


### PR DESCRIPTION
Dropping an unused variable in the Dropdown function inside the `dropdown.js` code.

There are no new/changed unit tests, as there are no feature/bug changes requiring new test cases.

For the record: I agree to dual-license this contribution under the Apache 2 and MIT licenses.
