### PR TITLE
Add `vendor/bundle` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _site
 .ruby-version
 .bundle
 vendor/cache
+vendor/bundle
 
 # Numerous always-ignore extensions
 *.diff


### PR DESCRIPTION
Ensure this directory is ignored so that any installed resources from Bundler aren't handled by Git; the directory gets created upon running `bundler`.
