### PR TITLE
Separate tasks for testing. Proposal for #14609

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -429,6 +429,15 @@ module.exports = function (grunt) {
   }
   grunt.registerTask('test', testSubtasks);
 
+  // JS tests only.
+  grunt.registerTask('test-js', ['dist-js', 'jshint:core', 'jshint:test', 'jshint:grunt', 'jscs:core', 'jscs:test', 'jscs:grunt', 'qunit']);
+
+  // CSS tests only.
+  grunt.registerTask('test-css', ['dist-css', 'csslint:dist']);
+
+  // Run both 'test-js' and 'test-css'
+  grunt.registerTask('test-css-js', ['test-js', 'test-css']);
+
   // JS distribution task.
   grunt.registerTask('dist-js', ['concat', 'uglify:core']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -430,7 +430,7 @@ module.exports = function (grunt) {
   grunt.registerTask('test', testSubtasks);
 
   // JS tests only.
-  grunt.registerTask('test-js', ['dist-js', 'jshint:core', 'jshint:test', 'jshint:grunt', 'jscs:core', 'jscs:test', 'jscs:grunt', 'qunit']);
+  grunt.registerTask('test-js', ['jshint:core', 'jshint:test', 'jshint:grunt', 'jscs:core', 'jscs:test', 'jscs:grunt', 'qunit']);
 
   // CSS tests only.
   grunt.registerTask('test-css', ['dist-css', 'csslint:dist']);


### PR DESCRIPTION
- JS tests `grunt test-js`
- CSS tests `grunt test-css`
- Both CSS and JS tests `grunt test-css-js`

I am not sure if it helps and that's why it's just a proposal for dealing with #14609
I will be glad if it gets merged. :smiley:
