### PR TITLE
Fixes double border in justified button groups.

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -216,6 +216,21 @@
   > .btn-group .btn {
     width: 100%;
   }
+  
+  // Prevent double borders between justified buttons
+  .btn + .btn,
+  .btn + .btn-group .btn,
+  .btn-group + .btn,
+  .btn-group + .btn-group .btn {
+    &:before {
+      position: absolute;
+      left: -1px;
+      top: 0;
+      content: "";
+      width: 1px;
+      height: 100%;
+    }
+  }
 
   > .btn-group .dropdown-menu {
     left: auto;

--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -7,6 +7,9 @@
   color: @color;
   background-color: @background;
   border-color: @border;
+  &:before {
+    background-color: @background;
+  }
 
   &:hover,
   &:focus,
@@ -17,6 +20,9 @@
     color: @color;
     background-color: darken(@background, 10%);
         border-color: darken(@border, 12%);
+    &:before {
+      background-color: darken(@background, 12%);
+    }
   }
   &:active,
   &.active,


### PR DESCRIPTION
Uses `:before` to create a 1px-wide strip of same background color as the button to cover the extra border. Modification added to `.button-variant` mixin to handle hover/focus/active states, i.e. match the colors of other states.

Not really in the same spirit as negative margins but definitely closer to it than nuking borders.
