### PR TITLE
HTML validation: No longer relax the `X-UA-Compatible` error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -321,7 +321,6 @@ module.exports = function (grunt) {
         failHard: true,
         reset: true,
         relaxerror: [
-          'Bad value X-UA-Compatible for attribute http-equiv on element meta.',
           'Element img is missing required attribute src.',
           'Attribute autocomplete not allowed on element input at this point.',
           'Attribute autocomplete not allowed on element button at this point.'


### PR DESCRIPTION
The validator no longer complains about it unless the value is different from `content=IE=edge`, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=27091

/cc @cvrebert @XhmikosR 
