### PR TITLE
v4 - Remove weird extra border from GitHub follow buttons on v4 Team page

### DIFF
--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -822,6 +822,7 @@ h1[id] {
   width: 180px;
   height: 20px;
   margin-top: 6px;
+  border: none;
 }
 .bs-team img {
   float: left;


### PR DESCRIPTION
Fix #17175

Caused by the inherit style of the iframes used.

EX:
<img width="1236" alt="screen shot 2015-08-20 at 9 51 35 pm" src="https://cloud.githubusercontent.com/assets/947110/9399667/a8f0a85a-4785-11e5-9b3a-4113b7701662.png">
