### PR TITLE
Use $ instead of jQuery

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -211,7 +211,7 @@
 
     // $.fn.offset doesn't round pixel values
     // so we use setOffset directly with our own function B-0
-    jQuery.offset.setOffset($tip[0], $.extend({
+    $.offset.setOffset($tip[0], $.extend({
       using: function (props) {
         $tip.css({
           top: Math.round(props.top),


### PR DESCRIPTION
`$` is passed into the function and is consistently the same value and `$` is also used everywhere else in this file.
