### PR TITLE
Adding autocomplete attribute in docs input search

### DIFF
--- a/docs/_includes/nav-docs.html
+++ b/docs/_includes/nav-docs.html
@@ -1,7 +1,7 @@
 <div class="bd-sidebar">
 
   <form class="bd-search hidden-sm-down">
-    <input type="text" class="form-control" id="search-input" placeholder="Search...">
+    <input type="text" class="form-control" id="search-input" placeholder="Search..." autocomplete="off">
     <div class="dropdown-menu bd-search-results" id="search-results"></div>
   </form>
 


### PR DESCRIPTION
The autocomplete input attribute generates a "bug" when docs autocomplete is triggered. Look the change below:

**Before**
## ![bootstrap](https://cloud.githubusercontent.com/assets/1021901/10473124/f2ce6a82-71fd-11e5-9b5e-86e53982b9c9.gif)

**After**
![bootstrap-normalized](https://cloud.githubusercontent.com/assets/1021901/10473125/f2ea155c-71fd-11e5-92c3-404c6d4e2a1b.gif)
