### PR TITLE
Fixed a typo in Sign-in page example

### DIFF
--- a/docs/examples/signin/index.html
+++ b/docs/examples/signin/index.html
@@ -35,7 +35,7 @@
         <h2 class="form-signin-heading">Please sign in</h2>
         <label for="inputEmail" class="sr-only">Email address</label>
         <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
-        <label for="inputPassword" class="sr-only">Email address</label>
+        <label for="inputPassword" class="sr-only">Password</label>
         <input type="password" id="inputPassword" class="form-control" placeholder="Password" required>
         <div class="checkbox">
           <label>


### PR DESCRIPTION
Fixed a typo in Sign-in page example
http://getbootstrap.com/examples/signin/
