### PR TITLE
Fix bad anchor link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ implementing features, refactoring code, porting to a different language),
 otherwise you risk spending a lot of time working on something that the
 project's developers might not want to merge into the project.
 
-Please adhere to the [coding conventions](#code-conventions) used throughout a
+Please adhere to the [coding guidelines](#code-guidelines) used throughout a
 project (indentation, accurate comments, etc.) and any other requirements
 (such as test coverage).
 


### PR DESCRIPTION
Hey look, I'm contributing to CONTRIBUTING.md!

This anchor must have been overlooked while updating the docs in a previous commit.

Expected behavior: scroll the document to a linked section. Experienced behavior: nada.

This proposed file change renames the anchor text from `coding conventions` to `coding guidelines` and changes the anchor link from `#code-conventions` to `#code-guidelines`.
