### PR TITLE
Change popover auto right placement to use container right offset 

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -367,7 +367,9 @@ $(function () {
   })
 
   test('should be placed dynamically with the dynamic placement option', function () {
-    var $style = $('<style> a[rel="tooltip"] { display: inline-block; position: absolute; } </style>')
+    var $style = $('<style> div[role="tooltip"], a[rel="tooltip"] { display: inline-block; position: absolute; } </style>')
+      .appendTo('head')
+
     var $container = $('<div/>')
       .css({
         position: 'absolute',
@@ -375,11 +377,12 @@ $(function () {
         width: 600,
         height: 400,
         top: 0,
-        left: 0
+        left: 0,
+        margin: 600
       })
-      .appendTo(document.body)
+      .appendTo('#qunit-fixture')
 
-    var $topTooltip = $('<div style="left: 0; top: 0;" rel="tooltip" title="Top tooltip">Top Dynamic Tooltip</div>')
+    var $topTooltip = $('<a style="left: 0; top: 0;" rel="tooltip" title="Top tooltip">Top Dynamic Tooltip</a>')
       .appendTo($container)
       .bootstrapTooltip({ placement: 'auto' })
 
@@ -389,17 +392,24 @@ $(function () {
     $topTooltip.bootstrapTooltip('hide')
     equal($('.tooltip').length, 0, 'top positioned tooltip removed from dom')
 
-    var $rightTooltip = $('<div style="right: 0;" rel="tooltip" title="Right tooltip">Right Dynamic Tooltip</div>')
+    var $rightTooltip = $('<a rel="tooltip" title="Right tooltip">Right Dynamic Tooltip</a>')
       .appendTo($container)
       .bootstrapTooltip({ placement: 'right auto' })
 
+    $rightTooltip.bootstrapTooltip('show')
+    ok($('.tooltip').is('.right'), 'left positioned tooltip is positioned right')
+
+    $rightTooltip.bootstrapTooltip('hide')
+    equal($('.tooltip').length, 0, 'left positioned tooltip removed from dom')
+
+    $rightTooltip.css('right', 0);
     $rightTooltip.bootstrapTooltip('show')
     ok($('.tooltip').is('.left'), 'right positioned tooltip is dynamically positioned left')
 
     $rightTooltip.bootstrapTooltip('hide')
     equal($('.tooltip').length, 0, 'right positioned tooltip removed from dom')
 
-    var $leftTooltip = $('<div style="left: 0;" rel="tooltip" title="Left tooltip">Left Dynamic Tooltip</div>')
+    var $leftTooltip = $('<a rel="tooltip" title="Left tooltip">Left Dynamic Tooltip</a>')
       .appendTo($container)
       .bootstrapTooltip({ placement: 'auto left' })
 
@@ -409,7 +419,13 @@ $(function () {
     $leftTooltip.bootstrapTooltip('hide')
     equal($('.tooltip').length, 0, 'left positioned tooltip removed from dom')
 
-    $container.remove()
+    $leftTooltip.css('right', 0);
+    $leftTooltip.bootstrapTooltip('show')
+    ok($('.tooltip').is('.left'), 'right positioned tooltip is positioned left')
+
+    $leftTooltip.bootstrapTooltip('hide')
+    equal($('.tooltip').length, 0, 'right positioned tooltip removed from dom')
+
     $style.remove()
   })
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -193,7 +193,7 @@
 
         placement = placement == 'bottom' && pos.bottom + actualHeight > containerDim.bottom ? 'top'    :
                     placement == 'top'    && pos.top    - actualHeight < containerDim.top    ? 'bottom' :
-                    placement == 'right'  && pos.right  + actualWidth  > containerDim.width  ? 'left'   :
+                    placement == 'right'  && pos.right  + actualWidth  > containerDim.right  ? 'left'   :
                     placement == 'left'   && pos.left   - actualWidth  < containerDim.left   ? 'right'  :
                     placement
 


### PR DESCRIPTION
When using "auto right" as the placement for a popover, the auto placement code uses the container width instead of the right offset of the container to determine whether to use left or right placement. If the container has anything but zero for a left offset, this can result in incorrect usage of left placement when there is plenty of room for right placement.

Changed to compare the right offset of the container instead of the container width.

Fixes #15367
