### PR TITLE
Remove apparent dead code from docs JS

### DIFF
--- a/docs/assets/js/_src/application.js
+++ b/docs/assets/js/_src/application.js
@@ -85,11 +85,6 @@
     $('.tooltip-test').tooltip()
     $('.popover-test').popover()
 
-    $('.bs-docs-navbar').tooltip({
-      selector: 'a[data-toggle="tooltip"]',
-      container: '.bs-docs-navbar .nav'
-    })
-
     // Default popover demo
     $('.bs-docs-popover').popover()
 


### PR DESCRIPTION
The `.bs-docs-navbar` class doesn't seem to be used anywhere else at all...
