### PR TITLE
Add .navbar-toggleable-md class

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -129,6 +129,11 @@
       display: block !important;
     }
   }
+  &-md {
+    @include media-breakpoint-up(lg) {
+      display: block !important;
+    }
+  }
 }
 
 


### PR DESCRIPTION
In Bootstrap 3, the menu collapsed on the -sm- breakpoint, I believe the equivalent of this breakpoint in Bootstrap 4 is actually the -md- breakpoint. The navbar currently has no option to collapse at the -md- breakpoint and I'd like to add this.
