### PR TITLE
There is no jshint:src task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -346,7 +346,7 @@ module.exports = function (grunt) {
     watch: {
       src: {
         files: '<%= jshint.core.src %>',
-        tasks: ['jshint:src', 'qunit', 'concat']
+        tasks: ['jshint:core', 'qunit', 'concat']
       },
       test: {
         files: '<%= jshint.test.src %>',


### PR DESCRIPTION
Dunno if this is an actual thing or if I’ve overlooked something but I think the watch task should be `jshint:core` here since `jshint:src` does not exist.
