### PR TITLE
Added position: static to table th and td when using grid classes for sizing

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -141,6 +141,7 @@ table {
   td,
   th {
     &[class*="col-"] {
+      position: static; // Prevent border hiding in Firefox and IE9/10 (see https://github.com/twbs/bootstrap/issues/11623)
       float: none;
       display: table-cell;
     }


### PR DESCRIPTION
@mdo Quick one here... you added the `position: static` fix for `table col[class*="col-"]` to address Issue #11623 back on 12/1 -- just wondering if we can share the love and do the same for `table th[class*="col-"]` and `table td[class*="col-"]`?
