### PR TITLE
Delete duplicate property in .JSCSRC

### DIFF
--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -5,7 +5,6 @@
   "disallowMultipleLineStrings": true,
   "disallowMultipleVarDecl": true,
   "disallowQuotedKeysInObjects": "allButReserved",
-  "disallowSpaceAfterPrefixUnaryOperators": ["!"],
   "disallowSpaceBeforeBinaryOperators": [","],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],


### PR DESCRIPTION
Delete "disallowSpaceAfterPrefixUnaryOperators" property, because it duplicates the property on 10 line.
