### PR TITLE
add Issues & Releases links back to footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -21,6 +21,10 @@
       <li><a href="{{ site.expo }}">Expo</a></li>
       <li>&middot;</li>
       <li><a href="{{ site.blog }}">Blog</a></li>
+      <li>&middot;</li>
+      <li><a href="{{ site.repo }}/issues?state=open">Issues</a></li>
+      <li>&middot;</li>
+      <li><a href="{{ site.repo }}/releases">Releases</a></li>
     </ul>
   </div>
 </footer>


### PR DESCRIPTION
Not sure whether it was intentional, but the recent docs merge removed the Issues and Releases links from the docs site footer.
In case that was accidental, this PR restores those links.
/to @mdo for review.
