### PR TITLE
Fix #12563: Elaborate that popover('show') checks title/content

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -246,7 +246,7 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
   <p>Initializes popovers for an element collection.</p>
 
   <h4>.popover('show')</h4>
-  <p>Reveals an element's popover.</p>
+  <p>Reveals an element's popover. Popovers whose both title and content are zero-length are never displayed.</p>
   {% highlight js %}$('#element').popover('show'){% endhighlight %}
 
   <h4>.popover('hide')</h4>

--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -207,7 +207,7 @@ $('#example').tooltip(options)
   <p>Attaches a tooltip handler to an element collection.</p>
 
   <h4>.tooltip('show')</h4>
-  <p>Reveals an element's tooltip.</p>
+  <p>Reveals an element's tooltip. Tooltips with zero-length titles are never displayed.</p>
   {% highlight js %}$('#element').tooltip('show'){% endhighlight %}
 
   <h4>.tooltip('hide')</h4>


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/12563: Explain in Popover docs that the `show` method will [check](https://github.com/twbs/bootstrap/blob/8ee208e9c197d48828767764d7c89147ebde2a7e/js/tooltip.js#L128) to see if the element's title or content exists before displaying. 

This seemed like the only logical place for it since it should only happen if the `show` method is invokved. 
Another possible place is in the `content` section under Options, but it didn't seem right to explain here that the function would execute twice if `show` is invoked and the [title doesn't exist](https://github.com/twbs/bootstrap/blob/8ee208e9c197d48828767764d7c89147ebde2a7e/js/popover.js#L58-L60). 
