### PR TITLE
Remove box-shadow from focused c-select.

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -146,7 +146,6 @@
   &:focus {
     border-color: #51a7e8;
     outline: none;
-    @include box-shadow(inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 5px rgba(81, 167, 232, 0.5));
   }
 
   // Hides the default caret in IE11


### PR DESCRIPTION
Match the `focused` styling of `.form-control` input elements for the custom `.c-select` element.

Before:
<img width="224" alt="screen shot 2015-09-01 at 8 07 33 pm" src="https://cloud.githubusercontent.com/assets/3933204/9620830/3b4edcb8-50e5-11e5-8148-30c08fd9a590.png">

After:
<img width="231" alt="screen shot 2015-09-01 at 8 07 05 pm" src="https://cloud.githubusercontent.com/assets/3933204/9620832/40ee4bd6-50e5-11e5-8f66-ae8276c85c8a.png">

Let me know if anything additional is needed.
