### PR TITLE
Fix missing 1px below list-groups

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -11,6 +11,8 @@
   // No need to set list-style: none; since .list-group-item is block level
   margin-bottom: 20px;
   padding-left: 0; // reset padding because ul and ol
+  // Compensate .list-group-items margin-bottom of -1px
+  padding-bottom: 1px;
 }
 
 


### PR DESCRIPTION
One pixel was missing below list-groups. This was especially a problem when overflow: auto/scroll; is applied to the list, as a scrollbar will always be shown. That's because of the .list-group-items' nature of stacking via margin-bottom: -1px;
