### PR TITLE
Update bower.json to comply with new spec for `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,12 +16,7 @@
   "main": [
     "less/bootstrap.less",
     "dist/css/bootstrap.css",
-    "dist/js/bootstrap.js",
-    "dist/fonts/glyphicons-halflings-regular.eot",
-    "dist/fonts/glyphicons-halflings-regular.svg",
-    "dist/fonts/glyphicons-halflings-regular.ttf",
-    "dist/fonts/glyphicons-halflings-regular.woff",
-    "dist/fonts/glyphicons-halflings-regular.woff2"
+    "dist/js/bootstrap.js"
   ],
   "ignore": [
     "/.*",

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
   "homepage": "http://getbootstrap.com",
   "main": [
     "less/bootstrap.less",
-    "dist/css/bootstrap.css",
     "dist/js/bootstrap.js"
   ],
   "ignore": [


### PR DESCRIPTION
This updates our `bower.json` to comply with the new, long-awaited, more detailed spec for the `main` field of `bower.json`. See https://github.com/bower/bower.json-spec/pull/43

If you have a complaint about this, take it up with the Bower folks, not us:
https://github.com/bower/bower.json-spec/issues
Or consider using a different package manager.
