### PR TITLE
Flexbox grid column wrapping bug

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -46,6 +46,7 @@
 @mixin make-col-span($size, $columns: $grid-columns) {
   @if $enable-flex {
     flex: 0 0 percentage($size / $columns);
+    max-width: percentage($size / $columns);
   } @else {
     width: percentage($size / $columns);
   }


### PR DESCRIPTION
With flexbox enabled, please take a look at this in ~~IE10+~~ all browsers:

```
<div class="container">
    <div class="row">
        <div class="col-xs-7">
            <div class="bg-primary">content</div>
        </div>
        <div class="col-xs-5">
            <div class="bg-primary">sidebar</div>
        </div>
    </div>
</div>
```

This is what i get:
![flexbox](https://cloud.githubusercontent.com/assets/985838/10230968/d688b090-6888-11e5-9223-14f949a5913a.png)
