### PR TITLE
Use correct directory name for bootstrap contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ included in the project:
    # Clone your fork of the repo into the current directory
    git clone https://github.com/<your-username>/bootstrap.git
    # Navigate to the newly cloned directory
-   cd html5-boilerplate
+   cd bootstrap
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/twbs/bootstrap.git
    ```


### PR DESCRIPTION
Cloning a bootstrap fork will result the directory `bootstrap`. So the the changed the `cd html5-boilerplate` to `cd bootstrap`.
