### PR TITLE
Close parents('.alert') instead of parent() in alert

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -31,7 +31,10 @@
     if (e) e.preventDefault()
 
     if (!$parent.length) {
-      $parent = $this.hasClass('alert') ? $this : $this.parent()
+      $parent = $this.hasClass('alert') ? $this : $this.parents('.alert')
+      if (!$parent.length) {
+        $parent = $this.parent()
+      }
     }
 
     $parent.trigger(e = $.Event('close.bs.alert'))


### PR DESCRIPTION
This allows the close button to be nested deeper within the alert. For example, the alert content might be inside a .container.
