### PR TITLE
Fixed minor inconsistency in comments

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -93,7 +93,7 @@
     border-radius: @border-radius-large;
   }
 
-  // Nuke default margins from checkboxes and radios to vertically center within.
+  // Nuke default margins from checkboxes and radios to vertically center within
   input[type="radio"],
   input[type="checkbox"] {
     margin-top: 0;


### PR DESCRIPTION
I've noticed that single line comments don't have periods at the end, so I removed this one
