### PR TITLE
Remove superfluous cursor:pointer

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -3037,7 +3037,6 @@ fieldset[disabled] .btn-danger.active {
 .btn-link {
   font-weight: normal;
   color: #428bca;
-  cursor: pointer;
   border-radius: 0;
 }
 .btn-link,

--- a/docs/dist/css/bootstrap.css
+++ b/docs/dist/css/bootstrap.css
@@ -3037,7 +3037,6 @@ fieldset[disabled] .btn-danger.active {
 .btn-link {
   font-weight: normal;
   color: #428bca;
-  cursor: pointer;
   border-radius: 0;
 }
 .btn-link,

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -85,7 +85,6 @@
 .btn-link {
   color: @link-color;
   font-weight: normal;
-  cursor: pointer;
   border-radius: 0;
 
   &,


### PR DESCRIPTION
As far as I can tell the `.btn-link` class is supposed to always be used in conjunction with the `.btn` class. 

As `.btn` already sets `cursor: pointer;` it doesn't have to be set by `.btn-link` as well.
