### PR TITLE
Use full deprecation version

### DIFF
--- a/less/mixins/progress-bar.less
+++ b/less/mixins/progress-bar.less
@@ -3,7 +3,7 @@
 .progress-bar-variant(@color) {
   background-color: @color;
 
-  // Deprecated parent class requirement as of v3.2
+  // Deprecated parent class requirement as of v3.2.0
   .progress-striped & {
     #gradient > .striped();
   }

--- a/less/mixins/vendor-prefixes.less
+++ b/less/mixins/vendor-prefixes.less
@@ -1,6 +1,6 @@
 // Vendor Prefixes
 //
-// All vendor mixins are deprecated as of v3.2 due to the introduction of
+// All vendor mixins are deprecated as of v3.2.0 due to the introduction of
 // Autoprefixer in our Gruntfile. They will be removed in v4.
 
 // - Animations

--- a/less/progress-bars.less
+++ b/less/progress-bars.less
@@ -42,7 +42,7 @@
 
 // Striped bars
 //
-// `.progress-striped .progress-bar` is deprecated as of v3.2 in favor of the
+// `.progress-striped .progress-bar` is deprecated as of v3.2.0 in favor of the
 // `.progress-bar-striped` class, which you just add to an existing
 // `.progress-bar`.
 .progress-striped .progress-bar,
@@ -53,7 +53,7 @@
 
 // Call animation for the active one
 //
-// `.progress.active .progress-bar` is deprecated as of v3.2 in favor of the
+// `.progress.active .progress-bar` is deprecated as of v3.2.0 in favor of the
 // `.progress-bar.active` approach.
 .progress.active .progress-bar,
 .progress-bar.active {


### PR DESCRIPTION
Almost everywhere in the code we use the full version number in deprecation notices. There are a couple of exceptions though. This brings those exceptions in line with the rest of the codebase.
