### PR TITLE
Fix behavior of scrollspy with nested navigation

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -57,6 +57,7 @@ const ScrollSpy = (($) => {
     LI              : 'li',
     LI_DROPDOWN     : 'li.dropdown',
     NAV_LINKS       : '.nav-link',
+    NAV_ITEMS       : '.nav-item',
     DROPDOWN        : '.dropdown',
     DROPDOWN_ITEMS  : '.dropdown-item',
     DROPDOWN_TOGGLE : '.dropdown-toggle'
@@ -251,7 +252,8 @@ const ScrollSpy = (($) => {
       } else {
         // todo (fat) this is kinda sus…
         // recursively add actives to tested nav-links
-        $link.parents(Selector.LI).find(Selector.NAV_LINKS).addClass(ClassName.ACTIVE)
+        $link.addClass(ClassName.ACTIVE)
+        $link.parents(Selector.NAV_ITEMS).children(Selector.NAV_LINKS).addClass(ClassName.ACTIVE)
       }
 
       $(this._scrollElement).trigger(Event.ACTIVATE, {

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -211,9 +211,9 @@ $(function () {
     var done = assert.async()
     var navbarHtml = '<nav id="navigation" class="navbar">'
       + '<ul class="nav">'
-      + '<li><a id="a-1" class="nav-link" href="#div-1">div 1</a>'
+      + '<li class="nav-item"><a id="a-1" class="nav-link" href="#div-1">div 1</a>'
       + '<ul>'
-      + '<li><a id="a-2" class="nav-link" href="#div-2">div 2</a></li>'
+      + '<li class="nav-item"><a id="a-2" class="nav-link" href="#div-2">div 2</a></li>'
       + '</ul>'
       + '</li>'
       + '</ul>'


### PR DESCRIPTION
Consider a nav like this with scrollspy enabled:

```
<ul class="nav">

    ...

    <li class="nav-item">
        <a class="nav-link" href="#link-2">Link 2</a>
        <ul class="nav">
            <li class="nav-item">
                <a href="#link-2-a" class="nav-link">Link 2-A</a>
            </li>
            <li class="nav-item">
                <a href="#link-2-b" class="nav-link">Link 2-B</a>
            </li>
        </ul>
    </li>

    ...

</ul>
```

When scrolling without this patch applied and any of these links come
into view, they will all receive .active. With this patch applied, the
active link and links above it in the tree will receive .active. This
matches the behavior of Bootstrap 3.

Before:

![](https://sr.ht/BRIy.png)

After:

![](https://sr.ht/VorE.png)
