### PR TITLE
Make .dl-horizontal be a grid row

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -111,9 +111,7 @@ mark,
 
 // Horizontal description lists w/ grid classes
 .dl-horizontal {
-  margin-right: -$grid-gutter-width;
-  margin-left: -$grid-gutter-width;
-  @include clearfix;
+  @include make-row();
 }
 
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -110,8 +110,10 @@ mark,
 }
 
 // Horizontal description lists w/ grid classes
-.dl-horizontal {
-  @include make-row();
+@if $enable-grid-classes {
+  .dl-horizontal {
+    @include make-row();
+  }
 }
 
 


### PR DESCRIPTION
Making `.dl-horizontal` and his child grid classes working with or without flexbox enabled.

Problem:
![2015-10-28-18-41-56](https://cloud.githubusercontent.com/assets/985838/10795891/6b169792-7da4-11e5-9d83-4a971d60225e.png)
Code:

```
<dl class="dl-horizontal">
  <dt class="col-sm-3">dt.col-sm-3 title lorem ipsum</dt>
  <dd class="col-sm-9">dd.col-sm-9 description lorem ipsum</dd>
</dl>
```
