### PR TITLE
Prevent anchors in tooltip example from splitting across lines

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -266,6 +266,10 @@
 }
 
 // Tooltips
+.tooltip-demo a {
+  white-space: nowrap;
+}
+
 .bd-example-tooltip-static .tooltip {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
So as to decrease the number of future inquiries about said edge case (which is already documented) ("OMG, this tooltip in the docs is broken!").
Refs #18304.
CC: @mdo for review
