### PR TITLE
Add max-width: none to .media > .img-thumbnail

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -19,6 +19,11 @@
 
 .media-object {
   display: block;
+
+  // Fix collapse in webkit from max-width: 100% and display: table-cell.
+  &.img-thumbnail {
+    max-width: none;
+  }
 }
 
 .media-right,


### PR DESCRIPTION
I believe that this is the right place- although we could save a couple of bytes if we assume that .img-thumbnails will always be .media-objects.

Fixes #16120
