### PR TITLE
Add `.alert-warning` related change to migration doc

### DIFF
--- a/docs/migration.html
+++ b/docs/migration.html
@@ -81,6 +81,10 @@ lead: "Guidance on how to upgrade from Bootstrap v2.x to v3.x with emphasis on m
           <td><code>.btn-lg</code></td>
         </tr>
         <tr>
+          <td><code>.alert</code></td>
+          <td><code>.alert .alert-warning</code></td>
+        </tr>
+        <tr>
           <td><code>.alert-error</code></td>
           <td><code>.alert-danger</code></td>
         </tr>


### PR DESCRIPTION
In Bootstrap 3, `.alert`s don't get any default styling, unlike the older versions where `.alert-warning` is the default style.

The migration documentation seems to be missing this, though it covers similar behavior for `.btn`.

So, this pull request just adds this missing info.
