### PR TITLE
Removed bootstrap.less from bower main property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
   ],
   "homepage": "http://getbootstrap.com",
   "main": [
-    "less/bootstrap.less",
     "dist/css/bootstrap.css",
     "dist/js/bootstrap.js",
     "dist/fonts/glyphicons-halflings-regular.eot",


### PR DESCRIPTION
As state at https://github.com/bower/bower.json-spec#main bower's main
property should contain only the compiled versions.
