### PR TITLE
Use Jekyll configuration for blog/slack URLs

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -119,8 +119,8 @@ For improved cross-browser rendering, we use [Normalize.css](http://necolas.gith
 Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.
 
 - Follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap).
-- Read and subscribe to [The Official Bootstrap Blog](http://blog.getbootstrap.com).
-- Join [the official Slack room](https://bootstrap-slack.herokuapp.com).
+- Read and subscribe to [The Official Bootstrap Blog]({{ site.blog }}).
+- Join [the official Slack room]({{ site.slack }}).
 - Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.
 - Implementation help may be found at Stack Overflow (tagged [`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4)).
 - Developers should use the keyword `bootstrap` on packages which modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/browse/keyword/bootstrap) or similar delivery mechanisms for maximum discoverability.


### PR DESCRIPTION
This reuses the existing URLs in the docs Jekyll configuration rather than hard coding.
