### PR TITLE
Add text-color to .navbar-dark

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -214,12 +214,6 @@
       }
     }
 
-    @include text-emphasis-variant-inverse('.text-primary', $brand-primary);
-    @include text-emphasis-variant-inverse('.text-success', $brand-success);
-    @include text-emphasis-variant-inverse('.text-info',    $brand-info);
-    @include text-emphasis-variant-inverse('.text-warning', $brand-warning);
-    @include text-emphasis-variant-inverse('.text-danger',  $brand-danger);
-
     .open > .nav-link,
     .active > .nav-link,
     .nav-link.open,

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -214,6 +214,12 @@
       }
     }
 
+    @include text-emphasis-variant-inverse('.text-primary', $brand-primary);
+    @include text-emphasis-variant-inverse('.text-success', $brand-success);
+    @include text-emphasis-variant-inverse('.text-info',    $brand-info);
+    @include text-emphasis-variant-inverse('.text-warning', $brand-warning);
+    @include text-emphasis-variant-inverse('.text-danger',  $brand-danger);
+
     .open > .nav-link,
     .active > .nav-link,
     .nav-link.open,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -90,6 +90,15 @@
 
 @include text-emphasis-variant('.text-danger', $brand-danger);
 
+@include text-emphasis-variant-inverse('.text-primary-lighten', $brand-primary);
+
+@include text-emphasis-variant-inverse('.text-success-lighten', $brand-success);
+
+@include text-emphasis-variant-inverse('.text-info-lighten',    $brand-info);
+
+@include text-emphasis-variant-inverse('.text-warning-lighten', $brand-warning);
+
+@include text-emphasis-variant-inverse('.text-danger-lighten',  $brand-danger);
 
 // Contextual backgrounds
 // For now we'll leave these alongside the text classes until v4 when we can

--- a/scss/mixins/_text-emphasis.scss
+++ b/scss/mixins/_text-emphasis.scss
@@ -10,3 +10,14 @@
     }
   }
 }
+
+@mixin text-emphasis-variant-inverse($parent, $color) {
+  #{$parent} {
+    color: $color;
+  }
+  a#{$parent} {
+    @include hover-focus {
+      color: lighten($color, 10%);
+    }
+  }
+}


### PR DESCRIPTION
I add something useful in .navbar-dark.
It will override the old color.
result like follows:

<img width="156" alt="2015-10-27 9 24 06" src="https://cloud.githubusercontent.com/assets/11359892/10761436/5b918910-7cfc-11e5-8ec5-bee58ed38448.png">
<img width="285" alt="2015-10-27 9 25 23" src="https://cloud.githubusercontent.com/assets/11359892/10761442/611c80c4-7cfc-11e5-9c6c-f60f3c612eb1.png">
