### PR TITLE
Introduced sentence case text transform class

### DIFF
--- a/docs/_includes/css/type.html
+++ b/docs/_includes/css/type.html
@@ -210,11 +210,13 @@ You can use the mark tag to <mark>highlight</mark> text.
   <div class="bs-example" data-example-id="text-capitalization">
     <p class="text-lowercase">Lowercased text.</p>
     <p class="text-uppercase">Uppercased text.</p>
+    <p class="text-sentencecase">SENTENCE CASE TEXT.</p>
     <p class="text-capitalize">Capitalized text.</p>
   </div>
 {% highlight html %}
 <p class="text-lowercase">Lowercased text.</p>
 <p class="text-uppercase">Uppercased text.</p>
+<p class="text-sentencecase">SENTENCE CASE TEXT.</p>
 <p class="text-capitalize">Capitalized text.</p>
 {% endhighlight %}
 

--- a/less/type.less
+++ b/less/type.less
@@ -97,6 +97,12 @@ mark,
 .text-lowercase      { text-transform: lowercase; }
 .text-uppercase      { text-transform: uppercase; }
 .text-capitalize     { text-transform: capitalize; }
+.text-sentencecase {
+  text-transform: lowercase;
+  &:first-letter {
+    text-transform: uppercase;
+  }
+}
 
 // Contextual colors
 .text-muted {


### PR DESCRIPTION
Use text-sentencecase to ensure only the first character in the given
text block is shown
in uppercase.
