### PR TITLE
Fix error in condition in Tab plugin

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -88,7 +88,7 @@
         element.removeClass('fade')
       }
 
-      if (element.parent('.dropdown-menu')) {
+      if (element.parent('.dropdown-menu').length) {
         element
           .closest('li.dropdown')
             .addClass('active')


### PR DESCRIPTION
`if (someJqueryObject)` is a tautology.
Refs #15186.
