### PR TITLE
Specify a max-width for the medium grid

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -70,7 +70,7 @@
 //
 // Columns, offsets, pushes, and pulls for the desktop device range.
 
-@media (min-width: @screen-md-min) and (max-width: @screen-md-max;) {
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
   .make-grid(md);
 }
 

--- a/less/grid.less
+++ b/less/grid.less
@@ -70,7 +70,7 @@
 //
 // Columns, offsets, pushes, and pulls for the desktop device range.
 
-@media (min-width: @screen-md-min) {
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max;) {
   .make-grid(md);
 }
 


### PR DESCRIPTION
This prevents conflict when using col-md-\* and col-lg-\* classes together on the same element.

Example: 

```
<div class="col-lg-2 col-md-3 col-md-pull-4">
    ...
</div>
```

This causes the `col-md-pull-4` class to pull the element even when the browser window is larger than `@screen-lg-min`. This problem is fixed with this pull request.
