### PR TITLE
Added the removal of pill-content and pill-pane in the migration guide

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -688,6 +688,16 @@ bootstrap/
             <td class="text-muted">N/A</td>
           </tr>
           <tr>
+            <td>Pill-based tabbable area</td>
+            <td><code>.pill-content</code></td>
+            <td><code>.tab-content</code></td>
+          </tr>
+          <tr>
+            <td>Pill-based tabbable area pane</td>
+            <td><code>.pill-pane</code></td>
+            <td><code>.tab-pane</code></td>
+          </tr>
+          <tr>
             <td>Nav lists</td>
             <td><code>.nav-list</code> <code>.nav-header</code></td>
             <td>No direct equivalent, but <a href="../components/#list-group">list groups</a> and <a href="../javascript/#collapse"><code>.panel-group</code>s</a> are similar.</td>


### PR DESCRIPTION
`.pill-content` and `.pill-pane` used to do the same than `.tab-content` and `.tab-pane` in 2.x. But their removal was not mentionned in the migration guide.
