### PR TITLE
SCSS Lint: explicitly enable PseudoElement check

### DIFF
--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -381,6 +381,9 @@ linters:
     enabled: true
     extra_properties: []
 
+  PseudoElement:
+    enabled: true
+
   QualifyingElement:
     enabled: false
     allow_element_with_attribute: false


### PR DESCRIPTION
I believe we concluded that the psuedo-element form should be preferred over the pseudo-class form where both exist? This would enforce that in the SCSS linter.
