### PR TITLE
Wrap breadcrumbs with <nav>

### DIFF
--- a/docs/_includes/components/breadcrumbs.html
+++ b/docs/_includes/components/breadcrumbs.html
@@ -4,24 +4,32 @@
   <p class="lead">Indicate the current page's location within a navigational hierarchy.</p>
   <p>Separators are automatically added in CSS through <code>:before</code> and <code>content</code>.</p>
   <div class="bs-example" data-example-id="simple-breadcrumbs">
-    <ol class="breadcrumb">
-      <li class="active">Home</li>
-    </ol>
-    <ol class="breadcrumb">
-      <li><a href="#">Home</a></li>
-      <li class="active">Library</li>
-    </ol>
-    <ol class="breadcrumb">
-      <li><a href="#">Home</a></li>
-      <li><a href="#">Library</a></li>
-      <li class="active">Data</li>
-    </ol>
+    <nav aria-label="breadcrumb navigation">
+      <ol class="breadcrumb">
+        <li class="active">Home</li>
+      </ol>
+    </nav>
+    <nav aria-label="breadcrumb navigation">
+      <ol class="breadcrumb">
+        <li><a href="#">Home</a></li>
+        <li class="active">Library</li>
+      </ol>
+    </nav>
+    <nav aria-label="breadcrumb navigation">
+      <ol class="breadcrumb">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Library</a></li>
+        <li class="active">Data</li>
+      </ol>
+    </nav>
   </div>
 {% highlight html %}
-<ol class="breadcrumb">
-  <li><a href="#">Home</a></li>
-  <li><a href="#">Library</a></li>
-  <li class="active">Data</li>
-</ol>
+<nav aria-label="breadcrumb navigation">
+  <ol class="breadcrumb">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Library</a></li>
+    <li class="active">Data</li>
+  </ol>
+</nav>
 {% endhighlight %}
 </div>


### PR DESCRIPTION
This pull request wraps the breadcrumb component in a `<nav>` element per recommendations from:
- http://stackoverflow.com/questions/25326699/proper-aria-handling-of-breadcrumb-navigation
- http://www.uvd.co.uk/blog/accessible-breadcrumbs-using-aria/
- https://gist.github.com/jonathantneal/4037764

~~And it adds the `role="breadcrumbs"` as shown in the W3C list found here: http://www.w3.org/TR/2007/WD-aria-role-20070601/#breadcrumbs~~

~~EDIT: Apparently HTML Lint doesn't support the `role=breadcrumbs` so that is removed. Following up with `grunt-html` at jzaefferer/grunt-html#41~~

EDIT 2: `role=breadcrumbs` was removed from the spec
