### PR TITLE
Switch to a numerical color variant naming system based on lightness of variants

### DIFF
--- a/scss/_utilities-background.scss
+++ b/scss/_utilities-background.scss
@@ -28,9 +28,9 @@
 
 @include bg-variant('.bg-danger', $brand-danger);
 
-@include bg-variant('.bg-gray-100', $brand-gray-100);
-@include bg-variant('.bg-gray-300', $brand-gray-300);
-@include bg-variant('.bg-gray-500', $brand-gray-500);
-@include bg-variant('.bg-gray',     $brand-gray);
-@include bg-variant('.bg-gray-700', $brand-gray-700);
-@include bg-variant('.bg-gray-900', $brand-gray-900);
+@include bg-variant('.bg-gray-100', $gray-100);
+@include bg-variant('.bg-gray-300', $gray-300);
+@include bg-variant('.bg-gray-500', $gray-500);
+@include bg-variant('.bg-gray',     $gray);
+@include bg-variant('.bg-gray-700', $gray-700);
+@include bg-variant('.bg-gray-900', $gray-900);

--- a/scss/_utilities-background.scss
+++ b/scss/_utilities-background.scss
@@ -13,7 +13,12 @@
   background-color: $gray-lightest;
 }
 
-@include bg-variant('.bg-primary', $brand-primary);
+@include bg-variant('.bg-primary-100', $brand-primary-100);
+@include bg-variant('.bg-primary-300', $brand-primary-300);
+@include bg-variant('.bg-primary-500', $brand-primary-500);
+@include bg-variant('.bg-primary',     $brand-primary);
+@include bg-variant('.bg-primary-700', $brand-primary-700);
+@include bg-variant('.bg-primary-900', $brand-primary-900);
 
 @include bg-variant('.bg-success', $brand-success);
 
@@ -22,3 +27,10 @@
 @include bg-variant('.bg-warning', $brand-warning);
 
 @include bg-variant('.bg-danger', $brand-danger);
+
+@include bg-variant('.bg-gray-100', $brand-gray-100);
+@include bg-variant('.bg-gray-300', $brand-gray-300);
+@include bg-variant('.bg-gray-500', $brand-gray-500);
+@include bg-variant('.bg-gray',     $brand-gray);
+@include bg-variant('.bg-gray-700', $brand-gray-700);
+@include bg-variant('.bg-gray-900', $brand-gray-900);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -26,11 +26,25 @@
 //
 // Grayscale and brand colors for use across Bootstrap.
 
-$gray-dark:                 #373a3c !default;
-$gray:                      #55595c !default;
-$gray-light:                #818a91 !default;
-$gray-lighter:              #eceeef !default;
-$gray-lightest:             #f7f7f9 !default;
+$gray-base:                 #000;
+
+$gray-lightest:             lighten($gray-base, 93%) !default;
+$gray-lighter:              lighten($gray-base, 72%) !default;
+$gray-light:                lighten($gray-base, 46%) !default;
+$gray:                      lighten($gray-base, 33%) !default;
+$gray-dark:                 lighten($gray-base, 20%) !default;
+$gray-darker:               lighten($gray-base, 13%) !default;
+$gray-darkest:              lighten($gray-base,  5%) !default;
+
+
+$gray-100:                  $gray-lightest !default;
+$gray-300:                  $gray-lighter !default;
+$gray-400:                  $gray-light !default;
+$gray-500:                  $gray !default;
+$gray-600:                  $gray-dark !default;
+$gray-700:                  $gray-darker !default;
+$gray-900:                  $gray-darkest !default;
+
 
 $brand-primary:             #0275d8 !default;
 $brand-success:             #5cb85c !default;
@@ -38,6 +52,12 @@ $brand-info:                #5bc0de !default;
 $brand-warning:             #f0ad4e !default;
 $brand-danger:              #d9534f !default;
 
+
+$brand-primary-100:         lighten($brand-primary,22%) !default;
+$brand-primary-300:         lighten($brand-primary,10%) !default;
+$brand-primary-500:         $brand-primary !default;
+$brand-primary-700:         darken($brand-primary,10%) !default;
+$brand-primary-900:         darken($brand-primary,22%) !default;
 
 // Options
 //


### PR DESCRIPTION
Inspired by Font-Weights (200, 400, 600...) and the Material Design Color System (https://www.google.com/design/spec/style/color.html#color-color-palette):
Use numbers to define different shades of gray. This is much more consistent and extendable than light, lighter, lightest, lightest-light.
Because sometimes Designers want just more than 5 shades of gray (or primary colors)
