### PR TITLE
Remove "pointer" cursor on disabled list-group-item

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -74,7 +74,8 @@ a.list-group-item {
   &.disabled:focus {
     background-color: @list-group-disabled-bg;
     color: @list-group-disabled-color;
-
+    cursor: default;
+    
     // Force color to inherit for custom content
     .list-group-item-heading {
       color: inherit;

--- a/less/list-group.less
+++ b/less/list-group.less
@@ -74,7 +74,7 @@ a.list-group-item {
   &.disabled:focus {
     background-color: @list-group-disabled-bg;
     color: @list-group-disabled-color;
-    cursor: default;
+    cursor: not-allowed;
     
     // Force color to inherit for custom content
     .list-group-item-heading {


### PR DESCRIPTION
This update remove the "pointer" cursor when a "disabled" class is added to a linked list-group-item
