### PR TITLE
Don't clearfix if flexbox is enabled. Fixes #18849

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -12,7 +12,9 @@
 }
 
 .card-block {
-  @include clearfix;
+  @if (not $enable-flex) {
+    @include clearfix;
+  }
   padding: $card-spacer-x;
 }
 
@@ -69,7 +71,9 @@
 //
 
 .card-header {
-  @include clearfix;
+  @if (not $enable-flex) {
+    @include clearfix;
+  }
   padding: $card-spacer-y $card-spacer-x;
   background-color: $card-cap-bg;
   border-bottom: $card-border-width solid $card-border-color;
@@ -80,7 +84,9 @@
 }
 
 .card-footer {
-  @include clearfix;
+  @if (not $enable-flex) {
+    @include clearfix;
+  }
   padding: $card-spacer-y $card-spacer-x;
   background-color: $card-cap-bg;
   border-top: $card-border-width solid $card-border-color;


### PR DESCRIPTION
See #18849.
Added:

``` scss
@if (not $enable-flex) {
  @include clearfix;
}
```

to `.card-header`, `.card-block` and `.card-footer`
