### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
   "bugs": {
     "url": "https://github.com/twbs/bootstrap/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/twbs/bootstrap/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "devDependencies": {
     "btoa": "~1.1.2",
     "glob": "~5.0.5",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
