### PR TITLE
Remove http://bugzil.la/1048279 entry from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -50,16 +50,6 @@
 
 -
   browser: >
-    Firefox (Windows)
-  summary: >
-    Java applets that are descendants of elements with forced hardware acceleration using `translate3d(0,0,0)` are invisible.
-  upstream_bug: >
-    Mozilla#1048279
-  origin: >
-    Bootstrap#14124
-
--
-  browser: >
     Firefox
   summary: >
     Button elements with `width: 100%` become cropped in long tables.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1048279 has been closed as WONTFIX.
Refs #14124.
