### PR TITLE
Fix calculated width on media-body

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -22,6 +22,11 @@
   margin-top: 0;
 }
 
+// Ensure proper calculated width on body
+.media-body {
+  display: inline-block;
+}
+
 // For images and videos, set to block
 .media-object {
   display: block;


### PR DESCRIPTION
On some browsers, I'm looking at you firefox, the media width is calculated using only the media-body. I don't know why. So adding a media-object within a pull-left node, pushes the media-body out of the viewable area. This fixes that problem. It only happens when there isn't a fixed with. If the media object can expand to a set width it's fine, such as the the example usage: http://getbootstrap.com/components/#media. However putting the media node in a variable width node such as a popover, firefox gets upset.

I made a jsfiddle demonstrating the problem. Check it out in firefox. Toggle the media-body css setting. http://jsfiddle.net/givingstage/BFds2/

Thanks!
