### PR TITLE
Navbar dropdown on iOS

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -141,7 +141,7 @@
   right: 0;
   left: 0;
   z-index: @zindex-navbar-fixed;
-  .translate3d(0, 0, 0);
+  
 
   // Undo the rounded corners
   @media (min-width: @grid-float-breakpoint) {


### PR DESCRIPTION
In the navbar, open one dropdown.
After open another, without closing the first.
This will cause the 'dropdown-menu' to be cut off as you can see here:
http://jsbin.com/jeyuwi/1

Removing .translate3d(0, 0, 0); seems to fix this.
