### PR TITLE
clarify Grunt task licensing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,10 @@
 /* jshint node: true */
+/*!
+ * Bootstrap's Gruntfile
+ * http://getbootstrap.com
+ * Copyright 2013-2014 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
 
 module.exports = function (grunt) {
   'use strict';

--- a/docs/grunt/bs-glyphicons-data-generator.js
+++ b/docs/grunt/bs-glyphicons-data-generator.js
@@ -1,4 +1,10 @@
 /* jshint node: true */
+/*!
+ * Bootstrap Grunt task for Glyphicons data generation
+ * http://getbootstrap.com
+ * Copyright 2014 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
 
 var fs = require('fs')
 

--- a/docs/grunt/bs-lessdoc-parser.js
+++ b/docs/grunt/bs-lessdoc-parser.js
@@ -1,4 +1,10 @@
 /* jshint node: true */
+/*!
+ * Bootstrap Grunt task for parsing Less docstrings
+ * http://getbootstrap.com
+ * Copyright 2014 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
 
 var markdown = require('markdown').markdown;
 

--- a/docs/grunt/bs-raw-files-generator.js
+++ b/docs/grunt/bs-raw-files-generator.js
@@ -1,4 +1,10 @@
 /* jshint node: true */
+/*!
+ * Bootstrap Grunt task for generating raw-files.min.js for the Customizer
+ * http://getbootstrap.com
+ * Copyright 2014 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
 
 var btoa = require('btoa') // jshint ignore:line
 var fs = require('fs')


### PR DESCRIPTION
Clarifies that the custom Grunt tasks are MIT-licensed, despite currently being under `/docs/`.
