### PR TITLE
<code> have overflow on x-axis on small resolution

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -19,6 +19,10 @@ code {
   background-color: @code-bg;
   white-space: nowrap;
   border-radius: @border-radius-base;
+  
+  &.wrap {
+    white-space: pre-wrap;
+  }
 }
 
 // User input typically entered via keyboard

--- a/less/code.less
+++ b/less/code.less
@@ -19,10 +19,10 @@ code {
   background-color: @code-bg;
   white-space: nowrap;
   border-radius: @border-radius-base;
-  
-  &.wrap {
-    white-space: pre-wrap;
-  }
+}
+
+.code-wrap {
+  white-space: pre-wrap;
 }
 
 // User input typically entered via keyboard


### PR DESCRIPTION
Hi, I have PR for `<code>` wrap bug.
With small resolution I have overflow on x-axis (see screenshot or [check this page](http://theaqua.github.io/BrandButtons) (resize window, f.e.)) 

![Code wrap bug](https://f.cloud.github.com/assets/775692/2240554/66c4fe0a-9c9a-11e3-9eec-892c9bf28a9f.jpg)

I have 2 solutions:
- Add new class like `code.wrap` with `white-space: pre-wrap` (05e8abecc0d8979f8e79b231ad2274a15893d228)
- Or on small resolution made `white-space: pre-wrap` as default property (c3f76540b93d77c8e18a73d823d451611cc0ed99)
