### PR TITLE
docs>components>dropdowns.html headings

### DIFF
--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -3,7 +3,7 @@
 
   <p class="lead">Toggleable, contextual menu for displaying lists of links. Made interactive with the <a href="../javascript/#dropdowns">dropdown JavaScript plugin</a>.</p>
 
-  <h3 id="dropdowns-example">Example</h3>
+  <h2 id="dropdowns-example">Example</h2>
   <p>Wrap the dropdown's trigger and the dropdown menu within <code>.dropdown</code>, or another element that declares <code>position: relative;</code>. Then add the menu's HTML. Dropdown menus can be changed to expand upwards (instead of downwards) by adding <code>.dropup</code> to the parent.</p>
   <div class="bs-example" data-example-id="static-dropdown">
     <div class="dropdown clearfix">
@@ -56,7 +56,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="dropdowns-alignment">Alignment</h3>
+  <h2 id="dropdowns-alignment">Alignment</h2>
   <p>By default, a dropdown menu is automatically positioned 100% from the top and along the left side of its parent. Add <code>.dropdown-menu-right</code> to a <code>.dropdown-menu</code> to right align the dropdown menu.</p>
   <div class="bs-callout bs-callout-warning" id="callout-dropdown-positioning">
     <h4>May require additional positioning</h4>
@@ -72,7 +72,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-headers">Headers</h3>
+  <h2 id="dropdowns-headers">Headers</h2>
   <p>Add a header to label sections of actions in any dropdown menu.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
@@ -98,7 +98,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-divider">Divider</h3>
+  <h2 id="dropdowns-divider">Divider</h2>
   <p>Add a divider to separate series of links in a dropdown menu.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
@@ -123,7 +123,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-disabled">Disabled menu items</h3>
+  <h2 id="dropdowns-disabled">Disabled menu items</h2>
   <p>Add <code>.disabled</code> to a <code>&lt;li&gt;</code> in the dropdown to disable the link.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Dropdowns component.

**Before**
![bs-dropdowns-pre](https://cloud.githubusercontent.com/assets/80144/6341960/57414626-bb9f-11e4-9865-4b4869f75228.jpg)

![bs-dropdowns-look-pre](https://cloud.githubusercontent.com/assets/80144/6341962/5741a80a-bb9f-11e4-98d4-c5a9b633a581.jpg)

**After**
![bs-dropdowns-post](https://cloud.githubusercontent.com/assets/80144/6341961/57419496-bb9f-11e4-92a3-307a9c356bd6.jpg)

![bs-dropdowns-look-post](https://cloud.githubusercontent.com/assets/80144/6341959/574026ec-bb9f-11e4-8308-d46ce063070c.jpg)
