### PR TITLE
rm unnecessary border-radius properties from .btn-group-vertical code

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -177,11 +177,9 @@
     border-radius: 0;
   }
   &:first-child:not(:last-child) {
-    border-top-right-radius: $btn-border-radius;
     @include border-bottom-radius(0);
   }
   &:last-child:not(:first-child) {
-    border-bottom-left-radius: $btn-border-radius;
     @include border-top-radius(0);
   }
 }


### PR DESCRIPTION
FWICT in limited testing, settings these properties is redundant; they get inherited from `.btn` just fine.
Also it's not obvious why only the top-left and bottom-right would matter in these cases. If anything, I would think both sides of the top and both sides of the bottom would matter, respectively, in these cases.
