### PR TITLE
Add tether as bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "test-infra"
   ],
   "dependencies": {
-    "jquery": "1.9.1 - 2"
+    "jquery": "1.9.1 - 2",
+    "tether": "^1.1.1"
   }
 }


### PR DESCRIPTION
I know there was also talk of adding tether as a dependency in npm, but I figured I'd keep this PR limited to just bower so it's less likely to be met with resistance.
