### PR TITLE
Removed mixin from focus outline box-shadow fixes #17066

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -19,14 +19,14 @@
     z-index: -1; // Put the input behind the label so it doesn't overlay text
     opacity: 0;
 
-    &:focus ~ .c-indicator {
-      @include box-shadow(0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9);
-    }
-
     &:checked ~ .c-indicator {
       color: #fff;
       background-color: #0074d9;
       @include box-shadow(none);
+    }
+
+    &:focus ~ .c-indicator {
+      box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
     }
 
     &:active ~ .c-indicator {

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -26,6 +26,7 @@
     }
 
     &:focus ~ .c-indicator {
+      // the mixin is not used here to make sure there is feedback
       box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
     }
 


### PR DESCRIPTION
Fixed #17066 it used the box-shadow mixin for the outline, thus the box-shadow was not enabled when the $enable-shadows global was set to false.
![checkbox-fixed](https://cloud.githubusercontent.com/assets/570297/9418291/2aaab96c-4853-11e5-9594-303fcfd042ef.png)
