### PR TITLE
Add csslint support

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,18 @@
+{
+  "adjoining-classes": false,
+  "box-sizing": false,
+  "box-model": false,
+  "compatible-vendor-prefixes": false,
+  "floats": false,
+  "font-sizes": false,
+  "gradients": false,
+  "important": false,
+  "known-properties": false,
+  "outline-none": false,
+  "qualified-headings": false,
+  "regex-selectors": false,
+  "text-indent": false,
+  "unique-headings": false,
+  "universal-selector": false,
+  "unqualified-attributes": false
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,13 @@ module.exports = function (grunt) {
       }
     },
 
+    csslint: {
+      options: {
+        csslintrc: '.csslintrc'
+      },
+      src: ['dist/css/bootstrap.css', 'dist/css/bootstrap-theme.css']
+    },
+
     concat: {
       options: {
         banner: '<%= banner %><%= jqueryCheck %>',
@@ -300,6 +307,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-csslint');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-qunit');
   grunt.loadNpmTasks('grunt-contrib-uglify');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     , "grunt-contrib-concat": "~0.3.0"
     , "grunt-contrib-connect": "~0.5.0"
     , "grunt-contrib-copy": "~0.4.1"
+    , "grunt-contrib-csslint": "~0.2.0"
     , "grunt-contrib-jshint": "~0.7.0"
     , "grunt-contrib-qunit": "~0.3.0"
     , "grunt-contrib-uglify": "~0.2.4"


### PR DESCRIPTION
There's also https://github.com/kevinsawicki/grunt-lesslint but it still uses the old csslint.

I haven't added the csslint task in test since it has errors with the current .csslintrc.

```
C:\Users\xmr\Desktop\bootstrap>grunt csslint
Running "csslint:src" (csslint) task
Linting dist/css/bootstrap.css ...ERROR
[L1965:C3]
The properties margin-top, margin-bottom, margin-left, margin-right can be replaced by margin. Use shorthand properties where possible. (shorthand)
[L6782:C1]
>> Unknown @ rule: @-ms-viewport. This rule looks for recoverable syntax errors.
 (errors)
```

I chose the rules so that the errors are few but feel free to make suggestions.

/CC @mdo
