### PR TITLE
Table-responsive: changed overflow-x to auto to hide scrollbar when it's not overflown, fixes #13669.

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -173,7 +173,7 @@ table {
     width: 100%;
     margin-bottom: (@line-height-computed * 0.75);
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
     border: 1px solid @table-border-color;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
See the issue that i submitted: https://github.com/twbs/bootstrap/issues/13669
