### PR TITLE
[Fixes #15799] btn-group should have overflow: hidden added to it

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -21,6 +21,10 @@
   }
 }
 
+.btn-group {
+  overflow: hidden;
+}
+
 // Prevent double borders when buttons are next to each other
 .btn-group {
   .btn + .btn,


### PR DESCRIPTION
[Fixes #15799] btn-group should have overflow: hidden added to it
