### PR TITLE
Fix issue #17990

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -170,8 +170,6 @@ const Collapse = (($) => {
           .addClass(ClassName.COLLAPSE)
           .addClass(ClassName.IN)
 
-        this._element.style[dimension] = ''
-
         this.setTransitioning(false)
 
         $(this._element).trigger(Event.SHOWN)

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -116,7 +116,7 @@ const Util = (($) => {
     },
 
     reflow(element) {
-      new Function('bs', 'return bs')(element.offsetHeight)
+      return element.offsetHeight
     },
 
     triggerTransitionEnd(element) {


### PR DESCRIPTION
Removed a line which was causing the internal height representation of collapsible elements to reset to 0, which in turn caused the collapse animation to malfunction.
