### PR TITLE
Ensure not-allowed cursor event is shown on btn-disabled

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -41,7 +41,7 @@
   &.disabled,
   &:disabled,
   fieldset[disabled] & {
-    cursor: $cursor-disabled;
+    cursor: $cursor-disabled !important;
     opacity: .65;
     @include box-shadow(none);
   }


### PR DESCRIPTION
Fix #17231
