### PR TITLE
Bump markdown-it to ^3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "grunt-saucelabs": "~8.6.0",
     "grunt-sed": "~0.1.1",
     "load-grunt-tasks": "~3.1.0",
-    "markdown-it": "^3.0.6",
+    "markdown-it": "^3.0.7",
     "npm-shrinkwrap": "^200.1.0",
     "time-grunt": "~1.0.0"
   },


### PR DESCRIPTION
Bump markdown it to 3.0.7

3.0.7 / 2015-02-22

Match table columns count by header.
Added basic CLI support.
Added \v \f to valid whitespaces.
Use external package for unicode data (punctuation).
