### PR TITLE
Add woff2 font file to bower main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "dist/fonts/glyphicons-halflings-regular.eot",
     "dist/fonts/glyphicons-halflings-regular.svg",
     "dist/fonts/glyphicons-halflings-regular.ttf",
-    "dist/fonts/glyphicons-halflings-regular.woff"
+    "dist/fonts/glyphicons-halflings-regular.woff",
+    "dist/fonts/glyphicons-halflings-regular.woff2"
   ],
   "ignore": [
     "/.*",


### PR DESCRIPTION
If Bootstrap is installed through bower, the woff2 font file may not be
copied over as it's not in the "main" files. The LESS files still
reference the font file which results in errors.
