### PR TITLE
Do not color not link anchors i.e. <a> - color only <a href="something">

### DIFF
--- a/less/scaffolding.less
+++ b/less/scaffolding.less
@@ -45,7 +45,7 @@ textarea {
 
 // Links
 
-a {
+a:link {
   color: @link-color;
   text-decoration: none;
 


### PR DESCRIPTION
Related to #16616, #16615 - it should generate:

```
a:link {
  color: #2b6598;
  text-decoration: none;
}
a:link:hover,
a:link:focus {
  color: #1a3d5c;
  text-decoration: underline;
}
a:link:focus {
  outline: thin dotted;
  outline: 5px auto -webkit-focus-ring-color;
  outline-offset: -2px;
}
```

Not as now:

```
a {
  color: #2b6598;
  text-decoration: none;
}
a:hover,
a:focus {
  color: #1a3d5c;
  text-decoration: underline;
}
afocus {
  outline: thin dotted;
  outline: 5px auto -webkit-focus-ring-color;
  outline-offset: -2px;
}
```
