### PR TITLE
Clean more with Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
 
     // Task configuration.
     clean: {
-      dist: ['dist', 'docs/dist']
+      dist: ['dist', 'docs/dist', 'docs/assets/js/docs.min.js', 'docs/assets/js/raw-files.min.js', 'docs/assets/js/customize.min.js']
     },
 
     jshint: {


### PR DESCRIPTION
Sometimes I get conflicts in the generated files we use (mainly `raw-files.min.js`) and Grunt fails for me. This solves that for the `grunt` task, but `grunt dist` then simply ends up with a deleted `raw-files.min.js` since that's not part of the `dist` task.

Any help in separating this would be awesome—I'm fried at the moment.

<3
