### PR TITLE
Fixed transitions on offcanvas example by adding initial left and right properties

### DIFF
--- a/docs/examples/offcanvas/offcanvas.css
+++ b/docs/examples/offcanvas/offcanvas.css
@@ -25,6 +25,14 @@ footer {
             transition: all .25s ease-out;
   }
 
+  .row-offcanvas-right {
+    right: 0;
+  }
+
+  .row-offcanvas-left {
+    left: 0;
+  }
+
   .row-offcanvas-right
   .sidebar-offcanvas {
     right: -50%; /* 6 columns */


### PR DESCRIPTION
Ease-out transitions on the recently added offcanvas example don't seem to work without adding an initial `right: 0;` property. Tested in IE 11 / FF 27 / Chrome 32.
