### PR TITLE
Docs: Add missing pages to "Getting started" TOC

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -2,7 +2,9 @@
   pages:
     - title: Introduction
     - title: Download
+    - title: Contents
     - title: Browsers & devices
+    - title: JavaScript
     - title: Options
     - title: Flexbox
     - title: Build tools


### PR DESCRIPTION
Fixes #17986.
