### PR TITLE
Remove second tbody from Supported browsers

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -450,8 +450,6 @@ bootstrap/
           <th scope="row"><code>transition</code></th>
           <td colspan="2" class="text-danger"><span class="glyphicon glyphicon-remove"></span> Not supported</td>
         </tr>
-      </tbody>
-      <tbody>
         <tr>
           <th scope="row"><code>placeholder</code></th>
           <td colspan="2" class="text-danger"><span class="glyphicon glyphicon-remove"></span> Not supported</td>


### PR DESCRIPTION
Removed the second tbody from "Internet Explorer 8 and 9" Table
