### PR TITLE
Remove holder.js references from syntax-highlighted example HTML

### DIFF
--- a/docs/_includes/components/thumbnails.html
+++ b/docs/_includes/components/thumbnails.html
@@ -33,7 +33,7 @@
 <div class="row">
   <div class="col-xs-6 col-md-3">
     <a href="#" class="thumbnail">
-      <img data-src="holder.js/100%x180" alt="...">
+      <img src="..." alt="...">
     </a>
   </div>
   ...
@@ -80,7 +80,7 @@
 <div class="row">
   <div class="col-sm-6 col-md-4">
     <div class="thumbnail">
-      <img data-src="holder.js/300x300" alt="...">
+      <img src="..." alt="...">
       <div class="caption">
         <h3>Thumbnail label</h3>
         <p>...</p>


### PR DESCRIPTION
Our use of Holder.js in the docs is a mere implementation detail.
We don't want to confuse people into thinking Holder.js is somehow required by the Thumbnail component.
X-Ref: http://stackoverflow.com/questions/27602616/how-to-load-my-images-using-holder-js-bootstrap
