### PR TITLE
Allow heading-by-class to override heading-by-element

### DIFF
--- a/less/type.less
+++ b/less/type.less
@@ -44,12 +44,20 @@ h6, .h6 {
   }
 }
 
-h1, .h1 { font-size: @font-size-h1; }
-h2, .h2 { font-size: @font-size-h2; }
-h3, .h3 { font-size: @font-size-h3; }
-h4, .h4 { font-size: @font-size-h4; }
-h5, .h5 { font-size: @font-size-h5; }
-h6, .h6 { font-size: @font-size-h6; }
+h1 { font-size: @font-size-h1; }
+h2 { font-size: @font-size-h2; }
+h3 { font-size: @font-size-h3; }
+h4 { font-size: @font-size-h4; }
+h5 { font-size: @font-size-h5; }
+h6 { font-size: @font-size-h6; }
+
+// Allow an explicit class to override element style
+.h1 { font-size: @font-size-h1; }
+.h2 { font-size: @font-size-h2; }
+.h3 { font-size: @font-size-h3; }
+.h4 { font-size: @font-size-h4; }
+.h5 { font-size: @font-size-h5; }
+.h6 { font-size: @font-size-h6; }
 
 
 // Body text


### PR DESCRIPTION
Separating the `hX` and `.hX` rules allows an explicitly-stated class to override the font size applied by an element. Useful for situations in which you want the _semantic_ heading and the _visual_ heading to be different nodes.

This allows `<h1 class="h2">` to "work right" from a design perspective: I have explicitly stated I want this element to be visually consistent with other `h2` through the use of a class, though it is the primary heading of the page for semantic reasons.
