### PR TITLE
Fix for Issue #17711 - Added clearfix mixin to the nav-pills class.

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -91,6 +91,8 @@
 //
 
 .nav-pills {
+  @include clearfix();
+  
   .nav-item {
     float: left;
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -92,7 +92,6 @@
 
 .nav-pills {
   @include clearfix();
-  
   .nav-item {
     float: left;
 


### PR DESCRIPTION
Clearfix mixin included in the nav-tabs class but not nav pills. This results in the but highlighted in issue #17711 
