### PR TITLE
Restrict collapse effect to within Modal if applicable

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -158,8 +158,10 @@
     var href
     var target = $trigger.attr('data-target')
       || (href = $trigger.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
-
-    return $(target)
+    // look first in the closest modal
+    var realm = $trigger.closest('.modal')
+    if (!realm.length) realm = document
+    return $(target, realm)
   }
 
 


### PR DESCRIPTION
Our app is a CMS where you hover over a section to edit it.  The edit occurs in a Modal.  Html is copied verbatim from the source (on the page) to a ContentEditable area (on the modal).  We are stuck having 2 elements on the page with the same ID, because of this.  We noticed that if we have a Collapsible area, it doesn't work in the modal, since Bootstrap was just using the data-target as a straight selector (within the whole document scope).

I believe it is unlikely and ill-advised, for someone to want an element within a Modal, to trigger a collapsible that is not within that Modal.  Therefore I feel like this is a safe and harmless modification that helps with the condition I mentioned.

In my local copy of Bootstrap I've made the above modification, which works great for us.  I submit it here for the possible benefit of others. Thanks for your consideration.
