### PR TITLE
No need to specify class="embed-responsive-item" on the iframe

### DIFF
--- a/docs/_includes/components/responsive-embed.html
+++ b/docs/_includes/components/responsive-embed.html
@@ -12,12 +12,12 @@
 {% highlight html %}
 <!-- 16:9 aspect ratio -->
 <div class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item" src="..."></iframe>
+  <iframe src="..."></iframe>
 </div>
 
 <!-- 4:3 aspect ratio -->
 <div class="embed-responsive embed-responsive-4by3">
-  <iframe class="embed-responsive-item" src="..."></iframe>
+  <iframe src="..."></iframe>
 </div>
 {% endhighlight %}
 </div>


### PR DESCRIPTION
Why? See https://github.com/twbs/bootstrap/blob/v3.3.2/less/responsive-embed.less#L12
