### PR TITLE
Update JS Bin template in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Guidelines for bug reports:
 
 3. **Isolate the problem** &mdash; ideally create a [reduced test
    case](http://css-tricks.com/6263-reduced-test-cases/) and a live example.
-   [This JS Bin](http://jsbin.com/EBAwOkOK/1) is a helpful template.
+   [This JS Bin](http://jsbin.com/lefey/1/edit?html,output) is a helpful template.
 
 
 A good bug report shouldn't leave others needing to chase you up for more


### PR DESCRIPTION
Refs: #14109

Link: http://jsbin.com/zazif/1/edit?html,output

That bin still refers to https://github.com/necolas/issue-guidelines for bug reporting guidelines, is that still valid?

Also, I switched to using a CDN for the Bootstrap files, as @cvrebert mentioned a couple of times that we don't endorse hotlinking to getbootstrap.com
The reason why I chose jsDelivr over BootstrapCDN is that they actually have a up-to-date `/latest/` version. (See [jsDelivr](http://cdn.jsdelivr.net/bootstrap/latest/css/bootstrap.min.css) and [BootstrapCDN](http://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css).)

/cc @cvrebert
