### PR TITLE
Add white-space: nowrap; to .dropdown-header

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -155,6 +155,7 @@
   font-size: @font-size-small;
   line-height: @line-height-base;
   color: @dropdown-header-color;
+  white-space: nowrap; // as with > li > a
 }
 
 // Backdrop to catch body clicks on mobile, etc.


### PR DESCRIPTION
Dropdowns adjust their width to the width of their containing a elements - which have no line breaks [[*](https://github.com/twbs/bootstrap/commit/f226463b057f945795661c3d19fbcabf63b931f7)]. Consistent to this dropdown-headers also should be prevent to contain line breaks.
