### PR TITLE
[Fix Issue #15737] Display of div wrapped Tooltip on disabled elements and btn-group

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -18,6 +18,9 @@
     &.active {
       z-index: 2;
     }
+  > div {
+    display: inline-block;
+    }
   }
 }
 

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -18,9 +18,9 @@
     &.active {
       z-index: 2;
     }
+  }
   > div {
     display: inline-block;
-    }
   }
 }
 


### PR DESCRIPTION
[Fix Issue #15737] Tooltip on disabled elements and btn-group

Fix the display of a div within a button group.
