### PR TITLE
In modals we can't specify if certain elements can be focused or not

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -111,12 +111,16 @@
         .emulateTransitionEnd(300) :
       this.hideModal()
   }
+  
+  Modal.prototype.allowFocus = function(e) {
+      return false
+  }
 
   Modal.prototype.enforceFocus = function () {
     $(document)
       .off('focusin.bs.modal') // guard against infinite focus loop
       .on('focusin.bs.modal', $.proxy(function (e) {
-        if (this.$element[0] !== e.target && !this.$element.has(e.target).length) {
+        if (this.$element[0] !== e.target && !this.$element.has(e.target).length && !this.allowFocus(e)) {
           this.$element.focus()
         }
       }, this))

--- a/js/modal.js
+++ b/js/modal.js
@@ -112,7 +112,7 @@
       this.hideModal()
   }
   
-  Modal.prototype.allowFocus = function(e) {
+  Modal.prototype.allowFocus = function (e) {
       return false
   }
 


### PR DESCRIPTION
This is basically an improved version of pr #11686, only with some small fixes.
Please have a look on the describtion in #11686, which covers the problem in detail.

IMHO this pull request introduces only a small code change with no side affects but fixes (or better: allow to fix) a lot of issues users are experiencing using bootstrap in conjunction with other heavily used libraries like select2 or CKEditor.

Right now people using workarounds like disabling the Modal.prototype.enforceFocus function or overriding it (like https://github.com/twbs/bootstrap/issues/6996#issuecomment-23617382).
This is not the best approach e.g. when upgrading bootstrap you have to check for changes in the enforceFocus function and apply it to the overriden one.

With this fix, all you have to do is declaring the allowFocus function to fix any problems with other libraries, e.g. for select2 this would be:

```
$.fn.modal.Constructor.prototype.allowFocus = function (e) {
    return !!$(e.target).closest('.select2-drop');
};
```

I (and probably lot's of other developers) would highly appreciate if this pr gets merged.

Thanks!
