### PR TITLE
text-inverse can be used when background is inverse, and button documentation changes

### DIFF
--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -79,22 +79,22 @@ Fancy larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes
 Create block level buttons—those that span the full width of a parent—by adding `.btn-block`.
 
 {% example html %}
-<div>
+<p>
 <button type="button" class="btn btn-primary btn-lg">Large button</button>
 <button type="button" class="btn btn-secondary btn-lg">Large button</button>
-</div>
-<div>
+</p>
+<p>
 <button type="button" class="btn btn-primary">Normal button</button>
 <button type="button" class="btn btn-secondary">Normal button</button>
-</div>
-<div>
+</p>
+<p>
 <button type="button" class="btn btn-primary btn-sm">Small button</button>
 <button type="button" class="btn btn-secondary btn-sm">Small button</button>
-</div>
-<div>
+</p>
+<p>
 <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
 <button type="button" class="btn btn-secondary btn-lg btn-block">Block level button</button>
-</div>
+</p>
 {% endexample %}
 
 ## Active state

--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -76,21 +76,25 @@ In need of a button, but not the hefty background colors they bring? Replace the
 
 Fancy larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes.
 
-{% example html %}
-<button type="button" class="btn btn-primary btn-lg">Large button</button>
-<button type="button" class="btn btn-secondary btn-lg">Large button</button>
-{% endexample %}
-
-{% example html %}
-<button type="button" class="btn btn-primary btn-sm">Small button</button>
-<button type="button" class="btn btn-secondary btn-sm">Small button</button>
-{% endexample %}
-
 Create block level buttons—those that span the full width of a parent—by adding `.btn-block`.
 
 {% example html %}
+<div>
+<button type="button" class="btn btn-primary btn-lg">Large button</button>
+<button type="button" class="btn btn-secondary btn-lg">Large button</button>
+</div>
+<div>
+<button type="button" class="btn btn-primary">Normal button</button>
+<button type="button" class="btn btn-secondary">Normal button</button>
+</div>
+<div>
+<button type="button" class="btn btn-primary btn-sm">Small button</button>
+<button type="button" class="btn btn-secondary btn-sm">Small button</button>
+</div>
+<div>
 <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
 <button type="button" class="btn btn-secondary btn-lg btn-block">Block level button</button>
+</div>
 {% endexample %}
 
 ## Active state

--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -122,6 +122,7 @@ Convey meaning through color with a handful of emphasis utility classes. These m
 <p class="text-info">Maecenas sed diam eget risus varius blandit sit amet non magna.</p>
 <p class="text-warning">Etiam porta sem malesuada magna mollis euismod.</p>
 <p class="text-danger">Donec ullamcorper nulla non metus auctor fringilla.</p>
+<p class="bg-inverse text-inverse">Curabitur blandit tempus porttitor.</p>
 {% endexample %}
 
 Similar to the contextual text color classes, easily set the background of an element to any contextual class. Anchor components will darken on hover, just like the text classes.

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -110,6 +110,8 @@
 
 @include text-emphasis-variant('.text-danger', $brand-danger);
 
+@include text-emphasis-variant('.text-danger', $body-bg);
+
 
 // Contextual backgrounds
 // For now we'll leave these alongside the text classes until v4 when we can


### PR DESCRIPTION
In situations where the background image has inverse color scheme, text-inverse can be used to display text in the original body background color.

Solution for feature request https://github.com/twbs/bootstrap/issues/17634
Enhanced documentation for https://github.com/twbs/bootstrap/issues/17541
