### PR TITLE
Re-introduce Accessibility page into nav

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,13 +1,13 @@
 - title: Getting started
   pages:
     # - title: JavaScript
-    # - title: Accessibility
     - title: Introduction
     - title: Download
     - title: Browsers & devices
     - title: Options
     - title: Flexbox
     - title: Build tools
+    - title: Accessibility
     - title: Best practices
 
 - title: Layout


### PR DESCRIPTION
Not sure if this was excluded from nav for a specific reason (in de2971c9cc34b0cef59a35111dc281dd4b9f07a1), but this PR ensures the accessibility page shows in the Getting Started navigation listing.
