### PR TITLE
Added thicker border for thead after tbody

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -51,6 +51,10 @@ th {
   > tbody + tbody {
     border-top: 2px solid @table-border-color;
   }
+  // Thead after tbody
+  > tbody + thead {
+    border-top: 2px solid $table-border-color;
+  }
 
   // Nesting
   .table {


### PR DESCRIPTION
Sometimes table is too big to use only one thead at the beginning of it.
When you may want to add additional theads in the middle/bottom.
