### PR TITLE
<input> buttons line-height Firefox bugfix has been shipped!

### DIFF
--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -173,6 +173,6 @@
   <div class="bs-callout bs-callout-warning">
     <h4>Cross-browser rendering</h4>
     <p>As a best practice, <strong>we highly recommend using the <code>&lt;button&gt;</code> element whenever possible</strong> to ensure matching cross-browser rendering.</p>
-    <p>Among other things, there's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451">a Firefox bug</a> that prevents us from setting the <code>line-height</code> of <code>&lt;input&gt;</code>-based buttons, causing them to not exactly match the height of other buttons on Firefox.</p>
+    <p>Among other things, there's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451">a bug in Firefox &lt;30</a> that prevents us from setting the <code>line-height</code> of <code>&lt;input&gt;</code>-based buttons, causing them to not exactly match the height of other buttons on Firefox.</p>
   </div>
 </div>

--- a/docs/browser-bugs.html
+++ b/docs/browser-bugs.html
@@ -24,12 +24,6 @@ lead: "A list of the browser bugs that Bootstrap is currently grappling with."
       </thead>
       <tbody>
         <tr>
-          <td>Firefox &lt;30</td>
-          <td>Allow use of line-height for <code>&lt;input&gt;</code>-based buttons</td>
-          <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451">Mozilla bug #697451</a></td>
-          <td><a href="https://github.com/twbs/bootstrap/issues/2985">#2985</a></td>
-        </tr>
-        <tr>
           <td>Firefox</td>
           <td>Unusual default form control styles on Android</td>
           <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=900871">Closed Mozilla bug #900871</a>, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=763671">Open Mozilla bug #763671</a></td>


### PR DESCRIPTION
See http://www.mozilla.org/en-US/firefox/30.0/releasenotes/
- Remove Wall of Browser Bugs entry.
- Update mention of the bug in the CSS docs.

To: @mdo for review
