### PR TITLE
Remove max height and set overflow-y to visible

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -48,7 +48,6 @@
 // content for the user's viewport.
 
 .navbar-collapse {
-  max-height: 340px;
   overflow-x: visible;
   padding-right: @navbar-padding-horizontal;
   padding-left:  @navbar-padding-horizontal;
@@ -58,7 +57,7 @@
   -webkit-overflow-scrolling: touch;
 
   &.in {
-    overflow-y: auto;
+    overflow-y: visible;
   }
 
   @media (min-width: @grid-float-breakpoint) {


### PR DESCRIPTION
![twbs-navbar-collapse-height-issue](https://f.cloud.github.com/assets/2298024/1950488/a0016314-8149-11e3-88c3-1338c721f9c3.JPG)

As seen on the attached image, the overflow-y: auto and the max-height results in another scrollbar.
