### PR TITLE
Uncomment Firefox <progress> styles

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -35,10 +35,27 @@
   // Remove right-hand border of value bar from IE10+/Edge
   border: 0;
 }
+.progress[value]::-moz-progress-bar {
+  background-color: $progress-bar-color;
+  border-top-left-radius: $border-radius;
+  border-bottom-left-radius: $border-radius;
+}
 .progress[value]::-webkit-progress-value {
   background-color: $progress-bar-color;
   border-top-left-radius: $border-radius;
   border-bottom-left-radius: $border-radius;
+}
+// Tweaks for empty progress bar
+.progress[value="0"]::-moz-progress-bar {
+  min-width: 2rem;
+  color: $gray-light;
+  background-color: transparent;
+  background-image: none;
+}
+// Tweaks for full progress bar
+.progress[value="100"]::-moz-progress-bar {
+  border-top-right-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
 }
 .progress[value="100"]::-webkit-progress-value {
   border-top-right-radius: $border-radius;
@@ -51,33 +68,12 @@
   @include border-radius($border-radius);
   @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
-
-// Firefox styles must be entirely separate or it busts Webkit styles.
-//
-// Commented out for now because linter.
-//
-// $-moz-document url-prefix() {
-//   .progress[value] {
-//     background-color: $progress-bg;
-//     .border-radius($border-radius);
-//     .box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
-//   }
-//   .progress[value]::-moz-progress-bar {
-//     background-color: $progress-bar-color;
-//     border-top-left-radius: $border-radius;
-//     border-bottom-left-radius: $border-radius;
-//   }
-//   .progress[value="0"]::-moz-progress-bar {
-//     color: $gray-light;
-//     min-width: 2rem;
-//     background-color: transparent;
-//     background-image: none;
-//   }
-//   .progress[value="100"]::-moz-progress-bar {
-//     border-top-right-radius: $border-radius;
-//     border-bottom-right-radius: $border-radius;
-//   }
-// }
+base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make these styles Firefox-only
+.progress[value] {
+  background-color: $progress-bg;
+  @include border-radius($border-radius);
+  @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
+}
 
 // IE9 hacks to accompany custom markup. We don't need to scope this via media queries, but I feel better doing it anyway.
 @media screen and (min-width:0\0) {

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -28,15 +28,12 @@
   // Set overall border radius
   @include border-radius($border-radius);
 }
+
+// Filled-in portion of the bar
 .progress[value]::-ms-fill {
   background-color: $progress-bar-color;
   // Remove right-hand border of value bar from IE10+/Edge
   border: 0;
-}
-.progress[value]::-webkit-progress-bar {
-  background-color: $progress-bg;
-  @include border-radius($border-radius);
-  @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
 .progress[value]::-webkit-progress-value {
   background-color: $progress-bar-color;
@@ -46,6 +43,13 @@
 .progress[value="100"]::-webkit-progress-value {
   border-top-right-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
+}
+
+// Unfilled portion of the bar
+.progress[value]::-webkit-progress-bar {
+  background-color: $progress-bg;
+  @include border-radius($border-radius);
+  @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
 
 // Firefox styles must be entirely separate or it busts Webkit styles.


### PR DESCRIPTION
These should be safely ignored by other browsers; they'll bail out due to unrecognized pseudo-elements.
No need to put them within `$-moz-document url-prefix() {...}`
