### PR TITLE
mentioned .table group where pixel shift occurs

### DIFF
--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -98,7 +98,7 @@ $('#example').tooltip(options)
   </div>
   <div class="bs-callout bs-callout-warning" id="callout-tooltip-groups">
     <h4>Tooltips in button groups and input groups require special setting</h4>
-    <p>When using tooltips on elements within a <code>.btn-group</code> or an <code>.input-group</code>, you'll have to specify the option <code>container: 'body'</code> (documented below) to avoid unwanted side effects (such as the element growing wider and/or losing its rounded corners when the tooltip is triggered).</p>
+    <p>When using tooltips on elements within a <code>.btn-group</code> or a <code>.table</code> or an <code>.input-group</code>, you'll have to specify the option <code>container: 'body'</code> (documented below) to avoid unwanted side effects (such as the element growing wider and/or losing its rounded corners when the tooltip is triggered).</p>
   </div>
   <div class="bs-callout bs-callout-warning" id="callout-tooltip-hidden">
     <h4>Don't try to show tooltips on hidden elements</h4>


### PR DESCRIPTION
Added the instance where pixel shift occurs when tooltip is used in table headers.

see the illustration here: http://jsfiddle.net/uday99/74rwp51o/2/

Issue first reported:
https://github.com/twbs/bootstrap/issues/5865

but the documentation lacks to mention about pixel shift occurrence in `<table>` tag/ `.table` group.
