### PR TITLE
Fix jsbin link

### DIFF
--- a/docs/_includes/getting-started/browser-device-support.html
+++ b/docs/_includes/getting-started/browser-device-support.html
@@ -188,5 +188,5 @@ $(function () {
 })
 </script>
 {% endhighlight %}
-  <p>Want to see an example? <a href="httphttp://jsbin.com/kuvoz/1">Check out this JS Bin demo.</a></p>
+  <p>Want to see an example? <a href="http://jsbin.com/kuvoz/1">Check out this JS Bin demo.</a></p>
 </div>


### PR DESCRIPTION
I think @mdo wanted to be extremely sure the new link from aa730472549087e9a1a76d4031d7f54867372097 uses http. :stuck_out_tongue_winking_eye:
