### PR TITLE
Fix tooltip destroy method memory leak

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -436,8 +436,8 @@
     clearTimeout(this.timeout)
     this.hide(function () {
       that.$element.off('.' + that.type).removeData('bs.' + that.type)
-	  that.$tip = null
-	  that.$arrow = null
+      that.$tip = null
+      that.$arrow = null
     })
   }
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -436,6 +436,8 @@
     clearTimeout(this.timeout)
     this.hide(function () {
       that.$element.off('.' + that.type).removeData('bs.' + that.type)
+	  that.$tip = null
+	  that.$arrow = null
     })
   }
 


### PR DESCRIPTION
...p and $arrow. Memory-leak detected by Chrome inspector.
