### PR TITLE
re-enable OS X Firefox in Sauce tests

### DIFF
--- a/test-infra/sauce_browsers.yml
+++ b/test-infra/sauce_browsers.yml
@@ -14,10 +14,10 @@
     platform: "OS X 10.9"
   },
 
-  # { # FIXME: currently fails 1 tooltip test
-  #   browserName: "firefox",
-  #   platform: "OS X 10.9"
-  # },
+  {
+    browserName: "firefox",
+    platform: "OS X 10.9"
+  },
 
   # Mac Opera not currently supported by Sauce Labs
 


### PR DESCRIPTION
Passes on BrowserStack, so it oughtta be okay to enable it for Sauce too.
