### PR TITLE
Remove doubled border for list-groups which are the last item inside cards

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -9,6 +9,10 @@
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
+  
+  > .list-group:last-child > .list-group-item:last-child {
+    border-bottom: 0;
+  }
 }
 
 .card-block {

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -9,7 +9,7 @@
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
-  
+
   > .list-group:last-child > .list-group-item:last-child {
     border-bottom: 0;
   }


### PR DESCRIPTION
Remove doubled border for list-groups beeing the last item inside cards.
