### PR TITLE
Use CSS hack to fix IE8 .caret regression

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -3561,6 +3561,7 @@ tbody.collapse.in {
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
+  border-top: 4px solid\9;
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
 }

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -11,6 +11,7 @@
   margin-left: 2px;
   vertical-align: middle;
   border-top:   @caret-width-base dashed;
+  border-top:   @caret-width-base ~"solid\9"; // IE8
   border-right: @caret-width-base solid transparent;
   border-left:  @caret-width-base solid transparent;
 }


### PR DESCRIPTION
Fixes #16172. Confirmed via Sauce Labs manual testing in IE8.
Refs #15697.
Demo: http://jsfiddle.net/nLr8o82w/1/show/
CC: @mdo for review
