### PR TITLE
composer.json: Use Twitter in `authors` to match package.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,7 @@
   "homepage": "http://getbootstrap.com",
   "authors": [
     {
-      "name": "Mark Otto",
-      "email": "markdotto@gmail.com"
-    },
-    {
-      "name": "Jacob Thornton",
-      "email": "jacobthornton@gmail.com"
+      "name": "Twitter, Inc."
     }
   ],
   "support": {


### PR DESCRIPTION
Changes the `authors` field in `composer.json` to more closely match `package.json`.
Also, I seem to vaguely recall you guys not wanting your email addresses to be in some other Bootstrap file. Or perhaps I'm not remembering correctly.
CC: @mdo @fat 
