### PR TITLE
jsOnly option for Tooltip.js

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -39,6 +39,7 @@
     delay: 0,
     html: false,
     container: false,
+    jsOnly: false,
     viewport: {
       selector: 'body',
       padding: 0
@@ -317,9 +318,11 @@
   }
 
   Tooltip.prototype.fixTitle = function () {
-    var $e = this.$element
-    if ($e.attr('title') || typeof ($e.attr('data-original-title')) != 'string') {
-      $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
+    if (this.options.jsOnly === false) {
+      var $e = this.$element
+      if ($e.attr('title') || typeof ($e.attr('data-original-title')) != 'string') {
+        $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #15359 
When using Tooltip.js it adds `data-original-title` and `title` to the DOM if they does not exist.

Calling 

``` js
$(this).tooltip({ 'placement': 'bottom', 'title': 'Tooltip text'})
```

Gets a code like this

``` html
<span data-original-title="" title="">John</span>
```

After this PR you can call tooltip with an optional attribute for javascript only solutions (not using data html attributes).
Calling

``` js
$(this).tooltip({ 'placement': 'bottom', 'title': 'Tooltip text', jsOnly: true })
```

Now does not change the DOM

``` html
<span>John</span>
```
