### PR TITLE
fires closed.bs.alert *after* DOM detach() as per #12379

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -42,7 +42,8 @@
     $parent.removeClass('in')
 
     function removeElement() {
-      $parent.detach().trigger('closed.bs.alert')
+      // detach from parent, fire event then clean up data
+      $parent.detach().trigger('closed.bs.alert').remove()
     }
 
     $.support.transition && $parent.hasClass('fade') ?

--- a/js/alert.js
+++ b/js/alert.js
@@ -42,7 +42,7 @@
     $parent.removeClass('in')
 
     function removeElement() {
-      $parent.trigger('closed.bs.alert').remove()
+      $parent.detach().trigger('closed.bs.alert')
     }
 
     $.support.transition && $parent.hasClass('fade') ?


### PR DESCRIPTION
As per #12379

Fires closed.bs.alert _after_ element is removed from DOM.
Previously it fired while the element was still attached.
