### PR TITLE
Redo jumbotron padding

### DIFF
--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -4,7 +4,8 @@
 
 
 .jumbotron {
-  padding: @jumbotron-padding (@jumbotron-padding / 2);
+  padding-top:    @jumbotron-padding;
+  padding-bottom: @jumbotron-padding;
   margin-bottom: @jumbotron-padding;
   color: @jumbotron-color;
   background-color: @jumbotron-bg;
@@ -34,7 +35,8 @@
   }
 
   @media screen and (min-width: @screen-sm-min) {
-    padding: (@jumbotron-padding * 1.6) 0;
+    padding-top:    (@jumbotron-padding * 1.6);
+    padding-bottom: (@jumbotron-padding * 1.6);
 
     .container &,
     .container-fluid & {


### PR DESCRIPTION
Fixes #16374.
- In general, there are very few instances that would require a jumbotron without a parent or child container.
- Right now we account for that behavior though with some horizontal padding on the `.jumbotron` class.
- This removes that horizontal `padding` as it narrows our grid classes unnecessarily and accounts for a super small use case.
- It also improves consistency across breakpoints, in that `padding` isn't being added and removed.
- In doing so, I also removed the shorthand `padding` property and went with the specific ones (because yay specificity).

/cc @rlindner81
