### PR TITLE
Update static form control example

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -397,14 +397,14 @@ When you need to place plain text next to a form label within a form, use the `.
 
 {% example html %}
 <form class="form-horizontal">
-  <div class="form-group">
-    <label class="col-sm-2 control-label">Email</label>
+  <div class="form-group row">
+    <label class="col-sm-2 form-control-label">Email</label>
     <div class="col-sm-10">
       <p class="form-control-static">email@example.com</p>
     </div>
   </div>
-  <div class="form-group">
-    <label for="inputPassword" class="col-sm-2 control-label">Password</label>
+  <div class="form-group row">
+    <label for="inputPassword" class="col-sm-2 form-control-label">Password</label>
     <div class="col-sm-10">
       <input type="password" class="form-control" id="inputPassword" placeholder="Password">
     </div>


### PR DESCRIPTION
Use the `row` class on the `form-group`, and change the `control-label` class to `form-control-label`

This fixes a problem brought up in #17320, but also adds `row` classes...
