### PR TITLE
Fix right margin of the carousel "next" button

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -223,7 +223,7 @@
     }
     .glyphicon-chevron-right,
     .icon-next {
-      margin-right: -15px;
+      margin-right: -16px;
     }
   }
 


### PR DESCRIPTION
The calculated offset of carousel's right-arrow differs with left-arrow on large viewport sizes. The problem was well described and illustrated [here](https://github.com/twbs/bootstrap/pull/13242#issuecomment-39086675) and [here](https://github.com/twbs/bootstrap/pull/13242#issuecomment-39087556) by @hnrch02. This PR is just a missing part of #13242
