### PR TITLE
Stop oversized images in .card-img-* from overflowing the card's boundaries

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -168,11 +168,11 @@
 // Card image caps
 .card-img-top {
   @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
-  max-width: 100%;
+  @include img-fluid(block);
 }
 .card-img-bottom {
   @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
-  max-width: 100%;
+  @include img-fluid(block);
 }
 
 

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -168,9 +168,11 @@
 // Card image caps
 .card-img-top {
   @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
+  max-width: 100%;
 }
 .card-img-bottom {
   @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
+  max-width: 100%;
 }
 
 


### PR DESCRIPTION
Images in cards using card-img-top or card-img-bottom ~~via src="" (instead of data-src="")~~ would overflow past the bounds of the card if the image width was too large.  Now they will at most be equal to the width of the card.
