### PR TITLE
Use variables for .progress base colors

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -29,7 +29,7 @@
   @include border-radius($border-radius);
 }
 .progress[value]::-ms-fill {
-  background-color: #0074d9;
+  background-color: $progress-bar-color;
   // Remove right-hand border of value bar from IE10+/Edge
   border: 0;
 }
@@ -39,7 +39,7 @@
   @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
 .progress[value]::-webkit-progress-value {
-  background-color: #0074d9;
+  background-color: $progress-bar-color;
   border-top-left-radius: $border-radius;
   border-bottom-left-radius: $border-radius;
 }
@@ -59,7 +59,7 @@
 //     .box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 //   }
 //   .progress[value]::-moz-progress-bar {
-//     background-color: #0074d9;
+//     background-color: $progress-bar-color;
 //     border-top-left-radius: $border-radius;
 //     border-bottom-left-radius: $border-radius;
 //   }
@@ -86,7 +86,7 @@
     display: inline-block;
     height: $spacer-y;
     text-indent: -999rem; // Simulate hiding of value as in native `<progress>`
-    background-color: #0074d9;
+    background-color: $progress-bar-color;
     border-top-left-radius: $border-radius;
     border-bottom-left-radius: $border-radius;
   }

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -20,7 +20,7 @@
 }
 .progress[value] {
   // Set overall background
-  background-color: #eee;
+  background-color: $progress-bg;
   // Remove Firefox and Opera border
   border: 0;
   // Reset the default appearance
@@ -34,7 +34,7 @@
   border: 0;
 }
 .progress[value]::-webkit-progress-bar {
-  background-color: #eee;
+  background-color: $progress-bg;
   @include border-radius($border-radius);
   @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 }
@@ -54,7 +54,7 @@
 //
 // $-moz-document url-prefix() {
 //   .progress[value] {
-//     background-color: #eee;
+//     background-color: $progress-bg;
 //     .border-radius($border-radius);
 //     .box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
 //   }
@@ -78,7 +78,7 @@
 // IE9 hacks to accompany custom markup. We don't need to scope this via media queries, but I feel better doing it anyway.
 @media screen and (min-width:0\0) {
   .progress {
-    background-color: #eee;
+    background-color: $progress-bg;
     @include border-radius($border-radius);
     @include box-shadow(inset 0 .1rem .1rem rgba(0,0,0,.1));
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -581,7 +581,7 @@ $alert-danger-border:         $state-danger-border !default;
 
 // Progress bars
 
-$progress-bg:                 #f5f5f5 !default;
+$progress-bg:                 #eee !default;
 $progress-bar-color:          #0074d9 !default;
 $progress-border-radius:      $border-radius !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -582,7 +582,7 @@ $alert-danger-border:         $state-danger-border !default;
 // Progress bars
 
 $progress-bg:                 #f5f5f5 !default;
-$progress-bar-color:          #fff !default;
+$progress-bar-color:          #0074d9 !default;
 $progress-border-radius:      $border-radius !default;
 
 $progress-bar-bg:             $brand-primary !default;


### PR DESCRIPTION
Fixes #18535.
We had variables for this (`$progress-bg`, `$progress-bar-color`), we just weren't using them and they had different values.
