### PR TITLE
Disable double-tap-zoom via Pointer Events to remove 300ms click delay

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -17,6 +17,11 @@
   // Prevent floats from breaking the navbar
   &:extend(.clearfix all);
 
+  // Disable double-tap-zoom via Pointer Events to remove 300ms click delay
+  -ms-touch-action: none;
+  touch-action: none;
+
+  
   @media (min-width: @grid-float-breakpoint) {
     border-radius: @navbar-border-radius;
   }


### PR DESCRIPTION
Currently, double tapping on nav bar zooms it in. In most cases, the buttons or actions on navbar just need to be clicked and not zoomed.

Adding the code to disable zooming. 
