### PR TITLE
Button: Fix `checked` prop on button's input not always applied correctly

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -102,10 +102,10 @@
 
   $(document)
     .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-      var $btn = $(e.target)
-      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-      Plugin.call($btn, 'toggle')
+      var $target = $(e.target)
+      if (!$target.hasClass('btn')) $target = $target.closest('.btn')
       e.preventDefault()
+      setTimeout(function () { Plugin.call($target, 'toggle') }, 1)
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
       $(e.target).closest('.btn').toggleClass('focus', e.type == 'focus')


### PR DESCRIPTION
Fixes #14137

This fixes it properly rather than just reverting 4b40ee6.

Example: http://jsbin.com/kudav/1

BTW, the key to reproducing the problem mentioned in #14137 is to search for the point in the button where the cursor is in its default state and by that hovering over the invisible checkbox. Said checkbox can also be clicked and that's what is primarily causing these problems. This was introduced by #12794.

/cc @cvrebert @fat @Kolyunya @pixelchutes
