### PR TITLE
Update typography docs re: global vars

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -15,11 +15,11 @@ Bootstrap includes simple and easily customized typography for headings, body te
 
 Bootstrap sets basic global display, typography, and link styles. Specifically, we:
 
-- Set `background-color: #fff;` on the `<body>`
+- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default)
 - Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base
 - Set the global link color via `$link-color` and apply link underlines only on `:hover`
 
-These styles can be found within `_reboot.scss`.
+These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`.
 
 
 ## Headings


### PR DESCRIPTION
Docs should indicate that `_reboot.scss` uses the variables, and that to see their values users would look in `_variables.scss`.
