### PR TITLE
Add support for Meteor 1.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,7 +18,9 @@ Package.onUse(function (api) {
     'dist/fonts/glyphicons-halflings-regular.svg',
     'dist/fonts/glyphicons-halflings-regular.ttf',
     'dist/fonts/glyphicons-halflings-regular.woff',
-    'dist/fonts/glyphicons-halflings-regular.woff2',
+    'dist/fonts/glyphicons-halflings-regular.woff2'
+  ], 'client', { isAsset: true });
+  api.addFiles([
     'dist/css/bootstrap.css',
     'dist/js/bootstrap.js'
   ], 'client');


### PR DESCRIPTION
This is a refactor to prepare for the upcoming Meteor 1.2 release as well as any preview versions up to that point.

The `{ isAsset: true }` is backwards compatible, it's just that once 1.2 comes around, it will be required for those kinds of files.

See [this issue](https://github.com/meteor/meteor/issues/4800) for more details.
