### PR TITLE
Tweak Affix top condition

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -42,7 +42,7 @@
     var position     = this.$element.offset()
     var targetHeight = this.$target.height()
 
-    if (offsetTop != null && this.affixed == 'top') return scrollTop < offsetTop ? 'top' : false
+    if (offsetTop != null && this.affixed == 'top') return scrollTop <= offsetTop ? 'top' : false
 
     if (this.affixed == 'bottom') {
       if (offsetTop != null) return (scrollTop + this.unpin <= position.top) ? false : 'bottom'


### PR DESCRIPTION
Bug if body shifted to the left or right affix becomes affix-top.
And if affix in top(top = 0).
But bottom condition:

``` javascript
if (offsetTop != null && scrollTop <= offsetTop) return 'top'
```
