### PR TITLE
Drop redundant module import

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,9 @@ module.exports = function (grunt) {
   // Force use of Unix newlines
   grunt.util.linefeed = '\n';
 
-  RegExp.quote = require('regexp-quote')
+  RegExp.quote = function (string) {
+    return string.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
+  }
   var btoa = require('btoa')
   // Project configuration.
   grunt.initConfig({

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     , "grunt-recess": "~0.5.0"
     , "grunt-saucelabs": "~4.1.2"
     , "grunt-sed": "~0.1.1"
-    , "regexp-quote": "~0.0.0"
   }
   , "jspm": {
       "main": "js/bootstrap"


### PR DESCRIPTION
Defines `RegExp.quote` directly, without module import. This speeds up tests because of one download less.

X-Ref: #11726
