### PR TITLE
Add dropped text-justify

### DIFF
--- a/docs/_includes/css/type.html
+++ b/docs/_includes/css/type.html
@@ -201,6 +201,7 @@ You can use the mark tag to <mark>highlight</mark> text.
 <p class="text-left">Left aligned text.</p>
 <p class="text-center">Center aligned text.</p>
 <p class="text-right">Right aligned text.</p>
+<p class="text-justify">Justified text.</p>
 <p class="text-nowrap">No wrap text.</p>
 {% endhighlight %}
 


### PR DESCRIPTION
This commit adds the `<p class="text-justify">Justified text.</p>` back into the type docs.

It looks like it got accidentally axed in commit dcbe484a09531da4ecc80fd2991a9910fb6a64ed
