### PR TITLE
Doc fix: mention that javascript invocation of dropdown.js still require...

### DIFF
--- a/docs/javascript.html
+++ b/docs/javascript.html
@@ -548,6 +548,7 @@ $('#myModal').on('hidden.bs.modal', function (e) {
 {% highlight js %}
 $('.dropdown-toggle').dropdown()
 {% endhighlight %}
+    <p>Note that <code>data-toggle="dropdown"</code> is still required on a link or button for a submenu to close.</p>
 
   <h3>Options</h3>
   <p><em>None</em></p>


### PR DESCRIPTION
Clarify documentation for dropdown.js to indicate the data-toggle attribute is required even when using javascript API. As per https://github.com/twbs/bootstrap/issues/4768
