### PR TITLE
Update doc with correct percentage for disabled buttons

### DIFF
--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -114,7 +114,7 @@
 
 
   <h2 id="buttons-disabled">Disabled state</h2>
-  <p>Make buttons look unclickable by fading them back 50%.</p>
+  <p>Make buttons look unclickable by fading them back 65%.</p>
 
   <h3>Button element</h3>
   <p>Add the <code>disabled</code> attribute to <code>&lt;button&gt;</code> buttons.</p>

--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -114,7 +114,7 @@
 
 
   <h2 id="buttons-disabled">Disabled state</h2>
-  <p>Make buttons look unclickable by fading them back 65%.</p>
+  <p>Make buttons look unclickable by fading them by 35%.</p>
 
   <h3>Button element</h3>
   <p>Add the <code>disabled</code> attribute to <code>&lt;button&gt;</code> buttons.</p>

--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -114,7 +114,7 @@
 
 
   <h2 id="buttons-disabled">Disabled state</h2>
-  <p>Make buttons look unclickable by fading them by 35%.</p>
+  <p>Make buttons look unclickable by fading the opacity.</p>
 
   <h3>Button element</h3>
   <p>Add the <code>disabled</code> attribute to <code>&lt;button&gt;</code> buttons.</p>


### PR DESCRIPTION
The css buttons doc states that disabled buttons have an opacity of 50%, but the actual percentage is 65%.
