### PR TITLE
v4: Change the default value of $font-size-sm to .875rem

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -132,7 +132,7 @@ $font-size-root:             16px !default;
 
 $font-size-base:             1rem !default;
 $font-size-lg:               1.25rem !default;
-$font-size-sm:               .85rem !default;
+$font-size-sm:               .875rem !default;
 $font-size-xs:               .75rem !default;
 
 $font-size-h1:               2.5rem !default;


### PR DESCRIPTION
Hi,

I was taking a look at the new typography and I found that the only non-round value was the one generated from `$font-size-sm`.

``` css
$font-size-root:             16px !default;

$font-size-base:             1rem !default;    // 16px
$font-size-lg:               1.25rem !default; // 20px
$font-size-sm:               .85rem !default;  // 13.6px <--
$font-size-xs:               .75rem !default;  // 12px

$font-size-h1:               2.5rem !default;  // 40px
$font-size-h2:               2rem !default;    // 32px
$font-size-h3:               1.75rem !default; // 28px
$font-size-h4:               1.5rem !default;  // 24px
$font-size-h5:               1.25rem !default; // 20px
$font-size-h6:               1rem !default;    // 16px

$display1-size:               3.5rem !default; // 56px
$display2-size:               4.5rem !default; // 72px
$display3-size:               5.5rem !default; // 88px
$display4-size:               6rem !default;   // 96px
```

This PR changes the default value of `$font-size-sm` from `.85rem` to `.875rem`, which gives us a round `14px` font size.

Sorry if the 13.6px value was intended
