### PR TITLE
make modal restore original padding-right on <body> when it's done

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -254,11 +254,12 @@
 
   Modal.prototype.setScrollbar = function () {
     var bodyPad = parseInt((this.$body.css('padding-right') || 0), 10)
+    this.originalBodyPad = bodyPad // Remember the original body pad
     if (this.bodyIsOverflowing) this.$body.css('padding-right', bodyPad + this.scrollbarWidth)
   }
 
   Modal.prototype.resetScrollbar = function () {
-    this.$body.css('padding-right', '')
+    this.$body.css('padding-right', this.originalBodyPad)
   }
 
   Modal.prototype.measureScrollbar = function () { // thx walsh

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -270,7 +270,7 @@ $(function () {
 
     $toggleBtn.click()
   })
-  
+
   test('Closing modal should not wipe the original body padding', function () {
     stop()
     var originalBodyPad = 100
@@ -278,8 +278,8 @@ $(function () {
     $body.css('paddingRight', originalBodyPad)
     $('<div id="modal-test"></div>')
     .on('hidden.bs.modal', function () {
-        var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
-        strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
+      var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
+      strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
     })
     .bootstrapModal('show').bootstrapModal('hide')
   })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -280,7 +280,11 @@ $(function () {
     .on('hidden.bs.modal', function () {
       var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
       strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
+      start()
     })
-    .bootstrapModal('show').bootstrapModal('hide')
+    .on('shown.bs.modal', function () {
+      $(this).bootstrapModal('hide')
+    })
+    .bootstrapModal('show')
   })
 })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -270,4 +270,17 @@ $(function () {
 
     $toggleBtn.click()
   })
+  
+  test('Closing modal should not wipe the original body padding', function () {
+    stop()
+    var originalBodyPad = 100
+    var $body = $('body')
+    $body.css('paddingRight', originalBodyPad)
+    $('<div id="modal-test"></div>')
+    .on('hidden.bs.modal', function () {
+        var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
+        strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
+    })
+    .bootstrapModal('show').bootstrapModal('hide')
+  })
 })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -277,14 +277,14 @@ $(function () {
     var $body = $('body')
     $body.css('paddingRight', originalBodyPad)
     $('<div id="modal-test"></div>')
-    .on('hidden.bs.modal', function () {
-      var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
-      strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
-      start()
-    })
-    .on('shown.bs.modal', function () {
-      $(this).bootstrapModal('hide')
-    })
-    .bootstrapModal('show')
+      .on('hidden.bs.modal', function () {
+        var currentBodyPad = parseInt(($body.css('padding-right') || 0), 10)
+        strictEqual(currentBodyPad, originalBodyPad, 'Original body padding was not changed.')
+        start()
+      })
+      .on('shown.bs.modal', function () {
+        $(this).bootstrapModal('hide')
+      })
+      .bootstrapModal('show')
   })
 })


### PR DESCRIPTION
Fixing a problem:

If the page has a padding-right: 100px; initially for example, after opening and closing a modal dialog, this value will be wiped.
