### PR TITLE
Add "showing" event to modal

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -63,7 +63,7 @@
         .show()
         .scrollTop(0)
         
-      // jck: to allow additional positioning and/or animation which can't be done until element is visible
+      // Allow additional positioning and/or animation which can't be done until element is visible
       that.$element.trigger($.Event('showing.bs.modal'),{relatedTarget:_relatedTarget})
 
       if (transition) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -62,6 +62,9 @@
       that.$element
         .show()
         .scrollTop(0)
+        
+      // jck: to allow additional positioning and/or animation which can't be done until element is visible
+      that.$element.trigger($.Event('showing.bs.modal'),{relatedTarget:_relatedTarget})
 
       if (transition) {
         that.$element[0].offsetWidth // force reflow

--- a/js/modal.js
+++ b/js/modal.js
@@ -64,7 +64,7 @@
         .scrollTop(0)
         
       // Allow additional positioning and/or animation which can't be done until element is visible
-      that.$element.trigger($.Event('showing.bs.modal'),{relatedTarget:_relatedTarget})
+      that.$element.trigger($.Event('showing.bs.modal', { relatedTarget: _relatedTarget }))
 
       if (transition) {
         that.$element[0].offsetWidth // force reflow


### PR DESCRIPTION
Allow additional positioning and/or animation which can't be done until element is visible by triggering a new event called 'showing'.  If the 'show' trigger is used then a delay is seen between the two animations; this allows them to be seemless.
