### PR TITLE
Remove double bottom border on sub header in dashboard example

### DIFF
--- a/docs/examples/dashboard/index.html
+++ b/docs/examples/dashboard/index.html
@@ -89,7 +89,7 @@
             </div>
           </div>
 
-          <h2 class="sub-header">Section title</h2>
+          <h2>Section title</h2>
           <div class="table-responsive">
             <table class="table table-striped">
               <thead>


### PR DESCRIPTION
Before:
<img width="566" alt="screen shot 2015-10-08 at 8 43 02 am" src="https://cloud.githubusercontent.com/assets/947110/10366468/b528cc86-6d98-11e5-96f0-7043e1914000.png">
After:
<img width="766" alt="screen shot 2015-10-08 at 8 43 10 am" src="https://cloud.githubusercontent.com/assets/947110/10366469/b529154c-6d98-11e5-9d19-69aee8fd8561.png">

The table includes a border between the two making this unnecessary
