### PR TITLE
Add jekyll-redirect-from plugin in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :development, :test do
   gem 'rouge', '~> 1.7.4'
   gem 'sass', '~> 3.4.9'
   gem 'scss-lint', '~> 0.31'
+  gem 'jekyll-redirect-from', '~> 0.8.0'
 end


### PR DESCRIPTION
Add jekyll-redirect-from plugin in Gemfile, ohterwise report 

".../jekyll/plugin_mannager.rb:29:in require: cannot load such file -- jekyll-redirect-from (LoadError)" 

when jekyll build
