### PR TITLE
Added replace directive for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
     "branch-alias": {
       "dev-master": "3.1.x-dev"
     }
+  },
+  "replace": {
+    "twitter/bootstrap": "self.version"
   }
 }


### PR DESCRIPTION
When renaming a package, you should add a [`replace`](https://getcomposer.org/doc/04-schema.md#replace) directive. be0974802d9ff19d6b4c12c288b3a4fd5c625415

Current problem: Some packages require twitter/bootstrap while are require twbs/bootstrap, making it impossible to use these package together. See also jasny/bootstrap#254
