### PR TITLE
add a data attribute for retrieving the parent element of a dropdown

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -95,6 +95,7 @@
   }
 
   function getParent($this) {
+    if($this.attr('data-parent')) return $($this.attr('data-parent'));
     var selector = $this.attr('data-target')
 
     if (!selector) {


### PR DESCRIPTION
Maybe there was another way I could have done this, but I was having trouble getting scrollspy, and a dropdown in my primary nav to use their data-target options.

So I added a data-parent option to the dropdown, the simplest solution I could come up with.
