### PR TITLE
Navbar dropdown on iPad

### DIFF
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -728,13 +728,13 @@ if (typeof jQuery === 'undefined') { throw new Error('Bootstrap\'s JavaScript re
 
       if (e.isDefaultPrevented()) return
 
-      $this
-        .trigger('focus')
-        .attr('aria-expanded', 'true')
-
       $parent
         .toggleClass('open')
         .trigger('shown.bs.dropdown', relatedTarget)
+
+      $this
+        .trigger('focus')
+        .attr('aria-expanded', 'true')
     }
 
     return false


### PR DESCRIPTION
In the navbar, open one dropdown.
After open another, without closing the first.
This will cause the 'dropdown-menu' to be cut off as you can see here:
http://imgur.com/mqmA0IF,czqJ9SY#0
http://imgur.com/mqmA0IF,czqJ9SY#1

This doesn't happend if you move focus down.
