### PR TITLE
Don't show border for the successive group cells

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -31,7 +31,7 @@
   .btn + .btn-group,
   .btn-group + .btn,
   .btn-group + .btn-group {
-    margin-left: -1px;
+    border-left: none;
   }
 }
 


### PR DESCRIPTION
Negative margins don't work on cells within table with separate borders
