### PR TITLE
reuse popover variables to set popover arrow colors.

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -525,9 +525,9 @@
 //** Popover outer arrow width
 @popover-arrow-outer-width:           (@popover-arrow-width + 1);
 //** Popover outer arrow color
-@popover-arrow-outer-color:           rgba(0,0,0,.25);
+@popover-arrow-outer-color:           @popover-border-color;
 //** Popover outer arrow fallback color
-@popover-arrow-outer-fallback-color:  #999;
+@popover-arrow-outer-fallback-color:  @popover-fallback-border-color;
 
 
 //== Labels


### PR DESCRIPTION
The arrow of a popover should often look like a fin of the box with same background and border color.
So I suggest to reuse this values to specify the arrow values.
IMHO it makes also more clear for what this variables are standing for.
