### PR TITLE
modal.md - wrapped rows to a .container-fluid, added .bd-example-row...

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -275,26 +275,28 @@ To take advantage of the Bootstrap grid system within a modal, just nest `.conta
         <h4 class="modal-title" id="gridModalLabel">Modal title</h4>
       </div>
       <div class="modal-body">
-        <div class="row">
-          <div class="col-md-4">.col-md-4</div>
-          <div class="col-md-4 col-md-offset-4">.col-md-4 .col-md-offset-4</div>
-        </div>
-        <div class="row">
-          <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
-          <div class="col-md-2 col-md-offset-4">.col-md-2 .col-md-offset-4</div>
-        </div>
-        <div class="row">
-          <div class="col-md-6 col-md-offset-3">.col-md-6 .col-md-offset-3</div>
-        </div>
-        <div class="row">
-          <div class="col-sm-9">
-            Level 1: .col-sm-9
-            <div class="row">
-              <div class="col-xs-8 col-sm-6">
-                Level 2: .col-xs-8 .col-sm-6
-              </div>
-              <div class="col-xs-4 col-sm-6">
-                Level 2: .col-xs-4 .col-sm-6
+        <div class="container-fluid bd-example-row">
+          <div class="row">
+            <div class="col-md-4">.col-md-4</div>
+            <div class="col-md-4 col-md-offset-4">.col-md-4 .col-md-offset-4</div>
+          </div>
+          <div class="row">
+            <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
+            <div class="col-md-2 col-md-offset-4">.col-md-2 .col-md-offset-4</div>
+          </div>
+          <div class="row">
+            <div class="col-md-6 col-md-offset-3">.col-md-6 .col-md-offset-3</div>
+          </div>
+          <div class="row">
+            <div class="col-sm-9">
+              Level 1: .col-sm-9
+              <div class="row">
+                <div class="col-xs-8 col-sm-6">
+                  Level 2: .col-xs-8 .col-sm-6
+                </div>
+                <div class="col-xs-4 col-sm-6">
+                  Level 2: .col-xs-4 .col-sm-6
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
…for better visualization

The guide text for the `Using the grid system" in`modal.md` says

> To take advantage of the Bootstrap grid system within a modal, just nest .container-fluid within the .modal-body and then use the normal grid system classes within this container.

But the example itself didn't contain the wrapper.

I also added `.bd-example-row` for the wrapper to improve the visualization on of the grid system

Before:
![image](https://cloud.githubusercontent.com/assets/7641760/9405407/1d3e0da4-4800-11e5-9d8a-0d4f1a5049b0.png)

After: 
![image](https://cloud.githubusercontent.com/assets/7641760/9405400/0dc705ec-4800-11e5-9364-2a15ff2649b8.png)

Fixes #17898.
