### PR TITLE
Added JavaScript cookies - Create, Read and Erase

### DIFF
--- a/js/cookies.js
+++ b/js/cookies.js
@@ -23,14 +23,14 @@
 	}
 
 	function readCookie(name) {
-		var c_name = name + '=';
-		var c_split = document.cookie.split(';');
-		for(var i=0;i < c_split.length;i++) {
-			var c = c_split[i];
+		var cname = name + '=';
+		var csplit = document.cookie.split(';');
+		for(var i=0;i < csplit.length;i++) {
+			var c = csplit[i];
 			while (c.charAt(0)==' ') {
 				c = c.substring(1,c.length);
-				if (c.indexOf(c_name) === 0) {
-					return c.substring(c_name.length,c.length);
+				if (c.indexOf(cname) === 0) {
+					return c.substring(cname.length,c.length);
 				}
 			}
 		}

--- a/js/cookies.js
+++ b/js/cookies.js
@@ -13,28 +13,32 @@
   	// ================
 
   	function createCookie(name,value,days) {
+  		var expires = '';
 		if (days) {
 			var date = new Date();
 			date.setTime(date.getTime()+(days*24*60*60*1000));
-			var expires = "; expires="+date.toGMTString();
+			expires = '; expires='+date.toGMTString();
 		}
-		else var expires = "";
-		document.cookie = name+"="+value+expires+"; path=/";
+		document.cookie = name+'='+value+expires+'; path=/';
 	}
 
 	function readCookie(name) {
-		var nameEQ = name + "=";
-		var ca = document.cookie.split(';');
-		for(var i=0;i < ca.length;i++) {
-			var c = ca[i];
-			while (c.charAt(0)==' ') c = c.substring(1,c.length);
-			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+		var c_name = name + '=';
+		var c_split = document.cookie.split(';');
+		for(var i=0;i < c_split.length;i++) {
+			var c = c_split[i];
+			while (c.charAt(0)==' ') {
+				c = c.substring(1,c.length);
+				if (c.indexOf(c_name) === 0) {
+					return c.substring(c_name.length,c.length);
+				}
+			}
 		}
 		return null;
 	}
 
 	function eraseCookie(name) {
-		createCookie(name,"",-1);
+		createCookie(name,'',-1);
 	}
 
 }

--- a/js/cookies.js
+++ b/js/cookies.js
@@ -1,0 +1,40 @@
+/* ========================================================================
+ * Bootstrap: cookies.js v3.3.5
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+    // MANAGING COOKIES
+  	// ================
+
+  	function createCookie(name,value,days) {
+		if (days) {
+			var date = new Date();
+			date.setTime(date.getTime()+(days*24*60*60*1000));
+			var expires = "; expires="+date.toGMTString();
+		}
+		else var expires = "";
+		document.cookie = name+"="+value+expires+"; path=/";
+	}
+
+	function readCookie(name) {
+		var nameEQ = name + "=";
+		var ca = document.cookie.split(';');
+		for(var i=0;i < ca.length;i++) {
+			var c = ca[i];
+			while (c.charAt(0)==' ') c = c.substring(1,c.length);
+			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+		}
+		return null;
+	}
+
+	function eraseCookie(name) {
+		createCookie(name,"",-1);
+	}
+
+}


### PR DESCRIPTION
We all know that JavaScript can create, read, and delete cookies with the document.cookie property. Why not adding a embeded cookie script that lets you easily manage those cookies? If you're not working with PHP, this can be a little stressful, but not anymore. 
