### PR TITLE
Document utility class .bg-inverse

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -293,7 +293,8 @@
   .bg-success,
   .bg-info,
   .bg-warning,
-  .bg-danger {
+  .bg-danger,
+  .bg-inverse {
     &:not(.navbar) {
       padding: .5rem;
       margin-top: .5rem;

--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -132,6 +132,7 @@ Similar to the contextual text color classes, easily set the background of an el
 <div class="bg-info">Maecenas sed diam eget risus varius blandit sit amet non magna.</div>
 <div class="bg-warning">Etiam porta sem malesuada magna mollis euismod.</div>
 <div class="bg-danger">Donec ullamcorper nulla non metus auctor fringilla.</div>
+<div class="bg-inverse">Cras mattis consectetur purus sit amet fermentum.</div>
 {% endexample %}
 
 {% callout info %}


### PR DESCRIPTION
`.bg-inverse` is used with NavBars (see `navbar.md#L66` for example) but it wasn't documented anywhere. 
