### PR TITLE
Use @border-radius-small for .label border-radius

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -12,7 +12,7 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: .25em;
+  border-radius: @border-radius-small;
 
   // Add hover effects, but only for links
   a& {


### PR DESCRIPTION
border radius can be assigned the @border-radius-small value instead of defining it as 0.25em. Will be easier to update styles using variables.less.
