### PR TITLE
v4 - remove bottom margin from .card-block's last-child

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -12,6 +12,9 @@
 
 .card-block {
   padding: $card-spacer-x;
+  > *:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .card-title {
@@ -20,11 +23,6 @@
 
 .card-subtitle {
   margin-top: -($card-spacer-y / 2);
-  margin-bottom: 0;
-}
-
-.card-text:last-child {
-  margin-bottom: 0;
 }
 
 // .card-actions {


### PR DESCRIPTION
Last child from `.card-block` should have a `margin-bottom: 0;`
I was trying this: http://s.zalog.ro/2015-09-08-01-30-39.png
