### PR TITLE
Specify configBridge as relative path to source for Jekyll

### DIFF
--- a/docs/_plugins/bridge.rb
+++ b/docs/_plugins/bridge.rb
@@ -3,7 +3,8 @@ require 'yaml'
 module Bridge
   class Generator < Jekyll::Generator
     def generate(site)
-      site.data["configBridge"] = YAML.load_file("./grunt/configBridge.json")
+      path = File.join(site.source, "../grunt/configBridge.json")
+      site.data["configBridge"] = YAML.load_file(path)
     end
   end
 end


### PR DESCRIPTION
This adjusts the load path for the `configBridge.json` file from one that's relative to where user is running the build or serve command (eg `jekyll serve`), to one that's relative to the `source` configuration setting for Jekyll.

The result is that a user can now have a `_config.yml` anywhere on her filesystem and point to Bootstrap's `docs` directory to use as Jekyll's `source`.  Previously, customisations involved the original `_config.yml` needing to be modified inside (a forked) Bootstrap.  Similarly, the `jekyll` command could only be run at the root of the Bootstrap package since the original file path to `configBridge.json` was only valid there; a command like `jekyll serve --source path/to/bootstrap/docs` (run from any directory) can succeed.

The existing behaviour is not affected as the `grunt/` directory is always a sibling of `docs` in the current structure.
