### PR TITLE
move Community & Translations docs sections from About to Getting Started

### DIFF
--- a/docs/_includes/nav-about.html
+++ b/docs/_includes/nav-about.html
@@ -7,9 +7,3 @@
 <li>
   <a href="#team">Team</a>
 </li>
-<li>
-  <a href="#community">Community</a>
-</li>
-<li>
-  <a href="#translations">Translations</a>
-</li>

--- a/docs/_includes/nav-getting-started.html
+++ b/docs/_includes/nav-getting-started.html
@@ -21,6 +21,9 @@
   </ul>
 </li>
 <li>
+  <a href="#community">Community</a>
+</li>
+<li>
   <a href="#disable-responsive">Disabling responsiveness</a>
 </li>
 <li>
@@ -58,4 +61,7 @@
 </li>
 <li>
   <a href="#customizing">Customizing Bootstrap</a>
+</li>
+<li>
+  <a href="#translations">Translations</a>
 </li>

--- a/docs/about.html
+++ b/docs/about.html
@@ -147,35 +147,3 @@ lead: "Learn about the history of Bootstrap, meet the core team, and check out t
   </div>
   <p>The <a href="{{ site.sass_repo }}">official Sass port of Bootstrap</a> was created and is maintained by this team. It became part of Bootstrap's organization with v3.1.</p>
 </div>
-
-
-<!-- Community
-================================================== -->
-<div class="bs-docs-section">
-  <h1 id="community" class="page-header">Community</h1>
-
-  <p class="lead">Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.</p>
-  <ul>
-    <li>Read and subscribe to <a href="http://blog.getbootstrap.com/">The Official Bootstrap Blog</a>.</li>
-    <li>Chat with fellow Bootstrappers using IRC in the <code>irc.freenode.net</code> server, in the <a href="irc://irc.freenode.net/#twitter-bootstrap">##twitter-bootstrap channel</a>.</li>
-    <li>Find inspiring examples of people building with Bootstrap at the <a href="http://expo.getbootstrap.com">Bootstrap Expo</a>.</li>
-  </ul>
-  <p>You can also follow <a href="https://twitter.com/twbootstrap">@twbootstrap on Twitter</a> for the latest gossip and awesome music videos.</p>
-</div>
-
-
-<!-- Translations
-================================================== -->
-<div class="bs-docs-section">
-  <h1 id="translations" class="page-header">Translations</h1>
-
-  <p class="lead">Community members have translated Bootstrap's documentation into various languages. None are officially supported and may not always be up to date.</p>
-  <ul>
-    <li><a href="http://v3.bootcss.com/">Bootstrap 中文文档 (Chinese)</a></li>
-    <li><a href="http://www.oneskyapp.com/docs/bootstrap/ru">Bootstrap по-русски (Russian)</a></li>
-    <li><a href="http://www.oneskyapp.com/docs/bootstrap/es">Bootstrap en Español (Spanish)</a></li>
-    <li><a href="http://twbs.site-konstruktor.com.ua">Bootstrap ua Українською (Ukrainian)</a></li>
-    <li><a href="http://www.oneskyapp.com/docs/bootstrap/fr">Bootstrap en Français (French)</a></li>
-  </ul>
-  <p>Have another language to add, or perhaps a different or better translation? Let us know by <a href="https://github.com/twbs/bootstrap/issues/new">opening an issue</a>.</p>
-</div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -307,6 +307,22 @@ bootstrap/
 
 
 
+<!-- Community
+================================================== -->
+<div class="bs-docs-section">
+  <h1 id="community" class="page-header">Community</h1>
+
+  <p class="lead">Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.</p>
+  <ul>
+    <li>Read and subscribe to <a href="http://blog.getbootstrap.com/">The Official Bootstrap Blog</a>.</li>
+    <li>Chat with fellow Bootstrappers using IRC in the <code>irc.freenode.net</code> server, in the <a href="irc://irc.freenode.net/#twitter-bootstrap">##twitter-bootstrap channel</a>.</li>
+    <li>Find inspiring examples of people building with Bootstrap at the <a href="http://expo.getbootstrap.com">Bootstrap Expo</a>.</li>
+  </ul>
+  <p>You can also follow <a href="https://twitter.com/twbootstrap">@twbootstrap on Twitter</a> for the latest gossip and awesome music videos.</p>
+</div>
+
+
+
 <!-- Template
 ================================================== -->
 <div class="bs-docs-section">
@@ -1093,4 +1109,22 @@ if (isAndroid) {
   <h3>Removing potential bloat</h3>
   <p>Not all sites and applications need to make use of everything Bootstrap has to offer, especially in production environments where optimizing bandwidth is an issue. We encourage you to remove whatever is unused with our <a href="../customize/">Customizer</a>.</p>
   <p>Using the Customizer, simply uncheck any component, feature, or asset you don't need. Hit download and swap out the default Bootstrap files with these newly customized ones. You'll get vanilla Bootstrap, but without the features *you* deem unnecessary. All custom builds include compiled and minified versions, so use whichever works for you.</p>
+</div>
+
+
+
+<!-- Translations
+================================================== -->
+<div class="bs-docs-section">
+  <h1 id="translations" class="page-header">Translations</h1>
+
+  <p class="lead">Community members have translated Bootstrap's documentation into various languages. None are officially supported and they may not always be up to date.</p>
+  <ul>
+    <li><a href="http://v3.bootcss.com/">Bootstrap 中文文档 (Chinese)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/ru">Bootstrap по-русски (Russian)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/es">Bootstrap en Español (Spanish)</a></li>
+    <li><a href="http://twbs.site-konstruktor.com.ua">Bootstrap ua Українською (Ukrainian)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/fr">Bootstrap en Français (French)</a></li>
+  </ul>
+  <p>Have another language to add, or perhaps a different or better translation? Let us know by <a href="https://github.com/twbs/bootstrap/issues/new">opening an issue</a>.</p>
 </div>


### PR DESCRIPTION
Gives these important+useful sections greater visibility now that the About page is no longer in the navbar.
