### PR TITLE
V4 remove holderjs references from carousel and card docs

### DIFF
--- a/docs/_plugins/highlight_alt.rb
+++ b/docs/_plugins/highlight_alt.rb
@@ -57,11 +57,16 @@ eos
       def example(output)
         "<div class=\"bd-example\" data-example-id=\"#{@options[:id]}\">\n#{output}\n</div>"
       end
+    
+      def remove_holderjs(code)
+        code = code.gsub(/"holder.js.+?"/, '"..."')
+      end
 
       def render_rouge(code)
         require 'rouge'
         formatter = Rouge::Formatters::HTML.new(line_numbers: @options[:linenos], wrap: false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
+        code = remove_holderjs(code)
         code = formatter.format(lexer.lex(code))
         "<div class=\"highlight\"><pre>#{code}</pre></div>"
       end


### PR DESCRIPTION
This pull request removes the holder.js references in the docs as per #17217
Removed for both cards and carousel.
