### PR TITLE
Changed the value when the navbar should collapse, this value doesn't match with visible-xs and visible-sm

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -322,7 +322,7 @@
 @grid-gutter-width:         30px;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
-@grid-float-breakpoint:     @screen-sm-min;
+@grid-float-breakpoint:     @screen-sm-max;
 //** Point at which the navbar begins collapsing.
 @grid-float-breakpoint-max: (@grid-float-breakpoint - 1);
 


### PR DESCRIPTION
please see this two examples:

"fixed":
https://dl.dropboxusercontent.com/u/4727553/bootstrapExample/withfix/index.html

"notfixed":
https://dl.dropboxusercontent.com/u/4727553/bootstrapExample/withnofix/index.htm

the first image shows the table and the navbar collapsed:
![withfix](https://cloud.githubusercontent.com/assets/2349816/6496445/ca0cbf18-c2cb-11e4-9c99-436bff61f9dc.png)

the second image shows the table collpsed and the navbar is not collapsed:
![withnofix](https://cloud.githubusercontent.com/assets/2349816/6496446/ca30ef1e-c2cb-11e4-9e63-2e6a5ffade8c.png)
