### PR TITLE
Added !important switches to text alignments

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -82,10 +82,10 @@ small,
 cite    { font-style: normal; }
 
 // Alignment
-.text-left           { text-align: left; }
-.text-right          { text-align: right; }
-.text-center         { text-align: center; }
-.text-justify        { text-align: justify; }
+.text-left           { text-align: left !important; }
+.text-right          { text-align: right !important; }
+.text-center         { text-align: center !important; }
+.text-justify        { text-align: justify !important; }
 
 // Contextual colors
 .text-muted {


### PR DESCRIPTION
In order to use the classes effectively fe. overriding alignments for reusable blocks that are defined in custom css. !importants can always be re-overridden in the custom css. Alternatively could be done with .text-left-important classes.
