### PR TITLE
Fix #14936: Use correct left/right and margin on tooltip arrows

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -49,13 +49,15 @@
   }
   &.top-left .tooltip-arrow {
     bottom: 0;
-    left: @tooltip-arrow-width;
+    right: @tooltip-arrow-width;
+    margin-bottom: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
     border-top-color: @tooltip-arrow-color;
   }
   &.top-right .tooltip-arrow {
     bottom: 0;
-    right: @tooltip-arrow-width;
+    left: @tooltip-arrow-width;
+    margin-bottom: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
     border-top-color: @tooltip-arrow-color;
   }
@@ -82,13 +84,15 @@
   }
   &.bottom-left .tooltip-arrow {
     top: 0;
-    left: @tooltip-arrow-width;
+    right: @tooltip-arrow-width;
+    margin-top: -@tooltip-arrow-width;
     border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
     border-bottom-color: @tooltip-arrow-color;
   }
   &.bottom-right .tooltip-arrow {
     top: 0;
-    right: @tooltip-arrow-width;
+    left: @tooltip-arrow-width;
+    margin-top: -@tooltip-arrow-width;
     border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
     border-bottom-color: @tooltip-arrow-color;
   }


### PR DESCRIPTION
Fixes #14936 by implementing the third option from https://github.com/twbs/bootstrap/issues/14936#issuecomment-61109275.
