### PR TITLE
No need for mixin repeating unstyled styles

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -167,14 +167,14 @@ ol {
 // List options
 
 // Unstyled keeps list items block level, just removes default browser padding and list-style
-.list-unstyled {
+.list-unstyled,
+.list-inline {
   padding-left: 0;
   list-style: none;
 }
 
 // Inline turns list items into inline-block
 .list-inline {
-  .list-unstyled();
   margin-left: -5px;
 
   > li {


### PR DESCRIPTION
I initially replaced with mixin with .extend but why not just do it manually.
