### PR TITLE
Proposal for well.ls

### DIFF
--- a/less/wells.less
+++ b/less/wells.less
@@ -16,6 +16,9 @@
     border-color: #ddd;
     border-color: rgba(0,0,0,.15);
   }
+  .form-group:last-of-type {
+		margin-bottom: 0px;	// was '15ì
+	}
 }
 
 // Sizes


### PR DESCRIPTION
Well already have an internal padding of 10px.

Every form-group has a 15px of margin-bottom, but this create a total of 25px of margin beetween last form group and the bottom border of the .well container.

Using this, reduces vertical space needed and .well itself is more simmetric
