### PR TITLE
Clarify JS error message about missing jQuery

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
             ' * Copyright 2011-<%= grunt.template.today("yyyy") %> <%= pkg.author %>\n' +
             ' * Licensed under <%= _.pluck(pkg.licenses, "type") %> (<%= _.pluck(pkg.licenses, "url") %>)\n' +
             ' */\n',
-    jqueryCheck: 'if (typeof jQuery === \'undefined\') { throw new Error(\'Bootstrap requires jQuery\') }\n\n',
+    jqueryCheck: 'if (typeof jQuery === \'undefined\') { throw new Error(\'Bootstrap\\\'s JavaScript requires jQuery\') }\n\n',
 
     // Task configuration.
     clean: {


### PR DESCRIPTION
Most of Bootstrap's components are pure CSS and thus don't require jQuery.
Refs https://news.ycombinator.com/item?id=7156305
