### PR TITLE
Improve alignment of the dashboard placeholder images

### DIFF
--- a/docs/examples/dashboard/dashboard.css
+++ b/docs/examples/dashboard/dashboard.css
@@ -89,5 +89,6 @@ body {
   margin-bottom: 20px;
 }
 .placeholder img {
+  display: inline-block;
   border-radius: 50%;
 }


### PR DESCRIPTION
Clean solution to not pollute responsive images overall, but to fix placeholder images.

Fixes #12435.
