### PR TITLE
Add German translation

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -763,10 +763,11 @@ if (isAndroid) {
   <p class="lead">Community members have translated Bootstrap's documentation into various languages. None are officially supported and they may not always be up to date.</p>
   <ul>
     <li><a href="http://v3.bootcss.com/">Bootstrap 中文文档 (Chinese)</a></li>
+    <li><a href="http://www.oneskyapp.com/docs/bootstrap/fr">Bootstrap en Français (French)</a></li>
+    <li><a href="http://holdirbootstrap.de/">Bootstrap auf Deutsch (German)</a></li>
     <li><a href="http://www.oneskyapp.com/docs/bootstrap/ru">Bootstrap по-русски (Russian)</a></li>
     <li><a href="http://www.oneskyapp.com/docs/bootstrap/es">Bootstrap en Español (Spanish)</a></li>
     <li><a href="http://twbs.site-konstruktor.com.ua">Bootstrap ua Українською (Ukrainian)</a></li>
-    <li><a href="http://www.oneskyapp.com/docs/bootstrap/fr">Bootstrap en Français (French)</a></li>
   </ul>
   <p>Have another language to add, or perhaps a different or better translation? Let us know by <a href="https://github.com/twbs/bootstrap/issues/new">opening an issue</a>.</p>
 </div>


### PR DESCRIPTION
Adds link to the unofficial German translation of our documentation, which I crafted over the last few days and reorders the links by English version of the languages' names.

/to @mdo @cvrebert to review and check out. For now, the site features a "Coming up." message. I'll update my local version of the finished translation with upstream changes and launch the final product alongside v3.1.

http://holdirbootstrap.de / http://juthilo.github.io/bootstrap-german
http://github.com/juthilo/bootstrap-german
