### PR TITLE
Corrected tag for Alert JS animation Example to <button>

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1366,7 +1366,7 @@ $('#myPopover').on('hidden.bs.popover', function () {
 
   <h3>Markup</h3>
   <p>Just add <code>data-dismiss="alert"</code> to your close button to automatically give an alert close functionality.</p>
-  {% highlight html %}<a class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</a>{% endhighlight %}
+  {% highlight html %}<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>{% endhighlight %}
 
   <h3>Methods</h3>
 

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1366,7 +1366,7 @@ $('#myPopover').on('hidden.bs.popover', function () {
 
   <h3>Markup</h3>
   <p>Just add <code>data-dismiss="alert"</code> to your close button to automatically give an alert close functionality.</p>
-  {% highlight html %}<a class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</a>{% endhighlight %}
+  {% highlight html %}<button class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</button>{% endhighlight %}
 
   <h3>Methods</h3>
 

--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -1366,7 +1366,7 @@ $('#myPopover').on('hidden.bs.popover', function () {
 
   <h3>Markup</h3>
   <p>Just add <code>data-dismiss="alert"</code> to your close button to automatically give an alert close functionality.</p>
-  {% highlight html %}<button class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</button>{% endhighlight %}
+  {% highlight html %}<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>{% endhighlight %}
 
   <h3>Methods</h3>
 


### PR DESCRIPTION
The docs incorrectly stated that the markup for the close button should be an `<a>` tag. To verify you can check the example alerts above my revision.
