### PR TITLE
v4 — Use the body color for dropdown menu text in navbars

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -44,6 +44,7 @@
   min-width: 160px;
   padding: 5px 0;
   margin: 2px 0 0; // override default ul
+  color: $body-color;
   font-size: $font-size-base;
   text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
   list-style: none;


### PR DESCRIPTION
Fix #17276
