### PR TITLE
[Fix #15253] Trigger hide event when escape key is pressed

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -106,9 +106,9 @@
 
     e = $.Event('hide.bs.modal')
 
-    this.$element.trigger(e)
-
     if (!this.isShown || e.isDefaultPrevented()) return
+
+    this.$element.trigger(e)
 
     this.isShown = false
 
@@ -121,6 +121,7 @@
       .removeClass('in')
       .attr('aria-hidden', true)
       .off('click.dismiss.bs.modal')
+      .hide()
 
     $.support.transition && this.$element.hasClass('fade') ?
       this.$element
@@ -142,7 +143,7 @@
   Modal.prototype.escape = function () {
     if (this.isShown && this.options.keyboard) {
       this.$element.on('keydown.dismiss.bs.modal', $.proxy(function (e) {
-        e.which == 27 && this.hide()
+        e.which == 27 && this.hideModal()
       }, this))
     } else if (!this.isShown) {
       this.$element.off('keydown.dismiss.bs.modal')
@@ -159,12 +160,14 @@
 
   Modal.prototype.hideModal = function () {
     var that = this
-    this.$element.hide()
+    this.hide()
     this.backdrop(function () {
-      that.$body.removeClass('modal-open')
-      that.resetAdjustments()
-      that.resetScrollbar()
-      that.$element.trigger('hidden.bs.modal')
+      if (that.$body.hasClass('modal-open')) {
+        that.$body.removeClass('modal-open')
+        that.resetAdjustments()
+        that.resetScrollbar()
+        that.$element.trigger('hidden.bs.modal')
+      }
     })
   }
 

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -232,6 +232,22 @@ $(function () {
       .bootstrapModal('show')
   })
 
+  QUnit.test('should trigger hide event when escape key is pressed', function (assert) {
+    var done = assert.async()
+    var triggered = false
+
+    var div = $('<div id="modal-test"><div class="contents"/></div>')
+    div.on('shown.bs.modal', function () {
+        div.trigger($.Event('keydown', { which: 27 }))
+      })
+      .on('hide.bs.modal', function () {
+        triggered = true
+        assert.strictEqual(triggered, true, 'modal hide event triggered on escape key')
+        done()
+      })
+      .bootstrapModal('show')
+  })
+
   QUnit.test('should close reopened modal with [data-dismiss="modal"] click', function (assert) {
     var done = assert.async()
 


### PR DESCRIPTION
Hi,

I took the work of @JackEllis and I had a unit test to check if the hide event is called or not
to fix this issue #15253.
Now you have all the modal event fired when espace key is pressed (hide,hidden).
