### PR TITLE
Add section to docs explaining our stance on validators

### DIFF
--- a/docs/_includes/getting-started/browser-device-support.html
+++ b/docs/_includes/getting-started/browser-device-support.html
@@ -189,4 +189,9 @@ $(function () {
 </script>
 {% endhighlight %}
   <p>Want to see an example? <a href="http://jsbin.com/kuvoz/1">Check out this JS Bin demo.</a></p>
+
+  <h3 id="support-validators">Validators</h3>
+  <p>In order to provide the best possible experience to old and buggy browsers, Bootstrap uses <a href="http://browserhacks.com">CSS browser hacks</a> in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.</p>
+  <p>These validation warnings don't matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don't interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.</p>
+  <p>Our HTML docs likewise have some trivial and inconsequential HTML validation warnings due to our inclusion of <a href="#support-ie-compatibility-modes">X-UA-Compatible <code>&lt;meta&gt;</code> tags</a> to avoid Internet Explorer issues and our inclusion of a workaround for <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=654072">a certain Firefox bug</a>.</p>
 </div>

--- a/docs/_includes/nav/getting-started.html
+++ b/docs/_includes/nav/getting-started.html
@@ -52,6 +52,7 @@
     <li><a href="#support-browser-zooming">Browser zooming</a></li>
     <li><a href="#support-printing">Printer viewports</a></li>
     <li><a href="#support-android-stock-browser">Android stock browser</a></li>
+    <li><a href="#support-validators">Validators</a></li>
   </ul>
 </li>
 <li>


### PR DESCRIPTION
Since the question of why our CSS & HTML have some (trivial, inconsequential) validator warnings has come up a few times, I would like to have a section about it in the docs so I can just point people to that.

CC: @twbs/team 
