### PR TITLE
v4 - Use doge instead of css for <pre> example

### DIFF
--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -111,9 +111,9 @@ The `<pre>` element is reset to remove its `margin-top` and use `rem` units for 
 <div class="bd-example">
 {% markdown %}
 <pre>
-        Wow
-  such
-      preformatted text
+.example-element {
+  margin-bottom: 1rem;
+}
 </pre>
 {% endmarkdown %}
 </div>

--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -111,9 +111,9 @@ The `<pre>` element is reset to remove its `margin-top` and use `rem` units for 
 <div class="bd-example">
 {% markdown %}
 <pre>
-.element {
-  margin-bottom: 1rem;
-}
+        Wow
+  such
+      preformatted text
 </pre>
 {% endmarkdown %}
 </div>


### PR DESCRIPTION
When reading through this it looked like another code example, so to make it look extra example-y I made it doge.
