### PR TITLE
Reset height for form-group-* textarea

### DIFF
--- a/less/mixins/forms.less
+++ b/less/mixins/forms.less
@@ -79,7 +79,8 @@
   }
 
   textarea&,
-  select[multiple]& {
+  select[multiple]&,
+  &:not(input):not(select) {
     height: auto;
   }
 }


### PR DESCRIPTION
Because of css specificity textarea won't reset to height: auto when the parent is .form-group-sm or .form-group-lg.
Please take a look here: http://www.bootply.com/nuSb245tba

I hope this helps. You can close #15592

Also we have to keep in mind that this mixin output this:
line 81: **textarea&**
become: **textarea.form-group-lg .form-control**
and it's not fine :)

Thanks!
