### PR TITLE
SauceLabs tests: Bump iOS to v9.1

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -46,7 +46,7 @@
   {
     browserName: "iphone",
     platform: "OS X 10.10",
-    version: "8.2"
+    version: "9.1"
   },
 
   # iOS Chrome not currently supported by Sauce Labs


### PR DESCRIPTION
Blocked on #18376 or similar.
