### PR TITLE
fixes #11099 - $.collapse() overrides the original dimension of the coll...

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -59,7 +59,7 @@
       if (e && e.target != this.$element[0]) return
       this.$element
         .removeClass('collapsing')
-        .addClass('collapse in')[dimension]('auto')
+        .addClass('collapse in')[dimension]('')
       this.transitioning = 0
       this.$element.trigger('shown.bs.collapse')
     }

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -19,7 +19,7 @@ $(function () {
   test('should show a collapsed element', function () {
     var el = $('<div class="collapse"></div>').collapse('show')
     ok(el.hasClass('in'), 'has class in')
-    ok(/height/.test(el.attr('style')), 'has height set')
+    ok(!/height/.test(el.attr('style')), 'has height reset')
   })
 
   test('should hide a collapsed element', function () {
@@ -51,7 +51,7 @@ $(function () {
         ok(this.style.height == '0px')
       })
       .on('shown.bs.collapse', function () {
-        ok(this.style.height == 'auto')
+        ok(this.style.height === '')
         start()
       })
       .collapse('show')


### PR DESCRIPTION
...apsed element when uncollapsing
fixes #11099

@mdo
