### PR TITLE
fixes #13216

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -249,8 +249,8 @@
 
 @zindex-navbar:            1000;
 @zindex-dropdown:          1000;
-@zindex-popover:           1010;
-@zindex-tooltip:           1030;
+@zindex-popover:           1060; // @fix #13216
+@zindex-tooltip:           1070; // @fix #13216 
 @zindex-navbar-fixed:      1030;
 @zindex-modal-background:  1040;
 @zindex-modal:             1050;


### PR DESCRIPTION
Fixes #13216.
Change `@zindex-popover` and `@zindex-tooltip` values to be greater than
those set for `@zindex-modal` allowing tooltips and popovers to be
displayed in front of modals (and all other content).
