### PR TITLE
assign background to row of .table-striped

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -106,6 +106,7 @@ th {
 
 .table-striped {
   > tbody > tr:nth-child(odd) {
+    background-color: @table-bg-accent;
     > td,
     > th {
       background-color: @table-bg-accent;

--- a/less/tables.less
+++ b/less/tables.less
@@ -107,10 +107,6 @@ th {
 .table-striped {
   > tbody > tr:nth-child(odd) {
     background-color: @table-bg-accent;
-    > td,
-    > th {
-      background-color: @table-bg-accent;
-    }
   }
 }
 
@@ -121,10 +117,7 @@ th {
 
 .table-hover {
   > tbody > tr:hover {
-    > td,
-    > th {
-      background-color: @table-bg-hover;
-    }
+    background-color: @table-bg-hover;
   }
 }
 


### PR DESCRIPTION
if background is not set on row, striping doesn't work properly in responsive tables where row and cells are set to  display: block.

sorry, no bug report - jumped straight to fixing

bin
http://jsbin.com/cuyov/1/edit?html,css,output
