### PR TITLE
Added list feedback classes

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -5,6 +5,7 @@
 
 @import "variables.less";
 @import "mixins.less";
+@import "glyphicons.less";
 
 
 
@@ -245,3 +246,39 @@
   @shadow: inset 0 1px 3px rgba(0,0,0,.05), 0 1px 0 rgba(255,255,255,.1);
   .box-shadow(@shadow);
 }
+
+
+
+//
+// Lists
+// --------------------------------------------------
+
+.list-feedback li {
+  position: relative;
+}
+.list-style-variant(@color, @character) {
+  color: @color;
+  list-style-type: none;
+  
+  &:before {
+    .glyphicon();
+    
+    position: absolute;
+    
+    left: 0;
+    margin-left: -1.4em;
+    width: 1.4em;
+    
+    content: @character;
+  }
+}
+li.list-success {
+  .list-style-variant(@state-success-text, "\e013"); //glyphicon-ok
+}
+li.list-warning {
+  .list-style-variant(@state-warning-text, "\e107"); //glyphicon-warning-sign
+}
+li.list-error {
+  .list-style-variant(@state-danger-text, "\e014"); //glyphicon-remove
+}
+


### PR DESCRIPTION
While working on a registration form, I thought it would be neat to provide feedback to the user in the form of a list. I couldn't find this functionality anywhere in Bootstrap, so I decided to write it myself. I'm quite pleased with the results, so I decided to share it

![image](https://cloud.githubusercontent.com/assets/2425554/2772202/1d8e22f4-ca79-11e3-8036-1af23793dfc1.png)
(To be clear, the list is the only thing affected by these styles. Everything around it is only included to show how it fits in with other elements.)

This pull request adds support for list feedback, styled after the form feedback classes. These classes allow styling each element of a list to enhance feedback. This is appropriate in cases where there a list of constraints a user must meet: a list can be styled as a "checklist", and updated as requirements are fulfilled.

Usage is very simple:

```
<ul class="list-feedback">
    <li>This item is has no feedback class.</li>
    <li class="list-success">Item with list-success</li>
    <li class="list-warning">Item with list-warning</li>
    <li class="list-error">Item with list-error</li>
</ul>
```

Note that this code may need a bit of polish before being merged. I've only recently started using Bootstrap, so I'm not even close to familiar with the project organization. In particular, theme.less may not be the best place for these styles. 

I haven't noticed any compatibility problems in any of the browsers I tested. (Desktop: Chrome 35, Firefox 27.0.1; Mobile: Browser 2.3.5, Firefox 28.0.1)
