### PR TITLE
Added 'destroy' method to affix

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -112,6 +112,17 @@
     }
   }
 
+  Affix.prototype.destroy = function () {
+    this.$target = $(this.options.target)
+      .off('scroll.bs.affix.data-api')
+      .off('click.bs.affix.data-api')
+
+    this.$element
+      .removeClass(Affix.RESET)
+      .removeAttr('style')
+
+    $(this.$element).removeData()
+  }
 
   // AFFIX PLUGIN DEFINITION
   // =======================

--- a/js/tests/unit/affix.js
+++ b/js/tests/unit/affix.js
@@ -104,4 +104,12 @@ $(function () {
       }, 250)
     }, 250)
   })
+
+  QUnit.test('should be destroyed', function (assert) {
+    assert.expect(1)
+    var $el = $('<div />')
+    var $affix = $el.bootstrapAffix()
+    $el.bootstrapAffix('destroy')
+    assert.strictEqual($affix.data('bs.affix'), undefined, 'affix was removed')
+  })
 })


### PR DESCRIPTION
I'm writing an ajax application that requires the affix plugin to be toggled on and off, depending on whether the page/content as sufficient height to warrant the affix.

The destroy method has allowed me to do this, and I think could be useful to others.  It removes the the plugin from the element, stops the events triggering, and removes any styles.

If this is indeed useful to others, the unit test could be fleshed out to ensure the style and event triggering are removed - right now it just checks the plugin was removed.
