### PR TITLE
Add CSS source maps reference to docs. Closes #15211

### DIFF
--- a/docs/_includes/getting-started/whats-included.html
+++ b/docs/_includes/getting-started/whats-included.html
@@ -16,8 +16,10 @@ Copy any changes made here over to the README too. -->
 bootstrap/
 ├── css/
 │   ├── bootstrap.css
+│   ├── bootstrap.css.map
 │   ├── bootstrap.min.css
 │   ├── bootstrap-theme.css
+│   ├── bootstrap-theme.css.map
 │   └── bootstrap-theme.min.css
 ├── js/
 │   ├── bootstrap.js
@@ -29,7 +31,7 @@ bootstrap/
     └── glyphicons-halflings-regular.woff
 {% endhighlight %}
 
-  <p>This is the most basic form of Bootstrap: precompiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (<code>bootstrap.*</code>), as well as compiled and minified CSS and JS (<code>bootstrap.min.*</code>). Fonts from Glyphicons are included, as is the optional Bootstrap theme.</p>
+  <p>This is the most basic form of Bootstrap: precompiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (<code>bootstrap.*</code>), as well as compiled and minified CSS and JS (<code>bootstrap.min.*</code>) and CSS source maps (<code>bootstrap.*.map</code>) for use with web browsers developer tools (if you are curious about CSS source maps check out Google Chrome developer network <a href="https://developers.google.com/chrome-developer-tools/docs/css-preprocessors" target="_blank">Working with CSS Preprocessors</a>). Fonts from Glyphicons are included, as is the optional Bootstrap theme.</p>
 
   <h2 id="whats-included-source">Bootstrap source code</h2>
   <p>The Bootstrap source code download includes the precompiled CSS, JavaScript, and font assets, along with source Less, JavaScript, and documentation. More specifically, it includes the following and more:</p>


### PR DESCRIPTION
This rather trivial PR adds relevant information about CSS source map to "What's included" documentation section and it:
- updates distribution file list with relevant files
- adds a short reference to CSS source map purpose.

```
bootstrap/
├── css/
│   ├── bootstrap.css
│   ├── bootstrap.css.map
│   ├── bootstrap.min.css
│   ├── bootstrap-theme.css
│   ├── bootstrap-theme.css.map
│   └── bootstrap-theme.min.css
```

```
[...] and minified CSS and JS (bootstrap.min.*) and CSS source maps (bootstrap.*.map) for use with web browsers developer tools. 
Fonts from Glyphicons are included, as is the optional Bootstrap theme. [...]
```

This PR is not trying to make documentation capable of fully answering questions like this one:
http://stackoverflow.com/questions/21504611/what-are-the-map-files-used-for-in-bootstrap-3-1
