### PR TITLE
Fix multiline tooltips, by not allowing them

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -12,6 +12,7 @@
   font-size: @font-size-small;
   line-height: 1.4;
   .opacity(0);
+  white-space: nowrap;
 
   &.in     { .opacity(@tooltip-opacity); }
   &.top    { margin-top:  -3px; padding: @tooltip-arrow-width 0; }


### PR DESCRIPTION
This problem, the little arrow is in the middle of the tooltip. This is clearly not okay. So here is a rather crude fix by just forcing a single line of content in tooltips.

![bootstrap](https://cloud.githubusercontent.com/assets/1162278/5686380/a3f90c9a-9842-11e4-8a57-cf514b7ab2be.png)
