### PR TITLE
Ultra-small version of the well for displaying dense row-data.

### DIFF
--- a/less/wells.less
+++ b/less/wells.less
@@ -28,7 +28,7 @@
   border-radius: @border-radius-small;
 }
 
-.well-tny {
+.well-xs {
   padding: 4px;
   margin-bottom: 5px;
   border-radius: @border-radius-small;

--- a/less/wells.less
+++ b/less/wells.less
@@ -27,3 +27,9 @@
   padding: 9px;
   border-radius: @border-radius-small;
 }
+
+.well-tny {
+  padding: 4px;
+  margin-bottom: 5px;
+  border-radius: @border-radius-small;
+}


### PR DESCRIPTION
This (very minor) change just adds a even smaller version of the `well` class, intended for displaying data with greater screen-efficiency.

It builds and works fine, but I don't have Jekyll or java on the box I have node on, and don't want to install at least java if I can't absolutely avoid it. The change is so small I don't think it's too important anyways.
