### PR TITLE
Permit modal stacking

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -168,7 +168,9 @@
     var that = this
     this.$element.hide()
     this.backdrop(function () {
-      that.$body.removeClass('modal-open')
+      if ($('.modal:visible').length === 0) {
+        that.$body.removeClass('modal-open')
+      }
       that.resetAdjustments()
       that.resetScrollbar()
       that.$element.trigger('hidden.bs.modal')


### PR DESCRIPTION
By checking for other visible modals before removing `modal-open` class at the body level, we can allow modals to stack and scrolling behavior will be preserved correctly.  Please note, stacked modals must be ordered in the Html markup from lowest to highest.
