### PR TITLE
Add !important to text and background color utility classes

### DIFF
--- a/scss/mixins/_background-variant.scss
+++ b/scss/mixins/_background-variant.scss
@@ -2,8 +2,8 @@
 
 @mixin bg-variant($parent, $color) {
   #{$parent} {
-    color: #fff;
-    background-color: $color;
+    color: #fff !important;
+    background-color: $color !important;
   }
   a#{$parent} {
     @include hover-focus {

--- a/scss/mixins/_text-emphasis.scss
+++ b/scss/mixins/_text-emphasis.scss
@@ -2,7 +2,7 @@
 
 @mixin text-emphasis-variant($parent, $color) {
   #{$parent} {
-    color: $color;
+    color: $color !important;
   }
   a#{$parent} {
     @include hover-focus {


### PR DESCRIPTION
Using `!important` is reasonable in this case since these are utility classes; see
- http://davidtheclark.com/on-utility-classes/
- https://css-tricks.com/when-using-important-is-the-right-choice/

CC: @mdo for approval
