### PR TITLE
Officially support Android Firefox

### DIFF
--- a/docs/_includes/getting-started/browser-device-support.html
+++ b/docs/_includes/getting-started/browser-device-support.html
@@ -20,7 +20,7 @@
         <tr>
           <th>Android</th>
           <td class="text-success"><span class="glyphicon glyphicon-ok"></span> <span class="sr-only">Supported</span></td>
-          <td class="text-danger"><span class="glyphicon glyphicon-remove"></span> <span class="sr-only">Not Supported</span></td>
+          <td class="text-success"><span class="glyphicon glyphicon-ok"></span> <span class="sr-only">Supported</span></td>
           <td class="text-muted" rowspan="3" style="vertical-align: middle;">N/A</td>
           <td class="text-danger"><span class="glyphicon glyphicon-remove"></span> <span class="sr-only">Not Supported</span></td>
           <td class="text-muted">N/A</td>


### PR DESCRIPTION
I propose that we officially support Android Firefox.
We already support Firefox on other platforms, and to my recollection thus far we've only encountered 2 bugs specific to Android Firefox (#8702, #11371). The fix for the former bug was small and pretty reasonable, and we opted to include it anyway despite not officially supporting Android Firefox at the time. The latter bug was fixed by Mozilla relatively quickly.
So, Android Firefox has been pretty problem-free and should hopefully only impose a minimal additional maintenance burden.

/to @twbs/team for discussion.
