### PR TITLE
[Fixes #15825] .initialism class should use mixin

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -238,7 +238,7 @@ abbr[data-original-title] {
 }
 .initialism {
   font-size: 90%;
-  text-transform: uppercase;
+  .text-uppercase();
 }
 
 // Blockquotes


### PR DESCRIPTION
[Fixes #15825] .initialism class should use text-uppercase() LESS mixin.
