### PR TITLE
fix affix leave `position: relative` when unpin issue

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -68,7 +68,12 @@
                 offsetTop    != null && (scrollTop <= offsetTop) ? 'top' : false
 
     if (this.affixed === affix) return
-    if (this.unpin != null) this.$element.css('top', '')
+    if (this.unpin != null) {
+      this.$element.css({
+        top: '',
+        position: ''
+      });
+    }
 
     var affixType = 'affix' + (affix ? '-' + affix : '')
     var e         = $.Event(affixType + '.bs.affix')


### PR DESCRIPTION
when using `offset({top: x})` to set top, that will change `position` to `relative` (see [here](http://devdocs.io/jquery/offset#offset-functionindex--coords)), if not remove this inline css `relative`, it will override `affix` class `fixed` property.
