### PR TITLE
docs>components>thumbnails headings

### DIFF
--- a/docs/_includes/components/thumbnails.html
+++ b/docs/_includes/components/thumbnails.html
@@ -4,7 +4,7 @@
   <p class="lead">Extend Bootstrap's <a href="../css/#grid">grid system</a> with the thumbnail component to easily display grids of images, videos, text, and more.</p>
   <p>If you're looking for Pinterest-like presentation of thumbnails of varying heights and/or widths, you'll need to use a third-party plugin such as <a href="http://masonry.desandro.com">Masonry</a>, <a href="http://isotope.metafizzy.co">Isotope</a>, or <a href="http://salvattore.com">Salvattore</a>.</p>
 
-  <h3 id="thumbnails-default">Default example</h3>
+  <h2 id="thumbnails-default">Default example</h2>
   <p>By default, Bootstrap's thumbnails are designed to showcase linked images with minimal required markup.</p>
   <div class="bs-example" data-example-id="simple-thumbnails">
     <div class="row">
@@ -41,7 +41,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="thumbnails-custom-content">Custom content</h3>
+  <h2 id="thumbnails-custom-content">Custom content</h2>
   <p>With a bit of extra markup, it's possible to add any kind of HTML content like headings, paragraphs, or buttons into thumbnails.</p>
   <div class="bs-example" data-example-id="thumbnails-with-custom-content">
     <div class="row">


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Thumbnails component.

**Before**
![bs-thumbnails-pre](https://cloud.githubusercontent.com/assets/80144/6342321/247adb34-bba5-11e4-9e26-0871fbcbb312.jpg)

**After**
![bs-thumbnails-post](https://cloud.githubusercontent.com/assets/80144/6342320/247a6c12-bba5-11e4-9436-77f1ced51187.jpg)
