### PR TITLE
Exempt getUID() from ESLint's no-bitwise rule

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -10,7 +10,7 @@
         // Possible Errors
         "comma-dangle": [2, "never"],
         "handle-callback-err": 2,
-        "no-bitwise": 0,
+        "no-bitwise": 2,
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -99,7 +99,9 @@ const Util = (($) => {
 
     getUID(prefix) {
       do {
+        /* eslint-disable no-bitwise */
         prefix += ~~(Math.random() * 1000000) // "~~" acts like a faster Math.floor() here
+        /* eslint-enable no-bitwise */
       } while (document.getElementById(prefix))
       return prefix
     },


### PR DESCRIPTION
With the goal of enabling `no-bitwise` everywhere else.
