### PR TITLE
Official Meteor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Four quick start options are available:
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`.
 - Install with [Bower](http://bower.io): `bower install bootstrap`.
 - Install with [npm](https://www.npmjs.org): `npm install bootstrap`.
+- Install with [Meteor](https://www.meteor.com/): `meteor add twbs:bootstrap`.
 
 Read the [Getting started page](http://getbootstrap.com/getting-started/) for information on the framework contents, templates and examples, and more.
 

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
-	api.use('jquery');
+	api.use('jquery', 'client');
   api.addFiles([
     'dist/fonts/glyphicons-halflings-regular.eot',
     'dist/fonts/glyphicons-halflings-regular.svg',

--- a/package.js
+++ b/package.js
@@ -1,0 +1,22 @@
+// package metadata file for Meteor.js
+
+Package.describe({
+  name: 'twbs:bootstrap',  // http://atmospherejs.com/twbs/bootstrap
+  summary: 'The most popular front-end framework for developing responsive, mobile first projects on the web.',
+  version: '3.3.2',
+  git: 'https://github.com/twbs/bootstrap.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0');
+	api.use('jquery');
+  api.addFiles([
+    'dist/fonts/glyphicons-halflings-regular.eot',
+    'dist/fonts/glyphicons-halflings-regular.svg',
+    'dist/fonts/glyphicons-halflings-regular.ttf',
+    'dist/fonts/glyphicons-halflings-regular.woff',
+    'dist/fonts/glyphicons-halflings-regular.woff2',
+    'dist/css/bootstrap.css',
+    'dist/js/bootstrap.js',
+  ], 'client');
+});

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
-	api.use('jquery', 'client');
+  api.use('jquery', 'client');
   api.addFiles([
     'dist/fonts/glyphicons-halflings-regular.eot',
     'dist/fonts/glyphicons-halflings-regular.svg',


### PR DESCRIPTION
Hello guys,

As you might know, the [Meteor](https://www.meteor.com/) community is widely using Bootstrap. We had many different wrapper packages all doing the same thing, so I'm submitting a PR that integrates Meteor packaging directly into your repository: at the end of this merge process, in case you'll find yourself comfortable with it, we'll get automated new meteor package releases at every new release of Bootstrap.

I'm aware of the [previous attempt](https://github.com/twbs/bootstrap/pull/15376) made by @dandv, but I've made this one as lean as possible so not to pick up too much space within your repository: basically it adds only a `pacakge.js` file among the ones already present for the other PMs. This should be not too much pretending.

All you have to do after accepting this PR would be:
1. create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and we'll add you as a maintainer of the `twbs` organization (which has been alredy reserved to make things simpler for you).
2. head to [autopublish.meteor.com](http://autopublish.meteor.com/) sign in with your gitHub account, locate this repository and enable it for autopublish by toggling the checkbox you'll find on the right side of the repository item. You can get an idea about how Meteor Autopublish works by having a quick look at [this page](http://autopublish.meteor.com/howitworks), but basically it creates a [web hook](https://help.github.com/articles/about-webhooks/) to let us know when you push new tags. And when you'll release new versions, autopublish.meteor.com will automatically take delivery for publishing the new version also for Meteor!

Please note that you will not be able to toggle your repository until you'll have the `package.js` file on your master branch.

Please also note that we've already published the current version of the package on [Atmosphere](https://atmospherejs.com/twbs/bootstrap) (Meteor's package directory) under the name `twbs:bootstrap`. 
But if you think another name would be a better fit, just let us know!

Thanks in advance for your availability and collaboration and congratulation for the awesome project!
Luca & the [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)
