### PR TITLE
Keep the shortcut functionality "Open in new tab" in modal anchors.

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -310,7 +310,11 @@
     var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) // strip for ie7
     var option  = $target.data('bs.modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
-    if ($this.is('a')) e.preventDefault()
+    if ($this.is('a')) {
+      if (e.ctrlKey) return
+
+      e.preventDefault()
+    }
 
     $target.one('show.bs.modal', function (showEvent) {
       if (showEvent.isDefaultPrevented()) return // only register focus restorer if modal will actually get shown

--- a/js/modal.js
+++ b/js/modal.js
@@ -311,7 +311,7 @@
     var option  = $target.data('bs.modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
     if ($this.is('a')) {
-      if (e.ctrlKey) return
+      if (e.ctrlKey || e.metaKey) return
 
       e.preventDefault()
     }


### PR DESCRIPTION
Keep the "Click + Ctrl" functionality clicking in a modal anchor, in order to keep this usability.

If the user clicks an anchor pressing the "Ctrl" key, the likelihood is that this user wants to open the hypertext link in a new tab rather than open the modal.
