### PR TITLE
[Fix #17498][V4] Align form control labels properly

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -76,7 +76,8 @@
 // For use with horizontal and inline forms, when you need the label text to
 // align with the form controls.
 .form-control-label {
-  padding: $input-padding-y $input-padding-x;
+  padding-top: $input-padding-y;
+  padding-bottom: $input-padding-y;
   margin-bottom: 0; // Override the `<label>` default
 }
 


### PR DESCRIPTION
Remove left and right padding from `.form-control-label` so it aligns with the edges of `.container`s. Also, it aligns with any controls placed underneath them.

Resolves #17498
