### PR TITLE
v4 docs Missed navbar color scheme name changes

### DIFF
--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -15,7 +15,7 @@ The navbar is a simple wrapper for positioning branding, navigation, and other e
 
 Here's what you need to know before getting started with the navbar:
 
-- Navbars require a wrapping `.navbar` and a color scheme class (either `.navbar-default` or `.navbar-inverse`).
+- Navbars require a wrapping `.navbar` and a color scheme class (either `.navbar-light` or `.navbar-dark`).
 - Navbars and their contents are fluid by default. Use [optional containers](#containers) to limit their horizontal width.
 - Use `.pull-left` and `.pull-right` to quickly align sub-components.
 - Ensure accessibility by using a `<nav>` element or, if using a more generic element such as a `<div>`, add a `role="navigation"` to every navbar to explicitly identify it as a landmark region for users of assistive technologies.


### PR DESCRIPTION
Change d6b6a20a0daaed70ec6f395dd813ea460b394e6c missed two doc mentions 
of previous names when changing to new:
-    `.navbar-default`  -->  `.navbar-light`
-    `.navbar-inverse`  -->  `.navbar-dark`
