### PR TITLE
Add docs for #15340

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -187,6 +187,7 @@
 
 // TODO: Rename `@input-border-radius` to `@input-border-radius-base` in v4
 //** Default `.form-control` border radius
+// This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
 @input-border-radius:            @border-radius-base;
 //** Large `.form-control` border radius
 @input-border-radius-large:      @border-radius-large;


### PR DESCRIPTION
The `border-radius` CSS property doesn't affect `<select>`s in some browsers.
Hence, `@input-border-radius` doesn't affect `<select class="form-control">` in some browsers.
To: @mdo for review
