### PR TITLE
Allow listbox AIRA role on dropdown component.

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -77,7 +77,8 @@
       return $this.click()
     }
 
-    var $items = $('[role=menu] li:not(.divider):visible a', $parent)
+    var desc = ' li:not(.divider):visible a'
+    var $items = $parent.find('[role=menu]' + desc, '[role=listbox]' + desc)
 
     if (!$items.length) return
 
@@ -149,6 +150,6 @@
     .on('click.bs.dropdown.data-api', clearMenus)
     .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
     .on('click.bs.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
-    .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
+    .on('keydown.dropdown.data-api', toggle + ', [role=menu], [role=listbox]' , Dropdown.prototype.keydown)
 
 }(jQuery);


### PR DESCRIPTION
Definition of listbox role from http://www.w3.org/TR/wai-aria/roles#listbox

> A widget that allows the user to select one or more items from a list of choices. 

Dropdown, when used a a replacement for a native select, fits this description. Allowing a choice in the role gives more flexibility to the developer using the component.
