### PR TITLE
Call out `.icon-next`, `.icon-prev` alternative classes for Carousel

### DIFF
--- a/docs/_includes/js/carousel.html
+++ b/docs/_includes/js/carousel.html
@@ -85,6 +85,11 @@
     <p>The <code>.active</code> class needs to be added to one of the slides. Otherwise, the carousel will not be visible.</p>
   </div>
 
+  <div class="bs-callout bs-callout-info" id="callout-carousel-without-glyphicons">
+    <h4>Glyphicon icons not necessary</h4>
+    <p>The <code>.glyphicon .glyphicon-chevron-left</code> and <code>.glyphicon .glyphicon-chevron-right</code> classes are not necessarily needed for the controls. Bootstrap provides <code>.icon-prev</code> and <code>.icon-next</code> as plain unicode alternatives.</p>
+  </div>
+
   <h3>Optional captions</h3>
   <p>Add captions to your slides easily with the <code>.carousel-caption</code> element within any <code>.item</code>. Place just about any optional HTML within there and it will be automatically aligned and formatted.</p>
   <div class="bs-example" data-example-id="carousel-with-captions">


### PR DESCRIPTION
Closes #16964.
