### PR TITLE
Add equal-width columns for flexbox grid

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -73,12 +73,12 @@
       .col-#{$breakpoint}-bottom { align-self: flex-end; }
     }
   }
-  
+
   // Auto-width columns
 
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
-      .col-#{$breakpoint}-auto { 
+      .col-#{$breakpoint}-auto {
         flex: 1;
       }
     }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -73,4 +73,14 @@
       .col-#{$breakpoint}-bottom { align-self: flex-end; }
     }
   }
+  
+  // Auto-width columns
+
+  @each $breakpoint in map-keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      .col-#{$breakpoint}-auto { 
+        flex: 1;
+      }
+    }
+  }
 }


### PR DESCRIPTION
see: https://github.com/twbs/bootstrap/issues/17131

suggested documentation:

```
### Example: Auto-width columns

Use the `col-{breakpoint}-auto` classes to create rows with 5, 7, 8, and 10 columns. Each column gets the same width.

<div class="bd-example-row">
{% example html %}
<div class="row">
  <div class="col-md-auto">1</div>
  <div class="col-md-auto">2</div>
  <div class="col-md-auto">3</div>
  <div class="col-md-auto">4</div>
  <div class="col-md-auto">5</div>   
</div>
{% endexample %}
</div>
```
