### PR TITLE
change note in .resizable() mixin for accuracy

### DIFF
--- a/less/mixins/resize.less
+++ b/less/mixins/resize.less
@@ -2,5 +2,5 @@
 
 .resizable(@direction) {
   resize: @direction; // Options: horizontal, vertical, both
-  overflow: auto; // Safari fix
+  overflow: auto; // Per CSS3 UI, `resize` only applies when `overflow` isn't `visible`
 }


### PR DESCRIPTION
It's not a Safari bug. It's standards-compliant.

Quoting from http://www.w3.org/TR/css3-ui/#resize :

> ### 8.1. `resize` property
> - Applies to: elements with `overflow` other than `visible`
> 
> The `resize` property applies to elements whose computed `overflow` value is something other than `visible`.

Original comment was added in commit 648c4689273647c321dd6e3979d910282e9a9339.

/to @mdo for review

[Part of the bs-css-hacks documentation initiative!](https://github.com/cvrebert/bs-css-hacks/blob/ccd9daad71efbd2c7711795c940bfe14eb51c07b/README.md#resize-requires-overflow-other-than-visible)
