### PR TITLE
Use mousedown instead of click for backdrop click detection; fixes #13816

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -166,7 +166,7 @@
       this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
         .appendTo(this.$body)
 
-      this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
+      this.$element.on('mousedown.dismiss.bs.modal', $.proxy(function (e) {
         if (e.target !== e.currentTarget) return
         this.options.backdrop == 'static'
           ? this.$element[0].focus.call(this.$element[0])

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -154,7 +154,7 @@ $(function () {
         ok($('#modal-test').length, 'modal insterted into dom')
         $('.contents').click()
         ok($('#modal-test').is(':visible'), 'modal visible')
-        $('#modal-test').click()
+        $('#modal-test').mousedown()
       })
       .on('hidden.bs.modal', function () {
         ok(!$('#modal-test').is(':visible'), 'modal hidden')
@@ -174,7 +174,7 @@ $(function () {
     div
       .on('shown.bs.modal', function () {
         triggered = 0
-        $('#modal-test').click()
+        $('#modal-test').mousedown()
       })
       .on('hide.bs.modal', function () {
         triggered += 1


### PR DESCRIPTION
See #13816.

In action [here](http://rawgit.com/hnrch02/bootstrap/d90e8bf5096cf79a9c5b242648c88ed6cdf060b2/js/tests/visual/modal.html).
