### PR TITLE
use S3-cached Jekyll install to further speed up the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,19 @@ language: node_js
 node_js:
   - 0.10
 before_install:
-  - time sudo pip install --use-mirrors -r ./test-infra/requirements.txt
+  - time sudo pip install --use-mirrors -r test-infra/requirements.txt
+  - rvm use 1.9.3 --fuzzy
+  - if [ "$TWBS_TEST" = validate-html ]; then echo "ruby=$(basename $(rvm gemdir)) jekyll=$JEKYLL_VERSION" > pseudo_Gemfile.lock; fi
 install:
-  - if [ "$TWBS_TEST" = validate-html ]; then time gem install jekyll; fi
   - time npm install -g grunt-cli
-  - time ./test-infra/node_modules_cache.py download package.json ./node_modules || time npm install
+  - time ./test-infra/s3_cache.py download 'node.js packages' package.json ./node_modules || time npm install
+  - if [ "$TWBS_TEST" = validate-html ]; then time ./test-infra/s3_cache.py download rubygems pseudo_Gemfile.lock $(rvm gemdir) || gem install -N jekyll -v $JEKYLL_VERSION; fi
 after_script:
-  - if [ "$TWBS_TEST" = core ]; then time ./test-infra/node_modules_cache.py upload package.json ./node_modules; fi
+  - if [ "$TWBS_TEST" = core ]; then time ./test-infra/s3_cache.py upload 'node.js packages' package.json ./node_modules; fi
+  - if [ "$TWBS_TEST" = validate-html ]; then time ./test-infra/s3_cache.py upload rubygems pseudo_Gemfile.lock $(rvm gemdir); fi
 env:
   global:
+    - JEKYLL_VERSION: 1.4.1
     - SAUCE_USERNAME: bootstrap
     - secure: "pJkBwnuae9dKU5tEcCqccfS1QQw7/meEcfz63fM7ba7QJNjoA6BaXj08L5Z3Vb5vBmVPwBawxo5Hp0jC0r/Z/O0hGnAmz/Cz09L+cy7dSAZ9x4hvZePSja/UAusaB5ogMoO8l2b773MzgQeSmrLbExr9BWLeqEfjC2hFgdgHLaQ="
     - secure: "gqjqISbxBJK6byFbsmr1AyP1qoWH+rap06A2gI7v72+Tn2PU2nYkIMUkCvhZw6K889jv+LhQ/ybcBxDOXHpNCExCnSgB4dcnmYp+9oeNZb37jSP0rQ+Ib4OTLjzc3/FawE/fUq5kukZTC7porzc/k0qJNLAZRx3YLALmK1GIdUY="

--- a/test-infra/s3_cache.py
+++ b/test-infra/s3_cache.py
@@ -58,22 +58,22 @@ def _extract_tarball(directory):
 def download(directory):
     _delete_file_quietly(NEED_TO_UPLOAD_MARKER)
     try:
-        print("Downloading {} tarball from S3...".format(basename(directory)))
+        print("Downloading {} tarball from S3...".format(friendly_name))
         key.get_contents_to_filename(_tarball_filename_for(directory))
     except S3ResponseError as err:
         open(NEED_TO_UPLOAD_MARKER, 'a').close()
         print(err)
-        raise SystemExit("Cached {} download failed!".format(basename(directory)))
+        raise SystemExit("Cached {} download failed!".format(friendly_name))
     print("Downloaded {}.".format(_tarball_size(directory)))
     _extract_tarball(directory)
-    print("{} successfully installed from cache.".format(directory))
+    print("{} successfully installed from cache.".format(friendly_name))
 
 
 def upload(directory):
     _create_tarball(directory)
-    print("Uploading {} tarball to S3... ({})".format(basename(directory), _tarball_size(directory)))
+    print("Uploading {} tarball to S3... ({})".format(friendly_name, _tarball_size(directory)))
     key.set_contents_from_filename(_tarball_filename_for(directory))
-    print("{} cache successfully updated.".format(directory))
+    print("{} cache successfully updated.".format(friendly_name))
     _delete_file_quietly(NEED_TO_UPLOAD_MARKER)
 
 
@@ -82,9 +82,9 @@ if __name__ == '__main__':
     #   AWS_ACCESS_KEY_ID - AWS Access Key ID
     #   AWS_SECRET_ACCESS_KEY - AWS Secret Access Key
     argv.pop(0)
-    if len(argv) != 3:
-        raise SystemExit("USAGE: node_modules_cache.py <download | upload> <dependencies file> <directory>")
-    mode, dependencies_file, directory = argv
+    if len(argv) != 4:
+        raise SystemExit("USAGE: node_modules_cache.py <download | upload> <friendly name> <dependencies file> <directory>")
+    mode, friendly_name, dependencies_file, directory = argv
 
     conn = S3Connection()
     bucket = conn.lookup(BUCKET_NAME)


### PR DESCRIPTION
After a *lot* of pain, I am pleased to present a further improvement to the build process:
Caching the installation of Jekyll, using S3.

This approximately halves the duration of the HTML validation sub-build:
- [2 min 4 sec](https://travis-ci.org/twbs/bootstrap/jobs/15509333) → [1 min 10 sec](https://travis-ci.org/twbs/bootstrap/jobs/15511489)

X-Ref: #11726.
