### PR TITLE
Fix bug #18852 .dropdown-menu-right position

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -20,6 +20,7 @@
 .dropup,
 .dropdown {
   position: relative;
+  display:inline-block;
 }
 
 // Prevent the focus on the dropdown toggle when closing dropdowns


### PR DESCRIPTION
The .dropdown and .dropup classes have been given display property of
inline-block to set their width to that of the button and hence align the edges of the
dropdown menu and button.
