### PR TITLE
Only hide modal on transitionend if the event originates from the modal;...

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -116,7 +116,10 @@
 
     $.support.transition && this.$element.hasClass('fade') ?
       this.$element
-        .one($.support.transition.end, $.proxy(this.hideModal, this))
+        .one($.support.transition.end, $.proxy(function (e) {
+          if (!$(e.target).is(this.$element)) return
+          this.hideModal()
+        }, this))
         .emulateTransitionEnd(300) :
       this.hideModal()
   }


### PR DESCRIPTION
... fixes #13223

Needs testing from @spotts-ce, as I myself cannot reproduce the problem he is encountering.

/cc @fat @cvrebert
