### PR TITLE
Fix #16703. Prevent disabled buttons set to active on click.

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -110,7 +110,7 @@
     .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
       var $btn = $(e.target)
       if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-      Plugin.call($btn, 'toggle')
+      if (!$btn.hasClass('disabled')) Plugin.call($btn, 'toggle')
       if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) e.preventDefault()
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -110,6 +110,18 @@ $(function () {
     assert.ok($btn.hasClass('active'), 'btn has class active')
   })
 
+  QUnit.test('should prevent toggle active when disabled btn children are clicked', function (assert) {
+    assert.expect(2)
+    var $btn = $('<button class="btn disabled" data-toggle="button">mdo</button>')
+    var $inner = $('<i/>')
+    $btn
+      .append($inner)
+      .appendTo('#qunit-fixture')
+    assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
+    $inner.trigger('click')
+    assert.ok(!$btn.hasClass('active'), 'btn still does not have class active')
+  })
+
   QUnit.test('should toggle aria-pressed', function (assert) {
     assert.expect(2)
     var $btn = $('<button class="btn" data-toggle="button" aria-pressed="false">redux</button>')

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -98,6 +98,15 @@ $(function () {
     assert.ok($btn.hasClass('active'), 'btn has class active')
   })
 
+  QUnit.test('should prevent toggle active on click when button disabled', function (assert) {
+    assert.expect(2)
+    var $btn = $('<button class="btn disabled" data-toggle="button" disabled>mdo</button>')
+    $btn
+    assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
+    $btn.trigger('click')
+    assert.ok(!$btn.hasClass('active'), 'btn still does not have class active')
+  })
+
   QUnit.test('should toggle active when btn children are clicked', function (assert) {
     assert.expect(2)
     var $btn = $('<button class="btn" data-toggle="button">mdo</button>')
@@ -111,15 +120,30 @@ $(function () {
   })
 
   QUnit.test('should prevent toggle active when disabled btn children are clicked', function (assert) {
-    assert.expect(2)
-    var $btn = $('<button class="btn disabled" data-toggle="button">mdo</button>')
-    var $inner = $('<i/>')
-    $btn
-      .append($inner)
-      .appendTo('#qunit-fixture')
-    assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
-    $inner.trigger('click')
-    assert.ok(!$btn.hasClass('active'), 'btn still does not have class active')
+    assert.expect(8)
+    var groupHTML = '<div class="btn-group" data-toggle="buttons">'
+      + '<label class="btn btn-primary active">'
+      + '<input type="radio" name="options" id="option1" checked="true"> Option 1'
+      + '</label>'
+      + '<label class="btn btn-primary disabled" disabled>'
+      + '<input type="radio" name="options" id="option2" disabled> Option 2'
+      + '</label>'
+      + '</div>'
+    var $group = $(groupHTML).appendTo('#qunit-fixture')
+
+    var $btn1 = $group.children().eq(0)
+    var $btn2 = $group.children().eq(1)
+
+    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
+    assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
+    assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
+    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
+    $btn2.find('input').trigger('click')
+    assert.ok($btn1.hasClass('active'), 'btn1 still has active class')
+    assert.ok($btn1.find('input').prop('checked'), 'btn1 is still checked')
+    assert.ok(!$btn2.hasClass('active'), 'btn2 does not active class')
+    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
+
   })
 
   QUnit.test('should toggle aria-pressed', function (assert) {

--- a/js/tests/visual/button.html
+++ b/js/tests/visual/button.html
@@ -22,7 +22,7 @@
     <h1>Button <small>Bootstrap Visual Test</small></h1>
   </div>
 
-  <button type="button" data-loading-text="Loading for 3 seconds..." class="btn btn-primary js-loading-button">
+  <button type="button" data-loading-text="Loading for 3 seconds..." class="btn btn-primary js-loading-button" onClick="alert('lol')">
     Loading state
   </button>
 
@@ -47,10 +47,12 @@
     <label class="btn btn-primary">
       <input type="radio" name="options" id="option2"> Radio 2
     </label>
-    <label class="btn btn-primary">
-      <input type="radio" name="options" id="option3"> Radio 3
+    <label class="btn btn-primary disabled" disabled>
+      <input type="radio" name="options" id="option3" disabled> Radio 3
     </label>
   </div>
+
+  <button type="button" class="btn btn-primary disabled" disabled>disabled</button>
 
 </div>
 


### PR DESCRIPTION
Resolves #16703. Conditional added in click event to check if the target button has the class of 'disabled'. If it does not have 'disabled' it calls the 'toggle' function. Otherwise, if button has 'disabled' class, toggle does not run.
