### PR TITLE
Add dataBinder support to Tooltip and Popover setContent

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -50,6 +50,10 @@
       this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
     ](content)
 
+   if ($.isFunction(this.options.dataBinding)) {
+      this.options.dataBinder($tip);
+    }
+
     $tip.removeClass('fade top bottom left right in')
 
     // IE8 doesn't accept hiding via the `:empty` pseudo selector, we have to do

--- a/js/popover.js
+++ b/js/popover.js
@@ -50,7 +50,7 @@
       this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
     ](content)
 
-    if ($.isFunction(this.options.dataBinding)) {
+    if ($.isFunction(this.options.dataBinder)) {
       this.options.dataBinder($tip);
     }
 

--- a/js/popover.js
+++ b/js/popover.js
@@ -50,7 +50,7 @@
       this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
     ](content)
 
-   if ($.isFunction(this.options.dataBinding)) {
+    if ($.isFunction(this.options.dataBinding)) {
       this.options.dataBinder($tip);
     }
 

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -188,18 +188,10 @@ $(function () {
     equal($('.popover').length, 0, 'popover was removed')
   })
 
-  test('should detach popover content rather than removing it so that event handlers are left intact', function (assert) {
-    var $content = $('<div class="content-with-handler"><a class="btn btn-warning">Button with event handler</a></div>').appendTo('#qunit-fixture')
-
-    var handlerCalled = false
-    $('.content-with-handler .btn').click(function () {
-      handlerCalled = true
-    })
-
   test('should call dataBinder', function () {
     var testBinder = function (pop) {
-      var $content = $(pop).find('.popover-content'),
-          $title = $(pop).find('.popover-title')
+      var $content = $(pop).find('.popover-content')
+      var $title = $(pop).find('.popover-title')
       $title.text($title.text().replace('{{things}}', 'DATA'))
       $content.text($content.text().replace('{{stuff}}', 'BOUND'))
     };
@@ -221,7 +213,15 @@ $(function () {
     $popover.bootstrapPopover('hide')
     equal($('.popover').length, 0, 'popover was removed')
   })
-  
+
+  test('should detach popover content rather than removing it so that event handlers are left intact', function (assert) {
+    var $content = $('<div class="content-with-handler"><a class="btn btn-warning">Button with event handler</a></div>').appendTo('#qunit-fixture')
+
+    var handlerCalled = false
+    $('.content-with-handler .btn').click(function () {
+      handlerCalled = true
+    })
+
     var $div = $('<div><a href="#">Show popover</a></div>')
       .appendTo('#qunit-fixture')
       .bootstrapPopover({

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -203,13 +203,14 @@ $(function () {
       $title.text($title.text().replace('{{things}}', 'DATA'))
       $content.text($content.text().replace('{{stuff}}', 'BOUND'))
     };
+
     var $popover = $('<a href="#">@idisposable</a>')
-        .appendTo('#qunit-fixture')
-        .bootstrapPopover({
-          title: 'Test {{things}}',
-          content: 'Test {{stuff}}',
-          dataBinder: testBinder
-        })
+      .appendTo('#qunit-fixture')
+      .bootstrapPopover({
+        title: 'Test {{things}}',
+        content: 'Test {{stuff}}',
+        dataBinder: testBinder
+      })
 
     $popover.bootstrapPopover('show')
 

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -117,7 +117,6 @@ $(function () {
     equal($('.popover').length, 0, 'popover was removed')
   })
 
-
   test('should get title and content from attributes ignoring options passed via js', function () {
     var $popover = $('<a href="#" title="@mdo" data-content="loves data attributes (づ｡◕‿‿◕｡)づ ︵ ┻━┻" >@mdo</a>')
       .appendTo('#qunit-fixture')
@@ -189,26 +188,31 @@ $(function () {
   })
 
   test('should call dataBinder', function () {
+    var wasCalled = false
     var testBinder = function (pop) {
-      var $content = $(pop).find('.popover-content')
-      var $title = $(pop).find('.popover-title')
-      $title.text($title.text().replace('{{things}}', 'DATA'))
-      $content.text($content.text().replace('{{stuff}}', 'BOUND'))
+      wasCalled = true
+      var $pop = $(pop)
+      var $title = $pop.find('.popover-title')
+      $title.text('Title DATA')
+
+      var $content = $pop.find('.popover-content')
+      $content.text('Content BOUND')
     };
 
     var $popover = $('<a href="#">@idisposable</a>')
       .appendTo('#qunit-fixture')
       .bootstrapPopover({
-        title: 'Test {{things}}',
-        content: 'Test {{stuff}}',
+        title: 'Title {{things}}',
+        content: 'Content {{stuff}}',
         dataBinder: testBinder
       })
 
     $popover.bootstrapPopover('show')
 
     notEqual($('.popover').length, 0, 'popover was inserted')
-    equal($('.popover .popover-title').text(), 'Test DATA', 'title correctly dataBound')
-    equal($('.popover .popover-content').text(), 'Test BOUND', 'content correctly dataBound')
+    ok(wasCalled, 'dataBinder was called')
+    equal($('.popover .popover-title').text(), 'Title DATA', 'title correctly dataBound')
+    equal($('.popover .popover-content').text(), 'Content BOUND', 'content correctly dataBound')
 
     $popover.bootstrapPopover('hide')
     equal($('.popover').length, 0, 'popover was removed')

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -197,19 +197,19 @@ $(function () {
     })
 
   test('should call dataBinder', function () {
-    var testBinder = function(pop) {
+    var testBinder = function (pop) {
       var $content = $(pop).find('.popover-content'),
           $title = $(pop).find('.popover-title')
       $title.text($title.text().replace('{{things}}', 'DATA'))
       $content.text($content.text().replace('{{stuff}}', 'BOUND'))
     };
     var $popover = $('<a href="#">@idisposable</a>')
-      .appendTo('#qunit-fixture')
-      .bootstrapPopover({
-        title: 'Test {{things}}',
-        content: 'Test {{stuff}}',
-        dataBinder: testBinder
-      })}
+        .appendTo('#qunit-fixture')
+        .bootstrapPopover({
+          title: 'Test {{things}}',
+          content: 'Test {{stuff}}',
+          dataBinder: testBinder
+        })
 
     $popover.bootstrapPopover('show')
 

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -196,6 +196,31 @@ $(function () {
       handlerCalled = true
     })
 
+  test('should call dataBinder', function () {
+    var testBinder = function(pop) {
+      var $content = $(pop).find('.popover-content'),
+          $title = $(pop).find('.popover-title')
+      $title.text($title.text().replace('{{things}}', 'DATA')
+      $content.text($context.text().replace('{{stuff}}', 'BOUND')
+    };
+    var $popover = $('<a href="#">@idisposable</a>')
+      .appendTo('#qunit-fixture')
+      .bootstrapPopover({
+        title: 'Test {{things}}',
+        content: 'Test {{stuff}}',
+        dataBinder: testBinder
+      })}
+
+    $popover.bootstrapPopover('show')
+
+    notEqual($('.popover').length, 0, 'popover was inserted')
+    equal($('.popover .popover-title').text(), 'Test DATA', 'title correctly dataBound')
+    equal($('.popover .popover-content').text(), 'Test BOUND', 'content correctly dataBound')
+
+    $popover.bootstrapPopover('hide')
+    equal($('.popover').length, 0, 'popover was removed')
+  })
+  
     var $div = $('<div><a href="#">Show popover</a></div>')
       .appendTo('#qunit-fixture')
       .bootstrapPopover({

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -200,8 +200,8 @@ $(function () {
     var testBinder = function(pop) {
       var $content = $(pop).find('.popover-content'),
           $title = $(pop).find('.popover-title')
-      $title.text($title.text().replace('{{things}}', 'DATA')
-      $content.text($context.text().replace('{{stuff}}', 'BOUND')
+      $title.text($title.text().replace('{{things}}', 'DATA'))
+      $content.text($content.text().replace('{{stuff}}', 'BOUND'))
     };
     var $popover = $('<a href="#">@idisposable</a>')
       .appendTo('#qunit-fixture')

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -282,6 +282,10 @@
     var $tip  = this.tip()
     var title = this.getTitle()
 
+    if ($.isFunction(this.options.dataBinder)) {
+      this.options.dataBinder($tip);
+    }
+
     $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
     $tip.removeClass('fade in top bottom left right')
   }


### PR DESCRIPTION
Add the ability to set a binder in the **Tooltip** & **Popover** `options` to support data-binding of the created DOM in `setContent`. This allows having binding expressions in the template that will be applied as the tooltip/popover is created during the show event.  This can be used by setting the dataBinder to a function that will apply bindings. Since the DOM elements are not created until the tooltip is shown, the best place for this seems to be set `setContent` method.

An example of the use of this it for knockout binds, here we create a knockout binding that hooks itself up:

``` javascript
     ko.bindingHandlers.popover = {
         init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
            var options = $.extend({ disabled: false }, ko.toJS(valueAccessor()));
            ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
                $(element).popover('destroy');
            });
         },
         update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
            var $element = $(element);
            var options = $.extend({ disabled: false }, ko.toJS(valueAccessor()));
            $element.popover('destroy');
            if (options.disabled)
                return;

            options.dataBinder = function ($tip) {
                ko.cleanNode($tip[0]);
                $tip.applyBindings(viewModel);
            };
            $element.popover(options);
         }
     };
```
