### PR TITLE
Fix border issue on nav tabs when justified

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -85,6 +85,8 @@
       margin-right: 2px;
       line-height: @line-height-base;
       border: 1px solid transparent;
+      border-left: none;
+      border-right: none;
       border-radius: @border-radius-base @border-radius-base 0 0;
       &:hover {
         border-color: @nav-tabs-link-hover-border-color @nav-tabs-link-hover-border-color @nav-tabs-border-color;


### PR DESCRIPTION
When the nav is justified, there is a small interruption on the border-bottom, due to the border of the link.

Now, the border-left and border-right are disabled and the border-bottom is continuous.
