### PR TITLE
tooltip trigger must be called twice after call to hide

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -1322,4 +1322,21 @@ $(function () {
     })
   })
 
+  QUnit.test('should show on first trigger after hide', function (assert) {
+    assert.expect(3)
+
+    var $el = $('<a href="#" rel="tooltip" title="Test tooltip"/>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip({ trigger: 'click' })
+      
+    $el.bootstrapTooltip('show')
+    assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
+
+    $el.bootstrapTooltip('hide')
+    assert.ok($('.tooltip').not('.fade.in'), 'tooltip was faded out')
+
+    $el.trigger('click')
+    assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
+  })
+
 })

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -337,6 +337,8 @@
 
     this.hoverState = null
 
+    this.inState = { click: false, hover: false, focus: false }
+
     return this
   }
 


### PR DESCRIPTION
https://github.com/twbs/bootstrap/pull/16014 introduced a bug where a link must be clicked twice to show the tooltip after calling hide. Fixed by setting inState variables to false in the hide() method.
