### PR TITLE
Add touch-action: manipulate to .btn

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -2750,6 +2750,8 @@ select[multiple].form-group-lg .form-control {
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
+  -ms-touch-action: manipulation;
+      touch-action: manipulation;
   cursor: pointer;
   -webkit-user-select: none;
      -moz-user-select: none;

--- a/docs/dist/css/bootstrap.css
+++ b/docs/dist/css/bootstrap.css
@@ -2750,6 +2750,8 @@ select[multiple].form-group-lg .form-control {
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
+  -ms-touch-action: manipulation;
+      touch-action: manipulation;
   cursor: pointer;
   -webkit-user-select: none;
      -moz-user-select: none;

--- a/less/.csscomb.json
+++ b/less/.csscomb.json
@@ -109,6 +109,8 @@
       "list-style-type",
       "list-style-image",
       "pointer-events",
+      "-ms-touch-action",
+      "touch-action",
       "cursor",
       "visibility",
       "zoom",

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -12,6 +12,7 @@
   font-weight: @btn-font-weight;
   text-align: center;
   vertical-align: middle;
+  touch-action: manipulation;
   cursor: pointer;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;


### PR DESCRIPTION
By default on a lot of mobile devices there is a 300ms delay between tapping on a button and the tap being executed, as the system waits to see if the tap is actually a double tap. [More info here](https://developers.google.com/mobile/articles/fast_buttons).

On IE10 (with prefix) and IE11 you can specify the touch behavior by setting the `touch-action` CSS property of an element ([More info](http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx)).

This change adds `touch-action: manipulate` to the .btn class, effectively disabling double tap on buttons that use that class and thereby removing the 300ms delay when tapping those buttons in IE10+.
