### PR TITLE
do not trim trailing whitespace on markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.md]
+trim_trailing_whitespace = false
+
 [*.py]
 indent_size = 4


### PR DESCRIPTION
to preserve line breaks with two spaces
