### PR TITLE
Fix bug not re-calculating scrollbar width when opening modal

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -55,7 +55,7 @@
 
     this.isShown = true
 
-    this.scrollbarWidth = this.measureScrollbar()
+    this.checkScrollbar()
     this.$body.addClass('modal-open')
 
     this.setScrollbar()
@@ -204,6 +204,10 @@
     } else if (callback) {
       callback()
     }
+  }
+
+  Modal.prototype.checkScrollbar = function () {
+    this.scrollbarWidth = this.measureScrollbar()
   }
 
   Modal.prototype.setScrollbar = function () {

--- a/js/modal.js
+++ b/js/modal.js
@@ -55,7 +55,7 @@
 
     this.isShown = true
 
-    this.checkScrollbar()
+    this.scrollbarWidth = this.measureScrollbar()
     this.$body.addClass('modal-open')
 
     this.setScrollbar()
@@ -206,11 +206,6 @@
     }
   }
 
-  Modal.prototype.checkScrollbar = function () {
-    if (document.body.clientWidth >= window.innerWidth) return
-    this.scrollbarWidth = this.scrollbarWidth || this.measureScrollbar()
-  }
-
   Modal.prototype.setScrollbar = function () {
     var bodyPad = parseInt((this.$body.css('padding-right') || 0), 10)
     if (this.scrollbarWidth) this.$body.css('padding-right', bodyPad + this.scrollbarWidth)
@@ -221,6 +216,7 @@
   }
 
   Modal.prototype.measureScrollbar = function () { // thx walsh
+    if (document.body.clientWidth >= window.innerWidth) return 0
     var scrollDiv = document.createElement('div')
     scrollDiv.className = 'modal-scrollbar-measure'
     this.$body.append(scrollDiv)


### PR DESCRIPTION
If opening a modal when a scrollbar is present, closing it, then resizing the window so the scrollbar disappears, then opening the modal again, the content would shift. This fixes the problem by always calculating the scrollbar width every time a modal is opened.

See buggy example: http://jsfiddle.net/02rthxw5/
See fixed example: http://jsfiddle.net/02rthxw5/2/

Should I add compiled files to the PR? I could not find if this is desired in the docs.
