### PR TITLE
Override iOS search input's extra round corners

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -150,10 +150,24 @@ output {
   }
 }
 
+
+// Search inputs in iOS
+//
+// This overrides the extra rounded corners on search inputs in iOS so that our
+// `.form-control` class can properly style them. Note that this cannot simply
+// be added to `.form-control` as it's not specific enough. For details, see
+// https://github.com/twbs/bootstrap/issues/11586.
+
+input[type="search"] {
+  -webkit-appearance: none;
+}
+
+
 // Special styles for iOS date input
 //
 // In Mobile Safari, date inputs require a pixel line-height that matches the
 // given height of the input.
+
 input[type="date"] {
   line-height: @input-height-base;
 }


### PR DESCRIPTION
Fixes #11586.

Was originally just going to put this on `.form-control`, but it's not specific enough. Has to be the element with attribute selector.
