### PR TITLE
Remove transitions from button when using it as a form-control

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -51,6 +51,10 @@
     .opacity(.65);
     .box-shadow(none);
   }
+
+  &.form-control {
+    .transition(~"border-color 0, box-shadow 0");
+  }
 }
 
 


### PR DESCRIPTION
This [stack overflow post](http://stackoverflow.com/a/19777742/2570866) suggests that the `form-control` class should be used if you want a full-width button in your form. This sounds reasonable, but because of the focus glow in normal `.form-control` elements it pressing of the button gets an added transition. 
This pull request disables that transition.
