### PR TITLE
Use @line-height-base for .input-group-addon line-height

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -74,7 +74,7 @@
   padding: @padding-base-vertical @padding-base-horizontal;
   font-size: @font-size-base;
   font-weight: normal;
-  line-height: 1;
+  line-height: @line-height-base;
   color: @input-color;
   text-align: center;
   background-color: @input-group-addon-bg;


### PR DESCRIPTION
Better vertical aligning .input-group-addon with .form-control.
#17967
