### PR TITLE
dropdown.js: Use more straightforward phrasing for index bound check

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -250,7 +250,7 @@ const Dropdown = (($) => {
         index++
       }
 
-      if (!~index) {
+      if (index < 0) {
         index = 0
       }
 


### PR DESCRIPTION
`!~index` is unnecessarily tricky.
