### PR TITLE
Rename 2 navbar variables to comply with updated naming convention

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -5,7 +5,7 @@
 
 .navbar {
   position: relative;
-  padding: $navbar-padding-vertical $navbar-padding-horizontal;
+  padding: $navbar-padding-y $navbar-padding-x;
   @include clearfix;
 
   @include media-breakpoint-up(sm) {
@@ -89,8 +89,8 @@
   width: 1px;
   padding-top: .425rem;
   padding-bottom: .425rem;
-  margin-right: $navbar-padding-horizontal;
-  margin-left:  $navbar-padding-horizontal;
+  margin-right: $navbar-padding-x;
+  margin-left:  $navbar-padding-x;
   overflow: hidden;
 
   &::before {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -347,8 +347,8 @@ $zindex-modal:             1050 !default;
 // Navbar
 
 $navbar-border-radius:              $border-radius !default;
-$navbar-padding-horizontal:         $spacer !default;
-$navbar-padding-vertical:           ($spacer / 2) !default;
+$navbar-padding-x:                  $spacer !default;
+$navbar-padding-y:                  ($spacer / 2) !default;
 
 $navbar-dark-color:                 rgba(255,255,255,.5) !default;
 $navbar-dark-hover-color:           rgba(255,255,255,.75) !default;


### PR DESCRIPTION
- `$navbar-padding-horizontal` => `$navbar-padding-x`
- `$navbar-padding-vertical`=> `$navbar-padding-y`

This just leaves 2 breadcrumb vars using the old convention. I'll deal with that in another PR that'll also migrate the breadcrumb component over to being class-based.
