### PR TITLE
Updated all dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "license": "MIT",
   "devDependencies": {
     "btoa": "~1.1.2",
-    "glob": "~5.0.5",
+    "glob": "~5.0.10",
     "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~3.0.0",
+    "grunt-autoprefixer": "~3.0.3",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-concat": "~0.5.1",
@@ -46,7 +46,7 @@
     "grunt-contrib-qunit": "~0.7.0",
     "grunt-contrib-uglify": "~0.9.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-csscomb": "~3.0.0",
+    "grunt-csscomb": "~3.0.1",
     "grunt-exec": "~0.4.6",
     "grunt-html": "~4.0.3",
     "grunt-jekyll": "~0.4.2",
@@ -54,9 +54,9 @@
     "grunt-saucelabs": "~8.6.1",
     "grunt-sed": "twbs/grunt-sed#v0.2.0",
     "load-grunt-tasks": "~3.2.0",
-    "markdown-it": "^4.2.1",
-    "npm-shrinkwrap": "^200.4.0",
-    "time-grunt": "^1.2.0"
+    "markdown-it": "^4.2.2",
+    "npm-shrinkwrap": "^5.4.0",
+    "time-grunt": "^1.2.1"
   },
   "engines": {
     "node": ">=0.10.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-sed": "twbs/grunt-sed#v0.2.0",
     "load-grunt-tasks": "~3.2.0",
     "markdown-it": "^4.2.2",
-    "npm-shrinkwrap": "^5.4.0",
+    "npm-shrinkwrap": "^200.4.0",
     "time-grunt": "^1.2.1"
   },
   "engines": {

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -1,8 +1,8 @@
 {
   "name": "bootstrap",
   "version": "3.3.4",
-  "npm-shrinkwrap-version": "200.4.0",
-  "node-version": "v0.12.4",
+  "npm-shrinkwrap-version": "5.4.0",
+  "node-version": "v0.10.29",
   "dependencies": {
     "btoa": {
       "version": "1.1.2",
@@ -585,8 +585,8 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
             }
           }
         }
@@ -647,16 +647,16 @@
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.4.4.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.7",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
+                  "version": "1.2.9",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.0.13",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.11.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                          "version": "1.13.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                         }
                       }
                     },
@@ -667,12 +667,12 @@
                   }
                 },
                 "compressible": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.3.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                      "version": "1.13.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
                 },
@@ -767,16 +767,16 @@
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.3.6.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.7",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
+                  "version": "1.2.9",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.0.13",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.11.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                          "version": "1.13.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                         }
                       }
                     },
@@ -883,8 +883,8 @@
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.3.tgz",
               "dependencies": {
                 "basic-auth": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.2.1",
@@ -975,9 +975,19 @@
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.4.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.7",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
+                  "version": "1.2.9",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz",
                   "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.13.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
+                        }
+                      }
+                    },
                     "negotiator": {
                       "version": "0.5.3",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
@@ -993,12 +1003,12 @@
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.13",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                  "version": "2.0.14",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                      "version": "1.12.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 }
@@ -1057,20 +1067,20 @@
               }
             },
             "type-is": {
-              "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.3.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.13",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                      "version": "1.13.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
                 }
@@ -1263,8 +1273,8 @@
           }
         },
         "clean-css": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.3.0.tgz",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.3.2.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -1281,8 +1291,8 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             }
@@ -1305,14 +1315,14 @@
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.6",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+                      "version": "0.2.7",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
                 },
                 "concat-stream": {
-                  "version": "1.4.8",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+                  "version": "1.4.10",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -1397,8 +1407,8 @@
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                     },
                     "object-assign": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                     }
                   }
                 }
@@ -1537,8 +1547,8 @@
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
@@ -1579,8 +1589,8 @@
               }
             },
             "concat-stream": {
-              "version": "1.4.8",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "version": "1.4.10",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -1627,8 +1637,8 @@
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
@@ -1715,8 +1725,8 @@
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 }
               }
             }
@@ -1851,8 +1861,8 @@
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                         }
                       }
                     }
@@ -1939,8 +1949,8 @@
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
-              "version": "3.8.2",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "version": "3.8.3",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
               "dependencies": {
                 "domelementtype": {
                   "version": "1.3.0",
@@ -2167,8 +2177,8 @@
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
                 "combined-stream": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.4.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -2201,8 +2211,8 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.27",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
+                      "version": "2.9.30",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                     },
                     "chalk": {
                       "version": "1.0.0",
@@ -2291,8 +2301,8 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "boom": {
-                      "version": "2.7.2",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                      "version": "2.8.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
@@ -2335,12 +2345,12 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.13",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                  "version": "2.0.14",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                      "version": "1.12.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
@@ -2361,8 +2371,8 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
@@ -2375,8 +2385,8 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             }
@@ -2421,8 +2431,8 @@
                       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.1.tgz"
                     },
                     "rimraf": {
-                      "version": "2.3.4",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+                      "version": "2.4.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "4.5.3",
@@ -2487,8 +2497,8 @@
                   "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
                   "dependencies": {
                     "config-chain": {
-                      "version": "1.1.8",
-                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                      "version": "1.1.9",
+                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                       "dependencies": {
                         "proto-list": {
                           "version": "1.2.4",
@@ -2501,8 +2511,8 @@
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "ini": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                      "version": "1.3.4",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
@@ -2535,8 +2545,14 @@
                       }
                     },
                     "osenv": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        }
+                      }
                     },
                     "semver": {
                       "version": "4.3.6",
@@ -2685,8 +2701,8 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "tough-cookie": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.0",
@@ -2795,14 +2811,14 @@
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.6",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+                      "version": "0.2.7",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
                 },
                 "concat-stream": {
-                  "version": "1.4.8",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+                  "version": "1.4.10",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -2887,8 +2903,8 @@
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                     },
                     "object-assign": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                      "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                     }
                   }
                 }
@@ -2909,8 +2925,8 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             },
@@ -3045,8 +3061,8 @@
       "resolved": "https://registry.npmjs.org/grunt-csscomb/-/grunt-csscomb-3.0.1.tgz",
       "dependencies": {
         "csscomb": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/csscomb/-/csscomb-3.1.5.tgz",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/csscomb/-/csscomb-3.1.7.tgz",
           "dependencies": {
             "commander": {
               "version": "2.0.0",
@@ -3393,8 +3409,8 @@
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
-                      "version": "2.3.4",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+                      "version": "2.4.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "4.5.3",
@@ -3527,8 +3543,8 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
-          "version": "0.4.9",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
+          "version": "0.4.10",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz"
         }
       }
     },
@@ -3629,12 +3645,12 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
-                      "version": "2.0.13",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.13.tgz",
+                      "version": "2.0.14",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.11.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.11.0.tgz"
+                          "version": "1.12.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     }
@@ -3705,8 +3721,8 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
@@ -4207,12 +4223,12 @@
           }
         },
         "npm": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-2.11.0.tgz",
+          "version": "2.11.2",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.11.2.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "ansi": {
               "version": "0.3.0",
@@ -4281,12 +4297,12 @@
               }
             },
             "config-chain": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "version": "1.1.9",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
-                  "version": "1.2.3",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                  "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
@@ -4335,8 +4351,8 @@
               "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz"
             },
             "glob": {
-              "version": "5.0.7",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.7.tgz",
+              "version": "5.0.10",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
@@ -4345,8 +4361,8 @@
               }
             },
             "graceful-fs": {
-              "version": "3.0.7",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "hosted-git-info": {
               "version": "2.1.4",
@@ -4423,16 +4439,16 @@
               }
             },
             "node-gyp": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-1.0.3.tgz",
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-2.0.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "minimatch": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "version": "2.0.8",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
@@ -4457,8 +4473,30 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "dependencies": {
                     "sigmund": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-array": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "dependencies": {
+                    "array-index": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
@@ -4500,24 +4538,6 @@
                   "version": "1.4.8",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
                   "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
                     "typedarray": {
                       "version": "0.0.6",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
@@ -4541,24 +4561,6 @@
                     "delegates": {
                       "version": "0.1.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
                     }
                   }
                 },
@@ -4661,8 +4663,8 @@
               }
             },
             "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
@@ -4683,8 +4685,8 @@
               "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz"
             },
             "request": {
-              "version": "2.55.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "version": "2.57.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
@@ -4692,19 +4694,39 @@
                 },
                 "bl": {
                   "version": "0.9.4",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "caseless": {
-                  "version": "0.9.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                  "version": "0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
                 "combined-stream": {
-                  "version": "0.0.7",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
@@ -4717,18 +4739,28 @@
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                      "version": "0.9.2",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "har-validator": {
-                  "version": "1.6.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
+                  "version": "1.7.1",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.24",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+                      "version": "2.9.27",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
                     },
                     "chalk": {
                       "version": "1.0.0",
@@ -4759,8 +4791,8 @@
                       }
                     },
                     "commander": {
-                      "version": "2.7.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+                      "version": "2.8.1",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
@@ -4769,16 +4801,16 @@
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+                      "version": "2.12.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -4803,16 +4835,16 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "boom": {
-                      "version": "2.7.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
+                      "version": "2.7.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "hoek": {
-                      "version": "2.12.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+                      "version": "2.14.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -4821,8 +4853,8 @@
                   }
                 },
                 "http-signature": {
-                  "version": "0.10.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.1.11",
@@ -4843,16 +4875,16 @@
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "version": "2.0.12",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.8.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                      "version": "1.10.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                     }
                   }
                 },
@@ -4861,26 +4893,20 @@
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "oauth-sign": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                  "version": "0.8.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "qs": {
-                  "version": "2.4.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "tough-cookie": {
-                  "version": "0.12.1",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                    }
-                  }
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
@@ -4903,32 +4929,12 @@
               }
             },
             "semver": {
-              "version": "4.3.4",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+              "version": "4.3.6",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "sha": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/sha/-/sha-1.3.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/sha/-/sha-1.3.0.tgz"
             },
             "slide": {
               "version": "1.1.6",
@@ -5009,8 +5015,8 @@
           "resolved": "https://registry.npmjs.org/read-json/-/read-json-0.1.0.tgz"
         },
         "rimraf": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
           "dependencies": {
             "glob": {
               "version": "4.5.3",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -1,8 +1,8 @@
 {
   "name": "bootstrap",
   "version": "3.3.4",
-  "npm-shrinkwrap-version": "5.4.0",
-  "node-version": "v0.10.29",
+  "npm-shrinkwrap-version": "200.4.0",
+  "node-version": "v0.12.4",
   "dependencies": {
     "btoa": {
       "version": "1.1.2",


### PR DESCRIPTION
Updated all the dependencies. Also, not sure why we were previously pointing to version 200.4.0 of npm-shrinkwrap. The latest release on npm is 5.4.0.
