### PR TITLE
rm DIY full-width callout now that there's .container-fluid

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -82,11 +82,6 @@ lead: "Global CSS settings, fundamental HTML elements styled and enhanced with e
   </ul>
   <p>Look to the examples for applying these principles to your code.</p>
 
-  <div class="bs-callout bs-callout-info">
-    <h4>Grids and full-width layouts</h4>
-    <p>Folks looking to create fully fluid layouts (meaning your site stretches the entire width of the viewport) must wrap their grid content in a containing element with <code>padding: 0 15px;</code> to offset the <code>margin: 0 -15px;</code> used on <code>.row</code>s.</p>
-  </div>
-
   <h3 id="grid-media-queries">Media queries</h3>
   <p>We use the following media queries in our Less files to create the key breakpoints in our grid system.</p>
 {% highlight scss %}


### PR DESCRIPTION
This is unnecessary now that Bootstrap has `.container-fluid`, right?
/to @mdo for review
