### PR TITLE
Fix accidental triple colon from :before to ::before conversion

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -31,7 +31,7 @@
   @include border-radius($border-radius);
   @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
-.progress[value]::-webkit-progress-value:::before {
+.progress[value]::-webkit-progress-value::before {
   content: attr(value);
 }
 .progress[value]::-webkit-progress-value {


### PR DESCRIPTION
Fix #17288 — Sorry about that!

Double checked and this was the only instance this made it through
