### PR TITLE
Make the docs' nav sidebar scrollable

### DIFF
--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -638,6 +638,8 @@ body {
   .bs-docs-sidebar.affix {
     position: fixed; /* Undo the static from mobile first approach */
     top: 20px;
+    bottom: 0;
+    overflow-y: auto;
   }
   .bs-docs-sidebar.affix-bottom {
     position: absolute; /* Undo the static from mobile first approach */


### PR DESCRIPTION
Basically it's impossible to use the navigation if it's expanded. This will allow it to be scrollable so that the menus are accessable.
