### PR TITLE
Fixes #15672: Add support for tables to the collapse plugin

### DIFF
--- a/less/component-animations.less
+++ b/less/component-animations.less
@@ -22,6 +22,7 @@
   &.in      { display: block; visibility: visible; }
   tr&.in    { display: table-row; }
   tbody&.in { display: table-row-group; }
+  table&.in { display: table; }
 }
 
 .collapsing {


### PR DESCRIPTION
Fixes #15672 taking as base a similar fix for `tbody` and `tr`
