### PR TITLE
Remove all uses of `selector &` to support nested import

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -39,8 +39,7 @@
   }
 
   &.disabled,
-  &:disabled,
-  fieldset[disabled] & {
+  &:disabled {
     cursor: $cursor-disabled;
     opacity: .65;
     @include box-shadow(none);
@@ -111,8 +110,7 @@ fieldset[disabled] a.btn {
   &,
   &:active,
   &.active,
-  &:disabled,
-  fieldset[disabled] & {
+  &:disabled {
     background-color: transparent;
     @include box-shadow(none);
   }
@@ -129,8 +127,7 @@ fieldset[disabled] a.btn {
     text-decoration: $link-hover-decoration;
     background-color: transparent;
   }
-  &:disabled,
-  fieldset[disabled] & {
+  &:disabled {
     @include hover-focus {
       color: $btn-link-disabled-color;
       text-decoration: none;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -50,15 +50,13 @@
   // disabled if the fieldset is disabled. Due to implementation difficulty, we
   // don't honor that edge case; we style them as disabled anyway.
   &:disabled,
-  &[readonly],
-  fieldset[disabled] & {
+  &[readonly] {
     background-color: $input-bg-disabled;
     // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
     opacity: 1;
   }
 
-  &[disabled],
-  fieldset[disabled] & {
+  &:disabled {
     cursor: $cursor-disabled;
   }
 }
@@ -233,24 +231,21 @@
 input[type="radio"],
 input[type="checkbox"] {
   &:disabled,
-  &.disabled,
-  fieldset[disabled] & {
+  &.disabled {
     cursor: $cursor-disabled;
   }
 }
 // These classes are used directly on <label>s
 .radio-inline,
 .checkbox-inline {
-  &.disabled,
-  fieldset[disabled] & {
+  &.disabled {
     cursor: $cursor-disabled;
   }
 }
 // These classes are used on elements with <label> descendants
 .radio,
 .checkbox {
-  &.disabled,
-  fieldset[disabled] & {
+  &.disabled {
     label {
       cursor: $cursor-disabled;
     }

--- a/scss/_labels.scss
+++ b/scss/_labels.scss
@@ -19,12 +19,12 @@
   &:empty {
     display: none;
   }
+}
 
-  // Quick fix for labels in buttons
-  .btn & {
-    position: relative;
-    top: -1px;
-  }
+// Quick fix for labels in buttons
+.btn .label {
+  position: relative;
+  top: -1px;
 }
 
 // Add hover effects, but only for links

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -45,8 +45,7 @@
   }
 
   &.disabled,
-  &:disabled,
-  fieldset[disabled] & {
+  &:disabled {
     &:focus,
     &.focus {
       background-color: $background;
@@ -81,8 +80,7 @@
   }
 
   &.disabled,
-  &:disabled,
-  fieldset[disabled] & {
+  &:disabled {
     &:focus,
     &.focus {
       border-color: lighten($color, 20%);


### PR DESCRIPTION
If we want to support namespaced import:

``` scss
.twbs {
  @import 'bootstrap';
}
```

We cannot use `selector &`, see sass/sass#1817.

`fieldset[disabled] &` is not needed as we no longer support IE8.
