### PR TITLE
Fixes arrows in tooltips wrongly centred at times

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -252,13 +252,14 @@
     }
 
     var delta = this.getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight)
+    var vertical = delta.top !== undefined
 
-    if (delta.left) offset.left += delta.left
+    if (vertical) offset.left += delta.left
     else offset.top += delta.top
 
-    var arrowDelta          = delta.left ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
-    var arrowPosition       = delta.left ? 'left'        : 'top'
-    var arrowOffsetPosition = delta.left ? 'offsetWidth' : 'offsetHeight'
+    var arrowDelta          = vertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
+    var arrowPosition       = vertical ? 'left'        : 'top'
+    var arrowOffsetPosition = vertical ? 'offsetWidth' : 'offsetHeight'
 
     $tip.offset(offset)
     this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], arrowPosition)
@@ -343,7 +344,7 @@
   }
 
   Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {
-    var delta = { top: 0, left: 0 }
+    var delta = {}
     if (!this.$viewport) return delta
 
     var viewportPadding = this.options.viewport && this.options.viewport.padding || 0


### PR DESCRIPTION
Tooltips (and popovers) showing arrows wrongly positioned at times (centred, more commonly seen when zoom is enabled in the browser). The reason was, for example, with an arrow to be shown at the bottom of the tooltip, `getViewportAdjustedDelta()` returned `delta` with `left == 0` and the test `delta.left` failed. In these cases, when it happened _and_ there was an adjustment to be made (height != actualHeight), the arrow ended up being vertically centred instead of at the bottom of the tooltip.
