### PR TITLE
Fix documentation #17533

### DIFF
--- a/docs/_includes/components/panels.html
+++ b/docs/_includes/components/panels.html
@@ -21,7 +21,7 @@
 {% endhighlight %}
 
   <h2 id="panels-heading">Panel with heading</h2>
-  <p>Easily add a heading container to your panel with <code>.panel-heading</code>. You may also include any <code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code> with a <code>.panel-title</code> class to add a pre-styled heading.</p>
+  <p>Easily add a heading container to your panel with <code>.panel-heading</code>. You may also include any <code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code> with a <code>.panel-title</code> class to add a pre-styled heading. However the sizes of <code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code> are overridden by <code>.panel-heading</code>.</p>
   <p>For proper link coloring, be sure to place links in headings within <code>.panel-title</code>.</p>
   <div class="bs-example" data-example-id="panel-with-heading">
     <div class="panel panel-default">


### PR DESCRIPTION
Added information about how the `h1-h6` element size are overridden if `.panel-title` is used.
Fixes #17533.
