### PR TITLE
Collapse: count `.collapsing` elements as actives; closes #13447

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -42,7 +42,7 @@
     this.$element.trigger(startEvent)
     if (startEvent.isDefaultPrevented()) return
 
-    var actives = this.$parent && this.$parent.find('> .panel > .in')
+    var actives = this.$parent && this.$parent.find('> .panel').children('.in, .collapsing')
 
     if (actives && actives.length) {
       var hasData = actives.data('bs.collapse')


### PR DESCRIPTION
Fixes #13447

Before the fix: http://jsbin.com/sayeg/1
After the fix: http://jsbin.com/sayeg/2
(Best reproducible when opening collapse 3 and then collapse 2.)

Tried writing a unit test but due to us disabling transitions there, it wasn't possible.

/cc @fat @cvrebert
