### PR TITLE
Docs: update browser support info

### DIFF
--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -13,7 +13,9 @@ Bootstrap supports a wide variety of modern browsers and devices, and some older
 
 ## Supported browsers
 
-Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**. Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported – however, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
+Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**.
+
+Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
 ### Mobile devices
 

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -83,7 +83,7 @@ Similarly, the latest versions of most desktop browsers are supported.
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
-        <td class="text-muted">N/A</td>
+        <td class="text-danger">Not supported</td>
       </tr>
     </tbody>
   </table>

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -17,7 +17,7 @@ Bootstrap supports the **latest, stable releases** of all major browsers and pla
 
 ### Mobile devices
 
-Generally speaking, Bootstrap supports the latest versions of each major platform's default browsers.
+Generally speaking, Bootstrap supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini) are not supported.
 
 <div class="table-responsive">
   <table class="table table-bordered table-striped">
@@ -26,7 +26,6 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
         <td></td>
         <th>Chrome</th>
         <th>Firefox</th>
-        <th>Opera</th>
         <th>Safari</th>
         <th>Android Browser &amp; WebView</th>
       </tr>
@@ -36,15 +35,13 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
         <th scope="row">Android</th>
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
-        <td class="text-danger">Not supported</td>
         <td class="text-muted">N/A</td>
         <td class="text-success">Android v5.0+ supported</td>
       </tr>
       <tr>
         <th scope="row">iOS</th>
         <td class="text-success">Supported</td>
-        <td class="text-muted">N/A</td>
-        <td class="text-danger">Not supported</td>
+        <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
         <td class="text-muted">N/A</td>
       </tr>
@@ -86,7 +83,7 @@ Similarly, the latest versions of most desktop browsers are supported.
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
-        <td class="text-danger">Not supported</td>
+        <td class="text-muted">N/A</td>
       </tr>
     </tbody>
   </table>

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -13,7 +13,7 @@ Bootstrap supports a wide variety of modern browsers and devices, and some older
 
 ## Supported browsers
 
-Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**. Alternative browsers which use the latest version of Webkit, Blink, Gecko or the platform's own rendering engine / web view are not explicitly supported – however, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
+Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**. Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported – however, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
 ### Mobile devices
 

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -13,7 +13,7 @@ Bootstrap supports a wide variety of modern browsers and devices, and some older
 
 ## Supported browsers
 
-Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**. More specific support information is provided below.
+Bootstrap supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**. Alternative browsers which use the latest version of Webkit, Blink, Gecko or the platform's own rendering engine / web view are not explicitly supported – however, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
 ### Mobile devices
 

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -17,7 +17,7 @@ Bootstrap supports the **latest, stable releases** of all major browsers and pla
 
 ### Mobile devices
 
-Generally speaking, Bootstrap supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini) are not supported.
+Generally speaking, Bootstrap supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile's Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
 
 <div class="table-responsive">
   <table class="table table-bordered table-striped">

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -28,6 +28,7 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
         <th>Firefox</th>
         <th>Safari</th>
         <th>Android Browser &amp; WebView</th>
+        <th>Microsoft Edge</th>
       </tr>
     </thead>
     <tbody>
@@ -37,6 +38,7 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
         <td class="text-success">Supported</td>
         <td class="text-muted">N/A</td>
         <td class="text-success">Android v5.0+ supported</td>
+        <td class="text-muted">N/A</td>
       </tr>
       <tr>
         <th scope="row">iOS</th>
@@ -44,6 +46,15 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
         <td class="text-success">Supported</td>
         <td class="text-success">Supported</td>
         <td class="text-muted">N/A</td>
+        <td class="text-muted">N/A</td>
+      </tr>
+      <tr>
+        <th scope="row">Windows 10 Mobile</th>
+        <td class="text-muted">N/A</td>
+        <td class="text-muted">N/A</td>
+        <td class="text-muted">N/A</td>
+        <td class="text-muted">N/A</td>
+        <td class="text-success">Supported</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
- Remove Opera from the Android/iOS listing - it was not clear if this referred to Opera Mobile or Opera Mini. If the former, it's only available on Android, and uses Blink the same way that Chrome does, so it's supported. If the latter, it's worth expanding that in general we don't support proxy browsers
- Add proxy browser note
- Change Firefox/iOS from N/A to Supported (as it uses standard iOS web view) - closes https://github.com/twbs/bootstrap/issues/18602
- Remove Win/Safari, as there's not been any viable version since 2012
