### PR TITLE
Skip .disabled instead of .divider on dropdown keydown event

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -72,7 +72,7 @@
       return $this.trigger('click')
     }
 
-    var desc = ' li:not(.divider):visible a'
+    var desc = ' li:not(.disabled):visible a'
     var $items = $parent.find('[role="menu"]' + desc + ', [role="listbox"]' + desc)
 
     if (!$items.length) return

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -265,4 +265,25 @@ $(function () {
     $dropdown.click()
   })
 
+  test('should skip disabled element in a dropdown', function () {
+    var dropdownHTML = '<ul class="tabs">'
+        + '<li class="dropdown">'
+        + '<a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>'
+        + '<ul class="dropdown-menu" role="menu">'
+        + '<li class="disabled"><a href="#">Disabled link</a></li>'
+        + '<li><a href="#">Another link</a></li>'
+        + '</ul>'
+        + '</li>'
+        + '</ul>'
+    var $dropdown = $(dropdownHTML)
+      .appendTo('#qunit-fixture')
+      .find('[data-toggle="dropdown"]')
+      .bootstrapDropdown()
+      .click()
+
+    $dropdown.trigger($.Event('keydown', { which: 40 }))
+    $dropdown.trigger($.Event('keydown', { which: 40 }))
+
+    ok(!$(document.activeElement).parent().is('.disabled'), '.disabled is not focused')
+  })
 })


### PR DESCRIPTION
Thanks @ankurkaushal.

Fix #15147.
Closes #15281.
