### PR TITLE
Pause animation in docs if elem is out of viewport

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,7 @@ module.exports = function (grunt) {
         src: [
           'docs/assets/js/vendor/holder.js',
           'docs/assets/js/vendor/ZeroClipboard.min.js',
+          'docs/assets/js/vendor/smartscroll.js',
           'docs/assets/js/src/application.js'
         ],
         dest: 'docs/assets/js/docs.min.js'

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -43,6 +43,7 @@
 {% else %}
 <script src="../assets/js/vendor/holder.js"></script>
 <script src="../assets/js/vendor/ZeroClipboard.min.js"></script>
+<script src="../assets/js/vendor/smartscroll.js"></script>
 <script src="../assets/js/src/application.js"></script>
 {% endif %}
 {% if page.slug == "customize" %}

--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -1537,3 +1537,11 @@ h1[id] {
   -webkit-box-shadow: 0 0 8px rgba(82,168,236,.6);
           box-shadow: 0 0 8px rgba(82,168,236,.6);
 }
+
+/* Utility class to pause infinite animation loops (#14409) */
+.js-pause {
+  -webkit-animation-play-state: paused;
+      -ms-animation-play-state: paused;
+       -o-animation-play-state: paused;
+          animation-play-state: paused;
+}

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -142,12 +142,14 @@
     // Define what elems have infinite animations
     var $infinitelyAnimatedElems = $('.progress-bar.active')
 
-    // Check for infinitely animated elems in viewport on scroll (debounced)
-    $(window).smartscroll(function () {
+    if ($infinitelyAnimatedElems.length > 0) {
+      // Check for infinitely animated elems in viewport on scroll (debounced)
+      $(window).smartscroll(function () {
+        checkAnimatedElems()
+      })
+      // Check for infinitely animated elems in viewport on load
       checkAnimatedElems()
-    })
-    // Check for infinitely animated elems in viewport on load
-    checkAnimatedElems()
+    }
 
 
     // Config ZeroClipboard

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -109,6 +109,46 @@
       }, 3000)
     })
 
+    // Pause infinite animations until they are within the viewport
+    // @see: https://github.com/twbs/bootstrap/issues/14409
+    var isInViewport = function (elem) {
+      // Get the scroll position of the page.
+      var scrollElem      = ((navigator.userAgent.toLowerCase().indexOf('webkit') !== -1) ? 'body' : 'html')
+      var viewportTop     = $(scrollElem).scrollTop()
+      var viewportBottom  = viewportTop + $(window).height()
+
+      // Get the position of the element on the page.
+      var elemTop     = Math.round($(elem).offset().top)
+      var elemBottom  = elemTop + $(elem).height()
+
+      return ((elemTop < viewportBottom) && (elemBottom > viewportTop))
+    }
+
+    // Check if it's time to start the animation.
+    var checkAnimatedElems = function () {
+      return $infinitelyAnimatedElems.each(function () {
+        var $this = $(this)
+
+        if (isInViewport(this)) {
+          // Start the animation
+          $this.removeClass('js-pause')
+        } else {
+          // Pause the animation
+          $this.addClass('js-pause')
+        }
+      })
+    }
+
+    // Define what elems have infinite animations
+    var $infinitelyAnimatedElems = $('.progress-bar.active')
+
+    // Check for infinitely animated elems in viewport on scroll (debounced)
+    $(window).smartscroll(function () {
+      checkAnimatedElems()
+    })
+    // Check for infinitely animated elems in viewport on load
+    checkAnimatedElems()
+
 
     // Config ZeroClipboard
     ZeroClipboard.config({

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -113,8 +113,7 @@
     // @see: https://github.com/twbs/bootstrap/issues/14409
     var isInViewport = function (elem) {
       // Get the scroll position of the page.
-      var scrollElem      = ((navigator.userAgent.toLowerCase().indexOf('webkit') !== -1) ? 'body' : 'html')
-      var viewportTop     = $(scrollElem).scrollTop()
+      var viewportTop     = $(window).scrollTop()
       var viewportBottom  = viewportTop + $(window).height()
 
       // Get the position of the element on the page.

--- a/docs/assets/js/vendor/smartscroll.js
+++ b/docs/assets/js/vendor/smartscroll.js
@@ -1,0 +1,38 @@
+/*!
+* Debounced scroll event library for jQuery based on Paul Irish's smartresize
+* http://paulirish.com/2009/throttled-smartresize-jquery-event-handler/
+* https://github.com/peschee/jquery-smartscroll
+*/
+
+(function($, sscr){
+  'use strict';
+
+  var debounce = function (func, threshold, execAsap) {
+    var timeout;
+
+    return function debounced () {
+      var obj = this,
+         args = arguments
+
+      function delayed () {
+        if (!execAsap)
+          func.apply(obj, args)
+
+        timeout = null
+      }
+
+      if (timeout)
+        clearTimeout(timeout)
+      else if (execAsap)
+        func.apply(obj, args)
+
+      timeout = setTimeout(delayed, threshold || 100)
+    }
+
+  }
+
+  jQuery.fn[sscr] = function (fn) {
+    return fn ? this.bind('scroll', debounce(fn)) : this.trigger(sscr)
+  }
+
+})(jQuery, 'smartscroll');


### PR DESCRIPTION
> Proposed solution for #14409

Fairly simple fix to address possible memory leak caused by constant looping animation in documentation (progress bars).

When animated element is out of the viewport, it gains a `js-pause` CSS class that sets `animation-play-state` to `paused`.

Using a small scroll debouncer for performance considerations.

FYA @fat @cvrebert
