### PR TITLE
Allowing event to propogate for Angular binding to update the model

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -59,7 +59,7 @@
         if ($input.prop('checked') && this.$element.hasClass('active')) changed = false
         else $parent.find('.active').removeClass('active')
       }
-      if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('change')
+      if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('click')
     }
 
     if (changed) this.$element.toggleClass('active')

--- a/js/button.js
+++ b/js/button.js
@@ -61,8 +61,6 @@
       }
       if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('click')
     }
-
-    if (changed) this.$element.toggleClass('active')
   }
 
 

--- a/js/button.js
+++ b/js/button.js
@@ -61,7 +61,7 @@
       }
       if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('change')
     }
-    
+
     if (changed) this.$element.toggleClass('active')
   }
 

--- a/js/button.js
+++ b/js/button.js
@@ -59,8 +59,10 @@
         if ($input.prop('checked') && this.$element.hasClass('active')) changed = false
         else $parent.find('.active').removeClass('active')
       }
-      if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('click')
+      if (changed) $input.prop('checked', !this.$element.hasClass('active')).trigger('change')
     }
+    
+    if (changed) this.$element.toggleClass('active')
   }
 
 
@@ -103,7 +105,6 @@
       var $btn = $(e.target)
       if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
       Plugin.call($btn, 'toggle')
-      e.preventDefault()
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
       $(e.target).closest('.btn').toggleClass('focus', e.type == 'focus')


### PR DESCRIPTION
There is a bug where the model update is not triggered when changing the radio button. Allowing the event to propagate will allow it to trigger the change correctly.
