### PR TITLE
Typo in form.less (used '\' instead of '/')

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -240,7 +240,7 @@ input[type="search"] {
 .checkbox-inline input[type="checkbox"] {
   position: absolute;
   margin-left: -20px;
-  margin-top: 4px \9;
+  margin-top: 4px /9;
 }
 
 .radio + .radio,


### PR DESCRIPTION
This typo prevented less gem for compiling in rails.

Using Rails 3.2 with less 2.6.0
