### PR TITLE
Extract $btn-active-box-shadow variable & refactor accordingly

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -115,7 +115,7 @@
 // The clickable button for toggling the menu
 // Remove the gradient and set the same inset shadow as the :active state
 .btn-group.open .dropdown-toggle {
-  @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
+  @include box-shadow($btn-active-box-shadow);
 
   // Show no shadow for `.btn-link` since it has no other button styles.
   &.btn-link {

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -34,7 +34,7 @@
   &.active {
     background-image: none;
     outline: 0;
-    @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
+    @include box-shadow($btn-active-box-shadow);
   }
 
   &.disabled,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -237,6 +237,7 @@ $table-border-color:            $gray-lighter !default;
 $btn-padding-x:                  1rem !default;
 $btn-padding-y:                  .375rem !default;
 $btn-font-weight:                normal !default;
+$btn-active-box-shadow:          inset 0 3px 5px rgba(0,0,0,.125) !default;
 
 $btn-primary-color:              #fff !default;
 $btn-primary-bg:                 $brand-primary !default;

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -33,7 +33,7 @@
         border-color: $active-border;
     // Remove the gradient for the pressed/active state
     background-image: none;
-    @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
+    @include box-shadow($btn-active-box-shadow);
 
     &:hover,
     &:focus,


### PR DESCRIPTION
This makes the btn code DRY-er and increases customizability.
