### PR TITLE
Fixes #13297: Carousel indicator not working

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -49,7 +49,7 @@
   Carousel.prototype.getActiveIndex = function () {
     this.$active = this.$element.find('.item.active')
     this.$items  = this.$active.parent().children('.item')
-    return this.$active.prevAll(".item").length
+    return this.$active.prevAll('.item').length
   }
 
   Carousel.prototype.to = function (pos) {

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -49,8 +49,7 @@
   Carousel.prototype.getActiveIndex = function () {
     this.$active = this.$element.find('.item.active')
     this.$items  = this.$active.parent().children('.item')
-
-    return this.$items.index(this.$active)
+    return this.$active.prevAll(".item").size();
   }
 
   Carousel.prototype.to = function (pos) {

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -49,7 +49,7 @@
   Carousel.prototype.getActiveIndex = function () {
     this.$active = this.$element.find('.item.active')
     this.$items  = this.$active.parent().children('.item')
-    return this.$active.prevAll(".item").size();
+    return this.$active.prevAll(".item").length;
   }
 
   Carousel.prototype.to = function (pos) {

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -49,7 +49,7 @@
   Carousel.prototype.getActiveIndex = function () {
     this.$active = this.$element.find('.item.active')
     this.$items  = this.$active.parent().children('.item')
-    return this.$active.prevAll(".item").length;
+    return this.$active.prevAll(".item").length
   }
 
   Carousel.prototype.to = function (pos) {


### PR DESCRIPTION
JQuery's index() function is not working sometimes. Using prevAll() instead avoids the problem.
