### PR TITLE
Hiding an uninitialized tooltip/popover no longer initializes it

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -85,7 +85,7 @@
       var data    = $this.data('bs.popover')
       var options = typeof option == 'object' && option
 
-      if (!data && option == 'destroy') return
+      if (!data && /destroy|hide/.test(option)) return
       if (!data) $this.data('bs.popover', (data = new Popover(this, options)))
       if (typeof option == 'string') data[option]()
     })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -247,4 +247,16 @@ $(function () {
     }, new Error('`selector` option must be specified when initializing popover on the window.document object!'))
   })
 
+  QUnit.test('should do nothing when an attempt is made to hide an uninitialized popover', function (assert) {
+    assert.expect(1)
+
+    var $popover = $('<span data-toggle="popover" data-title="some title" data-content="some content">some text</span>')
+      .appendTo('#qunit-fixture')
+      .on('hidden.bs.popover shown.bs.popover', function () {
+        assert.ok(false, 'should not fire any popover events')
+      })
+      .bootstrapPopover('hide')
+    assert.strictEqual($popover.data('bs.popover'), undefined, 'should not initialize the popover')
+  })
+
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1168,4 +1168,16 @@ $(function () {
     }, new Error('`selector` option must be specified when initializing tooltip on the window.document object!'))
   })
 
+  QUnit.test('should do nothing when an attempt is made to hide an uninitialized tooltip', function (assert) {
+    assert.expect(1)
+
+    var $tooltip = $('<span data-toggle="tooltip" title="some tip">some text</span>')
+      .appendTo('#qunit-fixture')
+      .on('hidden.bs.tooltip shown.bs.tooltip', function () {
+        assert.ok(false, 'should not fire any tooltip events')
+      })
+      .bootstrapTooltip('hide')
+    assert.strictEqual($tooltip.data('bs.tooltip'), undefined, 'should not initialize the tooltip')
+  })
+
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -453,7 +453,7 @@
       var data    = $this.data('bs.tooltip')
       var options = typeof option == 'object' && option
 
-      if (!data && option == 'destroy') return
+      if (!data && /destroy|hide/.test(option)) return
       if (!data) $this.data('bs.tooltip', (data = new Tooltip(this, options)))
       if (typeof option == 'string') data[option]()
     })


### PR DESCRIPTION
Fixes #15874.
CC: @XhmikosR @hnrch02 for review
