### PR TITLE
Added whitespace between button-groups selectors

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -8,9 +8,11 @@
   position: relative;
   display: inline-block;
   vertical-align: middle; // match .btn alignment given font-size hack above
+  
   > .btn {
     position: relative;
     float: left;
+    
     // Bring the "active" button to the front
     &:hover,
     &:focus,
@@ -40,6 +42,7 @@
   .input-group {
     float: left;
   }
+  
   > .btn,
   > .btn-group,
   > .input-group {
@@ -54,6 +57,7 @@
 // Set corners individual because sometimes a single button can be in a .btn-group and we need :first-child and :last-child to both match
 .btn-group > .btn:first-child {
   margin-left: 0;
+  
   &:not(:last-child):not(.dropdown-toggle) {
     .border-right-radius(0);
   }
@@ -105,6 +109,7 @@
   padding-left: 8px;
   padding-right: 8px;
 }
+
 .btn-group > .btn-lg + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px;
@@ -126,11 +131,13 @@
 .btn .caret {
   margin-left: 0;
 }
+
 // Carets in other button sizes
 .btn-lg .caret {
   border-width: @caret-width-large @caret-width-large 0;
   border-bottom-width: 0;
 }
+
 // Upside down carets for .dropup
 .dropup .btn-lg .caret {
   border-width: 0 @caret-width-large @caret-width-large;
@@ -153,6 +160,7 @@
   // Clear floats so dropdown menus can be properly placed
   > .btn-group {
     &:extend(.clearfix all);
+    
     > .btn {
       float: none;
     }
@@ -171,24 +179,29 @@
   &:not(:first-child):not(:last-child) {
     border-radius: 0;
   }
+  
   &:first-child:not(:last-child) {
     border-top-right-radius: @border-radius-base;
     .border-bottom-radius(0);
   }
+  
   &:last-child:not(:first-child) {
     border-bottom-left-radius: @border-radius-base;
     .border-top-radius(0);
   }
 }
+
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
+
 .btn-group-vertical > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
     .border-bottom-radius(0);
   }
 }
+
 .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
   .border-top-radius(0);
 }
@@ -202,12 +215,14 @@
   width: 100%;
   table-layout: fixed;
   border-collapse: separate;
+  
   > .btn,
   > .btn-group {
     float: none;
     display: table-cell;
     width: 1%;
   }
+  
   > .btn-group .btn {
     width: 100%;
   }


### PR DESCRIPTION
More consistent whitespace between selectors. Some selectors had no blank line before them, others did have one. Made sure all selectors had a blank line before them to improve readability.
