### PR TITLE
Fix arrow colour on popover bottom

### DIFF
--- a/less/popovers.less
+++ b/less/popovers.less
@@ -108,8 +108,8 @@
     &:after {
       content: " ";
       top: 1px;
-      margin-left: -@popover-arrow-width - 1px;
-      border-width: @popover-arrow-width + 1px;
+      margin-left: (-@popover-arrow-width - 1px);
+      border-width: (@popover-arrow-width + 1px);
       border-top-width: 0;
       border-bottom-color: @popover-title-bg;
     }

--- a/less/popovers.less
+++ b/less/popovers.less
@@ -108,9 +108,10 @@
     &:after {
       content: " ";
       top: 1px;
-      margin-left: -@popover-arrow-width;
+      margin-left: -@popover-arrow-width - 1px;
+      border-width: @popover-arrow-width + 1px;
       border-top-width: 0;
-      border-bottom-color: @popover-arrow-color;
+      border-bottom-color: @popover-title-bg;
     }
   }
 


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/717345/2501487/bc62f8a6-b36c-11e3-85ee-20bf2dd80cf8.png)

After:
![after](https://f.cloud.github.com/assets/717345/2501492/c87264c4-b36c-11e3-9f9f-1ac09f1c32c9.png)

Stop arrow from being white on bottom popover, as the arrow sits on the title bar, so should match the title bar's background colour.
