### PR TITLE
CommonJS: require() jQuery if not already loaded

### DIFF
--- a/grunt/bs-commonjs-generator.js
+++ b/grunt/bs-commonjs-generator.js
@@ -20,7 +20,14 @@ module.exports = function generateCommonJSModule(grunt, srcFiles, destFilepath) 
     return 'require(\'' + requirePath + '\')';
   }
 
-  var moduleOutputJs = COMMONJS_BANNER + srcFiles.map(srcPathToDestRequire).join('\n');
+  var moduleOutputJs = [
+    COMMONJS_BANNER,
+    'if (typeof jQuery === \'undefined\')',
+    '    global.jQuery = require(\'jquery\');',
+    '',
+    srcFiles.map(srcPathToDestRequire).join('\n')
+  ].join('\n');
+
   try {
     fs.writeFileSync(destFilepath, moduleOutputJs);
   } catch (err) {


### PR DESCRIPTION
Bootstrap currently assumes jQuery is defined globally.  This has been bothering me for years.  Ideally I'd love it if each plugin was UMD-wrapped - I can put this into another PR if you are OK with it - but defining it globally is probably the quickest fix for the cjs-export.
