### PR TITLE
Remove duplicated grid variables

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -3,55 +3,6 @@
 // Includes relevant variables and mixins for the regular (non-flexbox) grid
 // system, as well as the generated predefined classes (e.g., `.col-4-sm`).
 
-
-//
-// Variables
-//
-
-
-// Grid breakpoints
-//
-// Define the minimum and maximum dimensions at which your layout will change,
-// adapting to different screen sizes, for use in media queries.
-
-$grid-breakpoints: (
-  // Extra small screen / phone
-  xs: 0,
-  // Small screen / phone
-  sm: 544px,
-  // Medium screen / tablet
-  md: 768px,
-  // Large screen / desktop
-  lg: 992px,
-  // Extra large screen / wide desktop
-  xl: 1200px
-) !default;
-
-
-// Grid containers
-//
-// Define the maximum width of `.container` for different screen sizes.
-
-$container-max-widths: (
-  sm: 576px,
-  md: 720px,
-  lg: 940px,
-  xl: 1140px
-) !default;
-
-
-// Grid columns
-//
-// Set the number of columns and specify the width of the gutters.
-
-$grid-columns:               12 !default;
-$grid-gutter-width:          1.875rem !default; // 30px
-
-
-//
-// Grid mixins
-//
-
 @import "custom";
 @import "variables";
 


### PR DESCRIPTION
Grid variables already defined in `_variables.scss`.

For test check two files, (before and after):
`sass scss/bootstrap-grid.scss > name.css`
