### PR TITLE
Remove popover content with .children().detach() instead of .empty()

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -46,8 +46,7 @@
     var content = this.getContent()
 
     $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
-    $tip.find('.popover-content').children().detach()
-    $tip.find('.popover-content')[ // we use append for html objects to maintain js events
+    $tip.find('.popover-content').children().detach().end()[ // we use append for html objects to maintain js events
       this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
     ](content)
 

--- a/js/popover.js
+++ b/js/popover.js
@@ -46,7 +46,8 @@
     var content = this.getContent()
 
     $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
-    $tip.find('.popover-content').empty()[ // we use append for html objects to maintain js events
+    $tip.find('.popover-content').children().detach()
+    $tip.find('.popover-content')[ // we use append for html objects to maintain js events
       this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
     ](content)
 


### PR DESCRIPTION
Using .empty() is bad because it blows up the content. If you're planning on using it later or swapping it around, you can't. jQuery won't let you reattach the content or rewire events to it. Instead, do .children().detach().

This is a refinement of the fix in #13165.
