### PR TITLE
Added best effort support for Collapse trigger detection

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -204,7 +204,7 @@
 
     var $target = getTargetFromTrigger($this)
     var data    = $target.data('bs.collapse')
-        var option  = data ? {toggle: true} : $this.data()
+    var option  = data ? { toggle: true } : $this.data()
     option.$trigger = $this
 
     Plugin.call($target, option)

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -18,6 +18,7 @@
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
     this.$trigger      = $('[data-toggle="collapse"][href="#' + element.id + '"],' +
                            '[data-toggle="collapse"][data-target="#' + element.id + '"]')
+                           .add(options.$trigger)
     this.transitioning = null
 
     if (this.options.parent) {
@@ -203,9 +204,11 @@
 
     var $target = getTargetFromTrigger($this)
     var data    = $target.data('bs.collapse')
-    var option  = data ? 'toggle' : $this.data()
+        var option  = data ? {toggle: true} : $this.data()
+    option.$trigger = $this
 
     Plugin.call($target, option)
+    $target.data('bs.collapse').toggle()
   })
 
 }(jQuery);

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -132,7 +132,7 @@ $(function () {
     assert.expect(2)
     var done = assert.async()
 
-    var $target = $('<a role="button" data-toggle="collapse" class="collapsed" data-target="[data-me=&quot;1&qupt;]" href="#"/>').appendTo('#qunit-fixture')
+    var $target = $('<a role="button" data-toggle="collapse" class="collapsed" data-target="[data-me=&quot;1&quot;]" href="#"/>').appendTo('#qunit-fixture')
     var $alt = $('<a role="button" data-toggle="collapse" class="collapsed" href="#test1"/>').appendTo('#qunit-fixture')
     var $alt2 = $('<a role="button" data-toggle="collapse" class="collapsed" href="#test1"/>').appendTo('#qunit-fixture')
 
@@ -170,7 +170,7 @@ $(function () {
     assert.expect(2)
     var done = assert.async()
 
-    var $target = $('<a role="button" data-toggle="collapse" data-target="[data-me=&quot;1&qupt;]" href="#"/>').appendTo('#qunit-fixture')
+    var $target = $('<a role="button" data-toggle="collapse" data-target="[data-me=&quot;1&quot;]" href="#"/>').appendTo('#qunit-fixture')
     var $alt = $('<a role="button" data-toggle="collapse" href="#test1"/>').appendTo('#qunit-fixture')
     var $alt2 = $('<a role="button" data-toggle="collapse" href="#test1"/>').appendTo('#qunit-fixture')
 

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -110,7 +110,7 @@ $(function () {
     $target.trigger('click')
   })
 
-  QUnit.test('should remove "collapsed" class from all triggers targeting the collapse when the collapse is shown', function (assert) {
+  QUnit.test('should remove "collapsed" class from all triggers targeting the collapse (by ID) when the collapse is shown', function (assert) {
     assert.expect(2)
     var done = assert.async()
 
@@ -122,6 +122,26 @@ $(function () {
       .on('shown.bs.collapse', function () {
         assert.ok(!$target.hasClass('collapsed'), 'target trigger does not have collapsed class')
         assert.ok(!$alt.hasClass('collapsed'), 'alt trigger does not have collapsed class')
+        done()
+      })
+
+    $target.trigger('click')
+  })
+
+  QUnit.test('should remove "collapsed" class from all triggers (by ID) targeting the collapse when the collapse is shown, including the trigger that first invoked the collpase (regardless of its ID relationship)', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+
+    var $target = $('<a role="button" data-toggle="collapse" class="collapsed" data-target="[data-me=&quot;1&qupt;]" href="#"/>').appendTo('#qunit-fixture')
+    var $alt = $('<a role="button" data-toggle="collapse" class="collapsed" href="#test1"/>').appendTo('#qunit-fixture')
+    var $alt2 = $('<a role="button" data-toggle="collapse" class="collapsed" href="#test1"/>').appendTo('#qunit-fixture')
+
+    $('<div id="test1" data-me="1"/>')
+      .appendTo('#qunit-fixture')
+      .on('shown.bs.collapse', function () {
+        assert.ok(!$target.hasClass('collapsed'), 'target trigger does not have collapsed class')
+        assert.ok(!$alt.hasClass('collapsed'), 'alt trigger does not have collapsed class')
+        assert.ok(!$alt2.hasClass('collapsed'), 'alt2 trigger does not have collapsed class')
         done()
       })
 
@@ -140,6 +160,26 @@ $(function () {
       .on('hidden.bs.collapse', function () {
         assert.ok($target.hasClass('collapsed'), 'target has collapsed class')
         assert.ok($alt.hasClass('collapsed'), 'alt trigger has collapsed class')
+        done()
+      })
+
+    $target.trigger('click')
+  })
+
+  QUnit.test('should add "collapsed" class to all triggers targeting the collapse when the collapse is hidden', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+
+    var $target = $('<a role="button" data-toggle="collapse" data-target="[data-me=&quot;1&qupt;]" href="#"/>').appendTo('#qunit-fixture')
+    var $alt = $('<a role="button" data-toggle="collapse" href="#test1"/>').appendTo('#qunit-fixture')
+    var $alt2 = $('<a role="button" data-toggle="collapse" href="#test1"/>').appendTo('#qunit-fixture')
+
+    $('<div id="test1" data-me="1" class="in"/>')
+      .appendTo('#qunit-fixture')
+      .on('hidden.bs.collapse', function () {
+        assert.ok($target.hasClass('collapsed'), 'target has collapsed class')
+        assert.ok($alt.hasClass('collapsed'), 'alt trigger has collapsed class')
+        assert.ok($alt2.hasClass('collapsed'), 'alt trigger has collapsed class')
         done()
       })
 

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -129,7 +129,7 @@ $(function () {
   })
 
   QUnit.test('should remove "collapsed" class from all triggers (by ID) targeting the collapse when the collapse is shown, including the trigger that first invoked the collpase (regardless of its ID relationship)', function (assert) {
-    assert.expect(2)
+    assert.expect(3)
     var done = assert.async()
 
     var $target = $('<a role="button" data-toggle="collapse" class="collapsed" data-target="[data-me=&quot;1&quot;]" href="#"/>').appendTo('#qunit-fixture')
@@ -166,8 +166,8 @@ $(function () {
     $target.trigger('click')
   })
 
-  QUnit.test('should add "collapsed" class to all triggers targeting the collapse when the collapse is hidden', function (assert) {
-    assert.expect(2)
+  QUnit.test('should add "collapsed" class to all triggers targeting the collapse when the collapse is hidden, including the trigger that first invoked the collpase (regardless of its ID relationship)', function (assert) {
+    assert.expect(3)
     var done = assert.async()
 
     var $target = $('<a role="button" data-toggle="collapse" data-target="[data-me=&quot;1&quot;]" href="#"/>').appendTo('#qunit-fixture')


### PR DESCRIPTION
The trigger was detected only if the target element had an ID attribute and it matched the value of either the href or data-target of the trigger.
This adds another minimal effort to the detection - if Collapse is triggered by clicking on a trigger, add it to the trigger list.
Test case -

``` html
<a data-toggle="collapse" data-target="[data-me=&quot;1&quot]">Trigger</a><div data-me="1" class="collapse"></div>
```
