### PR TITLE
More screenreader friendly Collapse, Take 2

### DIFF
--- a/less/component-animations.less
+++ b/less/component-animations.less
@@ -17,8 +17,9 @@
 
 .collapse {
   display: none;
+  visibility: hidden;
 
-  &.in      { display: block; }
+  &.in      { display: block; visibility: visible; }
   tr&.in    { display: table-row; }
   tbody&.in { display: table-row-group; }
 }
@@ -27,5 +28,7 @@
   position: relative;
   height: 0;
   overflow: hidden;
-  .transition(height .35s ease);
+  .transition-property(~"height, visibility");
+  .transition-duration(.35s);
+  .transition-timing-function(ease);
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -67,6 +67,7 @@
 
     &.collapse {
       display: block !important;
+      visibility: visible !important;
       height: auto !important;
       padding-bottom: 0; // Override default setting
       overflow: visible !important;

--- a/less/navs.less
+++ b/less/navs.less
@@ -223,9 +223,11 @@
 .tab-content {
   > .tab-pane {
     display: none;
+    visibility: hidden;
   }
   > .active {
     display: block;
+    visibility: visible;
   }
 }
 


### PR DESCRIPTION
This reverts 0ec05da0eea03849fc72bed84a2c7fe7be1de1b6 to bring back #14444, which fixes #14348 (again). I think I figured out all the kinks here now:
- Navbar contents are no longer hidden on desktop views  (missed that the last time around).
- Collapse demo works as expected.
- Tabs demo works as expected.

Does this screw with anything else? Am I missing any broken examples or components?

/cc @hnrch02 and @cvrebert for testing.
