### PR TITLE
Fix first element padding of list-inline

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -165,15 +165,12 @@ ol {
 // Inline turns list items into inline-block
 .list-inline {
   .list-unstyled();
+  margin-left: -5px;
 
   > li {
     display: inline-block;
     padding-left: 5px;
     padding-right: 5px;
-
-    &:first-child {
-      padding-left: 0;
-    }
   }
 }
 


### PR DESCRIPTION
Hi,

I noticed a strange behaviour of `list-inline` and I don't know if this is intended.

I'm using that class for list of tags and often they break up in multiple lines.

By default, elements on the lines other than the first, have a 5px padding on the left and I don't like that

The pull request contains a suggested fix (if this behaviour is not intended)

Example: http://jsfiddle.net/tagliala/rUZ2a/1/
