### PR TITLE
Move text color properties from .label to .label-variant

### DIFF
--- a/less/mixins/labels.less
+++ b/less/mixins/labels.less
@@ -2,11 +2,13 @@
 
 .label-variant(@color) {
   background-color: @color;
+  color: @label-color;
 
   &[href] {
     &:hover,
     &:focus {
       background-color: darken(@color, 10%);
+      color: @label-link-hover-color;
     }
   }
 }


### PR DESCRIPTION
Use fg-olors for the text with the mixin instead, so that the default class="label" stays to the default fg-color of body.
