### PR TITLE
docs>components>media object headings

### DIFF
--- a/docs/_includes/components/media.html
+++ b/docs/_includes/components/media.html
@@ -3,7 +3,7 @@
 
   <p class="lead">Abstract object styles for building various types of components (like blog comments, Tweets, etc) that feature a left- or right-aligned image alongside textual content.</p>
 
-  <h3 id="media-default">Default media</h3>
+  <h2 id="media-default">Default media</h2>
   <p>The default media displays a media object (images, video, audio) to the left or right of a content block.</p>
   <div class="bs-example" data-example-id="default-media">
     <div class="media">
@@ -82,7 +82,7 @@
 {% endhighlight %}
 
   <p>The classes <code>.pull-left</code> and <code>.pull-right</code> also exist and were previously used as part of the media component, but are deprecated for that use as of v3.3.0. They are approximately equivalent to <code>.media-left</code> and <code>.media-right</code>, except that <code>.media-right</code> should be placed after the <code>.media-body</code> in the html.</p>
-  <h3 id="media-alignment">Media alignment</h3>
+  <h2 id="media-alignment">Media alignment</h2>
   <p>The images or other media can be aligned top, middle, or bottom. The default is top aligned.</p>
   <div class="bs-example" data-example-id="media-alignment">
     <div class="media">
@@ -136,7 +136,7 @@
 </div>
 {% endhighlight %}
 
-  <h3 id="media-list">Media list</h3>
+  <h2 id="media-list">Media list</h2>
   <p>With a bit of extra markup, you can use media inside list (useful for comment threads or articles lists).</p>
   <div class="bs-example" data-example-id="media-list">
     <ul class="media-list">


### PR DESCRIPTION
Normalized the heading hierarchy in the documentation for the Media object component.

**Before**
![bs-media-pre](https://cloud.githubusercontent.com/assets/80144/6342493/beb4a00c-bba7-11e4-9e0c-6dcaadba55f2.jpg)
![bs-media-look-pre](https://cloud.githubusercontent.com/assets/80144/6342494/beb73894-bba7-11e4-949b-33c1e535d0ff.jpg)

**After**
![bs-media-post](https://cloud.githubusercontent.com/assets/80144/6342496/cbe7b476-bba7-11e4-86fe-d987895ce2af.jpg)
![bs-media-look-post](https://cloud.githubusercontent.com/assets/80144/6342497/d13815e2-bba7-11e4-8c7f-df895bebee05.jpg)
