### PR TITLE
Add variables for darkening percentages for button-variant hover/focus colors

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -217,8 +217,11 @@ $table-border-color:            $gray-lighter !default;
 $btn-padding-x:                  1rem !default;
 $btn-padding-y:                  .375rem !default;
 $btn-font-weight:                normal !default;
-$btn-darken:                     10% !default;
-$btn-border-darken:              12% !default;
+
+$btn-hover-darken:               10% !default;
+$btn-hover-border-darken:        12% !default;
+$btn-active-hover-darken:        17% !default;
+$btn-active-hover-border-darken: 25% !default;
 
 $btn-primary-color:              #fff !default;
 $btn-primary-bg:                 $brand-primary !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -217,6 +217,8 @@ $table-border-color:            $gray-lighter !default;
 $btn-padding-x:                  1rem !default;
 $btn-padding-y:                  .375rem !default;
 $btn-font-weight:                normal !default;
+$btn-darken:                     10% !default;
+$btn-border-darken:              12% !default;
 
 $btn-primary-color:              #fff !default;
 $btn-primary-bg:                 $brand-primary !default;

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -4,8 +4,8 @@
 // and disabled options for all buttons
 
 @mixin button-variant($color, $background, $border) {
-  $active-background: darken($background, $btn-darken);
-  $active-border: darken($border, $btn-border-darken);
+  $active-background: darken($background, $btn-hover-darken);
+  $active-border: darken($border, $btn-hover-border-darken);
 
   color: $color;
   background-color: $background;
@@ -39,8 +39,8 @@
     &:focus,
     &.focus {
       color: $color;
-      background-color: darken($background, ($btn-darken + 7));
-          border-color: darken($border, ($btn-darken + 13));
+      background-color: darken($background, $btn-active-hover-darken);
+          border-color: darken($border, $btn-active-hover-border-darken);
     }
   }
 

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -4,8 +4,8 @@
 // and disabled options for all buttons
 
 @mixin button-variant($color, $background, $border) {
-  $active-background: darken($background, 10%);
-  $active-border: darken($border, 12%);
+  $active-background: darken($background, $btn-darken);
+  $active-border: darken($border, $btn-border-darken);
 
   color: $color;
   background-color: $background;
@@ -39,8 +39,8 @@
     &:focus,
     &.focus {
       color: $color;
-      background-color: darken($background, 17%);
-          border-color: darken($border, 25%);
+      background-color: darken($background, ($btn-darken + 7));
+          border-color: darken($border, ($btn-darken + 13));
     }
   }
 


### PR DESCRIPTION
Instead of changing the $border-width it can be useful to colorize the border same way then the background and the result will be buttons without borders.
