### PR TITLE
add note to CONTRIBUTING.md about `outline: none`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,7 @@ license your work under the terms of the [MIT License](LICENSE.md).
 - Series of classes for a component should include a base class (e.g., `.component`) and use the base class as a prefix for modifier and sub-components (e.g., `.component-lg`).
 - Avoid inheritance and over nesting—use single, explicit classes whenever possible.
 - When feasible, default color palettes should comply with [WCAG color contrast guidelines](http://www.w3.org/TR/WCAG20/#visual-audio-contrast).
+- Except in rare cases, don't remove default `:focus` styles (via e.g. `outline: none;`) without providing alternative styles. See [this A11Y Project post](http://a11yproject.com/posts/never-remove-css-outlines/) for more details.
 
 ### JS
 


### PR DESCRIPTION
Naive issues/PRs that add (or request adding) an `outline: none` seem to crop up every once in a while.

If the conditions for when this guidance is applicable can be expressed better than "Except in rare cases", be my guest in improving that part.
