### PR TITLE
Specified media type in media queries, fixes a bug in safari when printing

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -199,7 +199,7 @@
 //
 // Reiterate per navbar.less and the modified component alignment there.
 
-@media (min-width: @grid-float-breakpoint) {
+@media screen and (min-width: @grid-float-breakpoint) {
   .navbar-right {
     .dropdown-menu {
       .dropdown-menu-right();

--- a/less/forms.less
+++ b/less/forms.less
@@ -421,7 +421,7 @@ input[type="checkbox"] {
 .form-inline {
 
   // Kick in the inline
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     // Inline-block all the things for "inline"
     .form-group {
       display: inline-block;
@@ -522,7 +522,7 @@ input[type="checkbox"] {
 
   // Reset spacing and right align labels, but scope to media queries so that
   // labels on narrow viewports stack the same as a default form example.
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     .control-label {
       text-align: right;
       margin-bottom: 0;
@@ -543,14 +543,14 @@ input[type="checkbox"] {
   // Quick utility class for applying `.input-lg` and `.input-sm` styles to the
   // inputs and labels within a `.form-group`.
   .form-group-lg {
-    @media (min-width: @screen-sm-min) {
+    @media screen and (min-width: @screen-sm-min) {
       .control-label {
         padding-top: ((@padding-large-vertical * @line-height-large) + 1);
       }
     }
   }
   .form-group-sm {
-    @media (min-width: @screen-sm-min) {
+    @media screen and (min-width: @screen-sm-min) {
       .control-label {
         padding-top: (@padding-small-vertical + 1);
       }

--- a/less/grid.less
+++ b/less/grid.less
@@ -10,13 +10,13 @@
 .container {
   .container-fixed();
 
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     width: @container-sm;
   }
-  @media (min-width: @screen-md-min) {
+  @media screen and (min-width: @screen-md-min) {
     width: @container-md;
   }
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     width: @container-lg;
   }
 }
@@ -61,7 +61,7 @@
 // Columns, offsets, pushes, and pulls for the small device range, from phones
 // to tablets.
 
-@media (min-width: @screen-sm-min) {
+@media screen and (min-width: @screen-sm-min) {
   .make-grid(sm);
 }
 
@@ -70,7 +70,7 @@
 //
 // Columns, offsets, pushes, and pulls for the desktop device range.
 
-@media (min-width: @screen-md-min) {
+@media screen and (min-width: @screen-md-min) {
   .make-grid(md);
 }
 
@@ -79,6 +79,6 @@
 //
 // Columns, offsets, pushes, and pulls for the large desktop device range.
 
-@media (min-width: @screen-lg-min) {
+@media screen and (min-width: @screen-lg-min) {
   .make-grid(lg);
 }

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -44,23 +44,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-offset(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-push(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-pull(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     right: percentage((@columns / @grid-columns));
   }
 }
@@ -72,23 +72,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-md-min) {
+  @media screen and (min-width: @screen-md-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-offset(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media screen and (min-width: @screen-md-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-push(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media screen and (min-width: @screen-md-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-pull(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media screen and (min-width: @screen-md-min) {
     right: percentage((@columns / @grid-columns));
   }
 }
@@ -100,23 +100,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-offset(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-push(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-pull(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     right: percentage((@columns / @grid-columns));
   }
 }

--- a/less/modals.less
+++ b/less/modals.less
@@ -131,7 +131,7 @@
 }
 
 // Scale up the modal
-@media (min-width: @screen-sm-min) {
+@media screen and (min-width: @screen-sm-min) {
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     width: @modal-md;
@@ -145,6 +145,6 @@
   .modal-sm { width: @modal-sm; }
 }
 
-@media (min-width: @screen-md-min) {
+@media screen and (min-width: @screen-md-min) {
   .modal-lg { width: @modal-lg; }
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -17,7 +17,7 @@
   // Prevent floats from breaking the navbar
   &:extend(.clearfix all);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     border-radius: @navbar-border-radius;
   }
 }
@@ -31,7 +31,7 @@
 .navbar-header {
   &:extend(.clearfix all);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     float: left;
   }
 }
@@ -60,7 +60,7 @@
     overflow-y: auto;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     width: auto;
     border-top: 0;
     box-shadow: none;
@@ -110,7 +110,7 @@
     margin-right: -@navbar-padding-horizontal;
     margin-left:  -@navbar-padding-horizontal;
 
-    @media (min-width: @grid-float-breakpoint) {
+    @media screen and (min-width: @grid-float-breakpoint) {
       margin-right: 0;
       margin-left:  0;
     }
@@ -129,7 +129,7 @@
   z-index: @zindex-navbar;
   border-width: 0 0 1px;
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     border-radius: 0;
   }
 }
@@ -144,7 +144,7 @@
   .translate3d(0, 0, 0);
 
   // Undo the rounded corners
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     border-radius: 0;
   }
 }
@@ -177,7 +177,7 @@
     display: block;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     .navbar > .container &,
     .navbar > .container-fluid & {
       margin-left: -@navbar-padding-horizontal;
@@ -219,7 +219,7 @@
     margin-top: 4px;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     display: none;
   }
 }
@@ -264,7 +264,7 @@
   }
 
   // Uncollapse the nav
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     float: left;
     margin: 0;
 
@@ -306,7 +306,7 @@
   .navbar-vertical-align(@input-height-base);
 
   // Undo 100% width for pull classes
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     width: auto;
     border: 0;
     margin-left: 0;
@@ -354,7 +354,7 @@
 .navbar-text {
   .navbar-vertical-align(@line-height-computed);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     float: left;
     margin-left: @navbar-padding-horizontal;
     margin-right: @navbar-padding-horizontal;
@@ -370,7 +370,7 @@
 //
 // Declared after the navbar components to ensure more specificity on the margins.
 
-@media (min-width: @grid-float-breakpoint) {
+@media screen and (min-width: @grid-float-breakpoint) {
   .navbar-left  { .pull-left(); }
   .navbar-right {
     .pull-right();

--- a/less/navs.less
+++ b/less/navs.less
@@ -173,7 +173,7 @@
     left: auto;
   }
 
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     > li {
       display: table-cell;
       width: 1%;
@@ -202,7 +202,7 @@
     border: 1px solid @nav-tabs-justified-link-border-color;
   }
 
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     > li > a {
       border-bottom: 1px solid @nav-tabs-justified-link-border-color;
       border-radius: @border-radius-base @border-radius-base 0 0;

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -69,64 +69,64 @@
 }
 
 .visible-sm {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media screen and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     .responsive-visibility();
   }
 }
 .visible-sm-block {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media screen and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: block !important;
   }
 }
 .visible-sm-inline {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media screen and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: inline !important;
   }
 }
 .visible-sm-inline-block {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media screen and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: inline-block !important;
   }
 }
 
 .visible-md {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media screen and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     .responsive-visibility();
   }
 }
 .visible-md-block {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media screen and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: block !important;
   }
 }
 .visible-md-inline {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media screen and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: inline !important;
   }
 }
 .visible-md-inline-block {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media screen and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: inline-block !important;
   }
 }
 
 .visible-lg {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     .responsive-visibility();
   }
 }
 .visible-lg-block {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     display: block !important;
   }
 }
 .visible-lg-inline {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     display: inline !important;
   }
 }
 .visible-lg-inline-block {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     display: inline-block !important;
   }
 }
@@ -137,17 +137,17 @@
   }
 }
 .hidden-sm {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media screen and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     .responsive-invisibility();
   }
 }
 .hidden-md {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media screen and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     .responsive-invisibility();
   }
 }
 .hidden-lg {
-  @media (min-width: @screen-lg-min) {
+  @media screen and (min-width: @screen-lg-min) {
     .responsive-invisibility();
   }
 }

--- a/less/type.less
+++ b/less/type.less
@@ -65,7 +65,7 @@ p {
   font-weight: 300;
   line-height: 1.4;
 
-  @media (min-width: @screen-sm-min) {
+  @media screen and (min-width: @screen-sm-min) {
     font-size: (@font-size-base * 1.5);
   }
 }
@@ -211,7 +211,7 @@ dd {
     &:extend(.clearfix all); // Clear the floated `dt` if an empty `dd` is present
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media screen and (min-width: @grid-float-breakpoint) {
     dt {
       float: left;
       width: (@dl-horizontal-offset - 20);


### PR DESCRIPTION
Fixes a bug in safari when printing content.

It seems some styles dedicated to screen applies in safari when printing.

Here is how to reproduce the bug:

1) Create a simple HTML document like this one: http://ghusse.com/bootstrap-bug/
2) Print it with safari, chrome, Firefox, IE

In Chrome, the result is similar to the result on screen:

![chrome](https://cloud.githubusercontent.com/assets/527245/4023488/97e1b47e-2b92-11e4-867e-d7bfee2de71c.png)

In Safari, something weird happens:
- The page is truncated on the right
- Font sizes are smaller

![bug-safari](https://cloud.githubusercontent.com/assets/527245/4023490/a6f66374-2b92-11e4-8806-0d88a26e52c8.png)

With this fix, everything works great in safari too

![safari-fixed](https://cloud.githubusercontent.com/assets/527245/4023491/bd926182-2b92-11e4-9988-c360f498e247.png)

If you want to test, here is the buggy version: http://ghusse.com/bootstrap-bug/
And here the fixed one: http://ghusse.com/bootstrap-bug/nobug.html

The fix consists to specify the media type (screen) on each media query specifying a min-width.
