### PR TITLE
avoid unnecessary HTML string building+parsing

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -34,7 +34,10 @@
     if (!isActive) {
       if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
         // if mobile we use a backdrop because click events don't delegate
-        $('<div class="dropdown-backdrop"/>').insertAfter($(this)).on('click', clearMenus)
+        $(document.createElement('div'))
+          .addClass('dropdown-backdrop')
+          .insertAfter($(this))
+          .on('click', clearMenus)
       }
 
       var relatedTarget = { relatedTarget: this }

--- a/js/modal.js
+++ b/js/modal.js
@@ -190,7 +190,8 @@
     if (this.isShown && this.options.backdrop) {
       var doAnimate = $.support.transition && animate
 
-      this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
+      this.$backdrop = $(document.createElement('div'))
+        .addClass('modal-backdrop ' + animate)
         .appendTo(this.$body)
 
       this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {


### PR DESCRIPTION
Rather than building a string of HTML and then parsing it, which is overkill and comparatively slow, this simply creates a new blank `<div>` and then adds the requisite classes via jQuery.
This could be further tweaked to use `className` instead of jQuery's `addClass` at the cost of a bit more verbosity; I opted to be conservative.
