### PR TITLE
Fixed nested tab elements li activation

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -40,7 +40,7 @@
 
     var $target = $(selector)
 
-    this.activate($this.parent('li'), $ul)
+    this.activate($this.closest('li'), $ul)
     this.activate($target, $target.parent(), function () {
       $this.trigger({
         type: 'shown.bs.tab',


### PR DESCRIPTION
Added closest li instead of direct parent so that you can nest multiple elements within tabs, such as button groups
