### PR TITLE
#16337 - .help-block Vertical Alignment in Form

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -600,3 +600,9 @@ input[type="checkbox"] {
     }
   }
 }
+
+// If the help-block is direct descendant of form-group align with control-label and form-control
+.form-horizontal .form-group > .help-block {
+  margin-top: 7px;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
Fixing vertical alignment issue with .help-block by adding some margins
to align it the with the label properly when used in a horizontal form.
Just added the code from the original post into the proper place.
Fixes #16337.
