### PR TITLE
Label css

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -3,7 +3,7 @@
 // --------------------------------------------------
 
 .label {
-  display: inline;
+  display: inline-block;
   padding: .2em .6em .3em;
   font-size: 75%;
   font-weight: bold;


### PR DESCRIPTION
Unfortunately because of `display: inline;` this code for example

```
<h3><span class="label label-info">Hello<br>Marios</span></h3>
```

forces the label to fail (because of the line break) while i want all this to be shown in an attractive label appearance.
