### PR TITLE
Don't ignore Gruntfile, it's required for compile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,9 +18,7 @@
     "js/tests",
     "CNAME",
     "CONTRIBUTING.md",
-    "Gruntfile.js",
     "composer.json",
-    "package.json",
     "*.html"
   ],
   "dependencies": {


### PR DESCRIPTION
To compile (not-excluded) `less/` and `js/` files, you'll need Gruntfile.
