### PR TITLE
Add !important to text transform utility classes

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -70,9 +70,9 @@
 
 // Transformation
 
-.text-lowercase      { text-transform: lowercase; }
-.text-uppercase      { text-transform: uppercase; }
-.text-capitalize     { text-transform: capitalize; }
+.text-lowercase      { text-transform: lowercase !important; }
+.text-uppercase      { text-transform: uppercase !important; }
+.text-capitalize     { text-transform: capitalize !important; }
 
 // Contextual colors
 


### PR DESCRIPTION
Again, these are utility classes, so using `!important` makes sense; see
- http://davidtheclark.com/on-utility-classes/
- https://css-tricks.com/when-using-important-is-the-right-choice/

CC: @mdo for review
