### PR TITLE
Avoid setting `jshint node: true` in every Grunt JS file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,9 @@ module.exports = function (grunt) {
         jshintrc: 'js/.jshintrc'
       },
       grunt: {
+        options: {
+          node: true
+        },
         src: ['Gruntfile.js', 'grunt/*.js']
       },
       src: {

--- a/docs/assets/js/customizer.js
+++ b/docs/assets/js/customizer.js
@@ -6,7 +6,7 @@
  * details, see http://creativecommons.org/licenses/by/3.0/.
  */
 
-/* jshint multistr:true */
+/* jshint multistr: true */
 
 window.onload = function () { // wait for load in a dumb way because B-0
   var cw = '/*!\n' +

--- a/grunt/bs-glyphicons-data-generator.js
+++ b/grunt/bs-glyphicons-data-generator.js
@@ -1,4 +1,3 @@
-/* jshint node: true */
 /*!
  * Bootstrap Grunt task for Glyphicons data generation
  * http://getbootstrap.com

--- a/grunt/bs-lessdoc-parser.js
+++ b/grunt/bs-lessdoc-parser.js
@@ -1,4 +1,3 @@
-/* jshint node: true */
 /*!
  * Bootstrap Grunt task for parsing Less docstrings
  * http://getbootstrap.com

--- a/grunt/bs-raw-files-generator.js
+++ b/grunt/bs-raw-files-generator.js
@@ -1,4 +1,3 @@
-/* jshint node: true */
 /* global btoa: true */
 
 /*!

--- a/grunt/shrinkwrap.js
+++ b/grunt/shrinkwrap.js
@@ -1,5 +1,3 @@
-/* jshint node: true */
-
 /*
 This Grunt task updates the npm-shrinkwrap.canonical.json file that's used as the key for Bootstrap's npm packages cache.
 This task should be run and the updated file should be committed whenever Bootstrap's dependencies change.


### PR DESCRIPTION
Avoids enabling JSHint `node` option in every Grunt JS file and instead adds `node: true` to config.
