### PR TITLE
Fixes #14172 Use box sizing inheritance

### DIFF
--- a/docs/_includes/getting-started/third-party-support.html
+++ b/docs/_includes/getting-started/third-party-support.html
@@ -4,48 +4,23 @@
 
   <h3 id="third-box-sizing">Box-sizing</h3>
   <p>Some third party software, including Google Maps and Google Custom Search Engine, conflict with Bootstrap due to <code>* { box-sizing: border-box; }</code>, a rule which makes it so <code>padding</code> does not affect the final computed width of an element. Learn more about <a href="http://css-tricks.com/box-sizing/">box model and sizing at CSS Tricks</a>.</p>
-  <p>Depending on the context, you may override as-needed (Option 1) or reset the box-sizing for entire regions (Option 2).</p>
 {% highlight scss %}
 /* Box-sizing resets
  *
- * Reset individual elements or override regions to avoid conflicts due to
- * global box model settings of Bootstrap. Two options, individual overrides and
- * region resets, are available as plain CSS and uncompiled Less formats.
+ * Override regions to avoid conflicts due to global box model settings of Bootstrap.
+ * Region resets are available as plain CSS and uncompiled Less formats.
  */
 
-/* Option 1A: Override a single element's box model via CSS */
+/* Option 1A: Reset an entire region's box model via CSS */
 .element {
   -webkit-box-sizing: content-box;
      -moz-box-sizing: content-box;
           box-sizing: content-box;
 }
 
-/* Option 1B: Override a single element's box model by using a Bootstrap Less mixin */
+/* Option 1B: Reset an entire region's box model by using a Bootstrap Less mixin */
 .element {
-  .box-sizing(content-box);
-}
-
-/* Option 2A: Reset an entire region via CSS */
-.reset-box-sizing,
-.reset-box-sizing *,
-.reset-box-sizing *:before,
-.reset-box-sizing *:after {
-  -webkit-box-sizing: content-box;
-     -moz-box-sizing: content-box;
-          box-sizing: content-box;
-}
-
-/* Option 2B: Reset an entire region with a custom Less mixin */
-.reset-box-sizing {
-  &,
-  *,
-  *:before,
-  *:after {
-    .box-sizing(content-box);
-  }
-}
-.element {
-  .reset-box-sizing();
+  .box-sizing(inherit);
 }
 {% endhighlight %}
 </div>

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -9,11 +9,11 @@
 // For recommendations on resolving such conflicts, see
 // http://getbootstrap.com/getting-started/#third-box-sizing
 * {
-  .box-sizing(border-box);
+  .box-sizing(inherit);
 }
 *:before,
 *:after {
-  .box-sizing(border-box);
+  .box-sizing(inherit);
 }
 
 
@@ -22,6 +22,7 @@
 html {
   font-size: 10px;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+  .box-sizing(border-box);
 }
 
 body {


### PR DESCRIPTION
Fixes #14172.
Updated the docs too.
Interested to see people thoughts on this and wether resetting whole regions was more or less common than reseting a single element.

Right now I'm thinking that resetting the whole region is most likely what people would want to do, especially to fix problems like the google maps bug described.
