### PR TITLE
Add max-width to file browser; fixes #18651

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -175,11 +175,13 @@
 .file {
   position: relative;
   display: inline-block;
+  max-width: 100%;
   height: 2.5rem;
   cursor: pointer;
 }
 .file input {
   min-width: 14rem;
+  max-width: 100%;
   margin: 0;
   filter: alpha(opacity = 0);
   opacity: 0;


### PR DESCRIPTION
Although visually the first added property fixes it, with only the first property Chrome was still displaying the element as leaking out of its container - this is what the second added property is for.
