### PR TITLE
affix plugin does not work within a pulled/pushed column

### DIFF
--- a/docs/_includes/js/affix.html
+++ b/docs/_includes/js/affix.html
@@ -8,6 +8,7 @@
 
   <h2 id="affix-usage">Usage</h2>
   <p>Use the affix plugin via data attributes or manually with your own JavaScript. <strong class="text-danger">In both situations, you must provide CSS for the positioning and width of your affixed content.</strong></p>
+  <p>Note: Do not use the affix plugin on an element contained in a relatively positioned element, such as a pulled or pushed column, due to a <a href="https://github.com/twbs/bootstrap/issues/12126">Safari rendering bug</a>.</p>
 
   <h3>Positioning via CSS</h3>
   <p>The affix plugin toggles between three classes, each representing a particular state: <code>.affix</code>, <code>.affix-top</code>, and <code>.affix-bottom</code>. You must provide the styles, with the exception of <code>position: fixed;</code> on <code>.affix</code>, for these classes yourself (independent of this plugin) to handle the actual positions.</p>


### PR DESCRIPTION
This documents the limitation discussed in https://github.com/twbs/bootstrap/issues/12126:

> When using column reordering and using the affix-plugin on an element positioned with push, the affix plugin doesn't work correctly - the element affected by the affix plugin is positioned to the left even when the element is in a column positioned on the right.

Seems to affect Safari (tested in version 8) only.

That issue has (unfortunately) been closed, so this at least documents the behavior.
