### PR TITLE
add a note about the Grunt `docs` command, closes #14628

### DIFF
--- a/docs/_includes/getting-started/grunt.html
+++ b/docs/_includes/getting-started/grunt.html
@@ -24,6 +24,9 @@
   <h3><code>grunt test</code> (Run tests)</h3>
   <p>Runs <a href="http://jshint.com">JSHint</a> and runs the <a href="http://qunitjs.com">QUnit</a> tests headlessly in <a href="http://phantomjs.org">PhantomJS</a>.</p>
 
+  <h3><code>grunt docs</code> (Generate local docs)</h3>
+  <p>Updates the local documentation, that can be served with <code>jekyll serve</code></p>
+
   <h3><code>grunt</code> (Build absolutely everything and run tests)</h3>
   <p>Compiles and minifies CSS and JavaScript, builds the documentation website, runs the HTML5 validator against the docs, regenerates the Customizer assets, and more. Usually only necessary if you're hacking on Bootstrap itself.</p>
 


### PR DESCRIPTION
Just a small improvement to the doc
