### PR TITLE
Refactor utility spacer to use a multiplier instead of hardcoded value

### DIFF
--- a/scss/_utilities-spacing.scss
+++ b/scss/_utilities-spacing.scss
@@ -17,21 +17,25 @@
 .m-y { margin-top:    $spacer-y !important; margin-bottom: $spacer-y !important; }
 .m-x-auto { margin-right: auto !important; margin-left: auto !important; }
 
-.m-a-md { margin:        ($spacer * 1.5) !important; }
-.m-t-md { margin-top:    ($spacer-y * 1.5) !important; }
-.m-r-md { margin-right:  ($spacer-y * 1.5) !important; }
-.m-b-md { margin-bottom: ($spacer-y * 1.5) !important; }
-.m-l-md { margin-left:   ($spacer-y * 1.5) !important; }
-.m-x-md { margin-right:  ($spacer-x * 1.5) !important; margin-left:   ($spacer-x * 1.5) !important; }
-.m-y-md { margin-top:    ($spacer-y * 1.5) !important; margin-bottom: ($spacer-y * 1.5) !important; }
+.m-a-md { margin:        ($spacer * $spacer-multiplier) !important; }
+.m-t-md { margin-top:    ($spacer-y * $spacer-multiplier) !important; }
+.m-r-md { margin-right:  ($spacer-y * $spacer-multiplier) !important; }
+.m-b-md { margin-bottom: ($spacer-y * $spacer-multiplier) !important; }
+.m-l-md { margin-left:   ($spacer-y * $spacer-multiplier) !important; }
+.m-x-md { margin-right:  ($spacer-x * $spacer-multiplier) !important;
+  margin-left:   ($spacer-x * $spacer-multiplier) !important; }
+.m-y-md { margin-top:    ($spacer-y * $spacer-multiplier) !important;
+  margin-bottom: ($spacer-y * $spacer-multiplier) !important; }
 
-.m-a-lg { margin:        ($spacer * 3) !important; }
-.m-t-lg { margin-top:    ($spacer-y * 3) !important; }
-.m-r-lg { margin-right:  ($spacer-y * 3) !important; }
-.m-b-lg { margin-bottom: ($spacer-y * 3) !important; }
-.m-l-lg { margin-left:   ($spacer-y * 3) !important; }
-.m-x-lg { margin-right:  ($spacer-x * 3) !important; margin-left:   ($spacer-x * 3) !important; }
-.m-y-lg { margin-top:    ($spacer-y * 3) !important; margin-bottom: ($spacer-y * 3) !important; }
+.m-a-lg { margin:        ($spacer * ($spacer-multiplier * 2)) !important; }
+.m-t-lg { margin-top:    ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.m-r-lg { margin-right:  ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.m-b-lg { margin-bottom: ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.m-l-lg { margin-left:   ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.m-x-lg { margin-right:  ($spacer-x * ($spacer-multiplier * 2)) !important;
+  margin-left:   ($spacer-x * ($spacer-multiplier * 2)) !important; }
+.m-y-lg { margin-top:    ($spacer-y * ($spacer-multiplier * 2)) !important;
+  margin-bottom: ($spacer-y * ($spacer-multiplier * 2)) !important; }
 
 // Padding
 
@@ -51,21 +55,25 @@
 .p-x { padding-right:  $spacer-x !important; padding-left:   $spacer-x !important; }
 .p-y { padding-top:    $spacer-y !important; padding-bottom: $spacer-y !important; }
 
-.p-a-md { padding:        ($spacer * 1.5) !important; }
-.p-t-md { padding-top:    ($spacer-y * 1.5) !important; }
-.p-r-md { padding-right:  ($spacer-y * 1.5) !important; }
-.p-b-md { padding-bottom: ($spacer-y * 1.5) !important; }
-.p-l-md { padding-left:   ($spacer-y * 1.5) !important; }
-.p-x-md { padding-right:  ($spacer-x * 1.5) !important; padding-left:   ($spacer-x * 1.5) !important; }
-.p-y-md { padding-top:    ($spacer-y * 1.5) !important; padding-bottom: ($spacer-y * 1.5) !important; }
+.p-a-md { padding:        ($spacer * $spacer-multiplier) !important; }
+.p-t-md { padding-top:    ($spacer-y * $spacer-multiplier) !important; }
+.p-r-md { padding-right:  ($spacer-y * $spacer-multiplier) !important; }
+.p-b-md { padding-bottom: ($spacer-y * $spacer-multiplier) !important; }
+.p-l-md { padding-left:   ($spacer-y * $spacer-multiplier) !important; }
+.p-x-md { padding-right:  ($spacer-x * $spacer-multiplier) !important;
+  padding-left: ($spacer-x * $spacer-multiplier) !important; }
+.p-y-md { padding-top:    ($spacer-y * $spacer-multiplier) !important;
+  padding-bottom: ($spacer-y * $spacer-multiplier) !important; }
 
-.p-a-lg { padding:        ($spacer * 3) !important; }
-.p-t-lg { padding-top:    ($spacer-y * 3) !important; }
-.p-r-lg { padding-right:  ($spacer-y * 3) !important; }
-.p-b-lg { padding-bottom: ($spacer-y * 3) !important; }
-.p-l-lg { padding-left:   ($spacer-y * 3) !important; }
-.p-x-lg { padding-right:  ($spacer-x * 3) !important; padding-left:   ($spacer-x * 3) !important; }
-.p-y-lg { padding-top:    ($spacer-y * 3) !important; padding-bottom: ($spacer-y * 3) !important; }
+.p-a-lg { padding:        ($spacer * ($spacer-multiplier * 2)) !important; }
+.p-t-lg { padding-top:    ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.p-r-lg { padding-right:  ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.p-b-lg { padding-bottom: ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.p-l-lg { padding-left:   ($spacer-y * ($spacer-multiplier * 2)) !important; }
+.p-x-lg { padding-right:  ($spacer-x * ($spacer-multiplier * 2)) !important;
+  padding-left:   ($spacer-x * ($spacer-multiplier * 2)) !important; }
+.p-y-lg { padding-top:    ($spacer-y * ($spacer-multiplier * 2)) !important;
+  padding-bottom: ($spacer-y * ($spacer-multiplier * 2)) !important; }
 
 // Positioning
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -60,6 +60,7 @@ $enable-grid-classes:       true !default;
 $spacer:                     1rem !default;
 $spacer-x:                   $spacer !default;
 $spacer-y:                   $spacer !default;
+$spacer-multiplier:          1.5;
 $border-width:               1px !default;
 
 


### PR DESCRIPTION
Fix for: refactor spacer utilities Sass to include a variable-based multiplier instead of a hard-coded one.
