### PR TITLE
Get rid of JSHint's `laxcomma` option now that the comma is used on the ...

### DIFF
--- a/docs-assets/js/application.js
+++ b/docs-assets/js/application.js
@@ -59,8 +59,8 @@
             var navOuterHeight = $('.bs-docs-nav').height()
 
             return (this.top = offsetTop - navOuterHeight - sideBarMargin)
-          }
-        , bottom: function () {
+          },
+          bottom: function () {
             return (this.bottom = $('.bs-footer').outerHeight(true))
           }
         }

--- a/docs-assets/js/customizer.js
+++ b/docs-assets/js/customizer.js
@@ -227,9 +227,9 @@ window.onload = function () { // wait for load in a dumb way because B-0
 
     try {
       var parser = new less.Parser({
-          paths: ['variables.less', 'mixins.less']
-        , optimization: 0
-        , filename: 'bootstrap.css'
+          paths: ['variables.less', 'mixins.less'],
+          optimization: 0,
+          filename: 'bootstrap.css'
       }).parse(css, function (err, tree) {
         if (err) {
           return showError('<strong>Ruh roh!</strong> Could not parse less files.', err)

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -9,7 +9,6 @@
   "eqnull"   : true,
   "expr"     : true,
   "laxbreak" : true,
-  "laxcomma" : true,
   "quotmark" : "single",
   "validthis": true
 }


### PR DESCRIPTION
...right side.
