### PR TITLE
.navbar-brand > img [Fixed issue #15222]

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -174,7 +174,7 @@
   }
 
   > img {
-    display: block;
+    display: inline-block;
   }
 
   @media (min-width: @grid-float-breakpoint) {


### PR DESCRIPTION
I changed a line to resolve issue 15222
/less/navbar.less @line 177
    display: block;
to
    display: inline-block;

https://github.com/twbs/bootstrap/issues/15222
it seems to be included to v3.3.2....

+first commit. if this commit does not need to resolve that issue, let me know.
