### PR TITLE
Exposed constructor functions

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -14,6 +14,16 @@
   // ======================
 
   var Affix = function (element, options) {
+    this.init(element, options)
+  }
+
+  Affix.RESET = 'affix affix-top affix-bottom'
+
+  Affix.DEFAULTS = {
+    offset: 0
+  }
+
+  Affix.prototype.init = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
     this.$window = $(window)
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
@@ -25,12 +35,6 @@
     this.pinnedOffset = null
 
     this.checkPosition()
-  }
-
-  Affix.RESET = 'affix affix-top affix-bottom'
-
-  Affix.DEFAULTS = {
-    offset: 0
   }
 
   Affix.prototype.getPinnedOffset = function () {

--- a/js/alert.js
+++ b/js/alert.js
@@ -14,7 +14,11 @@
   // ======================
 
   var dismiss = '[data-dismiss="alert"]'
-  var Alert   = function (el) {
+  var Alert = function (element, options) {
+    this.init(element, options)
+  }
+
+  Alert.prototype.init = function (el) {
     $(el).on('click', dismiss, this.close)
   }
 

--- a/js/button.js
+++ b/js/button.js
@@ -14,13 +14,17 @@
   // ==============================
 
   var Button = function (element, options) {
-    this.$element  = $(element)
-    this.options   = $.extend({}, Button.DEFAULTS, options)
-    this.isLoading = false
+    this.init(element, options)
   }
 
   Button.DEFAULTS = {
     loadingText: 'loading...'
+  }
+
+  Button.prototype.init = function (element, options) {
+    this.$element  = $(element)
+    this.options   = $.extend({}, Button.DEFAULTS, options)
+    this.isLoading = false
   }
 
   Button.prototype.setState = function (state) {

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -14,6 +14,16 @@
   // =========================
 
   var Carousel = function (element, options) {
+    this.init(element, options)
+  }
+
+  Carousel.DEFAULTS = {
+    interval: 5000,
+    pause: 'hover',
+    wrap: true
+  }
+
+  Carousel.prototype.init = function (element, options) {
     this.$element    = $(element)
     this.$indicators = this.$element.find('.carousel-indicators')
     this.options     = options
@@ -26,12 +36,6 @@
     this.options.pause == 'hover' && this.$element
       .on('mouseenter', $.proxy(this.pause, this))
       .on('mouseleave', $.proxy(this.cycle, this))
-  }
-
-  Carousel.DEFAULTS = {
-    interval: 5000,
-    pause: 'hover',
-    wrap: true
   }
 
   Carousel.prototype.cycle =  function (e) {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -14,16 +14,20 @@
   // ================================
 
   var Collapse = function (element, options) {
+    this.init(element, options)
+  }
+
+  Collapse.DEFAULTS = {
+    toggle: true
+  }
+
+  Collapse.prototype.init = function (element, options) {
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
     this.transitioning = null
 
     if (this.options.parent) this.$parent = $(this.options.parent)
     if (this.options.toggle) this.toggle()
-  }
-
-  Collapse.DEFAULTS = {
-    toggle: true
   }
 
   Collapse.prototype.dimension = function () {

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,7 +15,11 @@
 
   var backdrop = '.dropdown-backdrop'
   var toggle   = '[data-toggle=dropdown]'
-  var Dropdown = function (element) {
+  var Dropdown = function (element, options) {
+    this.init(element, options)
+  }
+
+  Dropdown.prototype.init = function (element) {
     $(element).on('click.bs.dropdown', this.toggle)
   }
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -14,6 +14,16 @@
   // ======================
 
   var Modal = function (element, options) {
+    this.init(element, options)
+  }
+
+  Modal.DEFAULTS = {
+    backdrop: true,
+    keyboard: true,
+    show: true
+  }
+
+  Modal.prototype.init = function (element, options) {
     this.options   = options
     this.$element  = $(element)
     this.$backdrop =
@@ -26,12 +36,6 @@
           this.$element.trigger('loaded.bs.modal')
         }, this))
     }
-  }
-
-  Modal.DEFAULTS = {
-    backdrop: true,
-    keyboard: true,
-    show: true
   }
 
   Modal.prototype.toggle = function (_relatedTarget) {

--- a/js/popover.js
+++ b/js/popover.js
@@ -14,7 +14,7 @@
   // ===============================
 
   var Popover = function (element, options) {
-    this.init('popover', element, options)
+    this.init(element, options)
   }
 
   if (!$.fn.tooltip) throw new Error('Popover requires tooltip.js')
@@ -31,6 +31,8 @@
   // ================================
 
   Popover.prototype = $.extend({}, $.fn.tooltip.Constructor.prototype)
+
+  Popover.prototype.type = 'popover'
 
   Popover.prototype.constructor = Popover
 

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -13,7 +13,15 @@
   // SCROLLSPY CLASS DEFINITION
   // ==========================
 
-  function ScrollSpy(element, options) {
+  var ScrollSpy = function (element, options) {
+    this.init(element, options)
+  }
+
+  ScrollSpy.DEFAULTS = {
+    offset: 10
+  }
+
+  ScrollSpy.prototype.init = function (element, options) {
     var href
     var process  = $.proxy(this.process, this)
 
@@ -30,10 +38,6 @@
 
     this.refresh()
     this.process()
-  }
-
-  ScrollSpy.DEFAULTS = {
-    offset: 10
   }
 
   ScrollSpy.prototype.refresh = function () {

--- a/js/tab.js
+++ b/js/tab.js
@@ -13,7 +13,11 @@
   // TAB CLASS DEFINITION
   // ====================
 
-  var Tab = function (element) {
+  var Tab = function (element, options) {
+    this.init(element, options)
+  }
+
+  Tab.prototype.init = function (element) {
     this.element = $(element)
   }
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -15,14 +15,7 @@
   // ===============================
 
   var Tooltip = function (element, options) {
-    this.type       =
-    this.options    =
-    this.enabled    =
-    this.timeout    =
-    this.hoverState =
-    this.$element   = null
-
-    this.init('tooltip', element, options)
+    this.init(element, options)
   }
 
   Tooltip.DEFAULTS = {
@@ -37,9 +30,12 @@
     container: false
   }
 
-  Tooltip.prototype.init = function (type, element, options) {
+  Tooltip.prototype.type = 'tooltip'
+
+  Tooltip.prototype.init = function (element, options) {
+    this.timeout    =
+    this.hoverState = null
     this.enabled  = true
-    this.type     = type
     this.$element = $(element)
     this.options  = this.getOptions(options)
 


### PR DESCRIPTION
This PR refactors the content of constructor functions into init functions on the prototype of constructors, following #12833. 

This PR may not be accepted as-is, because it contains a change to the Tooltip/Popover API, leaving out the first string argument for type. I expect to roll that back to avoid backward-incompatible changes, but I wanted to first demonstrate a consistent init() API.
