### PR TITLE
Include dist/ files in language stats on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 *.md    text eol=lf
 *.svg   text eol=lf
 *.yml   text eol=lf
+
+bootstrap-theme.css linguist-vendored=false
+bootstrap.css linguist-vendored=false
+bootstrap.js linguist-vendored=false


### PR DESCRIPTION
GitHub considers Bootstrap files to be vendored files, and excludes them from repository language statistics. This makes sense for most repositories, where Bootstrap is indeed third-party code. This repository is the exception; it's first-party code here, so should count toward the language statistics.

/cc @mdo
