### PR TITLE
.container, .container-fluid should be conditional upon $enable-grid-…

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -2,22 +2,23 @@
 //
 // Set the container width, and override it for fixed navbars in media queries.
 
-.container {
-  @include make-container();
-  @include make-container-max-widths();
-
+@if $enable-grid-classes {
+  .container {
+    @include make-container();
+    @include make-container-max-widths();
+  }
 }
-
 
 // Fluid container
 //
 // Utilizes the mixin meant for fixed width containers, but without any defined
 // width for fluid, full width layouts.
 
-.container-fluid {
-  @include make-container();
+@if $enable-grid-classes {
+  .container-fluid {
+    @include make-container();
+  }
 }
-
 
 // Row
 //


### PR DESCRIPTION
…classes

see: https://github.com/twbs/bootstrap/issues/17586

Notice that all code can also wrapped in a single `@if $enable-grid-classes {}` now.

Code can also be wrapped inside a mixin `grid-classes()` with the following code in bootstrap.scss:
    @import "grid";
    @if $enable-grid-classes {
      @include grid-classes;
    }

And finally notice that the `@import "grid";` is not needed at all when you do not need the precompiled grid classes. Removing the import from `bootstrap.scss` is as simple as setting    `$enable-grid-classes` to `false`.
