### PR TITLE
add center-table class to center a table

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -33,7 +33,7 @@
 
 // Layout
 @import "mixins/clearfix.less";
-@import "mixins/center-block.less";
+@import "mixins/centering.less";
 @import "mixins/nav-vertical-align.less";
 @import "mixins/grid-framework.less";
 @import "mixins/grid.less";

--- a/less/mixins/centering.less
+++ b/less/mixins/centering.less
@@ -5,3 +5,9 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+.center-table() {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/less/utilities.less
+++ b/less/utilities.less
@@ -12,6 +12,9 @@
 .center-block {
   .center-block();
 }
+.center-table {
+  .center-table();
+}
 .pull-right {
   float: right !important;
 }


### PR DESCRIPTION
center-block won't center a table, wrapping a table with a div with class center-block also does not center a table.

This is because center-block sets display:block. For tables, this needs to be display:table

Create center-table class here that can be used to center a table.
