### PR TITLE
Replace deprecated uses of .pull-left & .pull-right in .media docs

### DIFF
--- a/docs/_includes/components/media.html
+++ b/docs/_includes/components/media.html
@@ -43,16 +43,16 @@
       </a>
     </div>
     <div class="media">
-      <a class="pull-right" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
-      <a class="pull-left" href="#">
+      <a class="media-left" href="#">
         <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
-        <h4 class="media-heading">Deprecated pull-right pull-left example</h4>
+        <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
       </div>
+      <a class="media-right" href="#">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
+      </a>
     </div>
   </div><!-- /.bs-example -->
 {% highlight html %}


### PR DESCRIPTION
We don't generally give examples of deprecated things.
Refs https://github.com/twbs/bootstrap/blob/1339ab7a130600330b1db4e3acae9760710a0a41/docs/_includes/components/media.html#L70
Refs https://github.com/twbs/bootlint/pull/153
CC: @mdo
