### PR TITLE
Fix: IE10 or lower incorrectly determines the scrollheight of the body. ...

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -62,7 +62,7 @@
 
   ScrollSpy.prototype.process = function () {
     var scrollTop    = this.$scrollElement.scrollTop() + this.options.offset
-    var scrollHeight = this.$scrollElement[0].scrollHeight || this.$body[0].scrollHeight
+    var scrollHeight = this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight,﻿document.documentElement.scrollHeight)
     var maxScroll    = scrollHeight - this.$scrollElement.height()
     var offsets      = this.offsets
     var targets      = this.targets

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -62,7 +62,7 @@
 
   ScrollSpy.prototype.process = function () {
     var scrollTop    = this.$scrollElement.scrollTop() + this.options.offset
-    var scrollHeight = this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight,﻿document.documentElement.scrollHeight)
+    var scrollHeight = this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight, document.documentElement.scrollHeight)
     var maxScroll    = scrollHeight - this.$scrollElement.height()
     var offsets      = this.offsets
     var targets      = this.targets


### PR DESCRIPTION
IE10 or lower incorrectly determines the scrollheight of the body. Use document.documentElement for IE. To make this browser agnostic, the maximum scrollheight of both body and documentElement is used.
