### PR TITLE
Margin fix for buttons after button groups sibling in dialog footers

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -104,7 +104,8 @@
   &:extend(.clearfix all); // clear it in case folks use .pull-* classes on buttons
 
   // Properly space out buttons
-  .btn + .btn {
+  .btn + .btn,
+  .btn-group + .btn {
     margin-left: 5px;
     margin-bottom: 0; // account for input[type="submit"] which gets the bottom margin like all other inputs
   }


### PR DESCRIPTION
Buttons at the right of button groups in dialog footers are not currently getting the same margins than adjacent real buttons.
