### PR TITLE
Change CC link in footer to HTTPS

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,7 +6,7 @@
 
     <p>Designed and built with all the love in the world by <a href="https://twitter.com/mdo" target="_blank">@mdo</a> and <a href="https://twitter.com/fat" target="_blank">@fat</a>.</p>
     <p>Maintained by the <a href="https://github.com/orgs/twbs/people">core team</a> with the help of <a href="https://github.com/twbs/bootstrap/graphs/contributors">our contributors</a>.</p>
-    <p>Code licensed under <a href="https://github.com/twbs/bootstrap/blob/master/LICENSE" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
+    <p>Code licensed under <a href="https://github.com/twbs/bootstrap/blob/master/LICENSE" target="_blank">MIT</a>, documentation under <a href="https://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</p>
     <ul class="bs-docs-footer-links text-muted">
       <li>Currently v{{ site.current_version }}</li>
       <li>&middot;</li>


### PR DESCRIPTION
Update Creative Commons link to HTTPS.

Note: All web traffic should be considered sensitive and potentially correlated with other websites in unpredictable ways. As or more importantly, ISPs like Verizon and Comcast are now routinely injecting tracking material into their customers' traffic -- using HTTPS protects visitors from being manipulated this way.

The web community is in the middle of a big push to get the web moved over to HTTPS. Groups at the W3C, IETF, and Internet Architecture Board (IETF's sister org) have all declared that it's the web's future.

Part of getting this to happen is getting web developers to see it by the websites they visit, and to expect it of themselves.
