### PR TITLE
Fixes #12540

### DIFF
--- a/docs/migration.html
+++ b/docs/migration.html
@@ -106,14 +106,6 @@ lead: "Guidance on how to upgrade from Bootstrap v2.x to v3.x with emphasis on m
           <td>Split into <code>.hidden-md .hidden-lg</code></td>
         </tr>
         <tr>
-          <td><code>.input-small</code></td>
-          <td><code>.input-sm</code></td>
-        </tr>
-        <tr>
-          <td><code>.input-large</code></td>
-          <td><code>.input-lg</code></td>
-        </tr>
-        <tr>
           <td><code>.input-block-level</code></td>
           <td><code>.form-control</code></td>
         </tr>
@@ -261,6 +253,10 @@ lead: "Guidance on how to upgrade from Bootstrap v2.x to v3.x with emphasis on m
           <td><code>.col-sm-pull-*</code> <code>.col-md-pull-*</code> <code>.col-lg-pull-*</code></td>
         </tr>
         <tr>
+          <td>Input height sizes</td>
+          <td><code>.input-sm</code> <code>.input-lg</code></td>
+        </tr>
+        <tr>
           <td>Input groups</td>
           <td><code>.input-group</code> <code>.input-group-addon</code> <code>.input-group-btn</code></td>
         </tr>
@@ -345,7 +341,12 @@ lead: "Guidance on how to upgrade from Bootstrap v2.x to v3.x with emphasis on m
           <td class="text-muted">N/A</td>
         </tr>
         <tr>
-          <td>Block level from input</td>
+          <td>Fixed-width input sizes</td>
+          <td><code>.input-mini</code> <code>.input-small</code> <code>.input-medium</code> <code>.input-large</code> <code>.input-xlarge</code> <code>.input-xxlarge</code></td>
+          <td>Use <a href="../css/#forms-controls"><code>.form-control</code></a> and <a href="../css/#grid">the grid system</a> instead.</td>
+        </tr>
+        <tr>
+          <td>Block level form input</td>
           <td><code>.input-block-level</code></td>
           <td>No direct equivalent, but <a href="../css/#forms-controls">forms controls</a> are similar.</td>
         </tr>


### PR DESCRIPTION
Instead of stating that `.input-small` is now `.input-sm`, this accurately states that `.input-small` and friends were removed in favor of using the grid system, and that `.input-sm` and friends were added separately to deal strictly with height.
Fixes #12540.
