### PR TITLE
Fixed issue with multiple CSS transitions

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -131,7 +131,7 @@
           that.sliding = false
           setTimeout(function () { that.$element.trigger('slid.bs.carousel') }, 0) // yes, "slid". not a typo. past tense of "to slide".
         })
-        .emulateTransitionEnd($active.css('transition-duration').slice(0, -1) * 1000)
+        .emulateTransitionEnd($active.css('transition-duration'))
     } else {
       $active.removeClass('active')
       $next.addClass('active')

--- a/js/transition.js
+++ b/js/transition.js
@@ -32,12 +32,23 @@
     return false // explicit for ie8 (  ._.)
   }
 
+  // Find highest duration from comma-seperated list
+  function findDuration(duration) {
+    if((parseInt(duration) == parseFloat(duration)) && !isNaN(duration)) return duration
+    var durations = duration.split(','), max = null
+    for (var i = 0, j = durations.length; i < j; i++) {
+      var c = durations[i].trim().slice(0, -1)
+      max = c > max ? c : max
+    }
+    return max * 1000
+  }
+
   // http://blog.alexmaccaw.com/css-transitions
   $.fn.emulateTransitionEnd = function (duration) {
     var called = false, $el = this
     $(this).one($.support.transition.end, function () { called = true })
     var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
-    setTimeout(callback, duration)
+    setTimeout(callback, findDuration(duration))
     return this
   }
 


### PR DESCRIPTION
Fixed an issue with the transitions of the carousel, which failed to apply the `next`, `prev`, `left` and `right` classes when more than one CSS transition was set. This was due to multiple durations being returned as a comma-separated list (e.g. `".6s, 2s"`) which `slice(0, 1) * 1000` would turn into a `NaN`.

The fix adds another function, `findDuration`, to the `emulateTransitionEnd` flow, which returns the highest duration in the comma-separated list as milliseconds. The function won't interfere with existing uses, as integers are ignored.
