### PR TITLE
Fixed border radius for cards in group

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -246,6 +246,9 @@
       // Handle rounded corners
       @if $enable-rounded {
         &:first-child {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+
           .card-img-top {
             border-top-right-radius: 0;
           }
@@ -254,6 +257,9 @@
           }
         }
         &:last-child {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+
           .card-img-top {
             border-top-left-radius: 0;
           }


### PR DESCRIPTION
Using the same syntax as the img. Sample page only works because the first item is an img - the card it self needs border radius.
