### PR TITLE
Improve tooltip container placement

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1322,4 +1322,23 @@ $(function () {
     })
   })
 
+  QUnit.test('should only place tooltip in closest container', function (assert) {
+    assert.expect(2)
+    var $tooltipContainers = $('<div class="containers"/>').appendTo('#qunit-fixture');
+    var $firstContainer = $('<div id="container1" class="container"/>');
+    var $secondContainer = $('<div id="container2" class="container"/>');
+    $tooltipContainers.append($firstContainer, $secondContainer);
+
+    var $tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"/>')
+    .appendTo($secondContainer)
+    .bootstrapTooltip({ container: '.container' });
+
+    $tooltip.bootstrapTooltip('show');
+    assert.strictEqual($('.tooltip').length, 1, 'multiple tooltips added')
+
+    $tooltip.bootstrapTooltip('hide');
+    assert.strictEqual($('.tooltip').length, 0, 'not all tooltips were removed')
+
+  })
+
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -204,7 +204,7 @@
         .addClass(placement)
         .data('bs.' + this.type, this)
 
-      this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+      this.options.container ? $tip.appendTo(this.$element.closest(this.options.container)) : $tip.insertAfter(this.$element)
       this.$element.trigger('inserted.bs.' + this.type)
 
       var pos          = this.getPosition()


### PR DESCRIPTION
Tooltips are currently getting appended to all matching container
selectors. This changes it to use jquery's `closest` selector to
traverse up the dom tree until the container is found.

This fixes issue #16443 by limiting the containers found to 1 so when
the tooltip is removed, excess dom nodes aren't left in the tree.
