### PR TITLE
[Closes #16225] Font in code blocks does not distinguish { and ( clearly

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -45,7 +45,7 @@
 @font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
 @font-family-serif:       Georgia, "Times New Roman", Times, serif;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
-@font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
+@font-family-monospace:   Menlo, Monaco, Consolas, monospace;
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          14px;


### PR DESCRIPTION
[Closes #16225] Font in code blocks does not distinguish { and ( clearly
