### PR TITLE
Make x-ua-compatible lowercase

### DIFF
--- a/docs/_includes/getting-started/template.html
+++ b/docs/_includes/getting-started/template.html
@@ -9,7 +9,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>Bootstrap 101 Template</title>


### PR DESCRIPTION
This is really minor, I know, but HTML5 Boilerplate changed this tag to all lowercase. With Gzip compression on it can save 3 bytes. :-)
REF: https://github.com/h5bp/html5-boilerplate/issues/1656
