### PR TITLE
Fixing js error in IE9 where no transition is supported

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -68,7 +68,7 @@
   Carousel.prototype.pause = function (e) {
     e || (this.paused = true)
 
-    if (this.$element.find('.next, .prev').length && $.support.transition.end) {
+    if (this.$element.find('.next, .prev').length && $.support.transition) {
       this.$element.trigger($.support.transition.end)
       this.cycle(true)
     }


### PR DESCRIPTION
In IE8 / 9 where no transitions are supported transition.js returns false.
This line of code forgot to check whether transitions are supported.
