### PR TITLE
Add docs for default js settings

### DIFF
--- a/docs/_includes/js/overview.html
+++ b/docs/_includes/js/overview.html
@@ -48,10 +48,10 @@ $('#myModal').modal('show')                // initializes and invokes show immed
   <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[rel="popover"]').data('popover')</code>.</p>
 
   <h4>Default Settings</h4>
-  <p>You can override the default settings for a control by accessing them through the <code>Constructor.DEFAULTS</code> property.<p>
+  <p>You can override the default settings for a plugin by accessing them through the <code>Constructor.DEFAULTS</code> property.<p>
 
 {% highlight js %}
-$.fn.modal.Constructor.DEFAULTS.keyboard = false; // changes default modal keyboard option
+$.fn.modal.Constructor.DEFAULTS.keyboard = false // changes default modal keyboard option
 {% endhighlight %}
 
   <h3 id="js-noconflict">No conflict</h3>

--- a/docs/_includes/js/overview.html
+++ b/docs/_includes/js/overview.html
@@ -47,6 +47,13 @@ $('#myModal').modal('show')                // initializes and invokes show immed
 
   <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[rel="popover"]').data('popover')</code>.</p>
 
+  <h4>Default Settings</h4>
+  <p>You can override the default settings for a control by accessing them through the <code>Constructor.DEFAULTS</code> property.<p>
+
+{% highlight js %}
+$.fn.modal.Constructor.DEFAULTS.keyboard = false; // changes default modal keyboard option
+{% endhighlight %}
+
   <h3 id="js-noconflict">No conflict</h3>
   <p>Sometimes it is necessary to use Bootstrap plugins with other UI frameworks. In these circumstances, namespace collisions can occasionally occur. If this happens, you may call <code>.noConflict</code> on the plugin you wish to revert the value of.</p>
 {% highlight js %}


### PR DESCRIPTION
I believe it's the intention that someone can override the default settings on Javascript controls by using the following code:

``` js
$.fn.modal.Constructor.DEFAULTS.keyboard = true;
```

However, this doesn't seem to be documented anywhere.  This change just updates the [JavaScript page's programmaticAPI section](http://getbootstrap.com/javascript/#js-programmatic-api).
