### PR TITLE
Fire an event after content DOM created, before shown event for tooltip/popover 

### DIFF
--- a/docs/_includes/js/popovers.html
+++ b/docs/_includes/js/popovers.html
@@ -293,6 +293,10 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
           <td>hidden.bs.popover</td>
           <td>This event is fired when the popover has finished being hidden from the user (will wait for CSS transitions to complete).</td>
         </tr>
+        <tr>
+          <td>inserted.bs.popover</td>
+          <td>This event is fired after the <code>show.bs.popover</code> event when the popover template has been added to the DOM.</td>
+        </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -260,6 +260,10 @@ $('#example').tooltip(options)
           <td>hidden.bs.tooltip</td>
           <td>This event is fired when the tooltip has finished being hidden from the user (will wait for CSS transitions to complete).</td>
         </tr>
+        <tr>
+          <td>inserted.bs.tooltip</td>
+          <td>This event is fired after the <code>show.bs.tooltip</code> event when the tooltip template has been added to the DOM.</td>
+        </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -259,4 +259,21 @@ $(function () {
     assert.strictEqual($popover.data('bs.popover'), undefined, 'should not initialize the popover')
   })
 
+  QUnit.test('should fire inserted event', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+
+    $('<a href="#">@Johann-S</a>')
+      .appendTo('#qunit-fixture')
+      .on('inserted.bs.popover', function () {
+        assert.notEqual($('.popover').length, 0, 'popover was inserted')
+        assert.ok(true, 'inserted event fired')
+        done()
+      })
+      .bootstrapPopover({
+        title: 'Test',
+        content: 'Test'
+      })
+      .bootstrapPopover('show')
+  })
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -139,6 +139,20 @@ $(function () {
       .bootstrapTooltip('show')
   })
 
+  QUnit.test('should fire inserted event', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+
+    $('<div title="tooltip title"/>')
+      .appendTo('#qunit-fixture')
+      .on('inserted.bs.tooltip', function () {
+        assert.notEqual($('.tooltip').length, 0, 'tooltip was inserted')
+        assert.ok(true, 'inserted event fired')
+        done()
+      })
+      .bootstrapTooltip('show')
+  })
+
   QUnit.test('should fire shown event', function (assert) {
     assert.expect(1)
     var done = assert.async()

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -185,6 +185,7 @@
         .data('bs.' + this.type, this)
 
       this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+      this.$element.trigger('inserted.bs.' + this.type)
 
       var pos          = this.getPosition()
       var actualWidth  = $tip[0].offsetWidth


### PR DESCRIPTION
Hi,

This PR will allow user to know when the tooltip template or popover is added to the DOM.
Fixes #16124.

/CC @cvrebert 
