### PR TITLE
Update javascript.html to fix Tabs example

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -793,7 +793,7 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
 {% highlight html %}
 <!-- Nav tabs -->
 <ul class="nav nav-tabs">
-  <li><a href="#home" data-toggle="tab">Home</a></li>
+  <li class="active"><a href="#home" data-toggle="tab">Home</a></li>
   <li><a href="#profile" data-toggle="tab">Profile</a></li>
   <li><a href="#messages" data-toggle="tab">Messages</a></li>
   <li><a href="#settings" data-toggle="tab">Settings</a></li>


### PR DESCRIPTION
There is an issue in Tabs example where the div has been marked as 'active' but the li has not been.  The correct tab of data will be displayed on load, but no tab name will be highlighted.  The tabs in the fade example do not have this issue.  

jsFiddle shows issue in action, this is a copy/paste from the original example code: http://jsfiddle.net/uXV56/
