### PR TITLE
Jumbotron: Putting heading font size in variables to allow for easier overrides

### DIFF
--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -44,7 +44,7 @@
 
     h1,
     .h1 {
-      font-size: (@font-size-base * 4.5);
+      font-size: @jumbotron-heading-font-size;
     }
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -484,6 +484,7 @@
 @jumbotron-bg:                   @gray-lighter;
 @jumbotron-heading-color:        inherit;
 @jumbotron-font-size:            ceil((@font-size-base * 1.5));
+@jumbotron-heading-font-size:    ceil((@font-size-base * 4.5));
 
 
 //== Form states and alerts


### PR DESCRIPTION
This was relevant on one of my projects recently. It'd be nice to be able to change the jumbotron heading font-size with a simple variable override.

Thanks!
