### PR TITLE
navbar-nav button styling

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -260,6 +260,13 @@
         }
       }
     }
+
+    // Buttons display as block when collapsed
+    > li > button {
+      .btn-block();
+      margin-top:    5px;
+      margin-bottom: 5px;
+    }
   }
 
   // Uncollapse the nav

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -273,6 +273,10 @@
         padding-top:    @navbar-padding-vertical;
         padding-bottom: @navbar-padding-vertical;
       }
+      > button {
+        margin-left:  2px;
+        margin-right: 2px;
+      }
     }
   }
 }


### PR DESCRIPTION
As a developer, I want buttons in navbar-nav lists to look awesome, so that I can place buttons in navbar-nav lists, just like links.

Before:

![before-1](https://cloud.githubusercontent.com/assets/10576323/8587295/49971a5e-25ae-11e5-9952-e5312b7d0299.png)

![before-2](https://cloud.githubusercontent.com/assets/10576323/8587296/4db151f4-25ae-11e5-8751-bf2c37023919.png)

After:

![after-1](https://cloud.githubusercontent.com/assets/10576323/8587300/50390fa2-25ae-11e5-8e38-0c39ab13dc9d.png)

![after-2](https://cloud.githubusercontent.com/assets/10576323/8587301/53d628e8-25ae-11e5-86e0-303e8e662062.png)

Test with the following HTML:

``` html
<nav class="navbar navbar-default">
  <div class="container-fluid">
    <div class="navbar-header">
      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
        <span class="sr-only">Toggle navigation</span>
        <span class="icon-bar"></span>
        <span class="icon-bar"></span>
        <span class="icon-bar"></span>
      </button>
      <a class="navbar-brand" href="#">Brand</a>
    </div>
    <div class="collapse navbar-collapse" id="navbar-collapse">
      <ul class="nav navbar-nav">
        <li><a href="#">Link</a></li>
        <li><a href="#">Link</a></li>
        <li><button type="button" class="btn btn-default navbar-btn">Button</button></li>
        <li><button type="button" class="btn btn-default navbar-btn">Another Button</button></li>
      </ul>
    </div>
  </div>
</nav>
```
