### PR TITLE
Remove unnecessary style attribyte on docs (aligning-images)

### DIFF
--- a/docs/content/images.md
+++ b/docs/content/images.md
@@ -60,11 +60,11 @@ Align images with the [helper float classes]({{ site.baseurl }}/components/utili
 {% endhighlight %}
 
 <div class="bd-example bd-example-images">
-  <img data-src="holder.js/200x200" class="img-rounded center-block" style="display: block;" alt="A generic square placeholder image with rounded corners">
+  <img data-src="holder.js/200x200" class="img-rounded center-block" alt="A generic square placeholder image with rounded corners">
 </div>
 
 {% highlight html %}
-<img src="..." class="img-rounded center-block" style="display: block;" alt="...">
+<img src="..." class="img-rounded center-block" alt="...">
 {% endhighlight %}
 
 <div class="bd-example bd-example-images">


### PR DESCRIPTION
`.center-block` already exists `display: block`.
