### PR TITLE
re-enable OS X Chrome in Sauce tests

### DIFF
--- a/test-infra/sauce_browsers.yml
+++ b/test-infra/sauce_browsers.yml
@@ -5,12 +5,11 @@
     browserName: "safari",
     platform: "OS X 10.9"
   },
-  # FIXME: keeps timing out frequently for unknown reasons
-  # {
-  #   browserName: "chrome",
-  #   platform: "OS X 10.9"
-  # },
-
+  {
+    browserName: "chrome",
+    platform: "OS X 10.9",
+    version: "31"
+  },
   {
     browserName: "firefox",
     platform: "OS X 10.9"


### PR DESCRIPTION
Crossing my fingers that explicitly setting v31 avoids the timeout problems we were seeing before. I've re-run the build a few times and haven't seen a timeout yet.
