### PR TITLE
Specific gutter width for certain resolution states (xs, sm, md, lg).

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -8,7 +8,7 @@
 // Set the container width, and override it for fixed navbars in media queries.
 
 .container {
-  .container-fixed();
+  .container-fixed(@grid-xs-gutter-width);
 
   @media (min-width: @screen-sm-min) {
     width: @container-sm;
@@ -28,7 +28,7 @@
 // width for fluid, full width layouts.
 
 .container-fluid {
-  .container-fixed();
+  .container-fixed(@grid-xs-gutter-width);
 }
 
 
@@ -37,7 +37,7 @@
 // Rows contain and clear the floats of your columns.
 
 .row {
-  .make-row();
+  .make-row(@grid-xs-gutter-width);
 }
 
 
@@ -45,7 +45,7 @@
 //
 // Common styles for small and large grid columns
 
-.make-grid-columns();
+.make-grid-columns(@grid-xs-gutter-width);
 
 
 // Extra small grid
@@ -62,6 +62,16 @@
 // to tablets.
 
 @media (min-width: @screen-sm-min) {
+  .container {
+    .container-fixed(@grid-sm-gutter-width);
+  }
+  .container-fluid {
+    .container-fixed(@grid-sm-gutter-width);
+  }
+  .row {
+    .make-row(@grid-sm-gutter-width);
+  }
+  .make-grid-columns(@grid-sm-gutter-width);
   .make-grid(sm);
 }
 
@@ -71,6 +81,16 @@
 // Columns, offsets, pushes, and pulls for the desktop device range.
 
 @media (min-width: @screen-md-min) {
+  .container {
+    .container-fixed(@grid-md-gutter-width);
+  }
+  .container-fluid {
+    .container-fixed(@grid-md-gutter-width);
+  }
+  .row {
+    .make-row(@grid-md-gutter-width);
+  }
+  .make-grid-columns(@grid-md-gutter-width);
   .make-grid(md);
 }
 
@@ -80,5 +100,15 @@
 // Columns, offsets, pushes, and pulls for the large desktop device range.
 
 @media (min-width: @screen-lg-min) {
+  .container {
+    .container-fixed(@grid-lg-gutter-width);
+  }
+  .container-fluid {
+    .container-fixed(@grid-lg-gutter-width);
+  }
+  .row {
+    .make-row(@grid-lg-gutter-width);
+  }
+  .make-grid-columns(@grid-lg-gutter-width);
   .make-grid(lg);
 }

--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -3,7 +3,7 @@
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `@grid-columns`.
 
-.make-grid-columns() {
+.make-grid-columns(@gutter: @grid-gutter-width) {
   // Common styles for all sizes of grid columns, widths 1-12
   .col(@index) { // initial
     @item: ~".col-xs-@{index}, .col-sm-@{index}, .col-md-@{index}, .col-lg-@{index}";
@@ -19,8 +19,8 @@
       // Prevent columns from collapsing when empty
       min-height: 1px;
       // Inner gutter via padding
-      padding-left:  (@grid-gutter-width / 2);
-      padding-right: (@grid-gutter-width / 2);
+      padding-left:  (@gutter / 2);
+      padding-right: (@gutter / 2);
     }
   }
   .col(1); // kickstart it

--- a/less/variables.less
+++ b/less/variables.less
@@ -316,6 +316,10 @@
 @grid-columns:              12;
 //** Padding between columns. Gets divided in half for the left and right.
 @grid-gutter-width:         30px;
+@grid-xs-gutter-width:      (@grid-gutter-width / 3);
+@grid-sm-gutter-width:      @grid-gutter-width;
+@grid-md-gutter-width:      @grid-gutter-width;
+@grid-lg-gutter-width:      @grid-gutter-width;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
 @grid-float-breakpoint:     @screen-sm-min;


### PR DESCRIPTION
In bootstrap 3 the gutter is defined as 30px which well on desktops, but on mobile it takes too much space. I think it'll better if we could configure gutter width for certain resolution states (xs, sm, md, lg).
Thanks.
