### PR TITLE
Replace getElementsByTag by querySelector for IE10 Mobile platform.

### DIFF
--- a/docs/assets/js/application.js
+++ b/docs/assets/js/application.js
@@ -24,7 +24,7 @@
           '@-ms-viewport{width:auto!important}'
         )
       );
-      document.getElementsByTagName('head')[0].
+      document.querySelector('head').
         appendChild(msViewportStyle);
     }
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -852,7 +852,7 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
       "@-ms-viewport{width:auto!important}"
     )
   )
-  document.getElementsByTagName("head")[0].appendChild(msViewportStyle)
+  document.querySelector("head").appendChild(msViewportStyle)
 }
 {% endhighlight %}
     <p>For more information and usage guidelines, read <a href="http://timkadlec.com/2013/01/windows-phone-8-and-device-width/">Windows Phone 8 and Device-Width</a>.</p>


### PR DESCRIPTION
New PR associated to https://github.com/twbs/bootstrap/pull/12088
Replace getElementsByTag by querySelector for IE10 Mobile plateform.
Benefits: querySelector is a shorter and modern synthax, it returns directly a Node.
