### PR TITLE
Added bower reference to main less file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
   ],
   "homepage": "http://getbootstrap.com",
   "main": [
+    "less/bootstrap.less",
     "dist/css/bootstrap.css",
     "dist/js/bootstrap.js",
     "dist/fonts/glyphicons-halflings-regular.eot",


### PR DESCRIPTION
Myself, and many others, use grunt/gulp tasks to automate the injection of assets into index.html, unit test configurations, etc, by file type (see grunt-bower-install).  This same workflow is extremely useful for referencing external LESS libraries within our own less files so that we can reuse variables, mix-ins, etc, within our LESS.  However, we currently cannot do this with Bootstrap because bootstrap.less is not exposed.  By providing bootstrap.less as a main file with bower, we can facilitate this process and make developers' lives easier.
