### PR TITLE
Rename placeholders in forms.md according to the classes specified

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -484,9 +484,9 @@ Add the `readonly` boolean attribute on an input to prevent modification of the 
 Set heights using classes like `.form-control-lg`, and set widths using grid column classes like `.col-lg-*`.
 
 {% example html %}
-<input class="form-control form-control-lg" type="text" placeholder=".input-lg">
+<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg">
 <input class="form-control" type="text" placeholder="Default input">
-<input class="form-control form-control-sm" type="text" placeholder=".input-sm">
+<input class="form-control form-control-sm" type="text" placeholder=".form-control-sm">
 {% endexample %}
 
 {% example html %}


### PR DESCRIPTION
That particular example still used the old `.input-xx` classes as placeholders instead of `.form-control-xx`, this simple PR fixed that.
