### PR TITLE
Collapse empty alerts

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -16,6 +16,11 @@
   > p + p {
     margin-top: 5px;
   }
+
+  // Empty alerts collapse automatically
+  &:empty {
+    display: none;
+  }
 }
 
 // Headings for larger alerts


### PR DESCRIPTION
Following the pattern available in both badges and labels, set alerts to `display: none;` when they have no content.
