### PR TITLE
Remove `curly: false` from `.jshintrc`

### DIFF
--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -2,7 +2,6 @@
   "asi"      : true,
   "boss"     : true,
   "browser"  : true,
-  "curly"    : false,
   "debug"    : true,
   "devel"    : true,
   "eqeqeq"   : false,


### PR DESCRIPTION
`curly` defaults to `false`.
