### PR TITLE
Add grunt-contrib-compress.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -382,7 +382,27 @@ module.exports = function (grunt) {
       npmUpdate: {
         command: 'npm update'
       }
+    },
+
+    compress: {
+      main: {
+        options: {
+          archive: 'bootstrap-<%= pkg.version %>-dist.zip',
+          mode: 'zip',
+          level: 9,
+          pretty: true
+        },
+        files: [
+          {
+            expand: true,
+            cwd: 'dist/',
+            src: ['**'],
+            dest: 'bootstrap-<%= pkg.version %>-dist'
+          }
+        ]
+      }
     }
+
   });
 
 
@@ -465,7 +485,7 @@ module.exports = function (grunt) {
   grunt.registerTask('lint-docs-js', ['jshint:assets', 'jscs:assets']);
   grunt.registerTask('docs', ['docs-css', 'lint-docs-css', 'docs-js', 'lint-docs-js', 'clean:docs', 'copy:docs', 'build-customizer']);
 
-  grunt.registerTask('docs-github', ['jekyll:github']);
+  grunt.registerTask('prep-release', ['jekyll:github', 'compress']);
 
   // Task for updating the cached npm packages used by the Travis build (which are controlled by test-infra/npm-shrinkwrap.json).
   // This task should be run and the updated file should be committed whenever Bootstrap's dependencies change.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-autoprefixer": "~2.0.0",
     "grunt-banner": "~0.2.3",
     "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-compress": "~0.12.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.7.0",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -333,6 +333,168 @@
         }
       }
     },
+    "grunt-contrib-compress": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.12.0.tgz",
+      "dependencies": {
+        "archiver": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "buffer-crc32": {
+              "version": "0.2.4",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.4.tgz"
+            },
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lazystream": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "0.4.7",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.3",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "zip-stream": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
+              "dependencies": {
+                "compress-commons": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
+                  "dependencies": {
+                    "crc32-stream": {
+                      "version": "0.3.1",
+                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "prettysize": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
+        }
+      }
+    },
     "grunt-contrib-concat": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.0.tgz",


### PR DESCRIPTION
Now, the zip file is created when running `grunt docs-github`.

/CC @mdo @cvrebert 

Maybe we should rename the grunt target to `release` or something like that?
