### PR TITLE
hide inactive tab by setting height to 0

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -222,10 +222,11 @@
 // Hide tabbable panes to start, show them when `.active`
 .tab-content {
   > .tab-pane {
-    display: none;
+    height: 0;
+    overflow-y: hidden;
   }
   > .active {
-    display: block;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
Using `display:none` to hide inactive tab panes has an unexpected side effect,
the width becomes unavailable, this causes problems for things like Highcharts
to initialize correctly when placed in tab panes.

This patch is to hide inactive tabs in a way that the width is still available
via `height:0; overflow-y:hidden;`.

For active tabs, we use `height: auto`.

See [this discussion on SO](http://stackoverflow.com/questions/17206631#23267110).
