### PR TITLE
add less variable @pager-color

### DIFF
--- a/less/pager.less
+++ b/less/pager.less
@@ -15,6 +15,7 @@
     > span {
       display: inline-block;
       padding: 5px 14px;
+      color: @pager-color;
       background-color: @pager-bg;
       border: 1px solid @pager-border;
       border-radius: @pager-border-radius;

--- a/less/variables.less
+++ b/less/variables.less
@@ -454,6 +454,7 @@
 //
 //##
 
+@pager-color:                          @link-color;
 @pager-bg:                             @pagination-bg;
 @pager-border:                         @pagination-border;
 @pager-border-radius:                  15px;


### PR DESCRIPTION
While creating a dark theme for bootstrap i found that the pager has no less variable for its font color.

This fix addes the variable and enables changing the pager's font color.
