### PR TITLE
Make skip link look less "bare bones"

### DIFF
--- a/docs/_includes/getting-started/accessibility.html
+++ b/docs/_includes/getting-started/accessibility.html
@@ -3,12 +3,13 @@
   <p class="lead">Bootstrap follows common web standards and&mdash;with minimal extra effort&mdash;can be used to create sites that are accessible to those using <abbr title="Assistive Technology" class="initialism">AT</abbr>.</p>
 
   <h3>Skip navigation</h3>
-  <p>If your navigation contains many links and comes before the main content in the DOM, add a <code>Skip to main content</code> link immediately after your opening <code>&lt;body&gt;</code> tag. <a href="http://a11yproject.com/posts/skip-nav-links/">(read why)</a></p>
+  <p>If your navigation contains many links and comes before the main content in the DOM, add a <code>Skip to main content</code> link before the navigation <a href="http://a11yproject.com/posts/skip-nav-links/">(read why)</a>. Using the <code>.sr-only</code> class will visually hide the skip link, and the <code>.sr-only-focusable</code> class will ensure that the link becomes visible once focused (for sighted keyboard users).</p>
 {% highlight html %}
 <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
+  ...
   <div class="container" id="content">
-    The main page content.
+    <!-- The main page content -->
   </div>
 </body>
 {% endhighlight %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,7 +5,7 @@
     {% include header.html %}
   </head>
   <body>
-    <a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
+    <a id="skippy" class="sr-only sr-only-focusable" href="#content"><div class="container"><span class="skiplink-text">Skip to main content</span></div></a>
 
     <!-- Docs master nav -->
     {% include nav/main.html %}

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -5,7 +5,7 @@
     {% include header.html %}
   </head>
   <body class="bs-docs-home">
-    <a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
+    <a id="skippy" class="sr-only sr-only-focusable" href="#content"><div class="container"><span class="skiplink-text">Skip to main content</span></div></a>
 
     <!-- Docs master nav -->
     {% include nav/main.html %}

--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -90,6 +90,26 @@ body {
 
 
 /*
+ * Fancy skip link
+ *
+ * Make it look a bit less "bare bones"
+ */
+
+#skippy {
+  display: block;
+  padding: 1em;
+  color: #fff;
+  background-color: #6F5499;
+  outline: 0;
+}
+
+#skippy .skiplink-text {
+  padding: 0.5em;
+  outline: 1px dotted;
+}
+
+
+/*
  * Main navigation
  *
  * Turn the `.navbar` at the top of the docs purple.


### PR DESCRIPTION
Additional markup for the skip link (to ensure it has the same effective width as the main content, and to provide an outline around just the link text) plus some basic styles...make it look a bit more in keeping with the overall look and feel of the docs.
