### PR TITLE
dropdowns.html: Add role="button" and id="..." to link in example.

### DIFF
--- a/docs/_includes/js/dropdowns.html
+++ b/docs/_includes/js/dropdowns.html
@@ -104,7 +104,7 @@
   <p>Add <code>data-toggle="dropdown"</code> to a link or button to toggle a dropdown.</p>
 {% highlight html %}
 <div class="dropdown">
-  <a data-toggle="dropdown" href="#">Dropdown trigger</a>
+  <a id="dLabel" role="button" data-toggle="dropdown" href="#">Dropdown trigger</a>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
     ...
   </ul>
@@ -116,7 +116,6 @@
   <a id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="/page.html">
     Dropdown <span class="caret"></span>
   </a>
-
 
   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
     ...


### PR DESCRIPTION
- Add id. ".dropdown-menu" used aria-labelledby="id", but link not used this id.
- Add role="button".
- Remove second empty line (i have not found an example with two empty lines).
