### PR TITLE
Add `transform: translate3d(0, 0, 0)` iOS Safari bug to the Wall

### DIFF
--- a/docs/browser-bugs.html
+++ b/docs/browser-bugs.html
@@ -113,6 +113,12 @@ lead: "A list of the browser bugs that Bootstrap is currently grappling with."
           <td>(No public bug tracker)</td>
           <td><a href="https://github.com/twbs/bootstrap/issues/9774">#9774</a></td>
         </tr>
+        <tr>
+          <td>Safari</td>
+          <td><code>transform: translate3d(0, 0, 0);</code> iOS bug</td>
+          <td><a href="https://bugs.webkit.org/show_bug.cgi?id=138162">WebKit bug #138162</a>, <a href="http://openradar.appspot.com/18804973">Apple Safari Radar #18804973</a></td>
+          <td><a href="https://github.com/twbs/bootstrap/pull/14603">#14603</a></td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
Closes #14603 (again).
