### PR TITLE
Set Jekyll encoding and tweak Windows notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Bootstrap's documentation, included in this repo in the root directory, is built
 ### Running documentation locally
 
 1. If necessary, [install Jekyll](http://jekyllrb.com/docs/installation) (requires v1.x).
-  - **Windows users:** read [this unofficial guide](https://github.com/juthilo/run-jekyll-on-windows/) to get Jekyll up and running without problems.
+  - **Windows users:** Read [this unofficial guide](https://github.com/juthilo/run-jekyll-on-windows/) to get Jekyll up and running without problems. We use Pygments for syntax highlighting, so make sure to read the sections on installing Python and Pygments.
 2. From the root `/bootstrap` directory, run `jekyll serve` in the command line.
-  - **Windows users:** For Ruby 2.0.0 run `chcp 65001` first to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors. For Ruby 1.9.3 you can alternatively do `SET LANG=en_EN.UTF-8`. In addition, ensure you have Python installed and added in your `PATH` or the build will fail due to our Pygments dependency.
+  - **Windows users:** While we use Jekyll's `encoding` setting, you might still need to change the command prompt's character encoding ([code page](http://en.wikipedia.org/wiki/Windows_code_page)) to UTF-8 so Jekyll runs without errors. For Ruby 2.0.0 run `chcp 65001` first. For Ruby 1.9.3 you can alternatively do `SET LANG=en_EN.UTF-8`.
 3. Open <http://localhost:9001> in your browser, and voilà.
 
 Learn more about using Jekyll by reading its [documentation](http://jekyllrb.com/docs/home/).

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ host:             0.0.0.0
 port:             9001
 baseurl:          /
 url:              http://localhost:9001
+encoding:         UTF-8
 
 # Custom vars
 current_version:  3.0.3


### PR DESCRIPTION
Via https://github.com/juthilo/run-jekyll-on-windows/issues/1 : Since v1.3.0, there's a new `encoding` option in Jekyll. If set to `UTF-8`, Windows users no longer need to manually change their command prompt's character encoding for a site. (I tested this locally.)

This adds `encoding: UTF-8` to our `_config.yml` and tweaks the "Windows users:" notes in the README.

@mdo @cvrebert Thoughts? Would love to get this into 3.1, given it's a relatively small change.
