### PR TITLE
Don't cycle carousel when the page isn't visible

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -59,7 +59,11 @@
 
     this.options.interval
       && !this.paused
-      && (this.interval = setInterval($.proxy(this.next, this), this.options.interval))
+      && (this.interval = setInterval(
+        // Make use of Page Visibility API when it's available
+        $.proxy(document.visibilityState ? this.nextWhenVisible : this.next, this),
+        this.options.interval
+      ))
 
     return this
   }
@@ -102,6 +106,15 @@
     this.interval = clearInterval(this.interval)
 
     return this
+  }
+
+  Carousel.prototype.nextWhenVisible = function () {
+    // Don't advance when the page isn't visible to the user.
+    // Saves the browser from doing unnecessary work and gives better UX.
+    // Also works around a Chrome bug: https://github.com/twbs/bootstrap/issues/15298
+    if (!document.hidden) {
+      this.next()
+    }
   }
 
   Carousel.prototype.next = function () {


### PR DESCRIPTION
This uses the [Page Visibility](www.w3.org/TR/page-visibility/) API (when available) to stop cycling the carousel when the page is hidden (e.g. in an inactive tab, minimized window, etc.).
This seems like better UX and also improves perf when the page is hidden (browser has less work to do).
This also addresses #15298 by not sliding while the page is hidden in Chrome in the first place (thus preventing the problematic situation from occurring).
