### PR TITLE
Removed margin-bottom from last p of .blog-footer

### DIFF
--- a/docs/examples/blog/blog.css
+++ b/docs/examples/blog/blog.css
@@ -161,3 +161,6 @@ h6, .h6 {
   background-color: #f9f9f9;
   border-top: 1px solid #e5e5e5;
 }
+.blog-footer p:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
With this fix the contents of the footer are aligned exactly in the middle instead of having extra bottom space. Here are the screenshots before and after..

![screen shot 2014-03-02 at 11 09 39](https://f.cloud.github.com/assets/125676/2303919/28ad5280-a1f3-11e3-950c-26e3c0bd2e0b.png)
