### PR TITLE
Style .input-group-btn according to form validation state

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -871,7 +871,7 @@
     }
   }
   // Set validation states also for addons
-  .input-group-addon {
+  .input-group-addon, .input-group-btn button {
     color: @text-color;
     border-color: @border-color;
     background-color: @background-color;


### PR DESCRIPTION
Apply validation state styling to buttons contained within input groups, similarly to what is already done for addons within input groups.
