### PR TITLE
Affix: Defer checkPosition for scroll event listener; fixes #13258

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -17,7 +17,7 @@
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
     this.$target = $(this.options.target)
-      .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
+      .on('scroll.bs.affix.data-api', $.proxy(this.checkPositionWithEventLoop, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 
     this.$element     = $(element)
@@ -25,7 +25,7 @@
     this.unpin        =
     this.pinnedOffset = null
 
-    this.checkPosition()
+    this.checkPositionWithEventLoop()
   }
 
   Affix.VERSION  = '3.2.0'


### PR DESCRIPTION
Fixes #13258

Live example at http://jsbin.com/hosuw/1

@mfernea @maniqui Can you confirm that this patch resolves your problems? 

/cc @fat @cvrebert
