### PR TITLE
Adjust for Scrollspy offset when calculating maxScroll.

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -69,7 +69,7 @@
   ScrollSpy.prototype.process = function () {
     var scrollTop    = this.$scrollElement.scrollTop() + this.options.offset
     var scrollHeight = this.$scrollElement[0].scrollHeight || Math.max(this.$body[0].scrollHeight, document.documentElement.scrollHeight)
-    var maxScroll    = scrollHeight - this.$scrollElement.height()
+    var maxScroll    = this.options.offset + scrollHeight - this.$scrollElement.height()
     var offsets      = this.offsets
     var targets      = this.targets
     var activeTarget = this.activeTarget

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -42,7 +42,8 @@ $(function () {
     ok($topbar.find('.active', true))
   })
 
-  test('should only switch active class on current target', function () {
+  asyncTest('should only switch active class on current target', function () {
+    expect(1);
     var sectionHTML = '<div id="root" class="active">' +
         '<div class="topbar">' +
         '<div class="topbar-inner">' +
@@ -75,7 +76,40 @@ $(function () {
         .find('#scrollspy-example')
         .bootstrapScrollspy({target: '#ss-target'})
 
+    $scrollSpy.on('scroll.bs.scrollspy', function () {
+      ok($section.hasClass('active'), 'Active class still on root node')
+      start()
+    })
     $scrollSpy.scrollTop(350);
-    ok($section.hasClass('active'), 'Active class still on root node')
+  })
+
+  asyncTest('middle navigation option correctly selected when large offset is used', function () {
+    expect(3);
+    var sectionHTML = '<div id="header" style="height: 500px;"></div>' +
+        '<nav id="navigation" class="navbar">' +
+        '<ul class="nav navbar-nav">' +
+        '<li class="active"><a id="one-link" href="#one">One</a></li>' +
+        '<li><a id="two-link" href="#two">Two</a></li>' +
+        '<li><a id="three-link" href="#three">Three</a></li>' +
+        '</ul>' +
+        '</nav>' +
+        '<div id="content" style="height: 200px; overflow-y: auto;">' +
+        '<div id="one" style="height: 500px;"></div>' +
+        '<div id="two" style="height: 300px;"></div>' +
+        '<div id="three" style="height: 10px;"></div>' +
+        '</div>',
+        $section = $(sectionHTML).appendTo('#qunit-fixture'),
+        $scrollSpy = $section
+        .show()
+        .filter('#content')
+    $scrollSpy.bootstrapScrollspy({target: '#navigation', offset: $scrollSpy.position().top})
+
+    $scrollSpy.on('scroll.bs.scrollspy', function () {
+      ok(!$section.find('#one-link').parent().hasClass('active'), 'Active class removed from first section')
+      ok($section.find('#two-link').parent().hasClass('active'), 'Active class on middle section')
+      ok(!$section.find('#three-link').parent().hasClass('active'), 'Active class not on last section')
+      start()
+    })
+    $scrollSpy.scrollTop(550);
   })
 })


### PR DESCRIPTION
There is a bug in Scrollspy where it will prematurely jump to the last navigation element when using an offset. The larger the offset used, the more prominent the problem becomes.

Here is a JSFiddle that shows the issue:
http://jsfiddle.net/4gnGy/4/

The fix is to add the offset to the maxScroll. All of the offsets created during Scrollspy initialization will be the offset + each element's scrollTop value so maxScroll needs to account for the offset as well.
