### PR TITLE
Move variable declaration before its use (for Sass)

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -822,6 +822,8 @@
 //
 //##
 
+//** Horizontal offset for forms and lists.
+@component-offset-horizontal: 180px;
 //** Text muted color
 @text-muted:                  @gray-light;
 //** Abbreviations and acronyms border color
@@ -838,14 +840,7 @@
 @page-header-border-color:    @gray-lighter;
 //** Width of horizontal description list titles
 @dl-horizontal-offset:        @component-offset-horizontal;
-
-
-//== Miscellaneous
-//
-//##
-
 //** Horizontal line color.
 @hr-border:                   @gray-lighter;
 
-//** Horizontal offset for forms and lists.
-@component-offset-horizontal: 180px;
+


### PR DESCRIPTION
In Sass, a variable must be declared before it is used.
This moves `$component-offset-horizontal` and `$hr-border` to Typography (arguably horizontal rule line color and form / list paddings are Typography). Perhaps instead Miscellaneous should be moved before Type, or the port should deal with this?
