### PR TITLE
Browserstack runner tunnel timeout

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -2,6 +2,7 @@
   "username": "--secure--",
   "key": "--secure--",
   "test_path": "js/tests/index.html",
+  "debug": true,
   "browsers": [
     {
       "browser": "firefox",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "devDependencies": {
-    "browserstack-runner": "~0.0.13",
+    "browserstack-runner": "~0.0.14",
     "btoa": "~1.1.1",
     "grunt": "~0.4.2",
     "grunt-banner": "~0.2.0",


### PR DESCRIPTION
Current integration with BrowserStack is sometimes failing because tunnel setup is failing from travis servers to BrowserStack servers. This pull request enables debug logs for tunnel setup, to help us nail the problem.
