### PR TITLE
Inherit box-sizing: border-box property

### DIFF
--- a/docs/_includes/getting-started/third-party-support.html
+++ b/docs/_includes/getting-started/third-party-support.html
@@ -3,49 +3,25 @@
   <p class="lead">While we don't officially support any third party plugins or add-ons, we do offer some useful advice to help avoid potential issues in your projects.</p>
 
   <h2 id="third-box-sizing">Box-sizing</h2>
-  <p>Some third party software, including Google Maps and Google Custom Search Engine, conflict with Bootstrap due to <code>* { box-sizing: border-box; }</code>, a rule which makes it so <code>padding</code> does not affect the final computed width of an element. Learn more about <a href="https://css-tricks.com/box-sizing/">box model and sizing at CSS Tricks</a>.</p>
-  <p>Depending on the context, you may override as-needed (Option 1) or reset the box-sizing for entire regions (Option 2).</p>
+  <p>Some third party software, including Google Maps and Google Custom Search Engine, conflict with Bootstrap's usage of <code>box-sizing: border-box;</code>, a rule which makes it so <code>padding</code> does not affect the final computed width of an element. Learn more about <a href="https://css-tricks.com/box-sizing/">box model and sizing at CSS Tricks</a>.</p>
+  <p>Bootstrap is making all the elements inherit the <code>box-sizing</code> property from their parents. So you only need to set <code>.component { box-sizing: content-box; }</code> to make your <code>content-box</code> component work. Learn more about <a href="https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/">inheriting box-sizing at CSS Tricks</a>.</p>
 {% highlight scss %}
 /* Box-sizing resets
  *
  * Reset individual elements or override regions to avoid conflicts due to
- * global box model settings of Bootstrap. Two options, individual overrides and
- * region resets, are available as plain CSS and uncompiled Less formats.
+ * global box model settings of Bootstrap.
  */
 
-/* Option 1A: Override a single element's box model via CSS */
-.element {
+/* Option 1A: Override an element's and its children box model via CSS */
+.component {
   -webkit-box-sizing: content-box;
      -moz-box-sizing: content-box;
           box-sizing: content-box;
 }
 
-/* Option 1B: Override a single element's box model by using a Bootstrap Less mixin */
-.element {
+/* Option 1B: Override an element's and its children box model by using a Bootstrap Less mixin */
+.component {
   .box-sizing(content-box);
-}
-
-/* Option 2A: Reset an entire region via CSS */
-.reset-box-sizing,
-.reset-box-sizing *,
-.reset-box-sizing *:before,
-.reset-box-sizing *:after {
-  -webkit-box-sizing: content-box;
-     -moz-box-sizing: content-box;
-          box-sizing: content-box;
-}
-
-/* Option 2B: Reset an entire region with a custom Less mixin */
-.reset-box-sizing {
-  &,
-  *,
-  *:before,
-  *:after {
-    .box-sizing(content-box);
-  }
-}
-.element {
-  .reset-box-sizing();
 }
 {% endhighlight %}
 </div>

--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -8,12 +8,13 @@
 // Heads up! This reset may cause conflicts with some third-party widgets.
 // For recommendations on resolving such conflicts, see
 // http://getbootstrap.com/getting-started/#third-box-sizing
-* {
+html {
   .box-sizing(border-box);
 }
+*,
 *:before,
 *:after {
-  .box-sizing(border-box);
+  .box-sizing(inherit);
 }
 
 


### PR DESCRIPTION
The use of inheriting the `box-sizing: border-box` rule is recommended.

There are two benefits:
- Easier overriding for third-party components.
- No wildcard selectors for third-party components. So it could be a bit faster.

Here are some references:
- [CSS Tricks](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/)
- [Paul Irish updated `box-sizing` article](http://www.paulirish.com/2012/box-sizing-border-box-ftw/)

I think this quote from CSS Tricks says it all:

> This isn't a majorly huge thing. You might already be using the `box-sizing` reset the "old way" and never have gotten bit by it. That's the case for me. But as long as we're promoting a "best practice" style snippet, we might as well hone it to be the best it can be.
