### PR TITLE
fix examples/offcanvas to use em units in its media query

### DIFF
--- a/docs/examples/offcanvas/offcanvas.css
+++ b/docs/examples/offcanvas/offcanvas.css
@@ -17,7 +17,9 @@ footer {
  * Off Canvas
  * --------------------------------------------------
  */
-@media screen and (max-width: 767px) {
+
+/* Extra small devices (portrait phones, less than 34em) */
+@media screen and (max-width: 33.9em) {
   .row-offcanvas {
     position: relative;
     -webkit-transition: all .25s ease-out;


### PR DESCRIPTION
An example could not work properly.
There was old breaking point declaration defined in **pixels** not **ems**.
I only switch PXs to EMs and it **works fine** how it's expected.  
