### PR TITLE
Update grid-framework.less

### DIFF
--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -5,7 +5,7 @@
 
 .make-grid-columns() {
   // Common styles for all sizes of grid columns, widths 1-12
-  .col(@index) when (@index = 1) { // initial
+  .col(@index) { // initial
     @item: ~".col-xs-@{index}, .col-sm-@{index}, .col-md-@{index}, .col-lg-@{index}";
     .col((@index + 1), @item);
   }
@@ -27,7 +27,7 @@
 }
 
 .float-grid-columns(@class) {
-  .col(@index) when (@index = 1) { // initial
+  .col(@index) { // initial
     @item: ~".col-@{class}-@{index}";
     .col((@index + 1), @item);
   }


### PR DESCRIPTION
The `when (@index = 1)` guards are not needed cause the mixins already only match on arity.
