### PR TITLE
Add arrow class for alerts

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -2239,6 +2239,19 @@ body { padding-bottom: 70px; }
   <a href="#" class="alert-link">...</a>
 </div>
 {% endhighlight %}
+
+  <h2 id="alerts-arrows">Context arrows</h2>
+  <p>An alert can point to an adjacent item above itself with the <code>.alert-arrow</code> class.</p>
+  <div class="bs-example">
+    <div class="alert alert-info alert-arrow">
+      <strong>Heads up!</strong> Take a look at the item directly above me.
+    </div>
+  </div>
+{% highlight html %}
+<div class="alert alert-info alert-arrow">
+  ...
+</div>
+{% endhighlight %}
 </div>
 
 

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -436,6 +436,19 @@
   .alert-link {
     color: darken(@text-color, 10%);
   }
+
+  &.alert-arrow {
+    position: relative;
+
+    &:before {
+      position: absolute;
+      top: -@alert-arrow-width;
+      border-bottom: @alert-arrow-width solid @border;
+      border-left: @alert-arrow-width solid transparent;
+      border-right: @alert-arrow-width solid transparent;
+      content: "";
+    }
+  }
 }
 
 // Tables

--- a/less/variables.less
+++ b/less/variables.less
@@ -590,6 +590,7 @@
 @alert-danger-text:           @state-danger-text;
 @alert-danger-border:         @state-danger-border;
 
+@alert-arrow-width:           10px;
 
 //== Progress bars
 //


### PR DESCRIPTION
I have created a class `.alert-arrow` that displays a small arrow above an alert:

![arrow](https://f.cloud.github.com/assets/1253444/2027688/7f992952-88bc-11e3-8f87-8549da7b878f.png)

The basic idea is that the arrow can be used to indicate that the message in an alert pertains to the element directly above it. This could be used underneath a form control, for example, and combined with the `.alert-danger` class to indicate a validation error.

My commit includes modifications to the`.alert-variant` mixin and documentation for the new style.

This is my first pull request for Bootstrap, so please be gentle on me if I have made a mistake. I did my best to ensure that I was following the contribution guidelines as far as coding style and commit messages go. However, I always seem to get mixed up in Git - so hopefully I got everything right this time.

Thanks!
