### PR TITLE
v4 - .navbar-nav needs clearfix

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -137,6 +137,7 @@
 // Custom navbar navigation built on the base `.nav` styles.
 
 .navbar-nav {
+  @include clearfix;
   .nav-item {
     float: left;
   }


### PR DESCRIPTION
When `.nav.navbar-nav`, we need to clear floats.
Or maybe clearfix on the base `.nav`...?
