### PR TITLE
Scrollspy generates wrong offsets for a page-- recalculate offsets if `scrollheight` changes.

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -41,6 +41,7 @@
 
     this.offsets = $([])
     this.targets = $([])
+    this.scrollHeight = this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight, document.documentElement.scrollHeight)
 
     var self     = this
     var $targets = this.$body
@@ -70,6 +71,10 @@
     var targets      = this.targets
     var activeTarget = this.activeTarget
     var i
+
+    if (this.scrollHeight != scrollHeight) {
+      this.refresh()
+    }
 
     if (scrollTop >= maxScroll) {
       return activeTarget != (i = targets.last()[0]) && this.activate(i)


### PR DESCRIPTION
I have a long landing page that has a lot of images, and occasionally the images load after scrollspy's offset has been generated.  The result is that the offset array generated is wrong and it will highlight the wrong images.

Looking at the code in `scrollspy.js`, there is no detection for a change in document height.

So here's the fix!
