### PR TITLE
Don't exclude fonts from bower installs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "_*",
     "docs-assets",
     "examples",
-    "/fonts",
     "js/tests",
     "CNAME",
     "CONTRIBUTING.md",


### PR DESCRIPTION
Excluding fonts/ from bower installs causes glyphicons to be unavailable to projects using development Bootstrap LESS files.
