### PR TITLE
textarea getting expanded more than container

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -153,7 +153,7 @@ output {
   // Reset height for `textarea`s
   textarea& {
     height: auto;
-    resize: vertical;
+    resize: vertical; // fix to stop horizontal resize.
     &[disabled] {
      resize: vertical;
     }

--- a/less/forms.less
+++ b/less/forms.less
@@ -153,6 +153,10 @@ output {
   // Reset height for `textarea`s
   textarea& {
     height: auto;
+    max-width: 100%;
+    &[disabled] {
+      max-width: 100%;
+    }
   }
 }
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -153,9 +153,9 @@ output {
   // Reset height for `textarea`s
   textarea& {
     height: auto;
-    max-width: 100%;
+    resize: vertical;
     &[disabled] {
-      max-width: 100%;
+     resize: vertical;
     }
   }
 }


### PR DESCRIPTION
The issue is when you resize the text area(drag from right bottom) It goes out of the container. Fix for this is having resize:vertical  for the text area.
