### PR TITLE
v4: Tweak predefined grid classes

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -21,10 +21,10 @@
 
     <div class="container">
       <div class="row">
-        <div class="col-md-3 col-md-push-9 bd-sidebar">
+        <div class="col col-md-3 push-md-9 bd-sidebar">
           {% include nav-docs.html %}
         </div>
-        <div class="col-md-9 col-md-pull-3 bd-content">
+        <div class="col col-md-9 pull-md-3 bd-content">
           <h1 class="bd-title">{{ page.title }}</h1>
           {{ content }}
         </div>

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -37,6 +37,15 @@
 //
 // Common styles for small and large grid columns
 
+.col {
+  position: relative;
+  // Prevent columns from collapsing when empty
+  min-height: 1px;
+  // Inner gutter via padding
+  padding-left: ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width / 2);
+}
+
 @include make-grid-columns();
 
 

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -4,21 +4,7 @@
 // any value of `$grid-columns`.
 
 @mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
-  // Common properties for all breakpoints
-  %grid-column {
-    position: relative;
-    // Prevent columns from collapsing when empty
-    min-height: 1px;
-    // Inner gutter via padding
-    padding-left: ($gutter / 2);
-    padding-right: ($gutter / 2);
-  }
   @each $breakpoint in map-keys($breakpoints) {
-    @for $i from 1 through $columns {
-      .col-#{$breakpoint}-#{$i} {
-        @extend %grid-column;
-      }
-    }
     @include media-breakpoint-up($breakpoint) {
       // Work around cross-media @extend (https://github.com/sass/sass/issues/1050)
       %grid-column-float-#{$breakpoint} {
@@ -34,7 +20,7 @@
       }
       @each $modifier in (pull, push, offset) {
         @for $i from 0 through $columns {
-          .col-#{$breakpoint}-#{$modifier}-#{$i} {
+          .#{$modifier}-#{$breakpoint}-#{$i} {
             @include make-col-modifier($modifier, $i, $columns)
           }
         }


### PR DESCRIPTION
Changes the approach for the grid classes from this:

``` html
<div class="col-sm-9 col-push-sm-9"></div>
```

to something a bit more succinct:

``` html
<div class="col col-sm-9 push-sm-9"></div>
```

The motivation for this was primarily to shorten class names if we went with fractional classes (e.g., `.col-sm-1-3`) so we don't end up with something like `.col-push-sm-1-3` and the like. Haven't leaned into the fractional stuff yet though to explore that.

/cc @twbs/sass 
