### PR TITLE
Add resposive text-align classes

### DIFF
--- a/docs/_includes/css/type.html
+++ b/docs/_includes/css/type.html
@@ -189,12 +189,16 @@ You can use the mark tag to <mark>highlight</mark> text.
   </div>
 
   <h2 id="type-alignment">Alignment classes</h2>
-  <p>Easily realign text to components with text alignment classes.</p>
+  <p>Easily realign text to components with text alignment classes, depending on the screen size.</p>
   <div class="bs-example" data-example-id="text-alignment">
-    <p class="text-left">Left aligned text.</p>
-    <p class="text-center">Center aligned text.</p>
-    <p class="text-right">Right aligned text.</p>
-    <p class="text-justify">Justified text.</p>
+	<p class="text-left">Left aligned text.</p>
+	<p class="text-center">Center aligned text.</p>
+	<p class="text-right">Right aligned text.</p>
+	<p class="text-justify">Justified text.</p>
+    <p class="text-xs-left text-sm-right text-md-center text-lg-justify">XS-L, SM-R, MD-C, LG-J</p>
+    <p class="text-xs-right text-sm-center text-md-justify text-lg-left">XS-R, SM-C, MD-J, LG-L</p>
+    <p class="text-xs-center text-sm-justify text-md-left text-lg-right">XS-C, SM-J, MD-C, LG-R</p>
+    <p class="text-xs-justify text-sm-left text-md-right text-lg-center">XS-J, SM-L, MD-R, LG-C</p>
     <p class="text-nowrap">No wrap text.</p>
   </div>
 {% highlight html %}
@@ -202,6 +206,10 @@ You can use the mark tag to <mark>highlight</mark> text.
 <p class="text-center">Center aligned text.</p>
 <p class="text-right">Right aligned text.</p>
 <p class="text-justify">Justified text.</p>
+<p class="text-xs-left text-sm-right text-md-center text-lg-justify">XS-L, SM-R, MD-C, LG-J</p>
+<p class="text-xs-right text-sm-center text-md-justify text-lg-left">XS-R, SM-C, MD-J, LG-L</p>
+<p class="text-xs-center text-sm-justify text-md-left text-lg-right">XS-C, SM-J, MD-C, LG-R</p>
+<p class="text-xs-justify text-sm-left text-md-right text-lg-center">XS-J, SM-L, MD-R, LG-C</p>
 <p class="text-nowrap">No wrap text.</p>
 {% endhighlight %}
 

--- a/less/type.less
+++ b/less/type.less
@@ -93,6 +93,61 @@ mark,
 .text-justify        { text-align: justify; }
 .text-nowrap         { white-space: nowrap; }
 
+// Responsive text-alignment elements:
+
+//   For aligning left at given screen size
+.make-align-left(@class) {
+  .text-@{class}-left {
+    text-align: left;
+  }
+}
+
+// For aligning right at given screen size
+.make-align-right(@class) {
+  .text-@{class}-right {
+    text-align: right;
+  }
+}
+
+// For aligning center at given screen size
+.make-align-center(@class) {
+  .text-@{class}-center {
+    text-align: center;
+  }
+}
+
+// For justified aligning at given screen size
+.make-align-justify(@class) {
+  .text-@{class}-justify {
+    text-align: justify;
+  }
+}
+
+.make-aligns(@class) {
+  .make-align-left(@class);
+  .make-align-right(@class);
+  .make-align-center(@class);
+  .make-align-justify(@class);
+}
+
+// For extra small grid
+.make-aligns(xs);
+
+// For small grid
+@media (min-width: @screen-sm-min) {
+  .make-aligns(sm);
+}
+
+// For medium grid
+@media (min-width: @screen-md-min) {
+  .make-aligns(md);
+}
+
+// For large grid
+@media (min-width: @screen-lg-min) {
+  .make-aligns(lg);
+}
+
 // Transformation
 .text-lowercase      { text-transform: lowercase; }
 .text-uppercase      { text-transform: uppercase; }


### PR DESCRIPTION
Some times you want the text to be left-aligned for large screens and centred for phones. I was surprised these classes didn't already exist.
