### PR TITLE
replace js test for scrollspy default behavior

### DIFF
--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -25,23 +25,6 @@ $(function () {
     ok($(document.body).bootstrapScrollspy()[0] == document.body, 'document.body returned')
   })
 
-  test('should switch active class on scroll', function () {
-    var sectionHTML = '<div id="masthead"></div>',
-        topbarHTML = '<div class="topbar">' +
-        '<div class="topbar-inner">' +
-        '<div class="container">' +
-        '<h3><a href="#">Bootstrap</a></h3>' +
-        '<li><a href="#masthead">Overview</a></li>' +
-        '</ul>' +
-        '</div>' +
-        '</div>' +
-        '</div>',
-        $topbar = $(topbarHTML).bootstrapScrollspy()
-
-    $(sectionHTML).append('#qunit-fixture')
-    ok($topbar.find('.active', true))
-  })
-
   test('should only switch active class on current target', function () {
     var sectionHTML = '<div id="root" class="active">' +
         '<div class="topbar">' +

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -78,4 +78,41 @@ $(function () {
     $scrollSpy.scrollTop(350);
     ok($section.hasClass('active'), 'Active class still on root node')
   })
+
+  test('should add the active class to the correct element', function(assert){
+    var navbarHtml =
+      '<div class="navbar">' +
+        '<ul class="nav">' +
+          '<li id="li-1"><a href="#div-1">div 1</a></li>' +
+          '<li id="li-2"><a href="#div-2">div 2</a></li>' +
+        '</ul>' +
+      '</div>'
+    var contentHtml =
+      '<div class="content" style="overflow: auto;height: 50px">' +
+        '<div id="div-1" style="height: 100px; padding: 0; margin: 0">div 1</div>' +
+        '<div id="div-2" style="height: 200px; padding: 0; margin: 0">div 2</div>' +
+      '</div>'
+
+    var $navbar = $(navbarHtml).appendTo('#qunit-fixture')
+    var $content = $(contentHtml)
+      .appendTo('#qunit-fixture')
+      .bootstrapScrollspy({offset:0, target: '.navbar'})
+
+    var testElementIsActiveAfterScroll = function(element, target){
+      var deferred = $.Deferred()
+      var scrollHeight = $content.scrollTop() + $(target).position().top
+      stop()
+      $content.one('scroll', function(){
+        ok($(element).hasClass('active'), 'target:' + target + ', element' + element)
+        start()
+        deferred.resolve()
+      })
+      $content.scrollTop(scrollHeight)
+      return deferred.promise()
+    }
+
+    $.when(testElementIsActiveAfterScroll('#li-1', '#div-1'))
+      .then(function(){ return testElementIsActiveAfterScroll('#li-2', '#div-2') })
+  })
+
 })


### PR DESCRIPTION
The "should switch active class on scroll" test looked incorrect to me so I replaced it. In this case ok($topbar.find('.active')) was always truthy.

 I'm not very experienced with qunit and used promises to make the tests pass, I'm not sure if that is a good practice. I also would have preferred to make separate tests with a setup but qunit doesn't support "sub modules" yet.

I wrote more tests and will submit them if this one is approved (if code style is ok etc).
