### PR TITLE
Tweak .text-capitalize example to show what happens to interior capital letters

### DIFF
--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -108,7 +108,7 @@ Transform text in components with text capitalization classes.
 {% example html %}
 <p class="text-lowercase">Lowercased text.</p>
 <p class="text-uppercase">Uppercased text.</p>
-<p class="text-capitalize">Capitalized text.</p>
+<p class="text-capitalize">CapiTaliZed text.</p>
 {% endexample %}
 
 ## Contextual colors and backgrounds


### PR DESCRIPTION
Refs #17893.
/to @mdo for review
