### PR TITLE
Switch to actually-Safari-specific CSS hack for iOS temporal input fix

### DIFF
--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -396,6 +396,7 @@ linters:
   SelectorFormat:
     enabled: true
     convention: hyphenated_lowercase # or 'BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    ignored_types: ["element"]
 
   Shorthand:
     enabled: true

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -92,26 +92,28 @@
 //
 // Note that as of 8.3, iOS doesn't support `week`.
 
-@media screen and (-webkit-min-device-pixel-ratio: 0) {
-  input[type="date"],
-  input[type="time"],
-  input[type="datetime-local"],
-  input[type="month"] {
-    &.form-control {
-      line-height: $input-height;
-    }
+// SCSS-Lint exemption until https://github.com/brigade/scss-lint/pull/672 gets merged
+// scss-lint:disable PseudoElement
+_::-webkit-full-page-media, // Hack to make this CSS be Safari-only; see http://browserbu.gs/css-hacks/webkit-full-page-media/
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"],
+input[type="month"] {
+  &.form-control {
+    line-height: $input-height;
+  }
 
-    &.input-sm,
-    .input-group-sm &.form-control {
-      line-height: $input-height-sm;
-    }
+  &.input-sm,
+  .input-group-sm &.form-control {
+    line-height: $input-height-sm;
+  }
 
-    &.input-lg,
-    .input-group-lg &.form-control {
-      line-height: $input-height-lg;
-    }
+  &.input-lg,
+  .input-group-lg &.form-control {
+    line-height: $input-height-lg;
   }
 }
+// scss-lint:enable PseudoElement
 
 
 // Static form control text


### PR DESCRIPTION
Fixes #17308.
Research backing up this hack: http://browserbu.gs/css-hacks/webkit-full-page-media/

Chrome screenshot with the patch applied (temporal inputs are no longer super-tall):
<img width="571" alt="chrome" src="https://cloud.githubusercontent.com/assets/419884/12215165/a9cff722-b665-11e5-9736-9825df4192ff.png">

iOS 9 Safari screenshot with the patch applied (text in temporal inputs is still vertically centered (at least by eyeball)):
![](https://cloud.githubusercontent.com/assets/419884/12215173/1583a68a-b666-11e5-9e30-211a5432723f.png)

---

The heights of `datetime-local` `date`, `month`, `week`, and `time` inputs in Chrome now become 40px, which is still different from the 38px height of the other textual inputs, but that particular discrepancy isn't caused by the iOS CSS that we're fixing here. Will open a new issue for that.

There is some slight redundancy in the generated selectors, but it doesn't affect the potency of the hack. Here's what I mean:

``` css
_::-webkit-full-page-media.input-lg,
.input-group-lg _::-webkit-full-page-media.form-control,
input[type="date"].input-lg,
...
```

I couldn't find a way in Sass, when nesting is involved, to tack a selector onto a selector list without it getting cross-producted with the nestees. Perhaps there's some particular Sass judo I don't know about.

CC: @mdo 
