### PR TITLE
Apply word-wrap:break-word to Tooltips and Popovers

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -10,6 +10,8 @@
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
   font-size: $font-size-sm;
+  // Allow breaking very long words so they don't overflow the popover's bounds
+  word-wrap: break-word;
   background-color: $popover-bg;
   background-clip: padding-box;
   border: $popover-border-width solid $popover-border-color;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -7,6 +7,8 @@
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
   font-size: $font-size-sm;
+  // Allow breaking very long words so they don't overflow the tooltip's bounds
+  word-wrap: break-word;
   opacity: 0;
 
   &.in { opacity: $tooltip-opacity; }

--- a/scss/mixins/_reset-text.scss
+++ b/scss/mixins/_reset-text.scss
@@ -1,6 +1,6 @@
 @mixin reset-text {
   font-family: $font-family-base;
-  // We deliberately do NOT reset font-size.
+  // We deliberately do NOT reset font-size or word-wrap.
   font-style: normal;
   font-weight: normal;
   letter-spacing: normal;
@@ -14,5 +14,4 @@
   white-space: normal;
   word-break: normal;
   word-spacing: normal;
-  word-wrap: normal;
 }


### PR DESCRIPTION
Fixes #16871 for v4.
