### PR TITLE
Have breadcrumb separator CSS accommodate <script>s among the crumbs

### DIFF
--- a/less/breadcrumbs.less
+++ b/less/breadcrumbs.less
@@ -13,7 +13,7 @@
   > li {
     display: inline-block;
 
-    + li:before {
+    ~ li:before {
       content: "@{breadcrumb-separator}\00a0"; // Unicode space added since inline-block means non-collapsing white-space
       padding: 0 5px;
       color: @breadcrumb-color;


### PR DESCRIPTION
Because ember's handlebars currently inserts `<script>` tags before and after bound elements
the breadcrumb `.breadcrumb > li + li:before` doesn't work, as the next sibling is no longer an li but script tag.

accordingly I changed it to the general siblings selector `.breadcrumb > li ~ li:before`
