### PR TITLE
.media-right regardless of dom order

### DIFF
--- a/scss/_media.scss
+++ b/scss/_media.scss
@@ -12,6 +12,9 @@
   .media-bottom {
     align-self: flex-end;
   }
+  .media-right {
+    order: 1;
+  }
 } @else {
   .media {
     margin-top: 15px;


### PR DESCRIPTION
The docs show the use of .media-right requiring reordering .media-body and .media-right in the dom.

As we now have flex-box we can just use order so the dom order doesn't matter.

In the case of having css turned off having the image come first is often better.
