### PR TITLE
Full ISO in CSS references for asterisk and plus glyphicons

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -32,8 +32,8 @@
 }
 
 // Individual icons
-.glyphicon-asterisk               { &:before { content: "\2a"; } }
-.glyphicon-plus                   { &:before { content: "\2b"; } }
+.glyphicon-asterisk               { &:before { content: "\002a"; } }
+.glyphicon-plus                   { &:before { content: "\002b"; } }
 .glyphicon-euro,
 .glyphicon-eur                    { &:before { content: "\20ac"; } }
 .glyphicon-minus                  { &:before { content: "\2212"; } }


### PR DESCRIPTION
I'm using babel and webpack with less-loader to bundle all resources maybe this will cause this issue.
