### PR TITLE
tip method in popover.js can be removed

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -75,11 +75,6 @@
     return (this.$arrow = this.$arrow || this.tip().find('.arrow'))
   }
 
-  Popover.prototype.tip = function () {
-    if (!this.$tip) this.$tip = $(this.options.template)
-    return this.$tip
-  }
-
 
   // POPOVER PLUGIN DEFINITION
   // =========================


### PR DESCRIPTION
Popover is extend Tooltip, the tip function can use tootltip's tip, so we can remove the tip function definition in popover to reduce the js filesize

tip function definition in tooltip.js https://github.com/twbs/bootstrap/blob/master/js/tooltip.js#L405-L407
