### PR TITLE
Add pointer to Masonry (& similar) in the Thumbnail docs

### DIFF
--- a/docs/_includes/components/thumbnails.html
+++ b/docs/_includes/components/thumbnails.html
@@ -2,6 +2,7 @@
   <h1 id="thumbnails" class="page-header">Thumbnails</h1>
 
   <p class="lead">Extend Bootstrap's <a href="../css/#grid">grid system</a> with the thumbnail component to easily display grids of images, videos, text, and more.</p>
+  <p>If you're looking for Pinterest-like presentation of thumbnails of varying heights and/or widths, you'll need to use a third-party plugin such as <a href="http://masonry.desandro.com">Masonry</a>, <a href="http://isotope.metafizzy.co">Isotope</a>, or <a href="http://salvattore.com">Salvattore</a>.</p>
 
   <h3 id="thumbnails-default">Default example</h3>
   <p>By default, Bootstrap's thumbnails are designed to showcase linked images with minimal required markup.</p>


### PR DESCRIPTION
Questions about how to achieve Masonry-style image layouts from folks who haven't heard of Masonry come up decently often on StackOverflow.
