### PR TITLE
Removed   visibility: hidden !important from .hidden class

### DIFF
--- a/less/utilities.less
+++ b/less/utilities.less
@@ -44,7 +44,6 @@
 
 .hidden {
   display: none !important;
-  visibility: hidden !important;
 }
 
 


### PR DESCRIPTION
  This .hidden was taken from HTML 5 Boilerplate and yesterday we discussed on twitter that visibility: hidden !important can be removed now. https://twitter.com/jitendravyas/status/562940090553733121
