### PR TITLE
Fix Missing !defualt Tag to Buttons Variables

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -212,8 +212,8 @@ $table-border-color:            $gray-lighter !default;
 //
 // For each of Bootstrap's buttons, define text, background and border color.
 
-$btn-padding-x:                  1rem;
-$btn-padding-y:                  .375rem;
+$btn-padding-x:                  1rem !default;
+$btn-padding-y:                  .375rem !default;
 $btn-font-weight:                normal !default;
 
 $btn-primary-color:              #fff !default;


### PR DESCRIPTION
Trying to override two of the buttons variables -
- $btn-padding-x
- $btn-padding-y

is impossible because theyre missing the !default tag.
This commit added the said tag.
