### PR TITLE
Fix #17593 adding $screen-*-min/max

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -99,6 +99,16 @@ $grid-breakpoints: (
   xl: 75em
 ) !default;
 
+$screen-sm-min: breakpoint-min(sm, $grid-breakpoints) !default;
+$screen-md-min: breakpoint-min(md, $grid-breakpoints) !default;
+$screen-lg-min: breakpoint-min(lg, $grid-breakpoints) !default;
+$screen-xl-min: breakpoint-min(xl, $grid-breakpoints) !default;
+
+$screen-xs-max: breakpoint-max(xs, $grid-breakpoints) !default;
+$screen-sm-max: breakpoint-max(sm, $grid-breakpoints) !default;
+$screen-md-max: breakpoint-max(md, $grid-breakpoints) !default;
+$screen-lg-max: breakpoint-max(lg, $grid-breakpoints) !default;
+
 
 // Grid containers
 //


### PR DESCRIPTION
Fix twbs/bootstrap#17593 Uses static variable assignment since SASS doesn't support dynamic variable assignment yet.
