### PR TITLE
Proposed fix for double-borders in justified button groups

### DIFF
--- a/docs/_includes/components/button-groups.html
+++ b/docs/_includes/components/button-groups.html
@@ -190,10 +190,6 @@
   <h3 id="btn-groups-justified">Justified button groups</h3>
   <p>Make a group of buttons stretch at equal sizes to span the entire width of its parent. Also works with button dropdowns within the button group.</p>
 
-  <div class="bs-callout bs-callout-warning" id="callout-btn-group-justified-dbl-border">
-    <h4>Handling borders</h4>
-    <p>Due to the specific HTML and CSS used to justify buttons (namely <code>display: table-cell</code>), the borders between them are doubled. In regular button groups, <code>margin-left: -1px</code> is used to stack the borders instead of removing them. However, <code>margin</code> doesn't work with <code>display: table-cell</code>. As a result, depending on your customizations to Bootstrap, you may wish to remove or re-color the borders.</p>
-  </div>
   <div class="bs-callout bs-callout-warning" id="callout-btn-group-ie8-border">
     <h4>IE8 and borders</h4>
     <p>Internet Explorer 8 doesn't render borders on buttons in a justified button group, whether it's on <code>&lt;a&gt;</code> or <code>&lt;button&gt;</code> elements. To get around that, wrap each button in another <code>.btn-group</code>.</p>

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -208,6 +208,10 @@
     display: table-cell;
     width: 1%;
   }
+  > .btn:not(:first-child),
+  > .btn:not(:first-child) .btn {
+    border-left: none;
+  }
   > .btn-group .btn {
     width: 100%;
   }

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -209,7 +209,7 @@
     width: 1%;
   }
   > .btn:not(:first-child),
-  > .btn:not(:first-child) .btn {
+  > .btn-group:not(:first-child) .btn {
     border-left: none;
   }
   > .btn-group .btn {


### PR DESCRIPTION
This fix works for all the examples in the docs (and my own application) in IE9+. The fix is null in IE8 dues to lack of `:not()` support – I though't I'd better put this out there in case I was missing an obvious caveat before working on IE8-compatible code (which would involve resetting all justified button left borders and re-applying them in the case of the first child).
