### PR TITLE
Fix for issue #16871

### DIFF
--- a/less/tooltip.less
+++ b/less/tooltip.less
@@ -48,6 +48,8 @@
     margin-left: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
     border-top-color: @tooltip-arrow-color;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   &.top-left .tooltip-arrow {
     bottom: 0;


### PR DESCRIPTION
This will prevent a long word from breaking the tooltip.
Example: https://jsfiddle.net/frpeqfmL/
Fixes #16871.
