### PR TITLE
v4 - Remove weird extra border from GitHub follow buttons on v4 Team page

### DIFF
--- a/docs/assets/scss/_team.scss
+++ b/docs/assets/scss/_team.scss
@@ -12,6 +12,7 @@
   }
 
   .github-btn {
+    border: none;
     float: right;
     width: 180px;
     height: 1.25rem;


### PR DESCRIPTION
Fix #17175

X-Ref Original Against Wrong Branch: #17179
