### PR TITLE
Move Figures from _type to _images

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -26,3 +26,23 @@
 .img-circle {
   border-radius: 50%;
 }
+
+//
+// Figures
+//
+
+.figure {
+  // Ensures the caption's text aligns with the image.
+  display: inline-block;
+
+  > img {
+    @extend .img-responsive;
+    margin-bottom: ($spacer-y / 2);
+    line-height: 1;
+  }
+}
+
+.figure-caption {
+  font-size: 90%;
+  color: $gray-light;
+}

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -165,23 +165,3 @@ mark,
     }
   }
 }
-
-//
-// Figures
-//
-
-.figure {
-  // Ensures the caption's text aligns with the image.
-  display: inline-block;
-
-  > img {
-    @extend .img-responsive;
-    margin-bottom: ($spacer-y / 2);
-    line-height: 1;
-  }
-}
-
-.figure-caption {
-  font-size: 90%;
-  color: $gray-light;
-}


### PR DESCRIPTION
This is perhaps open to discussion but if I want typography, I don't want to be forced to include the _images_ component. 

While it is hard to argue that Caption is not typography; but it is easy to see how a caption specifically for images wouldn't be used without images.
