### PR TITLE
Make autoprefixer browsers fixed

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,7 +180,7 @@ module.exports = function (grunt) {
 
     autoprefixer: {
       options: {
-        browsers: ['last 2 versions', 'ie 8', 'ie 9', 'android 2.3', 'android 4', 'opera 12']
+        browsers: ['Android 2.3', 'Android >= 4', 'Chrome >= 20', 'Firefox >= 24', 'Explorer >= 8', 'iOS >= 6', 'Opera >= 12', 'Safari >= 6'] /* Firefox 24 is the latest ESR */
       },
       core: {
         options: {


### PR DESCRIPTION
Lets make the browsers we support through autoprefixer fixed, so we can control when we don't want to support specific browsers anymore and avoid issues like in #13792.

For the browsers which weren't explicitly set I used the oldest version that wouldn't cause new prefixes to be added as a baseline.
