### PR TITLE
Provide jQuery.loaded() callback args to 'loaded.bs.modal' callback

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -320,7 +320,7 @@ $('#myModal').modal({
        </tr>
        <tr>
          <td>loaded.bs.modal</td>
-         <td>This event is fired when the modal has loaded content using the remote option. The callback for this event triggered with the extra parameters <code>responseText, textStatus and XMLHttpRequest</code>.</td>
+         <td>This event is fired when the modal has loaded content using the remote option. The callback for this event is triggered with the extra parameters <code>responseText, textStatus and XMLHttpRequest</code>.</td>
        </tr>
       </tbody>
     </table>

--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -320,7 +320,7 @@ $('#myModal').modal({
        </tr>
        <tr>
          <td>loaded.bs.modal</td>
-         <td>This event is fired when the modal has loaded content using the remote option.</td>
+         <td>This event is fired when the modal has loaded content using the remote option. The callback for this event triggered with the extra parameters <code>responseText, textStatus and XMLHttpRequest</code>.</td>
        </tr>
       </tbody>
     </table>

--- a/js/modal.js
+++ b/js/modal.js
@@ -24,7 +24,7 @@
       this.$element
         .find('.modal-content')
         .load(this.options.remote, $.proxy(function () {
-          this.$element.trigger('loaded.bs.modal')
+          this.$element.trigger('loaded.bs.modal', arguments)
         }, this))
     }
   }


### PR DESCRIPTION
This little patch allows you to check for failures when loading remote modal content. I'm using it to hide the empty modal that failed to load and show a little error message.

I'd appreciate it if you could merge this :) Thanks for all the hard work on bootstrap, I'm a big fan!
