### PR TITLE
Dropdown menu in justified button-group

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -216,6 +216,10 @@
   > .btn-group .btn {
     width: 100%;
   }
+
+  > .btn-group .dropdown-menu {
+    left: auto;
+  }
 }
 
 


### PR DESCRIPTION
This is a firefox issue. I tested it on firefox latest (28.0).

It seems that dropdown-menu in justified button-group appears at the far left of the group.

Check the problem in [Bootstrap site](http://getbootstrap.com/components/#btn-groups-justified).

![ff28-btn-group](https://cloud.githubusercontent.com/assets/7236465/2729097/f4b5627c-c602-11e3-9023-ce8a4c3fed5c.PNG)
