### PR TITLE
Fix issue using Collapse without Panel

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -38,7 +38,7 @@
     this.$element.trigger(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
-    var actives = this.$parent && this.$parent.find('> .panel > .in')
+    var actives = this.$parent && this.$parent.find('.in')
 
     if (actives && actives.length) {
       var hasData = actives.data('bs.collapse')


### PR DESCRIPTION
## Overview

If you try to use Collapse without Panel, you **must** use the `.panel` class to get it work.
## Example

```
<div id="accordion">
  <div>
    <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">Item #1</a>
    <div id="collapseOne" class="collapse in">
      Lorem Ipsum
    </div>
  </div>
  <div>
    <a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">Item #2</a>
    <div id="collapseTwo" class="collapse">
      Lorem Ipsum
    </div>
  </div>
  <div>
    <a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">Item #3</a>
    <div id="collapseThree" class="collapse">
      Lorem Ipsum
    </div>
  </div>
</div>
```
## Expected behavior

On `Item #2` click, we expect the first block (under `Item #1`) to collapse, and the second one (under `Item #2`) to extend.
## Current behavior

On `Item #2` click, and the second block (under `Item #2`) extends. The first block (under `Item #1`) doesn't collapse.
