### PR TITLE
Fixes alignment issue in static control example

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -398,13 +398,13 @@ When you need to place plain text next to a form label within a form, use the `.
 {% example html %}
 <form class="form-horizontal">
   <div class="form-group">
-    <label class="col-sm-2 control-label">Email</label>
+    <label class="col-sm-2 form-control-label">Email</label>
     <div class="col-sm-10">
       <p class="form-control-static">email@example.com</p>
     </div>
   </div>
   <div class="form-group">
-    <label for="inputPassword" class="col-sm-2 control-label">Password</label>
+    <label for="inputPassword" class="col-sm-2 form-control-label">Password</label>
     <div class="col-sm-10">
       <input type="password" class="form-control" id="inputPassword" placeholder="Password">
     </div>


### PR DESCRIPTION
Fix #17195. Replaced control-label with form-control-label class which
is new in v4.
