### PR TITLE
docs>components>button-dropdowns headings 

### DIFF
--- a/docs/_includes/components/button-dropdowns.html
+++ b/docs/_includes/components/button-dropdowns.html
@@ -8,7 +8,7 @@
     <p>Button dropdowns require the <a href="../javascript/#dropdowns">dropdown plugin</a> to be included in your version of Bootstrap.</p>
   </div>
 
-  <h3 id="btn-dropdowns-single">Single button dropdowns</h3>
+  <h2 id="btn-dropdowns-single">Single button dropdowns</h2>
   <p>Turn a button into a dropdown toggle with some basic markup changes.</p>
   <div class="bs-example" data-example-id="single-button-dropdown">
     <div class="btn-group">
@@ -88,7 +88,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="btn-dropdowns-split">Split button dropdowns</h3>
+  <h2 id="btn-dropdowns-split">Split button dropdowns</h2>
   <p>Similarly, create split button dropdowns with the same markup changes, only with a separate button.</p>
   <div class="bs-example" data-example-id="split-button-dropdown">
     <div class="btn-group">
@@ -194,7 +194,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="btn-dropdowns-sizing">Sizing</h3>
+  <h2 id="btn-dropdowns-sizing">Sizing</h2>
   <p>Button dropdowns work with buttons of all sizes.</p>
   <div class="bs-example" data-example-id="button-dropdown-sizing">
     <div class="btn-toolbar" role="toolbar">
@@ -272,7 +272,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="btn-dropdowns-dropup">Dropup variation</h3>
+  <h2 id="btn-dropdowns-dropup">Dropup variation</h2>
   <p>Trigger dropdown menus above elements by adding <code>.dropup</code> to the parent.</p>
   <div class="bs-example" data-example-id="button-dropdown-dropup">
     <div class="btn-toolbar" role="toolbar">

--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -3,7 +3,7 @@
 
   <p class="lead">Toggleable, contextual menu for displaying lists of links. Made interactive with the <a href="../javascript/#dropdowns">dropdown JavaScript plugin</a>.</p>
 
-  <h3 id="dropdowns-example">Example</h3>
+  <h2 id="dropdowns-example">Example</h2>
   <p>Wrap the dropdown's trigger and the dropdown menu within <code>.dropdown</code>, or another element that declares <code>position: relative;</code>. Then add the menu's HTML. Dropdown menus can be changed to expand upwards (instead of downwards) by adding <code>.dropup</code> to the parent.</p>
   <div class="bs-example" data-example-id="static-dropdown">
     <div class="dropdown clearfix">
@@ -56,7 +56,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="dropdowns-alignment">Alignment</h3>
+  <h2 id="dropdowns-alignment">Alignment</h2>
   <p>By default, a dropdown menu is automatically positioned 100% from the top and along the left side of its parent. Add <code>.dropdown-menu-right</code> to a <code>.dropdown-menu</code> to right align the dropdown menu.</p>
   <div class="bs-callout bs-callout-warning" id="callout-dropdown-positioning">
     <h4>May require additional positioning</h4>
@@ -72,7 +72,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-headers">Headers</h3>
+  <h2 id="dropdowns-headers">Headers</h2>
   <p>Add a header to label sections of actions in any dropdown menu.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
@@ -98,7 +98,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-divider">Divider</h3>
+  <h2 id="dropdowns-divider">Divider</h2>
   <p>Add a divider to separate series of links in a dropdown menu.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">
@@ -123,7 +123,7 @@
 </ul>
 {% endhighlight %}
 
-  <h3 id="dropdowns-disabled">Disabled menu items</h3>
+  <h2 id="dropdowns-disabled">Disabled menu items</h2>
   <p>Add <code>.disabled</code> to a <code>&lt;li&gt;</code> in the dropdown to disable the link.</p>
   <div class="bs-example">
     <div class="dropdown clearfix">


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Button dropdowns component.

**Before**
![bs-buttondropdowns-pre](https://cloud.githubusercontent.com/assets/80144/6342157/9bb8e40a-bba2-11e4-98b4-02fb93b61f3c.jpg)

**After**
![bs-buttondropdowns-post](https://cloud.githubusercontent.com/assets/80144/6342156/9bb88fb4-bba2-11e4-8dd4-d9ad90d595fa.jpg)
