### PR TITLE
Make the "panel-title" easily clickable

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -20,7 +20,6 @@
 
 // Optional heading
 .panel-heading {
-  padding: @panel-heading-padding;
   border-bottom: 1px solid transparent;
   .border-top-radius((@panel-border-radius - 1));
 
@@ -37,6 +36,8 @@
   color: inherit;
 
   > a {
+    display: block;
+    padding: @panel-heading-padding;
     color: inherit;
   }
 }


### PR DESCRIPTION
![accordion-screenshot](https://cloud.githubusercontent.com/assets/5230079/3399761/f83d969e-fd3e-11e3-90a7-46612b912415.jpg)

I think this is useful because it makes the `accordion plugin` much easier to operate. With this change you can click anywhere on the `panel-title` and the link which opens the accordion will work just fine.

I hope it helps!

Best regards, Lubomir Georgiev.
