### PR TITLE
Added optional history.pushState behaviour to Tab.show.

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -825,6 +825,17 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
 </div>
 {% endhighlight %}
 
+    <h3>Update Address</h3>
+    <p>To make tab changes update the url in the address bar, add <code>follow-url</code> as an attribute to each <code>data-toggle</code> element.</p>
+{% highlight html %}
+<ul class="nav nav-tabs">
+  <li><a href="#home" data-toggle="tab" follow-url>Home</a></li>
+  <li><a href="#profile" data-toggle="tab" follow-url>Profile</a></li>
+  <li><a href="#messages" data-toggle="tab" follow-url>Messages</a></li>
+  <li><a href="#settings" data-toggle="tab" follow-url>Settings</a></li>
+</ul>
+{% endhighlight %}
+
     <h3>Methods</h3>
     <h4>$().tab</h4>
     <p>

--- a/js/tab.js
+++ b/js/tab.js
@@ -46,6 +46,9 @@
         relatedTarget: previous
       })
     })
+    
+    if($this.is('[follow-url]'))
+      history.pushState(null, document.title, selector)
   }
 
   Tab.prototype.activate = function (element, container, callback) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -47,7 +47,7 @@
       })
     })
     
-    if($this.is('[follow-url]'))
+    if ($this.is('[follow-url]'))
       history.pushState(null, document.title, selector)
   }
 


### PR DESCRIPTION
`history.pushState` updates the browser history and address bar.

I found it unusual that the functionality of pressing tabs updating the address bar to this url was unavailable, so that tabs could be more easily treated as a single page nav. I understand this behaviour isn't always necessary, hence the optional usage by adding `follow-url` as an attribute to the anchor which is used to show the tab.

Loading the correct tab then works something like this where all tab anchors have `.my_tabs`

``` javascript
$(document).ready(function(){
    $address=document.URL;
    if($address.replace(/^[^#]*/, "").length==0)
       $address=$address+$(".my_tabs.active").attr("href");
    $selector = $address.replace(/^[^#]*/, "");
    $(".phase_link").each(
        function( index ) {
            if ($selector == $(this).attr("href"))
                $(this).tab("show");
        }
    );
});
```

`history.pushState` is HTML5 so wont work in older browsers, however this functionality is implemented at the end of the show method so any javascript error caused by it would't break the primary functionality of tabs. If it were desired for this to implemented for older browsers this stackoverflow post suggests a method which I haven't tested; http://stackoverflow.com/a/136506/1646387
