### PR TITLE
Repaint Fixes When Scrolling

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -31,10 +31,10 @@
 
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {
-    .translate(0, -25%);
+    .translate3d(0, -25%, 0);
     .transition-transform(~"0.3s ease-out");
   }
-  &.in .modal-dialog { .translate(0, 0)}
+  &.in .modal-dialog { .translate3d(0, 0, 0) }
 }
 
 // Shell div to position the modal with bottom padding

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -141,6 +141,7 @@
   right: 0;
   left: 0;
   z-index: @zindex-navbar-fixed;
+  .translate3d(0, 0, 0);
 
   // Undo the rounded corners
   @media (min-width: @grid-float-breakpoint) {

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -53,4 +53,5 @@
 
 .affix {
   position: fixed;
+  .translate3d(0, 0, 0);
 }


### PR DESCRIPTION
Heya guys!

Here's my 2nd attempt at this. Thanks again for being so patient with my first try.

Ideally, `translateZ(0)` would work the best in the spots that I've added the vendor-prefix mixin of `.translate3d()` as it has IE9 support. Based on feedback from my first PR, I avoided adding a mixin specifically for `translateZ`.

The translate3d fix for `.modal` is tricky. It effectively fixes repaints on scroll.. but it might be problematic for IE  8-9.

Thanks!
