### PR TITLE
Defined and use variables for .panel-heading & .panel-footer padding

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -20,7 +20,7 @@
 
 // Optional heading
 .panel-heading {
-  padding: 10px 15px;
+  padding: @panel-heading-padding;
   border-bottom: 1px solid transparent;
   .border-top-radius((@panel-border-radius - 1));
 
@@ -43,7 +43,7 @@
 
 // Optional footer (stays gray in every modifier class)
 .panel-footer {
-  padding: 10px 15px;
+  padding: @panel-footer-padding;
   background-color: @panel-footer-bg;
   border-top: 1px solid @panel-inner-border;
   .border-bottom-radius((@panel-border-radius - 1));

--- a/less/variables.less
+++ b/less/variables.less
@@ -663,6 +663,8 @@
 
 @panel-bg:                    #fff;
 @panel-body-padding:          15px;
+@panel-heading-padding:       10px 15px;
+@panel-footer-padding:        @panel-heading-padding;
 @panel-border-radius:         @border-radius-base;
 
 //** Border color for elements within panels


### PR DESCRIPTION
Hej.

In my opinion .panel-heading's & .panel-footer's padding earn a variable in variables.less.
It came in very handy for a Bootstrap-based project of my own where I needed certain panel styles and was surprised the padding wasn't set by a var since I needed it.

So I thought I share it and you may agree.

Cheers,
