### PR TITLE
removing unnecessary max-width on tables

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -4,7 +4,6 @@
 
 
 table {
-  max-width: 100%;
   background-color: @table-bg;
 }
 th {


### PR DESCRIPTION
From the history, it appears max-width was added to tables.less when various css declarations originating in reset.less were relocated to appropriate less files so that reset.less could be removed in favor of normalize.less.

However, this max-width declaration did not come from Eric Meyer's reset.less. Instead, it was added in the following check-in by @mdo "help tables not look like shit on mobile maybe?"

https://github.com/twbs/bootstrap/commit/97b285896f50bed4a66b00a70ed67eb3224bc7f3

I don't believe that this declaration has proven it helps layouts on mobile. However it does cause layout problems when using bootstrap in conjunction with other javascript libraries.

If the original implementation was iffy to begin with, lets just remove it.
