### PR TITLE
Eliminate .list-group-flush double border.

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -37,6 +37,12 @@
     border-width: .0625rem 0;
     border-radius: 0;
   }
+  &:first-child {
+    margin-top: -.0625rem;
+  }
+  &:last-child {
+    margin-bottom: -.0625rem;
+  }
 }
 
 


### PR DESCRIPTION
Fixes #17431.
![border-pr](https://cloud.githubusercontent.com/assets/567038/9621773/b7240c7e-50df-11e5-9692-08df52b75405.png)
