### PR TITLE
explicitly set more HTML5 validator options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,6 +193,8 @@ module.exports = function (grunt) {
 
     validation: {
       options: {
+        charset: 'utf-8',
+        doctype: 'HTML5',
         reset: true,
         relaxerror: [
           'Bad value X-UA-Compatible for attribute http-equiv on element meta.',


### PR DESCRIPTION
Avoids any reliance upon unwanted/unintended autodetection for these settings.
