### PR TITLE
Fixed #16976 .label without .label-* is invisible

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -8,7 +8,6 @@
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
-  color: @label-color;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
@@ -18,7 +17,6 @@
   a& {
     &:hover,
     &:focus {
-      color: @label-link-hover-color;
       text-decoration: none;
       cursor: pointer;
     }

--- a/less/mixins/labels.less
+++ b/less/mixins/labels.less
@@ -1,11 +1,13 @@
 // Labels
 
 .label-variant(@color) {
+  color: @label-color;
   background-color: @color;
 
   &[href] {
     &:hover,
     &:focus {
+      color: @label-link-hover-color;
       background-color: darken(@color, 10%);
     }
   }


### PR DESCRIPTION
I moved the label color declarations to the variants themselves so that any existing non-Bootstrap HTML using .label class declarations don't just have elements disappear so that they have to be noticed & found before we even start figuring out why they disappeared in the first place.

Also it just makes sense.  color & background should be declared at the same time.
