### PR TITLE
Don't ignore every dot file in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "dist/fonts/glyphicons-halflings-regular.woff"
   ],
   "ignore": [
-    "**/.*",
+    ".*",
     "_config.yml",
     "CNAME",
     "composer.json",


### PR DESCRIPTION
Fixes #12929.

Adjusts what to ignore so that `.csscomb.json` and more come down with a Bower install.
