### PR TITLE
Deprecate diagonal tooltip classes

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -39,6 +39,7 @@
   border-color: transparent;
   border-style: solid;
 }
+// Note: Deprecated .top-left, .top-right, .bottom-left, and .bottom-right as of v3.3.1
 .tooltip {
   &.top .tooltip-arrow {
     bottom: 0;


### PR DESCRIPTION
As discussed in #14938, the classes `.top-left`, `.top-right`, `.bottom-left`, and `.bottom-right` were added as the first step for automatic diagonal placement of tooltips, but the corresponding JavaScript was never added.

X-Ref: #7961 and https://github.com/twbs/bootstrap/commit/88ece4fc5902f7dd9582fb4e5956062fe97af84c

Assuming that we don't want to add the JS for these specific classes more than a year later, they should therefore be deprecated.

/cc @cvrebert @hnrch02 
/fyi @mdo @fat
