### PR TITLE
Fix for btn-group-justify double borders

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -220,6 +220,39 @@
   > .btn-group .dropdown-menu {
     left: auto;
   }
+
+  > .btn {
+    border-right-width: 0px;
+  }
+
+  > .btn:last-child {
+    border-right-width: 1px;
+  }
+
+  > :hover,
+  > :focus,
+  > :active,
+  > .active {
+    &.btn-default + .btn {
+        border-left-color: darken(@btn-default-border, 14%);
+    }
+    &.btn-primary + .btn {
+        border-left-color: darken(@btn-primary-border, 14%);
+    }
+    &.btn-success + .btn {
+        border-left-color: darken(@btn-success-border, 14%);
+    }
+    &.btn-info + .btn {
+        border-left-color: darken(@btn-info-border, 14%);
+    }
+    &.btn-warning + .btn {
+        border-left-color: darken(@btn-warning-border, 14%);
+    }
+    &.btn-danger + .btn {
+        border-left-color: darken(@btn-default-border, 14%);
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
This is more of a proof of concept than a total fix. For this to fully work, the theme needs to be changed as well and rules need to be added for `open > .dropdown-toggle`. Those are both quite a bit of extra work and before I do that I would like to know if this solution is even appreciated. 

Furthermore any suggestions to make it more generic or less hacky are welcome. This was the best way I could think of.
