### PR TITLE
add `.shown` utility helper

### DIFF
--- a/less/utilities.less
+++ b/less/utilities.less
@@ -47,6 +47,11 @@
   visibility: hidden !important;
 }
 
+.shown {
+  display: block !important;
+  visibility: visible !important;
+}
+
 
 // For Affix plugin
 // -------------------------


### PR DESCRIPTION
We are using bootstrap less and mixins to extend bootstrap into our own CSS framework for our site, but there is not currently a mixin utility that reverses `.hidden`'s `visibility` property (which seems to be by design).  These utility mixins are a nice way to apply the basic `display: none;` properties we've been using to show / hide elements, so I think it would be nice to reuse them, but I understand if that does not coincide with the original intent. 
