### PR TITLE
Grunt: Factor out new docs-github task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -512,8 +512,9 @@ module.exports = function (grunt) {
   grunt.registerTask('docs-js', ['uglify:docsJs', 'uglify:customize']);
   grunt.registerTask('lint-docs-js', ['jshint:assets', 'jscs:assets']);
   grunt.registerTask('docs', ['docs-css', 'lint-docs-css', 'docs-js', 'lint-docs-js', 'clean:docs', 'copy:docs', 'build-glyphicons-data', 'build-customizer']);
+  grunt.registerTask('docs-github', ['jekyll:github', 'htmlmin']);
 
-  grunt.registerTask('prep-release', ['dist', 'docs', 'jekyll:github', 'htmlmin', 'compress']);
+  grunt.registerTask('prep-release', ['dist', 'docs', 'docs-github', 'compress']);
 
   // Task for updating the cached npm packages used by the Travis build (which are controlled by test-infra/npm-shrinkwrap.json).
   // This task should be run and the updated file should be committed whenever Bootstrap's dependencies change.


### PR DESCRIPTION
This factors out a new `docs-github` task for building the hosted docs, since they're occasionally patched outside of the long release cycle and since simply using Jekyll directly isn't sufficient anymore due to the HTML minification (which makes the diffs a pain to read, but that's a story for another time).
CC: @XhmikosR 
