### PR TITLE
Round results from gutter division to prevent decimal margins and padding

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -576,7 +576,7 @@ input[type="checkbox"] {
   // Reposition the icon because it's now within a grid column and columns have
   // `position: relative;` on them. Also accounts for the grid gutter padding.
   .has-feedback .form-control-feedback {
-    right: (@grid-gutter-width / 2);
+    right: floor((@grid-gutter-width / 2));
   }
 
   // Form group sizes

--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -19,8 +19,8 @@
       // Prevent columns from collapsing when empty
       min-height: 1px;
       // Inner gutter via padding
-      padding-left:  (@grid-gutter-width / 2);
-      padding-right: (@grid-gutter-width / 2);
+      padding-left:  ceil((@grid-gutter-width / 2));
+      padding-right: floor((@grid-gutter-width / 2));
     }
   }
   .col(1); // kickstart it

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -13,8 +13,8 @@
 
 // Creates a wrapper for a series of columns
 .make-row(@gutter: @grid-gutter-width) {
-  margin-left:  (@gutter / -2);
-  margin-right: (@gutter / -2);
+  margin-left:  ceil((@gutter / -2));
+  margin-right: floor((@gutter / -2));
   &:extend(.clearfix all);
 }
 


### PR DESCRIPTION
Fixes #16281

left rounds up, right rounds down. should keep everything playing nice.
