### PR TITLE
Add responsive media-mixins shortcut

### DIFF
--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -192,3 +192,26 @@
     .responsive-invisibility();
   }
 }
+
+/* Responsive media-mixins */
+.media-xs(@rules) {
+  @media (max-width: @screen-xs-max) {
+    @rules();
+  }
+}
+.media-sm(@rules) {
+  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+    @rules();
+  }
+}
+.media-md(@rules) {
+  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+    @rules();
+  }
+}
+.media-lg(@rules) {
+  @media (min-width: @screen-lg-min) {
+    @rules(); 
+  }
+}
+

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -193,7 +193,7 @@
   }
 }
 
-/* Responsive media-mixins */
+// Responsive media-mixins
 .media-xs(@rules) {
   @media (max-width: @screen-xs-max) {
     @rules();


### PR DESCRIPTION
usage example:

``` less
.media-xs({
  div {
    border:1px solid red;
  }
})
```

result:

``` css
@media (max-width: 767px) {
  div {
    border:1px solid red;
  }
}
```
