### PR TITLE
Update for custom accordion markup

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -38,7 +38,7 @@
     this.$element.trigger(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
-    var actives = this.$parent && this.$parent.find('> .panel > .in')
+    var actives = this.$parent && this.$parent.find('.in')
 
     if (actives && actives.length) {
       var hasData = actives.data('bs.collapse')


### PR DESCRIPTION
Setting up an accordion was quite restricted, as one had to use panels. Removing the panel class from the selector removes that restriction.
