### PR TITLE
Add documentation for Tab plugin's `show` method

### DIFF
--- a/docs/components/navs.md
+++ b/docs/components/navs.md
@@ -337,6 +337,14 @@ Activates a tab element and content container. Tab should have either a `data-ta
 </script>
 {% endhighlight %}
 
+#### .tab('show')
+
+Selects the given tab and shows its associated content. Any other tab that was previously selected becomes unselected and its associated content is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.bs.tab` event occurs).
+
+{% highlight js %}
+$('#someTab').tab('show')
+{% endhighlight %}
+
 ### Events
 
 When showing a new tab, the events fire in the following order:


### PR DESCRIPTION
Document show method for tab plugin

Closes : #18696 
