### PR TITLE
Affix: $('body') => $(document.body)

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -78,7 +78,7 @@
     var offset       = this.options.offset
     var offsetTop    = offset.top
     var offsetBottom = offset.bottom
-    var scrollHeight = $('body').height()
+    var scrollHeight = $(document.body).height()
 
     if (typeof offset != 'object')         offsetBottom = offsetTop = offset
     if (typeof offsetTop == 'function')    offsetTop    = offset.top(this.$element)


### PR DESCRIPTION
We use `$(document.body)` everywhere else. And it's obviously faster.
