### PR TITLE
Revert "Scrollspy: ignore invisible list items"

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -65,7 +65,6 @@
         return ($href
           && $href.length
           && $href.is(':visible')
-          && $el.is(':visible')
           && [[$href[offsetMethod]().top + offsetBase, href]]) || null
       })
       .sort(function (a, b) { return a[0] - b[0] })


### PR DESCRIPTION
Reverts #14569 in order to prevent the regression outlined in #14872. Fixes #14872.
