### PR TITLE
Improve affix-bottom behavior when document height is dynamic

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -81,7 +81,7 @@
   Affix.prototype.checkPosition = function () {
     if (!this.$element.is(':visible')) return
 
-    var scrollHeight = $(document).height()
+    var scrollHeight = $('body').height()
     var height       = this.$element.height()
     var offset       = this.options.offset
     var offsetTop    = offset.top

--- a/js/tests/visual/affix.html
+++ b/js/tests/visual/affix.html
@@ -6,11 +6,35 @@
 
   <style>
     /* Test Styles */
-    .affix {
+    .affixed-element-top.affix {
       top: 10px;
     }
-    .affix-bottom {
+    .affixed-element-top.affix-bottom {
       position: absolute;
+    }
+    .affixed-element-bottom {
+      margin-bottom: 0;
+    }
+    .affixed-element-bottom.affix {
+      bottom: 10px;
+    }
+    .affixed-element-bottom.affix-bottom {
+      position: relative;
+    }
+    .grow-btn, .shrink-btn {
+      color: #FFF;
+    }
+    .grow-btn {
+      background-color: #2ECC40;
+    }
+    .grow-btn:hover {
+      background-color: #3D9970;
+    }
+    .shrink-btn {
+      background-color: #FF4136;
+    }
+    .shrink-btn:hover {
+      background-color: #85144B;
     }
   </style>
 </head>
@@ -23,7 +47,7 @@
   </div>
 
   <div class="col-md-3">
-    <ul class="list-group js-affixed-element">
+    <ul class="list-group affixed-element-top js-affixed-element-top">
       <li class="list-group-item">Cras justo odio</li>
       <li class="list-group-item">Dapibus ac facilisis in</li>
       <li class="list-group-item">Morbi leo risus</li>
@@ -43,7 +67,7 @@
     </ul>
   </div>
 
-  <div class="col-md-9">
+  <div class="col-md-6 js-content">
 
     <p>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue. Maecenas sed diam eget risus varius blandit sit amet non magna.</p>
 
@@ -197,6 +221,27 @@
 
     <p>Aenean lacinia bibendum nulla sed consectetur. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Cras mattis consectetur purus sit amet fermentum. Sed posuere consectetur est at lobortis. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
 
+  </div>
+
+  <div class="col-md-3">
+    <ul class="list-group affixed-element-bottom js-affixed-element-bottom">
+      <li class="list-group-item">Sit necessitatibus aspernatur.</li>
+      <li class="list-group-item">Adipisicing alias dolor!</li>
+      <li class="list-group-item">Ipsum molestiae impedit.</li>
+      <li class="list-group-item">Amet quis iste?</li>
+      <li class="list-group-item">Ipsum quaerat porro.</li>
+      <li class="list-group-item">Elit lorem libero.</li>
+      <li class="list-group-item">Ipsum dolore facilis.</li>
+      <li class="list-group-item">Elit ad atque.</li>
+      <li class="list-group-item">Dolor amet sequi!</li>
+      <li class="list-group-item">Consectetur voluptatum facilis!</li>
+      <li class="list-group-item">Sit neque eligendi?</li>
+      <li class="list-group-item">Amet fuga consectetur!</li>
+      <li class="list-group-item">Amet molestias repellat!</li>
+      <li class="list-group-item">Consectetur minima repellendus.</li>
+      <li class="list-group-item grow-btn js-grow-btn">Grow content</li>
+      <li class="list-group-item shrink-btn js-shrink-btn">Shrink content</li>
+    </ul>
   </div>
 
   <div class="col-md-12 js-footer">
@@ -222,7 +267,7 @@
 <!-- JavaScript Test -->
 <script>
 $(function () {
-  $('.js-affixed-element').affix({
+  $('.js-affixed-element-top').affix({
     offset: {
       top: $('.js-page-header').outerHeight(true) - 10
     , bottom: $('.js-footer').outerHeight(true) + 10
@@ -231,6 +276,19 @@ $(function () {
   // todo(fat): sux you have to do this.
   .on('affix.bs.affix', function (e) {
     $(e.target).width(e.target.offsetWidth)
+  })
+
+  $('.js-affixed-element-bottom').affix({
+    offset: {
+      bottom: $('.js-footer').outerHeight(true) + 10
+    }
+  })
+
+  $('.js-grow-btn').on('click', function() {
+    $('.js-content').append('<p>Ipsum corrupti ipsam est temporibus.</p>')
+  })
+  $('.js-shrink-btn').on('click', function() {
+    $('.js-content p').last().remove()
   })
 })
 </script>


### PR DESCRIPTION
Hi, again!

This builds off of #13392 to make it so that an affixed element that relies on a bottom offset behave normally when there are changes that cause the document height to fluctuate.

Before:
- [Preview](http://embed.plnkr.co/ycevC4uWnoySq1UAhyYv/preview)
- [Code](http://plnkr.co/edit/ycevC4uWnoySq1UAhyYv)

After:
- [Preview](http://embed.plnkr.co/JXNbNHrt364mps0Pkfpt/preview)
- [Code](http://plnkr.co/edit/JXNbNHrt364mps0Pkfpt)

Determining the affix state is bundled into a separate method for correctness and so that it's slightly easier to understand (you can find an outline of how I understood the logic in the README for one of my plunks). Also, an element whose affix is determined to be `'bottom'` always has its offset set (instead of just bailing out when it has been determined that the affix hasn't changed). This is so that if the document height changes that the affix-bottom element ends up in the right place when the next `checkPosition` occurs.

Please check out the demo to get a sense of what I'm talking about. Change the document height with `+` and `-` and watch how the bottom affix toggles between `affix` and `affix-bottom` on master, but not on my branch. I've also checked how these changes affect the affix used in the bootstrap docs by building them locally and it all looks good on my end.

Thanks! Any feedback is appreciated. :smile:
