### PR TITLE
text-emphasis-variant mixin should change the anchor's "focused" state as well

### DIFF
--- a/less/mixins/text-emphasis.less
+++ b/less/mixins/text-emphasis.less
@@ -2,7 +2,7 @@
 
 .text-emphasis-variant(@color) {
   color: @color;
-  a&:hover {
+  a&:hover, a&:focus {
     color: darken(@color, 10%);
   }
 }


### PR DESCRIPTION
The ".text-emphasis-variant" mixin does not change the anchor's color when the anchor is in the focused state, causing the link to have the default a:focus color (defined in https://github.com/twbs/bootstrap/blob/master/less/scaffolding.less#L53).
