### PR TITLE
Fix #15706: navbar-text margin right in top fixed fluid container

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -118,6 +118,12 @@
   }
 }
 
+.container-fluid {
+  > .navbar-text.navbar-right:last-child {
+    margin-right: 0;
+  }
+}
+
 
 //
 // Navbar alignment options


### PR DESCRIPTION
Fixes #15706 navbar-text margin right in top fixed fluid container

Build failed due to Travis Error. Please trigger rebuild:

``` shell
Loading "autoprefixer.js" tasks...ERROR
>> Error: Cannot find module 'ansi-regex'
Warning: Task "autoprefixer:core" not found. Use --force to continue.
```
