### PR TITLE
Add SCSS configuration for Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,6 @@
+java_script:
+  enabled: false
+scss:
+  config_file: scss/.scss-lint.yml
+  enabled: true
+  ignore_file: scss/_normalize.scss


### PR DESCRIPTION
### What

This change uses Bootstrap's existing `scss/.scss-lint.yml` file to configure Hound's hosted SCSS-Lint instance.

It leaves existing JavaScript linting as-is because Hound does not support ESLint or JSCS yet. It does support JSHint for the master branch, but I decided to focus just on v4 for this change.
### How it works

On each pull request to Bootstrap, Hound will comment on any SCSS style violations in-line, like this:

![screenshot](https://images.thoughtbot.com/hound/scss-example.png)

If you update the pull request to adopt a suggestion, the comment will be hidden.

The same checks are maintained on pull requests. Instead of output such as this in Travis...

```
scss/_navbar.scss:216 [W] TrailingWhitespace: Line contains trailing whitespace
```

... it will be an in-line comment from Hound.

Hound is free for open source projects and is open source itself, like Travis: https://github.com/thoughtbot/hound
### Why

The advantages for the Bootstrap project might be:
- Ruby does not need to be installed on developer's machines in order for `grunt test` to run all lint checks.
- If `jekyll:docs` could be removed from the build, Ruby would not need to be installed on TravisCI.
- Hound runs in parallel to Travis, speeding up the time CI finishes by about 4.6s on builds such as https://travis-ci.org/twbs/bootstrap/jobs/83432163
- For parity with your current setup, I've set the `fail_on_violations: true` setting, but if SCSS-Lint has false positives or false negatives, you can change the setting to `false` to treat its comments more as suggestions than a binary outcome that should fail the build. https://houndci.com/configuration#configuration
