### PR TITLE
Add hover styles for buttons

### DIFF
--- a/less/hover-buttons.less
+++ b/less/hover-buttons.less
@@ -1,0 +1,40 @@
+.btn-danger-hover {
+    .btn-default;
+    color : @brand-danger;
+    
+    &:hover {
+        .btn-danger;
+    }
+}
+.btn-primary-hover {
+    .btn-default;
+    color : @brand-primary;
+    
+    &:hover {
+        .btn-primary;
+    }
+}
+.btn-success-hover {
+    .btn-default;
+    color : @brand-success;
+    
+    &:hover {
+        .btn-success;
+    }
+}
+.btn-info-hover {
+    .btn-default;
+    color : @brand-info;
+    
+    &:hover {
+        .btn-info;
+    }
+}
+.btn-warning-hover {
+    .btn-default;
+    color : @brand-warning;
+    
+    &:hover {
+        .btn-warning;
+    }
+}


### PR DESCRIPTION
Buttons using btn layouts on hover. Example:

```
<button class="btn btn-danger-hover">Danger!</button>
```

Uses btn-default background and border with @brand-{color} text color. On hover, inherits appropriate btn-{button-type} class.

Inspired by Github's "Cancel" button.
