### PR TITLE
Fix syntax of .text-hide's `font` property value

### DIFF
--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -1,6 +1,6 @@
 // CSS image replacement
 @mixin text-hide() {
-  font: "0/0" a;
+  font: 0/0 a;
   color: transparent;
   text-shadow: none;
   background-color: transparent;


### PR DESCRIPTION
In SCSS, the quotes were included verbatim in the resulting CSS, which isn't valid syntax for the `font` property.
Removing the quotes fixes the syntax error and does not cause any SCSS compiler error.
