### PR TITLE
Add utility functions for converting px to rem

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -147,3 +147,23 @@
 @function strip-unit($value) {
   @return $value / ($value * 0 + 1);
 }
+
+// Converts numeric value(s) to rem units, based
+// on the $font-size-root variable.
+// E.g. `rem-calc(14px 16px 0)` returns `0.875rem 1rem 0`
+
+@function rem-calc($values) {
+  $rem-values: ();
+
+  @each $value in $values {
+    @if ($value > 0) {
+      $value: strip-unit($value) / strip-unit($font-size-root) * 1rem;
+    } @else {
+      $value: 0; // ensure that `0rem` becomes unitless
+    }
+
+    $rem-values: append($rem-values, $value);
+  }
+
+  @return $rem-values;
+}

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -135,3 +135,15 @@
 @include bg-variant('.bg-warning', $brand-warning);
 
 @include bg-variant('.bg-danger', $brand-danger);
+
+
+//
+// Utility functions
+//
+
+// Strips the unit from a single value entered.
+// E.g. `strip-unit(30px)` returns `30`
+
+@function strip-unit($value) {
+  @return $value / ($value * 0 + 1);
+}


### PR DESCRIPTION
Introduced 2 utility functions in SCSS to allow converting pixels to rem units easily. This could come in handy for users (developers using Bootstrap) looking for a way to set values using pixels, but wanting to leverage the advantages of using rem units as well.

fixes #17811
