### PR TITLE
Add pointer-events:none to disabled pagination/pager links

### DIFF
--- a/scss/_pager.scss
+++ b/scss/_pager.scss
@@ -30,6 +30,7 @@
     > a {
       @include plain-hover-focus {
         color: $pager-disabled-color;
+        pointer-events: none;
         cursor: $cursor-disabled;
         background-color: $pager-bg;
       }

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -34,6 +34,7 @@
   &.disabled .page-link {
     @include plain-hover-focus {
       color: $pagination-disabled-color;
+      pointer-events: none;
       cursor: $cursor-disabled;
       background-color: $pagination-disabled-bg;
       border-color: $pagination-disabled-border;


### PR DESCRIPTION
as currently this was missed out (compared to disabled `a.btn`)
