### PR TITLE
Add retries to uncached-npm-install.sh

### DIFF
--- a/test-infra/uncached-npm-install.sh
+++ b/test-infra/uncached-npm-install.sh
@@ -2,5 +2,14 @@
 set -e
 cd ..  # /bootstrap/
 cp test-infra/npm-shrinkwrap.json npm-shrinkwrap.json
-npm install
+# npm is flaky, so try multiple times
+MAXTRIES=3
+TRIES=1
+while ! npm install; do
+    if [ $TRIES -ge $MAXTRIES ]; then
+        exit 1
+    fi
+    TRIES=$(($TRIES + 1))
+    echo "Retrying npm install (Try $TRIES of $MAXTRIES)..."
+done
 rm npm-shrinkwrap.json


### PR DESCRIPTION
Pull requests are frequently failing on Travis due to npm flakiness.
(I think) `travis_retry` isn't available in indirect subshells like this.
