### PR TITLE
affix: clear {"position":"relative"} when unpinning (scrolling back up)

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -87,7 +87,7 @@
     var affix = this.getState(scrollHeight, height, offsetTop, offsetBottom)
 
     if (this.affixed != affix) {
-      if (this.unpin != null) this.$element.css('top', '')
+      if (this.unpin != null) this.$element.css({ position: '', top: '' })
 
       var affixType = 'affix' + (affix ? '-' + affix : '')
       var e         = $.Event(affixType + '.bs.affix')


### PR DESCRIPTION
{position:relative} is implicitly set on the DOM element during the switch
to affix-bottom (happens in the call to `this.$element.offset()`), so it
needs to be cleared when switching from affix-bottom back to affix.

Recycling a jsfiddle from another issue that also demonstrates the problem: http://jsfiddle.net/eqrvupcq/12/embedded/result/

If you scroll down to the bottom of page then scroll back up, the target
element jumps to the top of the screen and no longer works.
