### PR TITLE
Autoprefixer

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -95,7 +95,6 @@ figure {
 hr {
   height: 0;
   -webkit-box-sizing: content-box;
-     -moz-box-sizing: content-box;
           box-sizing: content-box;
 }
 pre {
@@ -146,7 +145,6 @@ input {
 input[type="checkbox"],
 input[type="radio"] {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
           box-sizing: border-box;
   padding: 0;
 }
@@ -156,7 +154,6 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 input[type="search"] {
   -webkit-box-sizing: content-box;
-     -moz-box-sizing: content-box;
           box-sizing: content-box;
   -webkit-appearance: textfield;
 }
@@ -880,13 +877,11 @@ th {
 }
 * {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
           box-sizing: border-box;
 }
 *:before,
 *:after {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
           box-sizing: border-box;
 }
 html {
@@ -2314,7 +2309,6 @@ label {
 }
 input[type="search"] {
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
           box-sizing: border-box;
 }
 input[type="radio"],

--- a/docs/examples/signin/signin.css
+++ b/docs/examples/signin/signin.css
@@ -20,7 +20,6 @@ body {
   position: relative;
   height: auto;
   -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
           box-sizing: border-box;
   padding: 10px;
   font-size: 16px;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "canonical-json": "~0.0.4",
     "glob": "^4.0.0",
     "grunt": "~0.4.4",
-    "grunt-autoprefixer": "~0.7.2",
+    "grunt-autoprefixer": "~0.7.5",
     "grunt-banner": "~0.2.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.4.0",


### PR DESCRIPTION
Autoprefixer 1.2 and grunt-autoprefixer 0.7.5 were released earlier today.

This bumps the package.json to those versions.

This also introduces a change in the css, as the updated autoprefixer now knows about the Firefox 30 release which means that the latest two versions of Firefox (as specified in the config) no longer need the `-moz-box-sizing` prefix.
