### PR TITLE
Show active buttons when form disabled

### DIFF
--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -42,12 +42,9 @@
   &.disabled,
   &[disabled],
   fieldset[disabled] & {
-    &,
     &:hover,
     &:focus,
-    &.focus,
-    &:active,
-    &.active {
+    &.focus {
       background-color: @background;
           border-color: @border;
     }


### PR DESCRIPTION
Resolves #16767.

Button-variant mixins were overwriting the colors of active buttons when the forms were disabled. With the changes, the buttons are still noticeably disabled, but the active button is still faintly identifiable.

Original Issue:
http://codepen.io/seyfert/pen/PqRwXR?editors=101

Compiled Solution Code:
http://codepen.io/edwinlin1987/pen/XbqPJY
