### PR TITLE
Throw error when tooltip/popover template has multiple top-level elements

### DIFF
--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -259,6 +259,16 @@ $(function () {
     assert.strictEqual($popover.data('bs.popover'), undefined, 'should not initialize the popover')
   })
 
+  QUnit.test('should throw an error when template contains multiple top-level elements', function (assert) {
+    assert.expect(1)
+    assert.throws(function () {
+      $('<span data-toggle="popover" data-title="some title" data-content="some content">some text</span>')
+        .appendTo('#qunit-fixture')
+        .bootstrapPopover({ template: '<div>Foo</div><div>Bar</div>' })
+        .bootstrapPopover('show')
+    }, new Error('popover `template` option must consist of exactly 1 top-level element!'))
+  })
+
   QUnit.test('should fire inserted event', function (assert) {
     assert.expect(2)
     var done = assert.async()
@@ -276,4 +286,5 @@ $(function () {
       })
       .bootstrapPopover('show')
   })
+
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1225,4 +1225,14 @@ $(function () {
     assert.strictEqual($tooltip.data('bs.tooltip'), undefined, 'should not initialize the tooltip')
   })
 
+  QUnit.test('should throw an error when template contains multiple top-level elements', function (assert) {
+    assert.expect(1)
+    assert.throws(function () {
+      $('<a href="#" data-toggle="tooltip" title="Another tooltip"></a>')
+        .appendTo('#qunit-fixture')
+        .bootstrapTooltip({ template: '<div>Foo</div><div>Bar</div>' })
+        .bootstrapTooltip('show')
+    }, new Error('tooltip `template` option must consist of exactly 1 top-level element!'))
+  })
+
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -404,7 +404,13 @@
   }
 
   Tooltip.prototype.tip = function () {
-    return (this.$tip = this.$tip || $(this.options.template))
+    if (!this.$tip) {
+      this.$tip = $(this.options.template)
+      if (this.$tip.length != 1) {
+        throw new Error(this.type + ' `template` option must consist of exactly 1 top-level element!')
+      }
+    }
+    return this.$tip
   }
 
   Tooltip.prototype.arrow = function () {


### PR DESCRIPTION
Closes #16219.
CC: @hnrch02 @XhmikosR @patrickhlauke for review
