### PR TITLE
bower.json: set `moduleType` to `globals`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "web"
   ],
   "homepage": "http://getbootstrap.com",
+  "moduleType": "globals",
   "main": [
     "less/bootstrap.less",
     "dist/js/bootstrap.js"


### PR DESCRIPTION
Per https://github.com/bower/bower.json-spec/commit/632ff90a2c857e9cb4a4236e8ddb069cc0716865#commitcomment-10914138
