### PR TITLE
Fix name of Tooltip.replaceArrow() parameter

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -272,10 +272,10 @@
     this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], isVertical)
   }
 
-  Tooltip.prototype.replaceArrow = function (delta, dimension, isHorizontal) {
+  Tooltip.prototype.replaceArrow = function (delta, dimension, isVertical) {
     this.arrow()
-      .css(isHorizontal ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
-      .css(isHorizontal ? 'top' : 'left', '')
+      .css(isVertical ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
+      .css(isVertical ? 'top' : 'left', '')
   }
 
   Tooltip.prototype.setContent = function () {


### PR DESCRIPTION
`isHorizontal` => `isVertical`
The one place where we call this function, it is passed `isVertical` as an argument, not `isHorizontal`.
