### PR TITLE
Make $(document).tooltip({...}) without a `selector` throw an error

### DIFF
--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -225,4 +225,11 @@ $(function () {
       })
       .bootstrapPopover('show')
   })
+
+  test('should throw an error when initializing popover on the document object without specifying a delegation selector', function () {
+    throws(function () {
+      $(document).bootstrapPopover({ title: 'What am I on?', content: 'My selector is missing' })
+    }, new Error('`selector` option must be specified when initializing popover on the window.document object!'))
+  })
+
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1107,4 +1107,10 @@ $(function () {
     $element.bootstrapTooltip('show')
   })
 
+  test('should throw an error when initializing tooltip on the document object without specifying a delegation selector', function () {
+    throws(function () {
+      $(document).bootstrapTooltip({ title: 'What am I on?' })
+    }, new Error('`selector` option must be specified when initializing tooltip on the window.document object!'))
+  })
+
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -52,6 +52,10 @@
     this.options   = this.getOptions(options)
     this.$viewport = this.options.viewport && $(this.options.viewport.selector || this.options.viewport)
 
+    if (this.$element[0] instanceof window.Document && !this.options.selector) {
+      throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!');
+    }
+
     var triggers = this.options.trigger.split(' ')
 
     for (var i = triggers.length; i--;) {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -52,7 +52,7 @@
     this.options   = this.getOptions(options)
     this.$viewport = this.options.viewport && $(this.options.viewport.selector || this.options.viewport)
 
-    if (this.$element[0] instanceof window.Document && !this.options.selector) {
+    if (this.$element[0] instanceof document.constructor && !this.options.selector) {
       throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!');
     }
 


### PR DESCRIPTION
Alternative fix for #15484.
Makes `$(document).tooltip({...})` without specifying a `selector` option throw an explicit error, since not specifying a selector for delegation in this case is absurd.
