### PR TITLE
.transition() mixin should allow multiple arguments

### DIFF
--- a/less/mixins/vendor-prefixes.less
+++ b/less/mixins/vendor-prefixes.less
@@ -187,10 +187,11 @@
 
 // Transitions
 
-.transition(@transition) {
-  -webkit-transition: @transition;
-       -o-transition: @transition;
-          transition: @transition;
+.transition (@value1,@value2:X,...) {
+  @value: ~`"@{arguments}".replace(/[\[\]]|\,\sX/g, '')`;
+  -webkit-transition: @value;
+       -o-transition: @value;
+          transition: @value;
 }
 .transition-property(@transition-property) {
   -webkit-transition-property: @transition-property;


### PR DESCRIPTION
This allows the `.transition(@transition)` LESS mixin to allow multiple arguments, meaning multiple transitons on a single element, which is not uncommon.

For example, this will let a developer animate the box-shadow as well as the background-color of a button, on hover. I've been using this method ever since I've been LESSing.
