### PR TITLE
Add nested kbd element styles for actual keys or inputs

### DIFF
--- a/docs/_includes/css/code.html
+++ b/docs/_includes/css/code.html
@@ -13,7 +13,8 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
   <h2 id="code-user-input">User input</h2>
   <p>Use the <code>&lt;kbd&gt;</code> to indicate input that is typically entered via keyboard.</p>
 <div class="bs-example">
-  To switch directories, type <kbd>cd</kbd> followed by the name of the directory.
+  To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
+  To edit settings, press <kbd><kbd>ctrl</kbd> + <kbd>,</kbd></kbd>
 </div>
 {% highlight html %}
   To switch directories, type <kbd>cd</kbd> followed by the name of the directory.

--- a/less/code.less
+++ b/less/code.less
@@ -28,6 +28,12 @@ kbd {
   background-color: @kbd-bg;
   border-radius: @border-radius-small;
   box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+
+  kbd {
+    padding: 0;
+    font-size: 100%;
+    box-shadow: none;
+  }
 }
 
 // Blocks of code


### PR DESCRIPTION
> When the _kbd_ element is nested inside another _kbd_ element, it represents an actual key or other single unit of input as appropriate for the input mechanism.

http://www.whatwg.org/specs/web-apps/current-work/multipage/text-level-semantics.html#the-kbd-element

---

This will maintain visual styling when using the semantic markup for individual hotkeys or other input controls (i.e. nested `kbd` elements).
