### PR TITLE
Adding INR currency symbol - ISO 4217 code

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -1065,6 +1065,9 @@ th {
 .glyphicon-menu-up:before {
   content: "\e260";
 }
+.glyphicon-inr:before {
+  content: "\20b9";
+}
 * {
   -webkit-box-sizing: border-box;
      -moz-box-sizing: border-box;

--- a/docs/_data/glyphicons.yml
+++ b/docs/_data/glyphicons.yml
@@ -264,3 +264,4 @@
 - glyphicon-menu-right
 - glyphicon-menu-down
 - glyphicon-menu-up
+- glyphicon-inr

--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -303,3 +303,4 @@
 .glyphicon-menu-right             { &:before { content: "\e258"; } }
 .glyphicon-menu-down              { &:before { content: "\e259"; } }
 .glyphicon-menu-up                { &:before { content: "\e260"; } }
+.glyphicon-inr                    { &:before { content: "\20ac"; } }


### PR DESCRIPTION
Fixes [issue -16660](https://github.com/twbs/bootstrap/issues/16660)
Adding `.glyphicon-inr` class to enable ISO 4217 currency code for
Indian Rupee
