### PR TITLE
Link the blog post instead of main blog page

### DIFF
--- a/docs/_includes/old-bs-docs.html
+++ b/docs/_includes/old-bs-docs.html
@@ -3,6 +3,6 @@
     <strong>
       <a href="{{ site.baseurl }}2.3.2/">Looking for Bootstrap 2.3.2 docs?</a>
     </strong>
-    We've moved it to a new home while we push forward with Bootstrap 3. <a href="http://blog.getbootstrap.com/">Read the blog</a> for details.
+    We've moved it to a new home while we push forward with Bootstrap 3. <a href="{{ site.blog }}/2013/08/19/bootstrap-3-released/">Read the blog</a> for details.
   </div>
 </div>


### PR DESCRIPTION
Main blog page can be _overfilled_ and finding the right post is super hard then. Note about 3.0.0 → 2.3.2 docs migration is in _Bootstrap 3 released_ post, so I linked it.
