### PR TITLE
Use a Jekyll plugin instead of the `copy:configBridge` grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 _gh_pages
 _site
 .ruby-version
-docs/_data/configBridge.json
 
 # Numerous always-ignore extensions
 *.diff

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,10 +283,6 @@ module.exports = function (grunt) {
       docs: {
         src: 'dist/*/*',
         dest: 'docs/'
-      },
-      configBridge: {
-        src: 'grunt/configBridge.json',
-        dest: 'docs/_data/configBridge.json'
       }
     },
 
@@ -457,7 +453,7 @@ module.exports = function (grunt) {
   grunt.registerTask('lint-docs-css', ['csslint:docs', 'csslint:examples']);
   grunt.registerTask('docs-js', ['uglify:docsJs', 'uglify:customize']);
   grunt.registerTask('lint-docs-js', ['jshint:assets', 'jscs:assets']);
-  grunt.registerTask('docs', ['docs-css', 'lint-docs-css', 'docs-js', 'lint-docs-js', 'clean:docs', 'copy:docs', 'copy:configBridge', 'build-customizer']);
+  grunt.registerTask('docs', ['docs-css', 'lint-docs-css', 'docs-js', 'lint-docs-js', 'clean:docs', 'copy:docs', 'build-customizer']);
 
   // Task for updating the cached npm packages used by the Travis build (which are controlled by test-infra/npm-shrinkwrap.json).
   // This task should be run and the updated file should be committed whenever Bootstrap's dependencies change.

--- a/docs/_plugins/bridge.rb
+++ b/docs/_plugins/bridge.rb
@@ -1,0 +1,9 @@
+require 'yaml'
+
+module Bridge
+  class Generator < Jekyll::Generator
+    def generate(site)
+      site.data["configBridge"] = YAML.load_file("./grunt/configBridge.json")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #15029.

@XhmikosR Can you try this on Windows?

/cc @cvrebert 
