### PR TITLE
Bugfix for "Open modal is shifting body content to the left" #9855

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -2,14 +2,19 @@
 // Modals
 // --------------------------------------------------
 
-// .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and shit
 
-// Kill the scroll on the body
-.modal-open {
+// prevent shifting body content and double scrollbars while showing modal
+html {
+  -ms-overflow-style: scrollbar;
+  height: 100%;
   overflow: hidden;
+}
+body {
+  height: 100%;
+  overflow: auto;
 }
 
 // Container that the modal scrolls within


### PR DESCRIPTION
This solution do cover up the scrollbar of `body` with the scrollbar of `.modal`. So we have no shifting body content.

This solution removes the one property of class `.modal_open` and so this class seams obsolete.
May be the setter for this class should be removed in modal.js too.

A demo of this solution is here: http://jsbin.com/oHiPIJi/33
