### PR TITLE
Add referral to third party translations in docs; closes #13094

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -38,6 +38,9 @@
 {% if page.slug == "customize" %}
 <script src="../assets/js/customize.min.js"></script>
 {% endif %}
+{% if page.slug == "getting-started" or page.slug == "css" or page.slug == "components" or page.slug == "js" %}
+<script src="../assets/js/translation-notice.js"></script>
+{% endif %}
 
 {% comment %}
   Inject Twitter widgets asynchronously. Snippet snipped from Twitter's

--- a/docs/assets/js/translation-notice.js
+++ b/docs/assets/js/translation-notice.js
@@ -1,0 +1,47 @@
+---
+layout: nil
+---
+// NOTICE!! DO NOT USE ANY OF THIS JAVASCRIPT
+// IT'S JUST JUNK FOR OUR DOCS!
+// ++++++++++++++++++++++++++++++++++++++++++
+/*!
+ * Copyright 2011-2014 Twitter, Inc.
+ *
+ * Licensed under the Creative Commons Attribution 3.0 Unported License. For
+ * details, see http://creativecommons.org/licenses/by/3.0/.
+ */
+!function ($) {
+
+  var alreadyDismissed = localStorage.getItem('bs.dismissedTranslationNotice') === 'true'
+  var language = navigator.language || navigator.userLanguage
+  var translations = {
+    {% for language in site.data.translations %}
+    {{ language.code }}: {
+      name: '{{ language.name }}',
+      description: '{{ language.description }}',
+      url: '{{ language.url }}'
+    }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  }
+
+  if(!alreadyDismissed && language && language.substring(0, 2) in translations) {
+    var translation = translations[language]
+    var template = '<div class="alert alert-info js-translation-notice">' +
+      '<h4>' + translation.name + ' translation of this documentation available</h4>' +
+      '<p>We want to let you know that you can read this documentation in ' + translation.name + '!</p>' +
+      '<p><small>Please note that this translation has been authored by a third party and may not be up to date.</small></p>' +
+      '<p>' +
+        '<a class="btn btn-primary" href="' + translation.url + '">Open ' + translation.name + ' translation</a> ' +
+        '<button type="button" class="btn btn-default" data-dismiss="alert" data-target=".js-translation-notice">Don\'t show me this again</button>' +
+      '</p>' +
+    '</div>'
+
+    $(template)
+      .insertBefore('.bs-docs-section:first')
+      .alert()
+      .on('close.bs.alert', function () {
+        localStorage.setItem('bs.dismissedTranslationNotice', 'true')
+      })
+  }
+
+}(jQuery)

--- a/docs/assets/js/translation-notice.js
+++ b/docs/assets/js/translation-notice.js
@@ -18,14 +18,14 @@ layout: nil
     {% for language in site.data.translations %}
     {{ language.code }}: {
       name: '{{ language.name }}',
-      description: '{{ language.description }}',
       url: '{{ language.url }}'
     }{% unless forloop.last %},{% endunless %}
     {% endfor %}
   }
 
-  if(!alreadyDismissed && language && language.substring(0, 2) in translations) {
+  if (!alreadyDismissed && language && language.substring(0, 2) in translations) {
     var translation = translations[language]
+    translation.name = $('<div/>').text(translation.name).html()
     var template = '<div class="alert alert-info js-translation-notice">' +
       '<h4>' + translation.name + ' translation of this documentation available</h4>' +
       '<p>We want to let you know that you can read this documentation in ' + translation.name + '!</p>' +


### PR DESCRIPTION
Needs feedback on the phrasing, positioning and styling... pretty much everything.

Currently looks like this:
![bildschirmfoto 2014-05-14 um 00 34 53](https://cloud.githubusercontent.com/assets/1068978/2965111/12effe18-daef-11e3-8c5d-ed11dc5e7671.png)

Closes #13094.

/cc @juthilo @cvrebert @mdo @XhmikosR
