### PR TITLE
v4 - Update grunt-jscs to 2.1.0 to use JSCS 2.x

### DIFF
--- a/grunt/npm-shrinkwrap.json
+++ b/grunt/npm-shrinkwrap.json
@@ -133,8 +133,8 @@
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
             },
             "core-js": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.1.tgz"
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.2.tgz"
             },
             "debug": {
               "version": "2.2.0",
@@ -1007,8 +1007,8 @@
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000340",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000340.tgz"
+              "version": "1.0.30000347",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000347.tgz"
             },
             "num2fraction": {
               "version": "1.2.2",
@@ -1213,8 +1213,8 @@
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
             },
             "core-js": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.1.tgz"
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.2.tgz"
             },
             "debug": {
               "version": "2.2.0",
@@ -2349,8 +2349,8 @@
           }
         },
         "clean-css": {
-          "version": "3.4.5",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.5.tgz",
+          "version": "3.4.6",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.6.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -2397,8 +2397,8 @@
                   }
                 },
                 "concat-stream": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -2703,8 +2703,8 @@
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                     },
                     "jsonfile": {
-                      "version": "2.2.2",
-                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.2.tgz"
+                      "version": "2.2.3",
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
@@ -3129,8 +3129,8 @@
                   }
                 },
                 "concat-stream": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -3611,8 +3611,8 @@
       }
     },
     "grunt-eslint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
@@ -3653,12 +3653,12 @@
           }
         },
         "eslint": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.6.0.tgz",
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.7.1.tgz",
           "dependencies": {
             "concat-stream": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -3729,8 +3729,8 @@
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "dependencies": {
                 "es6-map": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
@@ -3738,45 +3738,19 @@
                     },
                     "es5-ext": {
                       "version": "0.10.8",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
-                      "dependencies": {
-                        "es6-iterator": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                        },
-                        "es6-symbol": {
-                          "version": "3.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
                     },
                     "es6-iterator": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                     },
                     "es6-set": {
                       "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
-                      "dependencies": {
-                        "es6-iterator": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                        },
-                        "es6-symbol": {
-                          "version": "3.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz"
                     },
                     "es6-symbol": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.4",
@@ -3831,8 +3805,8 @@
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
@@ -4027,8 +4001,8 @@
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
                 "cli-width": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
                 },
                 "figures": {
                   "version": "1.4.0",
@@ -4561,20 +4535,596 @@
       }
     },
     "grunt-jscs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-2.1.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.1.1.tgz",
           "dependencies": {
+            "babel-core": {
+              "version": "5.8.25",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.25.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.23",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "convert-source-map": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.2.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "line-numbers": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                  "dependencies": {
+                    "left-pad": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.35",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.3",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.5.1",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                        },
+                        "glob": {
+                          "version": "4.2.2",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.7.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.8",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "install": {
+                          "version": "0.1.8",
+                          "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.1",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.3",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "2.0.1",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.3",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "2.0.1",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.2",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.0",
+                              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.24",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.5",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.6.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.6.0.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-jscs": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz"
+            },
             "chalk": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
@@ -4585,32 +5135,28 @@
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
@@ -4625,28 +5171,44 @@
               }
             },
             "commander": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+              "version": "2.8.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
             },
             "esprima": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-            },
-            "esprima-harmony-jscs": {
-              "version": "1.1.0-bin",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
             },
             "estraverse": {
-              "version": "1.9.3",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
             },
             "exit": {
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
+            "jscs-jsdoc": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.1.0.tgz",
+              "dependencies": {
+                "comment-parser": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.0.tgz"
+                },
+                "jsdoctypeparser": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz"
+                }
+              }
+            },
             "lodash.assign": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
@@ -4655,24 +5217,6 @@
                     "lodash._basecopy": {
                       "version": "3.0.1",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                        }
-                      }
                     }
                   }
                 },
@@ -4691,6 +5235,24 @@
                     "lodash.restparam": {
                       "version": "3.6.1",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 }
@@ -4715,6 +5277,10 @@
                   }
                 }
               }
+            },
+            "natural-compare": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz"
             },
             "pathval": {
               "version": "0.1.1",
@@ -4810,9 +5376,37 @@
                 }
               }
             },
+            "reserved-words": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
             "strip-json-comments": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "to-double-quotes": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                }
+              }
+            },
+            "to-single-quotes": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                }
+              }
             },
             "vow-fs": {
               "version": "0.3.4",
@@ -4860,19 +5454,13 @@
             },
             "xmlbuilder": {
               "version": "2.6.5",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz"
             }
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "vow": {
           "version": "0.4.11",
@@ -4935,8 +5523,8 @@
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "postcss": {
-          "version": "5.0.9",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.9.tgz",
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.10.tgz",
           "dependencies": {
             "js-base64": {
               "version": "2.1.9",
@@ -5059,8 +5647,8 @@
                   "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
                   "dependencies": {
                     "concat-stream": {
-                      "version": "1.5.0",
-                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                      "version": "1.5.1",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
@@ -6731,8 +7319,8 @@
           "resolved": "https://registry.npmjs.org/css-mq-parser/-/css-mq-parser-0.0.3.tgz"
         },
         "postcss": {
-          "version": "5.0.9",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.9.tgz",
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.10.tgz",
           "dependencies": {
             "js-base64": {
               "version": "2.1.9",
@@ -6819,24 +7407,24 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "msee": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/msee/-/msee-0.1.1.tgz",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
           "dependencies": {
             "cardinal": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
               "dependencies": {
                 "ansicolors": {
                   "version": "0.2.1",
                   "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
                 },
                 "redeyed": {
-                  "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
                   "dependencies": {
-                    "esprima": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    "esprima-fb": {
+                      "version": "12001.1.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
                     }
                   }
                 }

--- a/js/.jscsrc
+++ b/js/.jscsrc
@@ -1,5 +1,6 @@
 {
   "esnext": true,
+  "verbose": true,
   "disallowEmptyBlocks": true,
   "disallowKeywords": ["with"],
   "disallowMixedSpacesAndTabs": true,
@@ -28,7 +29,7 @@
   "requireSpaceAfterLineComment": true,
   "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
   "requireSpaceBetweenArguments": true,
-  "requireSpacesInAnonymousFunctionExpression": { "beforeOpeningCurlyBrace": true, "beforeOpeningRoundBrace": true },
+  "requireSpacesInAnonymousFunctionExpression": { "beforeOpeningCurlyBrace": true, "beforeOpeningRoundBrace": true, "allExcept": ["shorthand"] },
   "requireSpacesInConditionalExpression": true,
   "requireSpacesInForStatement": true,
   "requireSpacesInFunctionDeclaration": { "beforeOpeningCurlyBrace": true },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-exec": "~0.4.6",
     "grunt-html": "~5.0.0",
     "grunt-jekyll": "~0.4.2",
-    "grunt-jscs": "~1.8.0",
+    "grunt-jscs": "~2.1.0",
     "grunt-line-remover": "0.0.2",
     "grunt-postcss": "^0.6.0",
     "grunt-sass": "^1.0.0",


### PR DESCRIPTION
Update jscs to 2.x to use babel-jscs (internally) instead of esprima-fb.
Updated a rule to account for ES6 method shorthand
Added `verbose: true` to print out rule names of any errors
