### PR TITLE
Remove About > Accessibility

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -59,7 +59,6 @@
   pages:
     - title: History
     - title: Team
-    - title: Accessibility
     - title: Brand
     - title: License
     - title: Translations

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -7,6 +7,7 @@
     - title: Flexbox
     - title: Build tools
     - title: Best practices
+    - title: Accessibility
 
 - title: Layout
   pages:


### PR DESCRIPTION
Currently, there is no actual accessibility page, so this avoids a 404
in the docs. More fundamentally, though, it makes more sense for
accessibility advice to be directly integrated in the docs (which we're
doing, for the most part - though we should ensure that we do
cover/mention everything where appropriate), so there's no need for a
separate accessibility page.

http://getbootstrap.com/getting-started/#accessibility in the old docs always felt a bit of a catch-all of random bits of advice. if we still think some of these nuggets of info are useful, we should integrate them where appropriate rather than segregating them into a separate sub-page that nobody will look at :)
