### PR TITLE
Removed blocker to build tools

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "dist/fonts/glyphicons-halflings-regular.woff"
   ],
   "ignore": [
-    ".*",
     "_config.yml",
     "CNAME",
     "composer.json",


### PR DESCRIPTION
`bower install bootstrap` is a very convenient way to install bootstrap into a project. It includes the dist folder for js and css files and also includes the build tools. However by ignoring " .\* " you are not allowing developers to download the configure files such as less/.csslintrc and grunt/.jshintc from bower. 

These are crucial elements to building with `grunt`. Its likely best to either only serve the dist folder with a `bower install bootstrap` or include all the tools necessary to build bootstrap similar to a git clone. I suggest the latter. 

Note: if there are crucial hidden files to ignore, implicit ignores may prove to be a better route.
