### PR TITLE
Fix disabled button toggle events

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -58,6 +58,10 @@
 
     if ($parent.length) {
       var $input = this.$element.find('input')
+      if ($input.is(':disabled')) {
+        // Disabled elements should not be allowed to continue
+        changed = false
+      }
       if ($input.prop('type') === 'radio') {
         // see if clicking on current one
         if ($input.prop('checked') && this.$element.hasClass('active'))

--- a/js/button.js
+++ b/js/button.js
@@ -62,7 +62,7 @@
         // Disabled elements should not be allowed to continue
         changed = false
       }
-      if ($input.prop('type') === 'radio') {
+      else if ($input.prop('type') === 'radio') {
         // see if clicking on current one
         if ($input.prop('checked') && this.$element.hasClass('active'))
           changed = false


### PR DESCRIPTION
Fixes a bug - In IE8 with the latest jQuery (1.10.*), the `Button.prototype.toggle()` method still fires for disabled checkboxes and radio buttons (untested with other button types). This explicitly checks to see if the button is disabled, and if so, the `changed` variable is set to false.
