### PR TITLE
Fix large button group with glyphicons

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -140,6 +140,12 @@
   border-width: 0 @caret-width-large @caret-width-large;
 }
 
+// Compatibility with glyphicons
+.btn-group > .btn-lg > .glyphicon, .btn-group-lg > .btn > .glyphicon {
+    line-height:0.9;
+    top:3px;
+}
+
 
 // Vertical button groups
 // ----------------------


### PR DESCRIPTION
When large buttons are used in button group then button with glyphicon inside is larger than should be.
See http://jsfiddle.net/D2RLR/4890/
