### PR TITLE
Fixed affix-bottom positioning

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -82,7 +82,7 @@
       .trigger($.Event(affixType.replace('affix', 'affixed')))
 
     if (affix == 'bottom') {
-      this.$element.offset({ top: position.top })
+      this.$element.offset({ top: scrollHeight - this.$element.height() - offsetBottom })
     }
   }
 


### PR DESCRIPTION
Hello,

When playing with an affixed sidebar, I noticed the sidebar could overlap my footer depending on the speed at which I scroll the page.

I also noticed that when I open Chrome dev tools and I make the dev tools panel take most of the height of the page, then refreshing the page would style my sidebar with `.affix-bottom` straight and also make it overlap my footer.

This is caused by `this.$element.offset({ top: position.top })` which positions the affixed element depending on its current position which only works if you transition smoothly from `.affix` to `.affix-bottom`.

I suggest this line gets replaced with `this.$element.offset({ top: scrollHeight - this.$element.height() - offsetBottom })` which corresponds to the computation made to decide whether or not to switch to `.affix-bottom` state.

I'm a first time Bootstrap user so please forgive me if I overlooked something obvious.
What do you think?
