### PR TITLE
Bump iOS to v8 in Autoprefixer settings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
       'Edge >= 12',
       'Explorer >= 9',
       // Out of leniency, we prefix these 1 version further back than the official policy.
-      'iOS >= 7',
+      'iOS >= 8',
       'Safari >= 7.1',
       // The following remain NOT officially supported, but we're lenient and include their prefixes to avoid severely breaking in them.
       'Android 2.3',


### PR DESCRIPTION
The latest iOS version is 9.1
Our prefixing policy dictates that we prefix 1 version back from the latest version.
9.1 - 1_major_version = 8.0

The resulting CSS happens to be unchanged.
