### PR TITLE
add center-table class to center a table

### DIFF
--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -187,7 +187,7 @@ Float an element to the left or right with a class. `!important` is included to 
 
 ## Center content
 
-Center an element via `margin`, `center-block` for most use cases, `center-tables` for tables. Available as mixins and classes.
+Center an element via `margin`. For most cases, use `.center-block`; for tables, use `.center-table`. Available as mixins and classes.
 
 {% example html %}
 <div class="center-block">Centered block</div>

--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -187,10 +187,16 @@ Float an element to the left or right with a class. `!important` is included to 
 
 ## Center content
 
-Set an element to `display: block;` and center via `margin`. Available as a mixin and class.
+Center an element via `margin`, center-block for most use cases, center-tables for tables. Available as mixins and classes.
 
 {% example html %}
 <div class="center-block">Centered block</div>
+
+<table class="center-table">
+  <tr>
+    <td>Plain old table</td>
+  </tr>
+</table>
 {% endexample %}
 
 {% highlight scss %}
@@ -201,10 +207,22 @@ Set an element to `display: block;` and center via `margin`. Available as a mixi
   margin-right: auto;
 }
 
+.center-table {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+
 // Usage as a mixin
 .element {
   @include center-block;
 }
+
+table.element {
+  @include center-table;
+}
+
 {% endhighlight %}
 
 Easily clear `float`s by adding `.clearfix` **to the parent element**. Utilizes [the micro clearfix](http://nicolasgallagher.com/micro-clearfix-hack/) as popularized by Nicolas Gallagher. Can also be used as a mixin.

--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -187,7 +187,7 @@ Float an element to the left or right with a class. `!important` is included to 
 
 ## Center content
 
-Center an element via `margin`, center-block for most use cases, center-tables for tables. Available as mixins and classes.
+Center an element via `margin`, `center-block` for most use cases, `center-tables` for tables. Available as mixins and classes.
 
 {% example html %}
 <div class="center-block">Centered block</div>

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -52,7 +52,7 @@
 
 // // Layout
 @import "mixins/clearfix";
-@import "mixins/center-block";
+@import "mixins/centering";
 // @import "mixins/navbar-align";
 @import "mixins/grid-framework";
 @import "mixins/grid";

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -10,6 +10,10 @@
   @include center-block();
 }
 
+.center-table {
+  @include center-table();
+}
+
 .pull-right {
   @include pull-right();
 }

--- a/scss/mixins/_centering.scss
+++ b/scss/mixins/_centering.scss
@@ -5,3 +5,9 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+@mixin center-table() {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
center-block won't center a table, wrapping a table with a div with class center-block also does not center a table.

This is because center-block sets display:block. For tables, this needs to be display:table

Create center-table class here that can be used to center a table.
