### PR TITLE
Fixes #14799: Add vertical alignment of image in media component

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -4886,29 +4886,34 @@ a.thumbnail.active {
   background-image:      -o-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
   background-image:         linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
-.media,
-.media-body {
-  overflow: hidden;
-  zoom: 1;
-}
-.media,
-.media .media {
+.media {
   margin-top: 15px;
+}
+.media .media-right,
+.media .pull-right {
+  padding-left: 10px;
+}
+.media .media-left,
+.media .pull-left {
+  padding-right: 10px;
 }
 .media:first-child {
   margin-top: 0;
 }
-.media-object {
-  display: block;
+.media .media-left,
+.media .media-right,
+.media .media-body {
+  display: table-cell;
+  vertical-align: top;
+}
+.media .media-middle {
+  vertical-align: middle;
+}
+.media .media-bottom {
+  vertical-align: bottom;
 }
 .media-heading {
-  margin: 0 0 5px;
-}
-.media > .pull-left {
-  margin-right: 10px;
-}
-.media > .pull-right {
-  margin-left: 10px;
+  margin: 0 0 5px 0;
 }
 .media-list {
   padding-left: 0;

--- a/docs/_includes/components/media.html
+++ b/docs/_includes/components/media.html
@@ -8,7 +8,7 @@
   <div class="bs-example">
     <div class="media">
       <a class="media-left" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
@@ -17,14 +17,14 @@
     </div>
     <div class="media">
       <a class="media-left" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
         <div class="media">
           <a class="media-left" href="#">
-            <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+            <img data-src="holder.js/64x64" alt="Generic placeholder image">
           </a>
           <div class="media-body">
             <h4 class="media-heading">Nested media heading</h4>
@@ -39,15 +39,15 @@
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
       </div>
       <a class="media-right" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
     </div>
     <div class="media">
       <a class="pull-right" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <a class="pull-left" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Deprecated pull-right pull-left example</h4>
@@ -58,7 +58,7 @@
 {% highlight html %}
 <div class="media">
   <a class="media-left" href="#">
-    <img class="media-object" src="..." alt="...">
+    <img src="..." alt="...">
   </a>
   <div class="media-body">
     <h4 class="media-heading">Media heading</h4>
@@ -73,7 +73,7 @@
   <div class="bs-example">
     <div class="media">
       <a class="media-left" href="#">
-        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+        <img data-src="holder.js/40x40" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Top aligned media</h4>
@@ -82,7 +82,7 @@
     </div>
     <div class="media">
       <a class="media-left media-middle" href="#">
-        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+        <img data-src="holder.js/40x40" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Middle aligned media</h4>
@@ -91,7 +91,7 @@
     </div>
     <div class="media">
       <a class="media-left media-bottom" href="#">
-        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+        <img data-src="holder.js/40x40" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Bottom aligned media</h4>
@@ -102,7 +102,7 @@
 {% highlight html %}
 <div class="media">
   <a class="media-left media-middle" href="#">
-    <img class="media-object" data-src="..." alt="...">
+    <img data-src="..." alt="...">
   </a>
   <div class="media-body">
     <h4 class="media-heading">Middle aligned media</h4>
@@ -117,7 +117,7 @@
     <ul class="media-list">
       <li class="media">
         <a class="media-left" href="#">
-          <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
         </a>
         <div class="media-body">
           <h4 class="media-heading">Media heading</h4>
@@ -125,7 +125,7 @@
           <!-- Nested media object -->
           <div class="media">
             <a class="media-left" href="#">
-              <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+              <img data-src="holder.js/64x64" alt="Generic placeholder image">
             </a>
             <div class="media-body">
               <h4 class="media-heading">Nested media heading</h4>
@@ -133,7 +133,7 @@
               <!-- Nested media object -->
               <div class="media">
                 <a class="media-left" href="#">
-                  <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+                  <img data-src="holder.js/64x64" alt="Generic placeholder image">
                 </a>
                 <div class="media-body">
                   <h4 class="media-heading">Nested media heading</h4>
@@ -145,7 +145,7 @@
           <!-- Nested media object -->
           <div class="media">
             <a class="media-left" href="#">
-              <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+              <img data-src="holder.js/64x64" alt="Generic placeholder image">
             </a>
             <div class="media-body">
               <h4 class="media-heading">Nested media heading</h4>
@@ -160,7 +160,7 @@
 <ul class="media-list">
   <li class="media">
     <a class="media-left" href="#">
-      <img class="media-object" src="..." alt="...">
+      <img src="..." alt="...">
     </a>
     <div class="media-body">
       <h4 class="media-heading">Media heading</h4>

--- a/docs/_includes/components/media.html
+++ b/docs/_includes/components/media.html
@@ -4,10 +4,10 @@
   <p class="lead">Abstract object styles for building various types of components (like blog comments, Tweets, etc) that feature a left- or right-aligned image alongside textual content.</p>
 
   <h3 id="media-default">Default media</h3>
-  <p>The default media allow to float a media object (images, video, audio) to the left or right of a content block.</p>
+  <p>The default media displays a media object (images, video, audio) to the left or right of a content block.</p>
   <div class="bs-example">
     <div class="media">
-      <a class="pull-left" href="#">
+      <a class="media-left" href="#">
         <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
@@ -16,14 +16,14 @@
       </div>
     </div>
     <div class="media">
-      <a class="pull-left" href="#">
+      <a class="media-left" href="#">
         <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
         <div class="media">
-          <a class="pull-left" href="#">
+          <a class="media-left" href="#">
             <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
           </a>
           <div class="media-body">
@@ -33,14 +33,79 @@
         </div>
       </div>
     </div>
+    <div class="media">
+      <div class="media-body">
+        <h4 class="media-heading">Media heading</h4>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+      </div>
+      <a class="media-right" href="#">
+        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+      </a>
+    </div>
+    <div class="media">
+      <a class="pull-right" href="#">
+        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+      </a>
+      <a class="pull-left" href="#">
+        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+      </a>
+      <div class="media-body">
+        <h4 class="media-heading">Deprecated pull-right pull-left example</h4>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+      </div>
+    </div>
   </div><!-- /.bs-example -->
 {% highlight html %}
 <div class="media">
-  <a class="pull-left" href="#">
+  <a class="media-left" href="#">
     <img class="media-object" src="..." alt="...">
   </a>
   <div class="media-body">
     <h4 class="media-heading">Media heading</h4>
+    ...
+  </div>
+</div>
+{% endhighlight %}
+
+  <p>The classes <code>.pull-left</code> and <code>.pull-right</code> also exist and were previously used as part of the media component, but are deprecated for that use as of v3.3.0. They are approximately equivalent to <code>.media-left</code> and <code>.media-right</code>, except that <code>.media-right</code> should be placed after the <code>.media-body</code> in the html.</p>
+  <h3 id="media-alignment">Media alignment</h3>
+  <p>The images or other media can be aligned top, middle, or bottom. The default is top aligned.</p>
+  <div class="bs-example">
+    <div class="media">
+      <a class="media-left" href="#">
+        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+      </a>
+      <div class="media-body">
+        <h4 class="media-heading">Top aligned media</h4>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+      </div>
+    </div>
+    <div class="media">
+      <a class="media-left media-middle" href="#">
+        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+      </a>
+      <div class="media-body">
+        <h4 class="media-heading">Middle aligned media</h4>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+      </div>
+    </div>
+    <div class="media">
+      <a class="media-left media-bottom" href="#">
+        <img class="media-object" data-src="holder.js/40x40" alt="Generic placeholder image">
+      </a>
+      <div class="media-body">
+        <h4 class="media-heading">Bottom aligned media</h4>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+      </div>
+    </div>
+  </div>
+{% highlight html %}
+<div class="media">
+  <a class="media-left media-middle" href="#">
+    <img class="media-object" data-src="..." alt="...">
+  </a>
+  <div class="media-body">
+    <h4 class="media-heading">Middle aligned media</h4>
     ...
   </div>
 </div>
@@ -51,7 +116,7 @@
   <div class="bs-example">
     <ul class="media-list">
       <li class="media">
-        <a class="pull-left" href="#">
+        <a class="media-left" href="#">
           <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
         </a>
         <div class="media-body">
@@ -59,7 +124,7 @@
           <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.</p>
           <!-- Nested media object -->
           <div class="media">
-            <a class="pull-left" href="#">
+            <a class="media-left" href="#">
               <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
             </a>
             <div class="media-body">
@@ -67,7 +132,7 @@
               Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
               <!-- Nested media object -->
               <div class="media">
-                <a class="pull-left" href="#">
+                <a class="media-left" href="#">
                   <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
                 </a>
                 <div class="media-body">
@@ -79,7 +144,7 @@
           </div>
           <!-- Nested media object -->
           <div class="media">
-            <a class="pull-left" href="#">
+            <a class="media-left" href="#">
               <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
             </a>
             <div class="media-body">
@@ -89,21 +154,12 @@
           </div>
         </div>
       </li>
-      <li class="media">
-        <a class="pull-right" href="#">
-          <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-        </a>
-        <div class="media-body">
-          <h4 class="media-heading">Media heading</h4>
-          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
-        </div>
-      </li>
     </ul>
   </div>
 {% highlight html %}
 <ul class="media-list">
   <li class="media">
-    <a class="pull-left" href="#">
+    <a class="media-left" href="#">
       <img class="media-object" src="..." alt="...">
     </a>
     <div class="media-body">

--- a/docs/dist/css/bootstrap.css
+++ b/docs/dist/css/bootstrap.css
@@ -4886,29 +4886,34 @@ a.thumbnail.active {
   background-image:      -o-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
   background-image:         linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
-.media,
-.media-body {
-  overflow: hidden;
-  zoom: 1;
-}
-.media,
-.media .media {
+.media {
   margin-top: 15px;
+}
+.media .media-right,
+.media .pull-right {
+  padding-left: 10px;
+}
+.media .media-left,
+.media .pull-left {
+  padding-right: 10px;
 }
 .media:first-child {
   margin-top: 0;
 }
-.media-object {
-  display: block;
+.media .media-left,
+.media .media-right,
+.media .media-body {
+  display: table-cell;
+  vertical-align: top;
+}
+.media .media-middle {
+  vertical-align: middle;
+}
+.media .media-bottom {
+  vertical-align: bottom;
 }
 .media-heading {
-  margin: 0 0 5px;
-}
-.media > .pull-left {
-  margin-right: 10px;
-}
-.media > .pull-right {
-  margin-left: 10px;
+  margin: 0 0 5px 0;
 }
 .media-list {
   padding-left: 0;

--- a/less/media.less
+++ b/less/media.less
@@ -1,50 +1,43 @@
-// Media objects
-// Source: http://stubbornella.org/content/?p=497
-// --------------------------------------------------
-
-
-// Common styles
-// -------------------------
-
-// Clear the floats
-.media,
-.media-body {
-  overflow: hidden;
-  zoom: 1;
-}
-
-// Proper spacing between instances of .media
-.media,
-.media .media {
+.media {
+  // Proper spacing between instances of .media
   margin-top: 15px;
-}
-.media:first-child {
-  margin-top: 0;
-}
 
-// For images and videos, set to block
-.media-object {
-  display: block;
+  // Proper spacing of .media-right
+  .media-right,
+  .pull-right {
+    padding-left: 10px;
+  }
+
+  // Proper spacing of .media-left
+  .media-left,
+  .pull-left {
+    padding-right: 10px;
+  }
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  .media-left,
+  .media-right,
+  .media-body {
+    display: table-cell;
+    vertical-align: top;
+  }
+
+  .media-middle {
+    vertical-align: middle;
+  }
+
+  .media-bottom {
+    vertical-align: bottom;
+  }
 }
 
 // Reset margins on headings for tighter default spacing
 .media-heading {
-  margin: 0 0 5px;
+  margin: 0 0 5px 0;
 }
-
-
-// Media image alignment
-// -------------------------
-
-.media {
-  > .pull-left {
-    margin-right: 10px;
-  }
-  > .pull-right {
-    margin-left: 10px;
-  }
-}
-
 
 // Media list variation
 // -------------------------


### PR DESCRIPTION
The `.media-left` and `.media-right` images can now be aligned vertically via the `.media-middle` and `.media-bottom` classes. Top is the default so we did not make an explicit `.media-top` class. 

The `.pull-right/left` version still works and we left one example in the docs for testing purposes. Do you usually do that? We weren't sure how to make sure the deprecated version is still tested without keeping it in the docs.

Any thoughts? We'd love feedback.

@stubbornella, @jenndodd, & @bebepeng

Fixes #14799.
