### PR TITLE
Feature: Overlapping modals

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -160,7 +160,9 @@
     var that = this
     this.$element.hide()
     this.backdrop(function () {
-      that.$body.removeClass('modal-open')
+      if ($('.modal.in').length === 0) {
+        that.$body.removeClass('modal-open')
+      }
       that.resetAdjustments()
       that.resetScrollbar()
       that.$element.trigger('hidden.bs.modal')


### PR DESCRIPTION
In documentation it is said, that modal overlapping is not supported. But with recent version of Bootstrap it is working fine, except one bug:

You can open the second modal on top of the first modal without any problems at all, but, when you close the second modal, 'modal-open' class is removed from 'body', and you can't scroll the first modal. I have created a [jsfiddle](http://jsfiddle.net/goooseman/tt835mow/) to illustrate this bug.

This pull request fixes this bug, so modal overlapping is fully supported.
