### PR TITLE
Fix #16297 - modal mousewheel scrolling issue on Chrome

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -28,6 +28,12 @@
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;
 
+  &.in {
+    // Fixes Chrome mousewheel scrolling issue. For details, see
+    // https://github.com/twbs/bootstrap/issues/16297
+    .translate3d(0, 0, 0);
+  }
+
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {
     .translate(0, -25%);


### PR DESCRIPTION
Fixes issue https://github.com/twbs/bootstrap/issues/16297

The bug occurs when the modal height exceeds window height -- Chrome mousewheel scrolling does not work unless the browser window is resized.

Related Chrome issue: https://code.google.com/p/chromium/issues/detail?id=343244
