### PR TITLE
Update generated markup by the tooltip plugin in docs; fixes #13796

### DIFF
--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -63,11 +63,11 @@ $('#example').tooltip(options)
 <a href="#" data-toggle="tooltip" title="Some tooltip text!">Hover over me</a>
 
 <!-- Generated markup by the plugin -->
-<div class="tooltip top">
+<div class="tooltip top" role="tooltip">
+  <div class="tooltip-arrow"></div>
   <div class="tooltip-inner">
     Some tooltip text!
   </div>
-  <div class="tooltip-arrow"></div>
 </div>
 {% endhighlight %}
 


### PR DESCRIPTION
Not sure about `id="tooltip[Random number]"`, any ideas @cvrebert? Would also need to mention that the triggering element gets `aria-describedby`.
Also, has the ID assignment and `aria-describedby` business been documented already?
