### PR TITLE
fixing rendering mistake

### DIFF
--- a/docs/_includes/css/grid.html
+++ b/docs/_includes/css/grid.html
@@ -267,7 +267,7 @@
 {% highlight html %}
 <div class="row">
   <div class="col-xs-9">.col-xs-9</div>
-  <div class="col-xs-4">.col-xs-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
+  <div class="col-xs-4">.col-xs-4<br>Since 9 + 4 = 13 > 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
   <div class="col-xs-6">.col-xs-6<br>Subsequent columns continue along the new line.</div>
 </div>
 {% endhighlight %}


### PR DESCRIPTION
greater than symbol can't be html encoded on the highlight, it gets interpreted literally on the site.
