### PR TITLE
v4: Add Liberation Mono to the code font stack

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -139,7 +139,7 @@ $grid-gutter-width: 1.875rem !default; // 30px
 
 $font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $font-family-serif:      Georgia, "Times New Roman", Times, serif !default;
-$font-family-monospace:  Menlo, Monaco, Consolas, "Courier New", monospace !default;
+$font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:       $font-family-sans-serif !default;
 
 // Pixel value used to responsively scale all typography. Applied to the `<html>` element.


### PR DESCRIPTION
Fixes #18609.

We use this at GitHub for our monospace font stack and it seems to be work out well for those users. Should serve us well, too.
