### PR TITLE
scrollspy: support for href URIs that don't start with # (issue 12227)

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -48,6 +48,7 @@
       .map(function () {
         var $el   = $(this)
         var href  = $el.data('target') || $el.attr('href')
+        if (href[0] != '#') href = '#' + href.split('#')[1];
         var $href = /^#./.test(href) && $(href)
 
         return ($href
@@ -96,7 +97,7 @@
 
     var selector = this.selector +
         '[data-target="' + target + '"],' +
-        this.selector + '[href="' + target + '"]'
+        this.selector + '[href$="' + target + '"]'
 
     var active = $(selector)
       .parents('li')


### PR DESCRIPTION
my fix for issue #12227:
- in refresh, anything before the # in the href attribute is discarded
- in activate, href$= is used, to ignore anything which might be before the #
