### PR TITLE
Handle lack of .width and .height from getBoundingClientRect() in IE8

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -324,6 +324,10 @@
     var isSvg  = window.SVGElement && el instanceof window.SVGElement
 
     var elRect    = el.getBoundingClientRect()
+    if (elRect.width == null) {
+      // width and height are missing in IE8, so compute them manually; see https://github.com/twbs/bootstrap/issues/14093
+      elRect = $.extend({}, elRect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top })
+    }
     var elOffset  = isBody ? { top: 0, left: 0 } : $element.offset()
     var scroll    = { scroll: isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.scrollTop() }
     var outerDims = isSvg ? {} : {


### PR DESCRIPTION
Closes #14093. Correction to #14090.
New relevant docs: https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect#Browser_compatibility
This takes the same approach as ZeroClipboard.
CC: @fat
