### PR TITLE
.collapse('hide') on hidden uninit-ed collapsible no longer shows it

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -172,7 +172,7 @@
       var data    = $this.data('bs.collapse')
       var options = $.extend({}, Collapse.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
-      if (!data && options.toggle && option == 'show') options.toggle = false
+      if (!data && options.toggle && /show|hide/.test(option)) options.toggle = false
       if (!data) $this.data('bs.collapse', (data = new Collapse(this, options)))
       if (typeof option == 'string') data[option]()
     })

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -147,7 +147,7 @@ $(function () {
     $target.click()
   })
 
-  QUnit.test('should not close a collapse when initialized with "show" if already shown', function (assert) {
+  QUnit.test('should not close a collapse when initialized with "show" option if already shown', function (assert) {
     assert.expect(0)
     var done = assert.async()
 
@@ -162,7 +162,7 @@ $(function () {
     setTimeout(done, 0)
   })
 
-  QUnit.test('should open a collapse when initialized with "show" if not already shown', function (assert) {
+  QUnit.test('should open a collapse when initialized with "show" option if not already shown', function (assert) {
     assert.expect(1)
     var done = assert.async()
 
@@ -173,6 +173,34 @@ $(function () {
       })
 
     $test.bootstrapCollapse('show')
+
+    setTimeout(done, 0)
+  })
+
+  QUnit.test('should not show a collapse when initialized with "hide" option if already hidden', function (assert) {
+    assert.expect(0)
+    var done = assert.async()
+
+    $('<div class="collapse"></div>')
+      .appendTo('#qunit-fixture')
+      .on('show.bs.collapse', function () {
+        assert.ok(false, 'showing a previously-uninitialized hidden collapse when the "hide" method is called')
+      })
+      .bootstrapCollapse('hide')
+
+    setTimeout(done, 0)
+  })
+
+  QUnit.test('should hide a collapse when initialized with "hide" option if not already hidden', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+
+    $('<div class="collapse in"></div>')
+      .appendTo('#qunit-fixture')
+      .on('hide.bs.collapse', function () {
+        assert.ok(true, 'hiding a previously-uninitialized shown collapse when the "hide" method is called')
+      })
+      .bootstrapCollapse('hide')
 
     setTimeout(done, 0)
   })

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -41,11 +41,10 @@ $(function () {
   })
 
   QUnit.test('should hide a collapsed element', function (assert) {
-    assert.expect(2)
+    assert.expect(1)
     var $el = $('<div class="collapse"/>').bootstrapCollapse('hide')
 
     assert.ok(!$el.hasClass('in'), 'does not have class "in"')
-    assert.ok(/height/i.test($el.attr('style')), 'has height set')
   })
 
   QUnit.test('should not fire shown when show is prevented', function (assert) {


### PR DESCRIPTION
Fixes #15315.
Closes #15807.
X-Ref: #14282, #14417

CC: @XhmikosR @hnrch02 @juthilo for review
