### PR TITLE
Make `popover-arrow-color` default to `popover-bg`

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -528,7 +528,7 @@
 //** Popover arrow width
 @popover-arrow-width:                 10px;
 //** Popover arrow color
-@popover-arrow-color:                 #fff;
+@popover-arrow-color:                 @popover-bg;
 
 //** Popover outer arrow width
 @popover-arrow-outer-width:           (@popover-arrow-width + 1);


### PR DESCRIPTION
Just like `@tooltip-arrow-color` defaults to `@tooltip-bg`. Makes more sense to me.
