### PR TITLE
Fix #17990

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -170,8 +170,6 @@ const Collapse = (($) => {
           .addClass(ClassName.COLLAPSE)
           .addClass(ClassName.IN)
 
-        this._element.style[dimension] = ''
-
         this.setTransitioning(false)
 
         $(this._element).trigger(Event.SHOWN)

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -49,7 +49,7 @@ $(function () {
     var $el = $('<div class="collapse"/>').bootstrapCollapse('show')
 
     assert.ok($el.hasClass('in'), 'has class "in"')
-    //assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
+    // assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
   })
 
   QUnit.test('should hide a collapsed element', function (assert) {

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -45,7 +45,7 @@ $(function () {
   })
 
   QUnit.test('should show a collapsed element', function (assert) {
-    assert.expect(2)
+    assert.expect(1)
     var $el = $('<div class="collapse"/>').bootstrapCollapse('show')
 
     assert.ok($el.hasClass('in'), 'has class "in"')

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -49,7 +49,7 @@ $(function () {
     var $el = $('<div class="collapse"/>').bootstrapCollapse('show')
 
     assert.ok($el.hasClass('in'), 'has class "in"')
-    assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
+    //assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
   })
 
   QUnit.test('should hide a collapsed element', function (assert) {
@@ -75,6 +75,7 @@ $(function () {
       .bootstrapCollapse('show')
   })
 
+  /*
   QUnit.test('should reset style to auto after finishing opening collapse', function (assert) {
     assert.expect(2)
     var done = assert.async()
@@ -89,6 +90,7 @@ $(function () {
       })
       .bootstrapCollapse('show')
   })
+  */
 
   QUnit.test('should remove "collapsed" class from target when collapse is shown', function (assert) {
     assert.expect(1)


### PR DESCRIPTION
Reseting the element height causes a malfunction to the animation if the collapsible block is not placed inside a .container or any other class that adjusts the padding. In such cases if height is auto, then offsetHeight is equal to 0, so the collapse animation starts from zero.
