### PR TITLE
Docs: Separate Tether out from docs.min.js

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -14,6 +14,8 @@
 <script src="{{ site.cdn.jquery }}"></script>
 <script>window.jQuery || document.write('<script src="{{ site.baseurl }}/assets/js/vendor/jquery.min.js"><\/script>')</script>
 
+<script src="{{ site.baseurl }}/assets/js/vendor/tether.min.js"></script>
+
 {% if site.github %}
   <script src="{{ site.baseurl }}/dist/js/bootstrap.min.js"></script>
 {% else %}

--- a/grunt/configBridge.json
+++ b/grunt/configBridge.json
@@ -4,7 +4,6 @@
       "../assets/js/vendor/anchor.min.js",
       "../assets/js/vendor/clipboard.min.js",
       "../assets/js/vendor/holder.min.js",
-      "../assets/js/vendor/tether.min.js",
       "../assets/js/src/application.js"
     ]
   }


### PR DESCRIPTION
We can't include it in docs.min.js because docs.min.js includes application.js,
application.js depends on bootstrap.js,
and the tooltip portion of bootstrap.js depends on Tether.

So instead, we need to load Tether separately before bootstrap.js

CC: @XhmikosR @hnrch02 
