### PR TITLE
Use the `border-radius` mixin for `.label-pill`

### DIFF
--- a/scss/_labels.scss
+++ b/scss/_labels.scss
@@ -43,9 +43,8 @@ a.label {
 .label-pill {
   padding-right: .6em;
   padding-left: .6em;
-  border-radius: 1rem;
+  @include border-radius(1rem);
 }
-
 
 // Colors
 //


### PR DESCRIPTION
Fix #18002
