### PR TITLE
modal.js!options.cache added

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -265,6 +265,17 @@
 {% endhighlight %}
          </td>
        </tr>
+       <tr>
+         <td>cache</td>
+         <td>boolean</td>
+         <td>true</td>
+         <td>
+             <p>Remotely loaded modal content is cached by default, you can set cache to false to hit the url each time if your remote is dynamic.</p>
+{% highlight html %}
+<a data-toggle="modal" href="remote.php" data-target="#modal" data-cache="false">Click me</a>
+{% endhighlight %}
+         </td>
+       </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/js/modal.js
+++ b/js/modal.js
@@ -32,7 +32,8 @@
   Modal.DEFAULTS = {
     backdrop: true,
     keyboard: true,
-    show: true
+    show: true,
+    cache: true
   }
 
   Modal.prototype.toggle = function (_relatedTarget) {
@@ -144,6 +145,11 @@
     this.$element.hide()
     this.backdrop(function () {
       that.removeBackdrop()
+      if (!that.options.cache) {
+        that.$element
+          .removeData('bs.modal')
+          .empty()
+      }
       that.$element.trigger('hidden.bs.modal')
     })
   }

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -68,14 +68,33 @@ $(function () {
     stop()
     $.support.transition = false
 
-    $('<div id="modal-test"></div>')
+    $('<div id="modal-test"><p>content</p></div>')
       .on('shown.bs.modal', function () {
         ok($('#modal-test').is(':visible'), 'modal visible')
         ok($('#modal-test').length, 'modal inserted into dom')
+        ok($('#modal-test').data('bs.modal'), 'modal is created')
+        ok($('#modal-test').children().length, 'modal is not empty')
         $(this).modal('hide')
       })
       .on('hidden.bs.modal', function () {
         ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        $('#modal-test').remove()
+        start()
+      })
+      .modal('show')
+  })
+
+  test('should clear modal when hide is called and cache is false', function () {
+    stop()
+    $.support.transition = false
+
+    $('<div id="modal-test" data-cache="false"><p>content</p></div>')
+      .on('shown.bs.modal', function () {
+        $(this).modal('hide')
+      })
+      .on('hidden.bs.modal', function () {
+        ok(!$('#modal-test').data('bs.modal'), 'modal is removed')
+        ok(!$('#modal-test').children().length, 'modal is empty')
         $('#modal-test').remove()
         start()
       })


### PR DESCRIPTION
tests and docs included
allows you to specify whether a modal caches its content after hidden or not

for reference
https://github.com/twbs/bootstrap/pull/12296
https://github.com/twbs/bootstrap/pull/13110
