### PR TITLE
Add Wall of Browser Bugs entry for #18228

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -50,6 +50,16 @@
 
 -
   browser: >
+    Internet Explorer 11 & Microsoft Edge
+  summary: >
+    Background color from lower layer bleeds through transparent border in some cases
+  upstream_bug: >
+    IE#2263132
+  origin: >
+    Bootstrap#18228
+
+-
+  browser: >
     Firefox
   summary: >
     `.table-bordered` with an empty `<tbody>` is missing borders.


### PR DESCRIPTION
See https://connect.microsoft.com/IE/feedback/details/2263132/edge-ie11-subpixel-problem-with-transparent-borders
Refs #18228.
