### PR TITLE
add WAI-ARIA guideline to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,7 @@ license your work under the terms of the [MIT License](LICENSE.md).
 - Always use proper indentation.
 - Use tags and elements appropriate for an HTML5 doctype (e.g., self-closing tags).
 - Use CDNs and HTTPS for third-party JS when possible. We don't use protocol-relative URLs in this case because they break when viewing the page locally via `file://`.
+- Use [WAI-ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) attributes in documentation examples to promote accessibility.
 
 ### CSS
 


### PR DESCRIPTION
Codifies our use of WAI-ARIA attributes in our HTML examples by making an addition to our contribution guidelines.
