### PR TITLE
scss/_utilities-responsive.scss: Fix outdated comment heading

### DIFF
--- a/scss/_utilities-responsive.scss
+++ b/scss/_utilities-responsive.scss
@@ -1,5 +1,5 @@
 //
-// Mixins
+// Responsive utilities
 //
 
 @each $bp in map-keys($grid-breakpoints) {


### PR DESCRIPTION
Since this file doesn't define any mixins, the comment no longer makes sense.
