### PR TITLE
Only disable pointer-events on disabled <a> btns

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -3033,12 +3033,15 @@ select[multiple].form-group-lg .form-control {
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn {
-  pointer-events: none;
   cursor: not-allowed;
   filter: alpha(opacity=65);
   -webkit-box-shadow: none;
           box-shadow: none;
   opacity: .65;
+}
+a.btn.disabled,
+fieldset[disabled] a.btn {
+  pointer-events: none;
 }
 .btn-default {
   color: #333;

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -47,9 +47,15 @@
   &[disabled],
   fieldset[disabled] & {
     cursor: @cursor-disabled;
-    pointer-events: none; // Future-proof disabling of clicks
     .opacity(.65);
     .box-shadow(none);
+  }
+
+  a& {
+    &.disabled,
+    fieldset[disabled] & {
+      pointer-events: none; // Future-proof disabling of clicks on `<a>` elements
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #16088.
Applying `pointer-events: none` to non-`<a>` buttons is unnecessary and prevents their `[disabled]:hover` styles, in particular their `cursor`, from applying.
