### PR TITLE
change translation docs in light of #11342 & its many dupes

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -772,5 +772,6 @@ if (isAndroid) {
     <li><a href="http://www.oneskyapp.com/docs/bootstrap/es">Bootstrap en Español (Spanish)</a></li>
     <li><a href="http://twbs.site-konstruktor.com.ua">Bootstrap ua Українською (Ukrainian)</a></li>
   </ul>
-  <p>Have another language to add, or perhaps a different or better translation? Let us know by <a href="https://github.com/twbs/bootstrap/issues/new">opening an issue</a>.</p>
+  <p><strong class="text-danger">We don't help organize or host translations, we just link to them.</strong></p>
+  <p>Finished a new or better translation? Open a pull request to add it to our list.</p>
 </div>


### PR DESCRIPTION
I propose changing the docs to try to cut down on the number of pointless "I want to translate Bootstrap into X" issues.
- Emphasize pull requests over issues.
- Emphasize that we don't organize or host translations.
- Emphasize finished translations.

Refs #11342.
