### PR TITLE
Add @jumbotron-margin-top LESS variable

### DIFF
--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -6,6 +6,7 @@
 .jumbotron {
   padding: @jumbotron-padding (@jumbotron-padding / 2);
   margin-bottom: @jumbotron-padding;
+  margin-top: @jumbotron-margin-top;
   color: @jumbotron-color;
   background-color: @jumbotron-bg;
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -480,6 +480,9 @@
 @jumbotron-bg:                   @gray-lighter;
 @jumbotron-heading-color:        inherit;
 @jumbotron-font-size:            ceil((@font-size-base * 1.5));
+//set this to -@navbar-margin-bottom if you want to position the jumbotron
+//right next to the navbar
+@jumbotron-margin-top:           initial;
 
 
 //== Form states and alerts


### PR DESCRIPTION
Let's start with a problem. Take a look at your basic [jumbotron example](http://getbootstrap.com/examples/jumbotron/) and change one thing: use `.navbar-static-top` instead of `.navbar-fixed-top`. This is what it looks like: 

![Bootstrap jumbotron example with `.navbar-static-top`](http://i.imgur.com/kZ2ngl5.png)

The white space above the navbar is there because in the jumbotron example, the body has a `padding-top` of 50px to line up the jumbotron with the navbar. However, this only worked because with `.navbar-fixed-top` the navbar was not affected by the padding. Now with `.navbar-static-top` we can no longer use this trick. So let's remove the body padding:

![Bootstrap jumbotron example with `.navbar-static-top` and no body padding](http://i.imgur.com/Ht6ZLTb.png)

Now there is just the margin from the navbar to deal with.  The way I see it, there is two ways to go about it:
 **A:** Add a negative `margin-top` on the jumbotron equivalent to the `margin-bottom` of the navbar.
 **B**: Remove the `margin-bottom` from the navbar.

**A** is bad because it means we have to set an absolute value, which means that in the event of any changes to the navbar margin, we must remember the change to jumbotron margin. **B** is bad because it means you can't use the same html for the jumbotron page as non-jumbotron pages (and most web implementations do like to reuse the navbar  code on all pages). 

But how nice would it be if there was a `@jumbotron-margin-top` variable in less so you could just add `@jumbotron-margin-top: -@navbar-margin-bottom;` to your variables file and forget about it?
