### PR TITLE
New URL for Chinese translation of Bootstrap 4.x

### DIFF
--- a/docs/_data/translations.yml
+++ b/docs/_data/translations.yml
@@ -1,7 +1,7 @@
 - name: Chinese
   code: zh
   description: Bootstrap 中文文档
-  url: http://v3.bootcss.com/
+  url: http://v4.bootcss.com/
 
 - name: Danish
   code: da


### PR DESCRIPTION
New URL for Chinese translation of Bootstrap 4.x :

http://v4.bootcss.com
