### PR TITLE
Kill last deprecated responsive var @screen-xs-min

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -92,7 +92,7 @@
   .navbar-collapse {
     max-height: @navbar-collapse-max-height;
 
-    @media (max-device-width: @screen-xs-min) and (orientation: landscape) {
+    @media (max-device-width: @screen-xs-max) and (orientation: landscape) {
       max-height: 200px;
     }
   }


### PR DESCRIPTION
Should that ever have been a min in the first place?
