### PR TITLE
Fix active Home tab in narrow-jumbotron example

### DIFF
--- a/docs/examples/narrow-jumbotron/index.html
+++ b/docs/examples/narrow-jumbotron/index.html
@@ -24,8 +24,8 @@
       <div class="header clearfix">
         <nav>
           <ul class="nav nav-pills pull-xs-right">
-            <li class="nav-item active">
-              <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+            <li class="nav-item">
+              <a class="nav-link active" href="#">Home <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#">About</a>


### PR DESCRIPTION
the active class should be moved from the list item to the link item
