### PR TITLE
Whitelist <li role="separator">...</li>

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -331,7 +331,8 @@ module.exports = function (grunt) {
         relaxerror: [
           'Element img is missing required attribute src.',
           'Attribute autocomplete not allowed on element input at this point.',
-          'Attribute autocomplete not allowed on element button at this point.'
+          'Attribute autocomplete not allowed on element button at this point.',
+          'Bad value separator for attribute role on element li.'
         ]
       },
       files: {


### PR DESCRIPTION
Makes our HTML validator Grunt task ignore spurious errors about `<li role="separator">`.
Refs https://www.w3.org/Bugs/Public/show_bug.cgi?id=27120 and #15263.
CC: @patrickhlauke
