### PR TITLE
Enable .text-hide to be used with <a> tags

### DIFF
--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -1,8 +1,14 @@
 // CSS image replacement
 @mixin text-hide() {
   font: "0/0" a;
-  color: transparent;
   text-shadow: none;
   background-color: transparent;
   border: 0;
+
+  &,
+  &:hover,
+  &:focus,
+  &:visited {
+    color: transparent;
+  }
 }


### PR DESCRIPTION
This PR:
- Renames the hide-text mixin file to text-hide (to maintain standard).
- Add `color: transparent;` to `.text-hide`'s `hover`, `focus` and `visited` pseudo-classes.

This way the `.text-hide` selector can be used with `<a>` tags out of the box.
