### PR TITLE
Fixing issue when scroll heights don't line up

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -82,6 +82,8 @@
 
     if (this.scrollHeight != scrollHeight) {
       this.refresh()
+      offsets = this.offsets
+      targets = this.targets
     }
 
     if (scrollTop >= maxScroll) {


### PR DESCRIPTION
Setting offsets and targets after a refresh call in process. Right now it just calls refresh and then offsets is still empty even though this.offsets isn't.
