### PR TITLE
Adds linting error for undefined variables

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -2,7 +2,8 @@
     "root": true,
     "parser": "babel-eslint",
     "env": {
-        "browser": true
+        "browser": true,
+        "jquery": true
     },
     "rules": {
 
@@ -98,7 +99,7 @@
         "no-label-var": 2,
         "no-shadow": 0,
         "no-shadow-restricted-names": 2,
-        "no-undef": 0,
+        "no-undef": 2,
         "no-undefined": 0,
         "no-undef-init": 2,
         "no-unused-vars": 2,

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -138,7 +138,7 @@ const Modal = (($) => {
       $(this._dialog).on(Event.MOUSEDOWN_DISMISS, () => {
         $(this._element).one(Event.MOUSEUP_DISMISS, (event) => {
           if ($(event.target).is(this._element)) {
-            that._ignoreBackdropClick = true
+            this._ignoreBackdropClick = true
           }
         })
       })

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -1,3 +1,5 @@
+/* global Tether */
+
 import Util from './util'
 
 


### PR DESCRIPTION
This stems from a discussion on PR #18146 about an undefined variable that wasn't caught by the linter.

This PR adds the rule to the .eslintrc, resolves the errors, one of which was included in #18146, and also adds an npm script to run the linting in the future with `npm run lint`.
