### PR TITLE
Modals return focus to [data-target="modal"] on hidden

### DIFF
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -1076,6 +1076,8 @@ if (typeof jQuery === 'undefined') { throw new Error('Bootstrap\'s JavaScript re
     Plugin.call($target, option, this)
     $target.one('hide', function () {
       $this.is(':visible') && $this.trigger('focus')
+    }).on('hidden.bs.modal', function() {
+      $this.trigger('focus')
     })
   })
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -271,6 +271,8 @@
     Plugin.call($target, option, this)
     $target.one('hide', function () {
       $this.is(':visible') && $this.trigger('focus')
+    }).on('hidden.bs.modal', function() {
+      $this.trigger('focus')
     })
   })
 

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -201,4 +201,27 @@ $(function () {
 
     div.remove()
   })
+
+  test('should return focus to element trigger with [data-toggle="modal"]', function () {
+    stop()
+    $.support.transition = false
+
+    var div = $('<div id="modal-test" class="modal"></div>')
+    var button = $('<button type="button" id="button" data-target="#modal-test" data-toggle="modal">Show</button>')
+
+    div.appendTo('#qunit-fixture')
+    button.appendTo('#qunit-fixture')
+
+    div
+      .one('shown.bs.modal', function () {
+        div.bootstrapModal('hide')
+      })
+      .one('hidden.bs.modal', function () {
+        start()
+        ok(document.activeElement == button[0], 'returned focus to button')
+      })
+    button.click()
+
+  })
+
 })


### PR DESCRIPTION
Resolves issue #12364
- small change in the data api to trigger focus on lauch element
- attempt to write a test (HELP Needed!)
