### PR TITLE
Wait for the expected target during a collapse

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -56,7 +56,11 @@
     this.transitioning = 1
 
     var complete = function (e) {
-      if (e && e.target != this.$element[0]) return
+      if (e && e.target != this.$element[0]) {
+        this.$element
+          .one($.support.transition.end, $.proxy(complete, this))
+        return
+      }
       this.$element
         .removeClass('collapsing')
         .addClass('collapse in')[dimension]('auto')
@@ -92,7 +96,11 @@
     this.transitioning = 1
 
     var complete = function (e) {
-      if (e && e.target != this.$element[0]) return
+      if (e && e.target != this.$element[0]) {
+        this.$element
+          .one($.support.transition.end, $.proxy(complete, this))
+        return
+      }
       this.transitioning = 0
       this.$element
         .trigger('hidden.bs.collapse')


### PR DESCRIPTION
Actually wait for the collapsed item to complete. If complete is called
with other target, instead of simply returning and do nothing, wait again
until the proper target triggers the event (otherwise this leaves collapse
in a broken state).
