### PR TITLE
[Fix Issue #15682] .caret is smaller in Firefox than other browsers

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -10,7 +10,7 @@
   height: 0;
   margin-left: 2px;
   vertical-align: middle;
-  border-top:   @caret-width-base solid;
+  border-top:   @caret-width-base dashed;
   border-right: @caret-width-base solid transparent;
   border-left:  @caret-width-base solid transparent;
 }


### PR DESCRIPTION
[Fix Issue twbs/bootstrap#15682] .caret is smaller in Firefox than other browsers
