### PR TITLE
Fix maximum value for breakpoint-max

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -29,13 +29,13 @@
 }
 
 // Maximum breakpoint width. Null for the largest (last) breakpoint.
-// The maximum value is calculated as the minimum of the next one less 0.1.
+// The maximum value is calculated as the minimum of the next one less 0.01.
 //
 //    >> breakpoint-max(sm, (xs: 0, sm: 34rem, md: 45rem))
 //    44.9rem
 @function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
   $next: breakpoint-next($name, $breakpoints);
-  @return if($next, breakpoint-min($next, $breakpoints) - 0.1, null);
+  @return if($next, breakpoint-min($next, $breakpoints) - 0.01, null);
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.


### PR DESCRIPTION
If you just substract 0.1 from breakpoint-min, there is always one particular width (for example 767px) where none of the breakpoints work.
