### PR TITLE
Add babel:dev to dist-js so `grunt test` doesn't use stale JS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -462,7 +462,7 @@ module.exports = function (grunt) {
   grunt.registerTask('test-js', ['eslint', 'jscs:core', 'jscs:test', 'jscs:grunt', 'qunit']);
 
   // JS distribution task.
-  grunt.registerTask('dist-js', ['concat', 'lineremover', 'babel:dist', 'stamp', 'uglify:core', 'commonjs']);
+  grunt.registerTask('dist-js', ['babel:dev', 'concat', 'lineremover', 'babel:dist', 'stamp', 'uglify:core', 'commonjs']);
 
   grunt.registerTask('test-scss', ['scsslint']);
 


### PR DESCRIPTION
This arguably could go in some other task like `test-js`, but at this point I'm just trying to get the build to start passing sanely.
FYI: @fat @XhmikosR @hnrch02 
