### PR TITLE
Intercalated list-groups fix

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -5491,28 +5491,28 @@ a.list-group-item-danger.active:focus {
 .panel > .panel-collapse > .list-group {
   margin-bottom: 0;
 }
-.panel > .list-group .list-group-item,
-.panel > .panel-collapse > .list-group .list-group-item {
+.panel > .list-group > .list-group-item,
+.panel > .panel-collapse > .list-group > .list-group-item {
   border-width: 1px 0;
   border-radius: 0;
 }
-.panel > .list-group:first-child .list-group-item:first-child,
-.panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
+.panel > .list-group:first-child > .list-group-item:first-child,
+.panel > .panel-collapse > .list-group:first-child > .list-group-item:first-child {
   border-top: 0;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
 }
-.panel > .list-group:last-child .list-group-item:last-child,
-.panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
+.panel > .list-group:last-child > .list-group-item:last-child,
+.panel > .panel-collapse > .list-group:last-child > .list-group-item:last-child {
   border-bottom: 0;
   border-bottom-right-radius: 3px;
   border-bottom-left-radius: 3px;
 }
-.panel > .panel-heading + .panel-collapse > .list-group .list-group-item:first-child {
+.panel > .panel-heading + .panel-collapse > .list-group > .list-group-item:first-child {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
-.panel-heading + .list-group .list-group-item:first-child {
+.panel-heading + .list-group > .list-group-item:first-child {
   border-top-width: 0;
 }
 .list-group + .panel-footer {


### PR DESCRIPTION
A quick fix in the case of intercalated list-groups.
In my case i have something like this:
![intercalated](https://cloud.githubusercontent.com/assets/5564199/7145846/be854dd0-e2f7-11e4-8266-0ae21b950c89.png)
I have intercalated list-groups on 3 levels.
The problem is that the css selector that makes the list-group inside a panel have no borders left and right, applies to any `.list-group-item` inside `.panel > .list-group`. To fix the problem i have added `>`, so that only the list-group with the parent .panel should have no borders.

I have applied my changes in my browser and it works as expected.
![problem-fixed](https://cloud.githubusercontent.com/assets/5564199/7146002/10aa6734-e2f9-11e4-82d0-5310dc573997.png)

I have applied the same fix for any selector that needs this.
