### PR TITLE
Add !important to text alignment utility classes

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -51,11 +51,11 @@
 
 // Alignment
 
-.text-left           { text-align: left; }
-.text-right          { text-align: right; }
-.text-center         { text-align: center; }
-.text-justify        { text-align: justify; }
-.text-nowrap         { white-space: nowrap; }
+.text-left           { text-align: left !important; }
+.text-right          { text-align: right !important; }
+.text-center         { text-align: center !important; }
+.text-justify        { text-align: justify !important; }
+.text-nowrap         { white-space: nowrap !important; }
 .text-truncate       { @include text-truncate; }
 
 // Responsive alignment


### PR DESCRIPTION
This addresses the problem pointed out in #16836.
Using `!important` is reasonable in this case since these are utility classes; see
- http://davidtheclark.com/on-utility-classes/
- https://css-tricks.com/when-using-important-is-the-right-choice/

CC: @mdo for review
