### PR TITLE
use :extend(.img-responsive) in Carousel's Less

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -307,7 +307,9 @@ figure {
 img {
   vertical-align: middle;
 }
-.img-responsive {
+.img-responsive,
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
   display: block;
   max-width: 100%;
   height: auto;
@@ -5421,9 +5423,6 @@ button.close {
 }
 .carousel-inner > .item > img,
 .carousel-inner > .item > a > img {
-  display: block;
-  max-width: 100%;
-  height: auto;
   line-height: 1;
 }
 .carousel-inner > .active,

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -21,7 +21,7 @@
     // Account for jankitude on images
     > img,
     > a > img {
-      .img-responsive();
+      &:extend(.img-responsive);
       line-height: 1;
     }
   }


### PR DESCRIPTION
Reduces redundancy in the CSS.

Besides/after this, the remaining places where `:extend` could be used seem trickier.
