### PR TITLE
Add .card-default that sets white background-color

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -91,6 +91,10 @@
 // Background variations
 //
 
+.card-default {
+  background-color: #fff;
+  border-color: #fff;
+}
 .card-primary {
   background-color: $brand-primary;
   border-color: $brand-primary;


### PR DESCRIPTION
Add an option for users who want a plain, white background for cards, instead of ~~inheriting the background~~ [having a transparent background – Ed.].

See issue #18153.
