### PR TITLE
Making card images fluid (responsive) by default

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -8,6 +8,10 @@
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
+
+  > img {
+      @extend .img-fluid;
+  }
 }
 
 .card-block {

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -10,7 +10,7 @@
   @include border-radius($card-border-radius);
 
   > img {
-      @extend .img-fluid;
+    @extend .img-fluid;
   }
 }
 


### PR DESCRIPTION
Because of card should replace thumbnails i think card images should fluid (responsive) by default instead of having to add the `img-fluid` class for each image.
