### PR TITLE
Use RegExp for button plugin's focus shim

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -110,7 +110,7 @@
       e.preventDefault()
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-      $(e.target).closest('.btn').toggleClass('focus', e.type == 'focus')
+      $(e.target).closest('.btn').toggleClass('focus', /^focus(in)?$/.test(e.type))
     })
 
 }(jQuery);


### PR DESCRIPTION
Fixes #14923.
