### PR TITLE
Simplify customisation of line height

### DIFF
--- a/docs/_includes/customizer-variables.html
+++ b/docs/_includes/customizer-variables.html
@@ -125,16 +125,6 @@
     <input id="input-@font-size-h6" type="text" value="ceil((@font-size-base * 0.85))" data-var="@font-size-h6" class="form-control"/>
   </div>
   <div class="bs-customizer-input">
-    <label for="input-@line-height-base">@line-height-base</label>
-    <input id="input-@line-height-base" type="text" value="1.428571429" data-var="@line-height-base" class="form-control"/>
-    <p class="help-block">Unit-less <code>line-height</code> for use in components like buttons.</p>
-  </div>
-  <div class="bs-customizer-input">
-    <label for="input-@line-height-computed">@line-height-computed</label>
-    <input id="input-@line-height-computed" type="text" value="floor((@font-size-base * @line-height-base))" data-var="@line-height-computed" class="form-control"/>
-    <p class="help-block">Computed &quot;line-height&quot; (<code>font-size</code> * <code>line-height</code>) for use with <code>margin</code>, <code>padding</code>, etc.</p>
-  </div>
-  <div class="bs-customizer-input">
     <label for="input-@headings-font-family">@headings-font-family</label>
     <input id="input-@headings-font-family" type="text" value="inherit" data-var="@headings-font-family" class="form-control"/>
     <p class="help-block">By default, this inherits from the <code>&lt;body&gt;</code>.</p>
@@ -150,6 +140,11 @@
   <div class="bs-customizer-input">
     <label for="input-@headings-color">@headings-color</label>
     <input id="input-@headings-color" type="text" value="inherit" data-var="@headings-color" class="form-control"/>
+  </div>
+  <div class="bs-customizer-input">
+    <label for="input-@line-height-target">@line-height-target</label>
+    <input id="input-@line-height-target" type="text" value="20px" data-var="@line-height-target" class="form-control"/>
+    <p class="help-block">Target <code>line-height</code></p>
   </div>
 </div>
 <h2 id="iconography">Iconography</h2>

--- a/less/variables.less
+++ b/less/variables.less
@@ -56,16 +56,20 @@
 @font-size-h5:            @font-size-base;
 @font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
 
-//** Unit-less `line-height` for use in components like buttons.
-@line-height-base:        1.428571429; // 20/14
-//** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
-
 //** By default, this inherits from the `<body>`.
 @headings-font-family:    inherit;
 @headings-font-weight:    500;
 @headings-line-height:    1.1;
 @headings-color:          inherit;
+
+//** Target `line-height`
+@line-height-target:      20px;
+
+//-- Typography
+//** Unit-less `line-height` for use in components like buttons.
+@line-height-base:        unit((@line-height-target / @font-size-base));
+//** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
+@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
 
 
 //== Iconography


### PR DESCRIPTION
Added new variable `@line-height-target` with a default value to `20px` to match the existing style.
Then updated `@line-height-base` so it was no longer a magic number with a comment of `20 / 14`

Seeing as this value was using math I've made it more explicit. The `@line-height-base` is now a unitless value derived from the base font size and new line height target.

Seeing as now the `@line-height-base` is variable driven I removed it from the customiser along with`@line-height-computed`
I think this may make it easier for people to customise the variables file and get the values they want without have to do the math themselves, and seems a lot more explicit.

Note: Would this now make `@line-height-computed` redundant? I've kept it it for compatibility but could this variable become deprecated in a future release? 
