### PR TITLE
Use OS X 10.10 for Sauce iPhone simulator

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -56,7 +56,7 @@
 
   {
     browserName: "iphone",
-    platform: "OS X 10.9",
+    platform: "OS X 10.10",
     version: "8.1"
   },
 


### PR DESCRIPTION
Sauce's autoconfigurator now recommends OS X 10.10 for its iPhone testing configurations.
