### PR TITLE
Fixed a spelling mistake.

### DIFF
--- a/js/tests/vendor/qunit.js
+++ b/js/tests/vendor/qunit.js
@@ -2412,7 +2412,7 @@ QUnit.log(function( details ) {
 
 		message += "</table>";
 
-	// this occours when pushFailure is set and we have an extracted stack trace
+	// this occurs when pushFailure is set and we have an extracted stack trace
 	} else if ( !details.result && details.source ) {
 		message += "<table>" +
 			"<tr class='test-source'><th>Source: </th><td><pre>" +


### PR DESCRIPTION
In a comment, the word "occurs" was misspelled as "occurs".
