### PR TITLE
Remove http://crbug.com/309483 from the Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -112,16 +112,6 @@
   browser: >
     Chrome
   summary: >
-    `display: table;` within `display: block;` forces sibling content to new line.
-  upstream_bug: >
-    Chromium#309483
-  origin: >
-    Bootstrap#9950
-
--
-  browser: >
-    Chrome
-  summary: >
     Incorrect viewport size used for media queries when printing.
   upstream_bug: >
     Chromium#273306


### PR DESCRIPTION
All current major browsers behave like Chrome here, so this bug is most likely invalid.
Refs http://crbug.com/309483
CC: @mdo
