### PR TITLE
Use numerical values for font-weight instead of keyword values

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -32,7 +32,7 @@ kbd {
   kbd {
     padding: 0;
     font-size: 100%;
-    font-weight: bold;
+    font-weight: 700;
     box-shadow: none;
   }
 }

--- a/less/forms.less
+++ b/less/forms.less
@@ -33,7 +33,7 @@ label {
   display: inline-block;
   max-width: 100%; // Force IE8 to wrap long content (see https://github.com/twbs/bootstrap/issues/13141)
   margin-bottom: 5px;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 

--- a/less/labels.less
+++ b/less/labels.less
@@ -6,7 +6,7 @@
   display: inline;
   padding: .2em .6em .3em;
   font-size: 75%;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1;
   color: @label-color;
   text-align: center;

--- a/less/type.less
+++ b/less/type.less
@@ -195,7 +195,7 @@ dd {
   line-height: @line-height-base;
 }
 dt {
-  font-weight: bold;
+  font-weight: 700;
 }
 dd {
   margin-left: 0; // Undo browser default

--- a/less/variables.less
+++ b/less/variables.less
@@ -622,7 +622,7 @@
 
 @alert-padding:               15px;
 @alert-border-radius:         @border-radius-base;
-@alert-link-font-weight:      bold;
+@alert-link-font-weight:      700;
 
 @alert-success-bg:            @state-success-bg;
 @alert-success-text:          @state-success-text;
@@ -778,7 +778,7 @@
 //** Badge background color in active nav link
 @badge-active-bg:             #fff;
 
-@badge-font-weight:           bold;
+@badge-font-weight:           700;
 @badge-line-height:           1;
 @badge-border-radius:         10px;
 
@@ -820,7 +820,7 @@
 //
 //##
 
-@close-font-weight:           bold;
+@close-font-weight:           700;
 @close-color:                 #000;
 @close-text-shadow:           0 1px 0 #fff;
 


### PR DESCRIPTION
Pull request in regards to Issue https://github.com/twbs/bootstrap/issues/18605

I replaced all the `font-weight: bold;` declaration with `font-weight: 700;` as this allows for a much easier and more consistent flow for font-weight's throughout bootstrap. `font-weight:` with a `700;` value on the chosen `sans-serif`, `serif` and `monospace` typefaces used in bootstrap is now supported by modern browsers.
