### PR TITLE
Added styles to lessen body scrolling bug in iOS

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -10,6 +10,11 @@
 // Kill the scroll on the body
 .modal-open {
   overflow: hidden;
+
+  // Assists in fix to lessen scrolling bugginess in mobile safari
+  position: fixed;
+  width: 100%;
+  height: 100%;
 }
 
 // Container that the modal scrolls within
@@ -45,6 +50,9 @@
   position: relative;
   width: auto;
   margin: 10px;
+
+  // Assists in fix to lessen scrolling bugginess in mobile safari
+  transform: translateZ(0);
 }
 
 // Actual modal


### PR DESCRIPTION
- Added position fixed to `.modal-open` to prevent body scrolling
- Add transform `translateZ` to lessen stacking touch bugginess to body

Example fix: http://plnkr.co/edit/79wwADPxuSSfSEceagAz?p=preview
