### PR TITLE
Specify that input-group-addon should be the last child

### DIFF
--- a/docs/_includes/components/input-groups.html
+++ b/docs/_includes/components/input-groups.html
@@ -26,6 +26,7 @@
   <p>Place one add-on or button on either side of an input. You may also place one on both sides of an input.</p>
   <p><strong class="text-danger">We do not support multiple add-ons on a single side.</strong></p>
   <p><strong class="text-danger">We do not support multiple form-controls in a single input group.</strong></p>
+  <p><strong class="text-danger"><code>input-group-addon</code> must be the last child within an input group.</strong></p>
   <form class="bs-example bs-example-form" data-example-id="simple-input-groups">
     <div class="input-group">
       <span class="input-group-addon" id="basic-addon1">@</span>


### PR DESCRIPTION
Fix #16540 — Specify that input-group-addon should / must be the `:last-child`
