### PR TITLE
Ukrainian site migrates on twbs.docs.org.ua

### DIFF
--- a/docs/_data/translations.yml
+++ b/docs/_data/translations.yml
@@ -36,4 +36,4 @@
 - name: Ukrainian
   code: uk
   description: Bootstrap українською
-  url: http://twbs.site-konstruktor.com.ua
+  url: http://twbs.docs.org.ua


### PR DESCRIPTION
I own a site twbs.site-konstruktor.com.ua. Now, content on this site migrates on twbs.docs.org.ua. Please update the link to the site.
