### PR TITLE
dropdown.js: preventDefault instead of return false

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -53,7 +53,7 @@
           .trigger('shown.bs.dropdown', relatedTarget)
       }
 
-      e.preventDefault(); // return false
+      e.preventDefault()
     }
 
     Dropdown.prototype.keydown = function (e) {

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -53,7 +53,7 @@
           .trigger('shown.bs.dropdown', relatedTarget)
       }
 
-      return false
+      e.preventDefault(); // return false
     }
 
     Dropdown.prototype.keydown = function (e) {


### PR DESCRIPTION
`return false` swallows up the event, meaning you cannot attach any other click events to this element.
