### PR TITLE
Use numerical values for font-weight instead of keyword values

### DIFF
--- a/docs/dist/css/bootstrap.css
+++ b/docs/dist/css/bootstrap.css
@@ -214,7 +214,7 @@ textarea {
 }
 
 optgroup {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 table {
@@ -374,7 +374,7 @@ ul ol {
 }
 
 dt {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 dd {
@@ -739,7 +739,7 @@ kbd {
 kbd kbd {
   padding: 0;
   font-size: 100%;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 pre {
@@ -4217,7 +4217,7 @@ input[type="button"].btn-block {
   display: inline-block;
   padding: .25em .4em;
   font-size: 75%;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1;
   color: #fff;
   text-align: center;
@@ -4339,7 +4339,7 @@ a.label:focus, a.label:hover {
 }
 
 .alert-link {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 .alert-dismissible {
@@ -4919,7 +4919,7 @@ button.list-group-item-danger.active:hover {
 .close {
   float: right;
   font-size: 1.5rem;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1;
   color: #000;
   text-shadow: 0 1px 0 #fff;
@@ -5759,7 +5759,7 @@ button.close {
 }
 
 .font-weight-bold {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 .font-italic {

--- a/docs/dist/css/bootstrap.css
+++ b/docs/dist/css/bootstrap.css
@@ -66,7 +66,7 @@ abbr[title] {
 
 b,
 strong {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 dfn {

--- a/docs/examples/cover/cover.css
+++ b/docs/examples/cover/cover.css
@@ -73,7 +73,7 @@ body {
 
 .nav-masthead .nav-link {
   padding: .25rem 0;
-  font-weight: bold;
+  font-weight: 700;
   color: rgba(255,255,255,.5);
   background-color: transparent;
   border-bottom: .25rem solid transparent;

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -75,7 +75,7 @@
 // Weight and italics
 
 .font-weight-normal  { font-weight: normal; }
-.font-weight-bold    { font-weight: bold; }
+.font-weight-bold    { font-weight: 700; }
 .font-italic         { font-style: italic; }
 
 // Contextual colors

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -194,9 +194,9 @@ $blockquote-border-color:     $gray-lighter !default;
 $hr-border-color:             rgba(0,0,0,.1) !default;
 $hr-border-width:             $border-width !default;
 
-$dt-font-weight:              bold !default;
+$dt-font-weight:              700 !default;
 
-$nested-kbd-font-weight:      bold !default;
+$nested-kbd-font-weight:      700 !default;
 
 $list-inline-padding:         5px !default;
 
@@ -529,7 +529,7 @@ $label-danger-bg:             $brand-danger !default;
 
 $label-color:                 #fff !default;
 $label-link-hover-color:      #fff !default;
-$label-font-weight:           bold !default;
+$label-font-weight:           700 !default;
 
 
 // Modals
@@ -559,7 +559,7 @@ $modal-sm:                    300px !default;
 
 $alert-padding:               15px !default;
 $alert-border-radius:         $border-radius !default;
-$alert-link-font-weight:      bold !default;
+$alert-link-font-weight:      700 !default;
 $alert-border-width:          $border-width !default;
 
 $alert-success-bg:            $state-success-bg !default;
@@ -651,7 +651,7 @@ $carousel-caption-color:                      #fff !default;
 
 // Close
 
-$close-font-weight:           bold !default;
+$close-font-weight:           700 !default;
 $close-color:                 #000 !default;
 $close-text-shadow:           0 1px 0 #fff !default;
 


### PR DESCRIPTION
Pull request in regards to 
Issue https://github.com/twbs/bootstrap/issues/18605
Pull request https://github.com/twbs/bootstrap/pull/18613

I replaced all the `font-weight: bold;` declaration with `font-weight: 700;` as this allows for a much easier and more consistent flow for font-weight's throughout bootstrap. `font-weight:` with a `700;` value on the chosen `sans-serif`, `serif` and `monospace` typefaces used in bootstrap is now supported by modern browsers.
