### PR TITLE
Remove http://wkbug.com/149935 from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -190,16 +190,6 @@
 
 -
   browser: >
-    Safari
-  summary: >
-    Unexplained `1px` horizontal space between `display: table-cell` elements
-  upstream_bug: >
-    WebKit#149935
-  origin: >
-    Bootstrap#17438, Bootstrap#14237
-
--
-  browser: >
     Safari (OS X)
   summary: >
     Scrollbar clipped in `select[multiple]` with padding.


### PR DESCRIPTION
It's been fixed in WebKit Nightly!
See https://trac.webkit.org/changeset/191623 and http://wkbug.com/149366
Refs #17438, #14237

http://getbootstrap.com/browser-bugs
