### PR TITLE
fix for #13747

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -202,10 +202,10 @@
         var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
 
         this.applyPlacement(calculatedOffset, placement)
-        this.hoverState = null
 
         var complete = function () {
           that.$element.trigger('shown.bs.' + that.type)
+          this.hoverState = null
         }
 
         $.support.transition && this.$tip.hasClass('fade') ?

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -205,7 +205,7 @@
 
         var complete = function () {
           that.$element.trigger('shown.bs.' + that.type)
-          this.hoverState = null
+          that.hoverState = null
         }
 
         $.support.transition && this.$tip.hasClass('fade') ?


### PR DESCRIPTION
The hoverState property was reseted before the show animation completed, which caused the tooltip to not show up again if the user leaves & enters again within a 150ms delay.
Fix for #13747.
