### PR TITLE
[Fix #15991] Pseudo-class :hover styles should allow class .hover

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -38,6 +38,7 @@
   // Hover state, but only for links
   a& {
     &:hover,
+    &.hover,
     &:focus {
       color: @badge-link-hover-color;
       text-decoration: none;

--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -13,6 +13,7 @@
     float: left;
     // Bring the "active" button to the front
     &:hover,
+    &.hover,
     &:focus,
     &:active,
     &.active {

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -30,6 +30,7 @@
   }
 
   &:hover,
+  &.hover,
   &:focus,
   &.focus {
     color: @btn-default-color;
@@ -100,11 +101,13 @@
   }
   &,
   &:hover,
+  &.hover,
   &:focus,
   &:active {
     border-color: transparent;
   }
   &:hover,
+  &.hover,
   &:focus {
     color: @link-hover-color;
     text-decoration: @link-hover-decoration;
@@ -113,6 +116,7 @@
   &[disabled],
   fieldset[disabled] & {
     &:hover,
+    &.hover,
     &:focus {
       color: @btn-link-disabled-color;
       text-decoration: none;

--- a/less/carousel.less
+++ b/less/carousel.less
@@ -116,6 +116,7 @@
 
   // Hover/focus state
   &:hover,
+  &.hover,
   &:focus {
     outline: 0;
     color: @carousel-control-color;

--- a/less/close.less
+++ b/less/close.less
@@ -13,6 +13,7 @@
   .opacity(.2);
 
   &:hover,
+  &.hover,
   &:focus {
     color: @close-color;
     text-decoration: none;

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -75,6 +75,7 @@
 // Hover/Focus state
 .dropdown-menu > li > a {
   &:hover,
+  &.hover,
   &:focus {
     text-decoration: none;
     color: @dropdown-link-hover-color;
@@ -86,6 +87,7 @@
 .dropdown-menu > .active > a {
   &,
   &:hover,
+  &.hover,
   &:focus {
     color: @dropdown-link-active-color;
     text-decoration: none;
@@ -101,12 +103,14 @@
 .dropdown-menu > .disabled > a {
   &,
   &:hover,
+  &.hover,
   &:focus {
     color: @dropdown-link-disabled-color;
   }
 
   // Nuke hover/focus effects
   &:hover,
+  &.hover,
   &:focus {
     text-decoration: none;
     background-color: transparent;

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -144,6 +144,7 @@
     }
     // Bring the "active" button to the front
     &:hover,
+    &.hover,
     &:focus,
     &:active {
       z-index: 2;

--- a/less/labels.less
+++ b/less/labels.less
@@ -17,6 +17,7 @@
   // Add hover effects, but only for links
   a& {
     &:hover,
+    &.hover,
     &:focus {
       color: @label-link-hover-color;
       text-decoration: none;

--- a/less/list-group.less
+++ b/less/list-group.less
@@ -52,6 +52,7 @@ a.list-group-item {
 
   // Hover state
   &:hover,
+  &.hover,
   &:focus {
     text-decoration: none;
     color: @list-group-link-hover-color;
@@ -63,6 +64,7 @@ a.list-group-item {
   // Disabled state
   &.disabled,
   &.disabled:hover,
+  &.disabled.hover,
   &.disabled:focus {
     background-color: @list-group-disabled-bg;
     color: @list-group-disabled-color;
@@ -80,6 +82,7 @@ a.list-group-item {
   // Active class on item itself, not parent
   &.active,
   &.active:hover,
+  &.active.hover,
   &.active:focus {
     z-index: 2; // Place active items above their siblings for proper border styling
     color: @list-group-active-color;

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -169,6 +169,7 @@
   height: @navbar-height;
 
   &:hover,
+  &.hover,
   &:focus {
     text-decoration: none;
   }
@@ -256,6 +257,7 @@
       > li > a {
         line-height: @line-height-computed;
         &:hover,
+        &.hover,
         &:focus {
           background-image: none;
         }
@@ -400,6 +402,7 @@
   .navbar-brand {
     color: @navbar-default-brand-color;
     &:hover,
+    &.hover,
     &:focus {
       color: @navbar-default-brand-hover-color;
       background-color: @navbar-default-brand-hover-bg;
@@ -415,6 +418,7 @@
       color: @navbar-default-link-color;
 
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-default-link-hover-color;
         background-color: @navbar-default-link-hover-bg;
@@ -423,6 +427,7 @@
     > .active > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-default-link-active-color;
         background-color: @navbar-default-link-active-bg;
@@ -431,6 +436,7 @@
     > .disabled > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-default-link-disabled-color;
         background-color: @navbar-default-link-disabled-bg;
@@ -441,6 +447,7 @@
   .navbar-toggle {
     border-color: @navbar-default-toggle-border-color;
     &:hover,
+    &.hover,
     &:focus {
       background-color: @navbar-default-toggle-hover-bg;
     }
@@ -460,6 +467,7 @@
     > .open > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         background-color: @navbar-default-link-active-bg;
         color: @navbar-default-link-active-color;
@@ -472,6 +480,7 @@
         > li > a {
           color: @navbar-default-link-color;
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-default-link-hover-color;
             background-color: @navbar-default-link-hover-bg;
@@ -480,6 +489,7 @@
         > .active > a {
           &,
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-default-link-active-color;
             background-color: @navbar-default-link-active-bg;
@@ -488,6 +498,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-default-link-disabled-color;
             background-color: @navbar-default-link-disabled-bg;
@@ -504,7 +515,8 @@
 
   .navbar-link {
     color: @navbar-default-link-color;
-    &:hover {
+    &:hover,
+    &.hover {
       color: @navbar-default-link-hover-color;
     }
   }
@@ -512,12 +524,14 @@
   .btn-link {
     color: @navbar-default-link-color;
     &:hover,
+    &.hover,
     &:focus {
       color: @navbar-default-link-hover-color;
     }
     &[disabled],
     fieldset[disabled] & {
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-default-link-disabled-color;
       }
@@ -534,6 +548,7 @@
   .navbar-brand {
     color: @navbar-inverse-brand-color;
     &:hover,
+    &.hover,
     &:focus {
       color: @navbar-inverse-brand-hover-color;
       background-color: @navbar-inverse-brand-hover-bg;
@@ -549,6 +564,7 @@
       color: @navbar-inverse-link-color;
 
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-inverse-link-hover-color;
         background-color: @navbar-inverse-link-hover-bg;
@@ -557,6 +573,7 @@
     > .active > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-inverse-link-active-color;
         background-color: @navbar-inverse-link-active-bg;
@@ -565,6 +582,7 @@
     > .disabled > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-inverse-link-disabled-color;
         background-color: @navbar-inverse-link-disabled-bg;
@@ -576,6 +594,7 @@
   .navbar-toggle {
     border-color: @navbar-inverse-toggle-border-color;
     &:hover,
+    &.hover,
     &:focus {
       background-color: @navbar-inverse-toggle-hover-bg;
     }
@@ -594,6 +613,7 @@
     > .open > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         background-color: @navbar-inverse-link-active-bg;
         color: @navbar-inverse-link-active-color;
@@ -612,6 +632,7 @@
         > li > a {
           color: @navbar-inverse-link-color;
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-inverse-link-hover-color;
             background-color: @navbar-inverse-link-hover-bg;
@@ -620,6 +641,7 @@
         > .active > a {
           &,
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-inverse-link-active-color;
             background-color: @navbar-inverse-link-active-bg;
@@ -628,6 +650,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &.hover,
           &:focus {
             color: @navbar-inverse-link-disabled-color;
             background-color: @navbar-inverse-link-disabled-bg;
@@ -639,7 +662,8 @@
 
   .navbar-link {
     color: @navbar-inverse-link-color;
-    &:hover {
+    &:hover,
+    &.hover {
       color: @navbar-inverse-link-hover-color;
     }
   }
@@ -647,12 +671,14 @@
   .btn-link {
     color: @navbar-inverse-link-color;
     &:hover,
+    &.hover,
     &:focus {
       color: @navbar-inverse-link-hover-color;
     }
     &[disabled],
     fieldset[disabled] & {
       &:hover,
+      &.hover,
       &:focus {
         color: @navbar-inverse-link-disabled-color;
       }

--- a/less/navs.less
+++ b/less/navs.less
@@ -21,6 +21,7 @@
       display: block;
       padding: @nav-link-padding;
       &:hover,
+      &.hover,
       &:focus {
         text-decoration: none;
         background-color: @nav-link-hover-bg;
@@ -32,6 +33,7 @@
       color: @nav-disabled-link-color;
 
       &:hover,
+      &.hover,
       &:focus {
         color: @nav-disabled-link-hover-color;
         text-decoration: none;
@@ -45,6 +47,7 @@
   .open > a {
     &,
     &:hover,
+    &.hover,
     &:focus {
       background-color: @nav-link-hover-bg;
       border-color: @link-color;
@@ -86,7 +89,8 @@
       line-height: @line-height-base;
       border: 1px solid transparent;
       border-radius: @border-radius-base @border-radius-base 0 0;
-      &:hover {
+      &:hover,
+      &.hover {
         border-color: @nav-tabs-link-hover-border-color @nav-tabs-link-hover-border-color @nav-tabs-border-color;
       }
     }
@@ -95,6 +99,7 @@
     &.active > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @nav-tabs-active-link-hover-color;
         background-color: @nav-tabs-active-link-hover-bg;
@@ -130,6 +135,7 @@
     &.active > a {
       &,
       &:hover,
+      &.hover,
       &:focus {
         color: @nav-pills-active-link-hover-color;
         background-color: @nav-pills-active-link-hover-bg;
@@ -198,6 +204,7 @@
 
   > .active > a,
   > .active > a:hover,
+  > .active > a.hover,
   > .active > a:focus {
     border: 1px solid @nav-tabs-justified-link-border-color;
   }
@@ -209,6 +216,7 @@
     }
     > .active > a,
     > .active > a:hover,
+    > .active > a.hover,
     > .active > a:focus {
       border-bottom-color: @nav-tabs-justified-active-link-border-color;
     }

--- a/less/pager.less
+++ b/less/pager.less
@@ -21,6 +21,7 @@
     }
 
     > a:hover,
+    > a.hover,
     > a:focus {
       text-decoration: none;
       background-color: @pager-hover-bg;
@@ -44,6 +45,7 @@
   .disabled {
     > a,
     > a:hover,
+    > a.hover,
     > a:focus,
     > span {
       color: @pager-disabled-color;

--- a/less/pagination.less
+++ b/less/pagination.less
@@ -39,6 +39,7 @@
   > li > a,
   > li > span {
     &:hover,
+    &.hover,
     &:focus {
       color: @pagination-hover-color;
       background-color: @pagination-hover-bg;
@@ -50,6 +51,7 @@
   > .active > span {
     &,
     &:hover,
+    &.hover,
     &:focus {
       z-index: 2;
       color: @pagination-active-color;
@@ -62,9 +64,11 @@
   > .disabled {
     > span,
     > span:hover,
+    > span.hover,
     > span:focus,
     > a,
     > a:hover,
+    > a.hover,
     > a:focus {
       color: @pagination-disabled-color;
       background-color: @pagination-disabled-bg;

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -50,6 +50,7 @@ a {
   text-decoration: none;
 
   &:hover,
+  &.hover,
   &:focus {
     color: @link-hover-color;
     text-decoration: @link-hover-decoration;

--- a/less/tables.less
+++ b/less/tables.less
@@ -122,7 +122,8 @@ th {
 // Placed here since it has to come after the potential zebra striping
 
 .table-hover {
-  > tbody > tr:hover {
+  > tbody > tr:hover,
+  > tbody > tr.hover {
     background-color: @table-bg-hover;
   }
 }

--- a/less/theme.less
+++ b/less/theme.less
@@ -41,6 +41,8 @@
   border-color: darken(@btn-color, 14%);
 
   &:hover,
+  &.hover,
+  &.hover,
   &:focus  {
     background-color: darken(@btn-color, 12%);
     background-position: 0 -15px;
@@ -93,12 +95,15 @@
 // --------------------------------------------------
 
 .dropdown-menu > li > a:hover,
+.dropdown-menu > li > a.hover,
+.dropdown-menu > li > a.hover,
 .dropdown-menu > li > a:focus {
   #gradient > .vertical(@start-color: @dropdown-link-hover-bg; @end-color: darken(@dropdown-link-hover-bg, 5%));
   background-color: darken(@dropdown-link-hover-bg, 5%);
 }
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
+.dropdown-menu > .active > a.hover,
 .dropdown-menu > .active > a:focus {
   #gradient > .vertical(@start-color: @dropdown-link-active-bg; @end-color: darken(@dropdown-link-active-bg, 5%));
   background-color: darken(@dropdown-link-active-bg, 5%);
@@ -157,6 +162,7 @@
   .navbar .navbar-nav .open .dropdown-menu > .active > a {
     &,
     &:hover,
+    &.hover,
     &:focus {
       color: #fff;
       #gradient > .vertical(@start-color: @dropdown-link-active-bg; @end-color: darken(@dropdown-link-active-bg, 5%));
@@ -227,6 +233,7 @@
 }
 .list-group-item.active,
 .list-group-item.active:hover,
+.list-group-item.active.hover,
 .list-group-item.active:focus {
   text-shadow: 0 -1px 0 darken(@list-group-active-bg, 10%);
   #gradient > .vertical(@start-color: @list-group-active-bg; @end-color: darken(@list-group-active-bg, 7.5%));

--- a/less/thumbnails.less
+++ b/less/thumbnails.less
@@ -23,6 +23,7 @@
 
   // Add a hover state for linked versions only
   a&:hover,
+  a&.hover,
   a&:focus,
   a&.active {
     border-color: @link-color;


### PR DESCRIPTION
[Fix #15991] Pseudo-class :hover styles should also be enabled with the class selector .hover
