### PR TITLE
add X-UA-Compatible <meta> to basic template

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -117,6 +117,7 @@ bootstrap/
 <!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Bootstrap 101 Template</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap -->


### PR DESCRIPTION
This makes the example snippet on the Getting Started page more consistent with `docs/examples/starter-template/index.html`.
