### PR TITLE
Fix spacing on justified nav pills

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -136,6 +136,10 @@
       }
     }
   }
+
+  &.nav-justified {
+    .nav-pills-justified();
+  }
 }
 
 
@@ -212,6 +216,21 @@
     > .active > a:focus {
       border-bottom-color: @nav-tabs-justified-active-link-border-color;
     }
+  }
+}
+
+// Mixin to fix spacing for justified pills
+.nav-pills-justified {
+  .nav-stacked();
+
+  > li > a {
+    // Margin handled by li instead
+    margin-bottom: 0;
+  }
+
+  @media (min-width: @screen-sm-min) {
+    // Replace li margin (which does not work on table-cell)
+    border-spacing: 2px 0;
   }
 }
 


### PR DESCRIPTION
Justified nav pills (`.nav-pills.nav-justified`) have the following spacing issues:
- there is no horizontal spacing between the pills on screens `sm` and larger
- on `xs` screens (with the pills stacked), the vertical spacing between the pills is substantially larger than when using `.nav-stacked`
- on `xs` screens, the first pill sticks out by 2px to the left (visible on hover and when active)

Example: http://codepen.io/anon/pen/vOzvMq (stacked and regular pills provided for comparison)

This patch fixes those issues by adding a gap between justified nav pills when they are displayed horizontally, and making them behave like `.nav-stacked` when they are displayed vertically.
