### PR TITLE
Replace single remaining v4 docs png with svg

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -135,7 +135,7 @@
   padding: .375rem 1.75rem .375rem .75rem;
   padding-right: .75rem \9;
   vertical-align: middle;
-  background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUCAMAAACzvE1FAAAADFBMVEUzMzMzMzMzMzMzMzMKAG/3AAAAA3RSTlMAf4C/aSLHAAAAPElEQVR42q3NMQ4AIAgEQTn//2cLdRKppSGzBYwzVXvznNWs8C58CiussPJj8h6NwgorrKRdTvuV9v16Afn0AYFOB7aYAAAAAElFTkSuQmCC) no-repeat right .75rem center;
+  background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIAogICAgIHp6eD0iMHB4IiB6enk9IjBweCIgCiAgICAgd2lkdGg9IjE2IiBoZWlnaHQ9IjIwIiB2aWV3Qm94PSIwIDAgMTYgMjAiIAogICAgIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDE2IDIwIj4KICA8cGF0aCBzdHlsZT0iZmlsbDojMzMzMzMzOyIgZD0iTSA4LDAgMCw4IDE2LDggWiIgLz4KICA8cGF0aCBzdHlsZT0iZmlsbDojMzMzMzMzOyIgZD0iTSA4LDIwIDAsMTIgMTYsMTIgeiIgLz4KPC9zdmc+Cg==) no-repeat right .75rem center;
   background-image: none \9;
   background-size: 8px 10px;
   border: 1px solid $input-border;


### PR DESCRIPTION
@XhmikosR pointed out that only one .png image still remained in the
v4 docs.  This inline svg image replaces that up/down arrows icon 
used for select element backgrounds.

This PR should close #18065
