### PR TITLE
IE8 button group support

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -232,5 +232,5 @@
 [data-toggle="buttons"] > .btn > input[type="checkbox"] {
   position: absolute;
   z-index: -1;
-  opacity: 0;
+  .opacity(0);
 }


### PR DESCRIPTION
Hi,

is there any particular reason for not supporting 0 opacity for button groups on IE8 ?
(i can't have them hidden with display:none)

If there is any reason behind it, ignore :)
