### PR TITLE
bs-commonjs-generator.js: always use forward slashes in the require path.

### DIFF
--- a/grunt/bs-commonjs-generator.js
+++ b/grunt/bs-commonjs-generator.js
@@ -8,7 +8,7 @@ module.exports = function generateCommonJSModule(grunt, srcFiles, destFilepath) 
   var destDir = path.dirname(destFilepath);
 
   function srcPathToDestRequire(srcFilepath) {
-    var requirePath = path.relative(destDir, srcFilepath);
+    var requirePath = path.relative(destDir, srcFilepath).replace(/\\/g, '/');
     return 'require(\'' + requirePath + '\')';
   }
 


### PR DESCRIPTION
Fixes #14875.
