### PR TITLE
Inline form example doesn't match its code.

### DIFF
--- a/docs/_includes/css/forms.html
+++ b/docs/_includes/css/forms.html
@@ -69,12 +69,9 @@
     <form class="form-inline" role="form">
       <div class="form-group">
         <label class="sr-only" for="exampleInputEmail2">Email address</label>
-        <input type="email" class="form-control" id="exampleInputEmail2" placeholder="Enter email">
-      </div>
-      <div class="form-group">
         <div class="input-group">
           <div class="input-group-addon">@</div>
-          <input class="form-control" type="email" placeholder="Enter email">
+          <input class="form-control" type="email" id="exampleInputEmail2" placeholder="Enter email">
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
This example of the inline form doesn't not match the highlighted code below it. 
It is quite confusing, because there are 2 email fields in the sample form that is shown. I have proposed the correction of this.

I hope this helps.

PS:
I don't think so, but if by any chance these two email fields were intentional, where the first field was for the local part of the email (e.g.: john.doe) and the second field for the domain part (e.g.: @domain.com), then I suggest right-aligning the first field. But I doubt was the intention, because it wouldn't be a very clear form example and quite an unusual approach.
