### PR TITLE
Fixes #16270.

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -12,7 +12,7 @@
   font-weight: @badge-font-weight;
   color: @badge-color;
   line-height: @badge-line-height;
-  vertical-align: baseline;
+  vertical-align: middle;
   white-space: nowrap;
   text-align: center;
   background-color: @badge-bg;


### PR DESCRIPTION
Badges now appeared vertically centered next to text. Previously, badges appeared to be somewhat lower than tall text such as h1's next to it.
