### PR TITLE
Issue #13554 - Add aria and keyboard a11y to Tab

### DIFF
--- a/docs/_includes/js/tabs.html
+++ b/docs/_includes/js/tabs.html
@@ -5,8 +5,13 @@
   <p>Add quick, dynamic tab functionality to transition through panes of local content, even via dropdown menus.</p>
   <div class="bs-example bs-example-tabs">
     <ul id="myTab" class="nav nav-tabs" role="tablist">
+<<<<<<< HEAD
       <li role="presentation" class="active"><a href="#home" id="home-tab" role="tab" data-toggle="tab" aria-controls="home" aria-expanded="true">Home</a></li>
       <li role="presentation"><a href="#profile" role="tab" id="profile-tab" data-toggle="tab" aria-controls="profile">Profile</a></li>
+=======
+      <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
+      <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+>>>>>>> Issue #13554 - Add aria and keyboard a11y to Tab
       <li role="presentation" class="dropdown">
         <a href="#" id="myTabDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="myTabDrop1-contents">Dropdown <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu" aria-labelledby="myTabDrop1" id="myTabDrop1-contents">
@@ -61,10 +66,10 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
 {% highlight html %}
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active"><a href="#home" role="tab" data-toggle="tab">Home</a></li>
-  <li role="presentation"><a href="#profile" role="tab" data-toggle="tab">Profile</a></li>
-  <li role="presentation"><a href="#messages" role="tab" data-toggle="tab">Messages</a></li>
-  <li role="presentation"><a href="#settings" role="tab" data-toggle="tab">Settings</a></li>
+  <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
+  <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+  <li role="presentation"><a id="mesages-tab" href="#messages" role="tab" data-toggle="tab">Messages</a></li>
+  <li role="presentation"><a id="settings-tab" href="#settings" role="tab" data-toggle="tab">Settings</a></li>
 </ul>
 
 <!-- Tab panes -->
@@ -94,10 +99,10 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
   </p>
 {% highlight html %}
 <ul class="nav nav-tabs" role="tablist" id="myTab">
-  <li role="presentation" class="active"><a href="#home" role="tab" data-toggle="tab">Home</a></li>
-  <li role="presentation"><a href="#profile" role="tab" data-toggle="tab">Profile</a></li>
-  <li role="presentation"><a href="#messages" role="tab" data-toggle="tab">Messages</a></li>
-  <li role="presentation"><a href="#settings" role="tab" data-toggle="tab">Settings</a></li>
+  <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
+  <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+  <li role="presentation"><a id="messages-tab" href="#messages" role="tab" data-toggle="tab">Messages</a></li>
+  <li role="presentation"><a id="settings-tab" href="#settings" role="tab" data-toggle="tab">Settings</a></li>
 </ul>
 
 <div class="tab-content">

--- a/docs/_includes/js/tabs.html
+++ b/docs/_includes/js/tabs.html
@@ -5,8 +5,8 @@
   <p>Add quick, dynamic tab functionality to transition through panes of local content, even via dropdown menus.</p>
   <div class="bs-example bs-example-tabs">
     <ul id="myTab" class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
-      <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+      <li role="presentation" class="active"><a href="#home" role="tab" data-toggle="tab">Home</a></li>
+      <li role="presentation"><a href="#profile" role="tab" data-toggle="tab">Profile</a></li>
       <li role="presentation" class="dropdown">
         <a href="#" id="myTabDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="myTabDrop1-contents">Dropdown <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu" aria-labelledby="myTabDrop1" id="myTabDrop1-contents">
@@ -61,10 +61,10 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
 {% highlight html %}
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
-  <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
-  <li role="presentation"><a id="mesages-tab" href="#messages" role="tab" data-toggle="tab">Messages</a></li>
-  <li role="presentation"><a id="settings-tab" href="#settings" role="tab" data-toggle="tab">Settings</a></li>
+  <li role="presentation" class="active"><a href="#home" role="tab" data-toggle="tab">Home</a></li>
+  <li role="presentation"><a href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+  <li role="presentation"><a href="#messages" role="tab" data-toggle="tab">Messages</a></li>
+  <li role="presentation"><a href="#settings" role="tab" data-toggle="tab">Settings</a></li>
 </ul>
 
 <!-- Tab panes -->
@@ -94,10 +94,10 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
   </p>
 {% highlight html %}
 <ul class="nav nav-tabs" role="tablist" id="myTab">
-  <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
-  <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
-  <li role="presentation"><a id="messages-tab" href="#messages" role="tab" data-toggle="tab">Messages</a></li>
-  <li role="presentation"><a id="settings-tab" href="#settings" role="tab" data-toggle="tab">Settings</a></li>
+  <li role="presentation" class="active"><a href="#home" role="tab" data-toggle="tab">Home</a></li>
+  <li role="presentation"><a href="#profile" role="tab" data-toggle="tab">Profile</a></li>
+  <li role="presentation"><a href="#messages" role="tab" data-toggle="tab">Messages</a></li>
+  <li role="presentation"><a href="#settings" role="tab" data-toggle="tab">Settings</a></li>
 </ul>
 
 <div class="tab-content">

--- a/docs/_includes/js/tabs.html
+++ b/docs/_includes/js/tabs.html
@@ -5,13 +5,8 @@
   <p>Add quick, dynamic tab functionality to transition through panes of local content, even via dropdown menus.</p>
   <div class="bs-example bs-example-tabs">
     <ul id="myTab" class="nav nav-tabs" role="tablist">
-<<<<<<< HEAD
-      <li role="presentation" class="active"><a href="#home" id="home-tab" role="tab" data-toggle="tab" aria-controls="home" aria-expanded="true">Home</a></li>
-      <li role="presentation"><a href="#profile" role="tab" id="profile-tab" data-toggle="tab" aria-controls="profile">Profile</a></li>
-=======
       <li role="presentation" class="active"><a id="home-tab" href="#home" role="tab" data-toggle="tab">Home</a></li>
       <li role="presentation"><a id="profile-tab" href="#profile" role="tab" data-toggle="tab">Profile</a></li>
->>>>>>> Issue #13554 - Add aria and keyboard a11y to Tab
       <li role="presentation" class="dropdown">
         <a href="#" id="myTabDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="myTabDrop1-contents">Dropdown <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu" aria-labelledby="myTabDrop1" id="myTabDrop1-contents">

--- a/js/tab.js
+++ b/js/tab.js
@@ -63,11 +63,11 @@
 
   Tab.prototype.keydown = function (e) {
     var $li     = $(e.target).parent()
-    var key     = e.which || e.keyCode
+    var key     = e.which
     var $items  = $li.closest('ul[role="tablist"]').find('li')
     var index   = $li.index()
-    var uBound  = $items.length -1
-    var newTab
+    var uBound  = $items.length - 1
+    var $newTab
 
     e.preventDefault()
     e.stopPropagation()
@@ -75,15 +75,17 @@
     switch (key) {
       case 37: // left
       case 38: // up
-        newTab = (index === 0) ? $items[uBound] : $items[index-1]
+        $newTab = (index === 0) ? $items.eq(uBound) : $items.eq(index - 1)
         break
       case 39: // right
       case 40: // down
-        newTab = (index === uBound) ? $items[0] : $items[index + 1]
+        $newTab = (index === uBound) ? $items.eq(0) : $items.eq(index + 1)
         break
     }
 
-    if (newTab) $(newTab).tab('show')
+    // if ($newTab) $(newTab).find('a').tab('show')
+
+    if ($newTab) Plugin.call($newTab.find('a'), 'show')
 
   }
 
@@ -107,16 +109,16 @@
           .find('> [role="tab"]')
           .attr({
             'aria-selected': false,
-            'tabindex': -1
+            tabindex: -1
           })
 
         element
           .find('> [role="tab"]')
           .attr({
             'aria-selected': true,
-            'tabindex': 0
+            tabindex: 0
           })
-          .focus()
+          .trigger('focus')
       }
 
       element.addClass('active')
@@ -184,32 +186,33 @@
     var $this   = $(this)
     var $parent = $this.parent()
     var active  = $parent.hasClass('active')
+    var selector = $this.data('target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
+    }
 
     $parent.attr('role', 'presentation')
 
     $this.attr({
       'aria-selected':  active,
-      'aria-controls':  $this.attr('href').replace('#', ''),
-      'role':           'tab',
-      'tabindex':       (active) ? 0 : -1
+      'aria-controls':  selector.replace('#', ''),
+      role:           'tab',
+      tabindex:       (active) ? 0 : -1
     })
 
-    $($this.attr('href')).attr({
+    $(selector).attr({
       'aria-hidden':      !active,
       'aria-labelledby':  $this.attr('id'),
-      'role':             'tabpanel'
+      role:             'tabpanel'
     })
   });
 
   $(document).on('click.bs.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
     e.preventDefault()
     Plugin.call($(this), 'show')
-  }
-
-  $(document)
-    .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
-    .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
-
-  $(document).on('keydown.bs.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', $.fn.tab.Constructor.prototype.keydown)
+  })
+  .on('keydown.bs.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', Tab.prototype.keydown)
 
 }(jQuery);

--- a/js/tab.js
+++ b/js/tab.js
@@ -65,25 +65,30 @@
     var $li     = $(e.target).parent()
     var key     = e.which
     var $items  = $li.closest('ul[role="tablist"]').find('li')
+    var len     = $items.length
     var index   = $li.index()
+    var dir
     var $newTab
-
-    e.preventDefault()
-    e.stopPropagation()
 
     switch (key) {
       case 37: // left
       case 38: // up
-        $newTab = (index == 0) ? $items.last() : $items.eq(index - 1)
+        dir = -1
         break
       case 39: // right
       case 40: // down
-        $newTab = (index == $items.length - 1) ? $items.eq(0) : $items.eq(index + 1)
+        dir = 1
         break
+      default:
+        return
     }
 
-    if ($newTab) Plugin.call($newTab.find('a'), 'show')
+    e.preventDefault()
+    e.stopPropagation()
 
+    $newTab = $items.eq((index + len + dir) % len)
+
+    if ($newTab) Plugin.call($newTab.find('a'), 'show')
   }
 
   Tab.prototype.activate = function (element, container, callback) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -66,7 +66,6 @@
     var key     = e.which
     var $items  = $li.closest('ul[role="tablist"]').find('li')
     var index   = $li.index()
-    var uBound  = $items.length - 1
     var $newTab
 
     e.preventDefault()
@@ -75,15 +74,13 @@
     switch (key) {
       case 37: // left
       case 38: // up
-        $newTab = (index === 0) ? $items.eq(uBound) : $items.eq(index - 1)
+        $newTab = (index == 0) ? $items.last() : $items.eq(index - 1)
         break
       case 39: // right
       case 40: // down
-        $newTab = (index === uBound) ? $items.eq(0) : $items.eq(index + 1)
+        $newTab = (index == $items.length - 1) ? $items.eq(0) : $items.eq(index + 1)
         break
     }
-
-    // if ($newTab) $(newTab).find('a').tab('show')
 
     if ($newTab) Plugin.call($newTab.find('a'), 'show')
 
@@ -101,7 +98,7 @@
         .find('> .dropdown-menu > .active')
           .removeClass('active')
 
-      if (element.attr('role') === 'tabpanel') { // Is this a panel or a tab
+      if (element.attr('role') == 'tabpanel') { // Is this a panel or a tab
         $active.attr('aria-hidden', true)
         element.attr('aria-hidden', false)
       } else {
@@ -151,6 +148,12 @@
     $active.removeClass('in')
   }
 
+  Tab.prototype.getUID = function (prefix) {
+    do prefix += ~~(Math.random() * 1000000)
+    while (document.getElementById(prefix))
+    return prefix
+  }
+
   // TAB PLUGIN DEFINITION
   // =====================
 
@@ -183,10 +186,10 @@
   // ============
 
   $('[data-toggle="tab"], [data-toggle="pill"]').each(function () {
-    var $this   = $(this)
-    var $parent = $this.parent()
-    var active  = $parent.hasClass('active')
-    var selector = $this.data('target')
+    var $this     = $(this)
+    var $parent   = $this.parent()
+    var active    = $parent.hasClass('active')
+    var selector  = $this.data('target')
 
     if (!selector) {
       selector = $this.attr('href')
@@ -196,16 +199,20 @@
     $parent.attr('role', 'presentation')
 
     $this.attr({
-      'aria-selected':  active,
-      'aria-controls':  selector.replace('#', ''),
-      role:           'tab',
-      tabindex:       (active) ? 0 : -1
+      'aria-selected': active,
+      'aria-controls': selector.replace('#', ''),
+      role: 'tab',
+      tabindex: (active) ? 0 : -1
     })
 
+    if (!$this.attr('id')) {
+      $this.attr('id', Tab.prototype.getUID('tab'))
+    }
+
     $(selector).attr({
-      'aria-hidden':      !active,
-      'aria-labelledby':  $this.attr('id'),
-      role:             'tabpanel'
+      'aria-hidden': !active,
+      'aria-labelledby': $this.attr('id'),
+      role: 'tabpanel'
     })
   });
 


### PR DESCRIPTION
Initial commit for issue #13554 

At this point, I am only looking for peer review. I have never used bootstrap but I am familiar with accessibility so I wanted to be a good citizen and help out.

This pull request adds proper aria and keyboard management to the Tab component by implementing the following:
- `aria-controls`, `aria-selected`, and `tabindex` to tabs
- keyboard navigation via arrows, and proper focus/ tab index management
- `aria-hidden` and `aria-labelledby` on panels
- `id` for tab added to example, as it is needed for `aria-labelledby`

**Note**: I did _not_ add aria-expanded as it is not required for this pattern

I also included the addition of aria roles via JS in case they were left off in the markup. The only required role in the markup is the `tablist` role that is added the `ul`. I feel this will help overall accessibility by not burdening developers with needing to include or failing a11y if not/ incorrectly including. However, I did leave them in the examples in order to raise awareness/ education. I am not sure what the Bootstrap policy is about this.

 If my approach is acceptable, I can continue with proper unit tests, documentation, etc.
