### PR TITLE
docs: use valid JSON in compound option value examples

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -175,7 +175,7 @@ $('.popover-dismiss').popover({
           <td>
            <p>Delay showing and hiding the popover (ms) - does not apply to manual trigger type</p>
            <p>If a number is supplied, delay is applied to both hide/show</p>
-           <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
+           <p>Object structure is: <code>delay: { "show": 500, "hide": 100 }</code></p>
           </td>
         </tr>
         <tr>
@@ -225,7 +225,7 @@ $('.popover-dismiss').popover({
          <td>string | object</td>
          <td>{ selector: 'body', padding: 0 }</td>
          <td>
-          <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ selector: '#viewport', padding: 0 }</code></p>
+          <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ "selector": "#viewport", "padding": 0 }</code></p>
          </td>
        </tr>
       </tbody>

--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -105,7 +105,7 @@ $('#example').tooltip(options)
          <td>
           <p>Delay showing and hiding the tooltip (ms) - does not apply to manual trigger type</p>
           <p>If a number is supplied, delay is applied to both hide/show</p>
-          <p>Object structure is: <code>delay: { show: 500, hide: 100 }</code></p>
+          <p>Object structure is: <code>delay: { "show": 500, "hide": 100 }</code></p>
          </td>
        </tr>
        <tr>
@@ -154,7 +154,7 @@ $('#example').tooltip(options)
          <td>string | object</td>
          <td>{ selector: 'body', padding: 0 }</td>
          <td>
-          <p>Keeps the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ selector: '#viewport', padding: 0 }</code></p>
+          <p>Keeps the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ "selector": "#viewport", "padding": 0 }</code></p>
          </td>
        </tr>
       </tbody>


### PR DESCRIPTION
Fixes #13874.
CC: @fat, @hansifer 
