### PR TITLE
Local install of grunt-cli to support `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt": "~0.4.4",
     "grunt-autoprefixer": "~0.7.2",
     "grunt-banner": "~0.2.2",
+    "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.7.1",


### PR DESCRIPTION
Leveraging npm scripts can let people get more done without global installs.  To support `npm install && npm test`, the `grunt-cli` package can be added as a dev dependency.  Even the `grunt-cli` devs [have acknowledged](https://github.com/gruntjs/grunt-cli/commit/b4e6b3d9a7c2091e642711b5f3db4238530cca5b) the value in this.

I've only suggested a minor change here.  If people are in favor of this direction, npm scripts could be added for common Grunt tasks.  E.g. this would support `npm run build && npm start` (without a global Grunt install):

``` diff
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "homepage": "http://getbootstrap.com",
   "author": "Twitter, Inc.",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "build": "grunt dist",
+    "start": "grunt watch"
   },
   "style": "dist/css/bootstrap.css",
   "less": "less/bootstrap.less",
```
