### PR TITLE
Reducing redundancy in output of the semantic grid columns system

### DIFF
--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -19,17 +19,17 @@
 }
 
 // Generate base styles for any column
-@mixin make-column(@gutter: @grid-gutter-width) {
+.make-column(@gutter: @grid-gutter-width) {
   position: relative;
-// Prevent columns from collapsing when empty
+  // Prevent columns from collapsing when empty
   min-height: 1px;
-// Inner gutter via padding
+  // Inner gutter via padding
   padding-left: (@gutter / 2);
   padding-right: (@gutter / 2);
 }
 
 // Generate the extra small columns
-.make-xs-column(@columns; @gutter: @grid-gutter-width) {
+.make-xs-column(@columns) {
   float: left;
   width: percentage((@columns / @grid-columns));
 }
@@ -44,7 +44,7 @@
 }
 
 // Generate the small columns
-.make-sm-column(@columns; @gutter: @grid-gutter-width) {
+.make-sm-column(@columns) {
   @media (min-width: @screen-sm-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
@@ -67,7 +67,7 @@
 }
 
 // Generate the medium columns
-.make-md-column(@columns; @gutter: @grid-gutter-width) {
+.make-md-column(@columns) {
   @media (min-width: @screen-md-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
@@ -90,7 +90,7 @@
 }
 
 // Generate the large columns
-.make-lg-column(@columns; @gutter: @grid-gutter-width) {
+.make-lg-column(@columns) {
   @media (min-width: @screen-lg-min) {
     float: left;
     width: percentage((@columns / @grid-columns));

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -18,14 +18,20 @@
   &:extend(.clearfix all);
 }
 
+// Generate base styles for any column
+@mixin make-column(@gutter: @grid-gutter-width) {
+  position: relative;
+// Prevent columns from collapsing when empty
+  min-height: 1px;
+// Inner gutter via padding
+  padding-left: (@gutter / 2);
+  padding-right: (@gutter / 2);
+}
+
 // Generate the extra small columns
 .make-xs-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
   float: left;
   width: percentage((@columns / @grid-columns));
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
 }
 .make-xs-column-offset(@columns) {
   margin-left: percentage((@columns / @grid-columns));
@@ -39,11 +45,6 @@
 
 // Generate the small columns
 .make-sm-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
   @media (min-width: @screen-sm-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
@@ -67,11 +68,6 @@
 
 // Generate the medium columns
 .make-md-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
   @media (min-width: @screen-md-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
@@ -95,11 +91,6 @@
 
 // Generate the large columns
 .make-lg-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
   @media (min-width: @screen-lg-min) {
     float: left;
     width: percentage((@columns / @grid-columns));


### PR DESCRIPTION
I often have the following use case when generating semantic columns:

```
.module {
  .make-xs-column(12);
  .make-sm-column(6);
  .make-md-column(3);
}
```

Meaning I need a class that fills a variable amount of columns, depending on breakpoints.
Before this patch, the code above would generate the following CSS:

```
.module {
  position: relative;
  min-height: 1px;
  padding-left: 15px;
  padding-right: 15px;
  float: left;
  width: 100%;
  position: relative;
  min-height: 1px;
  padding-left: 15px;
  padding-right: 15px;
  position: relative;
  min-height: 1px;
  padding-left: 15px;
  padding-right: 15px;
  margin-bottom: 24px;
}

@media (min-width: 768px) {
  .module {
    float: left;
    width: 50%;
  }
}

[etc. for the other media-queries]
```

I propose to use the grid system in the following way to reduce this redundancy:

```
.module {
  .make-column();
  .make-xs-column(12);
  .make-sm-column(6);
  .make-md-column(3);
}
```

or:

```
.module {
  .make-column();
  .make-md-column(3);
}
```

This means using the make-column mixin whenever we want to define a semantic column class. In my opinion this disadvantage beats redundant output though.

Your thoughts?
