### PR TITLE
Nested list-groups fix

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -64,14 +64,14 @@
   > .panel-collapse > .list-group {
     margin-bottom: 0;
 
-    .list-group-item {
+    > .list-group-item {
       border-width: 1px 0;
       border-radius: 0;
     }
 
     // Add border top radius for first one
     &:first-child {
-      .list-group-item:first-child {
+      > .list-group-item:first-child {
         border-top: 0;
         .border-top-radius((@panel-border-radius - 1));
       }
@@ -79,21 +79,21 @@
 
     // Add border bottom radius for last one
     &:last-child {
-      .list-group-item:last-child {
+      > .list-group-item:last-child {
         border-bottom: 0;
         .border-bottom-radius((@panel-border-radius - 1));
       }
     }
   }
   > .panel-heading + .panel-collapse > .list-group {
-    .list-group-item:first-child {
+    > .list-group-item:first-child {
       .border-top-radius(0);
     }
   }
 }
 // Collapse space between when there's no additional content.
 .panel-heading + .list-group {
-  .list-group-item:first-child {
+  > .list-group-item:first-child {
     border-top-width: 0;
   }
 }


### PR DESCRIPTION
A quick fix in the case of nested list-groups inside a panel.
In my case i have something like this:
![intercalated](https://cloud.githubusercontent.com/assets/5564199/7145846/be854dd0-e2f7-11e4-8266-0ae21b950c89.png)
I have nested list-groups on 3 levels.
The borders are changed inside my child list-groups too, so i fixed the problem with `>` so that those borders are changed only in `.panel > .list-group > .list-group-item`.

I have applied the changes in my browser and it works as expected.
![problem-fixed](https://cloud.githubusercontent.com/assets/5564199/7146002/10aa6734-e2f9-11e4-82d0-5310dc573997.png)
