### PR TITLE
Add a license header to bootstrap.scss

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,16 +278,6 @@ module.exports = function (grunt) {
       }
     },
 
-    usebanner: {
-      options: {
-        position: 'top',
-        banner: '<%= banner %>'
-      },
-      files: {
-        src: 'dist/css/*.css'
-      }
-    },
-
     csscomb: {
       options: {
         config: 'scss/.csscomb.json'
@@ -475,7 +465,7 @@ module.exports = function (grunt) {
   // grunt.registerTask('sass-compile', ['sass:core', 'sass:extras', 'sass:docs']);
   grunt.registerTask('sass-compile', ['sass:core', 'sass:docs']);
 
-  grunt.registerTask('dist-css', ['sass-compile', 'postcss:core', 'autoprefixer:core', 'usebanner', 'csscomb:dist', 'cssmin:core', 'cssmin:docs']);
+  grunt.registerTask('dist-css', ['sass-compile', 'postcss:core', 'autoprefixer:core', 'csscomb:dist', 'cssmin:core', 'cssmin:docs']);
 
   // Full distribution task.
   grunt.registerTask('dist', ['clean:dist', 'dist-css', 'dist-js']);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~2.2.0",
     "grunt-babel": "^5.0.0",
-    "grunt-banner": "~0.3.1",
     "grunt-build-control": "~0.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.13.0",

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,4 +1,10 @@
-// Core variables and mixins
+/*!
+ * Bootstrap v4.0.0-alpha (http://getbootstrap.com)
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+ // Core variables and mixins
 @import "variables";
 @import "mixins";
 


### PR DESCRIPTION
Context: https://github.com/twbs/bootstrap/pull/16494

The v4-dev branch for moving to SASS uses grunt-banner for integrating the license header during the dist build process. This was removed in the above pull request for LESS, but the change was not passed over for SASS.

Those of us who compile the Bootstrap CSS files out of the SASS files have to manually include the license header back into our final output in order to remain compliant with the license - an easy step to overlook as the default for including the project from Bower into one's build systems is to automatically pull in the scss/bootstrap.scss file, not dist/css/bootstrap.css.

Following with https://github.com/twbs/bootstrap/pull/16494, I removed grunt-banner to maintain parity with the current master branch commit.
