### PR TITLE
Wrong property set in .transition-timing-function() mixin

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -141,8 +141,8 @@
           transition-duration: @transition-duration;
 }
 .transition-timing-function(@timing-function) {
-  -webkit-animation-timing-function: @timing-function;
-          animation-timing-function: @timing-function;
+  -webkit-transition-timing-function: @timing-function;
+          transition-timing-function: @timing-function;
 }
 .transition-transform(@transition) {
   -webkit-transition: -webkit-transform @transition;


### PR DESCRIPTION
my last PR #12924 introducing `.transition-timing-function()` mixin was setting the wrong CSS property.
