### PR TITLE
enable IE11 in BrowserStack tests

### DIFF
--- a/browserstack.json
+++ b/browserstack.json
@@ -39,6 +39,12 @@
       "os": "ios",
       "os_version": "7.0",
       "device": "iPhone 5S"
+    },
+    {
+      "browser": "ie",
+      "browser_version": "11.0",
+      "os": "Windows",
+      "os_version": "8.1"
     }
   ]
 }


### PR DESCRIPTION
Increases parity between the Sauce tests and the BrowserStack tests.
