### PR TITLE
Fix syntax error: replace semicolon with comma

### DIFF
--- a/docs/_includes/css/less.html
+++ b/docs/_includes/css/less.html
@@ -431,16 +431,16 @@ a {
   <p>Specify the dimensions of an object more easily.</p>
 {% highlight scss %}
 // Mixins
-.size(@width; @height) {
+.size(@width, @height) {
   width: @width;
   height: @height;
 }
 .square(@size) {
-  .size(@size; @size);
+  .size(@size, @size);
 }
 
 // Usage
-.image { .size(400px; 300px); }
+.image { .size(400px, 300px); }
 .avatar { .square(48px); }
 {% endhighlight %}
 


### PR DESCRIPTION
It looks like in the documentation of Using Less -> Utility mixins, there was semicolon in place of comma. So, I have corrected that at every place.
