### PR TITLE
docs examples: input[placeholder]: "Enter email" => "Email"

### DIFF
--- a/docs/_includes/css/forms.html
+++ b/docs/_includes/css/forms.html
@@ -7,7 +7,7 @@
     <form>
       <div class="form-group">
         <label for="exampleInputEmail1">Email address</label>
-        <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+        <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Email">
       </div>
       <div class="form-group">
         <label for="exampleInputPassword1">Password</label>
@@ -30,7 +30,7 @@
 <form>
   <div class="form-group">
     <label for="exampleInputEmail1">Email address</label>
-    <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Enter email">
+    <input type="email" class="form-control" id="exampleInputEmail1" placeholder="Email">
   </div>
   <div class="form-group">
     <label for="exampleInputPassword1">Password</label>
@@ -97,7 +97,7 @@
     <form class="form-inline">
       <div class="form-group">
         <label class="sr-only" for="exampleInputEmail3">Email address</label>
-        <input type="email" class="form-control" id="exampleInputEmail3" placeholder="Enter email">
+        <input type="email" class="form-control" id="exampleInputEmail3" placeholder="Email">
       </div>
       <div class="form-group">
         <label class="sr-only" for="exampleInputPassword3">Password</label>
@@ -115,7 +115,7 @@
 <form class="form-inline">
   <div class="form-group">
     <label class="sr-only" for="exampleInputEmail3">Email address</label>
-    <input type="email" class="form-control" id="exampleInputEmail3" placeholder="Enter email">
+    <input type="email" class="form-control" id="exampleInputEmail3" placeholder="Email">
   </div>
   <div class="form-group">
     <label class="sr-only" for="exampleInputPassword3">Password</label>


### PR DESCRIPTION
For uniformity, as we don't seem to use this "Enter <X>" phrasing for placeholders anywhere else.
IIUC, we should probably be using an example email address (like `john.doe@example.com`) instead for most of these (unless the label is invisible), but I'll leave that for someone else to look at as a follow-up.
CC: @patrickhlauke for review
