### PR TITLE
Vertically aligned modals #14617

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -24,6 +24,18 @@
   outline: 0;
   -webkit-overflow-scrolling: touch;
 
+  // Vertical align
+  text-align: center;
+  white-space: nowrap;
+
+  &:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -0.25em;
+  }
+
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {
     transition: transform .3s ease-out;
@@ -39,8 +51,17 @@
 // Shell div to position the modal with bottom padding
 .modal-dialog {
   position: relative;
-  width: auto;
+  width: calc(100% - 20px);
   margin: 10px;
+
+  // Stops modal overflowing on mobiles
+  max-width: calc(100% - 20px);
+
+  // Vertical align
+  display: inline-block;
+  vertical-align: middle;
+  text-align : left;
+  white-space: normal;
 }
 
 // Actual modal
@@ -131,7 +152,6 @@
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     width: $modal-md;
-    margin: 30px auto;
   }
   .modal-content {
     @include box-shadow(0 5px 15px rgba(0,0,0,.5));

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -512,9 +512,9 @@ $modal-backdrop-opacity:      .5 !default;
 $modal-header-border-color:   #e5e5e5 !default;
 $modal-footer-border-color:   $modal-header-border-color !default;
 
-$modal-lg:                    900px !default;
-$modal-md:                    600px !default;
-$modal-sm:                    300px !default;
+$modal-lg:                    56.25rem !default;
+$modal-md:                    37.5rem !default;
+$modal-sm:                    18.75rem !default;
 
 
 // Alerts


### PR DESCRIPTION
Vertically aligned modals and converted modal widths to rems. Had to use calc() to fix the modal overflowing on smaller screens, but I could figure something else out if required.

If the modal content is longer than the height of the window it'll behave the same way it does currently.
