### PR TITLE
Lets set a color on panels since a background is already being set

### DIFF
--- a/less/mixins/panels.less
+++ b/less/mixins/panels.less
@@ -1,10 +1,10 @@
 // Panels
 
-.panel-variant(@border; @heading-text-color; @heading-bg-color; @heading-border) {
+.panel-variant(@border; @panel-text-color; @heading-bg-color; @heading-border) {
   border-color: @border;
+  color: @panel-text-color;
 
   & > .panel-heading {
-    color: @heading-text-color;
     background-color: @heading-bg-color;
     border-color: @heading-border;
 
@@ -13,7 +13,7 @@
     }
     .badge {
       color: @heading-bg-color;
-      background-color: @heading-text-color;
+      background-color: @panel-text-color;
     }
   }
   & > .panel-footer {


### PR DESCRIPTION
It almost looks like this is the way this mixin was intended to be.  We are setting variables for the panels color in  `less/variables.less` however were not using them other than to set the headings color.  Since panels set a background color we should probably set a foreground color.  

This also would fix this issue... http://jsfiddle.net/rwnnwy1b/2/
