### PR TITLE
Fix border-radius and :focus styles for custom form controls

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -230,5 +230,6 @@
 
 // Focus state
 .file input:focus ~ .file-custom {
-  @include box-shadow(0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9);
+    // the mixin is not used here to make sure there is feedback
+    box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
 }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -205,7 +205,7 @@
   user-select: none;
   background-color: #fff;
   border: .075rem solid #ddd;
-  border-radius: .25rem;
+  border-radius: $input-border-radius;
   @include box-shadow(inset 0 .2rem .4rem rgba(0,0,0,.05));
 }
 .file-custom::after {

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -231,5 +231,5 @@
 // Focus state
 .file input:focus ~ .file-custom {
     // the mixin is not used here to make sure there is feedback
-    box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
+    box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem $input-border-focus;
 }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -199,12 +199,12 @@
   height: 2.5rem;
   padding: .5rem 1rem;
   line-height: 1.5;
-  color: #555;
+  color: $input-color;
   user-select: none;
-  background-color: #fff;
-  border: .075rem solid #ddd;
+  background-color: $input-bg;
+  border: .075rem solid $input-border;
   border-radius: $input-border-radius;
-  @include box-shadow(inset 0 .2rem .4rem rgba(0,0,0,.05));
+  @include box-shadow($input-box-shadow);
 }
 .file-custom::after {
   content: "Choose file...";
@@ -219,9 +219,9 @@
   height: 2.5rem;
   padding: .5rem 1rem;
   line-height: 1.5;
-  color: #555;
+  color: $btn-secondary-color;
   content: "Browse";
-  background-color: #eee;
+  background-color: $btn-secondary-bg;
   border: .075rem solid #ddd;
   border-radius: 0 .25rem .25rem 0;
 }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -27,7 +27,7 @@
 
     &:focus ~ .c-indicator {
       // the mixin is not used here to make sure there is feedback
-      box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
+      box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem $input-border-focus;
     }
 
     &:active ~ .c-indicator {

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -153,9 +153,7 @@
   }
 
   &:focus {
-    border-color: $input-border-focus;
-    outline: none;
-    @include box-shadow(inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 5px rgba(81, 167, 232, 0.5));
+    @include form-control-focus();
   }
 
   // Hides the default caret in IE11

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -230,6 +230,6 @@
 
 // Focus state
 .file input:focus ~ .file-custom {
-    // the mixin is not used here to make sure there is feedback
-    box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem $input-border-focus;
+  // the mixin is not used here to make sure there is feedback
+  box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem $input-border-focus;
 }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -153,7 +153,7 @@
   }
 
   &:focus {
-    border-color: #51a7e8;
+    border-color: $input-border-focus;
     outline: none;
     @include box-shadow(inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 5px rgba(81, 167, 232, 0.5));
   }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -143,6 +143,15 @@
   -moz-appearance: none;
   -webkit-appearance: none;
 
+  @if $enable-rounded {
+    @include border-radius($input-border-radius);
+  } @else {
+    // Reset border-radius, otherwise the control will have a 5px border-radius from Chrome's
+    // user agent stylesheet. Note that we can't use the border-radius mixin because it doesn't
+    // execute when $enable-rounded is false.
+    border-radius: 0;
+  }
+
   &:focus {
     border-color: #51a7e8;
     outline: none;

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -88,18 +88,18 @@
   text-align: center;
   background-color: $input-group-addon-bg;
   border: 1px solid $input-group-addon-border-color;
-  @include border-radius($border-radius);
+  @include border-radius($input-border-radius);
 
   // Sizing
   &.form-control-sm {
     padding: $input-padding-y-sm $input-padding-x-sm;
     font-size: $font-size-sm;
-    @include border-radius($border-radius-sm);
+    @include border-radius($input-border-radius-sm);
   }
   &.form-control-lg {
     padding: $input-padding-y-lg $input-padding-x-lg;
     font-size: $font-size-lg;
-    @include border-radius($border-radius-lg);
+    @include border-radius($input-border-radius-lg);
   }
 
   // Nuke default margins from checkboxes and radios to vertically center within.


### PR DESCRIPTION
1. The custom select menu doesn't honor the `$enable-rounded` flag. It should also set the `border-radius` property using `$input-border-radius` for consistency.
2. When `$enable-rounded` is `false`, a 5px border-radius persists on the custom select menu control. It appears to be from Chrome's user agent stylesheet. This can't be reset using the border-radius mixin because it doesn't execute when `$enable-rounded` is `false`. ce77c09 fixes both these issues.
3. Input group addons use `$border-radius` instead of `$input-border-radius`, making them inconsistent with form controls when the default value is changed. 7430a26 fixes this.
4. Custom select menus, file inputs, checkboxes, and radios have hard-coded colors for their focus states. 463d83e, 5f57e41, and fe47d5c let them use `$input-border-focus` variable to stay consistent with other form controls.
5. The focus state on file inputs is not visible when `$enable-rounded` is `false`. ecc75f9 fixes this in the same manner that custom checkboxes/radios force the focus state.
6. Custom file inputs use hardcoded values. 9fcfdf9 and e940d60 makes them use variables to stay consistent with other form controls.
7. The box-shadow size for custom select menus is inconsistent with other form controls. Using the `form-control-focus` mixin in a0757d1 fixes this.

Sorry for all the little updates—I'm working on something with v4-dev and finding/fixing as I go.
