### PR TITLE
Update vendor-prefixes.less

### DIFF
--- a/less/mixins/vendor-prefixes.less
+++ b/less/mixins/vendor-prefixes.less
@@ -144,6 +144,7 @@
 }
 .translate3d(@x; @y; @z) {
   -webkit-transform: translate3d(@x, @y, @z);
+       -o-transform: translate3d(@x, @y, @z);
           transform: translate3d(@x, @y, @z);
 }
 .rotate(@degrees) {


### PR DESCRIPTION
The `.translate3d` mixin is the only transformation mixin which does not define the `-o-` prefix.
