### PR TITLE
auto determine transition durations

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -51,7 +51,7 @@
     $.support.transition && $parent.hasClass('fade') ?
       $parent
         .one($.support.transition.end, removeElement)
-        .emulateTransitionEnd(150) :
+        .emulateTransitionEnd() :
       removeElement()
   }
 

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -135,7 +135,7 @@
           that.sliding = false
           setTimeout(function () { that.$element.trigger(slidEvent) }, 0)
         })
-        .emulateTransitionEnd($active.css('transition-duration').slice(0, -1) * 1000)
+        .emulateTransitionEnd()
     } else {
       $active.removeClass('active')
       $next.addClass('active')

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -78,7 +78,7 @@
 
     this.$element
       .on($.support.transition.end + '.bs.collapse', $.proxy(complete, this))
-      .emulateTransitionEnd(350)[dimension](this.$element[0][scrollSize])
+      .emulateTransitionEnd()[dimension](this.$element[0][scrollSize])
   }
 
   Collapse.prototype.hide = function () {
@@ -117,7 +117,7 @@
     this.$element
       [dimension](0)
       .one($.support.transition.end, $.proxy(complete, this))
-      .emulateTransitionEnd(350)
+      .emulateTransitionEnd()
   }
 
   Collapse.prototype.toggle = function () {

--- a/js/modal.js
+++ b/js/modal.js
@@ -88,7 +88,7 @@
           .one($.support.transition.end, function () {
             that.$element.trigger('focus').trigger(e)
           })
-          .emulateTransitionEnd(300) :
+          .emulateTransitionEnd() :
         that.$element.trigger('focus').trigger(e)
     })
   }
@@ -119,7 +119,7 @@
     $.support.transition && this.$element.hasClass('fade') ?
       this.$element
         .one($.support.transition.end, $.proxy(this.hideModal, this))
-        .emulateTransitionEnd(300) :
+        .emulateTransitionEnd() :
       this.hideModal()
   }
 
@@ -182,7 +182,7 @@
       doAnimate ?
         this.$backdrop
           .one($.support.transition.end, callback)
-          .emulateTransitionEnd(150) :
+          .emulateTransitionEnd() :
         callback()
 
     } else if (!this.isShown && this.$backdrop) {
@@ -195,7 +195,7 @@
       $.support.transition && this.$element.hasClass('fade') ?
         this.$backdrop
           .one($.support.transition.end, callbackRemove)
-          .emulateTransitionEnd(150) :
+          .emulateTransitionEnd() :
         callbackRemove()
 
     } else if (callback) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -82,7 +82,7 @@
     transition ?
       $active
         .one($.support.transition.end, next)
-        .emulateTransitionEnd(150) :
+        .emulateTransitionEnd() :
       next()
 
     $active.removeClass('in')

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -201,7 +201,7 @@
       $.support.transition && this.$tip.hasClass('fade') ?
         $tip
           .one($.support.transition.end, complete)
-          .emulateTransitionEnd(150) :
+          .emulateTransitionEnd() :
         complete()
     }
   }
@@ -287,7 +287,7 @@
     $.support.transition && this.$tip.hasClass('fade') ?
       $tip
         .one($.support.transition.end, complete)
-        .emulateTransitionEnd(150) :
+        .emulateTransitionEnd() :
       complete()
 
     this.hoverState = null

--- a/js/transition.js
+++ b/js/transition.js
@@ -31,30 +31,27 @@
     return false // explicit for ie8 (  ._.)
   }
 
-  function determineTotalTransitionTime($el)
-  {
-    var max = 0, i, total,
-        duration = $el.css('transition-duration'),
-        delay = $el.css('transition-delay')
+  function determineTotalTransitionTime($el) {
+    var max = 0
+    var duration = $el.css('transition-duration')
+    var delay = $el.css('transition-delay')
 
     // for browsers that don't support transitions
-    if (duration === undefined) { return 0 }
-
-    duration = $.map(duration.split(', '), function(value) { return value.slice(0, -1); })
-    delay = $.map(delay.split(', '), function(value) { return value.slice(0, -1); })
+    if (duration === undefined) return 0
 
     // determine which transition takes the longest
-    for (i = 0; i < duration.length; i++) {
-      total = duration[i] + delay[i]
-      max = max > total ? total : max
+    for (var i = 0; i < duration.length; i++) {
+      var total = parseFloat(duration[i]) + parseFloat(delay[i])
+      max = max < total ? total : max
     }
 
     return max * 1000
   }
 
   // http://blog.alexmaccaw.com/css-transitions
-  $.fn.emulateTransitionEnd = function () {
-    var $this = this, called = false, duration = determineTotalTransitionTime($this)
+  $.fn.emulateTransitionEnd = function (duration) {
+    var $this = this, called = false,
+        duration = duration || determineTotalTransitionTime($this)
     $this.one($.support.transition.end, function () { called = true })
     var callback = function () { if (!called) $this.trigger($.support.transition.end) }
     setTimeout(callback, duration)

--- a/js/transition.js
+++ b/js/transition.js
@@ -39,6 +39,9 @@
     // for browsers that don't support transitions
     if (duration === undefined) return 0
 
+    duration = duration.split(', ')
+    delay = delay.split(', ')
+
     // determine which transition takes the longest
     for (var i = 0; i < duration.length; i++) {
       var total = parseFloat(duration[i]) + parseFloat(delay[i])

--- a/js/transition.js
+++ b/js/transition.js
@@ -18,7 +18,6 @@
 
     var transEndEventNames = {
       WebkitTransition : 'webkitTransitionEnd',
-      MozTransition    : 'transitionend',
       OTransition      : 'oTransitionEnd otransitionend',
       transition       : 'transitionend'
     }
@@ -32,13 +31,34 @@
     return false // explicit for ie8 (  ._.)
   }
 
+  function determineTotalTransitionTime($el)
+  {
+    var max = 0, i, total,
+        duration = $el.css('transition-duration'),
+        delay = $el.css('transition-delay')
+
+    // for browsers that don't support transitions
+    if (duration === undefined) { return 0 }
+
+    duration = $.map(duration.split(', '), function(value) { return value.slice(0, -1); })
+    delay = $.map(delay.split(', '), function(value) { return value.slice(0, -1); })
+
+    // determine which transition takes the longest
+    for (i = 0; i < duration.length; i++) {
+      total = duration[i] + delay[i]
+      max = max > total ? total : max
+    }
+
+    return max * 1000
+  }
+
   // http://blog.alexmaccaw.com/css-transitions
-  $.fn.emulateTransitionEnd = function (duration) {
-    var called = false, $el = this
-    $(this).one($.support.transition.end, function () { called = true })
-    var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
+  $.fn.emulateTransitionEnd = function () {
+    var $this = this, called = false, duration = determineTotalTransitionTime($this)
+    $this.one($.support.transition.end, function () { called = true })
+    var callback = function () { if (!called) $this.trigger($.support.transition.end) }
     setTimeout(callback, duration)
-    return this
+    return $this
   }
 
   $(function () {

--- a/js/transition.js
+++ b/js/transition.js
@@ -50,8 +50,10 @@
 
   // http://blog.alexmaccaw.com/css-transitions
   $.fn.emulateTransitionEnd = function (duration) {
-    var $this = this, called = false,
-        duration = duration || determineTotalTransitionTime($this)
+    var $this = this
+    var called = false
+    duration = duration || determineTotalTransitionTime($this)
+    
     $this.one($.support.transition.end, function () { called = true })
     var callback = function () { if (!called) $this.trigger($.support.transition.end) }
     setTimeout(callback, duration)

--- a/js/transition.js
+++ b/js/transition.js
@@ -53,7 +53,7 @@
     var $this = this
     var called = false
     duration = duration || determineTotalTransitionTime($this)
-    
+
     $this.one($.support.transition.end, function () { called = true })
     var callback = function () { if (!called) $this.trigger($.support.transition.end) }
     setTimeout(callback, duration)


### PR DESCRIPTION
this is very similar to pull request #13286
what @tdolsen did there is change .emulateTransitionEnd to take either a number or a string.
if you pass in a number, it acts the same as before. if you pass in a string (presumably one from $el.css('transition-duration'), thus giving you "2s" or "2s, 3s", etc) it will parse those, determine which is the greatest, and return that value in milliseconds

now that's a great start to fixing .emulateTransionEnd, however it leaves out 2 key factors
1. it does not take into account if transition-delay is not zero
2. you have to keep track of your css transition times in your javascript

i figured that because in practice you would always be calling .emulateTransitionEnd on an element with a transition, we can just fetch the duration and delays times right from the element using $.fn.css

this way we no longer have to pass what the supposed transition time to .emulateTransitionEnd, so when we make changes to those transition in css, we don't have to worry about making changes to our js as well

and second, obviously, i'm taking into account both duration and delay

i'm made changes to transition.js, implementing what i explained about, and also removed the arguments for all location that .emulateTransitionEnd is calls
