### PR TITLE
Input group sizes: Properly position `.form-control-feedback`

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -144,7 +144,7 @@ output {
     background-color: @input-bg-disabled;
     opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655
   }
-  
+
   &[disabled],
   fieldset[disabled] & {
     cursor: @cursor-disabled;
@@ -376,12 +376,14 @@ input[type="checkbox"] {
   text-align: center;
   pointer-events: none;
 }
-.input-lg + .form-control-feedback {
+.input-lg + .form-control-feedback,
+.input-group-lg + .form-control-feedback {
   width: @input-height-large;
   height: @input-height-large;
   line-height: @input-height-large;
 }
-.input-sm + .form-control-feedback {
+.input-sm + .form-control-feedback,
+.input-group-sm + .form-control-feedback {
   width: @input-height-small;
   height: @input-height-small;
   line-height: @input-height-small;


### PR DESCRIPTION
Ref https://github.com/twbs/bootstrap/issues/12868#issuecomment-76291513
Ref 7733f24

Before: http://jsbin.com/hubiju/1
After: http://jsbin.com/hubiju/2

The reason I didn't convert the selector into something like this

``` less
.input-lg,
.input-group-lg {
  + .form-control-feedback { ... }
}
```

is that it would be mixed into [here](https://github.com/twbs/bootstrap/blob/1ba2630ccf460106036129086c98c5bacd7baa98/less/input-groups.less#L43).

/cc @mdo
