### PR TITLE
Include color scheme support for navbar-toggler

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -193,6 +193,10 @@
   .navbar-divider {
     background-color: rgba(0,0,0,.075);
   }
+
+  .navbar-toggler {
+    color: $navbar-light-color;
+  }
 }
 
 // White links against a dark background
@@ -226,5 +230,9 @@
 
   .navbar-divider {
     background-color: rgba(255,255,255,.075);
+  }
+
+  .navbar-toggler {
+    color: $navbar-dark-color;
   }
 }


### PR DESCRIPTION
The navbar-toggler should use the $navbar-light-color and
$navbar-dark-color for the light and dark color schemes respectively.
