### PR TITLE
Clarify the bs-callout on multiple open modals

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -3,7 +3,7 @@
   <p>Modals are streamlined, but flexible, dialog prompts with the minimum required functionality and smart defaults.</p>
 
   <div class="bs-callout bs-callout-warning" id="callout-stacked-modals">
-    <h4>Overlapping modals not supported</h4>
+    <h4>Multiple open modals not supported</h4>
     <p>Be sure not to open a modal while another is still visible. Showing more than one modal at a time requires custom code.</p>
   </div>
   <div class="bs-callout bs-callout-warning" id="callout-modal-markup-placement">


### PR DESCRIPTION
[Fix #16502] Clarify the bs-callout on multiple open modals

Currently it states overlapping modals, this isn't the only case as this truly applies to any instance when a user would want to open multiple modals at the same time. For this reason, I have modified the title of the callout to make this more clear.
