### PR TITLE
Added NuGet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://img.shields.io/travis/twbs/bootstrap/master.svg)](https://travis-ci.org/twbs/bootstrap)
 [![devDependency Status](https://img.shields.io/david/dev/twbs/bootstrap.svg)](https://david-dm.org/twbs/bootstrap#info=devDependencies)
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/bootstrap.svg)](https://saucelabs.com/u/bootstrap)
+[![getbootstrap MyGet Build Status](https://www.myget.org/BuildSource/Badge/getbootstrap?identifier=b693c550-a98a-477e-b487-e339de16c1e3)](https://www.myget.org/)
 
 Bootstrap is a sleek, intuitive, and powerful front-end framework for faster and easier web development, created by [Mark Otto](https://twitter.com/mdo) and [Jacob Thornton](https://twitter.com/fat), and maintained by the [core team](https://github.com/orgs/twbs/people) with the massive support and involvement of the community.
 

--- a/nuget/MyGet.ps1
+++ b/nuget/MyGet.ps1
@@ -1,8 +1,7 @@
 $nuget = $env:NuGet
 
-#parse the version number out of the Jekyll _config.yml
-$yaml = (Select-String $env:SourcesPath\_config.yml -pattern "current_version").ToString().Split(" ");
-$bsversion = $yaml[$yaml.Length - 1]
+#parse the version number out of package.json
+$bsversion = ((Get-Content $env:SourcesPath\package.json) -join "`n" | ConvertFrom-Json).version
 
 #create packages
 & $nuget pack "nuget\bootstrap.nuspec" -Verbosity detailed -NonInteractive -NoPackageAnalysis -BasePath $env:SourcesPath -Version $bsversion

--- a/nuget/MyGet.ps1
+++ b/nuget/MyGet.ps1
@@ -1,0 +1,9 @@
+$nuget = $env:NuGet
+
+#parse the version number out of the Jekyll _config.yml
+$yaml = (Select-String $env:SourcesPath\_config.yml -pattern "current_version").ToString().Split(" ");
+$bsversion = $yaml[$yaml.Length - 1]
+
+#create packages
+& $nuget pack "nuget\bootstrap.nuspec" -Verbosity detailed -NonInteractive -NoPackageAnalysis -BasePath $env:SourcesPath -Version $bsversion
+& $nuget pack "nuget\bootstrap.less.nuspec" -Verbosity detailed -NonInteractive -NoPackageAnalysis -BasePath $env:SourcesPath -Version $bsversion

--- a/nuget/bootstrap.less.nuspec
+++ b/nuget/bootstrap.less.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>bootstrap.less</id>
+    <version>3.3</version>
+    <title>Bootstrap LESS</title>
+    <authors>Mark Otto,Jacob Thornton</authors>
+    <owners>bootstrap</owners>
+	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
+    <releaseNotes>http://blog.getbootstrap.com</releaseNotes>
+	<summary>Bootstrap framework in LESS. Includes fonts and javascript</summary>
+	<language>en-us</language>
+	<projectUrl>http://getbootstrap.com</projectUrl>
+    <iconUrl>http://getbootstrap.com/apple-touch-icon.png</iconUrl>
+	<licenseUrl>https://github.com/twbs/bootstrap/blob/master/LICENSE</licenseUrl>
+    <copyright>Copyright 2015</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+      <dependency id="jQuery" version="1.9.1" />
+    </dependencies>
+	<tags>css js less mobile-first responsive front-end framework web</tags>
+  </metadata>
+  <files>
+    <file src="less\**\*.*" target="content\Content\bootstrap" />
+    <file src="fonts\*.*" target="content\Content\fonts" />
+    <file src="dist\js\bootstrap*.js" target="content\Scripts" />
+  </files>
+</package>

--- a/nuget/bootstrap.less.nuspec
+++ b/nuget/bootstrap.less.nuspec
@@ -16,7 +16,7 @@
     <copyright>Copyright 2015</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="jQuery" version="1.9.1" />
+      <dependency id="jQuery" version="[1.9.1,3)" />
     </dependencies>
 	<tags>css js less mobile-first responsive front-end framework web</tags>
   </metadata>

--- a/nuget/bootstrap.less.nuspec
+++ b/nuget/bootstrap.less.nuspec
@@ -3,12 +3,12 @@
   <metadata>
     <id>bootstrap.less</id>
     <version>3.3</version>
-    <title>Bootstrap LESS</title>
-    <authors>Mark Otto,Jacob Thornton</authors>
+    <title>Bootstrap Less</title>
+    <authors>Twitter, Inc.</authors>
     <owners>bootstrap</owners>
 	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>http://blog.getbootstrap.com</releaseNotes>
-	<summary>Bootstrap framework in LESS. Includes fonts and javascript</summary>
+	<summary>Bootstrap framework in Less. Includes fonts and JavaScript</summary>
 	<language>en-us</language>
 	<projectUrl>http://getbootstrap.com</projectUrl>
     <iconUrl>http://getbootstrap.com/apple-touch-icon.png</iconUrl>

--- a/nuget/bootstrap.less.nuspec
+++ b/nuget/bootstrap.less.nuspec
@@ -21,7 +21,7 @@
 	<tags>css js less mobile-first responsive front-end framework web</tags>
   </metadata>
   <files>
-    <file src="less\**\*.*" target="content\Content\bootstrap" />
+    <file src="less\**\*.less" target="content\Content\bootstrap" />
     <file src="fonts\*.*" target="content\Content\fonts" />
     <file src="dist\js\bootstrap*.js" target="content\Scripts" />
   </files>

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -16,7 +16,7 @@
     <copyright>Copyright 2015</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="jQuery" version="1.9.1" />
+      <dependency id="jQuery" version="[1.9.1,3)" />
     </dependencies>
 	<tags>css js less mobile-first responsive front-end framework web</tags>
   </metadata>

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -4,11 +4,11 @@
     <id>bootstrap</id>
     <version>3.3</version>
     <title>Bootstrap CSS</title>
-    <authors>Mark Otto,Jacob Thornton</authors>
+    <authors>Twitter, Inc.</authors>
     <owners>bootstrap</owners>
 	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
 	<releaseNotes>http://blog.getbootstrap.com</releaseNotes>
-	<summary>Bootstrap framework in CSS. Includes fonts and javascript</summary>
+	<summary>Bootstrap framework in CSS. Includes fonts and JavaScript</summary>
 	<language>en-us</language>
 	<projectUrl>http://getbootstrap.com</projectUrl>
     <iconUrl>http://getbootstrap.com/apple-touch-icon.png</iconUrl>

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>bootstrap</id>
+    <version>3.3</version>
+    <title>Bootstrap CSS</title>
+    <authors>Mark Otto,Jacob Thornton</authors>
+    <owners>bootstrap</owners>
+	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
+	<releaseNotes>http://blog.getbootstrap.com</releaseNotes>
+	<summary>Bootstrap framework in CSS. Includes fonts and javascript</summary>
+	<language>en-us</language>
+	<projectUrl>http://getbootstrap.com</projectUrl>
+    <iconUrl>http://getbootstrap.com/apple-touch-icon.png</iconUrl>
+	<licenseUrl>https://github.com/twbs/bootstrap/blob/master/LICENSE</licenseUrl>
+    <copyright>Copyright 2015</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+      <dependency id="jQuery" version="1.9.1" />
+    </dependencies>
+	<tags>css js less mobile-first responsive front-end framework web</tags>
+  </metadata>
+  <files>
+    <file src="dist\css\*.*" target="content\Content" />
+    <file src="dist\fonts\*.*" target="content\fonts" />
+    <file src="dist\js\bootstrap*.js" target="content\Scripts" />
+  </files>
+</package>


### PR DESCRIPTION
Since it seems like there is some desire for [NuGet support](https://github.com/twbs/bootstrap/issues/16692), I went ahead and set it up with my fork as a demo. I got both a css and less version working. Since Sass is a different repo, I can do that one next.

@mdo and team, with a simple pull request, deploy key and webhook the NuGet packaging and publishing can be fully automated. I tried to match the general settings as close as possible to the npm, bower, etc packages. 

When you "release" a milestone it'll use the webhook to POST to MyGet.org to kick off the process. MyGet will pull the latest commit (not the actual release tag, didn't see that as an option) from the master branch. It runs a build script that parses the current_version out of the _config.yml Jekyll file and creates the packages. It'll then publish them to the myget feed and to the official nuget.org feed.

If anyone would like to test (and have v3.3.5!!!), you can add `https://www.myget.org/F/getbootstrap/api/v2` to your NuGet sources. This is temporary, eventually it'll be on the official nuget.org feed. I set it up so, if you use the [outercurve package](https://www.nuget.org/packages/bootstrap/), it'll detect it as an update. If we can't get outercurve to transfer the package id then it'll have to change to getbootstrap or something. There is also a new package called `bootstrap.less` that is the same structure as [Twitter.Bootstrap.Less](https://www.nuget.org/packages/Twitter.Bootstrap.Less/) but won't be a direct upgrade since the Twitter name isn't supposed to be used. Please let me know if there are any issues or suggestions. Would anyone want a version with the individual js components instead of the full bootstrap.js?
