### PR TITLE
Update the Firefox ESR version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
           'Android 2.3',
           'Android >= 4',
           'Chrome >= 20',
-          'Firefox >= 24', // Firefox 24 is the latest ESR
+          'Firefox >= 31', // Firefox 31 is the latest ESR
           'Explorer >= 8',
           'iOS >= 6',
           'Opera >= 12',


### PR DESCRIPTION
Firefox ESR 24 reached its EOL on October 14th, 2014.

/cc @cvrebert 
