### PR TITLE
Add left aligned form feedback icon

### DIFF
--- a/docs/_includes/css/forms.html
+++ b/docs/_includes/css/forms.html
@@ -689,6 +689,27 @@
 </div>
 {% endhighlight %}
 
+  <h4>Left Aligned optional icons</h4>
+  <p>You can left-align input icons by adding the <code>.has-feedback-left</code> class on the <code>.form-group</code> element.</p>
+  <div class="bs-callout bs-callout-warning">
+    <h5>Inline Form</h5>
+    <p>The Input and Icon elements must be wrapped together in a div with class <code>.inline-feedback</code> so there is something to help position the left aligned icon.  <code>.col-*</code>  already does this for horizontal forms, and the <code>.has-feedback</code> class takes care of it for basic forms.</p>
+  </div>
+  <div class="bs-example">
+    <div class="form-group has-feedback has-feedback-left">
+      <label class="control-label">Username</label>
+      <input type="text" class="form-control" placeholder="Username" />
+      <span class="form-control-feedback glyphicon glyphicon-user"></span>
+    </div>
+  </div>
+{% highlight html %}
+<div class="form-group has-feedback has-feedback-left">
+  <label class="control-label">Username</label>
+  <input type="text" class="form-control" placeholder="Username" />
+  <span class="form-control-feedback glyphicon glyphicon-user"></span>
+</div>
+{% endhighlight %}
+
 
   <h2 id="forms-control-sizes">Control sizing</h2>
   <p>Set heights using classes like <code>.input-lg</code>, and set widths using grid column classes like <code>.col-lg-*</code>.</p>

--- a/less/forms.less
+++ b/less/forms.less
@@ -326,8 +326,32 @@ input[type="checkbox"] {
   position: relative;
 
   // Ensure icons don't overlap text
+  .form-control{
+    padding-right: @input-height-base;
+  }
+  .form-control.input-sm,
+  &.form-group-sm .form-control{
+    padding-right: @input-height-small;
+  }
+  .form-control.input-lg,
+  &.form-group-lg .form-control {
+    padding-right: @input-height-large; 
+  }
+}
+.has-feedback-left {  
+  // Left Icon Input Padding
   .form-control {
-    padding-right: (@input-height-base * 1.25);
+    //reset changes to right
+    padding-right: @padding-base-horizontal;
+    padding-left: @input-height-base;
+  }
+  .form-control.input-sm,
+  &.form-group-sm .form-control{
+    padding-left: @input-height-small;
+  }
+  .form-control.input-lg,
+  &.form-group-lg .form-control {
+    padding-left: @input-height-large; 
   }
 }
 // Feedback icon (requires .glyphicon classes)
@@ -339,19 +363,25 @@ input[type="checkbox"] {
   display: block;
   width: @input-height-base;
   height: @input-height-base;
-  line-height: @input-height-base;
+  line-height: @input-height-base !important;
   text-align: center;
   pointer-events: none;
 }
-.input-lg + .form-control-feedback {
+// Left Align Icon
+.has-feedback-left .form-control-feedback {
+    left: 0; 
+}
+.input-lg + .form-control-feedback,
+.form-horizontal .form-group-sm .form-control-feedback {
   width: @input-height-large;
   height: @input-height-large;
-  line-height: @input-height-large;
+  line-height: @input-height-large !important;
 }
-.input-sm + .form-control-feedback {
+.input-sm + .form-control-feedback,
+.form-horizontal .form-group-lg .form-control-feedback {
   width: @input-height-small;
   height: @input-height-small;
-  line-height: @input-height-small;
+  line-height: @input-height-small !important;
 }
 
 // Feedback states
@@ -371,7 +401,8 @@ input[type="checkbox"] {
   & ~ .form-control-feedback {
      top: (@line-height-computed + 5); // Height of the `label` and its margin
   }
-  &.sr-only ~ .form-control-feedback {
+  &.sr-only ~ .form-control-feedback,
+  &.sr-only ~ div .form-control-feedback {
      top: 0;
   }
 }
@@ -411,7 +442,14 @@ input[type="checkbox"] {
       margin-bottom: 0;
       vertical-align: middle;
     }
-
+    
+    // Allow left aligned icon in inline form
+    .inline-feedback {
+      // enable absolute positioning
+      position: relative;
+      display: inline-block;
+    }
+    
     // In navbar-form, allow folks to *not* use `.form-group`
     .form-control {
       display: inline-block;
@@ -515,7 +553,9 @@ input[type="checkbox"] {
   .has-feedback .form-control-feedback {
     right: (@grid-gutter-width / 2);
   }
-
+  .has-feedback-left .form-control-feedback {
+    left: (@grid-gutter-width / 2);
+  }
   // Form group sizes
   //
   // Quick utility class for applying `.input-lg` and `.input-sm` styles to the


### PR DESCRIPTION
It's a relatively common use case to add a glyphicon _inside_ of an input box on the left and right.  Most of that functionality has already been developed with `form-control-feedback`, and it would be nice to make a few minor tweaks to add the ability to left align the icon as well.

![screenshot](http://i.imgur.com/BCjscRA.gif)
#### [Here is a demo in plunker illustrating most of the possible alignment scenarios](http://embed.plnkr.co/ZrnnkFR3Yv9HGQHrRMiW/preview)

I used this as a test case to make sure that the alignment stayed true across multiple form configurations, including basic, horizontal, inline, alternative sizing, with and without labels, and using both glyphicons and font awesome.

To get a scope of the desire to do this natively with Bootstrap, here a stack overflow question I answered with 38k+ views about [adding a Glyphicon to an Input Box](http://stackoverflow.com/q/18838964/1366033) 
