### PR TITLE
Allow .input-groups without addons.

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -34,7 +34,7 @@
 }
 
 .form-group .input-group {
-	width: auto;
+  width: auto;
 }
 
 // Sizing options

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -8,7 +8,8 @@
   position: relative; // For dropdowns
   display: table;
   border-collapse: separate; // prevent input groups from inheriting border styles from table cells when placed within a table
-
+  width: 100%;
+  
   // Undo padding and float of grid classes
   &[class*="col-"] {
     float: none;
@@ -101,7 +102,7 @@
 }
 
 // Reset rounded corners
-.input-group .form-control:first-child,
+.input-group .form-control:first-child:not(:only-child),
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
 .input-group-btn:first-child > .btn-group > .btn,
@@ -110,10 +111,10 @@
 .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
   .border-right-radius(0);
 }
-.input-group-addon:first-child {
+.input-group-addon:first-child:not(:only-child) {
   border-right: 0;
 }
-.input-group .form-control:last-child,
+.input-group .form-control:last-child:not(:only-child),
 .input-group-addon:last-child,
 .input-group-btn:last-child > .btn,
 .input-group-btn:last-child > .btn-group > .btn,
@@ -122,7 +123,7 @@
 .input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
   .border-left-radius(0);
 }
-.input-group-addon:last-child {
+.input-group-addon:last-child:not(:only-child) {
   border-left: 0;
 }
 

--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -33,6 +33,10 @@
   }
 }
 
+.form-group .input-group {
+	width: auto;
+}
+
 // Sizing options
 //
 // Remix the default form control sizing classes into new ones for easier


### PR DESCRIPTION
Under some circumstances, for example when dynamically generating content, it is helpful to have all your inputs formatted the same way. This commit allows only child inputs inside an .input-group to behave as they would not in an .input-group.
