### PR TITLE
Fix table-striped to work with bootstraps tooltips on rows

### DIFF
--- a/less/tables.less
+++ b/less/tables.less
@@ -111,7 +111,7 @@ th {
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
 .table-striped {
-  > tbody > tr:nth-child(odd) {
+  > tbody > tr:nth-of-type(odd) {
     background-color: @table-bg-accent;
   }
 }


### PR DESCRIPTION
Reported in this issue https://github.com/twbs/bootstrap/issues/6420

This fixes having popovers and tooltips on rows in a .table-striped table
The issue was that popovers add a div after the element which was changing the ordering of the striping
