### PR TITLE
Docs fixes

### DIFF
--- a/docs/_includes/getting-started/template.html
+++ b/docs/_includes/getting-started/template.html
@@ -27,7 +27,7 @@
     <h1>Hello, world!</h1>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="js/bootstrap.min.js"></script>
   </body>

--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -262,7 +262,7 @@
          <td>path</td>
          <td>false</td>
          <td>
-          <p><span class="text-danger">This option is deprecated since v3.2.1 and will be removed in v4.</span> We recommend instead using client-side templating or a data binding framework, or calling <a href="http://api.jquery.com/load/">jQuery.load</a> yourself.</p>
+          <p><strong class="text-danger">This option is deprecated since v3.3.0 and will be removed in v4.</strong> We recommend instead using client-side templating or a data binding framework, or calling <a href="http://api.jquery.com/load/">jQuery.load</a> yourself.</p>
           <p>If a remote URL is provided, <strong>content will be loaded one time</strong> via jQuery's <code>load</code> method and injected into the <code>.modal-content</code> div. If you're using the data-api, you may alternatively use the <code>href</code> attribute to specify the remote source. An example of this is shown below:</p>
 {% highlight html %}
 <a data-toggle="modal" href="remote.html" data-target="#modal">Click me</a>


### PR DESCRIPTION
- Fix the template in Getting Started to feature the latest version of jQuery, as per #14852
- Fix the modal documentation to mention the correct deprecation version (3.3.0 instead of the nonexistent 3.2.1).
