### PR TITLE
consider using remarkable

### DIFF
--- a/docs/_includes/customizer-variables.html
+++ b/docs/_includes/customizer-variables.html
@@ -295,7 +295,7 @@
   </div>
 </div>
 <h2 id="buttons">Buttons</h2>
-<p>For each of Bootstrap&#39;s buttons, define text, background and border color.</p>
+<p>For each of Bootstrap's buttons, define text, background and border color.</p>
 <div class="row">
   <div class="bs-customizer-input">
     <label for="input-@btn-font-weight">@btn-font-weight</label>

--- a/grunt/bs-lessdoc-parser.js
+++ b/grunt/bs-lessdoc-parser.js
@@ -6,11 +6,13 @@
  */
 'use strict';
 
-var markdown = require('markdown').markdown;
+var Remarkable = require('remarkable');
 
 function markdown2html(markdownString) {
+  var md = new Remarkable();
+
   // the slice removes the <p>...</p> wrapper output by Markdown processor
-  return markdown.toHTML(markdownString.trim()).slice(3, -4);
+  return md.render(markdownString.trim()).slice(3, -5);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "grunt-saucelabs": "~8.3.2",
     "grunt-sed": "~0.1.1",
     "load-grunt-tasks": "~1.0.0",
-    "markdown": "~0.5.0",
     "npm-shrinkwrap": "~4.0.0",
+    "remarkable": "^1.2.0",
     "time-grunt": "~1.0.0"
   },
   "engines": {


### PR DESCRIPTION
(this PR is a suggestion/request. Typically I know you would expect a PR like this to be discussed in advance, but I decided to do the PR first to show how minimal the impact would be, hopefully that's okay).

Replaces [markdown.js](https://github.com/evilstreak/markdown-js) with [remarkable](https://github.com/jonschlinkert/remarkable).
- remarkable has 100% support for [commonmark](http://jgm.github.io/CommonMark/spec.html)
- [faster](https://github.com/jonschlinkert/remarkable/tree/master/benchmark)
- easier to monkeypatch. this is a goal of ours, might be useful to you at some point given the custom tokenizing/parsing you're doing for documentation.
