### PR TITLE
Prevent button variant text from underlining on :hover, :active, and :focus states

### DIFF
--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -14,6 +14,7 @@
   &:active,
   &.active,
   .open > .dropdown-toggle& {
+    text-decoration: none;
     color: @color;
     background-color: darken(@background, 10%);
         border-color: darken(@border, 12%);


### PR DESCRIPTION
This is the default behavior with buttons so it should be the default for button variants.
