### PR TITLE
Fixes affix-top class not applying

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -53,7 +53,7 @@
     var colliderTop    = initializing ? scrollTop : position.top
     var colliderHeight = initializing ? targetHeight : height
 
-    if (offsetTop != null && colliderTop <= offsetTop) return 'top'
+    if (offsetTop != null && scrollTop <= offsetTop) return 'top'
     if (offsetBottom != null && (colliderTop + colliderHeight >= scrollHeight - offsetBottom)) return 'bottom'
 
     return false

--- a/js/tests/unit/affix.js
+++ b/js/tests/unit/affix.js
@@ -68,4 +68,34 @@ $(function () {
       }, 16) // for testing in a browser
     }, 0)
   })
+
+  test('should affix-top when scrolling up to offset when parent has padding', function () {
+    stop()
+
+    var templateHTML = '<div id="padding-offset" style="padding-top: 20px;">'
+        + '<div id="affixTopTarget">'
+        + '<p>Testing affix-top class is added</p>'
+        + '</div>'
+        + '<div style="height: 1000px; display: block;"/>'
+        + '</div>'
+    $(templateHTML).appendTo(document.body)
+
+    $('#affixTopTarget').bootstrapAffix({
+      offset: { top: 120, bottom: 0 }
+    })
+
+    $('#affixTopTarget')
+      .on('affixed-top.bs.affix', function () {
+        ok($('#affixTopTarget').hasClass('affix-top'), 'affix-top class applied')
+        start()
+      })
+
+    setTimeout(function () {
+      window.scrollTo(0, document.body.scrollHeight)
+
+      setTimeout(function () {
+        window.scroll(0, 119)
+      }, 0)
+    }, 0)
+  })
 })


### PR DESCRIPTION
Use scrollTop instead of colliderTop which uses the elements
offset().top, as the offset top does not account for padding.

This issue can be replicated by using a navbar-fixed-top and applying
relevant padding to the body. (A navbar-static-top with no padding on
the body does not encounter this issue)

Fixes #15078
