### PR TITLE
Improve fonts sizes to allow variability.

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -49,15 +49,15 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          14px;
-@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
-@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+@font-size-large:         1.25em; // ~18px
+@font-size-small:         0.85em; // ~12px
 
-@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
-@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
-@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
-@font-size-h5:            @font-size-base;
-@font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
+@font-size-h1:            2.6em; // ~36px
+@font-size-h2:            2.15em; // ~30px
+@font-size-h3:            1.7em; // ~24px
+@font-size-h4:            1.25em; // ~18px
+@font-size-h5:            1em;
+@font-size-h6:            0.85em; // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14


### PR DESCRIPTION
When using Bootstrap I cannot easily change the font size I would like to use site wide due to the way they are defined in the headers. You can see the problem I am describing and the way I think it should work at http://markbernard.github.io/bootstraptest/index.html.
