### PR TITLE
Build process: use module "load-grunt-tasks" to load grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -325,23 +325,7 @@ module.exports = function (grunt) {
 
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-banner');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-csslint');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-contrib-qunit');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-csscomb');
-  grunt.loadNpmTasks('grunt-html-validation');
-  grunt.loadNpmTasks('grunt-jekyll');
-  grunt.loadNpmTasks('grunt-jscs-checker');
-  grunt.loadNpmTasks('grunt-saucelabs');
-  grunt.loadNpmTasks('grunt-sed');
+    require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
 
   // Docs HTML validation task
   grunt.registerTask('validate-html', ['jekyll', 'validation']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -325,7 +325,7 @@ module.exports = function (grunt) {
 
 
   // These plugins provide necessary tasks.
-    require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
+  require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
 
   // Docs HTML validation task
   grunt.registerTask('validate-html', ['jekyll', 'validation']);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     , "grunt-saucelabs": "~4.1.2"
     , "grunt-sed": "~0.1.1"
     , "regexp-quote": "~0.0.0"
+    , "load-grunt-tasks": "~0.2.0"
   }
   , "jspm": {
       "main": "js/bootstrap"


### PR DESCRIPTION
This module loads the needed grunt tasks packages depending on the declaration in the package.json.

So we do not need to write it twice (in Gruntfile.js and package.json).

Here is a direct link to the used module: https://github.com/sindresorhus/load-grunt-tasks 
