### PR TITLE
Correctly doc args passed to function vals for `title` & `content` options of tooltips+popovers

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -163,7 +163,7 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
           <td>''</td>
           <td>
             <p>Default content value if <code>data-content</code> attribute isn't present.</p>
-            <p>If a function is given, it will be called with 1 argument, which is the element that the popover is attached to.</p>
+            <p>If a function is given, it will be called with its <code>this</code> reference set to the element that the popover is attached to.</p>
           </td>
         </tr>
         <tr>
@@ -210,7 +210,10 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
           <td>title</td>
           <td>string | function</td>
           <td>''</td>
-          <td>Default title value if <code>title</code> attribute isn't present</td>
+          <td>
+            <p>Default title value if <code>title</code> attribute isn't present.</p>
+            <p>If a function is given, it will be called with its <code>this</code> reference set to the element that the popover is attached to.</p>
+          </td>
         </tr>
         <tr>
           <td>trigger</td>

--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -141,7 +141,10 @@ $('#example').tooltip(options)
          <td>title</td>
          <td>string | function</td>
          <td>''</td>
-         <td>Default title value if <code>title</code> attribute isn't present</td>
+         <td>
+          <p>Default title value if <code>title</code> attribute isn't present.</p>
+          <p>If a function is given, it will be called with its <code>this</code> reference set to the element that the tooltip is attached to.</p>
+        </td>
        </tr>
        <tr>
          <td>trigger</td>


### PR DESCRIPTION
Fixes #14224.
