### PR TITLE
Make dropdown caret to right like select dropdown

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -5,11 +5,20 @@
 }
 
 .dropdown-toggle {
+  position: relative;
   // Generate the caret automatically
   &:after {
     display: inline-block;
     width: 0;
     height: 0;
+    right: 0.5em;
+    top: 50%;
+    transform: translateY(-50%);
+    -moz-transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
+    -o-transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    position: absolute;
     margin-left: .25rem;
     vertical-align: middle;
     content: "";

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -14,10 +14,6 @@
     right: 0.5em;
     top: 50%;
     transform: translateY(-50%);
-    -moz-transform: translateY(-50%);
-    -webkit-transform: translateY(-50%);
-    -o-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
     position: absolute;
     margin-left: .25rem;
     vertical-align: middle;


### PR DESCRIPTION
Sticks dropdown caret to right side like in default select dropdown of
browser. Usually in cases where data-toggle button is bigger size, caret
was in center thus was not looking good.
