### PR TITLE
re-enable requireCamelCaseOrUpperCaseIdentifiers in JSCS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,7 @@ module.exports = function (grunt) {
       },
       grunt: {
         options: {
+          'requireCamelCaseOrUpperCaseIdentifiers': null,
           'requireParenthesesAroundIIFE': true
         },
         src: '<%= jshint.grunt.src %>'

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -8,6 +8,7 @@
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
   "disallowTrailingWhitespace": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireLeftStickedOperators": [","],
   "requireLineFeedAtFileEnd": true,
   "requireRightStickedOperators": ["!"],


### PR DESCRIPTION
And use `null` override to disable it for just the Gruntfile.
Refs #12949.
