### PR TITLE
Fix carousel-control margin asymmetry

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -110,19 +110,21 @@
   .icon-prev,
   .glyphicon-chevron-left {
     left: 50%;
+    margin-left: -10px;
   }
   .icon-next,
   .glyphicon-chevron-right {
     right: 50%;
+    margin-right: -10px;
   }
   .icon-prev,
   .icon-next {
     width:  20px;
     height: 20px;
     margin-top: -10px;
-    margin-left: -10px;
     font-family: serif;
   }
+
 
   .icon-prev {
     &:before {
@@ -213,8 +215,15 @@
       width: 30px;
       height: 30px;
       margin-top: -15px;
-      margin-left: -15px;
       font-size: 30px;
+    }
+    .glyphicon-chevron-left,
+    .icon-prev {
+      margin-left: -15px;
+    }
+    .glyphicon-chevron-right,
+    .icon-next {
+      margin-right: -15px;
     }
   }
 


### PR DESCRIPTION
While using carousel default controls with a non-default background, I've noticed annoying asymmetry of arrows. Looks like somebody forgot to specify different margins for left and right arrows.
