### PR TITLE
Fixes issue 12435: responsive image alignment on Dashboard example.

### DIFF
--- a/docs/examples/dashboard/dashboard.css
+++ b/docs/examples/dashboard/dashboard.css
@@ -91,3 +91,7 @@ body {
 .placeholder img {
   border-radius: 50%;
 }
+
+.img-responsive {
+  display: inline-block;
+}


### PR DESCRIPTION
Display the responsive images inline but allow them to retain their block-level characteristics.
