### PR TITLE
Removed unnecessary top margin from .modal-footer

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -98,7 +98,6 @@
 
 // Footer (for actions)
 .modal-footer {
-  margin-top: 15px;
   padding: (@modal-inner-padding - 1) @modal-inner-padding @modal-inner-padding;
   text-align: right; // right align buttons
   border-top: 1px solid @modal-footer-border-color;


### PR DESCRIPTION
The `.modal-footer` element has a top margin causing there to be extra white-space between the `.modal-body` and `.modal-footer` top border.  I believe this top margin is completely unnecessary as the padding from `.modal-body` provides the needed white-space.

![screenshot 2014-02-20 14 29 55](https://f.cloud.github.com/assets/53531/2223731/3dc5ff2a-9a76-11e3-9db5-fecba9adcc53.png)

For the record, the margin was added with commit 8ca70bd83a.
