### PR TITLE
Tooltip arrow fixes

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -253,16 +253,17 @@
     if (delta.left) offset.left += delta.left
     else offset.top += delta.top
 
-    var arrowDelta          = delta.left ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
-    var arrowPosition       = delta.left ? 'left'        : 'top'
-    var arrowOffsetPosition = delta.left ? 'offsetWidth' : 'offsetHeight'
+    var topBottom           = /top|bottom/.test(placement)
+    var arrowDelta          = topBottom ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
+    var arrowOffsetPosition = topBottom ? 'offsetWidth' : 'offsetHeight'
 
     $tip.offset(offset)
-    this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], arrowPosition)
+    this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], topBottom)
   }
 
-  Tooltip.prototype.replaceArrow = function (delta, dimension, position) {
-    this.arrow().css(position, delta ? (50 * (1 - delta / dimension) + '%') : '')
+  Tooltip.prototype.replaceArrow = function (delta, dimension, rightLeft) {
+    this.arrow()
+      .css(rightLeft ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
   }
 
   Tooltip.prototype.setContent = function () {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -264,6 +264,7 @@
   Tooltip.prototype.replaceArrow = function (delta, dimension, rightLeft) {
     this.arrow()
       .css(rightLeft ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
+      .css(rightLeft ? 'top' : 'left', '')
   }
 
   Tooltip.prototype.setContent = function () {


### PR DESCRIPTION
This fixes two bugs in the tooltips plugin:
- The tooltip arrow orientation was chosen using the truthiness of the `delta.left` value returned by `getCalculatedOffset`, however there are cases when this value is 0, but the placement of the plugin is still top or bottom, which means the arrow should be positioned using the `left` property. This fix uses the existing `placement` variable (fixes #13696)
- If the page layout changes after the tooltip has been shown, the tooltip orientation could change, in which case the alternate CSS property was never reset (couldn't find an existing issue for this)
