### PR TITLE
Use document scroll height instead of offset height

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -73,7 +73,7 @@
     this.$element.removeClass(Affix.RESET).addClass('affix' + (affix ? '-' + affix : ''))
 
     if (affix == 'bottom') {
-      this.$element.offset({ top: document.body.offsetHeight - offsetBottom - this.$element.height() })
+      this.$element.offset({ top: scrollHeight - offsetBottom - this.$element.height() })
     }
   }
 


### PR DESCRIPTION
When body height is set in absolute pixels or percents of viewport, offsetHeight gives bad number. Use scrollHeight instead. It is also used in script few lines above this change.
