### PR TITLE
Minor tweak to make badges fit better inside .btn-xs buttons

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -28,6 +28,10 @@
     position: relative;
     top: -1px;
   }
+  .btn-xs .badge {
+    padding: 1px 3px;
+    top: 0px;
+  }
 }
 
 // Hover state, but only for links


### PR DESCRIPTION
Make `.badge`'s fit and look better when used inside `.btn-xs` buttons.

Before:

![screenshot - 14-01-13 - 01 27 52 pm](https://f.cloud.github.com/assets/47756/1905121/33aff17a-7c9a-11e3-9f2d-9f4c9e1c8a40.png)

After:

![screenshot - 14-01-13 - 01 28 02 pm](https://f.cloud.github.com/assets/47756/1905123/3985a180-7c9a-11e3-9a8b-8994d274e1fb.png)
