### PR TITLE
Add tooltip self-reference to address #12320

### DIFF
--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -37,6 +37,16 @@ $(function () {
         ok(!!popover.data('bs.popover'), 'popover instance exists')
       })
 
+      test('should store popover trigger in popover instance data object', function () {
+        $.support.transition = false
+        var popover = $('<a href="#" title="jason corns">@jasoncorns</a>')
+          .appendTo('#qunit-fixture')
+          .popover()
+        popover.popover('show')
+        ok(!!$('.popover').data('bs.popover'), 'popover trigger stored in instance data')
+        $('#qunit-fixture').empty()
+      })
+
       test('should get title and content from options', function () {
         $.support.transition = false
         var popover = $('<a href="#">@fat</a>')

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -32,6 +32,14 @@ $(function () {
         equal(tooltip.attr('data-original-title'), 'Another tooltip', 'original title preserved in data attribute')
       })
 
+    test('should store tooltip trigger in tooltip instance data object', function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="Tooltip Trigger backreference"></a>')
+            .appendTo('#qunit-fixture')
+            .tooltip('show')
+        ok(!!$('.tooltip').data('bs.tooltip'), 'tooltip trigger stored in instance data')
+        $('#qunit-fixture').empty()
+    })
+
       test('should place tooltips relative to placement option', function () {
         $.support.transition = false
         var tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"></a>')
@@ -285,6 +293,15 @@ $(function () {
           .tooltip({trigger: 'manual'})
           .tooltip('toggle')
         ok($('.tooltip').is('.fade.in'), 'tooltip should be toggled in')
+      })
+      test('should hide shown tooltip when toggle is called on tooltip', function () {
+        var tooltip = $('<a href="#" rel="tooltip" title="tooltip on toggle"></a>')
+          .appendTo('#qunit-fixture')
+          .tooltip({trigger: 'manual'})
+          .tooltip('toggle')
+        $('.tooltip', '#qunit-fixture').tooltip('toggle')
+        ok($('.tooltip').not('.fade.in'), 'tooltip should be toggled out')
+        $('#qunit-fixture').empty();
       })
 
       test('should place tooltips inside the body', function () {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -149,6 +149,7 @@
         .detach()
         .css({ top: 0, left: 0, display: 'block' })
         .addClass(placement)
+        .data('bs.' + this.type, this)
 
       this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
 


### PR DESCRIPTION
To fix #12320, add a data reference on the tooltip (and popover) such
that calling `$(‘#myTooltip’).tooltip(‘hide’)` will hide the visible tip.
