### PR TITLE
fixed IRC channel name typo in getting started docs

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -318,7 +318,7 @@ bootstrap/
   <p class="lead">Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.</p>
   <ul>
     <li>Read and subscribe to <a href="http://blog.getbootstrap.com/">The Official Bootstrap Blog</a>.</li>
-    <li>Chat with fellow Bootstrappers using IRC in the <code>irc.freenode.net</code> server, in the <a href="irc://irc.freenode.net/#twitter-bootstrap">##twitter-bootstrap channel</a>.</li>
+    <li>Chat with fellow Bootstrappers using IRC in the <code>irc.freenode.net</code> server, in the <a href="irc://irc.freenode.net/#twitter-bootstrap">#twitter-bootstrap channel</a>.</li>
     <li>Find inspiring examples of people building with Bootstrap at the <a href="http://expo.getbootstrap.com">Bootstrap Expo</a>.</li>
   </ul>
   <p>You can also follow <a href="https://twitter.com/twbootstrap">@twbootstrap on Twitter</a> for the latest gossip and awesome music videos.</p>


### PR DESCRIPTION
Simple documentation fix -- changing the IRC channel name link to display "#twitter-bootstrap" instead of "##twitter-bootstrap" in the Getting Started docs.
