### PR TITLE
Darken @gray-light to meet accessibility guidelines

### DIFF
--- a/docs/assets/css/_src/docs.css
+++ b/docs/assets/css/_src/docs.css
@@ -857,7 +857,7 @@ h1[id] {
   left: 15px;
   font-size: 12px;
   font-weight: bold;
-  color: #bbb;
+  color: #959595;
   text-transform: uppercase;
   letter-spacing: 1px;
   content: "Example";

--- a/less/variables.less
+++ b/less/variables.less
@@ -10,7 +10,7 @@
 @gray-darker:            lighten(#000, 13.5%); // #222
 @gray-dark:              lighten(#000, 20%);   // #333
 @gray:                   lighten(#000, 33.5%); // #555
-@gray-light:             lighten(#000, 60%);   // #999
+@gray-light:             lighten(#000, 46.7%); // #777
 @gray-lighter:           lighten(#000, 93.5%); // #eee
 
 @brand-primary:         #428bca;


### PR DESCRIPTION
`@gray-light` darkens from `#999` to `#777`, which puts `.text-muted` at the
threshold for the 4.5:1 WCAG minimum contrast[1]. `#777`:`#fff` is 4.48:1.

The “Example” headers in docs becomes #959595, which is contrast ratio
3:1, the minimum for larger text. Since the headers are less important
than the surrounding text, 3:1 is fine and an improvement on the
previous `#bbb`:`#fff` (1.92:1).

Fixes issue #13847.

[1] http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
