### PR TITLE
Use strict mode in jQuery version check module. Closes #15535

### DIFF
--- a/grunt/configBridge.json
+++ b/grunt/configBridge.json
@@ -34,6 +34,7 @@
     ],
     "jqueryVersionCheck": [
       "+function ($) {",
+      "  'use strict';",
       "  var version = $.fn.jquery.split(' ')[0].split('.')",
       "  if ((version[0] < 2 && version[1] < 9) || (version[0] == 1 && version[1] == 9 && version[2] < 1)) {",
       "    throw new Error('Bootstrap\\'s JavaScript requires jQuery version 1.9.1 or higher')",


### PR DESCRIPTION
This PR adds strict mode declaration missing in jQuery version check module which is inserted at runtime via Grunt tasks to distribution source code. Missing `use strict` missed JSHint code checks as it is part of content not covered by JSHint tests.

After build the non-minified distribution file will look like:

``` diff
diff --git a/dist/js/bootstrap.js b/dist/js/bootstrap.js
index 42e92bf..ab0ae1e 100644
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -9,6 +9,7 @@ if (typeof jQuery === 'undefined') {
 }

 +function ($) {
+  'use strict';
   var version = $.fn.jquery.split(' ')[0].split('.')
   if ((version[0] < 2 && version[1] < 9) || (version[0] == 1 && version[1] == 9 && version[2] < 1)) {
     throw new Error('Bootstrap\'s JavaScript requires jQuery version 1.9.1 or higher')
```

and version check module will look like:

``` JavaScript
+function ($) {
  'use strict';
  var version = $.fn.jquery.split(' ')[0].split('.')
  if ((version[0] < 2 && version[1] < 9) || (version[0] == 1 && version[1] == 9 && version[2] < 1)) {
    throw new Error('Bootstrap\'s JavaScript requires jQuery version 1.9.1 or higher')
  }
}(jQuery);
```

Thanks!
