### PR TITLE
Use $line-height variable for .input-group-addon line height

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -83,7 +83,7 @@
   padding: $input-padding-y $input-padding-x;
   font-size: $font-size-base;
   font-weight: normal;
-  line-height: 1;
+  line-height: $line-height;
   color: $input-color;
   text-align: center;
   background-color: $input-group-addon-bg;


### PR DESCRIPTION
To avoid this when setting a bigger `$line-height` with flexbox enabled:
![2015-10-18-23-57-44](https://cloud.githubusercontent.com/assets/985838/10566602/74b9a968-75f4-11e5-9ed7-463d2b3446c8.png)
line-height should be the same as on body, and .form-control

```
<fieldset class="form-group">
    <div class="input-group">
        <span class="input-group-addon" id="sizing-addon2">$</span>
        <input type="text" class="form-control" placeholder="Username" aria-describedby="sizing-addon2">
    </div>
</fieldset>
```
