### PR TITLE
Fix for stray 1px line under top navigation in Dashboard example

### DIFF
--- a/docs/examples/dashboard/dashboard.css
+++ b/docs/examples/dashboard/dashboard.css
@@ -17,6 +17,13 @@ body {
   border-bottom: 1px solid #eee;
 }
 
+/*
+ * Top navigation
+ * Hide default border to remove 1px line.
+ */
+.navbar-fixed-top {
+  border:0;
+}
 
 /*
  * Sidebar


### PR DESCRIPTION
If you add an "active" class to one of the `<li>` elements in the top navigation, and style it so that active tabs have a different color, it becomes clear that there is a 1 pixel stray line under the navigation. This style fixes that.
