### PR TITLE
Remove usages of and references to <input type="datetime">

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -114,7 +114,7 @@ Below is a complete list of the specific from controls supported by Bootstrap an
         Textual inputs
       </td>
       <td>
-        {% markdown %}`text`, `password`, `datetime`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search`, `tel`, `color`{% endmarkdown %}
+        {% markdown %}`text`, `password`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search`, `tel`, `color`{% endmarkdown %}
       </td>
     </tr>
     <tr>

--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -225,7 +225,7 @@ These changes, and more, are demonstrated below.
 
     <p>
       <label for="time">Example temporal</label>
-      <input type="datetime" id="time">
+      <input type="datetime-local" id="time">
     </p>
 
     <p>


### PR DESCRIPTION
It has been removed from the HTML specification: https://github.com/whatwg/html/issues/336
Only Presto Opera ever implemented a special UI for it.
