### PR TITLE
Remove `.modal-open` class after backdrop is hidden

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -107,9 +107,6 @@
 
     this.isShown = false
 
-    this.$body.removeClass('modal-open')
-
-    this.resetScrollbar()
     this.escape()
 
     $(document).off('focusin.bs.modal')
@@ -150,6 +147,8 @@
     var that = this
     this.$element.hide()
     this.backdrop(function () {
+      that.$body.removeClass('modal-open')
+      that.resetScrollbar()
       that.$element.trigger('hidden.bs.modal')
     })
   }


### PR DESCRIPTION
Fixes #14274 and #14632.
