### PR TITLE
Gruntfile.js: Add semicolon in "_update-shrinkwrap" task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -467,7 +467,7 @@ module.exports = function (grunt) {
     var done = this.async();
     npmShrinkwrap({ dev: true, dirname: __dirname }, function (err) {
       if (err) {
-        grunt.fail.warn(err)
+        grunt.fail.warn(err);
       }
       var dest = 'test-infra/npm-shrinkwrap.json';
       fs.renameSync('npm-shrinkwrap.json', dest);


### PR DESCRIPTION
In 3c4ba2a08cef519f2135922f0549bf787cf3010d commit contains a simple code-style error.
