### PR TITLE
missing a period after "Twitter, Inc"

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ For more information on SemVer, please visit <http://semver.org/>.
 
 ## Copyright and license
 
-Copyright 2011-2014 Twitter, Inc under [the MIT license](LICENSE).
+Copyright 2011-2014 Twitter, Inc. under [the MIT license](LICENSE).


### PR DESCRIPTION
Incredibly pedantic, but it just bugged me when I saw it so I figured I'd send a pull request (assuming this is helpful). :)
