### PR TITLE
remove default left-right print margins per upstream h5bp change

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -213,9 +213,6 @@ table {
   img {
     max-width: 100% !important;
   }
-  @page {
-    margin: 2cm .5cm;
-  }
   p,
   h2,
   h3 {
@@ -231,6 +228,10 @@ table {
   }
   .navbar {
     display: none;
+  }
+  @page {
+    margin-top: 2cm;
+    margin-bottom: 2cm;
   }
   .table td,
   .table th {

--- a/less/print.less
+++ b/less/print.less
@@ -50,10 +50,6 @@
     max-width: 100% !important;
   }
 
-  @page {
-    margin: 2cm .5cm;
-  }
-
   p,
   h2,
   h3 {
@@ -75,6 +71,10 @@
   // Bootstrap components
   .navbar {
     display: none;
+  }
+  @page {
+    margin-top:    2cm;
+    margin-bottom: 2cm;
   }
   .table {
     td,


### PR DESCRIPTION
See:
- https://github.com/h5bp/html5-boilerplate/commit/57be193031b95b003b96efe9eba7a4db7f58f4e1
- https://github.com/h5bp/html5-boilerplate/issues/1477

Might help out with #12078.

I've left the top & bottom margins in for now, but they weren't in the h5bp code to begin with; we added them in 54561f11212faee93ab682660503c6324d8b2cf8, but I'm not sure why. Do we still need them?

/to @mdo for review.
