### PR TITLE
Make IE <select> arrow full-height & flush with the right edge

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -110,7 +110,7 @@ output {
 // input[type="search"]
 // input[type="tel"]
 // input[type="color"]
-sel
+
 .form-control {
   display: block;
   width: 100%;

--- a/less/forms.less
+++ b/less/forms.less
@@ -110,7 +110,7 @@ output {
 // input[type="search"]
 // input[type="tel"]
 // input[type="color"]
-
+sel
 .form-control {
   display: block;
   width: 100%;
@@ -152,6 +152,13 @@ output {
   // Reset height for `textarea`s
   textarea& {
     height: auto;
+  }
+  
+  // <select> arrow fix for IE to make it cover all available area
+  select&::-ms-expand {
+    margin: -@padding-base-vertical -@padding-base-horizontal -@padding-base-vertical 0;
+    padding-top: 1px;
+    border: 0;
   }
 }
 


### PR DESCRIPTION
Fix for arrow in `<select>` to ignore`<select>` padding (that makes it small and ugly).
Now it should look much better and have no padding applied from its `<select>` parent.
