### PR TITLE
[V4] Throw error when a plugin is in transition

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -116,9 +116,10 @@ const Carousel = (($) => {
     // public
 
     next() {
-      if (!this._isSliding) {
-        this._slide(Direction.NEXT)
+      if (this._isSliding) {
+        throw new Error('Carousel is sliding')
       }
+      this._slide(Direction.NEXT)
     }
 
     nextWhenVisible() {
@@ -129,9 +130,10 @@ const Carousel = (($) => {
     }
 
     prev() {
-      if (!this._isSliding) {
-        this._slide(Direction.PREVIOUS)
+      if (this._isSliding) {
+        throw new Error('Carousel is sliding')
       }
+      this._slide(Direction.PREVIOUS)
     }
 
     pause(event) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -112,8 +112,11 @@ const Collapse = (($) => {
     }
 
     show() {
-      if (this._isTransitioning ||
-        $(this._element).hasClass(ClassName.ACTIVE)) {
+      if (this._isTransitioning) {
+        throw new Error('Collapse is transitioning')
+      }
+
+      if ($(this._element).hasClass(ClassName.ACTIVE)) {
         return
       }
 
@@ -193,8 +196,11 @@ const Collapse = (($) => {
     }
 
     hide() {
-      if (this._isTransitioning ||
-        !$(this._element).hasClass(ClassName.ACTIVE)) {
+      if (this._isTransitioning) {
+        throw new Error('Collapse is transitioning')
+      }
+
+      if (!$(this._element).hasClass(ClassName.ACTIVE)) {
         return
       }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -115,9 +115,8 @@ const Modal = (($) => {
         throw new Error('Modal is transitioning')
       }
 
-      let transition = Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.FADE)
-      if (transition) {
+      if (Util.supportsTransitionEnd() &&
+        $(this._element).hasClass(ClassName.FADE)) {
         this._isTransitioning = true
       }
       const showEvent = $.Event(Event.SHOW, {
@@ -166,7 +165,7 @@ const Modal = (($) => {
         throw new Error('Modal is transitioning')
       }
 
-      let transition = Util.supportsTransitionEnd() &&
+      const transition = Util.supportsTransitionEnd() &&
         $(this._element).hasClass(ClassName.FADE)
       if (transition) {
         this._isTransitioning = true
@@ -191,8 +190,7 @@ const Modal = (($) => {
       $(this._element).off(Event.CLICK_DISMISS)
       $(this._dialog).off(Event.MOUSEDOWN_DISMISS)
 
-      if (Util.supportsTransitionEnd() &&
-         $(this._element).hasClass(ClassName.FADE)) {
+      if (transition) {
         $(this._element)
           .one(Util.TRANSITION_END, (event) => this._hideModal(event))
           .emulateTransitionEnd(TRANSITION_DURATION)

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -306,10 +306,10 @@ const Tooltip = (($) => {
 
         const complete = () => {
           const prevHoverState = this._hoverState
-          this._hoverState     = null
+          this._hoverState   = null
+          this._isTransitioning = false
 
           $(this.element).trigger(this.constructor.Event.SHOWN)
-          this._isTransitioning = false
 
           if (prevHoverState === HoverState.OUT) {
             this._leave(null, this)
@@ -334,7 +334,7 @@ const Tooltip = (($) => {
       if (this._isTransitioning) {
         throw new Error('Tooltip is transitioning')
       }
-      let complete  = () => {
+      const complete  = () => {
         if (this._hoverState !== HoverState.ACTIVE && tip.parentNode) {
           tip.parentNode.removeChild(tip)
         }

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -46,11 +46,31 @@
     <script src="../../dist/carousel.js"></script>
 
     <script>
-      $(function() {
+      // Should throw an error because carousel is in transition
+      function testCarouselTransitionError() {
+        var err = false
+        var $carousel = $('#carousel-example-generic')
+        $carousel.on('slid.bs.carousel', function () {
+          $carousel.off('slid.bs.carousel')
+          if (!err) {
+            alert('No error thrown for : testCarouselTransitionError')
+          }
+        })
+        try {
+          $carousel.carousel('next').carousel('prev')
+        }
+        catch (e) {
+          err = true
+          console.error(e.message)
+        }
+      }
+
+      $(function () {
         // Test to show that the carousel doesn't slide when the current tab isn't visible
-        $('#carousel-example-generic').on('slid.bs.carousel', function(event) {
+        $('#carousel-example-generic').on('slid.bs.carousel', function (event) {
           console.log('slid at ', event.timeStamp)
         })
+        testCarouselTransitionError()
       })
     </script>
   </body>

--- a/js/tests/visual/collapse.html
+++ b/js/tests/visual/collapse.html
@@ -61,5 +61,30 @@
     <script src="../vendor/jquery.min.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/collapse.js"></script>
+    <script>
+      // JavaScript Test
+      $(function () {
+        testCollapseTransitionError()
+      });
+
+      // Should throw an error because carousel is in transition
+      function testCollapseTransitionError() {
+        var err = false
+        $('#collapseOne').on('hidden.bs.collapse', function (e) {
+          $(this).off('hidden.bs.collapse')
+          if (!err) {
+            alert('No error thrown for : testCollapseTransitionError')
+          }
+        })
+
+        try {
+          $('#collapseOne').collapse('hide').collapse('show')
+        }
+        catch (e) {
+          err = true
+          console.error(e.message)
+        }
+      }
+    </script>
   </body>
 </html>

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -188,6 +188,26 @@
         }
       }
 
+      // Should throw an error because modal is in transition
+      function testModalTransitionError() {
+        var err = false
+        // Close #myModal
+        $('#myModal').on('shown.bs.modal', function () {
+          $('#myModal').modal('hide').off('shown.bs.modal')
+          if (!err) {
+            alert('No error thrown for : testModalTransitionError')
+          }
+        })
+
+        try {
+          $('#myModal').modal('show').modal('hide')
+        }
+        catch (e) {
+          err = true
+          console.error(e.message)
+        }
+      }
+
       $(function () {
         $('[data-toggle="popover"]').popover()
         $('[data-toggle="tooltip"]').tooltip()
@@ -200,6 +220,7 @@
           $('#firefoxModal').on('focus', reportFirefoxTestResult.bind(false))
           $('#ff-bug-input').on('focus', reportFirefoxTestResult.bind(true))
         })
+        testModalTransitionError()
       })
     </script>
   </body>

--- a/js/tests/visual/tooltip.html
+++ b/js/tests/visual/tooltip.html
@@ -42,7 +42,26 @@
     <script>
       $(function () {
         $('[data-toggle="tooltip"]').tooltip()
+        testTooltipTransitionError()
       })
+
+      // Should throw an error because tooltip is in transition
+      function testTooltipTransitionError() {
+        var err = false
+        $('#btnOne').on('shown.bs.tooltip', function () {
+          $('#btnOne').tooltip('hide').off('shown.bs.tooltip')
+          if (!err) {
+            alert('No error thrown for : testTooltipTransitionError')
+          }
+        })
+        try {
+          $('#btnOne').tooltip('show').tooltip('hide')
+        }
+        catch (e) {
+          err = true
+          console.error(e.message)
+        }
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
Hi,

Feature #17800 

I'll try to add some unit tests but I'm not sure it will works very well because of transition support isn't enable when tests are run with Grunt
