### PR TITLE
popover-class-indicator (issue #14607)

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -54,7 +54,7 @@
 
     // IE8 doesn't accept hiding via the `:empty` pseudo selector, we have to do
     // this manually by checking the contents.
-    if (!$tip.find('.popover-title').html()) $tip.find('.popover-title').hide()
+    if (!$tip.find('.popover-title').html()) $tip.addClass('popover-no-title').find('.popover-title').hide()
   }
 
   Popover.prototype.hasContent = function () {


### PR DESCRIPTION
Addresses issue #14607 by adding 'no-title' to the popover tip.

If you'd prefer a different class name instead of `no-title` please let me know. The `.find('.popover-title').hide()` portion of this line could actually be removed, in favor of hiding the title via LESS and the new `no-title` class... if you think that change would be worthwhile, I could throw that in there.

Additionally, I tested this minor change via the `bootstrap/js/tests/visual/popover.html` and by running `grunt test`, however I did not commit the dist files that were generated. Let me know if you'd like those to be included and I will do so (along with a squash to make it one commit). Thanks!
