### PR TITLE
Added @gray-base variable to make @gray-{shade} reference, also allows @...

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -7,11 +7,12 @@
 //
 //## Gray and brand colors for use across Bootstrap.
 
-@gray-darker:            lighten(#000, 13.5%); // #222
-@gray-dark:              lighten(#000, 20%);   // #333
-@gray:                   lighten(#000, 33.5%); // #555
-@gray-light:             lighten(#000, 46.7%); // #777
-@gray-lighter:           lighten(#000, 93.5%); // #eee
+@gray-base:		 #000;
+@gray-darker:            lighten(@gray-base, 13.5%); // #222
+@gray-dark:              lighten(@gray-base, 20%);   // #333
+@gray:                   lighten(@gray-base, 33.5%); // #555
+@gray-light:             lighten(@gray-base, 46.7%); // #777
+@gray-lighter:           lighten(@gray-base, 93.5%); // #eee
 
 @brand-primary:         #428bca;
 @brand-success:         #5cb85c;

--- a/less/variables.less
+++ b/less/variables.less
@@ -7,7 +7,7 @@
 //
 //## Gray and brand colors for use across Bootstrap.
 
-@gray-base:		 #000;
+@gray-base:		  #000;
 @gray-darker:            lighten(@gray-base, 13.5%); // #222
 @gray-dark:              lighten(@gray-base, 20%);   // #333
 @gray:                   lighten(@gray-base, 33.5%); // #555


### PR DESCRIPTION
Also allows @gray-base to be modified with less#modifyVars (see [Using Less in the Browser](http://lesscss.org/usage/#using-less-in-the-browser)) and the vars to cascade.

The reason I did this is that as I mentioned it allows less to cascade the changes to the @gray variables if the @gray-base variable is changed.
It also makes sense as all the variables have the same value, so why not extract it into a single variable.

I have done something similar in my own [variables_custom.less](https://github.com/ilikeprograms/BootstrapThemeEditor/blob/master/src/variables-custom.less) file for my [BootstrapThemeEditor](https://github.com/ilikeprograms/BootstrapThemeEditor) project.
