### PR TITLE
Add support for split button dropdowns in justified button groups (with IE8 support)

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -217,6 +217,19 @@
     width: 100%;
   }
 
+  > .btn-group > .btn:first-child:not(:only-of-type) {
+    margin-right: -32px;
+    padding-right: 32px;
+  }  
+  > .btn-group > .dropdown-toggle{
+    float:right;
+    width:auto;    
+    z-index:3;
+  }  
+  > .btn-group:last-child > .btn:first-child {
+    .border-right-radius(@border-radius-large);
+  }
+  
   > .btn-group .dropdown-menu {
     left: auto;
   }

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -218,13 +218,13 @@
   }
 
   > .btn-group > .btn:first-child:not(:only-of-type) {
-    margin-right: -32px;
     padding-right: 32px;
+    margin-right: -32px;
   }  
   > .btn-group > .btn:first-child:not(:only-of-type) + .dropdown-toggle {
-    float:right;
-    width:auto;    
-    z-index:3;
+    z-index: 3;
+    float: right;
+    width: auto;
   }  
   > .btn-group:last-child > .btn:first-child {
     .border-right-radius(@border-radius-large);

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -217,11 +217,20 @@
     width: 100%;
   }
 
-  > .btn-group > .btn:first-child:not(:only-of-type) {
-    padding-right: 32px;
-    margin-right: -32px;
+  > .btn-group > .btn:first-child{
+    padding-right: (2 * @caret-width-base + 18);
+    margin-right: (-2 * @caret-width-base - 18);
   }  
-  > .btn-group > .btn:first-child:not(:only-of-type) + .dropdown-toggle {
+  > .btn-group-lg > .btn-lg:first-child {
+    padding-right: (2 * @caret-width-large + 26);
+    margin-right: (-2 * @caret-width-large - 26);
+  }
+  //fallback to exclude non-split button dropdown
+  > .btn-group > .btn.dropdown-toggle:first-child {
+    padding-right: 0;
+    margin-right: 0;
+  }
+  > .btn-group > .btn + .dropdown-toggle {
     z-index: 3;
     float: right;
     width: auto;

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -221,7 +221,7 @@
     margin-right: -32px;
     padding-right: 32px;
   }  
-  > .btn-group > .dropdown-toggle{
+  > .btn-group > .btn:first-child:not(:only-of-type) + .dropdown-toggle {
     float:right;
     width:auto;    
     z-index:3;


### PR DESCRIPTION
The fixed values 26px/36px are calculated based on caret size, the only variable available for this is `@caret-width-base`/`@caret-width-large`.

caret size = [`.dropdown-toggle padding`](https://github.com/twbs/bootstrap/blob/master/less/button-groups.less#L107-L115) \* 2 + [`.btn border`](https://github.com/twbs/bootstrap/blob/master/less/buttons.less#L18) \* 2 + ( [`.caret border`](https://github.com/twbs/bootstrap/blob/master/less/dropdowns.less#L14-L15) or [`.caret border lg`](https://github.com/twbs/bootstrap/blob/master/less/button-groups.less#L135)) \* 2

Sample: http://jsfiddle.net/seLk2khL
