### PR TITLE
Warn about IE emulation modes in docs+examples

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function (grunt) {
         src: 'js/tests/unit/*.js'
       },
       assets: {
-        src: 'docs/assets/js/_src/*.js'
+        src: ['docs/assets/js/_src/*.js', 'docs/assets/js/*.js', '!docs/assets/js/*.min.js']
       }
     },
 

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -20,7 +20,8 @@
 <link href="../assets/css/docs.min.css" rel="stylesheet">
 <!--[if lt IE 9]><script src="../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
+<script src="../assets/js/ie10-viewport-bug-workaround.js"></script>
+<script src="../assets/js/ie-emulation-modes-warning.js"></script>
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>

--- a/docs/assets/js/ie-emulation-modes-warning.js
+++ b/docs/assets/js/ie-emulation-modes-warning.js
@@ -12,40 +12,40 @@
   'use strict';
 
   function emulatedIEMajorVersion() {
-    var groups = /MSIE ([0-9.]+)/.exec(window.navigator.userAgent);
+    var groups = /MSIE ([0-9.]+)/.exec(window.navigator.userAgent)
     if (groups === null) {
-      return null;
+      return null
     }
-    var ieVersionNum = parseInt(groups[1], 10);
-    var ieMajorVersion = Math.floor(ieVersionNum);
-    return ieMajorVersion;
+    var ieVersionNum = parseInt(groups[1], 10)
+    var ieMajorVersion = Math.floor(ieVersionNum)
+    return ieMajorVersion
   }
 
   function actualNonEmulatedIEMajorVersion() {
     // Detects the actual version of IE in use, even if it's in an older-IE emulation mode.
     // IE JavaScript conditional compilation docs: http://msdn.microsoft.com/en-us/library/ie/121hztk3(v=vs.94).aspx
     // @cc_on docs: http://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx
-    var jscriptVersion = new Function('/*@cc_on return @_jscript_version; @*/')(); // jshint ignore:line
+    var jscriptVersion = new Function('/*@cc_on return @_jscript_version; @*/')() // jshint ignore:line
     if (jscriptVersion === undefined) {
-      return 11; // IE11+ not in emulation mode
+      return 11 // IE11+ not in emulation mode
     }
     if (jscriptVersion < 9) {
-      return 8; // IE8 (or lower; haven't tested on IE<8)
+      return 8 // IE8 (or lower; haven't tested on IE<8)
     }
-    return jscriptVersion; // IE9 or IE10 in any mode, or IE11 in non-IE11 mode
+    return jscriptVersion // IE9 or IE10 in any mode, or IE11 in non-IE11 mode
   }
 
-  var ua = window.navigator.userAgent;
+  var ua = window.navigator.userAgent
   if (ua.indexOf('Opera') > -1 || ua.indexOf('Presto') > -1) {
-    return; // Opera, which might pretend to be IE
+    return // Opera, which might pretend to be IE
   }
-  var emulated = emulatedIEMajorVersion();
+  var emulated = emulatedIEMajorVersion()
   if (emulated === null) {
-    return; // Not IE
+    return // Not IE
   }
-  var nonEmulated = actualNonEmulatedIEMajorVersion();
+  var nonEmulated = actualNonEmulatedIEMajorVersion()
 
   if (emulated !== nonEmulated) {
-    window.alert('WARNING: You appear to be using IE' + nonEmulated + ' in IE' + emulated + ' emulation mode.\nIE emulation modes can behave significantly differently from ACTUAL older versions of IE.\nPLEASE DON\'T FILE BOOTSTRAP BUGS based on testing in IE emulation modes!');
+    window.alert('WARNING: You appear to be using IE' + nonEmulated + ' in IE' + emulated + ' emulation mode.\nIE emulation modes can behave significantly differently from ACTUAL older versions of IE.\nPLEASE DON\'T FILE BOOTSTRAP BUGS based on testing in IE emulation modes!')
   }
 })();

--- a/docs/assets/js/ie-emulation-modes-warning.js
+++ b/docs/assets/js/ie-emulation-modes-warning.js
@@ -1,0 +1,51 @@
+// NOTICE!! DO NOT USE ANY OF THIS JAVASCRIPT
+// IT'S JUST JUNK FOR OUR DOCS!
+// ++++++++++++++++++++++++++++++++++++++++++
+/*!
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Creative Commons Attribution 3.0 Unported License. For
+ * details, see http://creativecommons.org/licenses/by/3.0/.
+ */
+// Intended to prevent false-positive bug reports about Bootstrap not working properly in old versions of IE due to folks testing using IE's unreliable emulation modes.
+(function () {
+  'use strict';
+
+  function emulatedIEMajorVersion() {
+    var groups = /MSIE ([0-9.]+)/.exec(window.navigator.userAgent);
+    if (groups === null) {
+      return null;
+    }
+    var ieVersionNum = parseInt(groups[1], 10);
+    var ieMajorVersion = Math.floor(ieVersionNum);
+    return ieMajorVersion;
+  }
+
+  function actualNonEmulatedIEMajorVersion() {
+    // Detects the actual version of IE in use, even if it's in an older-IE emulation mode.
+    // IE JavaScript conditional compilation docs: http://msdn.microsoft.com/en-us/library/ie/121hztk3(v=vs.94).aspx
+    // @cc_on docs: http://msdn.microsoft.com/en-us/library/ie/8ka90k2e(v=vs.94).aspx
+    var jscriptVersion = new Function('/*@cc_on return @_jscript_version; @*/')(); // jshint ignore:line
+    if (jscriptVersion === undefined) {
+      return 11; // IE11+ not in emulation mode
+    }
+    if (jscriptVersion < 9) {
+      return 8; // IE8 (or lower; haven't tested on IE<8)
+    }
+    return jscriptVersion; // IE9 or IE10 in any mode, or IE11 in non-IE11 mode
+  }
+
+  var ua = window.navigator.userAgent;
+  if (ua.indexOf('Opera') > -1 || ua.indexOf('Presto') > -1) {
+    return; // Opera, which might pretend to be IE
+  }
+  var emulated = emulatedIEMajorVersion();
+  if (emulated === null) {
+    return; // Not IE
+  }
+  var nonEmulated = actualNonEmulatedIEMajorVersion();
+
+  if (emulated !== nonEmulated) {
+    window.alert('WARNING: You appear to be using IE' + nonEmulated + ' in IE' + emulated + ' emulation mode.\nIE emulation modes can behave significantly differently from ACTUAL older versions of IE.\nPLEASE DON\'T FILE BOOTSTRAP BUGS based on testing in IE emulation modes!');
+  }
+})();

--- a/docs/examples/blog/index.html
+++ b/docs/examples/blog/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="blog.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/carousel/index.html
+++ b/docs/examples/carousel/index.html
@@ -13,8 +13,9 @@
     <!-- Bootstrap core CSS -->
     <link href="../../dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/cover/index.html
+++ b/docs/examples/cover/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="cover.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/dashboard/index.html
+++ b/docs/examples/dashboard/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="dashboard.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/equal-height-columns/index.html
+++ b/docs/examples/equal-height-columns/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="equal-height-columns.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="grid.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/jumbotron-narrow/index.html
+++ b/docs/examples/jumbotron-narrow/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="jumbotron-narrow.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/jumbotron/index.html
+++ b/docs/examples/jumbotron/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="jumbotron.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/justified-nav/index.html
+++ b/docs/examples/justified-nav/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="justified-nav.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/navbar-fixed-top/index.html
+++ b/docs/examples/navbar-fixed-top/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="navbar-fixed-top.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/navbar-static-top/index.html
+++ b/docs/examples/navbar-static-top/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="navbar-static-top.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/navbar/index.html
+++ b/docs/examples/navbar/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="navbar.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/non-responsive/index.html
+++ b/docs/examples/non-responsive/index.html
@@ -18,8 +18,9 @@
     <!-- Custom styles for this template -->
     <link href="non-responsive.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/offcanvas/index.html
+++ b/docs/examples/offcanvas/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="offcanvas.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/rtl/index.html
+++ b/docs/examples/rtl/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="rtl.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/signin/index.html
+++ b/docs/examples/signin/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="signin.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/starter-template/index.html
+++ b/docs/examples/starter-template/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="starter-template.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/sticky-footer-navbar/index.html
+++ b/docs/examples/sticky-footer-navbar/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="sticky-footer-navbar.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/sticky-footer/index.html
+++ b/docs/examples/sticky-footer/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="sticky-footer.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/theme/index.html
+++ b/docs/examples/theme/index.html
@@ -18,8 +18,9 @@
     <!-- Custom styles for this template -->
     <link href="theme.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>

--- a/docs/examples/tooltip-viewport/index.html
+++ b/docs/examples/tooltip-viewport/index.html
@@ -16,8 +16,9 @@
     <!-- Custom styles for this template -->
     <link href="tooltip-viewport.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
+    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
     <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
+    <script src="../../assets/js/ie-emulation-modes-warning.js"></script>
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>


### PR DESCRIPTION
This script, which I've pretty exhaustively tested manually using Sauce, alerts the user about the perils of trying to use IE's emulation modes to test older versions of IE.
These emulation modes can behave differently from actual IE, which can lead users to file Bootstrap bugs about supposed IE8 problems which don't occur when tested properly using actual IE8.

Examples of emulation inaccuracy:
- #13177
- http://stackoverflow.com/questions/5612170/web-testing-for-ie-how-accurate-is-ietester
- http://stackoverflow.com/questions/19446584/why-doesnt-ie11-honour-conditional-comments-even-when-emulating-ie8-document-mo
- http://stackoverflow.com/questions/10249454/how-well-does-ie7-8-mode-in-ie9-compare-to-actually-running-ie7-8

This should hopefully reduce the amount of time wasted chasing down false IE8 bug reports.
/cc @twbs/team for review
