### PR TITLE
Switch to JSCS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,9 @@ module.exports = function (grunt) {
         config: 'js/.jscsrc'
       },
       grunt: {
+        options: {
+          'requireParenthesesAroundIIFE': true
+        },
         src: ['Gruntfile.js', 'grunt/*.js']
       },
       src: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,16 +68,16 @@ module.exports = function (grunt) {
         options: {
           'requireParenthesesAroundIIFE': true
         },
-        src: ['Gruntfile.js', 'grunt/*.js']
+        src: '<%= jshint.grunt.src %>'
       },
       src: {
-        src: 'js/*.js'
+        src: '<%= jshint.src.src %>'
       },
       test: {
-        src: 'js/tests/unit/*.js'
+        src: '<%= jshint.test.src %>'
       },
       assets: {
-        src: ['docs/assets/js/application.js', 'docs/assets/js/customizer.js']
+        src: '<%= jshint.assets.src %>'
       }
     },
 

--- a/docs/assets/js/customizer.js
+++ b/docs/assets/js/customizer.js
@@ -72,9 +72,9 @@ window.onload = function () { // wait for load in a dumb way because B-0
     var vars = {}
 
     $('#less-variables-section input')
-        .each(function () {
-          $(this).val() && (vars[$(this).prev().text()] = $(this).val())
-        })
+      .each(function () {
+        $(this).val() && (vars[$(this).prev().text()] = $(this).val())
+      })
 
     var data = {
       vars: vars,
@@ -238,9 +238,9 @@ window.onload = function () { // wait for load in a dumb way because B-0
     var vars = {}
 
     $('#less-variables-section input')
-        .each(function () {
-          $(this).val() && (vars[$(this).prev().text()] = $(this).val())
-        })
+      .each(function () {
+        $(this).val() && (vars[$(this).prev().text()] = $(this).val())
+      })
 
     var bsLessSource    = generateLESS('bootstrap.less', lessFileIncludes, vars)
     var themeLessSource = generateLESS('theme.less',     lessFileIncludes, vars)

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -1,10 +1,10 @@
 {
-  "curly"    : true,
-  "eqeqeq"   : true,
-  "newcap"   : true,
-  "noarg"    : true,
-  "node"     : true,
-  "nonbsp"   : true,
-  "strict"   : true,
-  "undef"    : true
+  "curly" : true,
+  "eqeqeq": true,
+  "newcap": true,
+  "noarg" : true,
+  "node"  : true,
+  "nonbsp": true,
+  "strict": true,
+  "undef" : true
 }

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "camelcase": true,
   "curly"    : true,
   "eqeqeq"   : true,
   "immed"    : true,

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -1,15 +1,14 @@
 {
   "camelcase": true,
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "indent": 2,
-  "newcap": true,
-  "noarg": true,
-  "node": true,
-  "nonbsp": true,
-  "quotmark": "single",
-  "strict": true,
-  "trailing": true,
-  "undef": true
+  "curly"    : true,
+  "eqeqeq"   : true,
+  "immed"    : true,
+  "newcap"   : true,
+  "noarg"    : true,
+  "node"     : true,
+  "nonbsp"   : true,
+  "quotmark" : "single",
+  "strict"   : true,
+  "trailing" : true,
+  "undef"    : true
 }

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -1,7 +1,6 @@
 {
   "curly"    : true,
   "eqeqeq"   : true,
-  "immed"    : true,
   "newcap"   : true,
   "noarg"    : true,
   "node"     : true,

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -7,7 +7,6 @@
   "noarg"    : true,
   "node"     : true,
   "nonbsp"   : true,
-  "quotmark" : "single",
   "strict"   : true,
   "trailing" : true,
   "undef"    : true

--- a/grunt/.jshintrc
+++ b/grunt/.jshintrc
@@ -7,6 +7,5 @@
   "node"     : true,
   "nonbsp"   : true,
   "strict"   : true,
-  "trailing" : true,
   "undef"    : true
 }

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -7,6 +7,7 @@
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "disallowTrailingWhitespace": true,
   "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireLeftStickedOperators": [","],
   "requireLineFeedAtFileEnd": true,

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -7,6 +7,7 @@
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireLeftStickedOperators": [","],
   "requireLineFeedAtFileEnd": true,
   "requireRightStickedOperators": ["!"],

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -12,5 +12,6 @@
   "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
   "requireSpacesInFunctionExpression": { "beforeOpeningCurlyBrace": true },
   "validateIndentation": 2,
-  "validateLineBreaks": "LF"
+  "validateLineBreaks": "LF",
+  "validateQuoteMarks": "'"
 }

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -1,6 +1,9 @@
 {
+  "disallowEmptyBlocks": true,
   "disallowKeywords": ["with"],
   "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+  "disallowMixedSpacesAndTabs": true,
+  "disallowMultipleLineStrings": true,
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -1,15 +1,16 @@
 {
   "disallowKeywords": ["with"],
-  "requireLeftStickedOperators": [","],
   "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "requireLeftStickedOperators": [","],
   "requireLineFeedAtFileEnd": true,
   "requireRightStickedOperators": ["!"],
   "requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
   "requireSpacesInFunctionExpression": { "beforeOpeningCurlyBrace": true },
+  "validateIndentation": 2,
   "validateLineBreaks": "LF"
 }

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -7,7 +7,6 @@
   "eqeqeq"   : false,
   "eqnull"   : true,
   "expr"     : true,
-  "indent"   : 2,
   "laxbreak" : true,
   "quotmark" : "single",
   "validthis": true

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -8,6 +8,5 @@
   "eqnull"   : true,
   "expr"     : true,
   "laxbreak" : true,
-  "quotmark" : "single",
   "validthis": true
 }

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -273,8 +273,7 @@ $(function () {
   test('should show tooltip with delegate selector on click', function () {
     var div = $('<div><a href="#" rel="tooltip" title="Another tooltip"></a></div>')
     var tooltip = div.appendTo('#qunit-fixture')
-                     .tooltip({ selector: 'a[rel=tooltip]',
-                                trigger: 'click' })
+                     .tooltip({ selector: 'a[rel=tooltip]', trigger: 'click' })
     div.find('a').trigger('click')
     ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
   })
@@ -392,21 +391,21 @@ $(function () {
   test('tooltips should be placed dynamically, with the dynamic placement option', function () {
     $.support.transition = false
     var ttContainer = $('<div id="dynamic-tt-test"/>').css({
-        'height' : 400,
-        'overflow' : 'hidden',
-        'position' : 'absolute',
-        'top' : 0,
-        'left' : 0,
-        'width' : 600
-      })
-      .appendTo('body')
+      'height' : 400,
+      'overflow' : 'hidden',
+      'position' : 'absolute',
+      'top' : 0,
+      'left' : 0,
+      'width' : 600
+    })
+    .appendTo('body')
 
     var topTooltip = $('<div style="display: inline-block; position: absolute; left: 0; top: 0;" rel="tooltip" title="Top tooltip">Top Dynamic Tooltip</div>')
       .appendTo('#dynamic-tt-test')
       .tooltip({placement: 'auto'})
       .tooltip('show')
 
-    ok($('.tooltip').is('.bottom'),  'top positioned tooltip is dynamically positioned bottom')
+    ok($('.tooltip').is('.bottom'), 'top positioned tooltip is dynamically positioned bottom')
 
     topTooltip.tooltip('hide')
 
@@ -415,7 +414,7 @@ $(function () {
       .tooltip({placement: 'right auto'})
       .tooltip('show')
 
-    ok($('.tooltip').is('.left'),  'right positioned tooltip is dynamically positioned left')
+    ok($('.tooltip').is('.left'), 'right positioned tooltip is dynamically positioned left')
     rightTooltip.tooltip('hide')
 
     var leftTooltip = $('<div style="display: inline-block; position: absolute; left: 0;" rel="tooltip" title="Left tooltip">Left Dynamic Tooltip</div>')
@@ -423,7 +422,7 @@ $(function () {
       .tooltip({placement: 'auto left'})
       .tooltip('show')
 
-    ok($('.tooltip').is('.right'),  'left positioned tooltip is dynamically positioned right')
+    ok($('.tooltip').is('.right'), 'left positioned tooltip is dynamically positioned right')
     leftTooltip.tooltip('hide')
 
     ttContainer.remove()


### PR DESCRIPTION
Since JSHint plans to remove the style changes come v3, or move them to plugins, and we already use JSCS, I guess it makes sense to use that for the current checks.

Thanks to @mikesherov for working on fixing the issues we had upstream!

/CC @cvrebert @mdo

TODO:
- [x] Move `camelcase` to JSCS `requireCamelCaseOrUpperCaseIdentifiers`
- [x] Move `trailing` to JSCS `disallowTrailingWhitespace`
- [x] Move `laxbreak` to JSCS `"requireOperatorBeforeLineBreak": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],`
- [x] Move `immed` to JSCS `requireParenthesesAroundIIFE`
