### PR TITLE
Fixing issue where modal backdrop doesnt show

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -65,6 +65,7 @@
   position: absolute;
   top: 0;
   right: 0;
+  bottom: 0;
   left: 0;
   background-color: @modal-backdrop-bg;
   // Fade for backdrop


### PR DESCRIPTION
The modal backdrop shows as 0 height which means it isn't visible. This was removed in https://github.com/twbs/bootstrap/commit/14e5fb04e9bf7c406b799b75b0427522d87a4ccb but its not obvious why (and it does break stuff).  Further discussion on this commit.
