### PR TITLE
Have Travis CI use Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
   - "0.12"
 before_install:
   - travis_retry sudo pip install -r test-infra/requirements.txt
-  - rvm use 1.9.3 --fuzzy
+  - rvm install 2.0.0
+  - rvm use 2.0.0 --fuzzy
   - export GEMDIR=$(rvm gemdir)
   - if [ "$TWBS_TEST" = validate-html ]; then echo "ruby=$(basename $GEMDIR) jekyll=$JEKYLL_VERSION rouge=$ROUGE_VERSION" > pseudo_Gemfile.lock; fi
   - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""


### PR DESCRIPTION
Fix #17011

This updates to 2.0.0. Personally from a performance perspective 2.1 or 2.2 would make more sense. Though 2.0 is the minimum required for the gems used currently.
