### PR TITLE
Follow up to #13907: Add .focus styles for buttons

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -23,13 +23,15 @@
   &,
   &:active,
   &.active {
-    &:focus {
+    &:focus,
+    &.focus {
       .tab-focus();
     }
   }
 
   &:hover,
-  &:focus {
+  &:focus,
+  &.focus {
     color: @btn-default-color;
     text-decoration: none;
   }

--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -10,6 +10,7 @@
 
   &:hover,
   &:focus,
+  &.focus,
   &:active,
   &.active,
   .open > .dropdown-toggle& {
@@ -28,6 +29,7 @@
     &,
     &:hover,
     &:focus,
+    &.focus,
     &:active,
     &.active {
       background-color: @background;


### PR DESCRIPTION
While #13907 apparently works for me (haha), I do believe we need the `.focus` styles specified.

/cc @hnrch02
