### PR TITLE
Remove redundant :-moz-placeholder styles

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -54,8 +54,7 @@
 
 // Placeholder text
 .placeholder(@color: @input-color-placeholder) {
-  &:-moz-placeholder            { color: @color; } // Firefox 4-18
-  &::-moz-placeholder           { color: @color;   // Firefox 19+
+  &::-moz-placeholder           { color: @color;   // Firefox
                                   opacity: 1; } // See https://github.com/twbs/bootstrap/pull/11526
   &:-ms-input-placeholder       { color: @color; } // Internet Explorer 10+
   &::-webkit-input-placeholder  { color: @color; } // Safari and Chrome


### PR DESCRIPTION
No need for old Firefox versions support.
