### PR TITLE
Use non-minified CSS when running docs locally

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -14,7 +14,11 @@
 </title>
 
 <!-- Bootstrap core CSS -->
-<link href="{{ site.baseurl }}/dist/css/bootstrap.min.css" rel="stylesheet">
+{% if site.github %}
+  <link href="{{ site.baseurl }}/dist/css/bootstrap.min.css" rel="stylesheet">
+{% else %}
+  <link href="{{ site.baseurl }}/dist/css/bootstrap.css" rel="stylesheet">
+{% endif %}
 
 <!-- Documentation extras -->
 <link href="{{ site.baseurl }}/assets/css/docs.min.css" rel="stylesheet">


### PR DESCRIPTION
For easier debugging. Just like we already do for the JS.
CC: @XhmikosR 
