### PR TITLE
Changed .container max-width for large from 940px to 948px

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -95,7 +95,7 @@ See how aspects of the Bootstrap grid system work across multiple devices with a
         <td>None (auto)</td>
         <td>576px</td>
         <td>720px</td>
-        <td>940px</td>
+        <td>948px</td>
         <td>1140px</td>
       </tr>
       <tr>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -125,7 +125,7 @@ $grid-breakpoints: (
 $container-max-widths: (
   sm: 576px,
   md: 720px,
-  lg: 940px,
+  lg: 948px,
   xl: 1140px
 ) !default;
 

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -35,7 +35,7 @@ $grid-breakpoints: (
 $container-max-widths: (
   sm: 576px,
   md: 720px,
-  lg: 940px,
+  lg: 948px,
   xl: 1140px
 ) !default;
 


### PR DESCRIPTION
As discussed here:

https://github.com/twbs/bootstrap/issues/13120 and https://github.com/twbs/bootstrap/issues/18510

The two options that make sense are either 948px or 936px. Bootstrap 3 uses 940px. I think it's better to err on the side of having a few pixels more instead of less.

Then all containers will be divisible by 12 by default, which does away with uneven column widths.
