### PR TITLE
Add dropdown label support

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -68,6 +68,14 @@
     color: @dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
   }
+  
+  label {
+    color: @gray-light;
+    text-transform: uppercase;
+    white-space: nowrap; // prevent labels from randomly breaking onto new lines
+    padding: 0px 20px;
+    font-size: @font-size-small;
+  }
 }
 
 // Hover/Focus state


### PR DESCRIPTION
This adds support for a label inside a dropdown. You can use that label to mark a menu section.
