### PR TITLE
docs>components>labels headings

### DIFF
--- a/docs/_includes/components/labels.html
+++ b/docs/_includes/components/labels.html
@@ -1,7 +1,7 @@
 <div class="bs-docs-section">
   <h1 id="labels" class="page-header">Labels</h1>
 
-  <h3>Example</h3>
+  <h2>Example</h2>
   <div class="bs-example" data-example-id="labels-in-headings">
     <h1>Example heading <span class="label label-default">New</span></h1>
     <h2>Example heading <span class="label label-default">New</span></h2>
@@ -14,7 +14,7 @@
 <h3>Example heading <span class="label label-default">New</span></h3>
 {% endhighlight %}
 
-  <h3>Available variations</h3>
+  <h2>Available variations</h2>
   <p>Add any of the below mentioned modifier classes to change the appearance of a label.</p>
   <div class="bs-example" data-example-id="label-variants">
     <span class="label label-default">Default</span>


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Labels component.

**Before**
![bs-labels-pre](https://cloud.githubusercontent.com/assets/80144/6342253/14716c2c-bba4-11e4-8cf9-840877cd40dd.jpg)

**After**
![bs-labels-post](https://cloud.githubusercontent.com/assets/80144/6342252/147093b0-bba4-11e4-897d-04066aa3a737.jpg)
