### PR TITLE
[v4] remove border-radius for first and last cards in group

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -246,6 +246,8 @@
       // Handle rounded corners
       @if $enable-rounded {
         &:first-child {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
           .card-img-top {
             border-top-right-radius: 0;
           }
@@ -254,6 +256,8 @@
           }
         }
         &:last-child {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
           .card-img-top {
             border-top-left-radius: 0;
           }


### PR DESCRIPTION
In a group, cards don't have radius.
- The **right radius** for the **first** card in a group has been removed.
- The **left radius** for the **last** card in a group has been removed.
