### PR TITLE
Scope popover arrow css to direct descendant

### DIFF
--- a/less/popovers.less
+++ b/less/popovers.less
@@ -48,7 +48,7 @@
 //
 // .arrow is outer, .arrow:after is inner
 
-.popover .arrow {
+.popover > .arrow {
   &,
   &:after {
     position: absolute;
@@ -59,16 +59,16 @@
     border-style: solid;
   }
 }
-.popover .arrow {
+.popover > .arrow {
   border-width: @popover-arrow-outer-width;
 }
-.popover .arrow:after {
+.popover > .arrow:after {
   border-width: @popover-arrow-width;
   content: "";
 }
 
 .popover {
-  &.top .arrow {
+  &.top > .arrow {
     left: 50%;
     margin-left: -@popover-arrow-outer-width;
     border-bottom-width: 0;
@@ -83,7 +83,7 @@
       border-top-color: @popover-arrow-color;
     }
   }
-  &.right .arrow {
+  &.right > .arrow {
     top: 50%;
     left: -@popover-arrow-outer-width;
     margin-top: -@popover-arrow-outer-width;
@@ -98,7 +98,7 @@
       border-right-color: @popover-arrow-color;
     }
   }
-  &.bottom .arrow {
+  &.bottom > .arrow {
     left: 50%;
     margin-left: -@popover-arrow-outer-width;
     border-top-width: 0;
@@ -114,7 +114,7 @@
     }
   }
 
-  &.left .arrow {
+  &.left > .arrow {
     top: 50%;
     right: -@popover-arrow-outer-width;
     margin-top: -@popover-arrow-outer-width;


### PR DESCRIPTION
Fixes #12532:

If you've got a popover inside of another popover and they've got different placements, the styles for the parent popover arrow will cascade down to the arrow of the child popover.

Here's an example: http://jsbin.com/adIFiWer
