### PR TITLE
Removes border around select caret in IE. #16527

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -132,6 +132,12 @@ output {
   // Placeholder
   .placeholder();
 
+  // Removes the border and background color around the caret in IE
+  &::-ms-expand {
+    border: 0;
+    background-color: @input-bg;
+  }
+
   // Disabled and read-only inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
@@ -139,6 +145,8 @@ output {
   // don't honor that edge case; we style them as disabled anyway.
   &[disabled],
   &[readonly],
+  &[disabled]::-ms-expand,
+  &[readonly]::-ms-expand,
   fieldset[disabled] & {
     background-color: @input-bg-disabled;
     opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655

--- a/less/forms.less
+++ b/less/forms.less
@@ -146,6 +146,7 @@ output {
   &[disabled],
   &[readonly],
   &[disabled]::-ms-expand,
+  &[readonly]::-ms-expand,
   fieldset[disabled] & {
     background-color: @input-bg-disabled;
     opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655

--- a/less/forms.less
+++ b/less/forms.less
@@ -132,6 +132,12 @@ output {
   // Placeholder
   .placeholder();
 
+  // Removes the border and background color around the caret in IE
+  &::-ms-expand {
+    border: 0;
+    background-color: @input-bg;
+  }
+
   // Disabled and read-only inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
@@ -139,6 +145,7 @@ output {
   // don't honor that edge case; we style them as disabled anyway.
   &[disabled],
   &[readonly],
+  &[disabled]::-ms-expand,
   fieldset[disabled] & {
     background-color: @input-bg-disabled;
     opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655


### PR DESCRIPTION
Working example in JSbin. Open it using IE: http://jsbin.com/lapakociya/1/edit?html,css,output
Removes border around select caret. Fixes issue #16527 

Before and After in IE:
![image](https://cloud.githubusercontent.com/assets/5981331/7788960/977f83dc-0204-11e5-9ce4-aa32e1902311.png)
