### PR TITLE
Improve badges mixinability

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -3,7 +3,7 @@
 // --------------------------------------------------
 
 
-// Base classes
+// Base class
 .badge {
   display: inline-block;
   min-width: 10px;
@@ -32,24 +32,24 @@
     top: 0;
     padding: 1px 5px;
   }
-}
 
-// Hover state, but only for links
-a.badge {
-  &:hover,
-  &:focus {
-    color: @badge-link-hover-color;
-    text-decoration: none;
-    cursor: pointer;
+  // Hover state, but only for links
+  a& {
+    &:hover,
+    &:focus {
+      color: @badge-link-hover-color;
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
-}
 
-// Account for counters in navs
-a.list-group-item.active > .badge,
-.nav-pills > .active > a > .badge {
-  color: @badge-active-color;
-  background-color: @badge-active-bg;
-}
-.nav-pills > li > a > .badge {
-  margin-left: 3px;
+  // Account for badges in navs
+  a.list-group-item.active > &,
+  .nav-pills > .active > a > & {
+    color: @badge-active-color;
+    background-color: @badge-active-bg;
+  }
+  .nav-pills > li > a > & {
+    margin-left: 3px;
+  }
 }

--- a/less/labels.less
+++ b/less/labels.less
@@ -15,7 +15,7 @@
   border-radius: .25em;
 
   // Add hover effects, but only for links
-  &[href] {
+  a& {
     &:hover,
     &:focus {
       color: @label-link-hover-color;


### PR DESCRIPTION
This improves badges mixinability. Currently, I can't just do `.count { .badge() }`, but it can be simply fixed. This change was pulled off but I'm sending a new pull request with arguments.

If some changes should be reverted, tell me.

/cc @mdo
