### PR TITLE
use @popover-arrow-width for offset the popover 

### DIFF
--- a/less/popovers.less
+++ b/less/popovers.less
@@ -23,10 +23,10 @@
   white-space: normal;
 
   // Offset the popover to account for the popover arrow
-  &.top     { margin-top: -10px; }
-  &.right   { margin-left: 10px; }
-  &.bottom  { margin-top: 10px; }
-  &.left    { margin-left: -10px; }
+  &.top     { margin-top: -@popover-arrow-width; }
+  &.right   { margin-left: @popover-arrow-width; }
+  &.bottom  { margin-top: @popover-arrow-width; }
+  &.left    { margin-left: -@popover-arrow-width; }
 }
 
 .popover-title {


### PR DESCRIPTION
In popover.less, the offset to account for the popover arrow was set with absolute values (10px).
But this value depends on the width of arrow and this is set with the variable `@popover-arrow-width`.

So I replaced the absolute values with the variable. 
