### PR TITLE
Bump grunt-contrib-less to ~1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-contrib-cssmin": "~0.11.0",
     "grunt-contrib-jade": "~0.14.0",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-less": "~0.12.0",
+    "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-qunit": "~0.5.2",
     "grunt-contrib-uglify": "~0.7.0",
     "grunt-contrib-watch": "~0.6.1",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -1652,12 +1652,12 @@
       }
     },
     "grunt-contrib-less": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-0.12.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-1.0.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
@@ -1698,19 +1698,9 @@
           }
         },
         "less": {
-          "version": "1.7.5",
-          "resolved": "https://registry.npmjs.org/less/-/less-1.7.5.tgz",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/less/-/less-2.1.2.tgz",
           "dependencies": {
-            "clean-css": {
-              "version": "2.2.23",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
-                }
-              }
-            },
             "graceful-fs": {
               "version": "3.0.5",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
@@ -1729,33 +1719,81 @@
                 }
               }
             },
+            "promise": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-6.0.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                }
+              }
+            },
             "request": {
-              "version": "2.40.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+              "version": "2.51.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "bl": {
+                  "version": "0.9.3",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
                 },
                 "forever-agent": {
                   "version": "0.5.2",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "mime-types": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.5.tgz",
                       "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        "mime-db": {
+                          "version": "1.3.1",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                         }
                       }
                     }
@@ -1814,12 +1852,12 @@
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "oauth-sign": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "qs": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                  "version": "2.3.3",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
@@ -1856,96 +1894,6 @@
         "lodash": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "maxmin": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.1.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                },
-                "has-color": {
-                  "version": "0.1.7",
-                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-                },
-                "strip-ansi": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-                }
-              }
-            },
-            "gzip-size": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.1.1.tgz",
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.4.7",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                    }
-                  }
-                },
-                "zlib-browserify": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
-                  "dependencies": {
-                    "tape": {
-                      "version": "0.2.2",
-                      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
-                      "dependencies": {
-                        "deep-equal": {
-                          "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
-                        },
-                        "defined": {
-                          "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
-                        },
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "pretty-bytes": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
-            }
-          }
         }
       }
     },


### PR DESCRIPTION
This updates Grunt's Less.js from v1.7.5 to v2.1.2.
Per [the Less v2 upgrade guide](http://lesscss.org/usage/#v2-upgrade-guide), the language is basically unchanged.
The main changes are to Less.js's API, so the follow-up task of upgrading the version of Less used in the Customizer will be a bit harder.
No changes to our `.less` files are required, and there are no changes to the resulting CSS.
CC: @mdo
