### PR TITLE
Fixed typo at docs/examples/rtl/index.php

### DIFF
--- a/docs/examples/rtl/index.html
+++ b/docs/examples/rtl/index.html
@@ -11,7 +11,7 @@
     <title>RTL Template for Bootstrap</title>
 
     <!-- Bootstrap RTL CSS -->
-    <link href="../../dist/css/bootstrap.rtl.min.css" rel="stylesheet">
+    <link href="../../dist/css/bootstrap-rtl.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
     <link href="rtl.css" rel="stylesheet">


### PR DESCRIPTION
The file generated at dist/css/ called 'bootstrap-rtl.min.css'.
