### PR TITLE
[REVIEW] added semi-colons to prevent jsmin breaking

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -116,9 +116,9 @@
 
     var index = $items.index(e.target)
 
-    if (e.which == 38 && index > 0)                 index--         // up
-    if (e.which == 40 && index < $items.length - 1) index++         // down
-    if (!~index)                                    index = 0
+    if (e.which == 38 && index > 0)                 index--;         // up
+    if (e.which == 40 && index < $items.length - 1) index++;         // down
+    if (!~index)                                    index = 0;
 
     $items.eq(index).trigger('focus')
   }


### PR DESCRIPTION
Currently when using jsmin the dropdown component causes breaks.

dropdown.js:119:121

```
    if (e.which == 38 && index > 0)                 index--         // up
    if (e.which == 40 && index < $items.length - 1) index++         // down
    if (!~index)                                    index = 0
```

notice the missing ; at the end of line

results in

<img width="629" alt="screen shot 2015-09-03 at 08 49 15" src="https://cloud.githubusercontent.com/assets/397106/9652118/b682e828-5218-11e5-8e8c-6e128386627c.png">

<img width="618" alt="screen shot 2015-09-03 at 08 49 08" src="https://cloud.githubusercontent.com/assets/397106/9652119/b683ad4e-5218-11e5-8341-574e4e3023ef.png">
