### PR TITLE
Remove #12548's entry from the Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -112,16 +112,6 @@
   browser: >
     Chrome
   summary: >
-    `display: table-cell; width: 100%;` doesn't work correctly on `<input type="date">`.
-  upstream_bug: >
-    Chromium#346051
-  origin: >
-    Bootstrap#12548
-
--
-  browser: >
-    Chrome
-  summary: >
     `<input type="password">` sporadically causes bad widths on floated elements.
   upstream_bug: >
     Chromium#377346


### PR DESCRIPTION
Since https://crbug.com/346051 has been closed as WontFix.
The Chrome bug is now documented in MDN:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input$compare?locale=en-US&to=698785&from=693137
Refs #12548.
