### PR TITLE
Fixes two typos in carousel.less

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -206,8 +206,8 @@
 
   // Scale up the controls a smidge
   .carousel-control {
-    .glyphicons-chevron-left,
-    .glyphicons-chevron-right,
+    .glyphicon-chevron-left,
+    .glyphicon-chevron-right,
     .icon-prev,
     .icon-next {
       width: 30px;


### PR DESCRIPTION
Carousel.less has two typos in glyphicon classnames. This fixes them.
