### PR TITLE
Document that dropdowns are intentionally click-based rather than hover-based

### DIFF
--- a/docs/components/dropdowns.md
+++ b/docs/components/dropdowns.md
@@ -4,7 +4,7 @@ title: Dropdowns
 group: components
 ---
 
-Dropdowns are toggleable, contextual overlays for displaying lists of links and more. They're made interactive with the included Bootstrap dropdown JavaScript plugin.
+Dropdowns are toggleable, contextual overlays for displaying lists of links and more. They're made interactive with the included Bootstrap dropdown JavaScript plugin. They're toggled by clicking, not by hovering; this is [an intentional design decision.](http://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/)
 
 ## Contents
 


### PR DESCRIPTION
I think it's worth better documenting some of Bootstrap's design decisions and the reasons behind them, to improve the understanding of users and new contributors. "Why don't Dropdowns use hover?" has basically become a FAQ at this point, and it'd be nice to have something to steer folks to when they inquire about it.
Refs #16966.
