### PR TITLE
Increase .lead font-weight for better readability on mobile

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -62,7 +62,7 @@ p {
 .lead {
   margin-bottom: @line-height-computed;
   font-size: floor((@font-size-base * 1.15));
-  font-weight: 200;
+  font-weight: 300;
   line-height: 1.4;
 
   @media (min-width: @screen-sm-min) {


### PR DESCRIPTION
For better readability on mobile devices. As it stands, lead text appears on mobile with a thin font that doesn't stand out against regular paragraph text.
