### PR TITLE
fixed .clearfix example, + doc link

### DIFF
--- a/examples/grid/index.html
+++ b/examples/grid/index.html
@@ -112,9 +112,13 @@
       <hr>
 
       <h3>Column clearing</h3>
-      <p>Clear floats at specific breakpoints to prevent awkward wrapping with uneven content.</p>
+      <p><a href="http://getbootstrap.com/css/#grid-responsive-resets" title="Official documentation for clearfix">Clear floats</a> at specific breakpoints to prevent awkward wrapping with uneven content.</p>
       <div class="row">
-        <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
+        <div class="col-xs-6 col-sm-3">
+          .col-xs-6 .col-sm-3
+          <br>
+          Resize your viewport or check it out on your phone for an example.
+        </div>
         <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
 
         <!-- Add the extra clearfix for only the required viewport -->


### PR DESCRIPTION
Must be a copy/paste oversight, since there seemed to be no need for a `.clearfix`, _until_ I read the [official docs](http://getbootstrap.com/css/#grid-responsive-resets).

I took the liberty to link said docs inside the example.  I assume the examples are there to learn from, & deep linking to docs will improve learning.  I hope you'll let this one though, & perhaps encourage more of these links.
