### PR TITLE
Fix bug where a panel recieve extra top border when placed within a collapsible panel

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -206,7 +206,7 @@
 
   .panel-heading {
     border-bottom: 0;
-    + .panel-collapse .panel-body {
+    + .panel-collapse > .panel-body {
       border-top: 1px solid @panel-inner-border;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/13734

A panel placed inside of a collapsible panel receive extra top border.

This commit reduces the effect of a selector to apply a border only to
the collapsible panel body itself, not to any panel placed within it.
