### PR TITLE
Bump grunt-contrib-cssmin to ~0.11.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -224,7 +224,7 @@ module.exports = function (grunt) {
       options: {
         compatibility: 'ie8',
         keepSpecialComments: '*',
-        noAdvanced: true
+        advanced: false
       },
       minifyCore: {
         src: 'dist/css/<%= pkg.name %>.css',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-csslint": "~0.3.1",
-    "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-cssmin": "~0.11.0",
     "grunt-contrib-jade": "~0.14.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-less": "~0.12.0",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -1216,86 +1216,78 @@
       }
     },
     "grunt-contrib-cssmin": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.10.0.tgz",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.11.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
-            "has-color": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
             },
             "strip-ansi": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "clean-css": {
-          "version": "2.2.22",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.22.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.0.1.tgz",
           "dependencies": {
             "commander": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+            },
+            "source-map": {
+              "version": "0.1.41",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
             }
           }
         },
         "maxmin": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.0.0.tgz",
           "dependencies": {
-            "chalk": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-                },
-                "has-ansi": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                }
-              }
-            },
             "figures": {
               "version": "1.3.5",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "gzip-size": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "browserify-zlib": {
                   "version": "0.1.4",
@@ -1342,8 +1334,14 @@
               }
             },
             "pretty-bytes": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.2.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-1.0.0.tgz"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
After checking the resulting minified CSS, the only differences seem to be:
- Selectors get sorted; e.g. `.d, .c, .b {...} .a {...}` => `.b, .c, .d {...} .a {...}` Seems harmless. Have filed https://github.com/jakubpawlowicz/clean-css/issues/425 about using a smarter ordering though.
- `background: transparent !important;` now minifies to `background: 0 0 !important;` I'm not sure whether this matters

CC: @mdo @XhmikosR 
