### PR TITLE
Use $card-border-width for .card-inverse's header/footer border-bottom override

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -121,7 +121,7 @@
 .card-inverse {
   .card-header,
   .card-footer {
-    border-bottom: .075rem solid rgba(255,255,255,.2);
+    border-bottom: $card-border-width solid rgba(255,255,255,.2);
   }
   .card-header,
   .card-footer,


### PR DESCRIPTION
Fixes part of #18150.
CC: @mdo
