### PR TITLE
Add "disallowMultipleVarDecl" to the JSCS config

### DIFF
--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -1,5 +1,6 @@
 {
   "disallowEmptyBlocks": true,
+  "disallowMultipleVarDecl": true,
   "disallowKeywords": ["with"],
   "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "disallowMixedSpacesAndTabs": true,


### PR DESCRIPTION
We already adhere to it, so I was wondering why we didn't check for it.

See https://github.com/mdevils/node-jscs#disallowmultiplevardecl
