### PR TITLE
Tooltip/popover: Allow viewport option to be a function

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -733,7 +733,7 @@ $(function () {
       .appendTo($container)
       .bootstrapTooltip({
         placement: 'bottom',
-        viewport: function($element) {
+        viewport: function ($element) {
           return ($element.closest('.container-viewport'))
         }
       })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -719,6 +719,36 @@ $(function () {
     $styles.remove()
   })
 
+  QUnit.test('should get viewport element from function', function (assert) {
+    assert.expect(2)
+    var styles = '<style>'
+        + '.tooltip, .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+        + '.container-viewport { position: absolute; top: 50px; left: 60px; width: 300px; height: 300px; }'
+        + 'a[rel="tooltip"] { position: fixed; }'
+        + '</style>'
+    var $styles = $(styles).appendTo('head')
+
+    var $container = $('<div class="container-viewport"/>').appendTo(document.body)
+    var $target = $('<a href="#" rel="tooltip" title="tip" style="top: 50px; left: 350px;"/>')
+      .appendTo($container)
+      .bootstrapTooltip({
+        placement: 'bottom',
+        viewport: function($element) {
+          return ($element.closest('.container-viewport'))
+        }
+      })
+
+    $target.bootstrapTooltip('show')
+    var $tooltip = $container.find('.tooltip')
+    assert.strictEqual(Math.round($tooltip.offset().left), Math.round(60 + $container.width() - $tooltip[0].offsetWidth))
+
+    $target.bootstrapTooltip('hide')
+    assert.strictEqual($('.tooltip').length, 0, 'tooltip removed from dom')
+
+    $container.remove()
+    $styles.remove()
+  })
+
   QUnit.test('should not error when trying to show an auto-placed tooltip that has been removed from the dom', function (assert) {
     assert.expect(1)
     var passed = true

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -50,7 +50,12 @@
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-    this.$viewport = this.options.viewport && $(this.options.viewport.selector || this.options.viewport)
+
+    if (typeof this.options.viewport == 'function') {
+      this.$viewport = this.options.viewport.call(this, this.$element)
+    }
+
+    this.$viewport = this.$viewport || (this.options.viewport && $(this.options.viewport.selector || this.options.viewport))
 
     if (this.$element[0] instanceof document.constructor && !this.options.selector) {
       throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!')

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -50,12 +50,7 @@
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-
-    if (typeof this.options.viewport == 'function') {
-      this.$viewport = this.options.viewport.call(this, this.$element)
-    }
-
-    this.$viewport = this.$viewport || (this.options.viewport && $(this.options.viewport.selector || this.options.viewport))
+    this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
 
     if (this.$element[0] instanceof document.constructor && !this.options.selector) {
       throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!')


### PR DESCRIPTION
It might be really useful to be able to pass a function to the viewport option in some cases, just like that :

``` javascript
$('body').tooltip({
  selector: '[data-toggle="tooltip"]',
  viewport: function($element) {
    var viewport = $element.closest('.tooltip-viewport');
    return (viewport.length > 0 ? viewport : $('body'));
  }
});
```

I implemented that in this PR.

I'm open to suggestions, I'm not sure if it's a good idea to accept either a string, an object, or a function. (Did not update the doc yet because of that)

Regarding tests, I noticed that there are no tests asserting that using functions instead of string work (placement for instance), so I copied an existing viewport test, you tell me if that's enough.

Thanks
