### PR TITLE
Always use preserveComment: 'some'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,17 +109,14 @@ module.exports = function (grunt) {
     },
 
     uglify: {
+      options: {
+        preserveComments: 'some'
+      },
       bootstrap: {
-        options: {
-          banner: '<%= banner %>'
-        },
         src: '<%= concat.bootstrap.dest %>',
         dest: 'dist/js/<%= pkg.name %>.min.js'
       },
       customize: {
-        options: {
-          preserveComments: 'some'
-        },
         src: [
           'docs/assets/js/_vendor/less.min.js',
           'docs/assets/js/_vendor/jszip.min.js',
@@ -132,9 +129,6 @@ module.exports = function (grunt) {
         dest: 'docs/assets/js/customize.min.js'
       },
       docsJs: {
-        options: {
-          preserveComments: 'some'
-        },
         src: [
           'docs/assets/js/_vendor/holder.js',
           'docs/assets/js/_vendor/ZeroClipboard.min.js',


### PR DESCRIPTION
While creating the `bootstrap.js` file during `grunt dist` a header gets added to that file. 

When we then create the `bootstrap.min.js` file from it, we don't specify a `preserveComments` setting in the `uglify:bootstrap` task so the default will be to strip that banner out, but because we specify an explicit `banner` setting it gets added right back in.

Therefore we could change the `banner` setting to a `preserveComments: 'some'` setting, without changing the output.

But this would result in all `uglify` tasks having a `preserveComments: 'some'` setting, so we could hoist that setting up to be a global `uglify` setting.

This PR makes those changes.

The generated `.min.js` files are identical.
