### PR TITLE
v4 - Drop cursor pointer for button role 

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -194,17 +194,6 @@ img {
 }
 
 
-// iOS "clickable elements" fix for role="button"
-//
-// Fixes "clickability" issue (and more generally, the firing of events such as focus as well)
-// for traditionally non-focusable elements with role="button"
-// see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
-// Upstream patch for normalize.css submitted: https://github.com/necolas/normalize.css/pull/379 - remove this fix once that is merged
-
-[role="button"] {
-  cursor: pointer;
-}
-
 
 //
 // Tables


### PR DESCRIPTION
The patch is merged on `normalize`.
https://github.com/necolas/normalize.css/pull/379
We can drop these lines.
