### PR TITLE
Drop -mox and -o transition prefixes

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -142,8 +142,6 @@
 }
 .transition-transform(@transition) {
   -webkit-transition: -webkit-transform @transition;
-     -moz-transition: -moz-transform @transition;
-       -o-transition: -o-transform @transition;
           transition: transform @transition;
 }
 


### PR DESCRIPTION
The -o and -moz prefixes for transition aren't needed for our supported browsers so we could drop those:
http://caniuse.com/css-transitions
