### PR TITLE
added gutter size argument to .make-grid-columns

### DIFF
--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -3,7 +3,7 @@
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `@grid-columns`.
 
-.make-grid-columns() {
+.make-grid-columns(@gutter: @grid-gutter-width) {
   // Common styles for all sizes of grid columns, widths 1-12
   .col(@index) when (@index = 1) { // initial
     @item: ~".col-xs-@{index}, .col-sm-@{index}, .col-md-@{index}, .col-lg-@{index}";
@@ -19,8 +19,8 @@
       // Prevent columns from collapsing when empty
       min-height: 1px;
       // Inner gutter via padding
-      padding-left:  (@grid-gutter-width / 2);
-      padding-right: (@grid-gutter-width / 2);
+      padding-left:  (@gutter / 2);
+      padding-right: (@gutter / 2);
     }
   }
   .col(1); // kickstart it


### PR DESCRIPTION
This allows you to create multiple grids with different gutter sizes very easily. For example:

```
.row-small {
    .make-grid-columns(6px);
}
.row-medium {
    .make-grid-columns(12px);
}
```
