### PR TITLE
Use meteorhacks:inject-initial to inject meta tags at top of head

### DIFF
--- a/dist/js/meteor-add-meta.js
+++ b/dist/js/meteor-add-meta.js
@@ -1,5 +1,9 @@
-Inject.rawHead('bootstrap-meta',
+if (Inject.rawHeads['bootstrap-meta'] === undefined) {
+  Inject.rawHead('bootstrap-meta',
   '  <meta charset="utf-8">\n' +
   '  <meta http-equiv="X-UA-Compatible" content="IE=edge">\n' +
   '  <meta name="viewport" content="width=device-width, initial-scale=1">\n' +
-  '  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->\n');
+  '  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->\n' +
+  '  <!-- If you must replace them, run "meteor add meteorhacks:inject-initial" and add server code like this: -->\n' +
+  '  <!--   Inject.rawHead("bootstrap-meta", "YOUR REPLACEMENT"); -->\n');
+}

--- a/dist/js/meteor-add-meta.js
+++ b/dist/js/meteor-add-meta.js
@@ -1,0 +1,5 @@
+Inject.rawHead('bootstrap-meta',
+  '  <meta charset="utf-8">\n' +
+  '  <meta http-equiv="X-UA-Compatible" content="IE=edge">\n' +
+  '  <meta name="viewport" content="width=device-width, initial-scale=1">\n' +
+  '  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->\n');

--- a/dist/js/meteor-add-meta.js
+++ b/dist/js/meteor-add-meta.js
@@ -1,9 +1,10 @@
 if (Inject.rawHeads['bootstrap-meta'] === undefined) {
   Inject.rawHead('bootstrap-meta',
-  '  <meta charset="utf-8">\n' +
+  // <meta charset="utf-8"> should not be needed because Meteor server sets the encoding via HTTP header.
+  // See discussion at https://github.com/twbs/bootstrap/pull/16880.
   '  <meta http-equiv="X-UA-Compatible" content="IE=edge">\n' +
   '  <meta name="viewport" content="width=device-width, initial-scale=1">\n' +
-  '  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->\n' +
+  '  <!-- The above meta tags *must* come first in the head; any other head content must come *after* these tags -->\n' +
   '  <!-- If you must replace them, run "meteor add meteorhacks:inject-initial" and add server code like this: -->\n' +
   '  <!--   Inject.rawHead("bootstrap-meta", "YOUR REPLACEMENT"); -->\n');
 }

--- a/package.js
+++ b/package.js
@@ -13,6 +13,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
   api.use('jquery', 'client');
+  api.use('meteorhacks:inject-initial', 'server');
   api.addFiles([
     'dist/fonts/glyphicons-halflings-regular.eot',
     'dist/fonts/glyphicons-halflings-regular.svg',
@@ -22,4 +23,7 @@ Package.onUse(function (api) {
     'dist/css/bootstrap.css',
     'dist/js/bootstrap.js'
   ], 'client');
+  api.addFiles([
+    'dist/js/meteor-add-meta.js'
+  ], 'server');
 });


### PR DESCRIPTION
The twbs:bootstrap package for Meteor does not currently insert the 3 meta tags that need to be at the top of the `<head>` element. Moreover, Meteor users can't simply add the meta tags to the top of the `<head>` element of their html templates, because Meteor will place a lot of other tags before them in the HTML that it actually generates and sends to the browser . As a result, Meteor users that add the twbs:bootstrap package to their projects may experience problems associated with the missing meta tags (e.g. compatibility with older IE versions). This PR modifies the meteor package to use the meteorhacks:inject-initial package to inject the meta tags at the top of the head element.
