### PR TITLE
Clean up .navbar-text

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -357,15 +357,12 @@
 // Add a class to make any element properly align itself vertically within the navbars.
 
 .navbar-text {
-  .navbar-vertical-align(@line-height-computed);
-
-  @media (min-width: @grid-float-breakpoint) {
-    float: left;
-    margin-left: @navbar-padding-horizontal;
-    margin-right: @navbar-padding-horizontal;
+  &:extend(.nav > li > a);
+  &:extend(.navbar-nav > li > a);
+  p& {
+    margin: 0;
   }
 }
-
 
 // Component alignment
 //


### PR DESCRIPTION
In the first place i wonder why the docs suggest to use a `p` (block) instead of a `span` (inline) tag.
Using `p` tags seems a reason to set margins instead of padding (cause the `p` tag has a `bottom-margin` by default).
Also calling the `.navbar-vertical-align()` mixin does not make much sense, cause .navbar-text should only contain text and its height is keeps fixed by `@line-height-computed always`.
