### PR TITLE
Don't remove focus outline from buttons in button groups

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -18,10 +18,6 @@
     &.active {
       z-index: 2;
     }
-    &:focus {
-      // Remove focus outline when dropdown JS adds it after closing the menu
-      outline: 0;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #14939.

We were doing this to avoid some _undesirable_ aesthetics when using the dropdown plugin, but that's much less of a concern when you consider no one can currently tab through button groups.

/cc @hnrch02 @patrickhlauke 
