### PR TITLE
docs > js > headings

### DIFF
--- a/docs/_includes/js/overview.html
+++ b/docs/_includes/js/overview.html
@@ -1,7 +1,7 @@
 <div class="bs-docs-section">
   <h1 id="js-overview" class="page-header">Overview</h1>
 
-  <h3 id="js-individual-compiled">Individual or compiled</h3>
+  <h2 id="js-individual-compiled">Individual or compiled</h2>
   <p>Plugins can be included individually (using Bootstrap's individual <code>*.js</code> files), or all at once (using <code>bootstrap.js</code> or the minified <code>bootstrap.min.js</code>).</p>
 
   <div class="bs-callout bs-callout-danger" id="callout-overview-not-both">
@@ -14,7 +14,7 @@
     <p>Some plugins and CSS components depend on other plugins. If you include plugins individually, make sure to check for these dependencies in the docs. Also note that all plugins depend on jQuery (this means jQuery must be included <strong>before</strong> the plugin files). <a href="{{ site.repo }}/blob/v{{ site.current_version }}/bower.json">Consult our <code>bower.json</code></a> to see which versions of jQuery are supported.</p>
   </div>
 
-  <h3 id="js-data-attrs">Data attributes</h3>
+  <h2 id="js-data-attrs">Data attributes</h2>
   <p>You can use all Bootstrap plugins purely through the markup API without writing a single line of JavaScript. This is Bootstrap's first-class API and should be your first consideration when using a plugin.</p>
 
   <p>That said, in some situations it may be desirable to turn this functionality off. Therefore, we also provide the ability to disable the data attribute API by unbinding all events on the document namespaced with <code>data-api</code>. This looks like this:</p>
@@ -32,7 +32,7 @@ $(document).off('.alert.data-api')
     <p>Don't use data attributes from multiple plugins on the same element. For example, a button cannot both have a tooltip and toggle a modal. To accomplish this, use a wrapping element.</p>
   </div>
 
-  <h3 id="js-programmatic-api">Programmatic API</h3>
+  <h2 id="js-programmatic-api">Programmatic API</h2>
   <p>We also believe you should be able to use all Bootstrap plugins purely through the JavaScript API. All public APIs are single, chainable methods, and return the collection acted upon.</p>
 {% highlight js %}
 $('.btn.danger').button('toggle').addClass('fat')
@@ -53,14 +53,14 @@ $('#myModal').modal('show')                // initializes and invokes show immed
 $.fn.modal.Constructor.DEFAULTS.keyboard = false // changes default for the modal plugin's `keyboard` option to false
 {% endhighlight %}
 
-  <h3 id="js-noconflict">No conflict</h3>
+  <h2 id="js-noconflict">No conflict</h2>
   <p>Sometimes it is necessary to use Bootstrap plugins with other UI frameworks. In these circumstances, namespace collisions can occasionally occur. If this happens, you may call <code>.noConflict</code> on the plugin you wish to revert the value of.</p>
 {% highlight js %}
 var bootstrapButton = $.fn.button.noConflict() // return $.fn.button to previously assigned value
 $.fn.bootstrapBtn = bootstrapButton            // give $().bootstrapBtn the Bootstrap functionality
 {% endhighlight %}
 
-  <h3 id="js-events">Events</h3>
+  <h2 id="js-events">Events</h2>
   <p>Bootstrap provides custom events for most plugins' unique actions. Generally, these come in an infinitive and past participle form - where the infinitive (ex. <code>show</code>) is triggered at the start of an event, and its past participle form (ex. <code>shown</code>) is triggered on the completion of an action.</p>
   <p>As of 3.0.0, all Bootstrap events are namespaced.</p>
   <p>All infinitive events provide <code>preventDefault</code> functionality. This provides the ability to stop the execution of an action before it starts.</p>
@@ -70,13 +70,13 @@ $('#myModal').on('show.bs.modal', function (e) {
 })
 {% endhighlight %}
 
-  <h3 id="js-version-nums">Version numbers</h3>
+  <h2 id="js-version-nums">Version numbers</h2>
   <p>The version of each of Bootstrap's jQuery plugins can be accessed via the <code>VERSION</code> property of the plugin's constructor. For example, for the tooltip plugin:</p>
 {% highlight js %}
 $.fn.tooltip.Constructor.VERSION // => "{{ site.current_version }}"
 {% endhighlight %}
 
-  <h3 id="js-disabled">No special fallbacks when JavaScript is disabled</h3>
+  <h2 id="js-disabled">No special fallbacks when JavaScript is disabled</h2>
   <p>Bootstrap's plugins don't fall back particularly gracefully when JavaScript is disabled. If you care about the user experience in this case, use <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript"><code>&lt;noscript&gt;</code></a> to explain the situation (and how to re-enable JavaScript) to your users, and/or add your own custom fallbacks.</p>
 
   <div class="bs-callout bs-callout-warning" id="callout-third-party-libs">

--- a/docs/_includes/js/transitions.html
+++ b/docs/_includes/js/transitions.html
@@ -1,8 +1,8 @@
 <div class="bs-docs-section">
   <h1 id="transitions" class="page-header">Transitions <small>transition.js</small></h1>
 
-  <h3>About transitions</h3>
+  <h2>About transitions</h2>
   <p>For simple transition effects, include <code>transition.js</code> once alongside the other JS files. If you're using the compiled (or minified) <code>bootstrap.js</code>, there is no need to include this&mdash;it's already there.</p>
-  <h3>What's inside</h3>
+  <h2>What's inside</h2>
   <p>Transition.js is a basic helper for <code>transitionEnd</code> events as well as a CSS transition emulator. It's used by the other plugins to check for CSS transition support and to catch hanging transitions.</p>
 </div>


### PR DESCRIPTION
Accessibility changes to headings in `overview.html` and `transitions.html`.

The `overview.html` changes shake-out like this.  Changes in `transitions.html`are similar but more trivial.

![bs-overview](https://cloud.githubusercontent.com/assets/80144/6363342/a29a0baa-bc65-11e4-85b4-cc0faafe6787.jpg)
