### PR TITLE
Remove #13892's entry from the Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -102,16 +102,6 @@
   browser: >
     Chrome
   summary: >
-    `<input type="password">` sporadically causes bad widths on floated elements.
-  upstream_bug: >
-    Chromium#377346
-  origin: >
-    Bootstrap#13892
-
--
-  browser: >
-    Chrome
-  summary: >
     CSS infinite linear animation with alpha transparency leaks memory.
   upstream_bug: >
     Chromium#429375


### PR DESCRIPTION
http://crbug.com/377346 is claimed to be fixed in Chrome 41
Refs #13892, #14037.
