### PR TITLE
Vertically center .icon-prev and .icon-next in carousel

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -148,6 +148,7 @@
     width:  20px;
     height: 20px;
     margin-top: -10px;
+    line-height: 1;
     font-family: serif;
   }
 


### PR DESCRIPTION
Center .icon-prev and .icon-next the same way .glyphicon icon are.
And this is the html markup:

``` html
<a class="left carousel-control" href="#carousel-main-menu" role="button" data-slide="prev">
    <span class="icon-prev" aria-hidden="true"></span>
</a>
```
