### PR TITLE
Minor Updates to Scrollspy.js

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -14,16 +14,13 @@
   // ==========================
 
   function ScrollSpy(element, options) {
-    var href
     var process  = $.proxy(this.process, this)
 
     this.$element       = $(element).is('body') ? $(window) : $(element)
     this.$body          = $('body')
     this.$scrollElement = this.$element.on('scroll.bs.scrollspy', process)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
-    this.selector       = (this.options.target
-      || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
-      || '') + ' .nav li > a'
+    this.selector       = (this.options.target || '') + ' .nav li > a'
     this.offsets        = []
     this.targets        = []
     this.activeTarget   = null

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -16,15 +16,15 @@
   function ScrollSpy(element, options) {
     var process  = $.proxy(this.process, this)
 
-    this.$element       = $(element).is('body') ? $(window) : $(element)
     this.$body          = $('body')
-    this.$scrollElement = this.$element.on('scroll.bs.scrollspy', process)
+    this.$scrollElement = $(element).is('body') ? $(window) : $(element)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
     this.selector       = (this.options.target || '') + ' .nav li > a'
     this.offsets        = []
     this.targets        = []
     this.activeTarget   = null
 
+    this.$scrollElement.on('scroll.bs.scrollspy', process)
     this.refresh()
     this.process()
   }
@@ -36,7 +36,7 @@
   }
 
   ScrollSpy.prototype.refresh = function () {
-    var offsetMethod = this.$element[0] == window ? 'offset' : 'position'
+    var offsetMethod = this.$scrollElement[0] == window ? 'offset' : 'position'
 
     this.offsets = []
     this.targets = []

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -24,8 +24,8 @@
     this.selector       = (this.options.target
       || ((href = $(element).attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
       || '') + ' .nav li > a'
-    this.offsets        = $([])
-    this.targets        = $([])
+    this.offsets        = []
+    this.targets        = []
     this.activeTarget   = null
 
     this.refresh()
@@ -41,8 +41,8 @@
   ScrollSpy.prototype.refresh = function () {
     var offsetMethod = this.$element[0] == window ? 'offset' : 'position'
 
-    this.offsets = $([])
-    this.targets = $([])
+    this.offsets = []
+    this.targets = []
 
     var self     = this
 
@@ -76,7 +76,7 @@
     var i
 
     if (scrollTop >= maxScroll) {
-      return activeTarget != (i = targets.last()[0]) && this.activate(i)
+      return activeTarget != (i = targets[targets.length - 1]) && this.activate(i)
     }
 
     if (activeTarget && scrollTop <= offsets[0]) {

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -36,7 +36,13 @@
   }
 
   ScrollSpy.prototype.refresh = function () {
-    var offsetMethod = this.$scrollElement[0] == window ? 'offset' : 'position'
+    var offsetMethod = 'offset'
+    var offsetBase   = 0
+
+    if (!$.isWindow(this.$scrollElement[0])) {
+      offsetMethod = 'position'
+      offsetBase   = this.$scrollElement.scrollTop()
+    }
 
     this.offsets = []
     this.targets = []
@@ -54,7 +60,7 @@
         return ($href
           && $href.length
           && $href.is(':visible')
-          && [[ $href[offsetMethod]().top + (!$.isWindow(self.$scrollElement.get(0)) && self.$scrollElement.scrollTop()), href ]]) || null
+          && [[ $href[offsetMethod]().top + offsetBase, href ]]) || null
       })
       .sort(function (a, b) { return a[0] - b[0] })
       .each(function () {


### PR DESCRIPTION
Minor refactoring...
- Make `this.offsets` and `this.targets` vanilla javascript arrays again
- Removes check for href attribute on the scrollable element – No one is going to use an `<a>` tag to define a scrollable block
- Removes `this.$element` since it was merely a duplicate of `this.$scrollElement`
- Combine logic of multiple segments within the refresh method which depend on whether or not `$scrollElement` is equal to `window` for better speed and readability.
