### PR TITLE
Update jspm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,18 +76,12 @@
   ],
   "jspm": {
     "main": "js/bootstrap",
-    "directories": {
-      "example": "examples",
-      "lib": "dist"
-    },
     "shim": {
       "js/bootstrap": {
-        "imports": "jquery",
+        "deps": "jquery",
         "exports": "$"
       }
     },
-    "buildConfig": {
-      "uglify": true
-    }
+    "files": ["css", "fonts", "js"]
   }
 }


### PR DESCRIPTION
This updates to the latest jspm configuration options.

The `files` property is necessary to override the files property in the base package.json which caused the CSS folder to be ignored.
