### PR TITLE
Replace docs reference to iconography

### DIFF
--- a/docs/_includes/page-headers.html
+++ b/docs/_includes/page-headers.html
@@ -16,7 +16,7 @@
 {% elsif page.group == "components" %}
   <h1>Components</h1>
   <p class="lead">
-    Over a dozen reusable components built to provide iconography, dropdowns, input groups, navigation, alerts, and much more.
+    Over a dozen reusable components built to provide buttons, dropdowns, input groups, navigation, alerts, and much more.
   </p>
 {% elsif page.group == "javascript" %}
   <h1>JavaScript plugins</h1>


### PR DESCRIPTION
Since icons have been removed, this changes the components page header.
