### PR TITLE
docs>components>progress bars headings

### DIFF
--- a/docs/_includes/components/progress-bars.html
+++ b/docs/_includes/components/progress-bars.html
@@ -8,7 +8,7 @@
     <p>Progress bars use CSS3 transitions and animations to achieve some of their effects. These features are not supported in Internet Explorer 9 and below or older versions of Firefox. Opera 12 does not support animations.</p>
   </div>
 
-  <h3 id="progress-basic">Basic example</h3>
+  <h2 id="progress-basic">Basic example</h2>
   <p>Default progress bar.</p>
   <div class="bs-example" data-example-id="simple-progress-bar">
     <div class="progress">
@@ -25,7 +25,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="progress-label">With label</h3>
+  <h2 id="progress-label">With label</h2>
   <p>Remove the <code>&lt;span&gt;</code> with <code>.sr-only</code> class from within the progress bar to show a visible percentage.</p>
   <div class="bs-example" data-example-id="progress-bar-with-label">
     <div class="progress">
@@ -68,7 +68,7 @@
 {% endhighlight %}
 
 
-  <h3 id="progress-alternatives">Contextual alternatives</h3>
+  <h2 id="progress-alternatives">Contextual alternatives</h2>
   <p>Progress bars use some of the same button and alert classes for consistent styles.</p>
   <div class="bs-example" data-example-id="contextual-progress-bar">
     <div class="progress">
@@ -115,7 +115,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="progress-striped">Striped</h3>
+  <h2 id="progress-striped">Striped</h2>
   <p>Uses a gradient to create a striped effect. Not available in IE8.</p>
   <div class="bs-example" data-example-id="striped-progress-bar">
     <div class="progress">
@@ -162,7 +162,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="progress-animated">Animated</h3>
+  <h2 id="progress-animated">Animated</h2>
   <p>Add <code>.active</code> to <code>.progress-bar-striped</code> to animate the stripes right to left. Not available in IE9 and below.</p>
   <div class="bs-example" data-example-id="animated-progress-bar">
     <div class="progress">
@@ -178,7 +178,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="progress-stacked">Stacked</h3>
+  <h2 id="progress-stacked">Stacked</h2>
   <p>Place multiple bars into the same <code>.progress</code> to stack them.</p>
   <div class="bs-example" data-example-id="stacked-progress-bar">
     <div class="progress">


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Progress bars component.

**Before**
![bs-progressbars-pre](https://cloud.githubusercontent.com/assets/80144/6342393/346488a0-bba6-11e4-944f-94715ec1c607.jpg)

**After**
![bs-progressbars-post](https://cloud.githubusercontent.com/assets/80144/6342394/3464e354-bba6-11e4-9aa2-604766dafa6b.jpg)
