### PR TITLE
Fix .navbar-text margins

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -357,12 +357,12 @@
 // Add a class to make any element properly align itself vertically within the navbars.
 
 .navbar-text {
+  margin-left: @navbar-padding-horizontal;
+  margin-right: @navbar-padding-horizontal;
   .navbar-vertical-align(@line-height-computed);
 
   @media (min-width: @grid-float-breakpoint) {
     float: left;
-    margin-left: @navbar-padding-horizontal;
-    margin-right: @navbar-padding-horizontal;
   }
 }
 


### PR DESCRIPTION
For .navbar-text the margins (left / right) should not wrapped into the media query to make sure that the  .navbar-text don't differ from the nav links on the small grid.
