### PR TITLE
Fix issue causing .navbar-brand element height to be shorter than .navbar height

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -155,7 +155,7 @@
   padding: @navbar-padding-vertical @navbar-padding-horizontal;
   font-size: @font-size-large;
   line-height: @line-height-computed;
-  height: @line-height-computed;
+  height: @navbar-height;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
With Bootstrab 3.1.0 the `.navbar-brand` element is shorter than the surounding `.navbar` element.  You can even see this in the current 3.1.0 docs:

![screenshot 2014-01-30 15 08 51](https://f.cloud.github.com/assets/53531/2045622/8790d16a-89fb-11e3-850b-4e01b223f461.png)

This issue (introduced with commit e38fd138ce) causes there to be a 30px space at the bottom of the `.navbar-brand` element that is unclickable.

This patch fixes that by utilizing the `@navbar-height` variable for the `.navbar-brand` height.
