### PR TITLE
Reenable additional Sauce browsers

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -5,11 +5,10 @@
     browserName: "safari",
     platform: "OS X 10.9"
   },
-  # {
-  #   browserName: "chrome",
-  #   platform: "OS X 10.9",
-  #   version: "31"
-  # },
+  {
+    browserName: "chrome",
+    platform: "OS X 10.9"
+  },
   {
     browserName: "firefox",
     platform: "OS X 10.9"

--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -26,16 +26,16 @@
     version: "10",
     platform: "Windows 8"
   },
-  # {
-  #   browserName: "internet explorer",
-  #   version: "9",
-  #   platform: "Windows 7"
-  # },
-  # {
-  #   browserName: "internet explorer",
-  #   version: "8",
-  #   platform: "Windows 7"
-  # },
+  {
+    browserName: "internet explorer",
+    version: "9",
+    platform: "Windows 7"
+  },
+  {
+    browserName: "internet explorer",
+    version: "8",
+    platform: "Windows 7"
+  },
 
   # { # Unofficial
   #   browserName: "internet explorer",


### PR DESCRIPTION
Once https://github.com/axemclion/grunt-saucelabs/pull/136 is in place, our tests should be able to cope with flakier browsers, which will allow us to reenable testing with some of our officially supported browsers that were rather flaky on Sauce in our past experience.

This should only be merged after there is a new release of `grunt-saucelabs` and we've upgraded to it.
