### PR TITLE
modal-lg support small screen.

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -133,8 +133,6 @@
 
   // Modal sizes
   .modal-sm { width: @modal-sm; }
-  .modal-lg { width: 100%; }
-
 }
 
 @media (min-width: @screen-md-min) {

--- a/less/modals.less
+++ b/less/modals.less
@@ -137,6 +137,6 @@
 }
 
 @media (min-width: @screen-md-min) {
-  // Modal sizes
+  // Modal size
   .modal-lg { width: @modal-lg; }
 }

--- a/less/modals.less
+++ b/less/modals.less
@@ -133,6 +133,11 @@
 
   // Modal sizes
   .modal-sm { width: @modal-sm; }
-  .modal-lg { width: @modal-lg; }
+  .modal-lg { width: 100%; }
 
+}
+
+@media (min-width: @screen-md-min) {
+  // Modal sizes
+  .modal-lg { width: @modal-lg; }
 }

--- a/less/modals.less
+++ b/less/modals.less
@@ -133,6 +133,7 @@
 
   // Modal sizes
   .modal-sm { width: @modal-sm; }
+  .modal-lg { width: 100%; }
 }
 
 @media (min-width: @screen-md-min) {

--- a/less/modals.less
+++ b/less/modals.less
@@ -41,7 +41,16 @@
 .modal-dialog {
   position: relative;
   width: auto;
+  max-width: @modal-md;
   margin: 10px;
+}
+
+// Modal sizes
+.modal-sm {
+  max-width: @modal-sm;
+}
+.modal-lg {
+  max-width: @modal-lg;
 }
 
 // Actual modal
@@ -124,19 +133,32 @@
 
   // Automatically set modal's width for larger viewports
   .modal-dialog {
-    width: @modal-md;
     margin: 30px auto;
   }
   .modal-content {
     .box-shadow(0 5px 15px rgba(0,0,0,.5));
   }
-
-  // Modal sizes
-  .modal-sm { width: @modal-sm; }
-  .modal-lg { width: 100%; }
 }
-
-@media (min-width: @screen-md-min) {
-  // Modal sizes
-  .modal-lg { width: @modal-lg; }
+// Modal sizes
+@media (min-width: (@modal-sm + 10 * 2)) {
+  .modal-sm { 
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+@media (min-width: (@modal-md + 10 * 2)) {
+  .modal-dialog { 
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .modal-lg {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+}
+@media (min-width: (@modal-lg + 10 * 2)) {
+  .modal-lg { 
+    margin-left: auto;
+    margin-right: auto;
+  }
 }


### PR DESCRIPTION
modal-lg size support small screen size.
## current

``` css
@media (min-width: 768px) {
  .modal-lg {
    width: 900px;
  }
}
```
- When small screen size, the modal width is larger than window width , scrollbars are displayed. 
## this pull request

``` css
@media (min-width: 768px) {
  .modal-lg {
    width: 100%;
  }
}
@media (min-width: 992px) {
  .modal-lg {
    width: 900px;
  }
}

```
- When small screen size, the modal width is 100% , scrollbars are not displayed.
