### PR TITLE
Add !important to .invisible (visibility:hidden) utility class

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -37,7 +37,7 @@
 }
 
 .invisible {
-  visibility: hidden;
+  visibility: hidden !important;
 }
 
 .text-hide {


### PR DESCRIPTION
And once more, this is a utility class, so using `!important` makes sense; see
- http://davidtheclark.com/on-utility-classes/
- https://css-tricks.com/when-using-important-is-the-right-choice/

CC: @mdo for review
