### PR TITLE
BUGFIX #18045: fix for gulp main-bower-files injection issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
   "moduleType": "globals",
   "main": [
     "less/bootstrap.less",
-    "dist/js/bootstrap.js"
+    "dist/js/bootstrap.js",
+    "dist/css/bootstrap.css"
   ],
   "ignore": [
     "/.*",


### PR DESCRIPTION
`Gulp` `main-bower-files` auto injection issue as it css path is missing in bower.json.
Fixes #18045.
