### PR TITLE
Exclude development files in docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ baseurl:          /
 url:              http://localhost:9001
 encoding:         UTF-8
 
-exclude:          ["vendor"]
+exclude:          ["grunt", "*.jade", "vendor"]
 
 # Custom vars
 current_version:  3.1.0


### PR DESCRIPTION
This removes `grunt/` and `*.jade` files from docs.
