### PR TITLE
Remove <meta name="keywords"> from docs

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -2,7 +2,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Bootstrap, a sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.">
-<meta name="keywords" content="HTML, CSS, JS, JavaScript, framework, bootstrap, front-end, frontend, web development">
 <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
 
 <title>


### PR DESCRIPTION
Remove meta keywords - AFAIK no search engines use them for search ranking at all. There's no need for them to be included.
