### PR TITLE
added support for data-cache=false on modals

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -138,7 +138,7 @@
     this.backdrop(function () {
       that.removeBackdrop()
       if (that.options.cache === false) {
-        that.$element.removeData("bs.modal")
+        that.$element.removeData('bs.modal')
         that.$element.empty()
       }
       that.$element.trigger('hidden.bs.modal')

--- a/js/modal.js
+++ b/js/modal.js
@@ -138,8 +138,8 @@
     this.backdrop(function () {
       that.removeBackdrop()
       if (that.options.cache === false) {
-          that.$element.removeData("bs.modal")
-          that.$element.empty()
+        that.$element.removeData("bs.modal")
+        that.$element.empty()
       }
       that.$element.trigger('hidden.bs.modal')
     })

--- a/js/modal.js
+++ b/js/modal.js
@@ -137,6 +137,10 @@
     this.$element.hide()
     this.backdrop(function () {
       that.removeBackdrop()
+      if (that.options.cache === false) {
+          that.$element.removeData("bs.modal")
+          that.$element.empty()
+      }
       that.$element.trigger('hidden.bs.modal')
     })
   }

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -68,14 +68,33 @@ $(function () {
       stop()
       $.support.transition = false
 
-      $('<div id="modal-test"></div>')
+      $('<div id="modal-test"><p>content</p></div>')
         .on('shown.bs.modal', function () {
           ok($('#modal-test').is(':visible'), 'modal visible')
           ok($('#modal-test').length, 'modal inserted into dom')
+          ok($('#modal-test').data('bs.modal'), 'modal is created')
+          ok($('#modal-test').children().length, 'modal is not empty')
           $(this).modal('hide')
         })
         .on('hidden.bs.modal', function () {
           ok(!$('#modal-test').is(':visible'), 'modal hidden')
+          $('#modal-test').remove()
+          start()
+        })
+        .modal('show')
+    })
+
+    test('should clear modal when hide is called and cache is false', function () {
+      stop()
+      $.support.transition = false
+
+      $('<div id="modal-test" data-cache="false"><p>content</p></div>')
+        .on('shown.bs.modal', function () {
+          $(this).modal('hide')
+        })
+        .on('hidden.bs.modal', function () {
+          ok(!$('#modal-test').data('bs.modal'), 'modal is removed')
+          ok(!$('#modal-test').children().length, 'modal is empty')
           $('#modal-test').remove()
           start()
         })


### PR DESCRIPTION
when loading a remote model via a link the response is cached in the DOM
sometimes we want to load the remote each time, this allows you to add
data-cache=false to the link

e.g.
&lt;a href="/create" data-toggle="modal" data-target="#modal" data-cache="false"&gt;Create&lt;/a&gt;

when the model is hidden the component is destroyed and the cached model
content removed
see  Modal.prototype.hideModal

test have been added to check data-cache and backward compatability
