### PR TITLE
Docs: add ellipsis to modal example code

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -251,7 +251,7 @@ Modals have two optional sizes, available via modifier classes to be placed on a
 For modals that simply appear rather than fade in to view, remove the `.fade` class from your modal markup.
 
 {% highlight html %}
-<div class="modal" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">
+<div class="modal" tabindex="-1" role="dialog" aria-labelledby="..." aria-hidden="true">
   ...
 </div>
 {% endhighlight %}


### PR DESCRIPTION
Otherwise it may be mistaken as "it's cool to have an empty `aria-labelledby` attribute"
