### PR TITLE
Bump Safari to v8 in Autoprefixer settings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
       'Explorer >= 9',
       // Out of leniency, we prefix these 1 version further back than the official policy.
       'iOS >= 8',
-      'Safari >= 7.1',
+      'Safari >= 8',
       // The following remain NOT officially supported, but we're lenient and include their prefixes to avoid severely breaking in them.
       'Android 2.3',
       'Android >= 4',


### PR DESCRIPTION
The latest OS X Safari version is 9.0.1
Our prefixing policy dictates that we prefix 1 version back from the latest version.
9.0.1 - 1_major_version = 8.0
