### PR TITLE
fix nav links to end with / to avoid 301 redirect

### DIFF
--- a/docs/_includes/nav/main.html
+++ b/docs/_includes/nav/main.html
@@ -12,19 +12,19 @@
     <nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
       <ul class="nav navbar-nav">
         <li{% if page.slug == "getting-started" %} class="active"{% endif %}>
-          <a href="../getting-started">Getting started</a>
+          <a href="../getting-started/">Getting started</a>
         </li>
         <li{% if page.slug == "css" %} class="active"{% endif %}>
-          <a href="../css">CSS</a>
+          <a href="../css/">CSS</a>
         </li>
         <li{% if page.slug == "components" %} class="active"{% endif %}>
-          <a href="../components">Components</a>
+          <a href="../components/">Components</a>
         </li>
         <li{% if page.slug == "js" %} class="active"{% endif %}>
-          <a href="../javascript">JavaScript</a>
+          <a href="../javascript/">JavaScript</a>
         </li>
         <li{% if page.slug == "customize" %} class="active"{% endif %}>
-          <a href="../customize">Customize</a>
+          <a href="../customize/">Customize</a>
         </li>
       </ul>
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Nav links in header of http://getbootstrap.com/ point to a path which result a 301 to reach actual page. 

e.g. 
CSS should link to http://getbootstrap.com/css/ instead of http://getbootstrap.com/css

Fixed following links:
Getting started
CSS
Components
JavaScript
Customize
