### PR TITLE
Modal: Respect $enable-rounded setting

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -49,7 +49,7 @@
   background-color: $modal-content-bg;
   background-clip: padding-box;
   border: 1px solid $modal-content-border-color;
-  border-radius: $border-radius-lg;
+  @include border-radius($border-radius-lg);
   @include box-shadow(0 3px 9px rgba(0,0,0,.5));
   // Remove focus outline from opened modal
   outline: 0;


### PR DESCRIPTION
See issue: https://github.com/twbs/bootstrap/issues/18385

> I think this issue is still present, somewhat.
> .modal-content has rounded borders even if they have been disabled with the setting. Probably because it uses $border-radius-lg instead of the mixin.
> https://github.com/twbs/bootstrap/blob/v4-dev/scss/_modal.scss#L52
