### PR TITLE
Update docs per `.container-fluid` addition

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -350,10 +350,6 @@ bootstrap/
         </thead>
         <tbody>
           <tr>
-            <td><code>.container-fluid</code></td>
-            <td><code>.container</code></td>
-          </tr>
-          <tr>
             <td><code>.row-fluid</code></td>
             <td><code>.row</code></td>
           </tr>
@@ -678,11 +674,6 @@ bootstrap/
             <td>No direct equivalent, but <a href="../css/#forms-controls">forms controls</a> are similar.</td>
           </tr>
           <tr>
-            <td>Fluid container</td>
-            <td><code>.container-fluid</code></td>
-            <td><code>.container</code> (no more fixed grid)</td>
-          </tr>
-          <tr>
             <td>Fluid row</td>
             <td><code>.row-fluid</code></td>
             <td><code>.row</code> (no more fixed grid)</td>
@@ -744,7 +735,7 @@ bootstrap/
       <li>Text-based form controls with the <code>.form-control</code> class applied are now 100% wide by default. Wrap inputs inside <code>&lt;div class="col-*"&gt;&lt;/div&gt;</code> to control input widths.</li>
       <li><code>.badge</code> no longer has contextual (-success,-primary,etc..) classes.</li>
       <li><code>.btn</code> must also use <code>.btn-default</code> to get the "default" button.</li>
-      <li><code>.container</code> and <code>.row</code> are now fluid (percentage-based).</li>
+      <li><code>.row</code> is now fluid.</li>
       <li>Images are no longer responsive by default. Use <code>.img-responsive</code> for fluid <code>&lt;img&gt;</code> size.</li>
       <li>The icons, now <code>.glyphicon</code>, are now font based. Icons also require a base and icon class (e.g. <code>.glyphicon .glyphicon-asterisk</code>).</li>
       <li>Typeahead has been dropped, in favor of using <a href="http://twitter.github.io/typeahead.js/">Twitter Typeahead</a>.</li>


### PR DESCRIPTION
- Remove `.container-fluid` from "removed classes".
- Container isn't fluid by default (`.container`) and `.row` isn't percentage-based, so update docs.
