### PR TITLE
Correct getViewportAdjustedDelta right overflow

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -397,7 +397,7 @@
       var rightEdgeOffset = pos.left + viewportPadding + actualWidth
       if (leftEdgeOffset < viewportDimensions.left) { // left overflow
         delta.left = viewportDimensions.left - leftEdgeOffset
-      } else if (rightEdgeOffset > viewportDimensions.right) { // right overflow
+      } else if (rightEdgeOffset > viewportDimensions.width) { // right overflow
         delta.left = viewportDimensions.left + viewportDimensions.width - rightEdgeOffset
       }
     }


### PR DESCRIPTION
There was a problem with popovers/tooltips in large horizontal containers (with scroll) - the popovers that overflowed were being corrected but those who didn't were sometimes being rendered out of place.

This was due to a wrong value of the viewport adjusted `delta` being applied, as it was relying on the `viewportDimentions.right` (which comes from `getBoundingClientRect`, dependent on scroll) and not `viewportDimentions.width`, the total viewport's width.
