### PR TITLE
Link underlines

### DIFF
--- a/docs/_includes/css/less.html
+++ b/docs/_includes/css/less.html
@@ -81,11 +81,9 @@
 // Usage
 a {
   color: @link-color;
-  text-decoration: none;
 
   &:hover {
     color: @link-hover-color;
-    text-decoration: underline;
   }
 }
 {% endhighlight %}

--- a/docs/_includes/customizer-variables.html
+++ b/docs/_includes/customizer-variables.html
@@ -75,11 +75,6 @@
     <input id="input-@link-hover-color" type="text" value="darken(@link-color, 15%)" data-var="@link-hover-color" class="form-control"/>
     <p class="help-block">Link hover color set via <code>darken()</code> function.</p>
   </div>
-  <div class="col-xs-4">
-    <label for="input-@link-hover-decoration">@link-hover-decoration</label>
-    <input id="input-@link-hover-decoration" type="text" value="underline" data-var="@link-hover-decoration" class="form-control"/>
-    <p class="help-block">Link hover decoration.</p>
-  </div>
 </div>
 <h2 id="typography">Typography</h2>
 <p>Font, line-height, and color for body text, headings, and more.</p>

--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -606,12 +606,12 @@ body {
   margin-left: 10px;
   font-size: 12px;
   font-weight: 500;
+  text-decoration: none;
   color: #999;
 }
 .back-to-top:hover,
 .bs-docs-theme-toggle:hover {
   color: #563d7c;
-  text-decoration: none;
 }
 .bs-docs-theme-toggle {
   margin-top: 0;

--- a/docs/examples/blog/blog.css
+++ b/docs/examples/blog/blog.css
@@ -48,11 +48,11 @@ h6, .h6 {
   padding: 10px;
   font-weight: 500;
   color: #cdddeb;
+  text-decoration: none;
 }
 .blog-nav-item:hover,
 .blog-nav-item:focus {
   color: #fff;
-  text-decoration: none;
 }
 
 /* Active state gets a caret at the bottom */
@@ -108,6 +108,11 @@ h6, .h6 {
   padding: 15px;
   margin: 0 -15px 15px;
 }
+
+.sidebar-module a {
+  text-decoration: none;
+}
+
 .sidebar-module-inset {
   padding: 15px;
   background-color: #f5f5f5;

--- a/less/breadcrumbs.less
+++ b/less/breadcrumbs.less
@@ -18,6 +18,11 @@
       padding: 0 5px;
       color: @breadcrumb-color;
     }
+
+    > a {
+      text-decoration: none;
+    }
+
   }
 
   > .active {

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -11,6 +11,7 @@
   margin-bottom: 0; // For input.btn
   font-weight: @btn-font-weight;
   text-align: center;
+  text-decoration: none;
   vertical-align: middle;
   touch-action: manipulation;
   cursor: pointer;
@@ -33,7 +34,6 @@
   &:focus,
   &.focus {
     color: @btn-default-color;
-    text-decoration: none;
   }
 
   &:active,
@@ -88,6 +88,7 @@
 .btn-link {
   color: @link-color;
   font-weight: normal;
+  text-decoration: underline;
   border-radius: 0;
 
   &,
@@ -107,7 +108,6 @@
   &:hover,
   &:focus {
     color: @link-hover-color;
-    text-decoration: underline;
     background-color: transparent;
   }
   &[disabled],

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -66,6 +66,7 @@
     clear: both;
     font-weight: normal;
     line-height: @line-height-base;
+    text-decoration: none;
     color: @dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
   }
@@ -75,7 +76,6 @@
 .dropdown-menu > li > a {
   &:hover,
   &:focus {
-    text-decoration: none;
     color: @dropdown-link-hover-color;
     background-color: @dropdown-link-hover-bg;
   }
@@ -101,13 +101,13 @@
   &,
   &:hover,
   &:focus {
+    text-decoration: none;
     color: @dropdown-link-disabled-color;
   }
 
   // Nuke hover/focus effects
   &:hover,
   &:focus {
-    text-decoration: none;
     background-color: transparent;
     background-image: none; // Remove CSS gradient
     .reset-filter();

--- a/less/list-group.less
+++ b/less/list-group.less
@@ -45,6 +45,7 @@
 
 a.list-group-item {
   color: @list-group-link-color;
+  text-decoration: none;
 
   .list-group-item-heading {
     color: @list-group-link-heading-color;
@@ -53,7 +54,6 @@ a.list-group-item {
   // Hover state
   &:hover,
   &:focus {
-    text-decoration: none;
     color: @list-group-link-hover-color;
     background-color: @list-group-hover-bg;
   }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -167,11 +167,7 @@
   font-size: @font-size-large;
   line-height: @line-height-computed;
   height: @navbar-height;
-
-  &:hover,
-  &:focus {
-    text-decoration: none;
-  }
+  text-decoration: none;
 
   > img {
     display: block;

--- a/less/navs.less
+++ b/less/navs.less
@@ -20,9 +20,10 @@
       position: relative;
       display: block;
       padding: @nav-link-padding;
+      text-decoration: none;
+
       &:hover,
       &:focus {
-        text-decoration: none;
         background-color: @nav-link-hover-bg;
       }
     }
@@ -30,11 +31,11 @@
     // Disabled state sets text to gray and nukes hover/tab effects
     &.disabled > a {
       color: @nav-disabled-link-color;
+      text-decoration: none;
 
       &:hover,
       &:focus {
         color: @nav-disabled-link-hover-color;
-        text-decoration: none;
         background-color: transparent;
         cursor: @cursor-disabled;
       }

--- a/less/pager.less
+++ b/less/pager.less
@@ -15,6 +15,7 @@
     > span {
       display: inline-block;
       padding: 5px 14px;
+      text-decoration: none;
       background-color: @pager-bg;
       border: 1px solid @pager-border;
       border-radius: @pager-border-radius;
@@ -22,7 +23,6 @@
 
     > a:hover,
     > a:focus {
-      text-decoration: none;
       background-color: @pager-hover-bg;
     }
   }

--- a/less/panels.less
+++ b/less/panels.less
@@ -38,6 +38,7 @@
 
   > a {
     color: inherit;
+    text-decoration: none;
   }
 }
 

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -47,8 +47,7 @@ textarea {
 
 a {
   color: @link-color;
-  text-decoration: none;
-
+  
   &:hover,
   &:focus {
     color: @link-hover-color;

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -51,7 +51,6 @@ a {
   &:hover,
   &:focus {
     color: @link-hover-color;
-    text-decoration: @link-hover-decoration;
   }
 
   &:focus {

--- a/less/variables.less
+++ b/less/variables.less
@@ -34,8 +34,6 @@
 @link-color:            @brand-primary;
 //** Link hover color set via `darken()` function.
 @link-hover-color:      darken(@link-color, 15%);
-//** Link hover decoration.
-@link-hover-decoration: underline;
 
 
 //== Typography


### PR DESCRIPTION
As per twbs#15304 this removes the indiscriminate `text-decoration:none` used for all links - and then reintroduces it for specific cases where the link-like nature of a link is clear enough from usage/context.
Plus it adds explicit `text-decoration:underline` in  specific situation `<button class="btn-link">`
