### PR TITLE
Make @input-border-focus based on @brand-primary color

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -184,7 +184,7 @@
 //** `<input>` border radius
 @input-border-radius:            @border-radius-base;
 //** Border color for inputs on focus
-@input-border-focus:             #66afe9;
+@input-border-focus:             @brand-primary;
 
 //** Placeholder text color
 @input-color-placeholder:        @gray-light;


### PR DESCRIPTION
Does the @input-border-focus shouldn't be based on other color-variable?
