### PR TITLE
Added support for more embed-responsive formats

### DIFF
--- a/less/responsive-embed.less
+++ b/less/responsive-embed.less
@@ -24,12 +24,22 @@
   }
 }
 
-// Modifier class for 16:9 aspect ratio
-.embed-responsive-16by9 {
-  padding-bottom: 56.25%;
+// Modifier class for 1:1 aspect ratio
+.embed-responsive-1by1 {
+  padding-bottom: percentage((1 / 1)); // 100%;
 }
 
 // Modifier class for 4:3 aspect ratio
 .embed-responsive-4by3 {
-  padding-bottom: 75%;
+  padding-bottom: percentage((3 / 4)); // 75%;
+}
+
+// Modifier class for 16:9 aspect ratio
+.embed-responsive-16by9 {
+  padding-bottom: percentage((9 / 16)); // 56.25%;
+}
+
+// Modifier class for 21:9 aspect ratio
+.embed-responsive-21by9 {
+  padding-bottom: percentage((9 / 21)); // 42.85%;
 }

--- a/less/responsive-embed.less
+++ b/less/responsive-embed.less
@@ -34,6 +34,11 @@
   padding-bottom: percentage((3 / 4)); // 75%;
 }
 
+// Modifier class for 3:2 aspect ratio
+.embed-responsive-3by2 {
+  padding-bottom: percentage((2 / 3)); // 66.67%;
+}
+
 // Modifier class for 16:9 aspect ratio
 .embed-responsive-16by9 {
   padding-bottom: percentage((9 / 16)); // 56.25%;
@@ -42,4 +47,9 @@
 // Modifier class for 21:9 aspect ratio
 .embed-responsive-21by9 {
   padding-bottom: percentage((9 / 21)); // 42.85%;
+}
+
+// Modifier class for 2.35:1 aspect ratio
+.embed-responsive-235by1 {
+  padding-bottom: percentage((1 / 2.35)); // 42.55%;
 }


### PR DESCRIPTION
I've added support to the `embed-responsive` component for:
- Square `1:1` embedables format such as vine/instagram
- Mobile `3:2` for screencasts
- Cinematic `21:9` or `2.35:1` formats.
