### PR TITLE
Replace $.fn.bind with $.fn.on in alert docs

### DIFF
--- a/docs/_includes/js/alerts.html
+++ b/docs/_includes/js/alerts.html
@@ -64,7 +64,7 @@
     </table>
   </div><!-- /.table-responsive -->
 {% highlight js %}
-$('#my-alert').bind('closed.bs.alert', function () {
+$('#my-alert').on('closed.bs.alert', function () {
   // do something…
 })
 {% endhighlight %}


### PR DESCRIPTION
`.on()` is the recommended way of attaching handlers to events since jQuery 1.7 and besides that we exclusively use `.on()` – looks like nobody really payed attention to the alert JS docs since 2ebc0ad added this over two years ago...
