### PR TITLE
Fix #16284

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -17,7 +17,6 @@
     this.options             = options
     this.$body               = $(document.body)
     this.$element            = $(element)
-    this.$dialog             = this.$element.find('.modal-dialog')
     this.$backdrop           = null
     this.isShown             = null
     this.originalBodyPad     = null
@@ -66,8 +65,7 @@
     this.resize()
 
     this.$element.on('click.dismiss.bs.modal', '[data-dismiss="modal"]', $.proxy(this.hide, this))
-
-    this.$dialog.on('mousedown.dismiss.bs.modal', function () {
+    this.$element.find('.modal-dialog').on('mousedown.dismiss.bs.modal', function () {
       that.$element.one('mouseup.dismiss.bs.modal', function (e) {
         if ($(e.target).is(that.$element)) that.ignoreBackdropClick = true
       })
@@ -95,9 +93,8 @@
       that.enforceFocus()
 
       var e = $.Event('shown.bs.modal', { relatedTarget: _relatedTarget })
-
       transition ?
-        that.$dialog // wait for modal to slide in
+        that.$element.find('.modal-dialog') // wait for modal to slide in
           .one('bsTransitionEnd', function () {
             that.$element.trigger('focus').trigger(e)
           })
@@ -127,7 +124,7 @@
       .off('click.dismiss.bs.modal')
       .off('mouseup.dismiss.bs.modal')
 
-    this.$dialog.off('mousedown.dismiss.bs.modal')
+    this.$element.find('.modal-dialog').off('mousedown.dismiss.bs.modal')
 
     $.support.transition && this.$element.hasClass('fade') ?
       this.$element

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -61,6 +61,30 @@ $(function () {
       .bootstrapModal('show')
   })
 
+  QUnit.test('should trigger shown event after modal was filled', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+
+    $('<div id="modal-test"/>')
+      .on('show.bs.modal', function () {
+        var modalContent = [
+          '<div class="modal-dialog">',
+            '<div class="modal-content">',
+              '<div class="modal-body">',
+                '<p>Body of the modal</p>',
+              '</div>',
+            '</div>',
+          '</div>'
+        ].join('');
+        $(this).html(modalContent);
+      })
+      .on('shown.bs.modal', function () {
+        assert.ok(true, 'shown event fired')
+        done()
+      })
+      .bootstrapModal('show')
+  })
+
   QUnit.test('should not fire shown when show was prevented', function (assert) {
     assert.expect(1)
     var done = assert.async()


### PR DESCRIPTION
Hi,

This PR will Fix https://github.com/twbs/bootstrap/issues/16284 .

I don't know if it's possible to add a unit test because it's after the `show` event and before the `shown` event.
Maybe I can check on the `shown` event if the modal have an element with the `.modal-dialog` class.
