### PR TITLE
Fix transition-timing-function mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -152,8 +152,8 @@
 
 // Deprecated as of v3.2.0 due to the introduction of autoprefixer (will be removed in v4)
 .transition-timing-function(@timing-function) {
-  -webkit-animation-timing-function: @timing-function;
-          animation-timing-function: @timing-function;
+  -webkit-transition-timing-function: @timing-function;
+          transition-timing-function: @timing-function;
 }
 
 // Deprecated as of v3.2.0 due to the introduction of autoprefixer (will be removed in v4)


### PR DESCRIPTION
The mixin introduced in #12924 contains a bug I think.

While it is supposed to set the transition-timing-function attribute it's actually setting the animation-timing-function attribute.

This fixes that.
