### PR TITLE
enable Linux Chrome & Linux Firefox in Sauce tests

### DIFF
--- a/test-infra/sauce_browsers.yml
+++ b/test-infra/sauce_browsers.yml
@@ -63,16 +63,15 @@
 
   # iOS Chrome not currently supported by Sauce Labs
 
-  # Linux (unofficial):
-  # FIXME: currently fails 1 tooltip test
-  # {
-  #   browserName: "chrome",
-  #   platform: "Linux"
-  # },
-  # {
-  #   browserName: "firefox",
-  #   platform: "Linux"
-  # }
+  # Linux (unofficial)
+  {
+    browserName: "chrome",
+    platform: "Linux"
+  },
+  {
+    browserName: "firefox",
+    platform: "Linux"
+  }
 
   # Android Chrome not currently supported by Sauce Labs
 


### PR DESCRIPTION
I propose re-enabling testing of the Linux browsers since the underlying issues with the unit tests have now been fixed.
/to @twbs/team for review
