### PR TITLE
Remove broken link

### DIFF
--- a/docs/_includes/getting-started/examples.html
+++ b/docs/_includes/getting-started/examples.html
@@ -1,7 +1,7 @@
 <div class="bs-docs-section">
   <h1 id="examples" class="page-header">Examples</h1>
 
-  <p class="lead">Build on the basic template above with Bootstrap's many components. See also <a href="#customizing">Customizing Bootstrap</a> for tips on maintaining your own Bootstrap variants.</p>
+  <p class="lead">Build on the basic template above with Bootstrap's many components. We encourage you to customize and adapt Bootstrap to suit your individual project's needs.</p>
 
   <h3 id="examples-framework">Using the framework</h3>
   <div class="row bs-examples">


### PR DESCRIPTION
The Examples section from Getting started still has an internal link to the Customizing Bootstrap section, which no longer exists. I presume it got overlooked because the section was removed in the huge commit that split the docs up into _includes.

To: @mdo for proofreading/copy.
