### PR TITLE
Ensure proper z-indexing in input-groups

### DIFF
--- a/less/input-groups.less
+++ b/less/input-groups.less
@@ -29,6 +29,10 @@
 
     width: 100%;
     margin-bottom: 0;
+    
+    &:focus {
+      z-index: 3;
+    }
   }
 }
 


### PR DESCRIPTION
Alternate fix to #17007 that limits the `z-index: 3` to only be on `:focus`.
