### PR TITLE
Proposed better phrasing in the "images" section

### DIFF
--- a/docs/content/images.md
+++ b/docs/content/images.md
@@ -26,7 +26,7 @@ Images in Bootstrap are made responsive with `.img-fluid`. `max-width: 100%;` an
 {% callout warning %}
 #### SVG images and IE 9-10
 
-In Internet Explorer 9-10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. Bootstrap doesn't apply this automatically as it causes complications to other image formats.
+In Internet Explorer 9-10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. This fix improperly sizes other image formats, so Bootstrap doesn't apply it automatically.
 {% endcallout %}
 
 ## Image shapes


### PR DESCRIPTION
Previously, this read "Bootstrap doesn’t apply this automatically as it causes complications to other image formats." 

In this sentence, the number of the subject and the verb don't agree, and the word "this" is unclear.
