### PR TITLE
Let ScrollSpy support uri encoded hash fragments

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -60,7 +60,7 @@
       .map(function () {
         var $el   = $(this)
         var href  = $el.data('target') || $el.attr('href')
-        var $href = /^#./.test(href) && $(href)
+        var $href = /^#./.test(href) && $(decodeURIComponent(href))
 
         return ($href
           && $href.length

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -158,4 +158,27 @@ $(function () {
       .then(function () { return testElementIsActiveAfterScroll('#li-2', '#div-2') })
   })
 
+  test('should work with encoded hash fragments', function () {
+    stop()
+
+    var sectionHTML = '<div id="root" style="overflow: auto; height:100px">'
+      + '<nav id="navigation" class="navbar">'
+      + '<ul class="nav navbar-nav">'
+      + '<li id="li-1"><a href="#' + encodeURIComponent('こんにちは') + '">div 1</a></li>'
+      + '</ul>'
+      + '</nav>'
+      + '<div style="height: 500px;"></div>'
+      + '<div id="こんにちは" style="height: 200px;">div</div>'
+      + '</div>'
+    var $section = $(sectionHTML).appendTo('#qunit-fixture')
+        .show()
+        .bootstrapScrollspy({ target: '#navigation' })
+
+    $section.on('activate.bs.scrollspy', function () {
+      ok($section.find('#li-1').hasClass('active'))
+      start()
+    })
+
+    $section.scrollTop(550)
+  })
 })

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -161,18 +161,18 @@ $(function () {
   test('should work with encoded hash fragments', function () {
     stop()
 
-    var sectionHTML = '<div id="root" style="overflow: auto; height:100px">'
-      + '<nav id="navigation" class="navbar">'
-      + '<ul class="nav navbar-nav">'
-      + '<li id="li-1"><a href="#' + encodeURIComponent('こんにちは') + '">div 1</a></li>'
-      + '</ul>'
-      + '</nav>'
-      + '<div style="height: 500px;"></div>'
-      + '<div id="こんにちは" style="height: 200px;">div</div>'
-      + '</div>'
+    var sectionHTML = '<div id="root" style="overflow: auto; height: 100px;">'
+        + '<nav id="navigation" class="navbar">'
+        + '<ul class="nav navbar-nav">'
+        + '<li id="li-1"><a href="#' + encodeURIComponent('こんにちは') + '">div 1</a></li>'
+        + '</ul>'
+        + '</nav>'
+        + '<div style="height: 500px;"></div>'
+        + '<div id="こんにちは" style="height: 200px;">div</div>'
+        + '</div>'
     var $section = $(sectionHTML).appendTo('#qunit-fixture')
-        .show()
-        .bootstrapScrollspy({ target: '#navigation' })
+      .show()
+      .bootstrapScrollspy({ target: '#navigation' })
 
     $section.on('activate.bs.scrollspy', function () {
       ok($section.find('#li-1').hasClass('active'))


### PR DESCRIPTION
The updated line threw a syntax error when an encoded fragment is given.

``` js
href = encodeURIComponent('#テスト')
$(href)
// Error: Syntax error, unrecognized expression: %23%E3%83%86%E3%82%B9%E3%83%88
```

And browsers (at least Chrome 37.0.2062.124 and Firefox 32.0.3) automatically encodes `a[href]` values due to rfc3986:

``` html
<!-- server response -->
<a href="#テスト"></a>
<div id="テスト"></div>

<!-- browser recognizes as -->
<a href="#%23%E3%83%86%E3%82%B9%E3%83%88"></a>
<div id="テスト"></div>
```

This means that there is no way to use the plugin with non-ascii hash fragments. This PR fixes the problem.

Patched script works fine on my pages, however, I'm afraid of breaking something important because I'm not familiar with such encoding problems :fearful:  
Thanks.
