### PR TITLE
add "focus" to focused btns with button plugin

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -97,14 +97,30 @@
   }
 
 
+  // FOCUS SHIM (FOR BUTTON GROUPS)
+  // ==============================
+
+  function getBtnTarget(target) {
+    var $target = $(target)
+    return $target.hasClass('btn') ? $target : $target.parent('.btn')
+  }
+
+
   // BUTTON DATA-API
   // ===============
 
-  $(document).on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-    var $btn = $(e.target)
-    if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-    Plugin.call($btn, 'toggle')
-    e.preventDefault()
-  })
+  $(document)
+    .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
+      var $btn = $(e.target)
+      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
+      Plugin.call($btn, 'toggle')
+      e.preventDefault()
+    })
+    .on('focus.bs.button.data-api', '[data-toggle^="button"]', function (e) {
+      getBtnTarget(e.target).addClass('focus')
+    })
+    .on('blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
+      getBtnTarget(e.target).removeClass('focus')
+    })
 
 }(jQuery);


### PR DESCRIPTION
possible solution for #12145. 

bit tired tho so might have missed something…

similar to @hnrch02 – except uses focus/blur instead of focusin/focusout. I was going to use the latter, but read firefox doesn't support them (https://developer.mozilla.org/en-US/docs/Web/Events/focusout)… and this appears to work, even though i thought they didn't bubble :eyes: weird.

went back and forth with toggle class, but ultimately thought it might be safer to tie specific events to specific actions
