### PR TITLE
Adjusted "selector" option

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -19,7 +19,7 @@
     this.$body          = $('body')
     this.$scrollElement = $(element).is('body') ? $(window) : $(element)
     this.options        = $.extend({}, ScrollSpy.DEFAULTS, options)
-    this.selector       = (this.options.target || '') + ' .nav li > a'
+    this.selector       = (this.options.target || '') + ' a[href^=#]'
     this.offsets        = []
     this.targets        = []
     this.activeTarget   = null


### PR DESCRIPTION
Made this edit to make this.selector match every anchor whose href attribute starts with an # symbol.
It is useful for me (and for everyone else) to match the anchor of the logo in my navbar with the first section (#home) of the onepage I'm currently developing.
