### PR TITLE
variables.less: Removed the comments following @font-size-hN definitions...

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -46,15 +46,15 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          14px;
-@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
-@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+@font-size-large:         ceil((@font-size-base * 1.25));
+@font-size-small:         ceil((@font-size-base * 0.85));
 
-@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
-@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
-@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
+@font-size-h1:            floor((@font-size-base * 2.6));
+@font-size-h2:            floor((@font-size-base * 2.15));
+@font-size-h3:            ceil((@font-size-base * 1.7));
+@font-size-h4:            ceil((@font-size-base * 1.25));
 @font-size-h5:            @font-size-base;
-@font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
+@font-size-h6:            ceil((@font-size-base * 0.85));
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14


### PR DESCRIPTION
Rationale: I've upgraded Bootstrap versions many times before, for several projects.

The comments that accompany the `@font-size-hn` variables are dependent on the  `@font-size-base` value.

I suggest removing these because:
- the `@font-size-base` value is among the likeliest to change upon customization,
- the font-size progression just isn't difficult to grok,
- I can't imagine these comments in `variables.less` are useful to anyone.

At least, I've never found these `@font-size-hn` comments to be useful other than being incorrect quite soon in the customization process.
