### PR TITLE
Fix #11464 - JS noConflict() mode not working in 3.0.x

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -90,9 +90,7 @@
   // AFFIX PLUGIN DEFINITION
   // =======================
 
-  var old = $.fn.affix
-
-  $.fn.affix = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.affix')
@@ -103,6 +101,9 @@
     })
   }
 
+  var old = $.fn.affix
+
+  $.fn.affix             = Plugin
   $.fn.affix.Constructor = Affix
 
 
@@ -128,7 +129,7 @@
       if (data.offsetBottom) data.offset.bottom = data.offsetBottom
       if (data.offsetTop)    data.offset.top    = data.offsetTop
 
-      $spy.affix(data)
+      Plugin.call($spy, data)
     })
   })
 

--- a/js/alert.js
+++ b/js/alert.js
@@ -56,9 +56,7 @@
   // ALERT PLUGIN DEFINITION
   // =======================
 
-  var old = $.fn.alert
-
-  $.fn.alert = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this = $(this)
       var data  = $this.data('bs.alert')
@@ -68,6 +66,9 @@
     })
   }
 
+  var old = $.fn.alert
+
+  $.fn.alert             = Plugin
   $.fn.alert.Constructor = Alert
 
 

--- a/js/button.js
+++ b/js/button.js
@@ -67,9 +67,7 @@
   // BUTTON PLUGIN DEFINITION
   // ========================
 
-  var old = $.fn.button
-
-  $.fn.button = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.button')
@@ -82,6 +80,9 @@
     })
   }
 
+  var old = $.fn.button
+
+  $.fn.button             = Plugin
   $.fn.button.Constructor = Button
 
 
@@ -100,7 +101,7 @@
   $(document).on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
     var $btn = $(e.target)
     if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-    $btn.button('toggle')
+    Plugin.call($btn, 'toggle')
     e.preventDefault()
   })
 

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -148,9 +148,7 @@
   // CAROUSEL PLUGIN DEFINITION
   // ==========================
 
-  var old = $.fn.carousel
-
-  $.fn.carousel = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.carousel')
@@ -164,6 +162,9 @@
     })
   }
 
+  var old = $.fn.carousel
+
+  $.fn.carousel             = Plugin
   $.fn.carousel.Constructor = Carousel
 
 
@@ -186,7 +187,7 @@
     var slideIndex = $this.attr('data-slide-to')
     if (slideIndex) options.interval = false
 
-    $target.carousel(options)
+    Plugin.call($target, options)
 
     if (slideIndex = $this.attr('data-slide-to')) {
       $target.data('bs.carousel').to(slideIndex)
@@ -198,7 +199,7 @@
   $(window).on('load', function () {
     $('[data-ride="carousel"]').each(function () {
       var $carousel = $(this)
-      $carousel.carousel($carousel.data())
+      Plugin.call($carousel, $carousel.data())
     })
   })
 

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -43,7 +43,7 @@
     if (actives && actives.length) {
       var hasData = actives.data('bs.collapse')
       if (hasData && hasData.transitioning) return
-      actives.collapse('hide')
+      Plugin.call(actives, 'hide')
       hasData || actives.data('bs.collapse', null)
     }
 
@@ -124,9 +124,7 @@
   // COLLAPSE PLUGIN DEFINITION
   // ==========================
 
-  var old = $.fn.collapse
-
-  $.fn.collapse = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.collapse')
@@ -138,6 +136,9 @@
     })
   }
 
+  var old = $.fn.collapse
+
+  $.fn.collapse             = Plugin
   $.fn.collapse.Constructor = Collapse
 
 
@@ -169,7 +170,7 @@
       $this[$target.hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
     }
 
-    $target.collapse(option)
+    Plugin.call($target, option)
   })
 
 }(jQuery);

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -112,9 +112,7 @@
   // DROPDOWN PLUGIN DEFINITION
   // ==========================
 
-  var old = $.fn.dropdown
-
-  $.fn.dropdown = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this = $(this)
       var data  = $this.data('bs.dropdown')
@@ -124,6 +122,9 @@
     })
   }
 
+  var old = $.fn.dropdown
+
+  $.fn.dropdown             = Plugin
   $.fn.dropdown.Constructor = Dropdown
 
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -228,9 +228,7 @@
   // MODAL PLUGIN DEFINITION
   // =======================
 
-  var old = $.fn.modal
-
-  $.fn.modal = function (option, _relatedTarget) {
+  function Plugin(option, _relatedTarget) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.modal')
@@ -242,6 +240,9 @@
     })
   }
 
+  var old = $.fn.modal
+
+  $.fn.modal             = Plugin
   $.fn.modal.Constructor = Modal
 
 
@@ -265,11 +266,10 @@
 
     if ($this.is('a')) e.preventDefault()
 
-    $target
-      .modal(option, this)
-      .one('hide', function () {
-        $this.is(':visible') && $this.trigger('focus')
-      })
+    Plugin.call($target, option, this)
+    $target.one('hide', function () {
+      $this.is(':visible') && $this.trigger('focus')
+    })
   })
 
 }(jQuery);

--- a/js/popover.js
+++ b/js/popover.js
@@ -82,9 +82,7 @@
   // POPOVER PLUGIN DEFINITION
   // =========================
 
-  var old = $.fn.popover
-
-  $.fn.popover = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.popover')
@@ -96,6 +94,9 @@
     })
   }
 
+  var old = $.fn.popover
+
+  $.fn.popover             = Plugin
   $.fn.popover.Constructor = Popover
 
 

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -116,9 +116,7 @@
   // SCROLLSPY PLUGIN DEFINITION
   // ===========================
 
-  var old = $.fn.scrollspy
-
-  $.fn.scrollspy = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.scrollspy')
@@ -129,6 +127,9 @@
     })
   }
 
+  var old = $.fn.scrollspy
+
+  $.fn.scrollspy             = Plugin
   $.fn.scrollspy.Constructor = ScrollSpy
 
 
@@ -147,7 +148,7 @@
   $(window).on('load.bs.scrollspy.data-api', function () {
     $('[data-spy="scroll"]').each(function () {
       var $spy = $(this)
-      $spy.scrollspy($spy.data())
+      Plugin.call($spy, $spy.data())
     })
   })
 

--- a/js/tab.js
+++ b/js/tab.js
@@ -90,9 +90,7 @@
   // TAB PLUGIN DEFINITION
   // =====================
 
-  var old = $.fn.tab
-
-  $.fn.tab = function ( option ) {
+  function Plugin( option ) {
     return this.each(function () {
       var $this = $(this)
       var data  = $this.data('bs.tab')
@@ -102,6 +100,9 @@
     })
   }
 
+  var old = $.fn.tab
+
+  $.fn.tab             = Plugin
   $.fn.tab.Constructor = Tab
 
 
@@ -119,7 +120,7 @@
 
   $(document).on('click.bs.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
     e.preventDefault()
-    $(this).tab('show')
+    Plugin.call($(this), 'show')
   })
 
 }(jQuery);

--- a/js/tests/unit/affix.js
+++ b/js/tests/unit/affix.js
@@ -1,23 +1,32 @@
 $(function () {
 
-  module('affix')
-
-  test('should provide no conflict', function () {
-    var affix = $.fn.affix.noConflict()
-    ok(!$.fn.affix, 'affix was set back to undefined (org value)')
-    $.fn.affix = affix
-  })
+  module('affix plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).affix, 'affix method is defined')
   })
 
+  module('affix', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapAffix = $.fn.affix.noConflict()
+    },
+    teardown: function() {
+      $.fn.affix = $.fn.bootstrapAffix
+      delete $.fn.bootstrapAffix
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.affix, 'affix was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).affix()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapAffix()[0] == document.body, 'document.body returned')
   })
 
   test('should exit early if element is not visible', function () {
-    var $affix = $('<div style="display: none"></div>').affix()
+    var $affix = $('<div style="display: none"></div>').bootstrapAffix()
     $affix.data('bs.affix').checkPosition()
     ok(!$affix.hasClass('affix'), 'affix class was not added')
   })
@@ -28,7 +37,7 @@ $(function () {
     var template = $('<div id="affixTarget"><ul><li>Please affix</li><li>And unaffix</li></ul></div><div id="affixAfter" style="height: 20000px; display:block;"></div>')
     template.appendTo('body')
 
-    $('#affixTarget').affix({
+    $('#affixTarget').bootstrapAffix({
       offset: $('#affixTarget ul').position()
     })
 

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -1,19 +1,28 @@
 $(function () {
 
-  module('alert')
-
-  test('should provide no conflict', function () {
-    var alert = $.fn.alert.noConflict()
-    ok(!$.fn.alert, 'alert was set back to undefined (org value)')
-    $.fn.alert = alert
-  })
+  module('alert plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).alert, 'alert method is defined')
   })
 
+  module('alert', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapAlert = $.fn.alert.noConflict()
+    },
+    teardown: function() {
+      $.fn.alert = $.fn.bootstrapAlert
+      delete $.fn.bootstrapAlert
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.alert, 'alert was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).alert()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapAlert()[0] == document.body, 'document.body returned')
   })
 
   test('should fade element out on clicking .close', function () {
@@ -21,7 +30,7 @@ $(function () {
         '<a class="close" href="#" data-dismiss="alert">×</a>' +
         '<p><strong>Holy guacamole!</strong> Best check yo self, you\'re not looking too good.</p>' +
         '</div>',
-      alert = $(alertHTML).alert()
+      alert = $(alertHTML).bootstrapAlert()
 
     alert.find('.close').click()
 
@@ -35,7 +44,7 @@ $(function () {
         '<a class="close" href="#" data-dismiss="alert">×</a>' +
         '<p><strong>Holy guacamole!</strong> Best check yo self, you\'re not looking too good.</p>' +
         '</div>',
-      alert = $(alertHTML).appendTo('#qunit-fixture').alert()
+      alert = $(alertHTML).appendTo('#qunit-fixture').bootstrapAlert()
 
     ok($('#qunit-fixture').find('.alert-message').length, 'element added to dom')
 
@@ -56,7 +65,7 @@ $(function () {
       .on('closed.bs.alert', function () {
         ok(false)
       })
-      .alert('close')
+      .bootstrapAlert('close')
   })
 
 })

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -1,25 +1,34 @@
 $(function () {
 
-  module('button')
-
-  test('should provide no conflict', function () {
-    var button = $.fn.button.noConflict()
-    ok(!$.fn.button, 'button was set back to undefined (org value)')
-    $.fn.button = button
-  })
+  module('button plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).button, 'button method is defined')
   })
 
+  module('button', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapButton = $.fn.button.noConflict()
+    },
+    teardown: function() {
+      $.fn.button = $.fn.bootstrapButton
+      delete $.fn.bootstrapButton
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.button, 'button was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).button()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapButton()[0] == document.body, 'document.body returned')
   })
 
   test('should return set state to loading', function () {
     var btn = $('<button class="btn" data-loading-text="fat">mdo</button>')
     equal(btn.html(), 'mdo', 'btn text equals mdo')
-    btn.button('loading')
+    btn.bootstrapButton('loading')
     equal(btn.html(), 'fat', 'btn text equals fat')
     stop()
     setTimeout(function () {
@@ -32,7 +41,7 @@ $(function () {
   test('should return reset state', function () {
     var btn = $('<button class="btn" data-loading-text="fat">mdo</button>')
     equal(btn.html(), 'mdo', 'btn text equals mdo')
-    btn.button('loading')
+    btn.bootstrapButton('loading')
     equal(btn.html(), 'fat', 'btn text equals fat')
     stop()
     setTimeout(function () {
@@ -40,7 +49,7 @@ $(function () {
       ok(btn.hasClass('disabled'), 'btn has disabled class')
       start()
       stop()
-      btn.button('reset')
+      btn.bootstrapButton('reset')
       equal(btn.html(), 'mdo', 'btn text equals mdo')
       setTimeout(function () {
         ok(!btn.attr('disabled'), 'btn is not disabled')
@@ -54,7 +63,7 @@ $(function () {
   test('should toggle active', function () {
     var btn = $('<button class="btn">mdo</button>')
     ok(!btn.hasClass('active'), 'btn does not have active class')
-    btn.button('toggle')
+    btn.bootstrapButton('toggle')
     ok(btn.hasClass('active'), 'btn has class active')
   })
 

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -1,19 +1,28 @@
 $(function () {
 
-  module('carousel')
-
-  test('should provide no conflict', function () {
-    var carousel = $.fn.carousel.noConflict()
-    ok(!$.fn.carousel, 'carousel was set back to undefined (orig value)')
-    $.fn.carousel = carousel
-  })
+  module('carousel plugin')
 
   test('should be defined on jQuery object', function () {
     ok($(document.body).carousel, 'carousel method is defined')
   })
 
+  module('carousel', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapCarousel = $.fn.carousel.noConflict()
+    },
+    teardown: function() {
+      $.fn.carousel = $.fn.bootstrapCarousel
+      delete $.fn.bootstrapCarousel
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.carousel, 'carousel was set back to undefined (orig value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).carousel()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapCarousel()[0] == document.body, 'document.body returned')
   })
 
   test('should not fire slide when slide is prevented', function () {
@@ -28,7 +37,7 @@ $(function () {
       .on('slid.bs.carousel', function () {
         ok(false)
       })
-      .carousel('next')
+      .bootstrapCarousel('next')
   })
 
   test('should reset when slide is prevented', function () {
@@ -41,7 +50,7 @@ $(function () {
       setTimeout(function () {
         ok($carousel.find('.item:eq(0)').is('.active'))
         ok($carousel.find('.carousel-indicators li:eq(0)').is('.active'))
-        $carousel.carousel('next')
+        $carousel.bootstrapCarousel('next')
       }, 1)
     })
     $carousel.one('slid.bs.carousel', function () {
@@ -51,7 +60,7 @@ $(function () {
         start()
       }, 1)
     })
-    $carousel.carousel('next')
+    $carousel.bootstrapCarousel('next')
   })
 
   test('should fire slide event with direction', function () {
@@ -63,7 +72,7 @@ $(function () {
       ok(e.direction)
       ok(e.direction === 'right' || e.direction === 'left')
       start()
-    }).carousel('next')
+    }).bootstrapCarousel('next')
   })
 
   test('should fire slide event with relatedTarget', function () {
@@ -77,7 +86,7 @@ $(function () {
         ok($(e.relatedTarget).hasClass('item'))
         start()
       })
-      .carousel('next')
+      .bootstrapCarousel('next')
   })
 
   test('should set interval from data attribute', 4, function () {
@@ -103,7 +112,7 @@ $(function () {
 
     template.attr('data-interval', false)
     template.appendTo('body')
-    $('#myCarousel').carousel(1)
+    $('#myCarousel').bootstrapCarousel(1)
     ok($('#myCarousel').data('bs.carousel').options.interval === false, 'data attribute has higher priority than default options')
     $('#myCarousel').remove()
   })
@@ -127,11 +136,11 @@ $(function () {
       + '</div>'
     )
 
-    $template.carousel()
+    $template.bootstrapCarousel()
 
     equal($template.find('.item')[0], $template.find('.active')[0], 'the first carousel item should be active')
 
-    $template.carousel(1)
+    $template.bootstrapCarousel(1)
 
     equal($template.find('.item')[1], $template.find('.active')[0], 'the second carousel item should be active')
   })

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -1,29 +1,38 @@
 $(function () {
 
-  module('collapse')
-
-  test('should provide no conflict', function () {
-    var collapse = $.fn.collapse.noConflict()
-    ok(!$.fn.collapse, 'collapse was set back to undefined (org value)')
-    $.fn.collapse = collapse
-  })
+  module('collapse plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).collapse, 'collapse method is defined')
   })
 
+  module('collapse', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapCollapse = $.fn.collapse.noConflict()
+    },
+    teardown: function() {
+      $.fn.collapse = $.fn.bootstrapCollapse
+      delete $.fn.bootstrapCollapse
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.collapse, 'collapse was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).collapse()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapCollapse()[0] == document.body, 'document.body returned')
   })
 
   test('should show a collapsed element', function () {
-    var el = $('<div class="collapse"></div>').collapse('show')
+    var el = $('<div class="collapse"></div>').bootstrapCollapse('show')
     ok(el.hasClass('in'), 'has class in')
     ok(!/height/.test(el.attr('style')), 'has height reset')
   })
 
   test('should hide a collapsed element', function () {
-    var el = $('<div class="collapse"></div>').collapse('hide')
+    var el = $('<div class="collapse"></div>').bootstrapCollapse('hide')
     ok(!el.hasClass('in'), 'does not have class in')
     ok(/height/.test(el.attr('style')), 'has height set')
   })
@@ -40,7 +49,7 @@ $(function () {
       .on('shown.bs.collapse', function () {
         ok(false)
       })
-      .collapse('show')
+      .bootstrapCollapse('show')
   })
 
   test('should reset style to auto after finishing opening collapse', function () {
@@ -54,7 +63,7 @@ $(function () {
         ok(this.style.height === '')
         start()
       })
-      .collapse('show')
+      .bootstrapCollapse('show')
   })
 
   test('should add active class to target when collapse shown', function () {

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -1,20 +1,29 @@
 $(function () {
 
-  module('dropdowns')
-
-  test('should provide no conflict', function () {
-    var dropdown = $.fn.dropdown.noConflict()
-    ok(!$.fn.dropdown, 'dropdown was set back to undefined (org value)')
-    $.fn.dropdown = dropdown
-  })
+  module('dropdowns plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).dropdown, 'dropdown method is defined')
   })
 
+  module('dropdowns', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapDropdown = $.fn.dropdown.noConflict()
+    },
+    teardown: function() {
+      $.fn.dropdown = $.fn.bootstrapDropdown
+      delete $.fn.bootstrapDropdown
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.dropdown, 'dropdown was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
     var el = $('<div />')
-    ok(el.dropdown()[0] === el[0], 'same element returned')
+    ok(el.bootstrapDropdown()[0] === el[0], 'same element returned')
   })
 
   test('should not open dropdown if target is disabled', function () {
@@ -29,7 +38,7 @@ $(function () {
         '</ul>' +
         '</li>' +
         '</ul>',
-        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').dropdown().click()
+        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
 
     ok(!dropdown.parent('.dropdown').hasClass('open'), 'open class added on click')
   })
@@ -46,7 +55,7 @@ $(function () {
         '</ul>' +
         '</li>' +
         '</ul>',
-        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').dropdown().click()
+        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
 
     ok(!dropdown.parent('.dropdown').hasClass('open'), 'open class added on click')
   })
@@ -63,7 +72,7 @@ $(function () {
         '</ul>' +
         '</li>' +
         '</ul>',
-        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').dropdown().click()
+        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
 
     ok(dropdown.parent('.dropdown').hasClass('open'), 'open class added on click')
   })
@@ -80,7 +89,7 @@ $(function () {
         '</ul>' +
         '</li>' +
         '</ul>',
-        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').dropdown().click()
+        dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
 
     ok(dropdown.parent('.dropdown').hasClass('open'), 'open class added on click')
   })
@@ -101,7 +110,7 @@ $(function () {
         dropdown = $(dropdownHTML)
           .appendTo('#qunit-fixture')
           .find('[data-toggle="dropdown"]')
-          .dropdown()
+          .bootstrapDropdown()
           .click()
 
     ok(dropdown.parent('.dropdown').hasClass('open'), 'open class added on click')
@@ -163,7 +172,7 @@ $(function () {
         dropdown = $(dropdownHTML)
           .appendTo('#qunit-fixture')
           .find('[data-toggle="dropdown"]')
-          .dropdown()
+          .bootstrapDropdown()
 
     stop()
 
@@ -197,7 +206,7 @@ $(function () {
         dropdown = $(dropdownHTML)
           .appendTo('#qunit-fixture')
           .find('[data-toggle="dropdown"]')
-          .dropdown()
+          .bootstrapDropdown()
 
     stop()
 

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -1,26 +1,35 @@
 $(function () {
 
-  module('modal')
-
-  test('should provide no conflict', function () {
-    var modal = $.fn.modal.noConflict()
-    ok(!$.fn.modal, 'modal was set back to undefined (org value)')
-    $.fn.modal = modal
-  })
+  module('modal plugin')
 
   test('should be defined on jquery object', function () {
     var div = $('<div id="modal-test"></div>')
     ok(div.modal, 'modal method is defined')
   })
 
+  module('modal', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapModal = $.fn.modal.noConflict()
+    },
+    teardown: function() {
+      $.fn.modal = $.fn.bootstrapModal
+      delete $.fn.bootstrapModal
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.modal, 'modal was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
     var div = $('<div id="modal-test"></div>')
-    ok(div.modal() == div, 'document.body returned')
+    ok(div.bootstrapModal() == div, 'document.body returned')
     $('#modal-test').remove()
   })
 
   test('should expose defaults var for settings', function () {
-    ok($.fn.modal.Constructor.DEFAULTS, 'default object exposed')
+    ok($.fn.bootstrapModal.Constructor.DEFAULTS, 'default object exposed')
   })
 
   test('should insert into dom when show method is called', function () {
@@ -32,7 +41,7 @@ $(function () {
         $(this).remove()
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should fire show event', function () {
@@ -46,7 +55,7 @@ $(function () {
         $(this).remove()
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should not fire shown when default prevented', function () {
@@ -61,7 +70,7 @@ $(function () {
       .on('shown.bs.modal', function () {
         ok(false, 'shown was called')
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should hide modal when hide is called', function () {
@@ -72,14 +81,14 @@ $(function () {
       .on('shown.bs.modal', function () {
         ok($('#modal-test').is(':visible'), 'modal visible')
         ok($('#modal-test').length, 'modal inserted into dom')
-        $(this).modal('hide')
+        $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
         ok(!$('#modal-test').is(':visible'), 'modal hidden')
         $('#modal-test').remove()
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should toggle when toggle is called', function () {
@@ -90,14 +99,14 @@ $(function () {
       .on('shown.bs.modal', function () {
         ok($('#modal-test').is(':visible'), 'modal visible')
         ok($('#modal-test').length, 'modal inserted into dom')
-        div.modal('toggle')
+        div.bootstrapModal('toggle')
       })
       .on('hidden.bs.modal', function () {
         ok(!$('#modal-test').is(':visible'), 'modal hidden')
         div.remove()
         start()
       })
-      .modal('toggle')
+      .bootstrapModal('toggle')
   })
 
   test('should remove from dom when click [data-dismiss="modal"]', function () {
@@ -115,7 +124,7 @@ $(function () {
         div.remove()
         start()
       })
-      .modal('toggle')
+      .bootstrapModal('toggle')
   })
 
   test('should allow modal close with "backdrop:false"', function () {
@@ -125,14 +134,14 @@ $(function () {
     div
       .on('shown.bs.modal', function () {
         ok($('#modal-test').is(':visible'), 'modal visible')
-        div.modal('hide')
+        div.bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
         ok(!$('#modal-test').is(':visible'), 'modal hidden')
         div.remove()
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should close modal when clicking outside of modal-content', function () {
@@ -151,7 +160,7 @@ $(function () {
         div.remove()
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should trigger hide event once when clicking outside of modal-content', function () {
@@ -171,7 +180,7 @@ $(function () {
         ok(triggered === 1, 'modal hide triggered once')
         start()
       })
-      .modal('show')
+      .bootstrapModal('show')
   })
 
   test('should close reopened modal with [data-dismiss="modal"] click', function () {
@@ -186,9 +195,9 @@ $(function () {
       .one('hidden.bs.modal', function () {
         div.one('hidden.bs.modal', function () {
           start()
-        }).modal('show')
+        }).bootstrapModal('show')
       })
-      .modal('show')
+      .bootstrapModal('show')
 
     div.remove()
   })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -1,38 +1,47 @@
 $(function () {
 
-  module('popover')
-
-  test('should provide no conflict', function () {
-    var popover = $.fn.popover.noConflict()
-    ok(!$.fn.popover, 'popover was set back to undefined (org value)')
-    $.fn.popover = popover
-  })
+  module('popover plugin')
 
   test('should be defined on jquery object', function () {
     var div = $('<div></div>')
     ok(div.popover, 'popover method is defined')
   })
 
+  module('popover', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapPopover = $.fn.popover.noConflict()
+    },
+    teardown: function() {
+      $.fn.popover = $.fn.bootstrapPopover
+      delete $.fn.bootstrapPopover
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.popover, 'popover was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
     var div = $('<div></div>')
-    ok(div.popover() == div, 'document.body returned')
+    ok(div.bootstrapPopover() == div, 'document.body returned')
   })
 
   test('should render popover element', function () {
     $.support.transition = false
     var popover = $('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>')
       .appendTo('#qunit-fixture')
-      .popover('show')
+      .bootstrapPopover('show')
 
     ok($('.popover').length, 'popover was inserted')
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover removed')
   })
 
   test('should store popover instance in popover data object', function () {
     $.support.transition = false
     var popover = $('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>')
-      .popover()
+      .bootstrapPopover()
 
     ok(!!popover.data('bs.popover'), 'popover instance exists')
   })
@@ -41,7 +50,7 @@ $(function () {
     $.support.transition = false
     var popover = $('<a href="#">@fat</a>')
       .appendTo('#qunit-fixture')
-      .popover({
+      .bootstrapPopover({
         title: function () {
           return '@fat'
         },
@@ -50,13 +59,13 @@ $(function () {
         }
       })
 
-    popover.popover('show')
+    popover.bootstrapPopover('show')
 
     ok($('.popover').length, 'popover was inserted')
     equal($('.popover .popover-title').text(), '@fat', 'title correctly inserted')
     equal($('.popover .popover-content').text(), 'loves writing tests （╯°□°）╯︵ ┻━┻', 'content correctly inserted')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
     $('#qunit-fixture').empty()
   })
@@ -68,24 +77,24 @@ $(function () {
 
     var popover = $('<a href="#">@fat</a>')
       .appendTo('#qunit-fixture')
-      .popover({
+      .bootstrapPopover({
         content: function () {
           return $div
         }
       })
 
-    popover.popover('show')
+    popover.bootstrapPopover('show')
     ok($('.popover').length, 'popover was inserted')
     equal($('.popover .popover-content').html(), $div, 'content correctly inserted')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
 
-    popover.popover('show')
+    popover.bootstrapPopover('show')
     ok($('.popover').length, 'popover was inserted')
     equal($('.popover .popover-content').html(), $div, 'content correctly inserted')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
     $('#qunit-fixture').empty()
   })
@@ -94,14 +103,14 @@ $(function () {
     $.support.transition = false
     var popover = $('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>')
       .appendTo('#qunit-fixture')
-      .popover()
-      .popover('show')
+      .bootstrapPopover()
+      .bootstrapPopover('show')
 
     ok($('.popover').length, 'popover was inserted')
     equal($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
     equal($('.popover .popover-content').text(), 'loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻', 'content correctly inserted')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
     $('#qunit-fixture').empty()
   })
@@ -111,17 +120,17 @@ $(function () {
     $.support.transition = false
     var popover = $('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>')
       .appendTo('#qunit-fixture')
-      .popover({
+      .bootstrapPopover({
         title: 'ignored title option',
         content: 'ignored content option'
       })
-      .popover('show')
+      .bootstrapPopover('show')
 
     ok($('.popover').length, 'popover was inserted')
     equal($('.popover .popover-title').text(), '@mdo', 'title correctly inserted')
     equal($('.popover .popover-content').text(), 'loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻', 'content correctly inserted')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
     $('#qunit-fixture').empty()
   })
@@ -130,29 +139,29 @@ $(function () {
     $.support.transition = false
     var popover = $('<a href="#">@fat</a>')
       .appendTo('#qunit-fixture')
-      .popover({
+      .bootstrapPopover({
         title: 'Test',
         content: 'Test',
         template: '<div class="popover foobar"><div class="arrow"></div><div class="inner"><h3 class="title"></h3><div class="content"><p></p></div></div></div>'
       })
 
-    popover.popover('show')
+    popover.bootstrapPopover('show')
 
     ok($('.popover').length, 'popover was inserted')
     ok($('.popover').hasClass('foobar'), 'custom class is present')
 
-    popover.popover('hide')
+    popover.bootstrapPopover('hide')
     ok(!$('.popover').length, 'popover was removed')
     $('#qunit-fixture').empty()
   })
 
   test('should destroy popover', function () {
-    var popover = $('<div/>').popover({trigger: 'hover'}).on('click.foo', function () {})
+    var popover = $('<div/>').bootstrapPopover({trigger: 'hover'}).on('click.foo', function () {})
     ok(popover.data('bs.popover'), 'popover has data')
     ok($._data(popover[0], 'events').mouseover && $._data(popover[0], 'events').mouseout, 'popover has hover event')
     ok($._data(popover[0], 'events').click[0].namespace == 'foo', 'popover has extra click.foo event')
-    popover.popover('show')
-    popover.popover('destroy')
+    popover.bootstrapPopover('show')
+    popover.bootstrapPopover('destroy')
     ok(!popover.hasClass('in'), 'popover is hidden')
     ok(!popover.data('popover'), 'popover does not have data')
     ok($._data(popover[0],'events').click[0].namespace == 'foo', 'popover still has click.foo')

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -1,19 +1,28 @@
 $(function () {
 
-  module('scrollspy')
-
-  test('should provide no conflict', function () {
-    var scrollspy = $.fn.scrollspy.noConflict()
-    ok(!$.fn.scrollspy, 'scrollspy was set back to undefined (org value)')
-    $.fn.scrollspy = scrollspy
-  })
+  module('scrollspy plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).scrollspy, 'scrollspy method is defined')
   })
 
+  module('scrollspy', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapScrollspy = $.fn.scrollspy.noConflict()
+    },
+    teardown: function() {
+      $.fn.scrollspy = $.fn.bootstrapScrollspy
+      delete $.fn.bootstrapScrollspy
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.scrollspy, 'scrollspy was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).scrollspy()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapScrollspy()[0] == document.body, 'document.body returned')
   })
 
   test('should switch active class on scroll', function () {
@@ -27,7 +36,7 @@ $(function () {
         '</div>' +
         '</div>' +
         '</div>',
-        $topbar = $(topbarHTML).scrollspy()
+        $topbar = $(topbarHTML).bootstrapScrollspy()
 
     $(sectionHTML).append('#qunit-fixture')
     ok($topbar.find('.active', true))
@@ -64,7 +73,7 @@ $(function () {
         $scrollSpy = $section
         .show()
         .find('#scrollspy-example')
-        .scrollspy({target: '#ss-target'})
+        .bootstrapScrollspy({target: '#ss-target'})
 
     $scrollSpy.scrollTop(350);
     ok($section.hasClass('active'), 'Active class still on root node')

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -1,19 +1,28 @@
 $(function () {
 
-  module('tabs')
-
-  test('should provide no conflict', function () {
-    var tab = $.fn.tab.noConflict()
-    ok(!$.fn.tab, 'tab was set back to undefined (org value)')
-    $.fn.tab = tab
-  })
+  module('tabs plugin')
 
   test('should be defined on jquery object', function () {
     ok($(document.body).tab, 'tabs method is defined')
   })
 
+  module('tabs', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapTab = $.fn.tab.noConflict()
+    },
+    teardown: function() {
+      $.fn.tab = $.fn.bootstrapTab
+      delete $.fn.bootstrapTab
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.tab, 'tab was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
-    ok($(document.body).tab()[0] == document.body, 'document.body returned')
+    ok($(document.body).bootstrapTab()[0] == document.body, 'document.body returned')
   })
 
   test('should activate element by tab id', function () {
@@ -24,10 +33,10 @@ $(function () {
 
     $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture')
 
-    $(tabsHTML).find('li:last a').tab('show')
+    $(tabsHTML).find('li:last a').bootstrapTab('show')
     equal($('#qunit-fixture').find('.active').attr('id'), 'profile')
 
-    $(tabsHTML).find('li:first a').tab('show')
+    $(tabsHTML).find('li:first a').bootstrapTab('show')
     equal($('#qunit-fixture').find('.active').attr('id'), 'home')
   })
 
@@ -39,10 +48,10 @@ $(function () {
 
     $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture')
 
-    $(pillsHTML).find('li:last a').tab('show')
+    $(pillsHTML).find('li:last a').bootstrapTab('show')
     equal($('#qunit-fixture').find('.active').attr('id'), 'profile')
 
-    $(pillsHTML).find('li:first a').tab('show')
+    $(pillsHTML).find('li:first a').bootstrapTab('show')
     equal($('#qunit-fixture').find('.active').attr('id'), 'home')
   })
 
@@ -59,7 +68,7 @@ $(function () {
       .on('shown.bs.tab', function () {
         ok(false)
       })
-      .tab('show')
+      .bootstrapTab('show')
   })
 
   test('show and shown events should reference correct relatedTarget', function () {
@@ -72,7 +81,7 @@ $(function () {
         '</li>' +
         '</ul>'
 
-    $(dropHTML).find('ul>li:first a').tab('show').end()
+    $(dropHTML).find('ul>li:first a').bootstrapTab('show').end()
       .find('ul>li:last a')
       .on('show.bs.tab', function (event) {
         equal(event.relatedTarget.hash, '#1-1')
@@ -80,7 +89,7 @@ $(function () {
       .on('show.bs.tab', function (event) {
         equal(event.relatedTarget.hash, '#1-1')
       })
-      .tab('show')
+      .bootstrapTab('show')
   })
 
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1,34 +1,43 @@
 $(function () {
 
-  module('tooltip')
-
-  test('should provide no conflict', function () {
-    var tooltip = $.fn.tooltip.noConflict()
-    ok(!$.fn.tooltip, 'tooltip was set back to undefined (org value)')
-    $.fn.tooltip = tooltip
-  })
+  module('tooltip plugin')
 
   test('should be defined on jquery object', function () {
     var div = $('<div></div>')
     ok(div.tooltip, 'popover method is defined')
   })
 
+  module('tooltip', {
+    setup: function() {
+      // Run all tests in noConflict mode -- it's the only way to ensure that the plugin works in noConflict mode
+      $.fn.bootstrapTooltip = $.fn.tooltip.noConflict()
+    },
+    teardown: function() {
+      $.fn.tooltip = $.fn.bootstrapTooltip
+      delete $.fn.bootstrapTooltip
+    }
+  })
+
+  test('should provide no conflict', function () {
+    ok(!$.fn.tooltip, 'tooltip was set back to undefined (org value)')
+  })
+
   test('should return element', function () {
     var div = $('<div></div>')
-    ok(div.tooltip() == div, 'document.body returned')
+    ok(div.bootstrapTooltip() == div, 'document.body returned')
   })
 
   test('should expose default settings', function () {
-    ok(!!$.fn.tooltip.Constructor.DEFAULTS, 'defaults is defined')
+    ok(!!$.fn.bootstrapTooltip.Constructor.DEFAULTS, 'defaults is defined')
   })
 
   test('should empty title attribute', function () {
-    var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').tooltip()
+    var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').bootstrapTooltip()
     ok(tooltip.attr('title') === '', 'title attribute was emptied')
   })
 
   test('should add data attribute for referencing original title', function () {
-    var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').tooltip()
+    var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>').bootstrapTooltip()
     equal(tooltip.attr('data-original-title'), 'Another tooltip', 'original title preserved in data attribute')
   })
 
@@ -36,33 +45,33 @@ $(function () {
     $.support.transition = false
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({placement: 'bottom'})
-      .tooltip('show')
+      .bootstrapTooltip({placement: 'bottom'})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip').is('.fade.bottom.in'), 'has correct classes applied')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
   })
 
   test('should allow html entities', function () {
     $.support.transition = false
     var tooltip = $('<a href="#" rel="tooltip" title="<b>@fat</b>"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({html: true})
-      .tooltip('show')
+      .bootstrapTooltip({html: true})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip b').length, 'b tag was inserted')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
     ok(!$('.tooltip').length, 'tooltip removed')
   })
 
   test('should respect custom classes', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ template: '<div class="tooltip some-class"><div class="tooltip-arrow"/><div class="tooltip-inner"/></div>'})
-      .tooltip('show')
+      .bootstrapTooltip({ template: '<div class="tooltip some-class"><div class="tooltip-arrow"/><div class="tooltip-inner"/></div>'})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip').hasClass('some-class'), 'custom class is present')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
     ok(!$('.tooltip').length, 'tooltip removed')
   })
 
@@ -73,7 +82,7 @@ $(function () {
         ok(true, 'show was called')
         start()
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should fire shown event', function () {
@@ -83,7 +92,7 @@ $(function () {
         ok(true, 'shown was called')
         start()
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should not fire shown event when default prevented', function () {
@@ -97,40 +106,40 @@ $(function () {
       .on('shown.bs.tooltip', function () {
         ok(false, 'shown was called')
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should fire hide event', function () {
     stop()
     $('<div title="tooltip title"></div>')
       .on('shown.bs.tooltip', function () {
-        $(this).tooltip('hide')
+        $(this).bootstrapTooltip('hide')
       })
       .on('hide.bs.tooltip', function () {
         ok(true, 'hide was called')
         start()
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should fire hidden event', function () {
     stop()
     $('<div title="tooltip title"></div>')
       .on('shown.bs.tooltip', function () {
-        $(this).tooltip('hide')
+        $(this).bootstrapTooltip('hide')
       })
       .on('hidden.bs.tooltip', function () {
         ok(true, 'hidden was called')
         start()
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should not fire hidden event when default prevented', function () {
     stop()
     $('<div title="tooltip title"></div>')
       .on('shown.bs.tooltip', function () {
-        $(this).tooltip('hide')
+        $(this).bootstrapTooltip('hide')
       })
       .on('hide.bs.tooltip', function (e) {
         e.preventDefault()
@@ -140,13 +149,13 @@ $(function () {
       .on('hidden.bs.tooltip', function () {
         ok(false, 'hidden was called')
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
   })
 
   test('should not show tooltip if leave event occurs before delay expires', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: 200 })
+      .bootstrapTooltip({ delay: 200 })
 
     stop()
 
@@ -165,7 +174,7 @@ $(function () {
   test('should not show tooltip if leave event occurs before delay expires, even if hide delay is 0', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: { show: 200, hide: 0} })
+      .bootstrapTooltip({ delay: { show: 200, hide: 0} })
 
     stop()
 
@@ -184,7 +193,7 @@ $(function () {
   test('should wait 200 ms before hiding the tooltip', 3, function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: { show: 0, hide: 200} })
+      .bootstrapTooltip({ delay: { show: 0, hide: 200} })
 
     stop()
 
@@ -206,7 +215,7 @@ $(function () {
   test('should not hide tooltip if leave event occurs, then tooltip is show immediately again', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: { show: 0, hide: 200} })
+      .bootstrapTooltip({ delay: { show: 0, hide: 200} })
 
     stop()
 
@@ -229,7 +238,7 @@ $(function () {
   test('should not show tooltip if leave event occurs before delay expires', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: 100 })
+      .bootstrapTooltip({ delay: 100 })
     stop()
     tooltip.trigger('mouseenter')
     setTimeout(function () {
@@ -245,7 +254,7 @@ $(function () {
   test('should show tooltip if leave event hasn\'t occured before delay expires', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({ delay: 150 })
+      .bootstrapTooltip({ delay: 150 })
     stop()
     tooltip.trigger('mouseenter')
     setTimeout(function () {
@@ -258,12 +267,12 @@ $(function () {
   })
 
   test('should destroy tooltip', function () {
-    var tooltip = $('<div/>').tooltip().on('click.foo', function () {})
+    var tooltip = $('<div/>').bootstrapTooltip().on('click.foo', function () {})
     ok(tooltip.data('bs.tooltip'), 'tooltip has data')
     ok($._data(tooltip[0], 'events').mouseover && $._data(tooltip[0], 'events').mouseout, 'tooltip has hover event')
     ok($._data(tooltip[0], 'events').click[0].namespace == 'foo', 'tooltip has extra click.foo event')
-    tooltip.tooltip('show')
-    tooltip.tooltip('destroy')
+    tooltip.bootstrapTooltip('show')
+    tooltip.bootstrapTooltip('destroy')
     ok(!tooltip.hasClass('in'), 'tooltip is hidden')
     ok(!$._data(tooltip[0], 'bs.tooltip'), 'tooltip does not have data')
     ok($._data(tooltip[0], 'events').click[0].namespace == 'foo', 'tooltip still has click.foo')
@@ -273,7 +282,7 @@ $(function () {
   test('should show tooltip with delegate selector on click', function () {
     var div = $('<div><a href="#" rel="tooltip" title="Another tooltip"></a></div>')
     div.appendTo('#qunit-fixture')
-                     .tooltip({ selector: 'a[rel="tooltip"]', trigger: 'click' })
+                     .bootstrapTooltip({ selector: 'a[rel="tooltip"]', trigger: 'click' })
     div.find('a').trigger('click')
     ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
   })
@@ -281,19 +290,19 @@ $(function () {
   test('should show tooltip when toggle is called', function () {
     $('<a href="#" rel="tooltip" title="tooltip on toggle"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({trigger: 'manual'})
-      .tooltip('toggle')
+      .bootstrapTooltip({trigger: 'manual'})
+      .bootstrapTooltip('toggle')
     ok($('.tooltip').is('.fade.in'), 'tooltip should be toggled in')
   })
 
   test('should place tooltips inside the body', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({container: 'body'})
-      .tooltip('show')
+      .bootstrapTooltip({container: 'body'})
+      .bootstrapTooltip('show')
     ok($('body > .tooltip').length, 'inside the body')
     ok(!$('#qunit-fixture > .tooltip').length, 'not found in parent')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
   })
 
   test('should place tooltip inside window', function () {
@@ -302,8 +311,8 @@ $(function () {
     $('<a href="#" title="Very very very very very very very very long tooltip">Hover me</a>')
       .css({position: 'absolute', top: 0, left: 0})
       .appendTo(container)
-      .tooltip({placement: 'top', animate: false})
-      .tooltip('show')
+      .bootstrapTooltip({placement: 'top', animate: false})
+      .bootstrapTooltip('show')
 
     stop()
 
@@ -322,8 +331,8 @@ $(function () {
           tooltiped = $('<a href="#" title="very very very very very very very long tooltip">Hover me</a>')
             .css({marginTop: 200})
             .appendTo(p)
-            .tooltip({placement: 'top', animate: false})
-            .tooltip('show')
+            .bootstrapTooltip({placement: 'top', animate: false})
+            .bootstrapTooltip('show')
 
     stop()
 
@@ -342,8 +351,8 @@ $(function () {
     var container = $('<div />').appendTo('body'),
         target = $('<a href="#" rel="tooltip" title="very very very very very very very very long tooltip in one line"></a>')
           .appendTo(container)
-          .tooltip({placement: 'right', viewport: null})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'right', viewport: null})
+          .bootstrapTooltip('show'),
         tooltip = container.find('.tooltip')
 
     // this is some dumb hack shit because sub pixels in firefox
@@ -351,41 +360,41 @@ $(function () {
     var top2 = Math.round(tooltip.offset().top)
     var topDiff =  top - top2
     ok(topDiff <= 1 && topDiff >= -1)
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
   })
 
   test('tooltip title test #1', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Simple tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({})
-      .tooltip('show')
+      .bootstrapTooltip({})
+      .bootstrapTooltip('show')
     equal($('.tooltip').children('.tooltip-inner').text(), 'Simple tooltip', 'title from title attribute is set')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
     ok(!$('.tooltip').length, 'tooltip removed')
   })
 
   test('tooltip title test #2', function () {
     var tooltip = $('<a href="#" rel="tooltip" title="Simple tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({
+      .bootstrapTooltip({
         title: 'This is a tooltip with some content'
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
     equal($('.tooltip').children('.tooltip-inner').text(), 'Simple tooltip', 'title is set from title attribute while prefered over title option')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
     ok(!$('.tooltip').length, 'tooltip removed')
   })
 
   test('tooltip title test #3', function () {
     var tooltip = $('<a href="#" rel="tooltip" style="display: inline-block; position: absolute; top: 0; left: 0;"></a>')
       .appendTo('#qunit-fixture')
-      .tooltip({
+      .bootstrapTooltip({
         title: 'This is a tooltip with some content'
       })
-      .tooltip('show')
+      .bootstrapTooltip('show')
     equal($('.tooltip').children('.tooltip-inner').text(), 'This is a tooltip with some content', 'title from title option is set')
-    tooltip.tooltip('hide')
+    tooltip.bootstrapTooltip('hide')
     ok(!$('.tooltip').length, 'tooltip removed')
   })
 
@@ -403,28 +412,28 @@ $(function () {
 
     var topTooltip = $('<div style="display: inline-block; position: absolute; left: 0; top: 0;" rel="tooltip" title="Top tooltip">Top Dynamic Tooltip</div>')
       .appendTo('#dynamic-tt-test')
-      .tooltip({placement: 'auto'})
-      .tooltip('show')
+      .bootstrapTooltip({placement: 'auto'})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip').is('.bottom'), 'top positioned tooltip is dynamically positioned bottom')
 
-    topTooltip.tooltip('hide')
+    topTooltip.bootstrapTooltip('hide')
 
     var rightTooltip = $('<div style="display: inline-block; position: absolute; right: 0;" rel="tooltip" title="Right tooltip">Right Dynamic Tooltip</div>')
       .appendTo('#dynamic-tt-test')
-      .tooltip({placement: 'right auto'})
-      .tooltip('show')
+      .bootstrapTooltip({placement: 'right auto'})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip').is('.left'), 'right positioned tooltip is dynamically positioned left')
-    rightTooltip.tooltip('hide')
+    rightTooltip.bootstrapTooltip('hide')
 
     var leftTooltip = $('<div style="display: inline-block; position: absolute; left: 0;" rel="tooltip" title="Left tooltip">Left Dynamic Tooltip</div>')
       .appendTo('#dynamic-tt-test')
-      .tooltip({placement: 'auto left'})
-      .tooltip('show')
+      .bootstrapTooltip({placement: 'auto left'})
+      .bootstrapTooltip('show')
 
     ok($('.tooltip').is('.right'), 'left positioned tooltip is dynamically positioned right')
-    leftTooltip.tooltip('hide')
+    leftTooltip.bootstrapTooltip('hide')
 
     ttContainer.remove()
   })
@@ -435,12 +444,12 @@ $(function () {
     var container = $('<div />').appendTo('body'),
       target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; left: 0px;"></a>')
           .appendTo(container)
-          .tooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
+          .bootstrapTooltip('show'),
       tooltip = container.find('.tooltip')
 
     ok( Math.round(tooltip.offset().top) === 12 )
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
   })
 
@@ -450,12 +459,12 @@ $(function () {
     var container = $('<div />').appendTo('body'),
       target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; bottom: 0px; left: 0px;"></a>')
           .appendTo(container)
-          .tooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
+          .bootstrapTooltip('show'),
       tooltip = container.find('.tooltip')
 
     ok( Math.round(tooltip.offset().top) === Math.round($(window).height() - 12 - tooltip[0].offsetHeight) )
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
   })
 
@@ -465,12 +474,12 @@ $(function () {
     var container = $('<div />').appendTo('body'),
       target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; left: 0px;"></a>')
           .appendTo(container)
-          .tooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
+          .bootstrapTooltip('show'),
       tooltip = container.find('.tooltip')
 
     ok( Math.round(tooltip.offset().left) === 12 )
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
   })
 
@@ -480,12 +489,12 @@ $(function () {
     var container = $('<div />').appendTo('body'),
       target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; right: 0px;"></a>')
           .appendTo(container)
-          .tooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
+          .bootstrapTooltip('show'),
       tooltip = container.find('.tooltip')
 
     ok( Math.round(tooltip.offset().left) === Math.round($(window).width() - 12 - tooltip[0].offsetWidth) )
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
   })
 
@@ -496,12 +505,12 @@ $(function () {
     var container = $('<div />', {class: 'container-viewport'}).appendTo('body'),
       target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 50px; left: 350px;"></a>')
           .appendTo(container)
-          .tooltip({placement: 'bottom', viewport: '.container-viewport'})
-          .tooltip('show'),
+          .bootstrapTooltip({placement: 'bottom', viewport: '.container-viewport'})
+          .bootstrapTooltip('show'),
       tooltip = container.find('.tooltip')
 
     ok( Math.round(tooltip.offset().left) === Math.round(60 + container.width() - tooltip[0].offsetWidth) )
-    target.tooltip('hide')
+    target.bootstrapTooltip('hide')
     $('head #test').remove()
     $('head #viewport-style').remove()
   })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -99,7 +99,12 @@
 
   Tooltip.prototype.enter = function (obj) {
     var self = obj instanceof this.constructor ?
-      obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type)
+      obj : $(obj.currentTarget).data('bs.' + this.type)
+
+    if (!self) {
+      self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
+      $(obj.currentTarget).data('bs.' + this.type, self)
+    }
 
     clearTimeout(self.timeout)
 
@@ -114,7 +119,12 @@
 
   Tooltip.prototype.leave = function (obj) {
     var self = obj instanceof this.constructor ?
-      obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type)
+      obj : $(obj.currentTarget).data('bs.' + this.type)
+
+    if (!self) {
+      self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
+      $(obj.currentTarget).data('bs.' + this.type, self)
+    }
 
     clearTimeout(self.timeout)
 
@@ -381,7 +391,15 @@
   }
 
   Tooltip.prototype.toggle = function (e) {
-    var self = e ? $(e.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type) : this
+    var self = this
+    if (e) {
+      self = $(e.currentTarget).data('bs.' + this.type)
+      if (!self) {
+        self = new this.constructor(e.currentTarget, this.getDelegateOptions())
+        $(e.currentTarget).data('bs.' + this.type, self)
+      }
+    }
+
     self.tip().hasClass('in') ? self.leave(self) : self.enter(self)
   }
 
@@ -394,9 +412,7 @@
   // TOOLTIP PLUGIN DEFINITION
   // =========================
 
-  var old = $.fn.tooltip
-
-  $.fn.tooltip = function (option) {
+  function Plugin(option) {
     return this.each(function () {
       var $this   = $(this)
       var data    = $this.data('bs.tooltip')
@@ -408,6 +424,9 @@
     })
   }
 
+  var old = $.fn.tooltip
+
+  $.fn.tooltip             = Plugin
   $.fn.tooltip.Constructor = Tooltip
 
 


### PR DESCRIPTION
Refactor tests to run everything in noConflict mode.  This is a philosophy change, from "We're testing a jQuery plugin" to "We're testing a library that depends on jQuery". Then, almost as an afterthought, there is an additional test to make sure the library correctly gets attached as a jQuery plugin.

Refactor all plugins to use an internal `Plugin` reference to the plugin function.  The plugins can't expect to be attached to the jQuery object when in noConflict mode.
