### PR TITLE
Remove near-duplicate contextual list group example

### DIFF
--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -96,13 +96,6 @@ Add `.disabled` to a `.list-group-item` to gray it out to appear disabled.
 Use contextual classes to style list items, default or linked. Also includes `.active` state.
 
 {% example html %}
-<ul class="list-group">
-  <li class="list-group-item list-group-item-success">Dapibus ac facilisis in</li>
-  <li class="list-group-item list-group-item-info">Cras sit amet nibh libero</li>
-  <li class="list-group-item list-group-item-warning">Porta ac consectetur ac</li>
-  <li class="list-group-item list-group-item-danger">Vestibulum at eros</li>
-</ul>
-
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-success">Dapibus ac facilisis in</a>
   <a href="#" class="list-group-item list-group-item-info">Cras sit amet nibh libero</a>


### PR DESCRIPTION
I don't see why this particular example should be given in both `<div>` and `<ul>` form when we don't do that for any of the other list group examples.
