### PR TITLE
Tweak temporal inputs

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -178,9 +178,12 @@ input[type="search"] {
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   input[type="date"],
   input[type="time"],
+  input[type="week"],
   input[type="datetime-local"],
   input[type="month"] {
-    line-height: @input-height-base;
+    &.form-control {
+      line-height: @input-height-base;
+    }
 
     &.input-sm,
     .input-group-sm & {

--- a/less/forms.less
+++ b/less/forms.less
@@ -174,11 +174,12 @@ input[type="search"] {
 // text within the input to become vertically misaligned. As a workaround, we
 // set a pixel line-height that matches the given height of the input, but only
 // for Safari. See https://bugs.webkit.org/show_bug.cgi?id=139848
+//
+// Note that as of 8.3, iOS doesn't support `datetime` or `week`.
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   input[type="date"],
   input[type="time"],
-  input[type="week"],
   input[type="datetime-local"],
   input[type="month"] {
     &.form-control {


### PR DESCRIPTION
Fixes #16346.

Scopes the overrides for temporal inputs to our input classes rather than all inputs. Also accounts for `week` inputs.

/cc @cvrebert 
