### PR TITLE
Use 'disable-ontouchstart' instead of 'ontouchstart' in dropdown.js

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -32,7 +32,7 @@
     clearMenus()
 
     if (!isActive) {
-      if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
+      if ('disable-ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
         // if mobile we use a backdrop because click events don't delegate
         $('<div class="dropdown-backdrop"/>').insertAfter($(this)).on('click', clearMenus)
       }


### PR DESCRIPTION
Replace `ontouchstart` with `disable-ontouchstart` in `dropdown.js` to make links work on touch devices.
