### PR TITLE
Remove "Separated link" in example where it's not

### DIFF
--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -15,7 +15,6 @@
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Action</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Another action</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Something else here</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
       </ul>
     </div>
   </div><!-- /example -->


### PR DESCRIPTION
Removed "Separated link" in example where it's not separated. This may confuse people to think that it is separated.

I don't want to sound nitpicky, but I've been maintaining a custom internal Bootstrap installation with customized docs for a client, so I've been getting a lot of feedback from developers using the docs.
