### PR TITLE
Remove Firefox warning for customizer download.

### DIFF
--- a/docs/customize.html
+++ b/docs/customize.html
@@ -377,11 +377,6 @@ lead: Customize Bootstrap's components, Less variables, and jQuery plugins to ge
     <h1 id="download" class="page-header">Download</h1>
 
     <p class="lead">Hooray! Your custom version of Bootstrap is now ready to be compiled. Just click the button below to finish the process.</p>
-    <div id="firefox-customizer-alert" class="alert alert-warning alert-dismissible fade in" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <h4>Warning for Firefox users!</h4>
-      <p>Due to a possible browser bug, the customizer download randomly fails in Firefox. If this happens to you, we advise either retrying in Firefox or using one of the other browsers supported by the Customizer (Chrome or IE10+).</p>
-    </div>
     <div class="bs-customize-download">
       <button type="submit" id="btn-compile" disabled class="btn btn-block btn-lg btn-outline" onclick="ga('send', 'event', 'Customize', 'Download', 'Customize and Download');">Compile and Download</button>
     </div>


### PR DESCRIPTION
The previous download issue doesn't reproduce anymore.

Closes #15016.
