### PR TITLE
Use @panel-inner-border for .panel-heading border-bottom

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -21,7 +21,7 @@
 // Optional heading
 .panel-heading {
   padding: @panel-heading-padding;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid @panel-inner-border;
   .border-top-radius((@panel-border-radius - 1));
 
   > .dropdown .dropdown-toggle {


### PR DESCRIPTION
I noticed .panel-heading was not using @panel-inner-border for it's border, but .panel-footer was. It seems like these two things should be consistent.
