### PR TITLE
.transition-timing-function() Mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -140,6 +140,10 @@
   -webkit-transition-duration: @transition-duration;
           transition-duration: @transition-duration;
 }
+.transition-timing-function(@timing-function) {
+  -webkit-animation-timing-function: @timing-function;
+          animation-timing-function: @timing-function;
+}
 .transition-transform(@transition) {
   -webkit-transition: -webkit-transform @transition;
      -moz-transition: -moz-transform @transition;


### PR DESCRIPTION
added `.transition-timing-function(@timing-function)` mixin, defaults to `@timing-function`.

useful for customizing CSS transitions.

reference: [transition-timing-function on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function)
