### PR TITLE
Panel section line.

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -18,6 +18,11 @@
   &:extend(.clearfix all);
 }
 
+// Optional panel separator: use between two consecutive panel bodies
+.panel > hr {
+  margin: 0;
+}
+
 // Optional heading
 .panel-heading {
   padding: @panel-heading-padding;


### PR DESCRIPTION
Use the hr tag between two consecutive panel bodies to obtain a seamless division line that spits the panel into more sections.
