### PR TITLE
Docs button section restructure

### DIFF
--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -154,11 +154,6 @@
     <h4>Link functionality caveat</h4>
     <p>This class uses <code>pointer-events: none</code> to try to disable the link functionality of <code>&lt;a&gt;</code>s, but that CSS property is not yet standardized and isn't fully supported in Opera 18 and below, or in Internet Explorer 11. In addition, even in browsers that do support <code>pointer-events: none</code>, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links. So to be safe, use custom JavaScript to disable such links.</p>
   </div>
-  <div class="bs-callout bs-callout-warning" id="callout-buttons-context-usage">
-    <h4>Context-specific usage</h4>
-    <p>While button classes can be used on <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> elements, only <code>&lt;button&gt;</code> elements are supported within our nav and navbar components.</p>
-  </div>
-
 
   <h2 id="buttons-tags">Button tags</h2>
   <p>Use the button classes on an <code>&lt;a&gt;</code>, <code>&lt;button&gt;</code>, or <code>&lt;input&gt;</code> element.</p>
@@ -174,6 +169,11 @@
 <input class="btn btn-default" type="button" value="Input">
 <input class="btn btn-default" type="submit" value="Submit">
 {% endhighlight %}
+
+  <div class="bs-callout bs-callout-warning" id="callout-buttons-context-usage">
+    <h4>Context-specific usage</h4>
+    <p>While button classes can be used on <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> elements, only <code>&lt;button&gt;</code> elements are supported within our nav and navbar components.</p>
+  </div>
 
   <div class="bs-callout bs-callout-warning" id="callout-buttons-anchor-accessibility">
     <h4>Links acting as buttons</h4>

--- a/docs/_includes/css/buttons.html
+++ b/docs/_includes/css/buttons.html
@@ -1,6 +1,37 @@
 <div class="bs-docs-section">
   <h1 id="buttons" class="page-header">Buttons</h1>
 
+  <h2 id="buttons-tags">Button tags</h2>
+  <p>Use the button classes on an <code>&lt;a&gt;</code>, <code>&lt;button&gt;</code>, or <code>&lt;input&gt;</code> element.</p>
+  <form class="bs-example">
+    <a class="btn btn-default" href="#" role="button">Link</a>
+    <button class="btn btn-default" type="submit">Button</button>
+    <input class="btn btn-default" type="button" value="Input">
+    <input class="btn btn-default" type="submit" value="Submit">
+  </form>
+{% highlight html %}
+<a class="btn btn-default" href="#" role="button">Link</a>
+<button class="btn btn-default" type="submit">Button</button>
+<input class="btn btn-default" type="button" value="Input">
+<input class="btn btn-default" type="submit" value="Submit">
+{% endhighlight %}
+
+  <div class="bs-callout bs-callout-warning" id="callout-buttons-context-usage">
+    <h4>Context-specific usage</h4>
+    <p>While button classes can be used on <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> elements, only <code>&lt;button&gt;</code> elements are supported within our nav and navbar components.</p>
+  </div>
+
+  <div class="bs-callout bs-callout-warning" id="callout-buttons-anchor-accessibility">
+    <h4>Links acting as buttons</h4>
+    <p>If the <code>&lt;a&gt;</code> elements are used to act as buttons – triggering in-page functionality, rather than navigating to another document or section within the current page – they should also be given an appropriate <code>role="button"</code>.</p>
+  </div>
+
+  <div class="bs-callout bs-callout-warning" id="callout-buttons-ff-height">
+    <h4>Cross-browser rendering</h4>
+    <p>As a best practice, <strong>we highly recommend using the <code>&lt;button&gt;</code> element whenever possible</strong> to ensure matching cross-browser rendering.</p>
+    <p>Among other things, there's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451">a bug in Firefox &lt;30</a> that prevents us from setting the <code>line-height</code> of <code>&lt;input&gt;</code>-based buttons, causing them to not exactly match the height of other buttons on Firefox.</p>
+  </div>
+
   <h2 id="buttons-options">Options</h2>
   <p>Use any of the available button classes to quickly create a styled button.</p>
   <div class="bs-example">
@@ -155,34 +186,4 @@
     <p>This class uses <code>pointer-events: none</code> to try to disable the link functionality of <code>&lt;a&gt;</code>s, but that CSS property is not yet standardized and isn't fully supported in Opera 18 and below, or in Internet Explorer 11. In addition, even in browsers that do support <code>pointer-events: none</code>, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links. So to be safe, use custom JavaScript to disable such links.</p>
   </div>
 
-  <h2 id="buttons-tags">Button tags</h2>
-  <p>Use the button classes on an <code>&lt;a&gt;</code>, <code>&lt;button&gt;</code>, or <code>&lt;input&gt;</code> element.</p>
-  <form class="bs-example">
-    <a class="btn btn-default" href="#" role="button">Link</a>
-    <button class="btn btn-default" type="submit">Button</button>
-    <input class="btn btn-default" type="button" value="Input">
-    <input class="btn btn-default" type="submit" value="Submit">
-  </form>
-{% highlight html %}
-<a class="btn btn-default" href="#" role="button">Link</a>
-<button class="btn btn-default" type="submit">Button</button>
-<input class="btn btn-default" type="button" value="Input">
-<input class="btn btn-default" type="submit" value="Submit">
-{% endhighlight %}
-
-  <div class="bs-callout bs-callout-warning" id="callout-buttons-context-usage">
-    <h4>Context-specific usage</h4>
-    <p>While button classes can be used on <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> elements, only <code>&lt;button&gt;</code> elements are supported within our nav and navbar components.</p>
-  </div>
-
-  <div class="bs-callout bs-callout-warning" id="callout-buttons-anchor-accessibility">
-    <h4>Links acting as buttons</h4>
-    <p>If the <code>&lt;a&gt;</code> elements are used to act as buttons – triggering in-page functionality, rather than navigating to another document or section within the current page – they should also be given an appropriate <code>role="button"</code>.</p>
-  </div>
-
-  <div class="bs-callout bs-callout-warning" id="callout-buttons-ff-height">
-    <h4>Cross-browser rendering</h4>
-    <p>As a best practice, <strong>we highly recommend using the <code>&lt;button&gt;</code> element whenever possible</strong> to ensure matching cross-browser rendering.</p>
-    <p>Among other things, there's <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451">a bug in Firefox &lt;30</a> that prevents us from setting the <code>line-height</code> of <code>&lt;input&gt;</code>-based buttons, causing them to not exactly match the height of other buttons on Firefox.</p>
-  </div>
 </div>

--- a/docs/_includes/nav/css.html
+++ b/docs/_includes/nav/css.html
@@ -81,11 +81,11 @@
 <li>
   <a href="#buttons">Buttons</a>
   <ul class="nav">
+    <li><a href="#buttons-tags">Button tags</a></li>
     <li><a href="#buttons-options">Options</a></li>
     <li><a href="#buttons-sizes">Sizes</a></li>
     <li><a href="#buttons-active">Active state</a></li>
     <li><a href="#buttons-disabled">Disabled state</a></li>
-    <li><a href="#buttons-tags">Button tags</a></li>
   </ul>
 </li>
 <li>


### PR DESCRIPTION
as per https://github.com/twbs/bootstrap/issues/15130 - moved callout about context-specific usage into the "Button tags" section, and then moved this section to the start of "Button" section itself, where it seems to make most sense (and of course tidied up the right-hand navigation accordingly)
