### PR TITLE
Only run htmllint on Travis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,7 @@ module.exports = function (grunt) {
   var fs = require('fs');
   var path = require('path');
   var glob = require('glob');
+  var isTravis = require('is-travis');
   var npmShrinkwrap = require('npm-shrinkwrap');
   var mq4HoverShim = require('mq4-hover-shim');
 
@@ -436,7 +437,8 @@ module.exports = function (grunt) {
   }
   // Skip HTML validation if running a different subset of the test suite
   if (runSubset('validate-html') &&
-      // Skip HTML5 validator on Travis when [skip validator] is in the commit message
+      isTravis &&
+      // Skip HTML5 validator when [skip validator] is in the commit message
       isUndefOrNonZero(process.env.TWBS_DO_VALIDATOR)) {
     testSubtasks.push('validate-html');
   }

--- a/grunt/npm-shrinkwrap.json
+++ b/grunt/npm-shrinkwrap.json
@@ -2,7 +2,7 @@
   "name": "bootstrap",
   "version": "4.0.0-alpha",
   "npm-shrinkwrap-version": "200.4.0",
-  "node-version": "v4.1.0",
+  "node-version": "v4.1.1",
   "dependencies": {
     "babel-eslint": {
       "version": "4.1.3",
@@ -433,20 +433,28 @@
               }
             },
             "regexpu": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "dependencies": {
+                "esprima": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                },
                 "recast": {
-                  "version": "0.10.32",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
+                  "version": "0.10.33",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.8.11",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz"
+                      "version": "0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                     },
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
                     }
                   }
                 },
@@ -895,8 +903,8 @@
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000319",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000319.tgz"
+              "version": "1.0.30000322",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000322.tgz"
             },
             "num2fraction": {
               "version": "1.2.2",
@@ -1401,20 +1409,28 @@
               }
             },
             "regexpu": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "dependencies": {
+                "esprima": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                },
                 "recast": {
-                  "version": "0.10.32",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
+                  "version": "0.10.33",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.8.11",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz"
+                      "version": "0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                     },
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
                     }
                   }
                 },
@@ -3049,8 +3065,8 @@
       }
     },
     "grunt-eslint": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.1.0.tgz",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
@@ -3253,8 +3269,8 @@
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "file-entry-cache": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.3.tgz",
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
               "dependencies": {
                 "flat-cache": {
                   "version": "1.0.9",
@@ -3349,8 +3365,8 @@
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz"
             },
             "handlebars": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.2.tgz",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.4.2",
@@ -4435,24 +4451,24 @@
           }
         },
         "diff": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.1.1.tgz"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.1.2.tgz"
         },
         "es6-promise": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "postcss": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.6.tgz",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.8.tgz",
           "dependencies": {
             "js-base64": {
               "version": "2.1.9",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             },
             "source-map": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz"
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
             },
             "supports-color": {
               "version": "3.1.1",
@@ -5129,8 +5145,8 @@
               }
             },
             "request": {
-              "version": "2.63.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.63.0.tgz",
+              "version": "2.64.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
@@ -5345,8 +5361,8 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "yargs": {
-                  "version": "3.25.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.25.0.tgz",
+                  "version": "3.26.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.26.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
@@ -5936,6 +5952,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-stamp/-/grunt-stamp-0.1.0.tgz"
     },
+    "is-travis": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-travis/-/is-travis-1.0.0.tgz"
+    },
     "load-grunt-tasks": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.3.0.tgz",
@@ -6213,8 +6233,8 @@
           }
         },
         "npm": {
-          "version": "2.14.5",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-2.14.5.tgz",
+          "version": "2.14.6",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.14.6.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -6725,8 +6745,8 @@
               "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz"
             },
             "request": {
-              "version": "2.62.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.62.0.tgz",
+              "version": "2.63.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.63.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
@@ -6801,8 +6821,8 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.10.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz"
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz"
                     },
                     "chalk": {
                       "version": "1.1.1",
@@ -6887,16 +6907,16 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                   "dependencies": {
                     "boom": {
-                      "version": "2.8.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "hoek": {
-                      "version": "2.16.2",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.2.tgz"
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -6931,12 +6951,12 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.6",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
+                  "version": "2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.18.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz"
+                      "version": "1.19.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
                     }
                   }
                 },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "grunt-scss-lint": "^0.3.8",
     "grunt-sed": "~0.1.1",
     "grunt-stamp": "^0.1.0",
+    "is-travis": "^1.0.0",
     "load-grunt-tasks": "~3.3.0",
     "markdown-it": "^4.4.0",
     "mq4-hover-shim": "^0.2.0",


### PR DESCRIPTION
So as to avoid any dependence on Java for normal users of the Gruntfile.
(The local HTML validator, and thus htmllint, requires Java.)
