### PR TITLE
Setting the optional flag so bootstrap flex compiles for Ruby

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -30,7 +30,7 @@
       }
       @for $i from 1 through $columns {
         .col-#{$breakpoint}-#{$i} {
-          @extend %grid-column-float-#{$breakpoint};
+          @extend %grid-column-float-#{$breakpoint} !optional;
           @include make-col-span($i, $columns);
         }
       }


### PR DESCRIPTION
See issue: #17046

Quite possible this is just a hack to make it work and the problem is somewhere else, but this should get the discussion and interrest starting on why it wont compile with a ruby sass

Regards,
