### PR TITLE
Use `outline: 0` consistently

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -20,7 +20,7 @@
     }
     &:focus {
       // Remove focus outline when dropdown JS adds it after closing the menu
-      outline: none;
+      outline: 0;
     }
   }
 }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -91,7 +91,7 @@
   // Hover/focus state
   &:hover,
   &:focus {
-    outline: none;
+    outline: 0;
     color: @carousel-control-color;
     text-decoration: none;
     .opacity(.9);

--- a/less/modals.less
+++ b/less/modals.less
@@ -54,7 +54,7 @@
   .box-shadow(0 3px 9px rgba(0,0,0,.5));
   background-clip: padding-box;
   // Remove focus outline from opened modal
-  outline: none;
+  outline: 0;
 }
 
 // Modal background

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -200,7 +200,7 @@
   // We remove the `outline` here, but later compensate by attaching `:hover`
   // styles to `:focus`.
   &:focus {
-    outline: none;
+    outline: 0;
   }
 
   // Bars


### PR DESCRIPTION
As we're using `border: 0`, I think that we should use `outline: 0`. I can make the opposite change — use `outline: none` consistently.
