### PR TITLE
Update support for Meteor 1.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,13 +13,18 @@ Package.describe({
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
   api.use('jquery', 'client');
-  api.addFiles([
+  var assets = [
     'dist/fonts/glyphicons-halflings-regular.eot',
     'dist/fonts/glyphicons-halflings-regular.svg',
     'dist/fonts/glyphicons-halflings-regular.ttf',
     'dist/fonts/glyphicons-halflings-regular.woff',
     'dist/fonts/glyphicons-halflings-regular.woff2'
-  ], 'client', { isAsset: true });
+  ];
+  if (api.addAssets) {
+    api.addAssets(assets, 'client');
+  } else {
+    api.addFiles(assets, 'client', { isAsset: true });
+  }
   api.addFiles([
     'dist/css/bootstrap.css',
     'dist/js/bootstrap.js'


### PR DESCRIPTION
Now that Meteor 1.2 is out, we need to update how assets are added because [they made a backwards-incompatible change](https://github.com/meteor/meteor/pull/5082#issuecomment-142721974).
