### PR TITLE
Trivially simplify IE10 Mobile viewport bug workaround

### DIFF
--- a/docs/assets/js/ie10-viewport-bug-workaround.js
+++ b/docs/assets/js/ie10-viewport-bug-workaround.js
@@ -17,7 +17,7 @@
         '@-ms-viewport{width:auto!important}'
       )
     )
-    document.querySelector('head').appendChild(msViewportStyle)
+    document.head.appendChild(msViewportStyle)
   }
 
 })();

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -181,7 +181,7 @@ if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
       '@-ms-viewport{width:auto!important}'
     )
   )
-  document.querySelector('head').appendChild(msViewportStyle)
+  document.head.appendChild(msViewportStyle)
 }
 {% endhighlight %}
 


### PR DESCRIPTION
Per http://caniuse.com/#feat=documenthead , `document.head` is supported in IE Mobile 10+, so slightly simplify the JS accordingly (`document.querySelector('head')` => `document.head`).
