### PR TITLE
Use @carousel-control-font-size for in min-width sm

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -240,10 +240,10 @@
     .glyphicon-chevron-right,
     .icon-prev,
     .icon-next {
-      width: 30px;
-      height: 30px;
+      width: (@carousel-control-font-size * 1.5);
+      height: (@carousel-control-font-size * 1.5);
       margin-top: -15px;
-      font-size: 30px;
+      font-size: (@carousel-control-font-size * 1.5);
     }
     .glyphicon-chevron-left,
     .icon-prev {


### PR DESCRIPTION
Fix #16973

As 30px was hard coded for the following attribute values: `width`, `height`, and `font-size`, I have used the same pixel formula for each of these three as the `@carousel-control-width` is a percent value not a pixel value in variables.less

If `margin-top` should be calculated we can also do that with a `(@carousel-control-font-size * -0.75)`
