### PR TITLE
Remove fully supported features from IE9 limitations docs

### DIFF
--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -112,14 +112,6 @@ Internet Explorer 9 is also supported, however, please be aware that some CSS3 p
     </thead>
     <tbody>
       <tr>
-        <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius"><code>border-radius</code></a></th>
-        <td class="text-success">Supported</td>
-      </tr>
-      <tr>
-        <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow"><code>box-shadow</code></a></th>
-        <td class="text-success">Supported</td>
-      </tr>
-      <tr>
         <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/transform"><code>transform</code></a></th>
         <td class="text-success">Supported, with <code>-ms</code> prefix</td>
       </tr>


### PR DESCRIPTION
If these are supported, why bother mentioning them in a section that's about communicating what's not supported?
These rows made sense when the section also covered IE8 (http://getbootstrap.com/getting-started/#support-ie8-ie9 ), which doesn't support these features, but we no longer care about IE8 in v4.
