### PR TITLE
Enabled sizing input fields based on the expected length of the input

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -114,7 +114,7 @@ output {
 
 .form-control {
   display: block;
-  width: 100%;
+  max-width: 100%;
   height: @input-height-base; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
   padding: @padding-base-vertical @padding-base-horizontal;
   font-size: @font-size-base;


### PR DESCRIPTION
The length of a field should be indicative of the expected length of the input. This gives the user a hint about the expected length of the input. Forcing a width of 100% for all inputs removes that hint.

I've retained a `max-width` of 100% to ensure fields never extend beyond the available width.

Supports:
- <a href="https://rosenfeldmedia.com/books/web-form-design/">Web Form Design (pages 73–75)</a>
- <a href="http://baymard.com/blog/form-field-usability-matching-user-expectations">Form Field Usability: Matching User Expectations</a>
- <a href="http://www.userfocus.co.uk/resources/formschecklist.html">23 forms and data entry usability guidelines (Guideline 5)</a>
- <a href="http://cdn.intechopen.com/pdfs/10814/InTech-Simple_but_crucial_user_interfaces_in_the_world_wide_web_introducing_20_guidelines_for_usable_web_form_design.pdf">Simple but Crucial User Interfaces in the World Wide Web: Introducing 20 Guidelines for Usable Web Form Design (PDF, page 6, Guideline 7)</a>
