### PR TITLE
Refactor pagination classes to avoid tag selectors & child selectors

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -18,18 +18,18 @@ Simple pagination inspired by Rdio, great for apps and search results. The large
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li>
+    <li class="page">
       <a href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li><a href="#">1</a></li>
-    <li><a href="#">2</a></li>
-    <li><a href="#">3</a></li>
-    <li><a href="#">4</a></li>
-    <li><a href="#">5</a></li>
-    <li>
+    <li class="page"><a href="#">1</a></li>
+    <li class="page"><a href="#">2</a></li>
+    <li class="page"><a href="#">3</a></li>
+    <li class="page"><a href="#">4</a></li>
+    <li class="page"><a href="#">5</a></li>
+    <li class="page">
       <a href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -46,20 +46,20 @@ Links are customizable for different circumstances. Use `.disabled` for unclicka
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li class="disabled">
+    <li class="page disabled">
       <a href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="active">
+    <li class="page active">
       <a href="#">1 <span class="sr-only">(current)</span></a>
     </li>
-    <li><a href="#">2</a></li>
-    <li><a href="#">3</a></li>
-    <li><a href="#">4</a></li>
-    <li><a href="#">5</a></li>
-    <li>
+    <li class="page"><a href="#">2</a></li>
+    <li class="page"><a href="#">3</a></li>
+    <li class="page"><a href="#">4</a></li>
+    <li class="page"><a href="#">5</a></li>
+    <li class="page">
       <a href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -74,13 +74,13 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li class="disabled">
+    <li class="page disabled">
       <span aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </span>
     </li>
-    <li class="active"><span>1 <span class="sr-only">(current)</span></span></li>
+    <li class="page active"><span>1 <span class="sr-only">(current)</span></span></li>
   </ul>
 </nav>
 {% endexample %}
@@ -93,16 +93,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav>
   <ul class="pagination pagination-lg">
-    <li>
+    <li class="page">
       <a href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li><a href="#">1</a></li>
-    <li><a href="#">2</a></li>
-    <li><a href="#">3</a></li>
-    <li>
+    <li class="page"><a href="#">1</a></li>
+    <li class="page"><a href="#">2</a></li>
+    <li class="page"><a href="#">3</a></li>
+    <li class="page">
       <a href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -115,16 +115,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav>
   <ul class="pagination pagination-sm">
-    <li>
+    <li class="page">
       <a href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li><a href="#">1</a></li>
-    <li><a href="#">2</a></li>
-    <li><a href="#">3</a></li>
-    <li>
+    <li class="page"><a href="#">1</a></li>
+    <li class="page"><a href="#">2</a></li>
+    <li class="page"><a href="#">3</a></li>
+    <li class="page">
       <a href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -18,18 +18,18 @@ Simple pagination inspired by Rdio, great for apps and search results. The large
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li class="page">
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a class="page-link" href="#">1</a></li>
-    <li class="page"><a class="page-link" href="#">2</a></li>
-    <li class="page"><a class="page-link" href="#">3</a></li>
-    <li class="page"><a class="page-link" href="#">4</a></li>
-    <li class="page"><a class="page-link" href="#">5</a></li>
-    <li class="page">
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item"><a class="page-link" href="#">4</a></li>
+    <li class="page-item"><a class="page-link" href="#">5</a></li>
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -46,20 +46,20 @@ Links are customizable for different circumstances. Use `.disabled` for unclicka
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li class="page disabled">
+    <li class="page-item disabled">
       <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page active">
+    <li class="page-item active">
       <a class="page-link" href="#">1 <span class="sr-only">(current)</span></a>
     </li>
-    <li class="page"><a class="page-link" href="#">2</a></li>
-    <li class="page"><a class="page-link" href="#">3</a></li>
-    <li class="page"><a class="page-link" href="#">4</a></li>
-    <li class="page"><a class="page-link" href="#">5</a></li>
-    <li class="page">
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item"><a class="page-link" href="#">4</a></li>
+    <li class="page-item"><a class="page-link" href="#">5</a></li>
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -74,13 +74,13 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 {% example html %}
 <nav>
   <ul class="pagination">
-    <li class="page disabled">
+    <li class="page-item disabled">
       <span class="page-link" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </span>
     </li>
-    <li class="page active"><span class="page-link">1 <span class="sr-only">(current)</span></span></li>
+    <li class="page-item active"><span class="page-link">1 <span class="sr-only">(current)</span></span></li>
   </ul>
 </nav>
 {% endexample %}
@@ -93,16 +93,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav>
   <ul class="pagination pagination-lg">
-    <li class="page">
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a class="page-link" href="#">1</a></li>
-    <li class="page"><a class="page-link" href="#">2</a></li>
-    <li class="page"><a class="page-link" href="#">3</a></li>
-    <li class="page">
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
@@ -115,16 +115,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav>
   <ul class="pagination pagination-sm">
-    <li class="page">
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a class="page-link" href="#">1</a></li>
-    <li class="page"><a class="page-link" href="#">2</a></li>
-    <li class="page"><a class="page-link" href="#">3</a></li>
-    <li class="page">
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -19,18 +19,18 @@ Simple pagination inspired by Rdio, great for apps and search results. The large
 <nav>
   <ul class="pagination">
     <li class="page">
-      <a href="#" aria-label="Previous">
+      <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a href="#">1</a></li>
-    <li class="page"><a href="#">2</a></li>
-    <li class="page"><a href="#">3</a></li>
-    <li class="page"><a href="#">4</a></li>
-    <li class="page"><a href="#">5</a></li>
+    <li class="page"><a class="page-link" href="#">1</a></li>
+    <li class="page"><a class="page-link" href="#">2</a></li>
+    <li class="page"><a class="page-link" href="#">3</a></li>
+    <li class="page"><a class="page-link" href="#">4</a></li>
+    <li class="page"><a class="page-link" href="#">5</a></li>
     <li class="page">
-      <a href="#" aria-label="Next">
+      <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
       </a>
@@ -47,20 +47,20 @@ Links are customizable for different circumstances. Use `.disabled` for unclicka
 <nav>
   <ul class="pagination">
     <li class="page disabled">
-      <a href="#" aria-label="Previous">
+      <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
     <li class="page active">
-      <a href="#">1 <span class="sr-only">(current)</span></a>
+      <a class="page-link" href="#">1 <span class="sr-only">(current)</span></a>
     </li>
-    <li class="page"><a href="#">2</a></li>
-    <li class="page"><a href="#">3</a></li>
-    <li class="page"><a href="#">4</a></li>
-    <li class="page"><a href="#">5</a></li>
+    <li class="page"><a class="page-link" href="#">2</a></li>
+    <li class="page"><a class="page-link" href="#">3</a></li>
+    <li class="page"><a class="page-link" href="#">4</a></li>
+    <li class="page"><a class="page-link" href="#">5</a></li>
     <li class="page">
-      <a href="#" aria-label="Next">
+      <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
       </a>
@@ -75,12 +75,12 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 <nav>
   <ul class="pagination">
     <li class="page disabled">
-      <span aria-label="Previous">
+      <span class="page-link" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </span>
     </li>
-    <li class="page active"><span>1 <span class="sr-only">(current)</span></span></li>
+    <li class="page active"><span class="page-link">1 <span class="sr-only">(current)</span></span></li>
   </ul>
 </nav>
 {% endexample %}
@@ -94,16 +94,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <nav>
   <ul class="pagination pagination-lg">
     <li class="page">
-      <a href="#" aria-label="Previous">
+      <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a href="#">1</a></li>
-    <li class="page"><a href="#">2</a></li>
-    <li class="page"><a href="#">3</a></li>
+    <li class="page"><a class="page-link" href="#">1</a></li>
+    <li class="page"><a class="page-link" href="#">2</a></li>
+    <li class="page"><a class="page-link" href="#">3</a></li>
     <li class="page">
-      <a href="#" aria-label="Next">
+      <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
       </a>
@@ -116,16 +116,16 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <nav>
   <ul class="pagination pagination-sm">
     <li class="page">
-      <a href="#" aria-label="Previous">
+      <a class="page-link" href="#" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page"><a href="#">1</a></li>
-    <li class="page"><a href="#">2</a></li>
-    <li class="page"><a href="#">3</a></li>
+    <li class="page"><a class="page-link" href="#">1</a></li>
+    <li class="page"><a class="page-link" href="#">2</a></li>
+    <li class="page"><a class="page-link" href="#">3</a></li>
     <li class="page">
-      <a href="#" aria-label="Next">
+      <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>
       </a>

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -8,8 +8,7 @@
   .page {
     display: inline; // Remove list-style and block-level defaults
 
-    > a,
-    > span {
+    .page-link {
       position: relative;
       float: left; // Collapse white-space
       padding: $pagination-padding-y $pagination-padding-x;
@@ -21,22 +20,19 @@
       border: $pagination-border-width solid $pagination-border-color;
     }
     &:first-child {
-      > a,
-      > span {
+      .page-link {
         margin-left: 0;
         @include border-left-radius($border-radius);
       }
     }
     &:last-child {
-      > a,
-      > span {
+      .page-link {
         @include border-right-radius($border-radius);
       }
     }
   }
 
-  .page > a,
-  .page > span {
+  .page .page-link {
     @include hover-focus {
       color: $pagination-hover-color;
       background-color: $pagination-hover-bg;
@@ -44,8 +40,7 @@
     }
   }
 
-  .page.active > a,
-  .page.active > span {
+  .page.active .page-link {
     @include plain-hover-focus {
       z-index: 2;
       color: $pagination-active-color;
@@ -56,8 +51,7 @@
   }
 
   .page.disabled {
-    > span,
-    > a {
+    .page-link {
       @include plain-hover-focus {
         color: $pagination-disabled-color;
         cursor: $cursor-disabled;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -5,7 +5,7 @@
   margin-bottom: $spacer-y;
   @include border-radius();
 
-  > li {
+  .page {
     display: inline; // Remove list-style and block-level defaults
 
     > a,
@@ -35,8 +35,8 @@
     }
   }
 
-  > li > a,
-  > li > span {
+  .page > a,
+  .page > span {
     @include hover-focus {
       color: $pagination-hover-color;
       background-color: $pagination-hover-bg;
@@ -44,8 +44,8 @@
     }
   }
 
-  > .active > a,
-  > .active > span {
+  .page.active > a,
+  .page.active > span {
     @include plain-hover-focus {
       z-index: 2;
       color: $pagination-active-color;
@@ -55,7 +55,7 @@
     }
   }
 
-  > .disabled {
+  .page.disabled {
     > span,
     > a {
       @include plain-hover-focus {

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -6,7 +6,7 @@
   @include border-radius();
 }
 
-.page {
+.page-item {
   display: inline; // Remove list-style and block-level defaults
 
   &:first-child {

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -4,43 +4,24 @@
   margin-top: $spacer-y;
   margin-bottom: $spacer-y;
   @include border-radius();
+}
 
-  .page {
-    display: inline; // Remove list-style and block-level defaults
+.page {
+  display: inline; // Remove list-style and block-level defaults
 
+  &:first-child {
     .page-link {
-      position: relative;
-      float: left; // Collapse white-space
-      padding: $pagination-padding-y $pagination-padding-x;
-      margin-left: -1px;
-      line-height: $line-height;
-      color: $pagination-color;
-      text-decoration: none;
-      background-color: $pagination-bg;
-      border: $pagination-border-width solid $pagination-border-color;
+      margin-left: 0;
+      @include border-left-radius($border-radius);
     }
-    &:first-child {
-      .page-link {
-        margin-left: 0;
-        @include border-left-radius($border-radius);
-      }
-    }
-    &:last-child {
-      .page-link {
-        @include border-right-radius($border-radius);
-      }
+  }
+  &:last-child {
+    .page-link {
+      @include border-right-radius($border-radius);
     }
   }
 
-  .page .page-link {
-    @include hover-focus {
-      color: $pagination-hover-color;
-      background-color: $pagination-hover-bg;
-      border-color: $pagination-hover-border;
-    }
-  }
-
-  .page.active .page-link {
+  &.active .page-link {
     @include plain-hover-focus {
       z-index: 2;
       color: $pagination-active-color;
@@ -50,15 +31,31 @@
     }
   }
 
-  .page.disabled {
-    .page-link {
-      @include plain-hover-focus {
-        color: $pagination-disabled-color;
-        cursor: $cursor-disabled;
-        background-color: $pagination-disabled-bg;
-        border-color: $pagination-disabled-border;
-      }
+  &.disabled .page-link {
+    @include plain-hover-focus {
+      color: $pagination-disabled-color;
+      cursor: $cursor-disabled;
+      background-color: $pagination-disabled-bg;
+      border-color: $pagination-disabled-border;
     }
+  }
+}
+
+.page-link {
+  position: relative;
+  float: left; // Collapse white-space
+  padding: $pagination-padding-y $pagination-padding-x;
+  margin-left: -1px;
+  line-height: $line-height;
+  color: $pagination-color;
+  text-decoration: none;
+  background-color: $pagination-bg;
+  border: 1px solid $pagination-border;
+
+  @include hover-focus {
+    color: $pagination-hover-color;
+    background-color: $pagination-hover-bg;
+    border-color: $pagination-hover-border;
   }
 }
 

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -1,7 +1,7 @@
 // Pagination
 
 @mixin pagination-size($padding-vertical, $padding-horizontal, $font-size, $line-height, $border-radius) {
-  > li {
+  .page {
     > a,
     > span {
       padding: $padding-vertical $padding-horizontal;

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -2,21 +2,18 @@
 
 @mixin pagination-size($padding-vertical, $padding-horizontal, $font-size, $line-height, $border-radius) {
   .page {
-    > a,
-    > span {
+    .page-link {
       padding: $padding-vertical $padding-horizontal;
       font-size: $font-size;
       line-height: $line-height;
     }
     &:first-child {
-      > a,
-      > span {
+      .page-link {
         @include border-left-radius($border-radius);
       }
     }
     &:last-child {
-      > a,
-      > span {
+      .page-link {
         @include border-right-radius($border-radius);
       }
     }

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -1,12 +1,13 @@
 // Pagination
 
 @mixin pagination-size($padding-vertical, $padding-horizontal, $font-size, $line-height, $border-radius) {
+  .page-link {
+    padding: $padding-vertical $padding-horizontal;
+    font-size: $font-size;
+    line-height: $line-height;
+  }
+
   .page {
-    .page-link {
-      padding: $padding-vertical $padding-horizontal;
-      font-size: $font-size;
-      line-height: $line-height;
-    }
     &:first-child {
       .page-link {
         @include border-left-radius($border-radius);

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -7,7 +7,7 @@
     line-height: $line-height;
   }
 
-  .page {
+  .page-item {
     &:first-child {
       .page-link {
         @include border-left-radius($border-radius);


### PR DESCRIPTION
Refs https://github.com/twbs/bootstrap/issues/17484#issuecomment-138061549

I'm open to better names for the classes. I used `.page` and `.page-link`.

TODO: Add notes to the v4 migration docs once we've settled on the exact class names.
