### PR TITLE
Use backticks/<code> for JS snippets in docs headings

### DIFF
--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -180,7 +180,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-#### .carousel(options)
+#### `.carousel(options)`
 
 Initializes the carousel with an optional options `object` and starts cycling through items.
 
@@ -190,23 +190,23 @@ $('.carousel').carousel({
 })
 {% endhighlight %}
 
-#### .carousel('cycle')
+#### `.carousel('cycle')`
 
 Cycles through the carousel items from left to right.
 
-#### .carousel('pause')
+#### `.carousel('pause')`
 
 Stops the carousel from cycling through items.
 
-#### .carousel(number)
+#### `.carousel(number)`
 
 Cycles the carousel to a particular frame (0 based, similar to an array).
 
-#### .carousel('prev')
+#### `.carousel('prev')`
 
 Cycles to the previous item.
 
-#### .carousel('next')
+#### `.carousel('next')`
 
 Cycles to the next item.
 

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -145,7 +145,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-#### .collapse(options)
+#### `.collapse(options)`
 
 Activates your content as a collapsible element. Accepts an optional options `object`.
 
@@ -155,15 +155,15 @@ $('#myCollapsible').collapse({
 })
 {% endhighlight %}
 
-#### .collapse('toggle')
+#### `.collapse('toggle')`
 
 Toggles a collapsible element to shown or hidden.
 
-#### .collapse('show')
+#### `.collapse('show')`
 
 Shows a collapsible element.
 
-#### .collapse('hide')
+#### `.collapse('hide')`
 
 Hides a collapsible element.
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -428,7 +428,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-#### .modal(options)
+#### `.modal(options)`
 
 Activates your content as a modal. Accepts an optional options `object`.
 
@@ -438,19 +438,19 @@ $('#myModal').modal({
 })
 {% endhighlight %}
 
-#### .modal('toggle')
+#### `.modal('toggle')`
 
 Manually toggles a modal. **Returns to the caller before the modal has actually been shown or hidden** (i.e. before the `shown.bs.modal` or `hidden.bs.modal` event occurs).
 
 {% highlight js %}$('#myModal').modal('toggle'){% endhighlight %}
 
-#### .modal('show')
+#### `.modal('show')`
 
 Manually opens a modal. **Returns to the caller before the modal has actually been shown** (i.e. before the `shown.bs.modal` event occurs).
 
 {% highlight js %}$('#myModal').modal('show'){% endhighlight %}
 
-#### .modal('hide')
+#### `.modal('hide')`
 
 Manually hides a modal. **Returns to the caller before the modal has actually been hidden** (i.e. before the `hidden.bs.modal` event occurs).
 

--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -282,29 +282,29 @@ Options for individual popovers can alternatively be specified through the use o
 
 ### Methods
 
-#### $().popover(options)
+#### `$().popover(options)`
 
 Initializes popovers for an element collection.
 
-#### .popover('show')
+#### `.popover('show')`
 
 Reveals an element's popover. **Returns to the caller before the popover has actually been shown** (i.e. before the `shown.bs.popover` event occurs). This is considered a "manual" triggering of the popover. Popovers whose both title and content are zero-length are never displayed.
 
 {% highlight js %}$('#element').popover('show'){% endhighlight %}
 
-#### .popover('hide')
+#### `.popover('hide')`
 
 Hides an element's popover. **Returns to the caller before the popover has actually been hidden** (i.e. before the `hidden.bs.popover` event occurs). This is considered a "manual" triggering of the popover.
 
 {% highlight js %}$('#element').popover('hide'){% endhighlight %}
 
-#### .popover('toggle')
+#### `.popover('toggle')`
 
 Toggles an element's popover. **Returns to the caller before the popover has actually been shown or hidden** (i.e. before the `shown.bs.popover` or `hidden.bs.popover` event occurs). This is considered a "manual" triggering of the popover.
 
 {% highlight js %}$('#element').popover('toggle'){% endhighlight %}
 
-#### .popover('dispose')
+#### `.popover('dispose')`
 
 Hides and destroys an element's popover. Popvoers that use delegation (which are created using [the `selector` option](#options)) cannot be individually destroyed on descendant trigger elements.
 

--- a/docs/components/scrollspy.md
+++ b/docs/components/scrollspy.md
@@ -101,7 +101,7 @@ Target elements that are not [`:visible` according to jQuery](https://api.jquery
 
 ### Methods
 
-#### .scrollspy('refresh')
+#### `.scrollspy('refresh')`
 
 When using scrollspy in conjunction with adding or removing of elements from the DOM, you'll need to call the refresh method like so:
 

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -240,29 +240,29 @@ Options for individual tooltips can alternatively be specified through the use o
 
 ### Methods
 
-#### $().tooltip(options)
+#### `$().tooltip(options)`
 
 Attaches a tooltip handler to an element collection.
 
-#### .tooltip('show')
+#### `.tooltip('show')`
 
 Reveals an element's tooltip. **Returns to the caller before the tooltip has actually been shown** (i.e. before the `shown.bs.tooltip` event occurs). This is considered a "manual" triggering of the tooltip. Tooltips with zero-length titles are never displayed.
 
 {% highlight js %}$('#element').tooltip('show'){% endhighlight %}
 
-#### .tooltip('hide')
+#### `.tooltip('hide')`
 
 Hides an element's tooltip. **Returns to the caller before the tooltip has actually been hidden** (i.e. before the `hidden.bs.tooltip` event occurs). This is considered a "manual" triggering of the tooltip.
 
 {% highlight js %}$('#element').tooltip('hide'){% endhighlight %}
 
-#### .tooltip('toggle')
+#### `.tooltip('toggle')`
 
 Toggles an element's tooltip. **Returns to the caller before the tooltip has actually been shown or hidden** (i.e. before the `shown.bs.tooltip` or `hidden.bs.tooltip` event occurs). This is considered a "manual" triggering of the tooltip.
 
 {% highlight js %}$('#element').tooltip('toggle'){% endhighlight %}
 
-#### .tooltip('dispose')
+#### `.tooltip('dispose')`
 
 Hides and destroys an element's tooltip. Tooltips that use delegation (which are created using [the `selector` option](#options)) cannot be individually destroyed on descendant trigger elements.
 


### PR DESCRIPTION
Closes #17192.
