### PR TITLE
fixes #13296 Dropdown disappears with right-click on Firefox

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -83,6 +83,7 @@
   }
 
   function clearMenus(e) {
+    if (e && e.which === 3) return
     $(backdrop).remove()
     $(toggle).each(function () {
       var $parent = getParent($(this))


### PR DESCRIPTION
check if rightclick in firefox 
fixes #13296
