### PR TITLE
Adding subresource hashes to CDN links.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,5 +28,8 @@ expo:             http://expo.getbootstrap.com
 
 cdn:
   css:            https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css
+  css_hash:       sha384-pdapHxIh7EYuwy6K7iE41uXVxGCXY0sAjBzaElYGJUrzwodck3Lx6IE2lA0rFREo
   css_theme:      https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css
+  css_theme_hash: sha384-aUGj/X2zp5rLCbBxumKTCw2Z50WgIr1vs/PFN4praOTvYXWlVyh2UtNUU0KAUhAX
   js:             https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js
+  js_hash:        sha384-pPttEvTHTuUJ9L2kCoMnNqCRcaMPMVMsWVO+RLaaaYDmfSP5//dP6eKRusbPcqhZ

--- a/docs/_includes/getting-started/download.html
+++ b/docs/_includes/getting-started/download.html
@@ -31,13 +31,13 @@
   <p>The folks over at <a href="https://www.maxcdn.com/">MaxCDN</a> graciously provide CDN support for Bootstrap's CSS and JavaScript. Just use these <a href="https://www.bootstrapcdn.com/">Bootstrap CDN</a> links.</p>
 {% highlight html %}
 <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="{{ site.cdn.css }}">
+<link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 
 <!-- Optional theme -->
-<link rel="stylesheet" href="{{ site.cdn.css_theme }}">
+<link rel="stylesheet" href="{{ site.cdn.css_theme }}" integrity="{{ site.cdn.css_theme_hash }}" crossorigin="anonymous">
 
 <!-- Latest compiled and minified JavaScript -->
-<script src="{{ site.cdn.js }}"></script>
+<script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
 {% endhighlight %}
 
   <h2 id="download-bower">Install with Bower</h2>


### PR DESCRIPTION
In Firefox 43 and Chrome 45 there will be support for Subresource Integrity (SRI). More information here: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
