### PR TITLE
Remove defunct responsive-(in)visibility mixins

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -28,7 +28,6 @@
 @import "mixins/label";
 @import "mixins/reset-filter";
 @import "mixins/resize";
-@import "mixins/responsive-visibility";
 @import "mixins/screen-reader";
 @import "mixins/size";
 @import "mixins/tab-focus";

--- a/scss/_utilities-responsive.scss
+++ b/scss/_utilities-responsive.scss
@@ -44,6 +44,6 @@
 
 .hidden-print {
   @media print {
-    @include responsive-invisibility(".hidden-print");
+    display: none !important;
   }
 }

--- a/scss/mixins/_responsive-visibility.scss
+++ b/scss/mixins/_responsive-visibility.scss
@@ -1,19 +1,5 @@
 // Responsive utilities
 
-//
-// More easily include all the states for responsive-utilities.less.
-// [converter] $parent hack
-@mixin responsive-visibility($parent) {
-  #{$parent} {
-    display: block !important;
-  }
-  table#{$parent}  { display: table !important; }
-  tr#{$parent}     { display: table-row !important; }
-  th#{$parent},
-  td#{$parent}     { display: table-cell !important; }
-}
-
-// [converter] $parent hack
 @mixin responsive-invisibility($parent) {
   #{$parent} {
     display: none !important;

--- a/scss/mixins/_responsive-visibility.scss
+++ b/scss/mixins/_responsive-visibility.scss
@@ -1,7 +1,0 @@
-// Responsive utilities
-
-@mixin responsive-invisibility($parent) {
-  #{$parent} {
-    display: none !important;
-  }
-}


### PR DESCRIPTION
The new responsive utility classes (http://v4-alpha.getbootstrap.com/layout/responsive-utilities/ ) make these mixins unnecessary.
