### PR TITLE
Stop using $body-bg as default value of $nav-tabs-active-link-hover-bg

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -366,7 +366,7 @@ $nav-tabs-border-color:                     #ddd !default;
 
 $nav-tabs-link-hover-border-color:          $gray-lighter !default;
 
-$nav-tabs-active-link-hover-bg:             $body-bg !default;
+$nav-tabs-active-link-hover-bg:             #fff !default;
 $nav-tabs-active-link-hover-color:          $gray !default;
 $nav-tabs-active-link-hover-border-color:   #ddd !default;
 


### PR DESCRIPTION
$body-bg made no sense here
