### PR TITLE
[Fix Issue #15701] [Docs] Tooltip/popover destroy docs and delegation

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -264,7 +264,7 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
   {% highlight js %}$('#element').popover('toggle'){% endhighlight %}
 
   <h4>.popover('destroy')</h4>
-  <p>Hides and destroys an element's popover.</p>
+  <p>Popovers that use delegation (which are created using <a href="#popovers-options">the <code>selector</code> option</a>) cannot be individually destroyed on descendant trigger elements.</p>
   {% highlight js %}$('#element').popover('destroy'){% endhighlight %}
 
   <h3 id="popovers-events">Events</h3>

--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -225,7 +225,7 @@ $('#example').tooltip(options)
   {% highlight js %}$('#element').tooltip('toggle'){% endhighlight %}
 
   <h4>.tooltip('destroy')</h4>
-  <p>Hides and destroys an element's tooltip.</p>
+  <p>Tooltips that use delegation (which are created using <a href="#tooltips-options">the <code>selector</code> option</a>) cannot be individually destroyed on descendant trigger elements.</p>
   {% highlight js %}$('#element').tooltip('destroy'){% endhighlight %}
 
   <h3 id="tooltips-events">Events</h3>


### PR DESCRIPTION
[Fix Issue #15701] Tooltip/popover destroy docs don't explain the delegation case.
