### PR TITLE
iOS fix for role="button" elements; [fixes #15935]

### DIFF
--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -148,3 +148,14 @@ hr {
     clip: auto;
   }
 }
+
+
+// iOS "clickable elements" fix for role="button"
+//
+// Fixes "clickability" issue (and more generally, the firing of events such as focus as well)
+// for traditionally non-focusable elements with role="button"
+// see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
+
+[role="button"] {
+  cursor: pointer;
+}


### PR DESCRIPTION
Fixes "clickability" issue (and more generally, the firing of events such as focus as well) for traditionally non-focusable elements with `role="button"` (see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile)

Fixes #15935
