### PR TITLE
WebKit CSS3 carousel transforms for supported devices

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -5776,6 +5776,47 @@ button.close {
     bottom: 20px;
   }
 }
+@media all and (-webkit-transform-3d) {
+  .carousel .item {
+    -webkit-transition: -webkit-transform .6s ease-in-out;
+         -o-transition:      -o-transform .6s ease-in-out;
+            transition:         transform .6s ease-in-out;
+
+    -webkit-backface-visibility: hidden;
+        -ms-backface-visibility: hidden;
+         -o-backface-visibility: hidden;
+            backface-visibility: hidden;
+    -webkit-perspective: 1000;
+        -ms-perspective: 1000;
+         -o-perspective: 1000;
+            perspective: 1000;
+  }
+  .carousel .item.next,
+  .carousel .item.active.right {
+    left: 0;
+    -webkit-transform: translate3d(100%, 0, 0);
+        -ms-transform: translate3d(100%, 0, 0);
+         -o-transform: translate3d(100%, 0, 0);
+            transform: translate3d(100%, 0, 0);
+  }
+  .carousel .item.prev,
+  .carousel .item.active.left {
+    left: 0;
+    -webkit-transform: translate3d(-100%, 0, 0);
+        -ms-transform: translate3d(-100%, 0, 0);
+         -o-transform: translate3d(-100%, 0, 0);
+            transform: translate3d(-100%, 0, 0);
+  }
+  .carousel .item.next.left,
+  .carousel .item.prev.right,
+  .carousel .item.active {
+    left: 0;
+    -webkit-transform: translate3d(0%, 0, 0);
+        -ms-transform: translate3d(0%, 0, 0);
+         -o-transform: translate3d(0%, 0, 0);
+            transform: translate3d(0%, 0, 0);
+  }
+}
 .clearfix:before,
 .clearfix:after,
 .dl-horizontal dd:before,

--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -5610,6 +5610,47 @@ button.close {
 .carousel-inner > .item > a > img {
   line-height: 1;
 }
+@media all and (-webkit-transform-3d) {
+  .carousel-inner > .item {
+    -webkit-transition: -webkit-transform .6s ease-in-out;
+         -o-transition:      -o-transform .6s ease-in-out;
+            transition:         transform .6s ease-in-out;
+
+    -webkit-backface-visibility: hidden;
+        -ms-backface-visibility: hidden;
+         -o-backface-visibility: hidden;
+            backface-visibility: hidden;
+    -webkit-perspective: 1000;
+        -ms-perspective: 1000;
+         -o-perspective: 1000;
+            perspective: 1000;
+  }
+  .carousel-inner > .item.next,
+  .carousel-inner > .item.active.right {
+    left: 0;
+    -webkit-transform: translate3d(100%, 0, 0);
+        -ms-transform: translate3d(100%, 0, 0);
+         -o-transform: translate3d(100%, 0, 0);
+            transform: translate3d(100%, 0, 0);
+  }
+  .carousel-inner > .item.prev,
+  .carousel-inner > .item.active.left {
+    left: 0;
+    -webkit-transform: translate3d(-100%, 0, 0);
+        -ms-transform: translate3d(-100%, 0, 0);
+         -o-transform: translate3d(-100%, 0, 0);
+            transform: translate3d(-100%, 0, 0);
+  }
+  .carousel-inner > .item.next.left,
+  .carousel-inner > .item.prev.right,
+  .carousel-inner > .item.active {
+    left: 0;
+    -webkit-transform: translate3d(0, 0, 0);
+        -ms-transform: translate3d(0, 0, 0);
+         -o-transform: translate3d(0, 0, 0);
+            transform: translate3d(0, 0, 0);
+  }
+}
 .carousel-inner > .active,
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -5774,47 +5815,6 @@ button.close {
   }
   .carousel-indicators {
     bottom: 20px;
-  }
-}
-@media all and (-webkit-transform-3d) {
-  .carousel .item {
-    -webkit-transition: -webkit-transform .6s ease-in-out;
-         -o-transition:      -o-transform .6s ease-in-out;
-            transition:         transform .6s ease-in-out;
-
-    -webkit-backface-visibility: hidden;
-        -ms-backface-visibility: hidden;
-         -o-backface-visibility: hidden;
-            backface-visibility: hidden;
-    -webkit-perspective: 1000;
-        -ms-perspective: 1000;
-         -o-perspective: 1000;
-            perspective: 1000;
-  }
-  .carousel .item.next,
-  .carousel .item.active.right {
-    left: 0;
-    -webkit-transform: translate3d(100%, 0, 0);
-        -ms-transform: translate3d(100%, 0, 0);
-         -o-transform: translate3d(100%, 0, 0);
-            transform: translate3d(100%, 0, 0);
-  }
-  .carousel .item.prev,
-  .carousel .item.active.left {
-    left: 0;
-    -webkit-transform: translate3d(-100%, 0, 0);
-        -ms-transform: translate3d(-100%, 0, 0);
-         -o-transform: translate3d(-100%, 0, 0);
-            transform: translate3d(-100%, 0, 0);
-  }
-  .carousel .item.next.left,
-  .carousel .item.prev.right,
-  .carousel .item.active {
-    left: 0;
-    -webkit-transform: translate3d(0, 0, 0);
-        -ms-transform: translate3d(0, 0, 0);
-         -o-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
   }
 }
 .clearfix:before,

--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -5811,10 +5811,10 @@ button.close {
   .carousel .item.prev.right,
   .carousel .item.active {
     left: 0;
-    -webkit-transform: translate3d(0%, 0, 0);
-        -ms-transform: translate3d(0%, 0, 0);
-         -o-transform: translate3d(0%, 0, 0);
-            transform: translate3d(0%, 0, 0);
+    -webkit-transform: translate3d(0, 0, 0);
+        -ms-transform: translate3d(0, 0, 0);
+         -o-transform: translate3d(0, 0, 0);
+            transform: translate3d(0, 0, 0);
   }
 }
 .clearfix:before,

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -247,7 +247,7 @@
         left: 0;
       }
       &.next.left, &.prev.right, &.active {
-        .translate3d(0%, 0, 0);
+        .translate3d(0, 0, 0);
         left: 0;
       }
     }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -30,15 +30,20 @@
       .transition-transform(~'0.6s ease-in-out');
       .backface-visibility(~'hidden');
       .perspective(1000);
-      &.next, &.active.right {
+      
+      &.next,
+      &.active.right {
         .translate3d(100%, 0, 0);
         left: 0;
       }
-      &.prev, &.active.left {
+      &.prev,
+      &.active.left {
         .translate3d(-100%, 0, 0);
         left: 0;
       }
-      &.next.left, &.prev.right, &.active {
+      &.next.left,
+      &.prev.right,
+      &.active {
         .translate3d(0, 0, 0);
         left: 0;
       }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -26,7 +26,7 @@
     }
 
     // WebKit CSS3 transforms for supported devices
-    @media all and (-webkit-transform-3d) {
+    @media all and (transform-3d), (-webkit-transform-3d) {
       .transition-transform(~'0.6s ease-in-out');
       .backface-visibility(~'hidden');
       .perspective(1000);

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -24,6 +24,25 @@
       &:extend(.img-responsive);
       line-height: 1;
     }
+
+    // WebKit CSS3 transforms for supported devices
+    @media all and (-webkit-transform-3d) {
+      .transition-transform(~'0.6s ease-in-out');
+      .backface-visibility(~'hidden');
+      .perspective(1000);
+      &.next, &.active.right {
+        .translate3d(100%, 0, 0);
+        left: 0;
+      }
+      &.prev, &.active.left {
+        .translate3d(-100%, 0, 0);
+        left: 0;
+      }
+      &.next.left, &.prev.right, &.active {
+        .translate3d(0, 0, 0);
+        left: 0;
+      }
+    }
   }
 
   > .active,
@@ -228,28 +247,5 @@
   // Move up the indicators
   .carousel-indicators {
     bottom: 20px;
-  }
-}
-
-// WebKit CSS3 transforms for supported devices
-@media all and (-webkit-transform-3d) {
-  .carousel {
-    .item {
-      .transition-transform(~'0.6s ease-in-out');
-      .backface-visibility(~'hidden');
-      .perspective(1000);
-      &.next, &.active.right {
-        .translate3d(100%, 0, 0);
-        left: 0;
-      }
-      &.prev, &.active.left {
-        .translate3d(-100%, 0, 0);
-        left: 0;
-      }
-      &.next.left, &.prev.right, &.active {
-        .translate3d(0, 0, 0);
-        left: 0;
-      }
-    }
   }
 }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -235,19 +235,19 @@
 @media all and (-webkit-transform-3d) {
   .carousel {
     .item {
-      -webkit-transition: 0.6s -webkit-transform ease-in-out;
-      -webkit-backface-visibility: hidden;
-      -webkit-perspective: 1000;
+      .transition-transform(~'0.6s ease-in-out');
+      .backface-visibility(~'hidden');
+      .perspective(1000);
       &.next, &.active.right {
-        -webkit-transform: translate3d(100%,0,0);
+        .translate3d(100%, 0, 0);
         left: 0;
       }
       &.prev, &.active.left {
-        -webkit-transform: translate3d(-100%,0,0);
+        .translate3d(-100%, 0, 0);
         left: 0;
       }
       &.next.left, &.prev.right, &.active {
-        -webkit-transform: translate3d(0%,0,0);
+        .translate3d(0%, 0, 0);
         left: 0;
       }
     }

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -230,3 +230,26 @@
     bottom: 20px;
   }
 }
+
+// WebKit CSS3 transforms for supported devices
+@media all and (-webkit-transform-3d) {
+  .carousel {
+    .item {
+      -webkit-transition: 0.6s -webkit-transform ease-in-out;
+      -webkit-backface-visibility: hidden;
+      -webkit-perspective: 1000;
+      &.next, &.active.right {
+        -webkit-transform: translate3d(100%,0,0);
+        left: 0;
+      }
+      &.prev, &.active.left {
+        -webkit-transform: translate3d(-100%,0,0);
+        left: 0;
+      }
+      &.next.left, &.prev.right, &.active {
+        -webkit-transform: translate3d(0%,0,0);
+        left: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This issue was originally introduced 2 years ago in issue #1966 but was dismissed by @mdo, stating:

> In Chrome and Safari, I didn't notice much of a different at all (in fact I couldn't really discern any difference). We'll pass on this for now, but revisit it in a future point release since I know transitions and moving objects like this can get hairy quickly.

As @petewarden explained:

> The -webkit-transform extension causes webkit to switch to hardware-accelerated rendering on supported devices, which results in far smoother animations. This CSS change enables the extension for the carousel when it's available, and in practice we see iPad and iPhone animations improve from a juddery 2 frames-per-second at best, to something smooth enough to be native.

I believe it's time to reconsider this implementation as it suits Bootstrap 3's mobile-first approach. The effects of implementing CSS3 transforms are significant on all WebKit devices I've tested, especially when using high-res images or multiple carousels (due to the large repaint times). For a full description of this issue including technical info and research, check out [this Medium article](https://medium.com/p/29bfb20d1324).

I was going to comment on the previous issue but I rewrote the code to explicitly use 3D transforms to ensure hardware acceleration is enabled and some other helpful properties for visual integrity.
