### PR TITLE
Remove CSSLint references.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.8.0",
-    "grunt-contrib-csslint": "~0.4.0",
     "grunt-contrib-cssmin": "~0.12.2",
     "grunt-contrib-jade": "~0.14.1",
     "grunt-contrib-qunit": "~0.5.2",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -2346,68 +2346,6 @@
         }
       }
     },
-    "grunt-contrib-csslint": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-csslint/-/grunt-contrib-csslint-0.4.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
-        "csslint": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz",
-          "dependencies": {
-            "parserlib": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-        }
-      }
-    },
     "grunt-contrib-cssmin": {
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.12.3.tgz",


### PR DESCRIPTION
I know CSSLint has become obsolete and all, especially since we use Sass and SCSS Lint, but for the examples it can help catch stupid mistakes automatically.

If you think we should have CSSLint back let me know so that I close this and add it back. Otherwise this PR just cleans things up.

/CC @mdo @cvrebert 
