### PR TITLE
Document that nested tabs are not supported

### DIFF
--- a/docs/_includes/js/tabs.html
+++ b/docs/_includes/js/tabs.html
@@ -2,7 +2,7 @@
   <h1 id="tabs" class="page-header">Togglable tabs <small>tab.js</small></h1>
 
   <h2 id="tabs-examples">Example tabs</h2>
-  <p>Add quick, dynamic tab functionality to transition through panes of local content, even via dropdown menus.</p>
+  <p>Add quick, dynamic tab functionality to transition through panes of local content, even via dropdown menus. <strong>Nested tabs are not supported.</strong></p>
   <div class="bs-example bs-example-tabs" data-example-id="togglable-tabs">
     <ul id="myTabs" class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#home" id="home-tab" role="tab" data-toggle="tab" aria-controls="home" aria-expanded="true">Home</a></li>


### PR DESCRIPTION
Closes #16249 AFAIU. Lmk if that is incorrect, i.e. if we did after all "change our mind".

Inspired by the Carousel docs (`Nested carousels are not supported.`->`Nested tabs are not supported.`)

/cc @mdo @fat @cvrebert from original issue
