### PR TITLE
Added "collapseown" functionality to $.fn.collapse()

### DIFF
--- a/docs/_includes/js/collapse.html
+++ b/docs/_includes/js/collapse.html
@@ -154,6 +154,13 @@ $('.collapse').collapse()
          <td>If selector then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior - this dependent on the <code>panel</code> class)</td>
        </tr>
        <tr>
+          <td>collapseown</td>
+          <td>boolean</td>
+          <td>true</td>
+          <td>This is only useful for accordion behavior. If false, the element cannot collapse its own target, if it is currently visible. (in this way, you will always have an open item)</td>
+        </tr>
+        <tr>
+       <tr>
          <td>toggle</td>
          <td>boolean</td>
          <td>true</td>

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -114,6 +114,7 @@
   }
 
   Collapse.prototype.toggle = function () {
+    if (this.options.collapseown == false && this.$element.hasClass('in')) return;
     this[this.$element.hasClass('in') ? 'hide' : 'show']()
   }
 


### PR DESCRIPTION
This is intended to solve the annoyance where you click the heading of an already-opened accordion panel, causing the last visible panel to collapse and the accordion to effectively close completely.

This option makes it possible to configure the accordion in a way that will make sure there's always one visible item.
