### PR TITLE
Add @dropdown-caret-color variable back to variables.less

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -189,6 +189,9 @@
 
 @dropdown-header-color:          @gray-light;
 
+// Note: Deprecated @dropdown-caret-color as of v3.1.0
+@dropdown-caret-color:           #000;
+
 
 // COMPONENT VARIABLES
 // --------------------------------------------------


### PR DESCRIPTION
This variable should be added back for backward compatibility. Fixes issue #11823.

The pull request also resolves #11824 which was closed due to excessive commits.
