### PR TITLE
Fix hide and show events calling element methods

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -35,7 +35,7 @@
     if (this.transitioning || this.$element.hasClass('in')) return
 
     var startEvent = $.Event('show.bs.collapse')
-    this.$element.trigger(startEvent)
+    this.$element.triggerHandler(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
     var actives = this.$parent && this.$parent.find('> .panel > .in')
@@ -79,7 +79,7 @@
     if (this.transitioning || !this.$element.hasClass('in')) return
 
     var startEvent = $.Event('hide.bs.collapse')
-    this.$element.trigger(startEvent)
+    this.$element.triggerHandler(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
     var dimension = this.dimension()

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -36,7 +36,7 @@
       }
 
       var relatedTarget = { relatedTarget: this }
-      $parent.trigger(e = $.Event('show.bs.dropdown', relatedTarget))
+      $parent.triggerHandler(e = $.Event('show.bs.dropdown', relatedTarget))
 
       if (e.isDefaultPrevented()) return
 
@@ -88,7 +88,7 @@
       var $parent = getParent($(this))
       var relatedTarget = { relatedTarget: this }
       if (!$parent.hasClass('open')) return
-      $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
+      $parent.triggerHandler(e = $.Event('hide.bs.dropdown', relatedTarget))
       if (e.isDefaultPrevented()) return
       $parent.removeClass('open').trigger('hidden.bs.dropdown', relatedTarget)
     })

--- a/js/modal.js
+++ b/js/modal.js
@@ -42,7 +42,7 @@
     var that = this
     var e    = $.Event('show.bs.modal', { relatedTarget: _relatedTarget })
 
-    this.$element.trigger(e)
+    this.$element.triggerHandler(e)
 
     if (this.isShown || e.isDefaultPrevented()) return
 
@@ -90,7 +90,7 @@
 
     e = $.Event('hide.bs.modal')
 
-    this.$element.trigger(e)
+    this.$element.triggerHandler(e)
 
     if (!this.isShown || e.isDefaultPrevented()) return
 

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -160,5 +160,16 @@ $(function () {
 
     target3.click()
   })
+  
+  test('should not call element methods on show or hide', function () {
+    var el = $('<div class="collapse"></div>').get(0)
+
+    el.hide = function() { ok(false, 'element.hide method was called') }
+    el.show = function() { ok(false, 'element.show method was called') }
+    el = $(el)
+    el.collapse('hide')
+    el.collapse('show')
+    expect(0)
+  })
 
 })

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -215,4 +215,30 @@ $(function () {
     $(document.body).click()
   })
 
+  test('should not call element methods on show or hide', function () {
+    var dropdownHTML = '<ul class="tabs">' +
+        '<li class="dropdown">' +
+        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
+        '<ul class="dropdown-menu">' +
+        '<li><a href="#">Secondary link</a></li>' +
+        '<li><a href="#">Something else here</a></li>' +
+        '<li class="divider"></li>' +
+        '<li><a href="#">Another link</a></li>' +
+        '</ul>' +
+        '</li>' +
+        '</ul>',
+        dropdown = $(dropdownHTML)
+          .appendTo('#qunit-fixture')
+          .find('[data-toggle="dropdown"]')
+          .dropdown(),
+        el = dropdown.parent('.dropdown').get(0)
+
+    el.hide = function() { ok(false, 'element.hide method was called') }
+    el.show = function() { ok(false, 'element.show method was called') }
+
+    dropdown.click()
+    $(document.body).click()
+    expect(0)
+  })
+
 })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -192,4 +192,25 @@ $(function () {
 
     div.remove()
   })
+
+  test('should not call element methods on show or hide', function () {
+    var el = $('<div id="modal-test"></div>').get(0)
+
+    el.hide = function() { ok(false, 'element.hide method was called') }
+    el.show = function() { ok(false, 'element.show method was called') }
+
+    stop()
+    $.support.transition = false
+
+    $(el)
+      .on('shown.bs.modal', function () {
+        $(this).modal('hide')
+      })
+      .on('hidden.bs.modal', function () {
+        start()
+      })
+      .modal('show')
+    expect(0)
+  })
+
 })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -130,4 +130,18 @@ $(function () {
     ok(!$._data(popover[0], 'events').mouseover && !$._data(popover[0], 'events').mouseout, 'popover does not have any events')
   })
 
+  test('should not call element methods on show or hide', function () {
+    var popover = $('<a href="#" title="mdo" data-content="http://twitter.com/mdo">@mdo</a>').get(0)
+
+    popover.hide = function() { ok(false, 'element.hide method was called') }
+    popover.show = function() { ok(false, 'element.show method was called') }
+
+    $.support.transition = false
+    $(popover)
+      .appendTo('#qunit-fixture')
+      .popover('show')
+      .popover('hide')
+    expect(0)
+  })
+
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -428,5 +428,17 @@ $(function () {
 
     ttContainer.remove()
   })
+  
+  test('should not call element methods on show or hide', function () {
+    var tooltip = $('<div title="tooltip title"></div>').get(0)
+
+    tooltip.hide = function() { ok(false, 'element.hide method was called') }
+    tooltip.show = function() { ok(false, 'element.show method was called') }
+
+    $(tooltip)
+      .tooltip('show')
+      .tooltip('hide')
+    expect(0)
+  })
 
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -126,7 +126,7 @@
     var e = $.Event('show.bs.' + this.type)
 
     if (this.hasContent() && this.enabled) {
-      this.$element.trigger(e)
+      this.$element.triggerHandler(e)
 
       if (e.isDefaultPrevented()) return
       var that = this;
@@ -275,7 +275,7 @@
       that.$element.trigger('hidden.bs.' + that.type)
     }
 
-    this.$element.trigger(e)
+    this.$element.triggerHandler(e)
 
     if (e.isDefaultPrevented()) return
 


### PR DESCRIPTION
This is a revised pull request for #7547, with appropriate unit tests, for the current release.

This pull request prevents unintended behavior (specifically botched animations and disappearing DOM elements) when Bootstrap is combined with MooTools Element Shortcuts, or anything else that might directly add .hide() and .show() methods to elements.

I know cross-library compatibility is not a goal of the Bootstrap project, but this change should be side-effect free.
