### PR TITLE
Travis CI: Use Node.js 5 instead of "stable"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   depth: 10
 node_js:
   - "4"
-  - "stable"
+  - "5"
 before_install:
   - rvm install 2.2
   - rvm use 2.2 --fuzzy


### PR DESCRIPTION
Refs https://github.com/twbs/grunt-bootlint/pull/61
CC: @XhmikosR @hnrch02 
