### PR TITLE
UMD code style

### DIFF
--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -14,6 +14,7 @@
   "disallowTrailingComma": true,
   "disallowSpacesInsideParentheses": true,
   "disallowTrailingWhitespace": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireCapitalizedConstructors": true,
   "requireCommaBeforeLineBreak": true,
   "requireDotNotation": true,

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -9,6 +9,7 @@
   "latedef"  : true,
   "laxbreak" : true,
   "nonbsp"   : true,
+  "strict"   : true,
   "undef"    : true,
   "unused"   : true,
   "predef"   : [ "define", "require" ]

--- a/js/affix.js
+++ b/js/affix.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/affix.js
+++ b/js/affix.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/affix.js
+++ b/js/affix.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/alert.js
+++ b/js/alert.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/alert.js
+++ b/js/alert.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/alert.js
+++ b/js/alert.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/button.js
+++ b/js/button.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/button.js
+++ b/js/button.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/button.js
+++ b/js/button.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/modal.js
+++ b/js/modal.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/modal.js
+++ b/js/modal.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/modal.js
+++ b/js/modal.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/popover.js
+++ b/js/popover.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/popover.js
+++ b/js/popover.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/popover.js
+++ b/js/popover.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tab.js
+++ b/js/tab.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tab.js
+++ b/js/tab.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tab.js
+++ b/js/tab.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -10,7 +10,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -8,9 +8,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -9,8 +9,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/transition.js
+++ b/js/transition.js
@@ -9,7 +9,7 @@
 
 (function (o_o) {
   typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(this.jQuery)
+  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/transition.js
+++ b/js/transition.js
@@ -8,8 +8,8 @@
 
 
 (function (o_o) {
-  typeof define  === 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports === 'object' ? o_o(require('jquery')) : o_o(jQuery)
+  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
+  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
 })(function ($) {
 
   'use strict';

--- a/js/transition.js
+++ b/js/transition.js
@@ -7,9 +7,10 @@
  * ======================================================================== */
 
 
-(function (o_o) {
-  typeof define  == 'function' && define.amd ? define(['jquery'], o_o) :
-  typeof exports == 'object' ? o_o(require('jquery')) : o_o(jQuery)
+(function (factory) {
+  /* jshint strict: false */
+  typeof define  == 'function' && define.amd ? define(['jquery'], factory) :
+  typeof exports == 'object' ? factory(require('jquery')) : factory(jQuery)
 })(function ($) {
 
   'use strict';


### PR DESCRIPTION
This includes three rather controversial things:
1. 
   1. Renames the argument of the UMD function to `factory` from `o_o`
   2. Subsequently re-enables `requireCamelCaseOrUpperCaseIdentifiers` for JSCS
2. 
   1. Re-enables the `strict` rule of JSHint
   2. Adds `/* jshint strict: false */` to the function (as suggested by @XhmikosR)
3. Replaces `===` in favor of `==` in the UMD function to comply with the currently used comparator with `typeof` in the rest of the codebase. ([Ref](https://gist.github.com/hnrch02/496f60b534c1fa375a09))

This is why I have split this into two easy-to-revert commits, in case the hopefully vivid discussion following this PR concludes that something should be removed.

/cc @fat @cvrebert

(Remember, make love, not war <3)
