### PR TITLE
Tweak modals shadow

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -51,7 +51,7 @@
   border: 1px solid @modal-content-fallback-border-color; //old browsers fallback (ie8 etc)
   border: 1px solid @modal-content-border-color;
   border-radius: @border-radius-large;
-  .box-shadow(0 3px 9px rgba(0,0,0,.5));
+  .box-shadow(0 3px 9px rgba(0,0,0,.2));
   background-clip: padding-box;
   // Remove focus outline from opened modal
   outline: 0;
@@ -135,7 +135,7 @@
     margin: 30px auto;
   }
   .modal-content {
-    .box-shadow(0 5px 15px rgba(0,0,0,.5));
+    .box-shadow(0 5px 15px rgba(0,0,0,.2));
   }
 
   // Modal sizes


### PR DESCRIPTION
Make modal shadow lighter, it's too dark if users defined a light modal backdrop using `@modal-backdrop-opacity` or `@modal-backdrop-bg`
