### PR TITLE
Move text color properties from .label to .label-variant

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -8,7 +8,6 @@
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
-  color: @label-color;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
@@ -18,7 +17,6 @@
   a& {
     &:hover,
     &:focus {
-      color: @label-link-hover-color;
       text-decoration: none;
       cursor: pointer;
     }


### PR DESCRIPTION
Use fg-olors for the text with the mixin instead, so that the default class="label" stays to the default fg-color of body.
