### PR TITLE
Added missing file promised in _variables.scss

### DIFF
--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -1,0 +1,5 @@
+// Custom variables
+//
+// Copy settings from _variables.scss into this file to override
+// the Bootstrap defaults without modifying key, versioned files.
+

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -6,6 +6,7 @@
 
 // Core variables and mixins
 @import "variables";
+@import "custom";
 @import "mixins";
 
 // Reset and dependencies


### PR DESCRIPTION
_variables.scss mentions _custom.scss for custom variables, but is not included in the file structure or build list. This is a quick solution.
