### PR TITLE
Use z-index 3 to show focus state on all sides of input

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -20,7 +20,7 @@
     // Ensure that the input is always above the *appended* addon button for
     // proper border colors.
     position: relative;
-    z-index: 2;
+    z-index: 3;
 
     // IE9 fubars the placeholder attribute in text inputs and the arrows on
     // select elements in input groups. To fix it, we float the input. Details:


### PR DESCRIPTION
Fixes #17001

JSBin with fix: http://jsbin.com/gifexipibu/edit?html,css,output
