### PR TITLE
Remove sr-only from components/dropdowns example

### DIFF
--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -7,8 +7,8 @@
   <p>Wrap the dropdown's trigger and the dropdown menu within <code>.dropdown</code>, or another element that declares <code>position: relative;</code>. Then add the menu's HTML.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
-      <button class="btn dropdown-toggle sr-only" type="button" id="dropdownMenu1" data-toggle="dropdown">
-        Dropdown trigger
+      <button class="btn dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown">
+        Dropdown
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
@@ -23,7 +23,7 @@
 {% highlight html %}
 <div class="dropdown">
   <button class="btn dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown">
-    Dropdown trigger
+    Dropdown
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
@@ -56,7 +56,7 @@
   <p>Add a header to label sections of actions in any dropdown menu.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
-      <button class="btn dropdown-toggle sr-only" type="button" id="dropdownMenu2" data-toggle="dropdown">
+      <button class="btn dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown">
         Dropdown
         <span class="caret"></span>
       </button>
@@ -85,7 +85,7 @@
   <p>Add <code>.disabled</code> to a <code>&lt;li&gt;</code> in the dropdown to disable the link.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
-      <button class="btn dropdown-toggle sr-only" type="button" id="dropdownMenu3" data-toggle="dropdown">
+      <button class="btn dropdown-toggle" type="button" id="dropdownMenu3" data-toggle="dropdown">
         Dropdown
         <span class="caret"></span>
       </button>

--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -8,7 +8,7 @@
   <div class="bs-example">
     <div class="dropdown clearfix">
       <button class="btn dropdown-toggle sr-only" type="button" id="dropdownMenu1" data-toggle="dropdown">
-        Dropdown
+        Dropdown trigger
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
@@ -22,8 +22,8 @@
   </div><!-- /example -->
 {% highlight html %}
 <div class="dropdown">
-  <button class="btn dropdown-toggle sr-only" type="button" id="dropdownMenu1" data-toggle="dropdown">
-    Dropdown
+  <button class="btn dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown">
+    Dropdown trigger
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">


### PR DESCRIPTION
Assuming sr-only is used in the actual live code so that the menu can be
shown open already ... but having sr-only in the highlighted example
code itself is confusing/misleading.

Also, change the text for the button from "Dropdown" to "Dropdown
trigger" for clarity (and it then matches
http://getbootstrap.com/javascript/#dropdowns)
