### PR TITLE
Update dont' working csscomb properties

### DIFF
--- a/less/.csscomb.json
+++ b/less/.csscomb.json
@@ -1,7 +1,7 @@
 {
   "always-semicolon": true,
   "block-indent": 2,
-  "colon-space": true,
+  "colon-space": [0, 1],
   "color-case": "lower",
   "color-shorthand": true,
   "combinator-space": true,
@@ -10,7 +10,7 @@
   "leading-zero": false,
   "remove-empty-rulesets": true,
   "rule-indent": 2,
-  "stick-brace": true,
+  "stick-brace": " ",
   "strip-spaces": true,
   "unitless-zero": true,
   "vendor-prefix-align": true,


### PR DESCRIPTION
The two values don't work, see:
https://github.com/csscomb/csscomb.js/blob/v2.0.4/doc/options.md#colon-space
https://github.com/csscomb/csscomb.js/blob/v2.0.4/doc/options.md#stick-brace

Replace with this, like suggest Mark Otto http://mdo.github.io/code-guide/#css-syntax
