### PR TITLE
Reassigned minification of CSS files from the less task to the cssmin ta...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -175,15 +175,6 @@ module.exports = function (grunt) {
         files: {
           'dist/css/<%= pkg.name %>-theme.css': 'less/theme.less'
         }
-      },
-      minify: {
-        options: {
-          cleancss: true
-        },
-        files: {
-          'dist/css/<%= pkg.name %>.min.css': 'dist/css/<%= pkg.name %>.css',
-          'dist/css/<%= pkg.name %>-theme.min.css': 'dist/css/<%= pkg.name %>-theme.css'
-        }
       }
     },
 
@@ -238,6 +229,12 @@ module.exports = function (grunt) {
       options: {
         compatibility: 'ie8',
         keepSpecialComments: '*'
+      },
+      core: {
+        files: {
+          'dist/css/<%= pkg.name %>.min.css': 'dist/css/<%= pkg.name %>.css',
+          'dist/css/<%= pkg.name %>-theme.min.css': 'dist/css/<%= pkg.name %>-theme.css',
+        }
       },
       docs: {
         src: [
@@ -436,7 +433,7 @@ module.exports = function (grunt) {
 
   // CSS distribution task.
   grunt.registerTask('less-compile', ['less:compileCore', 'less:compileTheme']);
-  grunt.registerTask('dist-css', ['less-compile', 'autoprefixer', 'usebanner', 'csscomb', 'less:minify', 'cssmin']);
+  grunt.registerTask('dist-css', ['less-compile', 'autoprefixer', 'usebanner', 'csscomb', 'cssmin']);
 
   // Docs distribution task.
   grunt.registerTask('dist-docs', 'copy:docs');


### PR DESCRIPTION
Reassigned minification of CSS files from the `less` task to the `cssmin` task. 

This fixes issue [#1304](https://github.com/twbs/bootstrap/issues/13604) when using escaped code in LESS.
