### PR TITLE
Add .disabled class styling for .btn-styles in theme

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -52,6 +52,7 @@
     border-color: darken(@btn-color, 14%);
   }
 
+  &.disabled,
   &:disabled,
   &[disabled] {
     background-color: darken(@btn-color, 12%);


### PR DESCRIPTION
Bootstrap itself has .btn-default.disabled styled. IE8 with angularjs has some weird behaviour if anchor has disabled attribute set, so I use disabled class as a workaround and assume the .disabled class styles the buttons the same as disabled attribute would.
See https://github.com/liias/bootstrap/blob/master/less/buttons.less#L46
