### PR TITLE
Fix download link for Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, check out <http://getbootstrap.com>!
 
 Three quick start options are available:
 
-- [Download the latest release](https://github.com/twbs/bootstrap/archive/v3.1.0.zip).
+- [Download the latest release](https://github.com/twbs/bootstrap/archive/v3.0.3.zip).
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`.
 - Install with [Bower](http://bower.io): `bower install bootstrap`.
 


### PR DESCRIPTION
According to https://github.com/twbs/bootstrap/releases the latest released version of Bootstrap is `3.0.3`. But the link to download Bootstrap in README.md points to the unreleased version of `3.1.0` which results in 404 not found page.
