### PR TITLE
Simplify addClass/removeClass in collapse file.

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -88,8 +88,7 @@
 
     this.$element
       .addClass('collapsing')
-      .removeClass('collapse')
-      .removeClass('in')
+      .removeClass('collapse in')
 
     this.transitioning = 1
 
@@ -161,7 +160,7 @@
 
     if (!data || !data.transitioning) {
       if ($parent) $parent.find('[data-toggle="collapse"][data-parent="' + parent + '"]').not($this).addClass('collapsed')
-      $this[$target.hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
+      $this.toggleClass('collapsed', $target.hasClass('in'));
     }
 
     Plugin.call($target, option)


### PR DESCRIPTION
Simplify CSS classes toggling in collapse:
- use `toggleClass(condition)` instead of `condition ? addClass : hideClass`,
- use `removeClass('class1 class2')` instead of `removeClass('class1').removeClass('class2')`
