### PR TITLE
added optional grid-columns override argument to grid mixins

### DIFF
--- a/docs/_includes/css/grid.html
+++ b/docs/_includes/css/grid.html
@@ -403,7 +403,7 @@
 {% endhighlight %}
 
   <h4>Mixins</h4>
-  <p>Mixins are used in conjunction with the grid variables to generate semantic CSS for individual grid columns.</p>
+  <p>Mixins are used in conjunction with the grid variables to generate semantic CSS for individual grid columns. You can also optionaly override these variables if you need it in specific local situations.</p>
 {% highlight scss %}
 // Creates a wrapper for a series of columns
 .make-row(@gutter: @grid-gutter-width) {
@@ -423,7 +423,7 @@
 }
 
 // Generate the extra small columns
-.make-xs-column(@columns; @gutter: @grid-gutter-width) {
+.make-xs-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   // Prevent columns from collapsing when empty
   min-height: 1px;
@@ -434,12 +434,12 @@
   // Calculate width based on number of columns available
   @media (min-width: @grid-float-breakpoint) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the small columns
-.make-sm-column(@columns; @gutter: @grid-gutter-width) {
+.make-sm-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   // Prevent columns from collapsing when empty
   min-height: 1px;
@@ -450,29 +450,29 @@
   // Calculate width based on number of columns available
   @media (min-width: @screen-sm-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the small column offsets
-.make-sm-column-offset(@columns) {
+.make-sm-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-sm-column-push(@columns) {
+.make-sm-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-sm-column-pull(@columns) {
+.make-sm-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the medium columns
-.make-md-column(@columns; @gutter: @grid-gutter-width) {
+.make-md-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   // Prevent columns from collapsing when empty
   min-height: 1px;
@@ -483,29 +483,29 @@
   // Calculate width based on number of columns available
   @media (min-width: @screen-md-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the medium column offsets
-.make-md-column-offset(@columns) {
+.make-md-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-md-column-push(@columns) {
+.make-md-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-md-column-pull(@columns) {
+.make-md-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the large columns
-.make-lg-column(@columns; @gutter: @grid-gutter-width) {
+.make-lg-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   // Prevent columns from collapsing when empty
   min-height: 1px;
@@ -516,24 +516,24 @@
   // Calculate width based on number of columns available
   @media (min-width: @screen-lg-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the large column offsets
-.make-lg-column-offset(@columns) {
+.make-lg-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-lg-column-push(@columns) {
+.make-lg-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-lg-column-pull(@columns) {
+.make-lg-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }
 {% endhighlight %}
@@ -550,6 +550,9 @@
 .content-secondary {
   .make-lg-column(3);
   .make-lg-column-offset(1);
+}
+.content-one-fifth {
+  .make-md-column(1, @gutter-width, 5);
 }
 {% endhighlight %}
 {% highlight html %}

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -19,26 +19,26 @@
 }
 
 // Generate the extra small columns
-.make-xs-column(@columns; @gutter: @grid-gutter-width) {
+.make-xs-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   float: left;
-  width: percentage((@columns / @grid-columns));
+  width: percentage((@columns / @from-columns));
   min-height: 1px;
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 }
-.make-xs-column-offset(@columns) {
-  margin-left: percentage((@columns / @grid-columns));
+.make-xs-column-offset(@columns; @from-columns: @grid-columns) {
+  margin-left: percentage((@columns / @from-columns));
 }
-.make-xs-column-push(@columns) {
-  left: percentage((@columns / @grid-columns));
+.make-xs-column-push(@columns; @from-columns: @grid-columns) {
+  left: percentage((@columns / @from-columns));
 }
-.make-xs-column-pull(@columns) {
-  right: percentage((@columns / @grid-columns));
+.make-xs-column-pull(@columns; @from-columns: @grid-columns) {
+  right: percentage((@columns / @from-columns));
 }
 
 // Generate the small columns
-.make-sm-column(@columns; @gutter: @grid-gutter-width) {
+.make-sm-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   min-height: 1px;
   padding-left:  (@gutter / 2);
@@ -46,27 +46,27 @@
 
   @media (min-width: @screen-sm-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
-.make-sm-column-offset(@columns) {
+.make-sm-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-sm-column-push(@columns) {
+.make-sm-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-sm-column-pull(@columns) {
+.make-sm-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-sm-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the medium columns
-.make-md-column(@columns; @gutter: @grid-gutter-width) {
+.make-md-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   min-height: 1px;
   padding-left:  (@gutter / 2);
@@ -74,27 +74,27 @@
 
   @media (min-width: @screen-md-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
-.make-md-column-offset(@columns) {
+.make-md-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-md-column-push(@columns) {
+.make-md-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-md-column-pull(@columns) {
+.make-md-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-md-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }
 
 // Generate the large columns
-.make-lg-column(@columns; @gutter: @grid-gutter-width) {
+.make-lg-column(@columns; @gutter: @grid-gutter-width; @from-columns: @grid-columns) {
   position: relative;
   min-height: 1px;
   padding-left:  (@gutter / 2);
@@ -102,21 +102,21 @@
 
   @media (min-width: @screen-lg-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage((@columns / @from-columns));
   }
 }
-.make-lg-column-offset(@columns) {
+.make-lg-column-offset(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage((@columns / @from-columns));
   }
 }
-.make-lg-column-push(@columns) {
+.make-lg-column-push(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage((@columns / @from-columns));
   }
 }
-.make-lg-column-pull(@columns) {
+.make-lg-column-pull(@columns; @from-columns: @grid-columns) {
   @media (min-width: @screen-lg-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage((@columns / @from-columns));
   }
 }


### PR DESCRIPTION
In some cases there is need to have localy different number of columns in grid. Added optional argument to columns grid mixins to enable definition of columns with specific number of columns in the grid they are in. For example it is very handy when 5 columns grid is needed without need to change grid columns of whole page.
