### PR TITLE
Document that the autofocus attribute doesn't work in modals.

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -1,7 +1,5 @@
 <div class="bs-docs-section">
   <h1 id="modals" class="page-header">Modals <small>modal.js</small></h1>
-
-  <h2 id="modals-examples">Examples</h2>
   <p>Modals are streamlined, but flexible, dialog prompts with the minimum required functionality and smart defaults.</p>
 
   <div class="bs-callout bs-callout-warning" id="callout-stacked-modals">
@@ -16,6 +14,10 @@
     <h4>Mobile device caveats</h4>
     <p>There are some caveats regarding using modals on mobile devices. <a href="../getting-started/#support-fixed-position-keyboards">See our browser support docs</a> for details.</p>
   </div>
+
+  <p><strong class="text-danger">Due to how HTML5 defines its semantics, the <code>autofocus</code> HTML attribute has no effect in Bootstrap modals.</strong></p>
+
+  <h2 id="modals-examples">Examples</h2>
 
   <h3>Static example</h3>
   <p>A rendered modal with header, body, and set of actions in the footer.</p>


### PR DESCRIPTION
Closes #14478.
