### PR TITLE
show proper error message when viewing Customizer in IE8

### DIFF
--- a/docs/customize.html
+++ b/docs/customize.html
@@ -5,6 +5,23 @@ slug: customize
 lead: Customize Bootstrap's components, Less variables, and jQuery plugins to get your very own version.
 ---
 
+<!-- less.js isn't IE8-compatible and throws an exception during initialization, so our Blob compatibility check and error messaging code never get called in that case.
+  So we use a conditional comment instead to inform folks about the lack of IE8 support.
+  The alert covers up the entire customizer UI.
+-->
+<!--[if lt IE 9]>
+  <style>
+    .bs-customizer,
+    .bs-docs-sidebar {
+      display: none;
+    }
+  </style>
+  <div class="alert alert-danger bs-customizer-alert-ie">
+    <strong>The Bootstrap Customizer does not support IE9 and below.</strong><br>
+    Please take a second to <a href="http://browsehappy.com/">upgrade to a more modern browser</a>.
+  </div>
+<![endif]-->
+
 <!-- Customizer form -->
 <form class="bs-customizer" role="form">
   <div class="bs-docs-section" id="less-section">


### PR DESCRIPTION
Closes #13090.
Modulo the `<strong>` tag I've since added, here's what this looks like:
![ie8](https://cloud.githubusercontent.com/assets/419884/3011003/02634c02-df23-11e3-9e82-d3bbd83b185f.png)
Note that this only shows in IE<9.

@mdo Sound acceptable?
