### PR TITLE
Use $border-width for .btn-group margins that make borders overlap

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -27,7 +27,7 @@
   .btn + .btn-group,
   .btn-group + .btn,
   .btn-group + .btn-group {
-    margin-left: -1px;
+    margin-left: -$border-width;
   }
 }
 
@@ -167,7 +167,7 @@
   > .btn + .btn-group,
   > .btn-group + .btn,
   > .btn-group + .btn-group {
-    margin-top: -1px;
+    margin-top: -$border-width;
     margin-left: 0;
   }
 }


### PR DESCRIPTION
Fixes half of #18425.
