### PR TITLE
move SemVer info from README into the HTML docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ To get started, check out <http://getbootstrap.com>!
  - [Documentation](#documentation)
  - [Contributing](#contributing)
  - [Community](#community)
- - [Versioning](#versioning)
  - [Creators](#creators)
  - [Copyright and license](#copyright-and-license)
 
@@ -100,12 +99,6 @@ Keep track of development and community news.
 - Read and subscribe to [The Official Bootstrap Blog](http://blog.getbootstrap.com).
 - Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##twitter-bootstrap` channel.
 - Implementation help may be found at Stack Overflow (tagged [`twitter-bootstrap-3`](http://stackoverflow.com/questions/tagged/twitter-bootstrap-3)).
-
-
-
-## Versioning
-
-For transparency into our release cycle and in striving to maintain backward compatibility, Bootstrap is maintained under [the Semantic Versioning guidelines](http://semver.org/). Sometimes we screw up, but we'll adhere to those rules whenever possible.
 
 
 

--- a/docs/_includes/getting-started/versioning.html
+++ b/docs/_includes/getting-started/versioning.html
@@ -1,0 +1,17 @@
+<div class="bs-docs-section">
+  <h1 id="versioning" class="page-header">Versioning</h1>
+
+  <p>For transparency into our release cycle and in striving to maintain backward compatibility, Bootstrap is maintained under <a href="http://semver.org">the Semantic Versioning guidelines</a>. Sometimes we screw up, but we'll adhere to these rules whenever possible.</p>
+
+  <p>
+    Releases will be numbered with the following format:<br>
+    <code>&lt;major&gt;.&lt;minor&gt;.&lt;patch&gt;</code>
+  </p>
+
+  And constructed with the following guidelines:
+  <ul>
+    <li>Breaking backward compatibility <strong>bumps the major</strong> while resetting minor and patch</li>
+    <li>New additions without breaking backward compatibility <strong>bump the minor</strong> while resetting the patch</li>
+    <li>Bug fixes and misc changes <strong>bump only the patch</strong></li>
+  </ul>
+</div>

--- a/docs/_includes/nav/getting-started.html
+++ b/docs/_includes/nav/getting-started.html
@@ -61,6 +61,9 @@
   <a href="#accessibility">Accessibility</a>
 </li>
 <li>
+  <a href="#versioning">Versioning</a>
+</li>
+<li>
   <a href="#license-faqs">License FAQs</a>
 </li>
 <li>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -22,5 +22,6 @@ lead: "An overview of Bootstrap, how to download and use, basic templates and ex
 {% include getting-started/browser-device-support.html %}
 {% include getting-started/third-party-support.html %}
 {% include getting-started/accessibility.html %}
+{% include getting-started/versioning.html %}
 {% include getting-started/license.html %}
 {% include getting-started/translations.html %}


### PR DESCRIPTION
Streamlines the README a bit more.
