### PR TITLE
Make btn-groups in form-groups 100% just like any other input thing

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -241,3 +241,7 @@
     }
   }
 }
+
+.form-group > .btn-group {
+    width: 100%;
+}


### PR DESCRIPTION
This way it won't be right of the label when the group is small.
