### PR TITLE
Fixed issue where escape key wasn't firing correct events

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -141,7 +141,7 @@
   Modal.prototype.escape = function () {
     if (this.isShown && this.options.keyboard) {
       this.$element.on('keydown.dismiss.bs.modal', $.proxy(function (e) {
-        e.which == 27 && this.hide()
+        e.which == 27 && this.hideModal()
       }, this))
     } else if (!this.isShown) {
       this.$element.off('keydown.dismiss.bs.modal')


### PR DESCRIPTION
When the escape key is pressed, the hide() method was being called instead of hideModal(), therefore it's not firing the hide.bs.modal event. I've changed it to hideModal() and it now fires the expected events.
