### PR TITLE
Use proper variable for .dropdown-backdrop's z-index

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -161,7 +161,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: ($zindex-dropdown - 10);
+  z-index: $zindex-dropdown-backdrop;
 }
 
 // Right aligned dropdowns

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -359,6 +359,7 @@ $dropdown-header-color:          $gray-light !default;
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.
 
+$zindex-dropdown-backdrop:  990 !default;
 $zindex-navbar:            1000 !default;
 $zindex-dropdown:          1000 !default;
 $zindex-popover:           1060 !default;


### PR DESCRIPTION
Using a hardcoded formula to compute the value on-the-fly seems to defeat the point of having a central list of Z indices.
CC: @mdo 
