### PR TITLE
Relax collapse's descendants selector

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -158,7 +158,7 @@
   // COLLAPSE DATA-API
   // =================
 
-  $(document).on('click.bs.collapse.data-api', '[data-toggle="collapse"]', function (e) {
+  $(document).on('click.bs.collapse.data-api', '[data-toggle~="collapse"]', function (e) {
     var $this   = $(this), href
     var target  = $this.attr('data-target')
         || e.preventDefault()


### PR DESCRIPTION
Using an equal selector on the data-toggle attribute prevents the ability to combine collapse with another component (e.g. tooltip).

I'd propose relaxing the descendants selector to use a contains ('[data-toggle!="collapse"]), contains prefix ('[data-toggle*="collapse"]), or contains word ('[data-toggle~="collapse"]) selector. Although, I would venture to say that the contains word selector would be best suited in this case.
