### PR TITLE
Fixed: IE and Edge round percentages too aggressively

### DIFF
--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -46,11 +46,13 @@
 .calc-grid-column(@index, @class, @type) when (@type = width) and (@index > 0) {
   .col-@{class}-@{index} {
     width: percentage((@index / @grid-columns));
+    width: calc(100% * @index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = push) and (@index > 0) {
   .col-@{class}-push-@{index} {
     left: percentage((@index / @grid-columns));
+    left: calc(100% * @index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = push) and (@index = 0) {
@@ -61,6 +63,7 @@
 .calc-grid-column(@index, @class, @type) when (@type = pull) and (@index > 0) {
   .col-@{class}-pull-@{index} {
     right: percentage((@index / @grid-columns));
+    right: calc(100% * @index / @grid-columns);
   }
 }
 .calc-grid-column(@index, @class, @type) when (@type = pull) and (@index = 0) {
@@ -71,6 +74,7 @@
 .calc-grid-column(@index, @class, @type) when (@type = offset) {
   .col-@{class}-offset-@{index} {
     margin-left: percentage((@index / @grid-columns));
+    margin-left: calc(100% * @index / @grid-columns);
   }
 }
 

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -23,18 +23,22 @@
   position: relative;
   float: left;
   width: percentage((@columns / @grid-columns));
+  width: calc(100% * @columns / @grid-columns);
   min-height: 1px;
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 }
 .make-xs-column-offset(@columns) {
   margin-left: percentage((@columns / @grid-columns));
+  margin-left: calc(100% * @columns / @grid-columns);
 }
 .make-xs-column-push(@columns) {
   left: percentage((@columns / @grid-columns));
+  left: calc(100% * @columns / @grid-columns);
 }
 .make-xs-column-pull(@columns) {
   right: percentage((@columns / @grid-columns));
+  right: calc(100% * @columns / @grid-columns);
 }
 
 // Generate the small columns
@@ -47,21 +51,25 @@
   @media (min-width: @screen-sm-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
+    width: calc(100% * @columns / @grid-columns);
   }
 }
 .make-sm-column-offset(@columns) {
   @media (min-width: @screen-sm-min) {
     margin-left: percentage((@columns / @grid-columns));
+    margin-left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-sm-column-push(@columns) {
   @media (min-width: @screen-sm-min) {
     left: percentage((@columns / @grid-columns));
+    left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-sm-column-pull(@columns) {
   @media (min-width: @screen-sm-min) {
     right: percentage((@columns / @grid-columns));
+    right: calc(100% * @columns / @grid-columns);
   }
 }
 
@@ -75,21 +83,25 @@
   @media (min-width: @screen-md-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
+    width: calc(100% * @columns / @grid-columns);
   }
 }
 .make-md-column-offset(@columns) {
   @media (min-width: @screen-md-min) {
     margin-left: percentage((@columns / @grid-columns));
+    margin-left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-md-column-push(@columns) {
   @media (min-width: @screen-md-min) {
     left: percentage((@columns / @grid-columns));
+    left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-md-column-pull(@columns) {
   @media (min-width: @screen-md-min) {
     right: percentage((@columns / @grid-columns));
+    right: calc(100% * @columns / @grid-columns);
   }
 }
 
@@ -103,20 +115,24 @@
   @media (min-width: @screen-lg-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
+    width: calc(100% * @columns / @grid-columns);
   }
 }
 .make-lg-column-offset(@columns) {
   @media (min-width: @screen-lg-min) {
     margin-left: percentage((@columns / @grid-columns));
+    margin-left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-lg-column-push(@columns) {
   @media (min-width: @screen-lg-min) {
     left: percentage((@columns / @grid-columns));
+    left: calc(100% * @columns / @grid-columns);
   }
 }
 .make-lg-column-pull(@columns) {
   @media (min-width: @screen-lg-min) {
     right: percentage((@columns / @grid-columns));
+    right: calc(100% * @columns / @grid-columns);
   }
 }


### PR DESCRIPTION
Hi,

I'm a Layout PM of the Edge team and I recently detected a defect in our engine which affects a (probably very) small amount of websites using Bootstrap.

While the bug is general and probably worth fixing anyway, I figured out you may be interested in integrating a fix which will keep your users away from the issue. If so, feel free to do it. If not, this pull request will at least serve as a searchable reference in case anyone face this issue in the future.

**The issue is related to how IE/Edge parses css percentages**. Percentage values like are seemingly floored to two decimals only `66.666667% = 66.66%`. In most cases, that doesn't affect the visual rendering if you stick to using percentages for your entire layout. Infrequently, some people seem to use pixel units in their layout and rely on those working for proper wrapping, which causes issues in IE/Edge.

You can see the issue here: http://codepen.io/anon/pen/WQavNy

**The proposed fix is to avoid the CSS Parser for percentages** and to let browsers compute the right value directly using a calc expression like `calc(100% * 4 / 12)`. This has the nice advantage of being easily readable in the source code.

You can see the fix here: http://codepen.io/anon/pen/EVdjKa
