### PR TITLE
td's vertical-align

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -26,7 +26,7 @@ th {
       > td {
         padding: @table-cell-padding;
         line-height: @line-height-base;
-        vertical-align: top;
+        vertical-align: middle;
         border-top: 1px solid @table-border-color;
       }
     }


### PR DESCRIPTION
Why `td` have `vertical-align: top`, not middle?
![td's vertical-align](https://f.cloud.github.com/assets/775692/2240603/c4e7a2be-9c9d-11e3-9899-984d8cf67d29.jpg)
