### PR TITLE
Fix tooltip positioning with regards to viewports

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -728,7 +728,7 @@ $(function () {
 
     $target.bootstrapTooltip('show')
     var $tooltip = $container.find('.tooltip')
-    var $initialTop = $tooltip.offset().top
+    var $initialTop = Math.round($tooltip.offset().top)
 
     $target.bootstrapTooltip('hide')
 
@@ -737,7 +737,7 @@ $(function () {
     $target.bootstrapTooltip('show')
     $tooltip = $container.find('.tooltip')
 
-    equal($tooltip.offset().top, $initialTop, 'position is the same after scrolling')
+    equal(Math.round($tooltip.offset().top), $initialTop, 'position is the same after scrolling')
     equal($(document).scrollTop(), 2000, 'document scrolled')
 
     $target.bootstrapTooltip('hide')

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -711,6 +711,42 @@ $(function () {
     $styles.remove()
   })
 
+  test('should not be adjust position when scrolling', function () {
+    var styles = '<style>'
+        + '.large-spacer { height: 3000px; }'
+        + '</style>'
+    var $styles = $(styles).appendTo('head')
+
+    var $container = $('<div class="container-viewport"/>').appendTo(document.body)
+    var $target = $('<a href="#" rel="tooltip" title="tip"/>')
+      .appendTo($container)
+      .bootstrapTooltip({
+        placement: 'right',
+        viewport: 'body'
+      })
+    $('<div class="large-spacer"/>').appendTo($container)
+
+    $target.bootstrapTooltip('show')
+    var $tooltip = $container.find('.tooltip')
+    var $initialTop = $tooltip.offset().top
+
+    $target.bootstrapTooltip('hide')
+
+    window.scrollTo(0, 2000)
+
+    $target.bootstrapTooltip('show')
+    $tooltip = $container.find('.tooltip')
+
+    equal($tooltip.offset().top, $initialTop, 'position is the same after scrolling')
+    equal($(document).scrollTop(), 2000, 'document scrolled')
+
+    $target.bootstrapTooltip('hide')
+
+    $container.remove()
+    $styles.remove()
+    window.scrollTo(0, 0)
+  })
+
   test('should not error when trying to show an auto-placed tooltip that has been removed from the dom', function () {
     var passed = true
     var $tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"/>')

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -522,6 +522,42 @@ $(function () {
     $styles.remove()
   })
 
+  test('should not be adjust position when scrolling', function () {
+    var styles = '<style>'
+        + '.large-spacer { height: 3000px; }'
+        + '</style>'
+    var $styles = $(styles).appendTo('head')
+
+    var $container = $('<div class="container-viewport"/>').appendTo(document.body)
+    var $target = $('<a href="#" rel="tooltip" title="tip"/>')
+      .appendTo($container)
+      .bootstrapTooltip({
+        placement: 'right',
+        viewport: 'body'
+      })
+    $('<div class="large-spacer"/>').appendTo($container)
+
+    $target.bootstrapTooltip('show')
+    var $tooltip = $container.find('.tooltip')
+    var $initialTop = $tooltip.offset().top
+
+    $target.bootstrapTooltip('hide')
+
+    window.scrollTo(0, 2000)
+
+    $target.bootstrapTooltip('show')
+    $tooltip = $container.find('.tooltip')
+
+    equal($tooltip.offset().top, $initialTop, 'position is the same after scrolling')
+    equal($(document).scrollTop(), 2000, 'document scrolled')
+
+    $target.bootstrapTooltip('hide')
+
+    $container.remove()
+    $styles.remove()
+    window.scrollTo(0, 0)
+  })
+
   test('should not error when trying to show an auto-placed tooltip that has been removed from the dom', function () {
     var passed = true
     var $tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"/>')

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -404,7 +404,7 @@
 
     return delta
   }
-  
+
   Tooltip.prototype.getTitle = function () {
     var title
     var $e = this.$element

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -365,16 +365,16 @@
       }
     }
 
-    return { top: $viewport.offset().top, left: $viewport.offset().left, width: $viewport.outerWidth(), height: $viewport.outerHeight() }
+    return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
   }
 
   Tooltip.prototype.getScreenSpaceBounds = function () {
-    return $.extend({}, {
+    return {
       top: $('body').scrollTop(),
       left: $('body').scrollLeft(),
       width: $(window).width(),
       height: $(window).height()
-    })
+    }
   }
 
   Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -354,18 +354,18 @@
   }
 
   Tooltip.prototype.getViewportBounds = function ($viewport) {
-    if ($viewport.selector == 'body') {
-      var elementPositionAttribute = $(this.$element).css('position')
-
+    if ($viewport.is('body')) {
       // fixed and absolute elements should be tested against the window
-      switch (elementPositionAttribute) {
+      switch (this.$element.css('position')) {
         case 'absolute':
         case 'fixed':
-          return this.getScreenSpaceBounds();
+        {
+          return this.getScreenSpaceBounds()
+        }
       }
     }
 
-    return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
+    return { top: $viewport.offset().top, left: $viewport.offset().left, width: $viewport.outerWidth(), height: $viewport.outerHeight() }
   }
 
   Tooltip.prototype.getScreenSpaceBounds = function () {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -356,12 +356,8 @@
   Tooltip.prototype.getViewportBounds = function ($viewport) {
     if ($viewport.is('body')) {
       // fixed and absolute elements should be tested against the window
-      switch (this.$element.css('position')) {
-        case 'absolute':
-        case 'fixed':
-        {
-          return this.getScreenSpaceBounds()
-        }
+      if ((/fixed|absolute/).test(this.$element.css('position'))) {
+        return this.getScreenSpaceBounds()
       }
     }
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -340,7 +340,7 @@
     }
     var elOffset  = isBody ? { top: 0, left: 0 } : $element.offset()
     var scroll    = { scroll: isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.scrollTop() }
-    var outerDims = isBody ? { width: $(window).width(), height: $(window).height() } : null
+    var outerDims = isBody ? { width: $element.outerWidth(), height: $element.outerHeight() } : null
 
     return $.extend({}, elRect, scroll, outerDims, elOffset)
   }
@@ -353,16 +353,40 @@
 
   }
 
+  Tooltip.prototype.getViewportBounds = function ($viewport) {
+    if ($viewport.selector == 'body') {
+      var elementPositionAttribute = $(this.$element).css('position')
+
+      // fixed and absolute elements should be tested against the window
+      switch (elementPositionAttribute) {
+        case 'absolute':
+        case 'fixed':
+          return this.getScreenSpaceBounds();
+      }
+    }
+
+    return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
+  }
+
+  Tooltip.prototype.getScreenSpaceBounds = function () {
+    return $.extend({}, {
+      top: $('body').scrollTop(),
+      left: $('body').scrollLeft(),
+      width: $(window).width(),
+      height: $(window).height()
+    })
+  }
+
   Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {
     var delta = { top: 0, left: 0 }
     if (!this.$viewport) return delta
 
     var viewportPadding = this.options.viewport && this.options.viewport.padding || 0
-    var viewportDimensions = this.getPosition(this.$viewport)
+    var viewportDimensions = this.getViewportBounds(this.$viewport)
 
     if (/right|left/.test(placement)) {
-      var topEdgeOffset    = pos.top - viewportPadding - viewportDimensions.scroll
-      var bottomEdgeOffset = pos.top + viewportPadding - viewportDimensions.scroll + actualHeight
+      var topEdgeOffset    = pos.top - viewportPadding
+      var bottomEdgeOffset = pos.top + viewportPadding + actualHeight
       if (topEdgeOffset < viewportDimensions.top) { // top overflow
         delta.top = viewportDimensions.top - topEdgeOffset
       } else if (bottomEdgeOffset > viewportDimensions.top + viewportDimensions.height) { // bottom overflow
@@ -380,7 +404,7 @@
 
     return delta
   }
-
+  
   Tooltip.prototype.getTitle = function () {
     var title
     var $e = this.$element

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -354,20 +354,18 @@
   }
 
   Tooltip.prototype.getViewportBounds = function ($viewport) {
-    if ($viewport.is('body')) {
+    if ($viewport.is('body') && (/fixed|absolute/).test(this.$element.css('position'))) {
       // fixed and absolute elements should be tested against the window
-      if ((/fixed|absolute/).test(this.$element.css('position'))) {
-        return this.getScreenSpaceBounds()
-      }
+      return this.getScreenSpaceBounds($viewport)
     }
 
     return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
   }
 
-  Tooltip.prototype.getScreenSpaceBounds = function () {
+  Tooltip.prototype.getScreenSpaceBounds = function ($viewport) {
     return {
-      top: $('body').scrollTop(),
-      left: $('body').scrollLeft(),
+      top: $viewport.scrollTop(),
+      left: $viewport.scrollLeft(),
       width: $(window).width(),
       height: $(window).height()
     }

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -341,18 +341,18 @@
   }
 
   Tooltip.prototype.getViewportBounds = function ($viewport) {
-    if ($viewport.selector == 'body') {
-      var elementPositionAttribute = $(this.$element).css('position')
-
+    if ($viewport.is('body')) {
       // fixed and absolute elements should be tested against the window
-      switch (elementPositionAttribute) {
+      switch (this.$element.css('position')) {
         case 'absolute':
         case 'fixed':
-          return this.getScreenSpaceBounds();
+        {
+          return this.getScreenSpaceBounds()
+        }
       }
     }
 
-    return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
+    return { top: $viewport.offset().top, left: $viewport.offset().left, width: $viewport.outerWidth(), height: $viewport.outerHeight() }
   }
 
   Tooltip.prototype.getScreenSpaceBounds = function () {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -391,7 +391,7 @@
 
     return delta
   }
-  
+
   Tooltip.prototype.getTitle = function () {
     var title
     var $e = this.$element

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -343,12 +343,8 @@
   Tooltip.prototype.getViewportBounds = function ($viewport) {
     if ($viewport.is('body')) {
       // fixed and absolute elements should be tested against the window
-      switch (this.$element.css('position')) {
-        case 'absolute':
-        case 'fixed':
-        {
-          return this.getScreenSpaceBounds()
-        }
+      if ((/fixed|absolute/).test(this.$element.css('position'))) {
+        return this.getScreenSpaceBounds()
       }
     }
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -352,16 +352,16 @@
       }
     }
 
-    return { top: $viewport.offset().top, left: $viewport.offset().left, width: $viewport.outerWidth(), height: $viewport.outerHeight() }
+    return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
   }
 
   Tooltip.prototype.getScreenSpaceBounds = function () {
-    return $.extend({}, {
+    return {
       top: $('body').scrollTop(),
       left: $('body').scrollLeft(),
       width: $(window).width(),
       height: $(window).height()
-    })
+    }
   }
 
   Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -341,20 +341,18 @@
   }
 
   Tooltip.prototype.getViewportBounds = function ($viewport) {
-    if ($viewport.is('body')) {
+    if ($viewport.is('body') && (/fixed|absolute/).test(this.$element.css('position'))) {
       // fixed and absolute elements should be tested against the window
-      if ((/fixed|absolute/).test(this.$element.css('position'))) {
-        return this.getScreenSpaceBounds()
-      }
+      return this.getScreenSpaceBounds($viewport)
     }
 
     return $.extend({}, $viewport.offset(), { width: $viewport.outerWidth(), height: $viewport.outerHeight() })
   }
 
-  Tooltip.prototype.getScreenSpaceBounds = function () {
+  Tooltip.prototype.getScreenSpaceBounds = function ($viewport) {
     return {
-      top: $('body').scrollTop(),
-      left: $('body').scrollLeft(),
+      top: $viewport.scrollTop(),
+      left: $viewport.scrollLeft(),
       width: $(window).width(),
       height: $(window).height()
     }


### PR DESCRIPTION
The getPosition function was simplified with a new function,
getViewportBounds, was added to specifically
tackle the cases where we’re looking for the viewport bounds.

‘absolute’ and ‘fixed’ tooltips are now matched against the screen
where other ones are made to fit inside the viewport element.
