### PR TITLE
'change' event did not fire on radio button change

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -63,7 +63,7 @@
         if (($input.prop('checked')) !== this.$element.hasClass('active')) changed = false
         this.$element.toggleClass('active')
       }
-      $input.prop('checked', this.$element.hasClass('active'))
+      $parent.find('input').prop('checked', this.$element.hasClass('active'))
       if (changed) $input.trigger('change')
     } else {
       this.$element.attr('aria-pressed', !this.$element.hasClass('active'))

--- a/js/button.js
+++ b/js/button.js
@@ -57,13 +57,13 @@
       var $input = this.$element.find('input')
       if ($input.prop('type') == 'radio') {
         if ($input.prop('checked')) changed = false
-        $parent.find('.active').removeClass('active')
+        $parent.find('.active').removeClass('active').find('input').prop('checked', false)
         this.$element.addClass('active')
       } else if ($input.prop('type') == 'checkbox') {
         if (($input.prop('checked')) !== this.$element.hasClass('active')) changed = false
         this.$element.toggleClass('active')
       }
-      $parent.find('input').prop('checked', this.$element.hasClass('active'))
+      $input.prop('checked', this.$element.hasClass('active'))
       if (changed) $input.trigger('change')
     } else {
       this.$element.attr('aria-pressed', !this.$element.hasClass('active'))


### PR DESCRIPTION
Once $input.prop('checked') set to true, it never reset to false.
It causes a bug that does not fire 'change' event if you select "B" button and back to "A".
since f9cd88e09f1375702a68f03ef9895053ed14efb3
