### PR TITLE
Fix element precision bug in at media CSS elements widths

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -211,7 +211,7 @@ See it in action in <a href="http://jsbin.com/ruxona/edit">this rendered example
   @media (max-width: 32em) {
     @include make-col-span(6);
   }
-  @media (min-width: 32.1em) {
+  @media (min-width: 32.000001em) {
     @include make-col-span(8);
   }
 }
@@ -221,7 +221,7 @@ See it in action in <a href="http://jsbin.com/ruxona/edit">this rendered example
   @media (max-width: 32em) {
     @include make-col-span(6);
   }
-  @media (min-width: 32.1em) {
+  @media (min-width: 32.000001em) {
     @include make-col-span(4);
   }
 }

--- a/docs/layout/overview.md
+++ b/docs/layout/overview.md
@@ -88,16 +88,16 @@ We occasionally use media queries that go in the other direction (the given scre
 
 {% highlight scss %}
 // Extra small devices (portrait phones, less than 34em)
-@media (max-width: 33.9em) { ... }
+@media (max-width: 33.999999em) { ... }
 
 // Small devices (landscape phones, less than 48em)
-@media (max-width: 47.9em) { ... }
+@media (max-width: 47.999999em) { ... }
 
 // Medium devices (tablets, less than 62em)
-@media (max-width: 61.9em) { ... }
+@media (max-width: 61.9999999em) { ... }
 
 // Large devices (desktops, less than 75em)
-@media (max-width: 74.9em) { ... }
+@media (max-width: 74.9999999em) { ... }
 
 // Extra large devices (large desktops)
 // No media query since the extra-large breakpoint has no upper bound on its width

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -29,13 +29,13 @@
 }
 
 // Maximum breakpoint width. Null for the largest (last) breakpoint.
-// The maximum value is calculated as the minimum of the next one less 0.1.
+// The maximum value is calculated as the minimum of the next one less 0.000001.
 //
 //    >> breakpoint-max(sm, (xs: 0, sm: 34rem, md: 45rem))
 //    44.9rem
 @function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
   $next: breakpoint-next($name, $breakpoints);
-  @return if($next, breakpoint-min($next, $breakpoints) - 0.1, null);
+  @return if($next, breakpoint-min($next, $breakpoints) - 0.000001, null);
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.


### PR DESCRIPTION
Add more precision with @media (max-width: 33.9em) changed to @media (max-width: 33.999999em).
For bug example : http://v4-alpha.getbootstrap.com/layout/responsive-utilities/ with a layout of 750px, hidden-sm-down and hidden-md-up are visible both.
