### PR TITLE
input-group-btn: Fix IE8 crash with `font-size: 0;`

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -132,7 +132,7 @@
   position: relative;
   // Jankily prevent input button groups from wrapping with `white-space` and
   // `font-size` in combination with `inline-block` on buttons.
-  font-size: 0;
+  font-size: 0.1px;
   white-space: nowrap;
 
   // Negative margin for spacing, position for bringing hovered/focused/actived


### PR DESCRIPTION
I've found that using `font-size: 0;` in the case of the `.input-btn-group` class crashes Internet Explorer 8.

To recreate the crash visit http://getbootstrap.com/components/ in Internet Explorer 8 with Windows XP. This particular page starts to crash in Windows 7 but recovers eventually, but on one of my client's sites Win7/IE8 never recovers the page.

This is a rather ugly fix, so I am open to suggestions. 

**Update**
The issue with http://getbootstrap.com/components/ on Win7/IE8 is intermittent and seems more likely to happen if more tabs are open. I'm presented with a dialog that "Internet Explorer has stopped working". 

![screenshot 2014-06-09 02 27 20](https://cloud.githubusercontent.com/assets/3422554/3213875/00ee96aa-efa0-11e3-999a-d55e73c74e8e.png)

Clicking "Close the program" does not close IE but shows the dialog 0 to 2 more times, after which point IE recovers the page and it is browsable
