### PR TITLE
border-[top/right/bottom/left]-radius should check for negative radius

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -97,21 +97,37 @@
 // --------------------------------------------------
 
 // Single side border-radius
-.border-top-radius(@radius) {
+.border-top-radius(@radius) when (@radius >= 0) {
   border-top-right-radius: @radius;
    border-top-left-radius: @radius;
 }
-.border-right-radius(@radius) {
+.border-top-radius(@radius) when (@radius < 0) {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.border-right-radius(@radius) when (@radius >= 0) {
   border-bottom-right-radius: @radius;
      border-top-right-radius: @radius;
 }
-.border-bottom-radius(@radius) {
+.border-right-radius(@radius) when (@radius < 0) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.border-bottom-radius(@radius) when (@radius >= 0) {
   border-bottom-right-radius: @radius;
    border-bottom-left-radius: @radius;
 }
-.border-left-radius(@radius) {
+.border-bottom-radius(@radius) when (@radius < 0) {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.border-left-radius(@radius) when (@radius >= 0) {
   border-bottom-left-radius: @radius;
-     border-top-left-radius: @radius;
+  border-top-left-radius: @radius;
+}
+.border-left-radius(@radius) when (@radius < 0) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
 }
 
 // Drop shadows


### PR DESCRIPTION
The `border-top-radius`, `border-right-radius`, `border-bottom-radius` and `border-left-radius` mixins are sometime used with subtracted variables, e.g. 

``` css
.panel-heading {
  .border-top-radius((@panel-border-radius - 1));
```

this can easily result in passing negative values (resulting in invalid border-radius values), e.g. bootswatch's [Yeti theme](http://bootswatch.com/yeti/).

I think it's better to protect against it.
