### PR TITLE
Disregarding tooltip's hover state on hide when trigger mode is 'manual'.

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -271,7 +271,9 @@
     var e    = $.Event('hide.bs.' + this.type)
 
     function complete() {
-      if (that.hoverState != 'in') $tip.detach()
+      if (that.hoverState != 'in' || that.options.trigger == 'manual') { 
+        $tip.detach()
+      }
       that.$element.trigger('hidden.bs.' + that.type)
     }
 


### PR DESCRIPTION
I have an instance of a popover on a project which I'm triggering manually. The popover has a 'cancel' button on it, which is intended to close the popover. However, the hoverState is set to 'in' when clicking on the cancel button since it's on the popover itself, and the detach method isn't getting called. Given that the trigger mode is manual, I think it's reasonable not to put any restrictions on hiding the popover, even if it's being hovered over.
