### PR TITLE
Replace UTF-8 characters in s3_cache.py with ASCII characters

### DIFF
--- a/test-infra/s3_cache.py
+++ b/test-infra/s3_cache.py
@@ -79,8 +79,8 @@ def upload(directory):
 
 if __name__ == '__main__':
     # Uses environment variables:
-    #   AWS_ACCESS_KEY_ID - AWS Access Key ID
-    #   AWS_SECRET_ACCESS_KEY - AWS Secret Access Key
+    #   AWS_ACCESS_KEY_ID -- AWS Access Key ID
+    #   AWS_SECRET_ACCESS_KEY -- AWS Secret Access Key
     argv.pop(0)
     if len(argv) != 4:
         raise SystemExit("USAGE: node_modules_cache.py <download | upload> <friendly name> <dependencies file> <directory>")


### PR DESCRIPTION
Replaces mdash with double dash, to make `s3_cache` like Less files.
