### PR TITLE
Fixed: Modals Uncaught ReferenceError: that is not defined

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -138,7 +138,7 @@ const Modal = (($) => {
       $(this._dialog).on(Event.MOUSEDOWN_DISMISS, () => {
         $(this._element).one(Event.MOUSEUP_DISMISS, (event) => {
           if ($(event.target).is(this._element)) {
-            that._ignoreBackdropClick = true
+            this._ignoreBackdropClick = true
           }
         })
       })


### PR DESCRIPTION
This appears to be a bug from when the code was ported from ES6.

![image](https://cloud.githubusercontent.com/assets/1228807/9825200/fb20c640-588e-11e5-90ac-5be31fa9ca45.png)

![image](https://cloud.githubusercontent.com/assets/1228807/9825179/e5c23234-588e-11e5-90f2-c4467ba15543.png)
