### PR TITLE
Fix Jumbotron description in example

### DIFF
--- a/docs/examples/theme/index.html
+++ b/docs/examples/theme/index.html
@@ -70,7 +70,7 @@
       <!-- Main jumbotron for a primary marketing message or call to action -->
       <div class="jumbotron">
         <h1>Hello, world!</h1>
-        <p>This is a template for a simple marketing or informational website. It includes a large callout called a jumbotron and three supporting pieces of content. Use it as a starting point to create something more unique.</p>
+        <p>This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
         <p><a href="#" class="btn btn-primary btn-lg" role="button">Learn more &raquo;</a></p>
       </div>
 


### PR DESCRIPTION
Removed the confusing lead text alluding to a marketing website.
