### PR TITLE
Theme - Cleanup (btn-default)

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -69,7 +69,7 @@
 }
 
 // Apply the mixin to the buttons
-.btn-default { .btn-styles(@btn-default-bg); text-shadow: 0 1px 0 #fff; border-color: #ccc; }
+.btn-default { .btn-styles(@btn-default-bg); text-shadow: 0 1px 0 #fff; }
 .btn-primary { .btn-styles(@btn-primary-bg); }
 .btn-success { .btn-styles(@btn-success-bg); }
 .btn-info    { .btn-styles(@btn-info-bg); }


### PR DESCRIPTION
`border-color` is not nessessary. The color will be defined in the https://github.com/twbs/bootstrap/blob/master/less/buttons.less#L60.

```
.btn-default {
  .button-variant(@btn-default-color; @btn-default-bg;
@btn-default-border);
}
```

PS: I would also set the `text-shadow` to `none` or use the invert color of the `@btn-default-color`. If you change the theme to a dark skin, the buttons text shadow will not look very nice. What do you think about it?
