### PR TITLE
Updating "Reporting upstream browser bugs" for IE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ When feasible, we aim to report such upstream bugs to the relevant browser vendo
 | Mozilla       | Firefox                      | Gecko            | https://bugzilla.mozilla.org/enter_bug.cgi                                            | "Core" is normally the right product option to choose.   |
 | Apple         | Safari                       | WebKit           | https://bugs.webkit.org/enter_bug.cgi?product=WebKit <br> https://bugreport.apple.com | In Apple's bug reporter, choose "Safari" as the product. |
 | Google, Opera | Chrome, Chromium, Opera v15+ | Blink            | https://code.google.com/p/chromium/issues/list                                        | Click the "New issue" button.                            |
-| Microsoft     | Internet Explorer            | Trident          | https://connect.microsoft.com/IE/feedback/LoadSubmitFeedbackForm                      |                                                          |
+| Microsoft     | Internet Explorer/Microsoft Edge            | Trident/ EdgeHTML          | [https://connect.microsoft.com/IE/feedback/](https://connect.microsoft.com/IE/feedback/CreateFeedbackForm.aspx?FeedbackFormConfigurationID=5534&FeedbackType=1)                      |                                                          |
 
 ### Issues bots
 


### PR DESCRIPTION
Adding Microsoft Edge and the Rendering Engine EdgeHTML also updating the link to point directly to the bug feedback form.
