### PR TITLE
Add Wall of Browser Bugs entry for #18543

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -40,6 +40,16 @@
 
 -
   browser: >
+    Internet Explorer 11 & Microsoft Edge
+  summary: >
+    `@-ms-viewport{width: device-width;}` has side-effect of making scrollbars auto-hide
+  upstream_bug: >
+    IE#2256049
+  origin: >
+    Bootstrap#18543
+
+-
+  browser: >
     Firefox
   summary: >
     `.table-bordered` with an empty `<tbody>` is missing borders.


### PR DESCRIPTION
https://connect.microsoft.com/IE/feedback/details/2256049/edge-ie11-viewport-rule-has-side-effect-of-making-scrollbars-auto-hide
Refs #18543.
