### PR TITLE
Fix popover not passing element to content function

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -67,7 +67,7 @@
 
     return $e.attr('data-content')
       || (typeof o.content == 'function' ?
-            o.content.call($e[0]) :
+            o.content.call(this,$e[0]) :
             o.content)
   }
 


### PR DESCRIPTION
Given the following example code:

```
$(document).popover({
   trigger: 'hover',
   viewport: '#containerOverlay',
   placement: 'auto top',
   selector: '.leaderboard-popover',
   html: true,
   animation: true,
   delay: {
       show: 250,
       hide: 100
   },
   content: function(element) {
   console.log('passed element',element);
   }
});
```

console will output the following: `passed element undefined`.

With the inclusion of `this` to `content.call` we pass with context, and our element is defined. Console now outputs the following: `passed element <span class="display popover">....</span>`
