### PR TITLE
Fix #15194: Shrink media link area

### DIFF
--- a/docs/_includes/components/media.html
+++ b/docs/_includes/components/media.html
@@ -7,25 +7,31 @@
   <p>The default media displays a media object (images, video, audio) to the left or right of a content block.</p>
   <div class="bs-example">
     <div class="media">
-      <a class="media-left" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
       </div>
     </div>
     <div class="media">
-      <a class="media-left" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
         <div class="media">
-          <a class="media-left" href="#">
-            <img data-src="holder.js/64x64" alt="Generic placeholder image">
-          </a>
+          <div class="media-left">
+            <a href="#">
+              <img data-src="holder.js/64x64" alt="Generic placeholder image">
+            </a>
+          </div>
           <div class="media-body">
             <h4 class="media-heading">Nested media heading</h4>
             Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
@@ -38,28 +44,36 @@
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
       </div>
-      <a class="media-right" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-right">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
     </div>
     <div class="media">
-      <a class="media-left" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Media heading</h4>
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
       </div>
-      <a class="media-right" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-right">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
     </div>
   </div><!-- /.bs-example -->
 {% highlight html %}
 <div class="media">
-  <a class="media-left" href="#">
-    <img src="..." alt="...">
-  </a>
+  <div class="media-left">
+    <a href="#">
+      <img src="..." alt="...">
+    </a>
+  </div>
   <div class="media-body">
     <h4 class="media-heading">Media heading</h4>
     ...
@@ -72,9 +86,11 @@
   <p>The images or other media can be aligned top, middle, or bottom. The default is top aligned.</p>
   <div class="bs-example">
     <div class="media">
-      <a class="media-left" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Top aligned media</h4>
         <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
@@ -82,9 +98,11 @@
       </div>
     </div>
     <div class="media">
-      <a class="media-left media-middle" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left media-middle">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Middle aligned media</h4>
         <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
@@ -92,9 +110,11 @@
       </div>
     </div>
     <div class="media">
-      <a class="media-left media-bottom" href="#">
-        <img data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+      <div class="media-left media-bottom">
+        <a href="#">
+          <img data-src="holder.js/64x64" alt="Generic placeholder image">
+        </a>
+      </div>
       <div class="media-body">
         <h4 class="media-heading">Bottom aligned media</h4>
         <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
@@ -104,9 +124,11 @@
   </div>
 {% highlight html %}
 <div class="media">
-  <a class="media-left media-middle" href="#">
-    <img data-src="..." alt="...">
-  </a>
+  <div class="media-left media-middle">
+    <a href="#">
+      <img src="..." alt="...">
+    </a>
+  </div>
   <div class="media-body">
     <h4 class="media-heading">Middle aligned media</h4>
     ...
@@ -119,25 +141,31 @@
   <div class="bs-example">
     <ul class="media-list">
       <li class="media">
-        <a class="media-left" href="#">
-          <img data-src="holder.js/64x64" alt="Generic placeholder image">
-        </a>
+        <div class="media-left">
+          <a href="#">
+            <img data-src="holder.js/64x64" alt="Generic placeholder image">
+          </a>
+        </div>
         <div class="media-body">
           <h4 class="media-heading">Media heading</h4>
           <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.</p>
           <!-- Nested media object -->
           <div class="media">
-            <a class="media-left" href="#">
-              <img data-src="holder.js/64x64" alt="Generic placeholder image">
-            </a>
+            <div class="media-left">
+              <a href="#">
+                <img data-src="holder.js/64x64" alt="Generic placeholder image">
+              </a>
+            </div>
             <div class="media-body">
               <h4 class="media-heading">Nested media heading</h4>
               Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
               <!-- Nested media object -->
               <div class="media">
-                <a class="media-left" href="#">
-                  <img data-src="holder.js/64x64" alt="Generic placeholder image">
-                </a>
+                <div class="media-left">
+                  <a href="#">
+                    <img data-src="holder.js/64x64" alt="Generic placeholder image">
+                  </a>
+                </div>
                 <div class="media-body">
                   <h4 class="media-heading">Nested media heading</h4>
                   Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
@@ -147,9 +175,11 @@
           </div>
           <!-- Nested media object -->
           <div class="media">
-            <a class="media-left" href="#">
-              <img data-src="holder.js/64x64" alt="Generic placeholder image">
-            </a>
+            <div class="media-left">
+              <a href="#">
+                <img data-src="holder.js/64x64" alt="Generic placeholder image">
+              </a>
+            </div>
             <div class="media-body">
               <h4 class="media-heading">Nested media heading</h4>
               Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
@@ -162,9 +192,11 @@
 {% highlight html %}
 <ul class="media-list">
   <li class="media">
-    <a class="media-left" href="#">
-      <img src="..." alt="...">
-    </a>
+    <div class="media-left">
+      <a href="#">
+        <img src="..." alt="...">
+      </a>
+    </div>
     <div class="media-body">
       <h4 class="media-heading">Media heading</h4>
       ...


### PR DESCRIPTION
The corresponding CSS isn't element-specific, so this fixes #15194 without breaking backward compatibility.

/cc @interactivellama and @mdo
