### PR TITLE
Fix typo in grid.html

### DIFF
--- a/docs/_includes/css/grid.html
+++ b/docs/_includes/css/grid.html
@@ -69,7 +69,7 @@
       <tbody>
         <tr>
           <th class="text-nowrap" scope="row">Grid behavior</th>
-          <td>Horizontal at all times</td>
+          <td>Stacked at all times</td>
           <td colspan="3">Collapsed to start, horizontal above breakpoints</td>
         </tr>
         <tr>


### PR DESCRIPTION
Change "Horizontal" to "Stacked".  It says "Horizontal at all times" for how grids are displayed for mobile, but it should say "Stacked at all times."
