### PR TITLE
Remove nonstandard `zoom: 1` from media object

### DIFF
--- a/scss/_media.scss
+++ b/scss/_media.scss
@@ -23,7 +23,6 @@
   .media,
   .media-body {
     overflow: hidden;
-    zoom: 1;
   }
   .media-body {
     width: 10000px;


### PR DESCRIPTION
It should be unnecessary since we only support IE>=9, and this hasLayout hack is for IE6-7.
https://developer.mozilla.org/en-US/docs/Web/CSS/zoom
http://stackoverflow.com/questions/1794350/what-is-haslayout
CC: @mdo for review
