### PR TITLE
Tweak naming and docs of font utility classes

### DIFF
--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -121,13 +121,13 @@ Transform text in components with text capitalization classes.
 <p class="text-capitalize">CapiTaliZed text.</p>
 {% endexample %}
 
-## Font weight and style
+## Font weight and italics
 
-Quickly change the weight and style of text.
+Quickly change the weight (boldness) of text or italicize text.
 
 {% example html %}
-<p class="font-normal">Normal text.</p>
-<p class="font-bold">Bold text.</p>
+<p class="font-weight-bold">Bold text.</p>
+<p class="font-weight-normal">Normal weight text.</p>
 <p class="font-italic">Italicized text.</p>
 {% endexample %}
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -74,9 +74,9 @@
 
 // Weight and italics
 
-.font-normal  { font-weight: normal; }
-.font-bold    { font-weight: bold; }
-.font-italic  { font-style: italic; }
+.font-weight-normal  { font-weight: normal; }
+.font-weight-bold    { font-weight: bold; }
+.font-italic         { font-style: italic; }
 
 // Contextual colors
 


### PR DESCRIPTION
- `.font-normal` is way too generic (What does it make normal? There are many possibilities.). Rename it to `.font-weight-normal` for clarity.
- Rename `.font-bold` to `.font-weight-bold` so as to parallel `.font-weight-normal`. I admit this rename is more debatable.
- In docs, gloss "weight" term in relation to fonts for the benefit of non-typographiles.

Refs #18433.
