### PR TITLE
Fix card group rounding

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -241,6 +241,9 @@
     // Handle rounded corners
     @if $enable-rounded {
       &:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+
         .card-img-top {
           border-top-right-radius: 0;
         }
@@ -249,6 +252,9 @@
         }
       }
       &:last-child {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+
         .card-img-top {
           border-top-left-radius: 0;
         }

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -241,8 +241,7 @@
     // Handle rounded corners
     @if $enable-rounded {
       &:first-child {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        @include border-right-radius(0);
 
         .card-img-top {
           border-top-right-radius: 0;
@@ -252,8 +251,7 @@
         }
       }
       &:last-child {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        @include border-left-radius(0);
 
         .card-img-top {
           border-top-left-radius: 0;


### PR DESCRIPTION
Fixes #17203 

Looks much better when using groups without an image at the top
