### PR TITLE
Fix vertical alignment issue on floated label in list group item

### DIFF
--- a/scss/_labels.scss
+++ b/scss/_labels.scss
@@ -27,6 +27,17 @@
   top: -1px;
 }
 
+// Fix vertical alignment on floated labels in list group item
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    .list-group-item .label.pull-#{$breakpoint}-left,
+    .list-group-item .label.pull-#{$breakpoint}-right {
+        position: relative;
+        top: #{(($line-height / .75) - 1 - .5) / 2}em;
+    }
+  }
+}
+
 // Add hover effects, but only for links
 a.label {
   @include hover-focus {

--- a/scss/_labels.scss
+++ b/scss/_labels.scss
@@ -32,8 +32,8 @@
   @include media-breakpoint-up($breakpoint) {
     .list-group-item .label.pull-#{$breakpoint}-left,
     .list-group-item .label.pull-#{$breakpoint}-right {
-        position: relative;
-        top: #{(($line-height / .75) - 1 - .5) / 2}em;
+      position: relative;
+      top: #{(($line-height / .75) - 1 - .5) / 2}em;
     }
   }
 }


### PR DESCRIPTION
Fix #18574
Adding a position adjustment to compensate vertical positioning difference due to different font-size and line-height values.
