### PR TITLE
Fixes #15561: Badges not being resized inside .btn-group-xs

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -29,7 +29,7 @@
     top: -1px;
   }
 
-  .btn-xs & {
+  .btn-xs &, .btn-group-xs > .btn & {
     top: 0;
     padding: 1px 5px;
   }

--- a/less/badges.less
+++ b/less/badges.less
@@ -29,7 +29,8 @@
     top: -1px;
   }
 
-  .btn-xs &, .btn-group-xs > .btn & {
+  .btn-xs &,
+  .btn-group-xs > .btn & {
     top: 0;
     padding: 1px 5px;
   }


### PR DESCRIPTION
Fix issue twbs/bootstrap#15561 regarding how `.btn-group-xs` does not shrink badges (`.badge`) in subsequent `.btn`
