### PR TITLE
Allow the bootstrap package in npm to expose css and less

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "test": "grunt test"
   },
+  "style": "./dist/css/bootstrap.css",
+  "less": "./less/bootstrap.less",
   "repository": {
     "type": "git",
     "url": "https://github.com/twbs/bootstrap.git"


### PR DESCRIPTION
Accidentally screwed up the squash in https://github.com/twbs/bootstrap/pull/12441

This is the same, but in one commit.
