### PR TITLE
Replace Normalize with Normalize.css

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -48,8 +48,8 @@ lead: "Global CSS settings, fundamental HTML elements styled and enhanced with e
   </ul>
   <p>These styles can be found within <code>scaffolding.less</code>.</p>
 
-  <h3 id="overview-normalize">Normalize</h3>
-  <p>For improved cross-browser rendering, we use <a href="http://necolas.github.io/normalize.css/" target="_blank">Normalize</a>, a project by <a href="http://twitter.com/necolas" target="_blank">Nicolas Gallagher</a> and <a href="http://twitter.com/jon_neal" target="_blank">Jonathan Neal</a>.</p>
+  <h3 id="overview-normalize">Normalize.css</h3>
+  <p>For improved cross-browser rendering, we use <a href="http://necolas.github.io/normalize.css/" target="_blank">Normalize.css</a>, a project by <a href="http://twitter.com/necolas" target="_blank">Nicolas Gallagher</a> and <a href="http://twitter.com/jon_neal" target="_blank">Jonathan Neal</a>.</p>
 
   <h3 id="overview-container">Containers</h3>
   <p>Easily center a page's contents by wrapping its contents in a <code>.container</code>. Containers set <code>width</code> at various media query breakpoints to match our grid system.</p>


### PR DESCRIPTION
Replaces _Normalize_ with _Normalize.css_, as it's official project name.
