### PR TITLE
Add Wall of Browser Bugs entry for #18504

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -30,6 +30,16 @@
 
 -
   browser: >
+    Internet Explorer 11 & Microsoft Edge
+  summary: >
+    `background` of `<tr>` is only applied to first child cell instead of all cells in the row
+  upstream_bug: >
+    IE#2110930
+  origin: >
+    Bootstrap#18504
+
+-
+  browser: >
     Firefox
   summary: >
     `.table-bordered` with an empty `<tbody>` is missing borders.


### PR DESCRIPTION
https://connect.microsoft.com/IE/feedback/details/2110930/edge-ie11-gradient-background-image-on-tr-is-only-applied-to-first-td
Refs #18504
