### PR TITLE
Remove anchor link from list group example

### DIFF
--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -180,4 +180,5 @@
 
   anchors.options.placement = 'left';
   anchors.add('.bs-docs-section > h1, .bs-docs-section > h2, .bs-docs-section > h3, .bs-docs-section > h4, .bs-docs-section > h5')
+  anchors.remove('.list-group-item-heading')
 })();


### PR DESCRIPTION
Fix #16539 — Remove anchor link from list group example
