### PR TITLE
v4: font-weight: normal on labels

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -184,7 +184,6 @@
   label {
     padding-left: 1.25rem;
     margin-bottom: 0;
-    font-weight: normal;
     cursor: pointer;
 
     // When there's no labels, don't position the input.
@@ -216,7 +215,6 @@
   display: inline-block;
   padding-left: 1.25rem;
   margin-bottom: 0;
-  font-weight: normal;
   vertical-align: middle;
   cursor: pointer;
 }


### PR DESCRIPTION
Removing last two instances of this as we're no longer setting `<label>`s to bold (as of v4).

Fixes #17991.
