### PR TITLE
Fix #17321

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -103,11 +103,11 @@
 //
 
 // Give the line between buttons some depth
-.btn-group > .btn + .dropdown-toggle {
+.btn-group > .btn ~ .dropdown-toggle {
   padding-right: 8px;
   padding-left: 8px;
 }
-.btn-group > .btn-lg + .dropdown-toggle {
+.btn-group > .btn-lg ~ .dropdown-toggle {
   padding-right: 12px;
   padding-left: 12px;
 }


### PR DESCRIPTION
The adjacent sibling selector no longer applies to the dropdown toggle when the dropdown is opened and a `.dropdown-backdrop` element is created. When it no longer applies then the dropdown toggle loses its 8px padding and inherits 1rem padding making it wider.

The general sibling selector will apply regardless of the backdrop element being created.
