### PR TITLE
Temporarily disable RubyGem caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ install:
 cache:
   directories:
     - node_modules
-    - vendor/bundle
+# Disabled due to https://github.com/travis-ci/travis-ci/issues/5092
+#    - vendor/bundle
 env:
   global:
     - SAUCE_USERNAME="bootstrap"


### PR DESCRIPTION
Until https://github.com/travis-ci/travis-ci/issues/5092 gets resolved. A slow build is better than a broken build.
Based on @XhmikosR's findings in https://github.com/travis-ci/travis-ci/issues/5092#issuecomment-159580363
CC: @hnrch02 @XhmikosR 
