### PR TITLE
Set git clone depth to 10 for Travis to make it faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+git:
+  depth: 10
 node_js:
   - "0.10"
 before_install:


### PR DESCRIPTION
Just noticed that on the [Apache Cordova](https://github.com/apache/cordova-lib/) project they've set the git clone depth for Travis to 10 as a performance optimization.

Could be an interesting optimization for Bootstrap as well.

[Related Cordova commit](https://github.com/apache/cordova-lib/commit/e8eff3df960f937c3c999dfabda2147937cdef22)
