### PR TITLE
Prevent generation of invalid negative border-radius values

### DIFF
--- a/less/mixins/border-radius.less
+++ b/less/mixins/border-radius.less
@@ -1,18 +1,18 @@
 // Single side border-radius
 
 .border-top-radius(@radius) {
-  border-top-right-radius: @radius;
-   border-top-left-radius: @radius;
+  border-top-right-radius: max(0, @radius);
+   border-top-left-radius: max(0, @radius);
 }
 .border-right-radius(@radius) {
-  border-bottom-right-radius: @radius;
-     border-top-right-radius: @radius;
+  border-bottom-right-radius: max(0, @radius);
+     border-top-right-radius: max(0, @radius);
 }
 .border-bottom-radius(@radius) {
-  border-bottom-right-radius: @radius;
+  border-bottom-right-radius: max(0, @radius);
    border-bottom-left-radius: @radius;
 }
 .border-left-radius(@radius) {
-  border-bottom-left-radius: @radius;
-     border-top-left-radius: @radius;
+  border-bottom-left-radius: max(0, @radius);
+     border-top-left-radius: max(0, @radius);
 }


### PR DESCRIPTION
Fixes #16586. This will use the the higher of the two values — either 0 or the `@radius` variable.

The `max()` function documentation can be found here:
http://lesscss.org/functions/#math-functions-max
