### PR TITLE
(#15100) Eliminate spurrious padding in .bs-docs-header

### DIFF
--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -236,7 +236,7 @@ h4 code {
 .bs-docs-masthead,
 .bs-docs-header {
   position: relative;
-  padding: 30px 15px;
+  padding: 30px 0;
   color: #cdbfe3;
   text-align: center;
   text-shadow: 0 1px 0 rgba(0,0,0,.1);


### PR DESCRIPTION
I agree with all the comments so far [here](https://github.com/twbs/bootstrap/issues/15100).

Rather than dicker with container nesting at this late juncture, near sunset for BS 3.0x, let's just fix and move on.  It's docs only.

This PR addresses issue #15100 and eliminates the unnecessary horizontal scrollbar that appears for width for width >=768px and <= 782px.

Tested on three different iOS devices and FireFox/Chrome on OSX and it's fine now.

The only difference is the text in .bs-docs-header is shifted left by 15-pixels, lines are 30 px longer so wrap less in some circumstances in some viewports.

Fixes #15100.
