### PR TITLE
update to iOS v7 in Sauce test config

### DIFF
--- a/test-infra/sauce_browsers.yml
+++ b/test-infra/sauce_browsers.yml
@@ -58,7 +58,8 @@
 
   {
     browserName: "iphone",
-    platform: "OS X 10.8"
+    platform: "OS X 10.9",
+    version: "7"
   },
 
   # iOS Chrome not currently supported by Sauce Labs


### PR DESCRIPTION
For some reason, Sauce doesn't default to the latest version in this particular case, so this specifies v7 explicitly.
