### PR TITLE
v4 docs Popovers - confusion with doc class names

### DIFF
--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -93,13 +93,13 @@ Four options are available: top, right, bottom, and left aligned.
 ## Live demo
 
 {% example html %}
-<button type="button" class="btn btn-lg btn-danger bd-popover" data-toggle="popover" title="Popover title" data-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
+<button type="button" class="btn btn-lg btn-danger" data-toggle="popover" title="Popover title" data-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 {% endexample %}
 
 ### Four directions
 
 <div class="bd-example popover-demo">
-  <div class="bd-example-popovers">
+  <div class="bd-example-popover">
     <button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="top" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
       Popover on top
     </button>
@@ -145,7 +145,7 @@ For proper cross-browser and cross-platform behavior, you must use the `<a>` tag
 {% endcallout %}
 
 {% example html %}
-<a tabindex="0" class="btn btn-lg btn-danger bd-popover" role="button" data-toggle="popover" data-trigger="focus" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>
+<a tabindex="0" class="btn btn-lg btn-danger" role="button" data-toggle="popover" data-trigger="focus" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>
 {% endexample %}
 
 {% highlight js %}
@@ -306,7 +306,7 @@ Toggles an element's popover. **Returns to the caller before the popover has act
 
 #### `.popover('dispose')`
 
-Hides and destroys an element's popover. Popvoers that use delegation (which are created using [the `selector` option](#options)) cannot be individually destroyed on descendant trigger elements.
+Hides and destroys an element's popover. Popovers that use delegation (which are created using [the `selector` option](#options)) cannot be individually destroyed on descendant trigger elements.
 
 
 {% highlight js %}$('#element').popover('dispose'){% endhighlight %}


### PR DESCRIPTION
Extending/elaborating of v3 docs for Popovers introduced confused names
for doc example classes.  Though v3 docs had similar confusion also.

`/docs/assets/scss/_component-examples.scss` defines class name
`bd-example-popover`.  In file `components/popover.md` could be found
used class names `bd-example-popover`, `bd-example-popover`, and
`bd-popover`.

`bd-popover` was shown in page example code which is bad.  Trying out
either `.popover` or `.bd-example-popover` did not produce useful
results, so this change simply deletes these references.

`bd-example-popovers` was 'corrected' to `bd-example-popover` in
the example "Live demo / Four directions".  This added a background
which however looks out of place for that example, whereas the existing
use in structured example "Static demo" looks nice.  Should the class
have been deleted instead in "Four directions"?

Also one spelling typo corrected.
