### PR TITLE
Fix for issue #12854 on push and pull resets

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -827,14 +827,24 @@
     width: percentage((@index / @grid-columns));
   }
 }
-.calc-grid-column(@index, @class, @type) when (@type = push) {
+.calc-grid-column(@index, @class, @type) when (@type = push) and (@index > 0) {
   .col-@{class}-push-@{index} {
     left: percentage((@index / @grid-columns));
   }
 }
-.calc-grid-column(@index, @class, @type) when (@type = pull) {
+.calc-grid-column(@index, @class, @type) when (@type = push) and (@index = 0) {
+  .col-@{class}-push-0 {
+    left: auto;
+  }
+}
+.calc-grid-column(@index, @class, @type) when (@type = pull) and (@index > 0) {
   .col-@{class}-pull-@{index} {
     right: percentage((@index / @grid-columns));
+  }
+}
+.calc-grid-column(@index, @class, @type) when (@type = pull) and (@index = 0) {
+  .col-@{class}-pull-0 {
+    right: auto;
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = offset) {


### PR DESCRIPTION
The col-_-push-0 and col-_-pull-0 classes try to reset the positioning using 0% but this prevents the opposite direction positioning to freeze and not being set correctly.
To fix that, these must set the position to auto instead of 0% with means left:auto and right:auto instead of left:0% and right:0%.
