### PR TITLE
Modal is cut off when viewpoint is between sm breakpoint and modal-md variables.

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -138,9 +138,9 @@
   }
 
   // Modal sizes
-  .modal-sm { width: $modal-sm; }
+  .modal-sm { max-width: $modal-sm; }
 }
 
 @include media-breakpoint-up(md) {
-  .modal-lg { width: $modal-lg; }
+  .modal-lg { max-width: $modal-lg; }
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -130,7 +130,7 @@
 @include media-breakpoint-up(sm) {
   // Automatically set modal's width for larger viewports
   .modal-dialog {
-    width: $modal-md;
+    max-width: $modal-md;
     margin: 30px auto;
   }
   .modal-content {


### PR DESCRIPTION
Fix modal being cut off when caught between sm breakpoint and modal-md value.

When resizing the modal between the sm default breakpoint of 544px and the modal-md value of 600px, the modal gets cut off until it reaches the 600px width. The fix applied here was to use max-width instead of width.

![fix-sm-modal](https://cloud.githubusercontent.com/assets/516477/11610195/55aa8070-9b69-11e5-9dd1-a41aba9f9fb4.gif)
