### PR TITLE
Fix for accordion-like collapse toggle functionality

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -46,7 +46,7 @@
     if (this.transitioning || this.$element.hasClass('in')) return
 
     var activesData
-    var actives = this.$parent && this.$parent.children('.panel').children('.in, .collapsing')
+    var actives = this.$parent && this.$parent.children().children('.in, .collapsing')
 
     if (actives && actives.length) {
       activesData = actives.data('bs.collapse')


### PR DESCRIPTION
At the moment only child elements (of element referenced with `data-parent="#accordion"`) having `.panel` class toggle properly.
Since this is not emphasized or mentioned in docs I believe it's a bug. Otherwise it is very restricting design wise as `.panel` class has to be used. And due to it's own css styling it isn't fit for every situation where toggle functionality could be used.

This fix makes it more flexible to use and allows proper accordion-like toggling functionality for any child element (of any class).
