### PR TITLE
Make $card-border-radius default to $border-radius

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -450,7 +450,7 @@ $state-danger-border:            darken($state-danger-bg, 5%) !default;
 $card-spacer-x:            1.25rem !default;
 $card-spacer-y:            .75rem !default;
 $card-border-width:        .0625rem !default;
-$card-border-radius:       .25rem !default;
+$card-border-radius:       $border-radius !default;
 $card-border-color:        #e5e5e5 !default;
 $card-border-radius-inner: ($card-border-radius - $card-border-width) !default;
 $card-cap-bg:              #f5f5f5 !default;


### PR DESCRIPTION
Refs #17597.
They already share the same value (`.25rem`).
CC: @mdo for review
