### PR TITLE
Tooltip destroy function doesn't unbind events.

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -471,7 +471,7 @@
     var that = this
     clearTimeout(this.timeout)
     this.hide(function () {
-      that.$element.off('.' + that.type).removeData('bs.' + that.type)
+      that.$element.off('mouseenter focus blur mouseleave', '.' + that.type).removeData('bs.' + that.type)
       if (that.$tip) {
         that.$tip.detach()
       }


### PR DESCRIPTION
I have updated the destroy function so that the the call to off() actually works. Otherwise, it simply fails silently and doesn't unbind anything.

jQuery's off function takes a list of events as its first argument. Here's a reference: http://api.jquery.com/off/#off-events-selector
