### PR TITLE
Fix issue #17584

### DIFF
--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -36,6 +36,17 @@
       e.preventDefault()
     })
 
+    // Modal relatedTarget demo
+    $('#exampleModal').on('show.bs.modal', function (event) {
+      var $button = $(event.relatedTarget)      // Button that triggered the modal
+      var recipient = $button.data('whatever')  // Extract info from data-* attributes
+      // If necessary, you could initiate an AJAX request here (and then do the updating in a callback).
+      // Update the modal's content. We'll use jQuery here, but you could use a data binding library or other methods instead.
+      var $modal = $(this)
+      $modal.find('.modal-title').text('New message to ' + recipient)
+      $modal.find('.modal-body input').val(recipient)
+    })
+
     // Config ZeroClipboard
     ZeroClipboard.config({
       moviePath: '/assets/flash/ZeroClipboard.swf',


### PR DESCRIPTION
Fixes #17584.

For the v4 docs:
Added JS event handler & logic for `event.relatedTarget` for varying content modals based on the trigger button.

Now all 3 examples within the _Varying modal content based on trigger button_ section of modals with work properly according to the supporting documentation code example.

For reference, the current section [looks like this](http://v4-alpha.getbootstrap.com/components/modal/#varying-modal-content-based-on-trigger-button)

The fixed solution looks like this:
![issue-17584](https://cloud.githubusercontent.com/assets/2854919/9883306/6ab91b68-5ba7-11e5-90c6-b5458a4c8204.png)
.
