### PR TITLE
rm defunct workaround for OS X Chrome <select> printing bug

### DIFF
--- a/less/print.less
+++ b/less/print.less
@@ -67,12 +67,6 @@
     }
 
     // Bootstrap specific changes start
-    //
-    // Chrome (OSX) fix for https://github.com/twbs/bootstrap/issues/11245
-    // Once fixed, we can just straight up remove this.
-    select {
-        background: #fff !important;
-    }
 
     // Bootstrap components
     .navbar {


### PR DESCRIPTION
Chrome fixed the bug several versions ago (see https://github.com/twbs/bootstrap/issues/11245#issuecomment-57494756 ), thus rendering this workaround unnecessary.
