### PR TITLE
Color Contrast for panel heading

### DIFF
--- a/less/mixins/panels.less
+++ b/less/mixins/panels.less
@@ -11,6 +11,10 @@
     + .panel-collapse > .panel-body {
       border-top-color: @border;
     }
+    .badge {
+      color: @background-color;
+      background-color: @color;
+    }
   }
   & > .panel-footer {
     + .panel-collapse > .panel-body {

--- a/less/mixins/panels.less
+++ b/less/mixins/panels.less
@@ -12,8 +12,8 @@
       border-top-color: @border;
     }
     .badge {
-      color: @background-color;
-      background-color: @color;
+      color: @heading-bg-color;
+      background-color: @heading-text-color;
     }
   }
   & > .panel-footer {


### PR DESCRIPTION
Badges in primary panel heading is gray. please change that like other primary components.
related to #13686
