### PR TITLE
Allow SauceLabs tests to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ env:
     - TWBS_TEST=sauce-js-unit
 matrix:
   fast_finish: true
+  allow_failures:
+    - TWBS_TEST=sauce-js-unit


### PR DESCRIPTION
Temporary till random VM failures are addressed
