### PR TITLE
.navbar-nav - fix margin's value

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -230,7 +230,7 @@
 // the nav the full height of the horizontal nav (above 768px).
 
 .navbar-nav {
-  margin: (@navbar-padding-vertical / 2) -@navbar-padding-horizontal;
+  margin: (@navbar-padding-vertical / 2) - @navbar-padding-horizontal;
 
   > li > a {
     padding-top:    10px;


### PR DESCRIPTION
"margin: (@navbar-padding-vertical / 2) -@navbar-padding-horizontal;" isn't compiled correctly. Result is: "margin: 7.5px -15px;" unprecalculated value. Performance overhead.
