### PR TITLE
Disable jQuery event aliases when running test suite

### DIFF
--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -7,6 +7,46 @@
 
     <!-- jQuery -->
     <script src="vendor/jquery.min.js"></script>
+    <script>
+      // Disable jQuery event aliases to ensure we don't accidentally use any of them
+      (function () {
+        var eventAliases = [
+          'blur',
+          'focus',
+          'focusin',
+          'focusout',
+          'load',
+          'resize',
+          'scroll',
+          'unload',
+          'click',
+          'dblclick',
+          'mousedown',
+          'mouseup',
+          'mousemove',
+          'mouseover',
+          'mouseout',
+          'mouseenter',
+          'mouseleave',
+          'change',
+          'select',
+          'submit',
+          'keydown',
+          'keypress',
+          'keyup',
+          'error',
+          'contextmenu',
+          'hover',
+          'bind',
+          'unbind',
+          'delegate',
+          'undelegate'
+        ]
+        for (var i = 0; i < eventAliases.length; i++) {
+          $.fn[eventAliases[i]] = undefined
+        }
+      })()
+    </script>
 
     <!-- QUnit -->
     <link rel="stylesheet" href="vendor/qunit.css" media="screen">

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -40,7 +40,7 @@ $(function () {
         + '</div>'
     var $alert = $(alertHTML).bootstrapAlert()
 
-    $alert.find('.close').click()
+    $alert.find('.close').trigger('click')
 
     assert.strictEqual($alert.hasClass('in'), false, 'remove .in class on .close click')
   })
@@ -55,7 +55,7 @@ $(function () {
 
     assert.notEqual($('#qunit-fixture').find('.alert').length, 0, 'element added to dom')
 
-    $alert.find('.close').click()
+    $alert.find('.close').trigger('click')
 
     assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'element removed from dom')
   })

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -106,7 +106,7 @@ $(function () {
       .append($inner)
       .appendTo('#qunit-fixture')
     assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
-    $inner.click()
+    $inner.trigger('click')
     assert.ok($btn.hasClass('active'), 'btn has class active')
   })
 
@@ -126,7 +126,7 @@ $(function () {
       .append($inner)
       .appendTo('#qunit-fixture')
     assert.strictEqual($btn.attr('aria-pressed'), 'false', 'btn aria-pressed state is false')
-    $inner.click()
+    $inner.trigger('click')
     assert.strictEqual($btn.attr('aria-pressed'), 'true', 'btn aria-pressed state is true')
   })
 
@@ -139,7 +139,7 @@ $(function () {
       .append($btn.append($inner))
       .appendTo('#qunit-fixture')
     assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
-    $inner.click()
+    $inner.trigger('click')
     assert.ok($btn.hasClass('active'), 'btn has class active')
   })
 
@@ -165,13 +165,13 @@ $(function () {
     assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
     assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
     assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
-    $btn2.find('input').click()
+    $btn2.find('input').trigger('click')
     assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
     assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is checked')
     assert.ok($btn2.hasClass('active'), 'btn2 has active class')
     assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
 
-    $btn2.find('input').click() // clicking an already checked radio should not un-check it
+    $btn2.find('input').trigger('click') // clicking an already checked radio should not un-check it
     assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
     assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is checked')
     assert.ok($btn2.hasClass('active'), 'btn2 has active class')

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -336,19 +336,19 @@ $(function () {
     $carousel.attr('data-interval', 1814)
 
     $carousel.appendTo('body')
-    $('[data-slide]').first().click()
+    $('[data-slide]').first().trigger('click')
     assert.strictEqual($carousel.data('bs.carousel').options.interval, 1814)
     $carousel.remove()
 
     $carousel.appendTo('body').attr('data-modal', 'foobar')
-    $('[data-slide]').first().click()
+    $('[data-slide]').first().trigger('click')
     assert.strictEqual($carousel.data('bs.carousel').options.interval, 1814, 'even if there is an data-modal attribute set')
     $carousel.remove()
 
     $carousel.appendTo('body')
-    $('[data-slide]').first().click()
+    $('[data-slide]').first().trigger('click')
     $carousel.attr('data-interval', 1860)
-    $('[data-slide]').first().click()
+    $('[data-slide]').first().trigger('click')
     assert.strictEqual($carousel.data('bs.carousel').options.interval, 1814, 'attributes should be read only on initialization')
     $carousel.remove()
 

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -91,7 +91,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should add "collapsed" class to target when collapse is hidden', function (assert) {
@@ -107,7 +107,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should remove "collapsed" class from all triggers targeting the collapse when the collapse is shown', function (assert) {
@@ -125,7 +125,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should add "collapsed" class to all triggers targeting the collapse when the collapse is hidden', function (assert) {
@@ -143,7 +143,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should not close a collapse when initialized with "show" option if already shown', function (assert) {
@@ -235,7 +235,7 @@ $(function () {
         done()
       })
 
-    $target3.click()
+    $target3.trigger('click')
   })
 
   QUnit.test('should allow dots in data-parent', function (assert) {
@@ -269,7 +269,7 @@ $(function () {
         done()
       })
 
-    $target3.click()
+    $target3.trigger('click')
   })
 
   QUnit.test('should set aria-expanded="true" on target when collapse is shown', function (assert) {
@@ -285,7 +285,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should set aria-expanded="false" on target when collapse is hidden', function (assert) {
@@ -301,7 +301,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should set aria-expanded="true" on all triggers targeting the collapse when the collapse is shown', function (assert) {
@@ -319,7 +319,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should set aria-expanded="false" on all triggers targeting the collapse when the collapse is hidden', function (assert) {
@@ -337,7 +337,7 @@ $(function () {
         done()
       })
 
-    $target.click()
+    $target.trigger('click')
   })
 
   QUnit.test('should change aria-expanded from active accordion target to "false" and set the newly active one to "true"', function (assert) {
@@ -371,7 +371,7 @@ $(function () {
         done()
       })
 
-    $target3.click()
+    $target3.trigger('click')
   })
 
   QUnit.test('should not fire show event if show is prevented because other element is still transitioning', function (assert) {
@@ -396,13 +396,13 @@ $(function () {
     var $target2 = $('<a data-toggle="collapse" href="#body2" data-parent="#accordion"/>').appendTo($groups.eq(1))
     var $body2   = $('<div id="body2" class="collapse"/>').appendTo($groups.eq(1))
 
-    $target2.click()
+    $target2.trigger('click')
 
     $body2
       .toggleClass('in collapsing')
       .data('bs.collapse').transitioning = 1
 
-    $target1.click()
+    $target1.trigger('click')
 
     setTimeout(function () {
       assert.ok(!showFired, 'show event did not fire')

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -45,7 +45,7 @@ $(function () {
         + '</ul>'
         + '</li>'
         + '</ul>'
-    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
+    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().trigger('click')
 
     assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"open" class added on click')
   })
@@ -66,7 +66,7 @@ $(function () {
     var $dropdown = $(dropdownHTML)
       .find('[data-toggle="dropdown"]')
       .bootstrapDropdown()
-      .click()
+      .trigger('click')
 
     assert.strictEqual($dropdown.attr('aria-expanded'), 'true', 'aria-expanded is set to string "true" on click')
   })
@@ -97,8 +97,8 @@ $(function () {
         done()
       })
 
-    $dropdown.click()
-    $(document.body).click()
+    $dropdown.trigger('click')
+    $(document.body).trigger('click')
   })
 
   QUnit.test('should not open dropdown if target is disabled via class', function (assert) {
@@ -114,7 +114,7 @@ $(function () {
         + '</ul>'
         + '</li>'
         + '</ul>'
-    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
+    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().trigger('click')
 
     assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"open" class added on click')
   })
@@ -132,7 +132,7 @@ $(function () {
         + '</ul>'
         + '</li>'
         + '</ul>'
-    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
+    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().trigger('click')
 
     assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"open" class added on click')
   })
@@ -150,7 +150,7 @@ $(function () {
         + '</ul>'
         + '</li>'
         + '</ul>'
-    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().click()
+    var $dropdown = $(dropdownHTML).find('[data-toggle="dropdown"]').bootstrapDropdown().trigger('click')
 
     assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"open" class added on click')
   })
@@ -173,10 +173,10 @@ $(function () {
       .appendTo('#qunit-fixture')
       .find('[data-toggle="dropdown"]')
       .bootstrapDropdown()
-      .click()
+      .trigger('click')
 
     assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"open" class added on click')
-    $(document.body).click()
+    $(document.body).trigger('click')
     assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"open" class removed')
   })
 
@@ -204,16 +204,16 @@ $(function () {
 
     assert.strictEqual($dropdowns.length, 2, 'two dropdowns')
 
-    $first.click()
+    $first.trigger('click')
     assert.strictEqual($first.parents('.open').length, 1, '"open" class added on click')
     assert.strictEqual($('#qunit-fixture .open').length, 1, 'only one dropdown is open')
-    $(document.body).click()
+    $(document.body).trigger('click')
     assert.strictEqual($('#qunit-fixture .open').length, 0, '"open" class removed')
 
-    $last.click()
+    $last.trigger('click')
     assert.strictEqual($last.parent('.open').length, 1, '"open" class added on click')
     assert.strictEqual($('#qunit-fixture .open').length, 1, 'only one dropdown is open')
-    $(document.body).click()
+    $(document.body).trigger('click')
     assert.strictEqual($('#qunit-fixture .open').length, 0, '"open" class removed')
   })
 
@@ -247,8 +247,8 @@ $(function () {
         done()
       })
 
-    $dropdown.click()
-    $(document.body).click()
+    $dropdown.trigger('click')
+    $(document.body).trigger('click')
   })
 
 
@@ -282,8 +282,8 @@ $(function () {
         done()
       })
 
-    $dropdown.click()
-    $(document.body).click()
+    $dropdown.trigger('click')
+    $(document.body).trigger('click')
   })
 
   QUnit.test('should ignore keyboard events within <input>s and <textarea>s', function (assert) {
@@ -316,16 +316,16 @@ $(function () {
       .on('shown.bs.dropdown', function () {
         assert.ok(true, 'shown was fired')
 
-        $input.focus().trigger($.Event('keydown', { which: 38 }))
+        $input.trigger('focus').trigger($.Event('keydown', { which: 38 }))
         assert.ok($(document.activeElement).is($input), 'input still focused')
 
-        $textarea.focus().trigger($.Event('keydown', { which: 38 }))
+        $textarea.trigger('focus').trigger($.Event('keydown', { which: 38 }))
         assert.ok($(document.activeElement).is($textarea), 'textarea still focused')
 
         done()
       })
 
-    $dropdown.click()
+    $dropdown.trigger('click')
   })
 
   QUnit.test('should skip disabled element when using keyboard navigation', function (assert) {
@@ -343,7 +343,7 @@ $(function () {
       .appendTo('#qunit-fixture')
       .find('[data-toggle="dropdown"]')
       .bootstrapDropdown()
-      .click()
+      .trigger('click')
 
     $dropdown.trigger($.Event('keydown', { which: 40 }))
     $dropdown.trigger($.Event('keydown', { which: 40 }))

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -147,7 +147,7 @@ $(function () {
       .on('shown.bs.modal', function () {
         assert.ok($('#modal-test').is(':visible'), 'modal visible')
         assert.notEqual($('#modal-test').length, 0, 'modal inserted into dom')
-        $(this).find('.close').click()
+        $(this).find('.close').trigger('click')
       })
       .on('hidden.bs.modal', function () {
         assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
@@ -179,9 +179,9 @@ $(function () {
     $('<div id="modal-test"><div class="contents"/></div>')
       .on('shown.bs.modal', function () {
         assert.notEqual($('#modal-test').length, 0, 'modal inserted into dom')
-        $('.contents').click()
+        $('.contents').trigger('click')
         assert.ok($('#modal-test').is(':visible'), 'modal visible')
-        $('#modal-test').click()
+        $('#modal-test').trigger('click')
       })
       .on('hidden.bs.modal', function () {
         assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
@@ -239,7 +239,7 @@ $(function () {
     $('<div id="modal-test"><div class="contents"/></div>')
       .on('shown.bs.modal', function () {
         triggered = 0
-        $('#modal-test').click()
+        $('#modal-test').trigger('click')
       })
       .on('hide.bs.modal', function () {
         triggered += 1
@@ -255,14 +255,14 @@ $(function () {
 
     $('<div id="modal-test"><div class="contents"><div id="close" data-dismiss="modal"/></div></div>')
       .one('shown.bs.modal', function () {
-        $('#close').click()
+        $('#close').trigger('click')
       })
       .one('hidden.bs.modal', function () {
         // after one open-close cycle
         assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
         $(this)
           .one('shown.bs.modal', function () {
-            $('#close').click()
+            $('#close').trigger('click')
           })
           .one('hidden.bs.modal', function () {
             assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
@@ -287,11 +287,11 @@ $(function () {
         }, 0)
       })
       .on('shown.bs.modal', function () {
-        $('#close').click()
+        $('#close').trigger('click')
       })
       .appendTo('#qunit-fixture')
 
-    $toggleBtn.click()
+    $toggleBtn.trigger('click')
   })
 
   QUnit.test('should not restore focus to toggling element if the associated show event gets prevented', function (assert) {
@@ -303,7 +303,7 @@ $(function () {
     $('<div id="modal-test"><div class="contents"><div id="close" data-dismiss="modal"/></div>')
       .one('show.bs.modal', function (e) {
         e.preventDefault()
-        $otherBtn.focus()
+        $otherBtn.trigger('focus')
         setTimeout($.proxy(function () {
           $(this).bootstrapModal('show')
         }, this), 0)
@@ -315,11 +315,11 @@ $(function () {
         }, 0)
       })
       .on('shown.bs.modal', function () {
-        $('#close').click()
+        $('#close').trigger('click')
       })
       .appendTo('#qunit-fixture')
 
-    $toggleBtn.click()
+    $toggleBtn.trigger('click')
   })
 
   QUnit.test('should restore inline body padding after closing', function (assert) {

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -194,10 +194,10 @@ $(function () {
         trigger: 'click'
       })
 
-    $div.find('a').click()
+    $div.find('a').trigger('click')
     assert.notEqual($('.popover').length, 0, 'popover was inserted')
 
-    $div.find('a').click()
+    $div.find('a').trigger('click')
     assert.strictEqual($('.popover').length, 0, 'popover was removed')
   })
 
@@ -206,7 +206,7 @@ $(function () {
     var $content = $('<div class="content-with-handler"><a class="btn btn-warning">Button with event handler</a></div>').appendTo('#qunit-fixture')
 
     var handlerCalled = false
-    $('.content-with-handler .btn').click(function () {
+    $('.content-with-handler .btn').on('click', function () {
       handlerCalled = true
     })
 
@@ -228,7 +228,7 @@ $(function () {
           .one('hidden.bs.popover', function () {
             $div
               .one('shown.bs.popover', function () {
-                $('.content-with-handler .btn').click()
+                $('.content-with-handler .btn').trigger('click')
                 $div.bootstrapPopover('destroy')
                 assert.ok(handlerCalled, 'content\'s event handler still present')
                 done()

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -200,7 +200,7 @@ $(function () {
     assert.strictEqual($tabs.find('.active a').attr('aria-expanded'), 'true', 'shown tab has aria-expanded = true')
     assert.strictEqual($tabs.find('li:not(.active) a').attr('aria-expanded'), 'false', 'hidden tab has aria-expanded = false')
 
-    $tabs.find('li:last a').click()
+    $tabs.find('li:last a').trigger('click')
     assert.strictEqual($tabs.find('.active a').attr('aria-expanded'), 'true', 'after click, shown tab has aria-expanded = true')
     assert.strictEqual($tabs.find('li:not(.active) a').attr('aria-expanded'), 'false', 'after click, hidden tab has aria-expanded = false')
 
@@ -208,7 +208,7 @@ $(function () {
     assert.strictEqual($tabs.find('.active a').attr('aria-expanded'), 'true', 'shown tab has aria-expanded = true')
     assert.strictEqual($tabs.find('li:not(.active) a').attr('aria-expanded'), 'false', 'hidden tab has aria-expanded = false')
 
-    $tabs.find('li:first a').click()
+    $tabs.find('li:first a').trigger('click')
     assert.strictEqual($tabs.find('.active a').attr('aria-expanded'), 'true', 'after second show event, shown tab still has aria-expanded = true')
     assert.strictEqual($tabs.find('li:not(.active) a').attr('aria-expanded'), 'false', 'after second show event, hidden tab has aria-expanded = false')
   })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -248,10 +248,10 @@ $(function () {
         trigger: 'click'
       })
 
-    $div.find('a').click()
+    $div.find('a').trigger('click')
     assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
 
-    $div.find('a').click()
+    $div.find('a').trigger('click')
     assert.strictEqual($('.tooltip').length, 0, 'tooltip was removed from dom')
   })
 


### PR DESCRIPTION
To ensure that we don't accidentally use any of the aliases.
This should prevent any future regressions from #12761.
Also updates the test suite since it now can't use these aliases either.
CC: @hnrch02 
