### PR TITLE
Fixed nav-justified issue - occuring on android native browsers

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -159,6 +159,8 @@
 
 .nav-justified {
   width: 100%;
+  display: table;
+  table-layout: fixed;
 
   > li {
     float: none;
@@ -176,7 +178,7 @@
   @media (min-width: @screen-sm-min) {
     > li {
       display: table-cell;
-      width: 1%;
+      width: 100%;
       > a {
         margin-bottom: 0;
       }


### PR DESCRIPTION
nav-justified on android native browsers looked buggy and the tabs didn't aligned properly. This fix not only fixes the UI on android native browsers but also works fine with other mediums. I have tested this on Chrome, Mozilla, Opera, IE 10, Safari and Android Native browsers.
