### PR TITLE
Add tooltip `viewport` option, respect bounds of the viewport

### DIFF
--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -134,6 +134,14 @@ $('#example').tooltip(options)
           <p>Appends the tooltip to a specific element. Example: <code>container: 'body'</code></p>
          </td>
        </tr>
+       <tr>
+         <td>viewport</td>
+         <td>string | object</td>
+         <td>{ selector: 'body', padding: 0 }</td>
+         <td>
+          <p>Keeps the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ selector: '#viewport', padding: 0 }</code></p>
+         </td>
+       </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/examples/tooltips/viewport.html
+++ b/examples/tooltips/viewport.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="shortcut icon" href="../../docs-assets/ico/favicon.png">
+
+    <title>Tooltip Viewport Example for Bootstrap</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../../dist/css/bootstrap.css" rel="stylesheet">
+
+    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+    <style>
+    body {
+      height: 1200px;
+    }
+    .tooltip {
+      min-width: 250px;
+      max-width: 500px;
+    }
+    .tooltip .tooltip-inner {
+      min-height: 200px;
+      min-width: 250px;
+      max-width: 500px;
+    }
+    .placeholder {
+      height: 900px;
+    }
+    .container-viewport {
+      position: absolute;
+      left: 200px;
+      top: 600px;
+      width: 600px;
+      height: 400px;
+      background: #c00;
+    }
+    .btn-bottom {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+    }
+    </style>
+  </head>
+
+  <body>
+
+    <button class="btn pull-right tooltip-bottom", title="This should be shifted to the left">Shift Left</button>
+    <button class="btn tooltip-bottom", title="This should be shifted to the right">Shift Right</button>
+    <button class="btn tooltip-right", title="This should be shifted down">Shift Down</button>
+
+    <div class="placeholder">There is a button down there ↓</div>
+
+    <button class="btn tooltip-right", title="This should be shifted up">Shift Up</button>
+
+    <div class="container-viewport">
+      <button class="btn tooltip-viewport-bottom", title="This should be shifted Left">Shift Left</button>
+      <button class="btn tooltip-viewport-right", title="This should be shifted Down">Shift Down</button>
+
+      <button class="btn pull-right tooltip-viewport-bottom", title="This should be shifted Right">Shift Right</button>
+
+      <button class="btn tooltip-viewport-right btn-bottom", title="This should be shifted up">Shift Up</button>
+    </div>
+
+    <!-- Bootstrap core JavaScript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src="../../js/tooltip.js"></script>
+
+    <script>
+    $(function(){
+      $('.tooltip-right').tooltip({
+        placement: 'right',
+        viewport: {selector: 'body', padding: 2}
+      });
+      $('.tooltip-bottom').tooltip({
+        placement: 'bottom',
+        viewport: {selector: 'body', padding: 2}
+      });
+      $('.tooltip-viewport-right').tooltip({
+        placement: 'right',
+        viewport: {selector: '.container-viewport', padding: 2}
+      });
+      $('.tooltip-viewport-bottom').tooltip({
+        placement: 'bottom',
+        viewport: {selector: '.container-viewport', padding: 2}
+      });
+    });
+    </script>
+  </body>
+</html>

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -337,12 +337,12 @@ $(function () {
   })
 
   test('should add position class before positioning so that position-specific styles are taken into account', function () {
-    $('head').append('<style> .tooltip.right { white-space: nowrap; } .tooltip.right .tooltip-inner { max-width: none; } </style>')
+    $('head').append('<style id="test"> .tooltip.right { white-space: nowrap; } .tooltip.right .tooltip-inner { max-width: none; } </style>')
 
     var container = $('<div />').appendTo('body'),
         target = $('<a href="#" rel="tooltip" title="very very very very very very very very long tooltip in one line"></a>')
           .appendTo(container)
-          .tooltip({placement: 'right'})
+          .tooltip({placement: 'right', viewport: null})
           .tooltip('show'),
         tooltip = container.find('.tooltip')
 
@@ -352,6 +352,7 @@ $(function () {
     var topDiff =  top - top2
     ok(topDiff <= 1 && topDiff >= -1)
     target.tooltip('hide')
+    $('head #test').remove()
   })
 
   test('tooltip title test #1', function () {
@@ -428,4 +429,80 @@ $(function () {
     ttContainer.remove()
   })
 
+  test('should adjust the tip\'s top when up against the top of the viewport', function () {
+    $('head').append('<style id="test"> .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; } </style>')
+
+    var container = $('<div />').appendTo('body'),
+      target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; left: 0px;"></a>')
+          .appendTo(container)
+          .tooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
+          .tooltip('show'),
+      tooltip = container.find('.tooltip')
+
+    ok( Math.round(tooltip.offset().top) === 12 )
+    target.tooltip('hide')
+    $('head #test').remove()
+  })
+
+  test('should adjust the tip\'s top when up against the bottom of the viewport', function () {
+    $('head').append('<style id="test"> .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; } </style>')
+
+    var container = $('<div />').appendTo('body'),
+      target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; bottom: 0px; left: 0px;"></a>')
+          .appendTo(container)
+          .tooltip({placement: 'right', viewport: {selector: 'body', padding: 12}})
+          .tooltip('show'),
+      tooltip = container.find('.tooltip')
+
+    ok( Math.round(tooltip.offset().top) === Math.round($(window).height() - 12 - tooltip[0].offsetHeight) )
+    target.tooltip('hide')
+    $('head #test').remove()
+  })
+
+  test('should adjust the tip\'s left when up against the left of the viewport', function () {
+    $('head').append('<style id="test"> .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; } </style>')
+
+    var container = $('<div />').appendTo('body'),
+      target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; left: 0px;"></a>')
+          .appendTo(container)
+          .tooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
+          .tooltip('show'),
+      tooltip = container.find('.tooltip')
+
+    ok( Math.round(tooltip.offset().left) === 12 )
+    target.tooltip('hide')
+    $('head #test').remove()
+  })
+
+  test('should adjust the tip\'s left when up against the right of the viewport', function () {
+    $('head').append('<style id="test"> .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; } </style>')
+
+    var container = $('<div />').appendTo('body'),
+      target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 0px; right: 0px;"></a>')
+          .appendTo(container)
+          .tooltip({placement: 'bottom', viewport: {selector: 'body', padding: 12}})
+          .tooltip('show'),
+      tooltip = container.find('.tooltip')
+
+    ok( Math.round(tooltip.offset().left) === Math.round($(window).width() - 12 - tooltip[0].offsetWidth) )
+    target.tooltip('hide')
+    $('head #test').remove()
+  })
+
+  test('should adjust the tip when up against the right of an arbitrary viewport', function () {
+    $('head').append('<style id="test"> .tooltip, .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; } </style>')
+    $('head').append('<style id="viewport-style"> .container-viewport { position: absolute; top: 50px; left: 60px; width: 300px; height: 300px; } </style>')
+
+    var container = $('<div />', {class: 'container-viewport'}).appendTo('body'),
+      target = $('<a href="#" rel="tooltip" title="tip" style="position: fixed; top: 50px; left: 350px;"></a>')
+          .appendTo(container)
+          .tooltip({placement: 'bottom', viewport: '.container-viewport'})
+          .tooltip('show'),
+      tooltip = container.find('.tooltip')
+
+    ok( Math.round(tooltip.offset().left) === Math.round(60 + container.width() - tooltip[0].offsetWidth) )
+    target.tooltip('hide')
+    $('head #test').remove()
+    $('head #viewport-style').remove()
+  })
 })


### PR DESCRIPTION
Currently tooltips do not respect their container. eg. I have a button jammed up against the right side of the page, and place a tooltip on the top, it will stick out of the page.

So I added two new options: 
- `viewport`: defaults to `'body'`. It's the selector the tip should stay inside. 
- `viewport: padding`: how far, in px should it stay from the edges

With changes from the original at #11593. The tests pass for me in firefox.

@fat: What was the new offset method you mentioned in the other pull?
