### PR TITLE
Replace instances of 'control-label' with 'form-control-label'

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -535,7 +535,7 @@ Block help text—for below inputs or for longer lines of help text—can be eas
 
 ## Validation
 
-Bootstrap includes validation styles for error, warning, and success states on form controls. To use, add `.has-warning`, `.has-error`, or `.has-success` to the parent element. Any `.control-label`, `.form-control`, and `.text-help` within that element will receive the validation styles.
+Bootstrap includes validation styles for error, warning, and success states on form controls. To use, add `.has-warning`, `.has-error`, or `.has-success` to the parent element. Any `.form-control-label`, `.form-control`, and `.text-help` within that element will receive the validation styles.
 
 {% comment %}
 {% callout warning %}
@@ -549,15 +549,15 @@ Ensure that an alternative indication of state is also provided. For instance, y
 
 {% example html %}
 <div class="form-group has-success">
-  <label class="control-label" for="inputSuccess1">Input with success</label>
+  <label class="form-control-label" for="inputSuccess1">Input with success</label>
   <input type="text" class="form-control form-control-success" id="inputSuccess1">
 </div>
 <div class="form-group has-warning">
-  <label class="control-label" for="inputWarning1">Input with warning</label>
+  <label class="form-control-label" for="inputWarning1">Input with warning</label>
   <input type="text" class="form-control form-control-warning" id="inputWarning1">
 </div>
 <div class="form-group has-error">
-  <label class="control-label" for="inputError1">Input with error</label>
+  <label class="form-control-label" for="inputError1">Input with error</label>
   <input type="text" class="form-control form-control-error" id="inputError1">
 </div>
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -336,11 +336,11 @@ Have a bunch of buttons that all trigger the same modal, just with slightly diff
         <div class="modal-body">
           <form>
             <div class="form-group">
-              <label for="recipient-name" class="control-label">Recipient:</label>
+              <label for="recipient-name" class="form-control-label">Recipient:</label>
               <input type="text" class="form-control" id="recipient-name">
             </div>
             <div class="form-group">
-              <label for="message-text" class="control-label">Message:</label>
+              <label for="message-text" class="form-control-label">Message:</label>
               <textarea class="form-control" id="message-text"></textarea>
             </div>
           </form>

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -425,7 +425,7 @@ input[type="checkbox"] {
       width: 100%;
     }
 
-    .control-label {
+    .form-control-label {
       margin-bottom: 0;
       vertical-align: middle;
     }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -6,7 +6,7 @@
 @mixin form-control-validation($color) {
   // Color the label and help text
   .help-block,
-  .control-label,
+  .form-control-label,
   .radio,
   .checkbox,
   .radio-inline,


### PR DESCRIPTION
Not sure if this is completely correct, but on the form documentation pages the labels are using `.form-control-label` at the start, but then in some places they still use the `.control-label` (like in 'Static controls' and 'Validation').

This replaces the remaining `.control-label` with `.form-control-label`

Validation using `.control-label`
![validation-control-label](https://cloud.githubusercontent.com/assets/115825/9481980/7f833900-4bd2-11e5-9708-19d576d2a5bb.png)

Validation using `.form-control-label`
![validation-form-control-label](https://cloud.githubusercontent.com/assets/115825/9481979/7f82f90e-4bd2-11e5-9b91-1b4bc4086988.png)
