### PR TITLE
Ensure that hidden event is sent when content is really hidden (collapsi...

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -96,9 +96,9 @@
     var complete = function () {
       this.transitioning = 0
       this.$element
-        .trigger('hidden.bs.collapse')
         .removeClass('collapsing')
         .addClass('collapse')
+        .trigger('hidden.bs.collapse')
     }
 
     if (!$.support.transition) return complete.call(this)


### PR DESCRIPTION
We need to ensure that 'hidden' event is triggered only after the 'collapsing' class is removed from collapse element.

Otherwise we cannot rely on this event to find "hidden" children.

This behavior is wished if you want to implement WAI-ARIA features that dynamicaly adapt and rely on visibility of elements to build navigation or element descriptions.
