### PR TITLE
add keyboard support for carousel.

### DIFF
--- a/docs/examples/carousel/index.html
+++ b/docs/examples/carousel/index.html
@@ -70,7 +70,7 @@
 
     <!-- Carousel
     ================================================== -->
-    <div id="myCarousel" class="carousel slide" data-ride="carousel">
+    <div id="myCarousel" class="carousel slide" data-ride="carousel" tabindex='-1'>
       <!-- Indicators -->
       <ol class="carousel-indicators">
         <li data-target="#myCarousel" data-slide-to="0" class="active"></li>

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1817,9 +1817,9 @@ $('#myCollapsible').on('hidden.bs.collapse', function () {
     </div>
 
     <h2 id="carousel-examples">Examples</h2>
-    <p>The slideshow below shows a generic plugin and component for cycling through elements like a carousel.</p>
+    <p>The slideshow below shows a generic plugin and component for cycling through elements like a carousel. When carousel component is selected(focused), you can also use keyboard arrows (left: previous slide, right: next slide, up: first slide, down: last slide) to control slides.</p>
     <div class="bs-example">
-      <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+      <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" tabindex="-1">
         <ol class="carousel-indicators">
           <li data-target="#carousel-example-generic" data-slide-to="0" class="active"></li>
           <li data-target="#carousel-example-generic" data-slide-to="1"></li>

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -207,6 +207,7 @@
     var $focused = $(document.activeElement)
     type && $focused.data('ride') == 'carousel' && $focused.each(function () {
       var $carousel = $(this)
+      $carousel.carousel('pause')
       if (type == 'next' || type == 'prev')
         $carousel.carousel(type)
       else if (type == 'first')
@@ -215,6 +216,7 @@
         var nItems = $carousel.data('bs.carousel').$items.length
         $carousel.carousel(nItems - 1)
       }
+      $carousel.carousel('cycle')
     }) && e.preventDefault()
   })
 

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -194,6 +194,23 @@
     e.preventDefault()
   })
 
+  $(document).on("keydown", function (e) {
+    var type = e.which == 37 ? "prev" : null
+    type = e.which == 39 ? "next" : type
+    type = e.which == 38 ? "first" : type
+    type = e.which == 40 ? "last" : type
+    type && $('[data-ride="carousel"]').each(function () {
+      var $carousel = $(this)
+      $carousel.carousel($carousel.data())
+      if (type == "next" || type == "prev")
+        $carousel.data('bs.carousel').slide(type)
+      else if (type == "first")
+        $carousel.data('bs.carousel').to(0)
+      else if (type == "last")
+        $carousel.data("bs.carousel").to($carousel.data("bs.carousel").$items.length-1)
+    }) && e.preventDefault()
+  })
+
   $(window).on('load', function () {
     $('[data-ride="carousel"]').each(function () {
       var $carousel = $(this)

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -204,7 +204,8 @@
     // only accept arrow left, right, top and down.
     // default event behavior is prevented for these four keys.
     // other keyboard input is not affected
-    type && $('[data-ride="carousel"]').each(function () {
+    var $focused = $(document.activeElement)
+    type && $focused.data('ride') == 'carousel' && $focused.each(function () {
       var $carousel = $(this)
       if (type == 'next' || type == 'prev')
         $carousel.carousel(type)

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -194,20 +194,20 @@
     e.preventDefault()
   })
 
-  $(document).on("keydown", function (e) {
-    var type = e.which == 37 ? "prev" : null
-    type = e.which == 39 ? "next" : type
-    type = e.which == 38 ? "first" : type
-    type = e.which == 40 ? "last" : type
+  $(document).on('keydown', function (e) {
+    var type = e.which == 37 ? 'prev' : null
+    type = e.which == 39 ? 'next' : type
+    type = e.which == 38 ? 'first' : type
+    type = e.which == 40 ? 'last' : type
     type && $('[data-ride="carousel"]').each(function () {
       var $carousel = $(this)
       $carousel.carousel($carousel.data())
-      if (type == "next" || type == "prev")
+      if (type == 'next' || type == 'prev')
         $carousel.data('bs.carousel').slide(type)
-      else if (type == "first")
+      else if (type == 'first')
         $carousel.data('bs.carousel').to(0)
-      else if (type == "last")
-        $carousel.data("bs.carousel").to($carousel.data("bs.carousel").$items.length-1)
+      else if (type == 'last')
+        $carousel.data('bs.carousel').to($carousel.data('bs.carousel').$items.length-1)
     }) && e.preventDefault()
   })
 

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -194,21 +194,25 @@
     e.preventDefault()
   })
 
-  $(document).on('keydown', function (e) {
+  $(document).on('keydown', '[data-ride="carousel"]', function (e) {
+    // get the direction based on keyboard input
     var type = e.which == 37 ? 'prev' : null
     type = e.which == 39 ? 'next' : type
     type = e.which == 38 ? 'first' : type
     type = e.which == 40 ? 'last' : type
+
+    // only accept arrow left, right, top and down.
+    // default event behavior is prevented for these four keys.
+    // other keyboard input is not affected
     type && $('[data-ride="carousel"]').each(function () {
       var $carousel = $(this)
-      $carousel.carousel($carousel.data())
       if (type == 'next' || type == 'prev')
-        $carousel.data('bs.carousel').slide(type)
+        $carousel.carousel(type)
       else if (type == 'first')
-        $carousel.data('bs.carousel').to(0)
+        $carousel.carousel(0)
       else if (type == 'last') {
         var nItems = $carousel.data('bs.carousel').$items.length
-        $carousel.data('bs.carousel').to(nItems - 1)
+        $carousel.carousel(nItems - 1)
       }
     }) && e.preventDefault()
   })

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -206,8 +206,10 @@
         $carousel.data('bs.carousel').slide(type)
       else if (type == 'first')
         $carousel.data('bs.carousel').to(0)
-      else if (type == 'last')
-        $carousel.data('bs.carousel').to($carousel.data('bs.carousel').$items.length-1)
+      else if (type == 'last') {
+        var nItems = $carousel.data('bs.carousel').$items.length
+        $carousel.data('bs.carousel').to(nItems - 1)
+      }
     }) && e.preventDefault()
   })
 


### PR DESCRIPTION
support key arrow left, right, up, down, corresponding to slide action prev, next, first and last.
a live demo can be accessed at [jsbin](http://jsbin.com/eneRULi/4/)
not support focus only yet. Any heads up would be great, I'm not so familiar with DOM events/states just yet.
