### PR TITLE
Help Windows users install Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Bootstrap's documentation, included in this repo in the root directory, is built
 ### Running documentation locally
 
 1. If necessary, [install Jekyll](http://jekyllrb.com/docs/installation) (requires v1.x).
+  - **Windows users:** read [this unofficial guide](https://github.com/juthilo/run-jekyll-on-windows/) to get Jekyll up and running without problems.
 2. From the root `/bootstrap` directory, run `jekyll serve` in the command line.
   - **Windows users:** run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors.
 3. Open <http://localhost:9001> in your browser, and voilà.


### PR DESCRIPTION
See discussion at #11830, which overlaps with this PR.

This adds a link to my ["How to Run Jekyll on Windows"](https://github.com/juthilo/run-jekyll-on-windows/) guide to our readme.
I went through the guide once more and, safe for being tested by other users, it's quite ready in my belief.

@mdo @cvrebert Thoughts?
