### PR TITLE
fix doc typo

### DIFF
--- a/less/mixins/forms.less
+++ b/less/mixins/forms.less
@@ -39,7 +39,7 @@
 // Form control focus state
 //
 // Generate a customized focus state and for any input with the specified color,
-// which defaults to the `@input-focus-border` variable.
+// which defaults to the `@input-border-focus` variable.
 //
 // We highly encourage you to not customize the default value, but instead use
 // this to tweak colors on an as-needed basis. This aesthetic change is based on


### PR DESCRIPTION
one can find correct name of variable just few lines below the typo
