### PR TITLE
Deprecate the `remote` option of modals?

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -320,7 +320,7 @@ $('#myModal').modal({
        </tr>
        <tr>
          <td>loaded.bs.modal</td>
-         <td>This event is fired when the modal has loaded content using the remote option.</td>
+         <td>This event is fired when the modal has loaded content using the <code>remote</code> option.</td>
        </tr>
       </tbody>
     </table>

--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -259,7 +259,9 @@
          <td>remote</td>
          <td>path</td>
          <td>false</td>
-         <td><p class="text-danger">This option is deprecated since v3.2.1 and will be removed in v4.</p><p>If a remote URL is provided, <strong>content will be loaded one time</strong> via jQuery's <code>load</code> method and injected into the <code>.modal-content</code> div. If you're using the data-api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
+         <td>
+          <p><span class="text-danger">This option is deprecated since v3.2.1 and will be removed in v4.</span> We recommend instead using client-side templating or a data binding framework, or calling <a href="http://api.jquery.com/load/">jQuery.load</a> yourself.</p>
+          <p>If a remote URL is provided, <strong>content will be loaded one time</strong> via jQuery's <code>load</code> method and injected into the <code>.modal-content</code> div. If you're using the data-api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
 {% highlight html %}
 <a data-toggle="modal" href="remote.html" data-target="#modal">Click me</a>
 {% endhighlight %}

--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -259,7 +259,7 @@
          <td>remote</td>
          <td>path</td>
          <td>false</td>
-         <td><p>If a remote URL is provided, <strong>content will be loaded one time</strong> via jQuery's <code>load</code> method and injected into the <code>.modal-content</code> div. If you're using the data-api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
+         <td><p class="text-danger">This option is deprecated since v3.2.1 and will be removed in v4.</p><p>If a remote URL is provided, <strong>content will be loaded one time</strong> via jQuery's <code>load</code> method and injected into the <code>.modal-content</code> div. If you're using the data-api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
 {% highlight html %}
 <a data-toggle="modal" href="remote.html" data-target="#modal">Click me</a>
 {% endhighlight %}


### PR DESCRIPTION
- @fat closed #13788 (which would have added the completely-reasonable ability to disable unwanted caching for `remote`)
- `remote` doesn't currently give any "loading..." (or similar) visual indication while the network request is in-progress, and doesn't fire any "loading started" event
- `remote` doesn't currently give any visual indication or fire any event when the network request fails
- Depending on the use-case, the user may want to either reuse or refresh the modal's header/footer. In older versions, the user had no nice way of reloading the header. In newer versions, users who don't want to modify the header must regenerate it on their backend anyway. (See #13597)
- The existence of `remote` can discourage the use of client-side templating, even when it might be a preferable option.

So, I think we have 3 options:
1. Add several features to `remote` modals.
2. (This PR.) Deprecate `remote` modals.
3. Status quo: Intentionally leave `remote` modals in a somewhat half-assed state.

CC: @fat @twbs/team for discussion
