### PR TITLE
.list-group and .table appearance fixed when inside .panel-collapse

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -25,7 +25,8 @@
 // any kind of custom content between the two.
 
 .panel {
-  > .list-group {
+  > .list-group,
+  > .panel-collapse > .list-group {
     margin-bottom: 0;
 
     .list-group-item {
@@ -42,12 +43,6 @@
     }
   }
 }
-// Collapse space between when there's no additional content.
-.panel-heading + .list-group {
-  .list-group-item:first-child {
-    border-top-width: 0;
-  }
-}
 
 
 // Tables in panels
@@ -57,7 +52,9 @@
 
 .panel {
   > .table,
-  > .table-responsive {
+  > .table-responsive,
+  > .panel-collapse > .table,
+  > .panel-collapse > .table-responsive {
     margin-bottom: 0;
   }
   > .panel-body + .table,


### PR DESCRIPTION
I found out `.list-group` and `.table` didn't behave the same when put inside a `.panel > .panel-collapse`. Have a look and consider my pull request.

Also I removed the `border-top-width` definition for `.panel > .list-group` and `.panel > .panel-collapse > .list-group`, so they appear exactly like `.table`s.
