### PR TITLE
Apply <code> styling to obsolete <tt> element

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -7,12 +7,13 @@
 code,
 kbd,
 pre,
-samp {
+samp,
+tt {
   font-family: @font-family-monospace;
 }
 
 // Inline code
-code {
+code, tt {
   padding: 2px 4px;
   font-size: 90%;
   color: @code-color;

--- a/less/normalize.less
+++ b/less/normalize.less
@@ -229,7 +229,8 @@ pre {
 code,
 kbd,
 pre,
-samp {
+samp,
+tt {
   font-family: monospace, monospace;
   font-size: 1em;
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -44,7 +44,7 @@
 
 @font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
 @font-family-serif:       Georgia, "Times New Roman", Times, serif;
-//** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
+//** Default monospace fonts for `<code>`, `<kbd>`, `<pre>`, and `<tt>`.
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 @font-family-base:        @font-family-sans-serif;
 


### PR DESCRIPTION
I discovered that `<tt>` is unstyled and so looks different from `<code>` and `<pre>`.

Using the [Bootswatch Readable theme](http://bootswatch.com/readable/) with [Nikola](https://getnikola.com/), [ReStructuredText inline literal markup](http://docutils.sourceforge.net/docs/user/rst/quickref.html#inline-markup) (double backquotes fore and aft) is rendered using `<tt>`. Although `<tt>` is obsolete in HTML5, [RST targets HTML4.1](http://sourceforge.net/p/docutils/bugs/252/).

This pull request treats `<tt>` like `<code>`. It works in my snapshot of the Readable theme. I can't tell if any other changes are needed. I presume the change in `normalize.css` should be pushed to [Normalize](https://github.com/necolas/normalize.css).
