### PR TITLE
Fix dismissible spelling

### DIFF
--- a/docs/_includes/components/alerts.html
+++ b/docs/_includes/components/alerts.html
@@ -32,16 +32,16 @@
 <div class="alert alert-danger" role="alert">...</div>
 {% endhighlight %}
 
-  <h2 id="alerts-dismissable">Dismissable alerts</h2>
-  <p>Build on any alert by adding an optional <code>.alert-dismissable</code> and close button.</p>
+  <h2 id="alerts-dismissible">Dismissible alerts</h2>
+  <p>Build on any alert by adding an optional <code>.alert-dismissible</code> and close button.</p>
   <div class="bs-example">
-    <div class="alert alert-warning alert-dismissable" role="alert">
+    <div class="alert alert-warning alert-dismissible" role="alert">
       <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
       <strong>Warning!</strong> Better check yourself, you're not looking too good.
     </div>
   </div>
 {% highlight html %}
-<div class="alert alert-warning alert-dismissable" role="alert">
+<div class="alert alert-warning alert-dismissible" role="alert">
   <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
   <strong>Warning!</strong> Better check yourself, you're not looking too good.
 </div>

--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -111,10 +111,10 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
   <h4>Dismiss on next click</h4>
   <p>Use the <code>focus</code> trigger to dismiss popovers on their next click.</p>
   <div class="bs-example" style="padding-bottom: 24px;">
-    <button type="button" class="btn btn-lg btn-danger bs-docs-popover-dismiss" data-toggle="popover" title="Dismissable popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissable popover</button>
+    <button type="button" class="btn btn-lg btn-danger bs-docs-popover-dismiss" data-toggle="popover" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</button>
   </div>
 {% highlight html %}
-<button type="button" class="btn btn-lg btn-danger popover-dismiss" data-toggle="popover" title="Dismissable popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissable popover</button>
+<button type="button" class="btn btn-lg btn-danger popover-dismiss" data-toggle="popover" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</button>
 {% endhighlight %}
 {% highlight js %}
 $('.popover-dismiss').popover({

--- a/docs/_includes/nav/components.html
+++ b/docs/_includes/nav/components.html
@@ -94,7 +94,7 @@
   <a href="#alerts">Alerts</a>
   <ul class="nav">
     <li><a href="#alerts-examples">Examples</a></li>
-    <li><a href="#alerts-dismissable">Dismissable alerts</a></li>
+    <li><a href="#alerts-dismissible">Dismissible alerts</a></li>
     <li><a href="#alerts-links">Links in alerts</a></li>
   </ul>
 </li>

--- a/less/alerts.less
+++ b/less/alerts.less
@@ -33,11 +33,12 @@
   }
 }
 
-// Dismissable alerts
+// Dismissible alerts
 //
 // Expand the right padding and account for the close button's positioning.
 
-.alert-dismissable {
+.alert-dismissable, // The misspelled .alert-dismissable was deprecated in 3.2.0.
+.alert-dismissible {
   padding-right: (@alert-padding + 20);
 
   // Adjust close link position


### PR DESCRIPTION
Based on #10404.

In the code we use `dismissable`, while it should be `dismissible`. ([Dictionary entry](http://www.oxforddictionaries.com/definition/english/dismiss?q=dismissible#dismiss__15))

I changed all references in the docs, but kept a copy of the old class name in the `alerts.less` file, marked as deprecated, for backwards compatibility.
