### PR TITLE
btn-xxx-inverse class for hight contrasted website

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -60,24 +60,42 @@
 .btn-default {
   .button-variant(@btn-default-color; @btn-default-bg; @btn-default-border);
 }
+.btn-default-inverse {
+  .button-variant-inverse(@body-bg; @btn-default-color);
+}
 .btn-primary {
   .button-variant(@btn-primary-color; @btn-primary-bg; @btn-primary-border);
+}
+.btn-primary-inverse {
+  .button-variant-inverse(@body-bg; @btn-primary-bg);
 }
 // Success appears as green
 .btn-success {
   .button-variant(@btn-success-color; @btn-success-bg; @btn-success-border);
 }
+.btn-success-inverse {
+  .button-variant-inverse(@body-bg; @btn-success-bg);
+}
 // Info appears as blue-green
 .btn-info {
   .button-variant(@btn-info-color; @btn-info-bg; @btn-info-border);
+}
+.btn-info-inverse {
+  .button-variant-inverse(@body-bg; @btn-info-bg);
 }
 // Warning appears as orange
 .btn-warning {
   .button-variant(@btn-warning-color; @btn-warning-bg; @btn-warning-border);
 }
+.btn-warning-inverse {
+  .button-variant-inverse(@body-bg; @btn-warning-bg);
+}
 // Danger and error appear as red
 .btn-danger {
   .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
+}
+.btn-danger-inverse {
+  .button-variant-inverse(@body-bg; @btn-danger-bg);
 }
 
 

--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -16,7 +16,7 @@
   .open > .dropdown-toggle& {
     color: @color;
     background-color: darken(@background, 10%);
-        border-color: darken(@border, 12%);
+    border-color: darken(@border, 12%);
   }
   &:active,
   &.active,
@@ -33,13 +33,68 @@
     &:active,
     &.active {
       background-color: @background;
-          border-color: @border;
+      border-color: @border;
     }
   }
 
   .badge {
     color: @background;
     background-color: @color;
+  }
+}
+
+// famaridon : Button inverse variants style for hight contrast website
+
+.button-variant-inverse(@background; @color) {
+  color: @color;
+  background-color: @background;
+  border-color: @color;
+
+  &:hover,
+  &:focus,
+  &.focus,
+  &:active,
+  &.active,
+  .open > .dropdown-toggle& {
+    color: @background;
+    background-color: @color;
+    border-color: @color;
+  }
+  &:active,
+  &.active,
+  .open > .dropdown-toggle& {
+    background-image: none;
+  }
+
+  &.disabled,
+  &[disabled],
+  fieldset[disabled] & {
+    &,
+    &:hover,
+    &:focus,
+    &.focus,
+    &:active,
+    &.active {
+      background-color: @background;
+      border-color: @color;
+    }
+  }
+
+  .badge {
+    color: @background;
+    background-color: @color;
+  }
+  &:hover,
+  &:focus ,
+  &.focus ,
+  &:active ,
+  &.active 
+  {
+    & .badge
+    {
+      color: @color;
+      background-color: @background;
+    }
   }
 }
 


### PR DESCRIPTION
I have edit buttons.less to add inverse feature on button (like navbar).

In hight contrasted WebSite (navbar, header) standards btn-xxx styles can be useless in site header or body.

btn-outline getbootstrap.com homepage inspire this feature.

I use the variable @body-bg but I think it's not the best way (a transparent variable will better but need to add new variable).
### Example or Test
- Options : http://jsfiddle.net/hQv22/
- Sizes : http://jsfiddle.net/A5V3R/1/
- Active state : http://jsfiddle.net/mvrq4/2/
- Disabled state : http://jsfiddle.net/mvrq4/3/
- Button tags : http://jsfiddle.net/mvrq4/4/
- Glyphicon : http://jsfiddle.net/mvrq4/5/
- DropDown : http://jsfiddle.net/mvrq4/6/
- Button groups : http://jsfiddle.net/mvrq4/7/
- Button toolbar : http://jsfiddle.net/mvrq4/8/
- Button toolbar Sizing : http://jsfiddle.net/mvrq4/9/
- Button toolbar Nesting : http://jsfiddle.net/mvrq4/10/
- Button toolbar Vertical variation : http://jsfiddle.net/mvrq4/11/
- Justified button groups : http://jsfiddle.net/mvrq4/12/
- Split button dropdowns : http://jsfiddle.net/mvrq4/13/
- Dropup variation : http://jsfiddle.net/mvrq4/14/
- Button addons : http://jsfiddle.net/mvrq4/15/
- Inverted navbar : http://jsfiddle.net/mvrq4/16/
- With badge : http://jsfiddle.net/mvrq4/17/
