### PR TITLE
Revert "fix typo in carousel doc"

### DIFF
--- a/docs/_includes/js/carousel.html
+++ b/docs/_includes/js/carousel.html
@@ -240,7 +240,7 @@ $('.carousel').carousel({
          <td>This event fires immediately when the <code>slide</code> instance method is invoked.</td>
        </tr>
        <tr>
-         <td>slide.bs.carousel</td>
+         <td>slid.bs.carousel</td>
          <td>This event is fired when the carousel has completed its slide transition.</td>
        </tr>
       </tbody>


### PR DESCRIPTION
Reverts #15350, because "slid" is the past tense of "slide".

/fyi @patrickhlauke @emmanuelgautier 

Refs #12879 and #13249
