### PR TITLE
Fix gutter variable

### DIFF
--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -6,8 +6,8 @@
 .container-fixed(@gutter: @grid-gutter-width) {
   margin-right: auto;
   margin-left: auto;
-  padding-left:  (@grid-gutter-width / 2);
-  padding-right: (@grid-gutter-width / 2);
+  padding-left:  (@gutter / 2);
+  padding-right: (@gutter / 2);
   &:extend(.clearfix all);
 }
 


### PR DESCRIPTION
Issue #13616 was fixed by commit e06970948b963fa2fb11583533f726a3a8051967 earlier today, but I think part of the required changes accidentally got left out.

@gutter is now a parameter for the mixin, but the mixin itself still uses the old @grid-gutter-width variable.

This fixes that.
