### PR TITLE
Add <h3> header example to Cards docs

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -162,6 +162,17 @@ Add an optional header and/or footer within a card.
 
 {% example html %}
 <div class="card">
+  <h3 class="card-header">Featured</h3>
+  <div class="card-block">
+    <h4 class="card-title">Special title treatment</h4>
+    <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
+    <a href="#" class="btn btn-primary">Go somewhere</a>
+  </div>
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="card">
   <div class="card-header">
     Quote
   </div>


### PR DESCRIPTION
Fixes a docs bug where it didn't let the reader know that card headers could be done without any additional `<div>`s, just by adding the `.card-header` class to an hN tag.

resolves #17609 
