### PR TITLE
Reset height for form-group-* textarea

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -147,7 +147,9 @@ output {
   }
 
   // Reset height for `textarea`s
-  textarea& {
+  textarea&,
+  .form-group-sm textarea&,
+  .form-group-lg textarea& {
     height: auto;
   }
 }


### PR DESCRIPTION
Because of css specificity textarea won't reset to **height: auto** when the parent is **.form-group-sm** or **.form-group-lg**.
Please take a look here: http://www.bootply.com/nuSb245tba
Thanks!
