### PR TITLE
Fixed typos involving apostrophes

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -246,15 +246,15 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
   <p>Initializes popovers for an element collection.</p>
 
   <h4>.popover('show')</h4>
-  <p>Reveals an elements popover.</p>
+  <p>Reveals an element's popover.</p>
   {% highlight js %}$('#element').popover('show'){% endhighlight %}
 
   <h4>.popover('hide')</h4>
-  <p>Hides an elements popover.</p>
+  <p>Hides an element's popover.</p>
   {% highlight js %}$('#element').popover('hide'){% endhighlight %}
 
   <h4>.popover('toggle')</h4>
-  <p>Toggles an elements popover.</p>
+  <p>Toggles an element's popover.</p>
   {% highlight js %}$('#element').popover('toggle'){% endhighlight %}
 
   <h4>.popover('destroy')</h4>


### PR DESCRIPTION
Added apostrophes to 3 words to indicate possession (i.e. ownership of something) instead of plurality (i.e. multiples of something).
