### PR TITLE
Add min-height: 0% to .table-responsive; fixes #14837

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -170,6 +170,7 @@ table {
 
 .table-responsive {
   overflow-x: auto;
+  min-height: 0%; // Workaround for IE9 bug (see https://github.com/twbs/bootstrap/issues/14837)
 
   @media screen and (max-width: @screen-xs-max) {
     width: 100%;


### PR DESCRIPTION
Fixes #14837.
See also the 2nd paragraph of https://developer.mozilla.org/en-US/docs/Web/CSS/:hover#Browser_compatibility
CC: @mdo @hnrch02 
