### PR TITLE
Accessibility and headings hierarchy for the "Getting started" page

### DIFF
--- a/docs/_includes/getting-started/accessibility.html
+++ b/docs/_includes/getting-started/accessibility.html
@@ -2,7 +2,7 @@
   <h1 id="accessibility" class="page-header">Accessibility</h1>
   <p class="lead">Bootstrap follows common web standards and&mdash;with minimal extra effort&mdash;can be used to create sites that are accessible to those using <abbr title="Assistive Technology" class="initialism">AT</abbr>.</p>
 
-  <h3>Skip navigation</h3>
+  <h2>Skip navigation</h2>
   <p>If your navigation contains many links and comes before the main content in the DOM, add a <code>Skip to main content</code> link before the navigation (for a simple explanation, see this <a href="http://a11yproject.com/posts/skip-nav-links/">A11Y Project article on skip navigation links</a>). Using the <code>.sr-only</code> class will visually hide the skip link, and the <code>.sr-only-focusable</code> class will ensure that the link becomes visible once focused (for sighted keyboard users).</p>
   <div class="bs-callout bs-callout-danger" id="callout-skiplinks">
     <p>Due to long-standing shortcomings/bugs in Chrome (see <a href="https://code.google.com/p/chromium/issues/detail?id=262171" title="Chromium bug tracker - Issue 262171: Focus should cycle from named anchor">issue 262171 in the Chromium bug tracker</a>) and Internet Explorer (see this article on <a href="http://accessibleculture.org/articles/2010/05/in-page-links/">in-page links and focus order</a>), you will need to make sure that the target of your skip link is at least programmatically focusable by adding <code>tabindex="-1"</code>.</p>
@@ -19,14 +19,14 @@
 </body>
 {% endhighlight %}
 
-  <h3>Nested headings</h3>
+  <h2>Nested headings</h2>
   <p>When nesting headings (<code>&lt;h1&gt;</code> - <code>&lt;h6&gt;</code>), your primary document header should be an <code>&lt;h1&gt;</code>. Subsequent headings should make logical use of <code>&lt;h2&gt;</code> - <code>&lt;h6&gt;</code> such that screen readers can construct a table of contents for your pages.</p>
   <p>Learn more at <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/Section508/">HTML CodeSniffer</a> and <a href="http://accessibility.psu.edu/headings">Penn State's AccessAbility</a>.</p>
 
-  <h3>Color contrast</h3>
+  <h2>Color contrast</h2>
   <p>Currently, some of the default color combinations available in Bootstrap (such as the various <a href="../css/#buttons">styled button</a> classes, some of the code highlighting colors used for <a href="../css/#code-block">basic code blocks</a>, the <code>.bg-primary</code> <a href="../css/#helper-classes-backgrounds">contextual background</a> helper class, and the default link color when used on a white background) have a low contrast ratio (below the <a href="http://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">recommended ratio of 4.5:1</a>). This can cause problems to users with low vision or who are color blind. These default colors may need to be modified to increase their contrast and legibility.</p>
 
-  <h3>Additional resources</h3>
+  <h2>Additional resources</h2>
   <ul>
     <li><a href="https://github.com/squizlabs/HTML_CodeSniffer">"HTML Codesniffer" bookmarklet for identifying accessibility issues</a></li>
     <li><a href="https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en">Chrome's Accessibility Developer Tools extension</a></li>

--- a/docs/_includes/getting-started/browser-device-support.html
+++ b/docs/_includes/getting-started/browser-device-support.html
@@ -2,7 +2,7 @@
   <h1 id="support" class="page-header">Browser and device support</h1>
   <p class="lead">Bootstrap is built to work best in the latest desktop and mobile browsers, meaning older browsers might display differently styled, though fully functional, renderings of certain components.</p>
 
-  <h3 id="support-browsers">Supported browsers</h3>
+  <h2 id="support-browsers">Supported browsers</h2>
   <p>Specifically, we support the <strong>latest versions</strong> of the following browsers and platforms. On Windows, <strong>we support Internet Explorer 8-11</strong>. More specific support information is provided below.</p>
   <div class="table-responsive">
     <table class="table table-bordered table-striped">
@@ -53,7 +53,7 @@
   <p>Unofficially, Bootstrap should look and behave well enough in Chromium and Chrome for Linux, Firefox for Linux, and Internet Explorer 7, though they are not officially supported.</p>
   <p>For a list of some of the browser bugs that Bootstrap has to grapple with, see our <a href="../browser-bugs/">Wall of browser bugs</a>.</p>
 
-  <h3 id="support-ie8-ie9">Internet Explorer 8 and 9</h3>
+  <h2 id="support-ie8-ie9">Internet Explorer 8 and 9</h2>
   <p>Internet Explorer 8 and 9 are also supported, however, please be aware that some CSS3 properties and HTML5 elements are not fully supported by these browsers. In addition, <strong>Internet Explorer 8 requires the use of <a href="https://github.com/scottjehl/Respond">Respond.js</a> to enable media query support.</strong></p>
   <div class="table-responsive">
     <table class="table table-bordered table-striped">
@@ -94,22 +94,22 @@
 
   <p>Visit <a href="http://caniuse.com/">Can I use...</a> for details on browser support of CSS3 and HTML5 features.</p>
 
-  <h3 id="support-ie8-respondjs">Internet Explorer 8 and Respond.js</h3>
+  <h2 id="support-ie8-respondjs">Internet Explorer 8 and Respond.js</h2>
   <p>Beware of the following caveats when using Respond.js in your development and production environments for Internet Explorer 8.</p>
-  <h4 id="respond-js-x-domain">Respond.js and cross-domain CSS</h4>
+  <h3 id="respond-js-x-domain">Respond.js and cross-domain CSS</h3>
   <p>Using Respond.js with CSS hosted on a different (sub)domain (for example, on a CDN) requires some additional setup. <a href="https://github.com/scottjehl/Respond/blob/master/README.md#cdnx-domain-setup">See the Respond.js docs</a> for details.</p>
-  <h4 id="respond-file-proto">Respond.js and <code>file://</code></h4>
+  <h3 id="respond-file-proto">Respond.js and <code>file://</code></h3>
   <p>Due to browser security rules, Respond.js doesn't work with pages viewed via the <code>file://</code> protocol (like when opening a local HTML file). To test responsive features in IE8, view your pages over HTTP(S). <a href="https://github.com/scottjehl/Respond/blob/master/README.md#support--caveats">See the Respond.js docs</a> for details.</p>
-  <h4 id="respond-import">Respond.js and <code>@import</code></h4>
+  <h3 id="respond-import">Respond.js and <code>@import</code></h3>
   <p>Respond.js doesn't work with CSS that's referenced via <code>@import</code>. In particular, some Drupal configurations are known to use <code>@import</code>. <a href="https://github.com/scottjehl/Respond/blob/master/README.md#support--caveats">See the Respond.js docs</a> for details.</p>
 
-  <h3 id="support-ie8-box-sizing">Internet Explorer 8 and box-sizing</h3>
+  <h2 id="support-ie8-box-sizing">Internet Explorer 8 and box-sizing</h2>
   <p>IE8 does not fully support <code>box-sizing: border-box;</code> when combined with <code>min-width</code>, <code>max-width</code>, <code>min-height</code>, or <code>max-height</code>. For that reason, as of v3.0.1, we no longer use <code>max-width</code> on <code>.container</code>s.</p>
 
-  <h3 id="support-ie8-font-face">Internet Explorer 8 and @font-face</h3>
+  <h2 id="support-ie8-font-face">Internet Explorer 8 and @font-face</h2>
   <p>IE8 has some issues with <code>@font-face</code> when combined with <code>:before</code>. Bootstrap uses that combination with its Glyphicons. If a page is cached, and loaded without the mouse over the window (i.e. hit the refresh button or load something in an iframe) then the page gets rendered before the font loads. Hovering over the page (body) will show some of the icons and hovering over the remaining icons will show those as well. <a href="https://github.com/twbs/bootstrap/issues/13863">See issue #13863</a> for details.</p>
 
-  <h3 id="support-ie-compatibility-modes">IE Compatibility modes</h3>
+  <h2 id="support-ie-compatibility-modes">IE Compatibility modes</h2>
   <p>Bootstrap is not supported in the old Internet Explorer compatibility modes. To be sure you're using the latest rendering mode for IE, consider including the appropriate <code>&lt;meta&gt;</code> tag in your pages:</p>
 {% highlight html %}
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -118,7 +118,7 @@
   <p>This tag is included in all of Bootstrap's documentation and examples to ensure the best rendering possible in each supported version of Internet Explorer.</p>
   <p>See <a href="http://stackoverflow.com/questions/6771258/whats-the-difference-if-meta-http-equiv-x-ua-compatible-content-ie-edge">this StackOverflow question</a> for more information.</p>
 
-  <h3 id="support-ie10-width">Internet Explorer 10 in Windows 8 and Windows Phone 8</h3>
+  <h2 id="support-ie10-width">Internet Explorer 10 in Windows 8 and Windows Phone 8</h2>
   <p>Internet Explorer 10 doesn't differentiate <strong>device width</strong> from <strong>viewport width</strong>, and thus doesn't properly apply the media queries in Bootstrap's CSS. Normally you'd just add a quick snippet of CSS to fix this:</p>
 {% highlight scss %}
 @-ms-viewport       { width: device-width; }
@@ -146,28 +146,28 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
   <p>For more information and usage guidelines, read <a href="http://timkadlec.com/2013/01/windows-phone-8-and-device-width/">Windows Phone 8 and Device-Width</a>.</p>
   <p>As a heads up, we include this in all of Bootstrap's documentation and examples as a demonstration.</p>
 
-  <h3 id="support-safari-percentages">Safari percent rounding</h3>
+  <h2 id="support-safari-percentages">Safari percent rounding</h2>
   <p>The rendering engine of versions of Safari prior to v7.1 for OS X and Safari for iOS v8.0 had some trouble with the number of decimal places used in our <code>.col-*-1</code> grid classes. So if you had 12 individual grid columns, you'd notice that they came up short compared to other rows of columns. Besides upgrading Safari/iOS, you have some options for workarounds:</p>
   <ul>
     <li>Add <code>.pull-right</code> to your last grid column to get the hard-right alignment</li>
     <li>Tweak your percentages manually to get the perfect rounding for Safari (more difficult than the first option)</li>
   </ul>
 
-  <h3 id="support-fixed-position-keyboards">Modals, navbars, and virtual keyboards</h3>
-  <h4>Overflow and scrolling</h4>
+  <h2 id="support-fixed-position-keyboards">Modals, navbars, and virtual keyboards</h2>
+  <h3>Overflow and scrolling</h3>
   <p>Support for <code>overflow: hidden</code> on the <code>&lt;body&gt;</code> element is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the <code>&lt;body&gt;</code> content will begin to scroll.</p>
-  <h4>Virtual keyboards</h4>
+  <h3>Virtual keyboards</h3>
   <p>Also, note that if you're using a fixed navbar or using inputs within a modal, iOS has a rendering bug that doesn't update the position of fixed elements when the virtual keyboard is triggered. A few workarounds for this include transforming your elements to <code>position: absolute</code> or invoking a timer on focus to try to correct the positioning manually. This is not handled by Bootstrap, so it is up to you to decide which solution is best for your application.</p>
-  <h4>Navbar Dropdowns</h4>
+  <h3>Navbar Dropdowns</h3>
   <p>The <code>.dropdown-backdrop</code> element isn't used on iOS in the nav because of the complexity of z-indexing. Thus, to close dropdowns in navbars, you must directly click the dropdown element (or <a href="https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile">any other element which will fire a click event in iOS</a>).</p>
 
-  <h3 id="support-browser-zooming">Browser zooming</h3>
+  <h2 id="support-browser-zooming">Browser zooming</h2>
   <p>Page zooming inevitably presents rendering artifacts in some components, both in Bootstrap and the rest of the web. Depending on the issue, we may be able to fix it (search first and then open an issue if need be). However, we tend to ignore these as they often have no direct solution other than hacky workarounds.</p>
 
-  <h3 id="support-sticky-hover-mobile">Sticky <code>:hover</code>/<code>:focus</code> on mobile</h3>
+  <h2 id="support-sticky-hover-mobile">Sticky <code>:hover</code>/<code>:focus</code> on mobile</h2>
   <p>Even though real hovering isn't possible on most touchscreens, most mobile browsers emulate hovering support and make <code>:hover</code> "sticky". In other words, <code>:hover</code> styles start applying after tapping an element and only stop applying after the user taps some other element. This can cause Bootstrap's <code>:hover</code> states to become unwantedly "stuck" on such browsers. Some mobile browsers also make <code>:focus</code> similarly sticky. There is currently no simple workaround for these issues other than removing such styles entirely.</p>
 
-  <h3 id="support-printing">Printing</h3>
+  <h2 id="support-printing">Printing</h2>
   <p>Even in some modern browsers, printing can be quirky.</p>
   <p>In particular, as of Chrome v32 and regardless of margin settings, Chrome uses a viewport width significantly narrower than the physical paper size when resolving media queries while printing a webpage. This can result in Bootstrap's extra-small grid being unexpectedly activated when printing. <a href="https://github.com/twbs/bootstrap/issues/12078">See #12078 for some details.</a> Suggested workarounds:</p>
   <ul>
@@ -184,9 +184,9 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
 }
 {% endhighlight %}
 
-  <h3 id="support-android-stock-browser">Android stock browser</h3>
+  <h2 id="support-android-stock-browser">Android stock browser</h2>
   <p>Out of the box, Android 4.1 (and even some newer releases apparently) ship with the Browser app as the default web browser of choice (as opposed to Chrome). Unfortunately, the Browser app has lots of bugs and inconsistencies with CSS in general.</p>
-  <h4>Select menus</h4>
+  <h3>Select menus</h3>
   <p>On <code>&lt;select&gt;</code> elements, the Android stock browser will not display the side controls if there is a <code>border-radius</code> and/or <code>border</code> applied. (See <a href="http://stackoverflow.com/questions/14744437/html-select-box-not-showing-drop-down-arrow-on-android-version-4-0-when-set-with">this StackOverflow question</a> for details.) Use the snippet of code below to remove the offending CSS and render the <code>&lt;select&gt;</code> as an unstyled element on the Android stock browser. The user agent sniffing avoids interference with Chrome, Safari, and Mozilla browsers.</p>
 {% highlight html %}
 <script>
@@ -201,7 +201,7 @@ $(function () {
 {% endhighlight %}
   <p>Want to see an example? <a href="http://jsbin.com/kuvoz/1">Check out this JS Bin demo.</a></p>
 
-  <h3 id="support-validators">Validators</h3>
+  <h2 id="support-validators">Validators</h2>
   <p>In order to provide the best possible experience to old and buggy browsers, Bootstrap uses <a href="http://browserhacks.com">CSS browser hacks</a> in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren't yet fully standardized, but these are used purely for progressive enhancement.</p>
   <p>These validation warnings don't matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don't interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.</p>
   <p>Our HTML docs likewise have some trivial and inconsequential HTML validation warnings due to our inclusion of a workaround for <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=654072">a certain Firefox bug</a>.</p>

--- a/docs/_includes/getting-started/disabling-responsiveness.html
+++ b/docs/_includes/getting-started/disabling-responsiveness.html
@@ -4,7 +4,7 @@
   <p class="lead">Bootstrap automatically adapts your pages for various screen sizes.
     Here's how to disable this feature so your page works like <a href="../examples/non-responsive/">this non-responsive example</a>.</p>
 
-  <h3>Steps to disable page responsiveness</h3>
+  <h2>Steps to disable page responsiveness</h2>
   <ol>
     <li>Omit the viewport <code>&lt;meta&gt;</code> mentioned in <a href="../css/#overview-mobile">the CSS docs</a></li>
     <li>Override the <code>width</code> on the <code>.container</code> for each grid tier with a single width, for example <code>width: 970px !important;</code> Be sure that this comes after the default Bootstrap CSS. You can optionally avoid the <code>!important</code> with media queries or some selector-fu.</li>
@@ -14,7 +14,7 @@
   <p>You'll still need Respond.js for IE8 (since our media queries are still there and need to be processed).
     This disables the "mobile site" aspects of Bootstrap.</p>
 
-  <h3>Bootstrap template with responsiveness disabled</h3>
+  <h2>Bootstrap template with responsiveness disabled</h2>
   <p>We've applied these steps to an example. Read its source code to see the specific changes implemented.</p>
   <p>
     <a href="../examples/non-responsive/" class="btn btn-primary">View non-responsive example</a>

--- a/docs/_includes/getting-started/download.html
+++ b/docs/_includes/getting-started/download.html
@@ -27,7 +27,7 @@
     </div>
   </div>
 
-  <h3 id="download-cdn">Bootstrap CDN</h3>
+  <h2 id="download-cdn">Bootstrap CDN</h2>
   <p>The folks over at <a href="http://www.maxcdn.com/">MaxCDN</a> graciously provide CDN support for Bootstrap's CSS and JavaScript. Just use these <a href="http://www.bootstrapcdn.com/">Bootstrap CDN</a> links.</p>
 {% highlight html %}
 <!-- Latest compiled and minified CSS -->
@@ -40,11 +40,11 @@
 <script src="{{ site.cdn.js }}"></script>
 {% endhighlight %}
 
-  <h3 id="download-bower">Install with Bower</h3>
+  <h2 id="download-bower">Install with Bower</h2>
   <p>You can also install and manage Bootstrap's Less, CSS, JavaScript, and fonts using <a href="http://bower.io">Bower</a>:</p>
   {% highlight bash %}$ bower install bootstrap{% endhighlight %}
 
-  <h3 id="download-npm">Install with npm</h3>
+  <h2 id="download-npm">Install with npm</h2>
   <p>You can also install Bootstrap using <a href="https://www.npmjs.com">npm</a>:</p>
   {% highlight bash %}$ npm install bootstrap{% endhighlight %}
   <p><code>require('bootstrap')</code> will load all of Bootstrap's jQuery plugins onto the jQuery object. The <code>bootstrap</code> module itself does not export anything. You can manually load Bootstrap's jQuery plugins individually by loading the <code>/js/*.js</code> files under the package's top-level directory.</p>
@@ -54,6 +54,6 @@
     <li><code>style</code> - path to Bootstrap's non-minified CSS that's been precompiled using the default settings (no customization)</li>
   </ul>
 
-  <h3 id="download-autoprefixer">Autoprefixer required for Less/Sass</h3>
+  <h2 id="download-autoprefixer">Autoprefixer required for Less/Sass</h2>
   <p>Bootstrap uses <a href="https://github.com/postcss/autoprefixer">Autoprefixer</a> to deal with <a href="http://webdesign.about.com/od/css/a/css-vendor-prefixes.htm">CSS vendor prefixes</a>. If you're compiling Bootstrap from its Less/Sass source and not using our Gruntfile, you'll need to integrate Autoprefixer into your build process yourself. If you're using precompiled Bootstrap or using our Gruntfile, you don't need to worry about this because Autoprefixer is already integrated into our Gruntfile.</p>
 </div>

--- a/docs/_includes/getting-started/examples.html
+++ b/docs/_includes/getting-started/examples.html
@@ -3,20 +3,20 @@
 
   <p class="lead">Build on the basic template above with Bootstrap's many components. We encourage you to customize and adapt Bootstrap to suit your individual project's needs.</p>
 
-  <h3 id="examples-framework">Using the framework</h3>
+  <h2 id="examples-framework">Using the framework</h2>
   <div class="row bs-examples">
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/starter-template/">
         <img src="../examples/screenshots/starter-template.jpg" alt="Starter template example">
       </a>
-      <h4>Starter template</h4>
+      <h3>Starter template</h3>
       <p>Nothing but the basics: compiled CSS and JavaScript along with a container.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/theme/">
         <img src="../examples/screenshots/theme.jpg" alt="Bootstrap theme example">
       </a>
-      <h4>Bootstrap theme</h4>
+      <h3>Bootstrap theme</h3>
       <p>Load the optional Bootstrap theme for a visually enhanced experience.</p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -25,14 +25,14 @@
       <a class="thumbnail" href="../examples/grid/">
         <img src="../examples/screenshots/grid.jpg" alt="Multiple grids example">
       </a>
-      <h4>Grids</h4>
+      <h3>Grids</h3>
       <p>Multiple examples of grid layouts with all four tiers, nesting, and more.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/jumbotron/">
         <img src="../examples/screenshots/jumbotron.jpg" alt="Jumbotron example">
       </a>
-      <h4>Jumbotron</h4>
+      <h3>Jumbotron</h3>
       <p>Build around the jumbotron with a navbar and some basic grid columns.</p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -41,25 +41,25 @@
       <a class="thumbnail" href="../examples/jumbotron-narrow/">
         <img src="../examples/screenshots/jumbotron-narrow.jpg" alt="Narrow jumbotron example">
       </a>
-      <h4>Narrow jumbotron</h4>
+      <h3>Narrow jumbotron</h3>
       <p>Build a more custom page by narrowing the default container and jumbotron.</p>
     </div>
   </div>
 
-  <h3 id="examples-navbars">Navbars in action</h3>
+  <h2 id="examples-navbars">Navbars in action</h2>
   <div class="row bs-examples">
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/navbar/">
         <img src="../examples/screenshots/navbar.jpg" alt="Navbar example">
       </a>
-      <h4>Navbar</h4>
+      <h3>Navbar</h3>
       <p>Super basic template that includes the navbar along with some additional content.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/navbar-static-top/">
         <img src="../examples/screenshots/navbar-static.jpg" alt="Static top navbar example">
       </a>
-      <h4>Static top navbar</h4>
+      <h3>Static top navbar</h3>
       <p>Super basic template with a static top navbar along with some additional content.</p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -68,25 +68,25 @@
       <a class="thumbnail" href="../examples/navbar-fixed-top/">
         <img src="../examples/screenshots/navbar-fixed.jpg" alt="Fixed navbar example">
       </a>
-      <h4>Fixed navbar</h4>
+      <h3>Fixed navbar</h3>
       <p>Super basic template with a fixed top navbar along with some additional content.</p>
     </div>
   </div>
 
-  <h3 id="examples-custom">Custom components</h3>
+  <h2 id="examples-custom">Custom components</h2>
   <div class="row bs-examples">
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/cover/">
         <img src="../examples/screenshots/cover.jpg" alt="A one-page template example">
       </a>
-      <h4>Cover</h4>
+      <h3>Cover</h3>
       <p>A one-page template for building simple and beautiful home pages.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/carousel/">
         <img src="../examples/screenshots/carousel.jpg" alt="Carousel example">
       </a>
-      <h4>Carousel</h4>
+      <h3>Carousel</h3>
       <p>Customize the navbar and carousel, then add some new components.</p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -95,14 +95,14 @@
       <a class="thumbnail" href="../examples/blog/">
         <img src="../examples/screenshots/blog.jpg" alt="Blog layout example">
       </a>
-      <h4>Blog</h4>
+      <h3>Blog</h3>
       <p>Simple two-column blog layout with custom navigation, header, and type.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/dashboard/">
         <img src="../examples/screenshots/dashboard.jpg" alt="Dashboard example">
       </a>
-      <h4>Dashboard</h4>
+      <h3>Dashboard</h3>
       <p>Basic structure for an admin dashboard with fixed sidebar and navbar.</p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -111,14 +111,14 @@
       <a class="thumbnail" href="../examples/signin/">
         <img src="../examples/screenshots/sign-in.jpg" alt="Sign-in page example">
       </a>
-      <h4>Sign-in page</h4>
+      <h3>Sign-in page</h3>
       <p>Custom form layout and design for a simple sign in form.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/justified-nav/">
         <img src="../examples/screenshots/justified-nav.jpg" alt="Justified nav example">
       </a>
-      <h4>Justified nav</h4>
+      <h3>Justified nav</h3>
       <p>Create a custom navbar with justified links. Heads up! <a href="../components/#nav-justified">Not too Safari friendly.</a></p>
     </div>
     <div class="clearfix visible-xs"></div>
@@ -127,32 +127,32 @@
       <a class="thumbnail" href="../examples/sticky-footer/">
         <img src="../examples/screenshots/sticky-footer.jpg" alt="Sticky footer example">
       </a>
-      <h4>Sticky footer</h4>
+      <h3>Sticky footer</h3>
       <p>Attach a footer to the bottom of the viewport when the content is shorter than it.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/sticky-footer-navbar/">
         <img src="../examples/screenshots/sticky-footer-navbar.jpg" alt="Sticky footer with navbar example">
       </a>
-      <h4>Sticky footer with navbar</h4>
+      <h3>Sticky footer with navbar</h3>
       <p>Attach a footer to the bottom of the viewport with a fixed navbar at the top.</p>
     </div>
   </div>
 
-  <h3 id="examples-experiments">Experiments</h3>
+  <h2 id="examples-experiments">Experiments</h2>
   <div class="row bs-examples">
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/non-responsive/">
         <img src="../examples/screenshots/non-responsive.jpg" alt="Non-responsive example">
       </a>
-      <h4>Non-responsive Bootstrap</h4>
+      <h3>Non-responsive Bootstrap</h3>
       <p>Easily disable the responsiveness of Bootstrap <a href="#disable-responsive">per our docs</a>.</p>
     </div>
     <div class="col-xs-6 col-md-4">
       <a class="thumbnail" href="../examples/offcanvas/">
         <img src="../examples/screenshots/offcanvas.jpg" alt="Off-canvas navigation example">
       </a>
-      <h4>Off-canvas</h4>
+      <h3>Off-canvas</h3>
       <p>Build a toggleable off-canvas navigation menu for use with Bootstrap.</p>
     </div>
   </div>

--- a/docs/_includes/getting-started/license.html
+++ b/docs/_includes/getting-started/license.html
@@ -2,12 +2,12 @@
   <h1 id="license-faqs" class="page-header">License FAQs</h1>
   <p class="lead">Bootstrap is released under the MIT license and is copyright {{ site.time | date: "%Y" }} Twitter. Boiled down to smaller chunks, it can be described with the following conditions.</p>
 
-  <h4>It requires you to:</h4>
+  <h2>It requires you to:</h2>
   <ul>
     <li>Keep the license and copyright notice included in Bootstrap's CSS and JavaScript files when you use them in your works</li>
   </ul>
 
-  <h4>It permits you to:</h4>
+  <h2>It permits you to:</h2>
   <ul>
     <li>Freely download and use Bootstrap, in whole or in part, for personal, private, company internal, or commercial purposes</li>
     <li>Use Bootstrap in packages or distributions that you create</li>
@@ -15,7 +15,7 @@
     <li>Grant a sublicense to modify and distribute Bootstrap to third parties not included in the license</li>
   </ul>
 
-  <h4>It forbids you to:</h4>
+  <h2>It forbids you to:</h2>
   <ul>
     <li>Hold the authors and license owners liable for damages as Bootstrap is provided without warranty</li>
     <li>Hold the creators or copyright holders of Bootstrap liable</li>
@@ -24,7 +24,7 @@
     <li>Use any marks owned by Twitter in any way that might state or imply that you created the Twitter software in question</li>
   </ul>
 
-  <h4>It does not require you to:</h4>
+  <h2>It does not require you to:</h2>
   <ul>
     <li>Include the source of Bootstrap itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it</li>
     <li>Submit changes that you make to Bootstrap back to the Bootstrap project (though such feedback is encouraged)</li>

--- a/docs/_includes/getting-started/third-party-support.html
+++ b/docs/_includes/getting-started/third-party-support.html
@@ -2,7 +2,7 @@
   <h1 id="third-parties" class="page-header">Third party support</h1>
   <p class="lead">While we don't officially support any third party plugins or add-ons, we do offer some useful advice to help avoid potential issues in your projects.</p>
 
-  <h3 id="third-box-sizing">Box-sizing</h3>
+  <h2 id="third-box-sizing">Box-sizing</h2>
   <p>Some third party software, including Google Maps and Google Custom Search Engine, conflict with Bootstrap due to <code>* { box-sizing: border-box; }</code>, a rule which makes it so <code>padding</code> does not affect the final computed width of an element. Learn more about <a href="http://css-tricks.com/box-sizing/">box model and sizing at CSS Tricks</a>.</p>
   <p>Depending on the context, you may override as-needed (Option 1) or reset the box-sizing for entire regions (Option 2).</p>
 {% highlight scss %}


### PR DESCRIPTION
Fixed all instances of document hierarchy gaps from `h1` :arrow_right: `h3` and also the skips from `h1` :arrow_right: `h4` in `license.html`.

Here's the side-by-side before-and-after illustrating these changes — showing the last few sections within Getting Started.

![bs-setting-started](https://cloud.githubusercontent.com/assets/80144/6419221/6d9c4ef6-be89-11e4-998b-fe3135b83bed.jpg)
