### PR TITLE
Fix for some edge-case scenarios where ownerDocument is null.

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1115,8 +1115,8 @@ $(function () {
     } catch (err) {
       passed = false
       console.log(err)
-    }    
-	ok(passed && $('.tooltip').length === 0, 'document-level tooltip is correctly treated as invalid without raising errors')
-  })  
-  
+    }
+    ok(passed && $('.tooltip').length === 0, 'document-level tooltip is correctly treated as invalid without raising errors')
+  })
+
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1109,7 +1109,7 @@ $(function () {
 
   test('should gracefully treat document like any !inDom element without raising errors', function () {
     var passed = true
-    var $tooltip = $(document).bootstrapTooltip({ title: "document-level tooltip", template: '<div class="tooltip some-class">!inDom document-level Tooltip<div class="tooltip-arrow"/><div class="tooltip-inner"/></div>' })
+    var $tooltip = $(document).bootstrapTooltip({ title: 'document-level tooltip', template: '<div class="tooltip some-class">!inDom document-level Tooltip<div class="tooltip-arrow"/><div class="tooltip-inner"/></div>' })
     try {
       $tooltip.bootstrapTooltip('show')
     } catch (err) {

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1107,4 +1107,16 @@ $(function () {
     $element.bootstrapTooltip('show')
   })
 
+  test('should gracefully treat document like any !inDom element without raising errors', function () {
+    var passed = true
+    var $tooltip = $(document).bootstrapTooltip({ title: "document-level tooltip", template: '<div class="tooltip some-class">!inDom document-level Tooltip<div class="tooltip-arrow"/><div class="tooltip-inner"/></div>' })
+    try {
+      $tooltip.bootstrapTooltip('show')
+    } catch (err) {
+      passed = false
+      console.log(err)
+    }    
+	ok(passed && $('.tooltip').length === 0, 'document-level tooltip is correctly treated as invalid without raising errors')
+  })  
+  
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -152,7 +152,7 @@
     if (this.hasContent() && this.enabled) {
       this.$element.trigger(e)
 
-      var inDom = $.contains(this.$element[0].ownerDocument.documentElement, this.$element[0])
+      var inDom = $.contains((this.$element[0].ownerDocument || this.$element[0]).documentElement, this.$element[0])
       if (e.isDefaultPrevented() || !inDom) return
       var that = this
 


### PR DESCRIPTION
ownerDocument isn't guaranteed to have value. If you do something like $(document).tooltip(), the following error will occur:

Uncaught TypeError: Cannot read property ‘documentElement’ of null

This additional check (with a safe fallback provided) will fix it.
