### PR TITLE
Travis CI: test against node.js 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 git:
   depth: 10
 node_js:
-  - "0.12"
+  - "4"
+  - "stable"
 before_install:
   - rvm install 2.0.0 && rvm use 2.0.0
   - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""


### PR DESCRIPTION
I also let Travis ran with [0.10 and 0.12](https://travis-ci.org/twbs/bootstrap/builds/81244353) just to test if things still work there; everything went fine so we can keep the engines value we set in package.json to 0.10. Although it could break at any time and we wouldn't notice...

/CC @cvrebert 
