### PR TITLE
v4 - .c-select shouldn't inherit white text color

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -135,6 +135,7 @@
   padding: .375rem 1.75rem .375rem .75rem;
   padding-right: .75rem \9;
   vertical-align: middle;
+  color: $input-color;
   background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUCAMAAACzvE1FAAAADFBMVEUzMzMzMzMzMzMzMzMKAG/3AAAAA3RSTlMAf4C/aSLHAAAAPElEQVR42q3NMQ4AIAgEQTn//2cLdRKppSGzBYwzVXvznNWs8C58CiussPJj8h6NwgorrKRdTvuV9v16Afn0AYFOB7aYAAAAAElFTkSuQmCC) no-repeat right .75rem center;
   background-image: none \9;
   background-size: 8px 10px;


### PR DESCRIPTION
This:

``` html
<div class="bg-info">
    <select class="c-select">
        <option selected>Open this select menu</option>
        <option value="1">One</option>
        <option value="2">Two</option>
        <option value="3">Three</option>
    </select>
</div>
```

render this:
![2015-10-14-19-45-11](https://cloud.githubusercontent.com/assets/985838/10491020/e614f194-72ac-11e5-8328-70656cf48f28.png)
