### PR TITLE
Fix margins in highlighted code in docs

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -314,7 +314,7 @@
 
 .highlight {
   padding: 1rem;
-  margin: 1rem -1rem;
+  margin: 1rem (-$grid-gutter-width / 2);
   background-color: #f7f7f9;
 
   @include media-breakpoint-up(sm) {


### PR DESCRIPTION
Margin in `highlight` elements show horizontal scrollbar on small devices

http://v4-alpha.getbootstrap.com/
![screen shot 2015-12-31 at 19 32 01](https://cloud.githubusercontent.com/assets/556268/12067575/5554e992-affc-11e5-8c57-08785bdb52ed.png)
