### PR TITLE
Multiple button addons in input groups

### DIFF
--- a/docs/components/input-group.md
+++ b/docs/components/input-group.md
@@ -110,13 +110,22 @@ Buttons in input groups are a bit different and require one extra level of nesti
 </div>
 <br>
 <div class="row">
-  <div class="col-lg-offset-3 col-lg-6">
+  <div class="col-lg-6">
     <div class="input-group">
       <span class="input-group-btn">
         <button class="btn btn-secondary" type="button">Hate it</button>
       </span>
       <input type="text" class="form-control" placeholder="Product name">
       <span class="input-group-btn">
+        <button class="btn btn-secondary" type="button">Love it</button>
+      </span>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="input-group">
+      <input type="text" class="form-control" placeholder="Product name">
+      <span class="input-group-btn">
+        <button class="btn btn-secondary" type="button">Hate it</button>
         <button class="btn btn-secondary" type="button">Love it</button>
       </span>
     </div>
@@ -158,6 +167,38 @@ Buttons in input groups are a bit different and require one extra level of nesti
           <a class="dropdown-item" href="#">Something else here</a>
           <div role="separator" class="dropdown-divider"></div>
           <a class="dropdown-item" href="#">Separated link</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="col-lg-offset-3 col-lg-6">
+    <div class="input-group">
+      <input type="text" class="form-control" aria-label="Text input with dropdown button">
+      <div class="input-group-btn">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Hate it
+        </button>
+        <div class="dropdown-menu dropdown-menu-right">
+          <a class="dropdown-item" href="#">Be annoyed by it</a>
+          <a class="dropdown-item" href="#">Be angry with it</a>
+          <a class="dropdown-item" href="#">Shout at it</a>
+          <div role="separator" class="dropdown-divider"></div>
+          <a class="dropdown-item" href="#">Throw it away</a>
+        </div>
+      </div>
+      <div class="input-group-btn">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Love it
+        </button>
+        <div class="dropdown-menu dropdown-menu-right">
+          <a class="dropdown-item" href="#">Hug it</a>
+          <a class="dropdown-item" href="#">Laugh</a>
+          <a class="dropdown-item" href="#">Dance</a>
+          <div role="separator" class="dropdown-divider"></div>
+          <a class="dropdown-item" href="#">Share your love</a>
         </div>
       </div>
     </div>

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -35,7 +35,9 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  @include form-control-focus();
+  &:focus {
+    @include form-control-focus();
+  }
 
   // Placeholder
   &::placeholder {
@@ -58,6 +60,12 @@
 
   &:disabled {
     cursor: $cursor-disabled;
+  }
+
+  // Also highlight buttons and dropdown toggles after the focused input in an input group.
+  .input-group > &:first-child:focus ~ .input-group-btn > .btn,
+  .input-group > &:first-child:focus ~ .input-group-btn > .dropdown-toggle {
+    @include form-control-focus();
   }
 }
 

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -61,12 +61,6 @@
   &:disabled {
     cursor: $cursor-disabled;
   }
-
-  // Also highlight buttons and dropdown toggles after the focused input in an input group.
-  .input-group > &:first-child:focus ~ .input-group-btn > .btn,
-  .input-group > &:first-child:focus ~ .input-group-btn > .dropdown-toggle {
-    @include form-control-focus();
-  }
 }
 
 

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -101,7 +101,7 @@
   color: $input-color;
   text-align: center;
   background-color: $input-group-addon-bg;
-  border: 1px solid $input-group-addon-border-color;
+  border: $input-border-width solid $input-group-addon-border-color;
   @include border-radius($border-radius);
 
   // Sizing
@@ -180,18 +180,18 @@
     }
     @include focus-active {
       z-index: 4;
-      margin-left: -1px;
-      border-left-width: 1px;
+      margin-left: -$input-border-width;
+      border-left-width: $input-border-width;
     }
   }
 
-  // Negative margin to only have a 1px border between the two
+  // Negative margin to not have a double border between the two
   &:first-child {
     > .btn,
     > .btn-group {
-      margin-right: -1px;
+      margin-right: -$input-border-width;
       // Undo having no border here, because it is the first element
-      border-left-width: 1px;
+      border-left-width: $input-border-width;
       // Also do not move left on focus
       @include focus-active {
         margin-left: 0;

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -37,6 +37,12 @@
       width: 100%;
     }
     margin-bottom: 0;
+
+    // Also highlight buttons and dropdown toggles after the focused input in an input group.
+    &:first-child:focus ~ .input-group-btn > .btn,
+    &:first-child:focus ~ .input-group-btn > .dropdown-toggle {
+      @include form-control-focus();
+    }
   }
 }
 

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -174,8 +174,8 @@
     }
     @include focus-active {
       z-index: 4;
-      border-left-width: 1px;
       margin-left: -1px;
+      border-left-width: 1px;
     }
   }
 

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -19,9 +19,13 @@
     // proper border colors.
     position: relative;
     z-index: 2;
-    // Bring the "active" form control to the front
-    @include hover-focus-active {
+    // Bring the "active" form control to the front, but hover slightly less
+    // than focus/active so that hover does not cover focused inputs
+    @include hover {
       z-index: 3;
+    }
+    @include focus-active {
+      z-index: 4;
     }
     @if $enable-flex {
       flex: 1;
@@ -142,6 +146,9 @@
 .input-group-addon:last-child {
   border-left: 0;
 }
+.input-group > .input-group-btn:not(:last-child) > .btn {
+  @include border-radius(0);
+}
 
 
 //
@@ -155,16 +162,20 @@
   font-size: 0;
   white-space: nowrap;
 
-  // Negative margin for spacing, position for bringing hovered/focused/actived
-  // element above the siblings.
+  // No left border for spacing, position for bringing hovered/focused/actived
+  // element above the siblings, set the left border only then.
   > .btn {
     position: relative;
-    + .btn {
-      margin-left: -1px;
-    }
-    // Bring the "active" button to the front
-    @include hover-focus-active {
+    border-left-width: 0;
+    // Bring the "active" button to the front, but hover slightly less than
+    // focus/active so that hover does not cover focused inputs
+    @include hover {
       z-index: 3;
+    }
+    @include focus-active {
+      z-index: 4;
+      border-left-width: 1px;
+      margin-left: -1px;
     }
   }
 
@@ -173,16 +184,24 @@
     > .btn,
     > .btn-group {
       margin-right: -1px;
+      // Undo having no border here, because it is the first element
+      border-left-width: 1px;
+      // Also do not move left on focus
+      @include focus-active {
+        margin-left: 0;
+      }
     }
   }
   &:last-child {
     > .btn,
     > .btn-group {
       z-index: 2;
-      margin-left: -1px;
       // Because specificity
-      @include hover-focus-active {
+      @include hover {
         z-index: 3;
+      }
+      @include focus-active {
+        z-index: 4;
       }
     }
   }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -54,12 +54,10 @@
 // Example usage: change the default blue border and shadow to white for better
 // contrast against a dark gray background.
 @mixin form-control-focus() {
-  &:focus {
-    border-color: $input-border-focus;
-    outline: none;
-    $shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px $input-box-shadow-focus;
-    @include box-shadow($shadow);
-  }
+  border-color: $input-border-focus;
+  outline: none;
+  $shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px $input-box-shadow-focus;
+  @include box-shadow($shadow);
 }
 
 // Form control sizing

--- a/scss/mixins/_hover.scss
+++ b/scss/mixins/_hover.scss
@@ -61,6 +61,6 @@
 @mixin focus-active {
   &:focus,
   &:active {
-      @content
+    @content
   }
 }

--- a/scss/mixins/_hover.scss
+++ b/scss/mixins/_hover.scss
@@ -57,3 +57,10 @@
     }
   }
 }
+
+@mixin focus-active {
+  &:focus,
+  &:active {
+      @content
+  }
+}


### PR DESCRIPTION
_Let me start by saying that I am not sure if this qualifies as a bug fix or a feature request, but I feel like it is more a feature request, hence I am opening this against the `v4-dev` branch.
I can make this work for `master` too, if you like._

**Changes I made**
_(as screenshots, because images say more than a 1000 words and all that)_

**Before**
![before](https://cloud.githubusercontent.com/assets/1019269/11560768/25f66b02-99c3-11e5-9ef9-7b871ed4baac.png)
![before-focus](https://cloud.githubusercontent.com/assets/1019269/11560851/b6b9bf18-99c3-11e5-8eed-b2e3cfa15433.png)

**After**
![after](https://cloud.githubusercontent.com/assets/1019269/11560864/c491ca0e-99c3-11e5-8fe8-9a811c1ae73d.png)
![after-focus](https://cloud.githubusercontent.com/assets/1019269/11560867/c8bd7fce-99c3-11e5-9637-977bcec33c52.png)
![after-dropdown-1](https://cloud.githubusercontent.com/assets/1019269/11560870/cd8f8e20-99c3-11e5-83e2-b0ace520659a.png)
![after-dropdown-2](https://cloud.githubusercontent.com/assets/1019269/11560871/d079fdbe-99c3-11e5-8f8f-8fe0f9297e85.png)

**Aim of change**
In an `.input-group`, it is now possible to add multiple button addons after the input with dropdown menus. These have to be placed in separate `.input-group-btn` elements because otherwise the JavaScript breaks. Focus state now highlights the complete group of controls too, instead of only the input. Note that the highlighting only works if the input is the first element in the `.input-group`, because of CSS limitations (I want [`:focus-within`](https://drafts.csswg.org/selectors-4/#focus-within-pseudo)).

**Usecase**
In a project I implemented this for, I have a search box where the user can change a couple of settings for the search. There are three settings that are all of the type 'select from a couple of options'. My approach (that I feel is intuitive, correct me if I'm wrong) was to add three dropdown selects as addons. When that was not styled the way I expected it to be, I first tried to find out what I was doing wrong, then whipped up this, then improved it before creating this pull request.

**Remarks**
I am aware of the following issues:
- The highlighting does not work when there are addons before the input. I purposefully disabled the highlighting of other controls then, because I am unable to select the siblings before the `:focus`ed input with pure CSS. An implementation using JS is of course possible, but I think that that is not something you guys would be happy with, right? This can be fixed once (if) the CSS4 [`:focus-within`](https://drafts.csswg.org/selectors-4/#focus-within-pseudo) selector is supported.
- The left border of buttons is not visible when hovering them. The current implementation has exactly this issue, but for right borders. As soon as a button is focused or active, the border becomes visible. The current implementation will still not show the right border when the button is focused or active.

Finally, I feel that this pull request has an added value because it gets rid of a `margin-left: -1px` hack. This is in place currently to get rid of "double borders". I fix this by removing the left border of elements and adding it back on `:focus` (and `:active`) only. At that point the `z-index` is increased as well, as in the current implementation.

_Side note:_ are you considering to introduce variables for the border width as well, or will that remain "hard-coded" to a single pixel?

**How can I test this?**
I extended the Bootstrap documentation examples and used those for testing.

Link to [development server](http://localhost:9001/components/input-group/#button-addons) _(for your convenience :-))_ | [current documentation](http://v4-alpha.getbootstrap.com/components/input-group/#button-addons).

**To conclude**
It goes without saying that I am open to any and all suggestions, critique and feedback. I can update this pull request as required. Thanks in advance for considering this change.
