### PR TITLE
Update docs to reflect that Safari percentages were fixed in v7.1 & iOS 8.0

### DIFF
--- a/docs/_includes/getting-started/browser-device-support.html
+++ b/docs/_includes/getting-started/browser-device-support.html
@@ -147,7 +147,7 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
   <p>As a heads up, we include this in all of Bootstrap's documentation and examples as a demonstration.</p>
 
   <h3 id="support-safari-percentages">Safari percent rounding</h3>
-  <p>As of Safari v7.0.1 for OS X and Safari for iOS v7.0.1, Safari's rendering engine has some trouble with the number of decimal places used in our <code>.col-*-1</code> grid classes. So if you have 12 individual grid columns, you'll notice that they come up short compared to other rows of columns. We can't do much here (<a href="https://github.com/twbs/bootstrap/issues/9282">see #9282</a>) but you do have some options:</p>
+  <p>The rendering engine of versions of Safari prior to v7.1 for OS X and Safari for iOS v8.0 had some trouble with the number of decimal places used in our <code>.col-*-1</code> grid classes. So if you had 12 individual grid columns, you'd notice that they came up short compared to other rows of columns. Besides upgrading Safari/iOS, you have some options for workarounds:</p>
   <ul>
     <li>Add <code>.pull-right</code> to your last grid column to get the hard-right alignment</li>
     <li>Tweak your percentages manually to get the perfect rounding for Safari (more difficult than the first option)</li>


### PR DESCRIPTION
Fixes #14663.
