### PR TITLE
Make space between .navbar-right and screen when without container.

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -267,7 +267,8 @@
       }
     }
 
-    &.navbar-right:last-child {
+    .navbar > .container &.navbar-right:last-child,
+    .navbar > .container-fluid &.navbar-right:last-child {
       margin-right: -@navbar-padding-horizontal;
     }
   }


### PR DESCRIPTION
@navbar-padding-horizontal should only be subtracted from .navbar-right:last-child if it is inside a .container or .container-fluid.

Or else it will be crammed into the right side of the window. This is the same solution as .navbar-brand uses on the left side.
