### PR TITLE
Use $gray-lightest in _variables.scss

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -79,7 +79,7 @@
   position: relative;
   padding: 1rem;
   margin: 1rem -1rem;
-  border: solid #f7f7f9;
+  border: solid $gray-lightest;
   border-width: .2rem 0 0;
   @include clearfix();
 
@@ -222,7 +222,7 @@
 
 // Example modals
 .bd-example-modal {
-  background-color: #f5f5f5;
+  background-color: $gray-lightest;
 }
 .bd-example-modal .modal {
   position: relative;
@@ -327,7 +327,7 @@
 .highlight {
   padding: 1rem;
   margin: 1rem (-$grid-gutter-width / 2);
-  background-color: #f7f7f9;
+  background-color: $gray-lightest;
 
   @include media-breakpoint-up(sm) {
     padding: 1.5rem;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -42,7 +42,7 @@ $gray-dark:                 #373a3c !default;
 $gray:                      #55595c !default;
 $gray-light:                #818a91 !default;
 $gray-lighter:              #eceeef !default;
-$gray-lightest:             #f7f7f9 !default;
+$gray-lightest:             #f5f5f5 !default;
 
 $brand-primary:             #0275d8 !default;
 $brand-success:             #5cb85c !default;
@@ -245,7 +245,7 @@ $table-sm-cell-padding:         .3rem !default;
 
 $table-bg:                      transparent !default;
 $table-bg-accent:               #f9f9f9 !default;
-$table-bg-hover:                #f5f5f5 !default;
+$table-bg-hover:                $gray-lightest !default;
 $table-bg-active:               $table-bg-hover !default;
 
 $table-border-width:            $border-width !default;
@@ -442,7 +442,7 @@ $dropdown-box-shadow:            0 6px 12px rgba(0,0,0,.175) !default;
 
 $dropdown-link-color:            $gray-dark !default;
 $dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
-$dropdown-link-hover-bg:         #f5f5f5 !default;
+$dropdown-link-hover-bg:         $gray-lightest !default;
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -575,7 +575,7 @@ $card-border-width:        1px !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba(0,0,0,.125) !default;
 $card-border-radius-inner: $card-border-radius !default;
-$card-cap-bg:              #f5f5f5 !default;
+$card-cap-bg:              $gray-lightest !default;
 $card-bg:                  #fff !default;
 
 $card-link-hover-color:    #fff !default;
@@ -718,7 +718,7 @@ $list-group-border-color:       #ddd !default;
 $list-group-border-width:       $border-width !default;
 $list-group-border-radius:      $border-radius !default;
 
-$list-group-hover-bg:           #f5f5f5 !default;
+$list-group-hover-bg:           $gray-lightest !default;
 $list-group-active-color:       $component-active-color !default;
 $list-group-active-bg:          $component-active-bg !default;
 $list-group-active-border:      $list-group-active-bg !default;
@@ -806,12 +806,12 @@ $code-font-size:              90% !default;
 $code-padding-x:              .4rem !default;
 $code-padding-y:              .2rem !default;
 $code-color:                  #bd4147 !default;
-$code-bg:                     #f7f7f9 !default;
+$code-bg:                     $gray-lightest !default;
 
 $kbd-color:                   #fff !default;
 $kbd-bg:                      #333 !default;
 
-$pre-bg:                      #f7f7f9 !default;
+$pre-bg:                      $gray-lightest !default;
 $pre-color:                   $gray-dark !default;
 $pre-border-color:            #ccc !default;
 $pre-scrollable-max-height:   340px !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -437,7 +437,7 @@ $dropdown-margin-top:            2px !default;
 $dropdown-bg:                    #fff !default;
 $dropdown-border-color:          rgba(0,0,0,.15) !default;
 $dropdown-border-width:          $border-width !default;
-$dropdown-divider-bg:            #e5e5e5 !default;
+$dropdown-divider-bg:            $gray-lighter !default;
 $dropdown-box-shadow:            0 6px 12px rgba(0,0,0,.175) !default;
 
 $dropdown-link-color:            $gray-dark !default;
@@ -661,7 +661,7 @@ $modal-content-sm-up-box-shadow: 0 5px 15px rgba(0,0,0,.5) !default;
 
 $modal-backdrop-bg:           #000 !default;
 $modal-backdrop-opacity:      .5 !default;
-$modal-header-border-color:   #e5e5e5 !default;
+$modal-header-border-color:   $gray-lighter !default;
 $modal-footer-border-color:   $modal-header-border-color !default;
 $modal-header-border-width:   $modal-content-border-width !default;
 $modal-footer-border-width:   $modal-header-border-width !default;

--- a/scss/mixins/_nav-divider.scss
+++ b/scss/mixins/_nav-divider.scss
@@ -2,7 +2,7 @@
 //
 // Dividers (basically an hr) within dropdowns and nav lists
 
-@mixin nav-divider($color: #e5e5e5) {
+@mixin nav-divider($color: $gray-lighter) {
   height: 1px;
   margin: ($spacer-y / 2) 0;
   overflow: hidden;


### PR DESCRIPTION
Since we have two very similar colors, `#f5f5f5` and `#f7f7f9`, I'd propose to just use the first one -- so this PR replaces every occurrence of `#f7f7f9` with `$gray-lightest`.

Also, since we are not using `$gray-lightest` anywhere apart from [here](https://github.com/twbs/bootstrap/blob/v4-dev/scss/utilities/_background.scss#L13), I guess it would make sense to either remove it, or start using it somewhere else.

Thoughts?
