### PR TITLE
trigger 'affixed.bs.affix' instead of 'affixed'

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -83,7 +83,7 @@
     this.$element
       .removeClass(Affix.RESET)
       .addClass(affixType)
-      .trigger($.Event(affixType.replace('affix', 'affixed')))
+      .trigger($.Event(affixType.replace('affix', 'affixed') + '.bs.affix'))
 
     if (affix == 'bottom') {
       this.$element.offset({

--- a/js/affix.js
+++ b/js/affix.js
@@ -71,7 +71,7 @@
     if (this.unpin != null) this.$element.css('top', '')
 
     var affixType = 'affix' + (affix ? '-' + affix : '')
-    var e         = $.Event(affixType + '.bs.affix')
+    var e         = $.Event()
 
     this.$element.trigger(e)
 
@@ -83,7 +83,7 @@
     this.$element
       .removeClass(Affix.RESET)
       .addClass(affixType)
-      .trigger($.Event(affixType.replace('affix', 'affixed') + '.bs.affix'))
+      .trigger(affixType.replace('affix', 'affixed') + '.bs.affix')
 
     if (affix == 'bottom') {
       this.$element.offset({

--- a/js/affix.js
+++ b/js/affix.js
@@ -71,7 +71,7 @@
     if (this.unpin != null) this.$element.css('top', '')
 
     var affixType = 'affix' + (affix ? '-' + affix : '')
-    var e         = $.Event()
+    var e         = $.Event(affixType + '.bs.affix')
 
     this.$element.trigger(e)
 


### PR DESCRIPTION
Original is triggering `affixed` not `affixed.bs.affix`.
`.on('affixed.bs.affix', ...)` also catch `affixed` event, so it should work properly, but not matching the docs.
