### PR TITLE
Quote Node 0.10 so correct version is printed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
 before_install:
   - time sudo pip install --use-mirrors -r test-infra/requirements.txt
   - rvm use 1.9.3 --fuzzy


### PR DESCRIPTION
Travis treats unquoted numbers literally and strips the (unnecessary) trailing 0. Everything still builds correctly, but Travis will display "0.1" in the build UI otherwise.
