### PR TITLE
Add Pointer Events

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -341,6 +341,7 @@ input[type="checkbox"] {
   height: @input-height-base;
   line-height: @input-height-base;
   text-align: center;
+  pointer-events: none;
 }
 .input-lg + .form-control-feedback {
   width: @input-height-large;


### PR DESCRIPTION
The [form control validation feedback icons](http://getbootstrap.com/css/#forms-control-validation) interfere with focus actions. 

You can prevent this with [`pointer-events: none;`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events). It's definitely not a critical feature, but it's nice to have for [browsers that support it](http://caniuse.com/pointer-events).  It seems like it represents the intuitive UX principle because the icon is styled as if it was _inside_ the input box, so I would expect clicking anywhere inside of it would give the input focus.

Here's a [fiddle that demonstrates this issue](http://jsfiddle.net/KyleMit/U63qA/)

Here's a screenshot illustrating the difference:

![screenshot](http://i.imgur.com/hafhYjS.gif)
