### PR TITLE
Subdivide xs range into xs-A and xs-B, to introduce a fully BC 480px break point.

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -55,6 +55,12 @@
 
 .make-grid(xs);
 
+// Smaller grid
+// See https://github.com/twbs/bootstrap/issues/10203
+
+@media (min-width: @screen-xs-B-min) {
+  .make-grid(xs-B);
+}
 
 // Small grid
 //

--- a/less/variables.less
+++ b/less/variables.less
@@ -258,9 +258,15 @@
 
 // Extra small screen / phone
 // Note: Deprecated @screen-xs and @screen-phone as of v3.0.1
+// Note: xs does not really have a min-width, or the min-width would be 0.
+// The variable of 480px is bogus in this context.
 @screen-xs:                  480px;
 @screen-xs-min:              @screen-xs;
 @screen-phone:               @screen-xs-min;
+
+// Subdivision of the xs range into xs-A and xs-B.
+@screen-xs-A-min:            0px;
+@screen-xs-B-min:            480px;
 
 // Small screen / tablet
 // Note: Deprecated @screen-sm and @screen-tablet as of v3.0.1
@@ -284,6 +290,10 @@
 @screen-xs-max:              (@screen-sm-min - 1);
 @screen-sm-max:              (@screen-md-min - 1);
 @screen-md-max:              (@screen-lg-min - 1);
+
+// Maximum width for subdivisions
+@screen-xs-A-max:            (@screen-xs-B-min - 1);
+@screen-xs-B-max:            @screen-xs-max;
 
 
 //== Grid system


### PR DESCRIPTION
See https://github.com/twbs/bootstrap/issues/10203#issuecomment-36443874
An additional breakpoint at 480px has been requested heavily, but there have been concerns about BC, especially regarding features that regard those ranges as min-max intervals instead of open-end intervals.

Instead of redefining existing ranges, this PR introduces subdivisions of the old ranges:
- xs = 0..767 or 0..\* (no change)
- xs-A = 0..479 or 0..*
- xs-B = 480..767 or 480..*
- sm = 768..991 or 768..\* (no change)
- md = 992..1199 or 992..\* (no change)
- lg = 1200..\* (no change)

E.g. you can now write

```
<div class="row">
  <div class="col-xs-B-6 col-sm-4 col-md-3">..</div>
  ..
```

with the following effect:
- 0..479px: 1 column
- 480px..767px: 2 columns
- 768px..991px: 3 columns
- 992px..*: 4 columns
