### PR TITLE
Removed double parentheses from *.less files

### DIFF
--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -45,12 +45,12 @@
 
 .calc-grid-column(@index, @class, @type) when (@type = width) and (@index > 0) {
   .col-@{class}-@{index} {
-    width: percentage((@index / @grid-columns));
+    width: percentage(@index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = push) and (@index > 0) {
   .col-@{class}-push-@{index} {
-    left: percentage((@index / @grid-columns));
+    left: percentage(@index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = push) and (@index = 0) {
@@ -60,7 +60,7 @@
 }
 .calc-grid-column(@index, @class, @type) when (@type = pull) and (@index > 0) {
   .col-@{class}-pull-@{index} {
-    right: percentage((@index / @grid-columns));
+    right: percentage(@index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = pull) and (@index = 0) {
@@ -70,7 +70,7 @@
 }
 .calc-grid-column(@index, @class, @type) when (@type = offset) {
   .col-@{class}-offset-@{index} {
-    margin-left: percentage((@index / @grid-columns));
+    margin-left: percentage(@index / @grid-columns);
   }
 }
 

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -22,19 +22,19 @@
 .make-xs-column(@columns; @gutter: @grid-gutter-width) {
   position: relative;
   float: left;
-  width: percentage((@columns / @grid-columns));
+  width: percentage(@columns / @grid-columns);
   min-height: 1px;
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 }
 .make-xs-column-offset(@columns) {
-  margin-left: percentage((@columns / @grid-columns));
+  margin-left: percentage(@columns / @grid-columns);
 }
 .make-xs-column-push(@columns) {
-  left: percentage((@columns / @grid-columns));
+  left: percentage(@columns / @grid-columns);
 }
 .make-xs-column-pull(@columns) {
-  right: percentage((@columns / @grid-columns));
+  right: percentage(@columns / @grid-columns);
 }
 
 // Generate the small columns
@@ -46,22 +46,22 @@
 
   @media (min-width: @screen-sm-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage(@columns / @grid-columns);
   }
 }
 .make-sm-column-offset(@columns) {
   @media (min-width: @screen-sm-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage(@columns / @grid-columns);
   }
 }
 .make-sm-column-push(@columns) {
   @media (min-width: @screen-sm-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage(@columns / @grid-columns);
   }
 }
 .make-sm-column-pull(@columns) {
   @media (min-width: @screen-sm-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage(@columns / @grid-columns);
   }
 }
 
@@ -74,22 +74,22 @@
 
   @media (min-width: @screen-md-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage(@columns / @grid-columns);
   }
 }
 .make-md-column-offset(@columns) {
   @media (min-width: @screen-md-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage(@columns / @grid-columns);
   }
 }
 .make-md-column-push(@columns) {
   @media (min-width: @screen-md-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage(@columns / @grid-columns);
   }
 }
 .make-md-column-pull(@columns) {
   @media (min-width: @screen-md-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage(@columns / @grid-columns);
   }
 }
 
@@ -102,21 +102,21 @@
 
   @media (min-width: @screen-lg-min) {
     float: left;
-    width: percentage((@columns / @grid-columns));
+    width: percentage(@columns / @grid-columns);
   }
 }
 .make-lg-column-offset(@columns) {
   @media (min-width: @screen-lg-min) {
-    margin-left: percentage((@columns / @grid-columns));
+    margin-left: percentage(@columns / @grid-columns);
   }
 }
 .make-lg-column-push(@columns) {
   @media (min-width: @screen-lg-min) {
-    left: percentage((@columns / @grid-columns));
+    left: percentage(@columns / @grid-columns);
   }
 }
 .make-lg-column-pull(@columns) {
   @media (min-width: @screen-lg-min) {
-    right: percentage((@columns / @grid-columns));
+    right: percentage(@columns / @grid-columns);
   }
 }

--- a/less/panels.less
+++ b/less/panels.less
@@ -22,7 +22,7 @@
 .panel-heading {
   padding: @panel-heading-padding;
   border-bottom: 1px solid transparent;
-  .border-top-radius((@panel-border-radius - 1));
+  .border-top-radius(@panel-border-radius - 1);
 
   > .dropdown .dropdown-toggle {
     color: inherit;
@@ -33,7 +33,7 @@
 .panel-title {
   margin-top: 0;
   margin-bottom: 0;
-  font-size: ceil((@font-size-base * 1.125));
+  font-size: ceil(@font-size-base * 1.125);
   color: inherit;
 
   > a {
@@ -46,7 +46,7 @@
   padding: @panel-footer-padding;
   background-color: @panel-footer-bg;
   border-top: 1px solid @panel-inner-border;
-  .border-bottom-radius((@panel-border-radius - 1));
+  .border-bottom-radius(@panel-border-radius - 1);
 }
 
 
@@ -69,14 +69,14 @@
     &:first-child {
       .list-group-item:first-child {
         border-top: 0;
-        .border-top-radius((@panel-border-radius - 1));
+        .border-top-radius(@panel-border-radius - 1);
       }
     }
     // Add border bottom radius for last one
     &:last-child {
       .list-group-item:last-child {
         border-bottom: 0;
-        .border-bottom-radius((@panel-border-radius - 1));
+        .border-bottom-radius(@panel-border-radius - 1);
       }
     }
   }
@@ -110,7 +110,7 @@
   // Add border top radius for first one
   > .table:first-child,
   > .table-responsive:first-child > .table:first-child {
-    .border-top-radius((@panel-border-radius - 1));
+    .border-top-radius(@panel-border-radius - 1);
 
     > thead:first-child,
     > tbody:first-child {
@@ -132,7 +132,7 @@
   // Add border bottom radius for last one
   > .table:last-child,
   > .table-responsive:last-child > .table:last-child {
-    .border-bottom-radius((@panel-border-radius - 1));
+    .border-bottom-radius(@panel-border-radius - 1);
 
     > tbody:last-child,
     > tfoot:last-child {

--- a/less/type.less
+++ b/less/type.less
@@ -61,7 +61,7 @@ p {
 
 .lead {
   margin-bottom: @line-height-computed;
-  font-size: floor((@font-size-base * 1.15));
+  font-size: floor(@font-size-base * 1.15);
   font-weight: 300;
   line-height: 1.4;
 
@@ -77,7 +77,7 @@ p {
 // Ex: (12px small font / 14px base font) * 100% = about 85%
 small,
 .small {
-  font-size: floor((100% * @font-size-small / @font-size-base));
+  font-size: floor(100% * @font-size-small / @font-size-base);
 }
 
 mark,

--- a/less/variables.less
+++ b/less/variables.less
@@ -47,20 +47,20 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          14px;
-@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
-@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+@font-size-large:         ceil(@font-size-base * 1.25); // ~18px
+@font-size-small:         ceil(@font-size-base * 0.85); // ~12px
 
-@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
-@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
-@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
+@font-size-h1:            floor(@font-size-base * 2.6); // ~36px
+@font-size-h2:            floor(@font-size-base * 2.15); // ~30px
+@font-size-h3:            ceil(@font-size-base * 1.7); // ~24px
+@font-size-h4:            ceil(@font-size-base * 1.25); // ~18px
 @font-size-h5:            @font-size-base;
-@font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
+@font-size-h6:            ceil(@font-size-base * 0.85); // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
+@line-height-computed:    floor(@font-size-base * @line-height-base); // ~20px
 
 //** By default, this inherits from the `<body>`.
 @headings-font-family:    inherit;
@@ -322,17 +322,17 @@
 //## Define the maximum width of `.container` for different screen sizes.
 
 // Small screen / tablet
-@container-tablet:             ((720px + @grid-gutter-width));
+@container-tablet:             (720px + @grid-gutter-width);
 //** For `@screen-sm-min` and up.
 @container-sm:                 @container-tablet;
 
 // Medium screen / desktop
-@container-desktop:            ((940px + @grid-gutter-width));
+@container-desktop:            (940px + @grid-gutter-width);
 //** For `@screen-md-min` and up.
 @container-md:                 @container-desktop;
 
 // Large screen / wide desktop
-@container-large-desktop:      ((1140px + @grid-gutter-width));
+@container-large-desktop:      (1140px + @grid-gutter-width);
 //** For `@screen-lg-min` and up.
 @container-lg:                 @container-large-desktop;
 
@@ -345,7 +345,7 @@
 @navbar-height:                    50px;
 @navbar-margin-bottom:             @line-height-computed;
 @navbar-border-radius:             @border-radius-base;
-@navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
+@navbar-padding-horizontal:        floor(@grid-gutter-width / 2);
 @navbar-padding-vertical:          ((@navbar-height - @line-height-computed) / 2);
 @navbar-collapse-max-height:       340px;
 
@@ -473,7 +473,7 @@
 @jumbotron-color:                inherit;
 @jumbotron-bg:                   @gray-lighter;
 @jumbotron-heading-color:        inherit;
-@jumbotron-font-size:            ceil((@font-size-base * 1.5));
+@jumbotron-font-size:            ceil(@font-size-base * 1.5);
 
 
 //== Form states and alerts


### PR DESCRIPTION
I remember that Less introduced the strictMaths option in the 1.4.0 but it was never necessary to have a double parentheses, unless there is another thing that I'm missing and not aware of.
