### PR TITLE
Fix accordion and tab targets with special meaning characters

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -155,8 +155,8 @@
     var $this   = $(this)
     var target  = $this.attr('data-target')
         || e.preventDefault()
-        || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
-    var $target = $(target)
+        || (href = $this.attr('href')) && href.replace(/^#{1}/, '') && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
+    var $target = $('[id="' + target + '"]')
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()
     var parent  = $this.attr('data-parent')

--- a/js/tab.js
+++ b/js/tab.js
@@ -28,6 +28,7 @@
 
     if (!selector) {
       selector = $this.attr('href')
+      selector = selector && selector.replace(/^#{1}/, '')
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
@@ -42,7 +43,7 @@
 
     if (e.isDefaultPrevented()) return
 
-    var $target = $(selector)
+    var $target = $('[id="' + selector + '"]')
 
     this.activate($this.closest('li'), $ul)
     this.activate($target, $target.parent(), function () {


### PR DESCRIPTION
This fixes the issue of special meaning characters in id's on togglable tabs, and collapsible panels without the need for escaping the id's.

Refs: https://github.com/twbs/bootstrap/issues/14285, https://github.com/twbs/bootstrap/pull/13832
