### PR TITLE
Fix <progress> colors in IE10+

### DIFF
--- a/scss/mixins/_progress.scss
+++ b/scss/mixins/_progress.scss
@@ -9,6 +9,12 @@
     background-color: $color;
   }
 
+  // gt IE 10
+  &[value] {
+    color: $color;
+  }
+
+  // lt IE 9
   @media screen and (min-width:0\0) {
     .progress-bar {
       background-color: $color;

--- a/scss/mixins/_progress.scss
+++ b/scss/mixins/_progress.scss
@@ -9,12 +9,12 @@
     background-color: $color;
   }
 
-  // gt IE 10
+  // gt IE10
   &[value] {
     color: $color;
   }
 
-  // lt IE 9
+  // lt IE9
   @media screen and (min-width:0\0) {
     .progress-bar {
       background-color: $color;


### PR DESCRIPTION
IE 10+ support `color` for value not `background-color`. By this fix, it works now in IE 9+
