### PR TITLE
Border radius mixin logic change without dist changes

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -57,13 +57,13 @@
   margin-left: 0;
 
   &:not(:last-child):not(.dropdown-toggle) {
-    @include border-right-radius(0);
+    @include border-radius(0,right);
   }
 }
 // Need .dropdown-toggle since :last-child doesn't apply given a .dropdown-menu immediately after it
 .btn-group > .btn:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
-  @include border-left-radius(0);
+  @include border-radius(0,left);
 }
 
 // Custom edits for including btn-groups within btn-groups (useful for including dropdown buttons within a btn-group)
@@ -76,11 +76,11 @@
 .btn-group > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
-    @include border-right-radius(0);
+    @include border-radius(0,right);
   }
 }
 .btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
-  @include border-left-radius(0);
+  @include border-radius(0,left);
 }
 
 // On active and open, don't show outline
@@ -177,10 +177,10 @@
     border-radius: 0;
   }
   &:first-child:not(:last-child) {
-    @include border-bottom-radius(0);
+    @include border-radius(0,bottom);
   }
   &:last-child:not(:first-child) {
-    @include border-top-radius(0);
+    @include border-radius(0,top);
   }
 }
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
@@ -189,11 +189,11 @@
 .btn-group-vertical > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
-    @include border-bottom-radius(0);
+    @include border-radius(0,bottom);
   }
 }
 .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
-  @include border-top-radius(0);
+  @include border-radius(0,top);
 }
 
 

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -57,13 +57,13 @@
   margin-left: 0;
 
   &:not(:last-child):not(.dropdown-toggle) {
-    @include border-radius(0,right);
+    @include border-radius(0, right);
   }
 }
 // Need .dropdown-toggle since :last-child doesn't apply given a .dropdown-menu immediately after it
 .btn-group > .btn:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
-  @include border-radius(0,left);
+  @include border-radius(0, left);
 }
 
 // Custom edits for including btn-groups within btn-groups (useful for including dropdown buttons within a btn-group)
@@ -76,11 +76,11 @@
 .btn-group > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
-    @include border-radius(0,right);
+    @include border-radius(0, right);
   }
 }
 .btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
-  @include border-radius(0,left);
+  @include border-radius(0, left);
 }
 
 // On active and open, don't show outline
@@ -177,10 +177,10 @@
     border-radius: 0;
   }
   &:first-child:not(:last-child) {
-    @include border-radius(0,bottom);
+    @include border-radius(0, bottom);
   }
   &:last-child:not(:first-child) {
-    @include border-radius(0,top);
+    @include border-radius(0, top);
   }
 }
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
@@ -189,11 +189,11 @@
 .btn-group-vertical > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
-    @include border-radius(0,bottom);
+    @include border-radius(0, bottom);
   }
 }
 .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
-  @include border-radius(0,top);
+  @include border-radius(0, top);
 }
 
 

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -75,7 +75,7 @@
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
-    @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
+    @include border-radius($card-border-radius-inner,top);
   }
 }
 
@@ -86,7 +86,7 @@
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {
-    @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
+    @include border-radius($card-border-radius-inner,bottom);
   }
 }
 
@@ -167,10 +167,10 @@
 
 // Card image caps
 .card-img-top {
-  @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
+  @include border-radius($card-border-radius-inner,top);
 }
 .card-img-bottom {
-  @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
+  @include border-radius($card-border-radius-inner,bottom);
 }
 
 
@@ -245,7 +245,7 @@
       // Handle rounded corners
       @if $enable-rounded {
         &:first-child {
-          @include border-right-radius(0);
+          @include border-radius(0,right);
 
           .card-img-top {
             border-top-right-radius: 0;
@@ -255,7 +255,7 @@
           }
         }
         &:last-child {
-          @include border-left-radius(0);
+          @include border-radius(0,left);
 
           .card-img-top {
             border-top-left-radius: 0;

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -51,13 +51,13 @@
   .card {
     > .list-group:first-child {
       .list-group-item:first-child {
-        border-radius: $card-border-radius $card-border-radius 0 0;
+        @include border-radius($card-border-radius, top);
       }
     }
 
     > .list-group:last-child {
       .list-group-item:last-child {
-        border-radius: 0 0 $card-border-radius $card-border-radius;
+        @include border-radius($card-border-radius, bottom);
       }
     }
   }
@@ -75,7 +75,7 @@
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
-    @include border-radius($card-border-radius-inner,top);
+    @include border-radius($card-border-radius-inner, top);
   }
 }
 
@@ -86,7 +86,7 @@
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {
-    @include border-radius($card-border-radius-inner,bottom);
+    @include border-radius($card-border-radius-inner, bottom);
   }
 }
 
@@ -167,10 +167,10 @@
 
 // Card image caps
 .card-img-top {
-  @include border-radius($card-border-radius-inner,top);
+  @include border-radius($card-border-radius-inner, top);
 }
 .card-img-bottom {
-  @include border-radius($card-border-radius-inner,bottom);
+  @include border-radius($card-border-radius-inner, bottom);
 }
 
 
@@ -245,7 +245,7 @@
       // Handle rounded corners
       @if $enable-rounded {
         &:first-child {
-          @include border-radius(0,right);
+          @include border-radius(0, right);
 
           .card-img-top {
             border-top-right-radius: 0;
@@ -255,7 +255,7 @@
           }
         }
         &:last-child {
-          @include border-radius(0,left);
+          @include border-radius(0, left);
 
           .card-img-top {
             border-top-left-radius: 0;

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -236,6 +236,6 @@
     content: $custom-file-button-label;
     background-color: $custom-file-button-bg;
     border: $custom-file-border-width solid $custom-file-border-color;
-    @include border-radius(0 $custom-file-border-radius $custom-file-border-radius 0);
+    @include border-radius($custom-file-border-radius,right);
   }
 }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -236,6 +236,6 @@
     content: $custom-file-button-label;
     background-color: $custom-file-button-bg;
     border: $custom-file-border-width solid $custom-file-border-color;
-    @include border-radius($custom-file-border-radius,right);
+    @include border-radius($custom-file-border-radius, right);
   }
 }

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -125,7 +125,7 @@
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
-  @include border-radius(0,right);
+  @include border-radius(0, right);
 }
 .input-group-addon:first-child {
   border-right: 0;
@@ -137,7 +137,7 @@
 .input-group-btn:last-child > .dropdown-toggle,
 .input-group-btn:first-child > .btn:not(:first-child),
 .input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
-  @include border-radius(0,left);
+  @include border-radius(0, left);
 }
 .input-group-addon:last-child {
   border-left: 0;

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -125,7 +125,7 @@
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
-  @include border-right-radius(0);
+  @include border-radius(0,right);
 }
 .input-group-addon:first-child {
   border-right: 0;
@@ -137,7 +137,7 @@
 .input-group-btn:last-child > .dropdown-toggle,
 .input-group-btn:first-child > .btn:not(:first-child),
 .input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
-  @include border-left-radius(0);
+  @include border-radius(0,left);
 }
 .input-group-addon:last-child {
   border-left: 0;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -24,11 +24,11 @@
 
   // Round the first and last items
   &:first-child {
-    @include border-top-radius($list-group-border-radius);
+    @include border-radius($list-group-border-radius, top);
   }
   &:last-child {
     margin-bottom: 0;
-    @include border-bottom-radius($list-group-border-radius);
+    @include border-radius($list-group-border-radius,bottom);
   }
 }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -28,7 +28,7 @@
   }
   &:last-child {
     margin-bottom: 0;
-    @include border-radius($list-group-border-radius,bottom);
+    @include border-radius($list-group-border-radius, bottom);
   }
 }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -65,7 +65,7 @@
     display: block;
     padding: $nav-link-padding;
     border: $nav-tabs-border-width solid transparent;
-    @include border-radius($border-radius,top);
+    @include border-radius($border-radius, top);
 
     @include hover-focus {
       border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
@@ -93,7 +93,7 @@
     // Make dropdown border overlap tab border
     margin-top: -$nav-tabs-border-width;
     // Remove the top rounded corners here since there is a hard edge above the menu
-    @include border-radius(0,top);
+    @include border-radius(0, top);
   }
 }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -65,7 +65,7 @@
     display: block;
     padding: $nav-link-padding;
     border: $nav-tabs-border-width solid transparent;
-    @include border-radius($border-radius $border-radius 0 0);
+    @include border-radius($border-radius,top);
 
     @include hover-focus {
       border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
@@ -93,7 +93,7 @@
     // Make dropdown border overlap tab border
     margin-top: -$nav-tabs-border-width;
     // Remove the top rounded corners here since there is a hard edge above the menu
-    @include border-top-radius(0);
+    @include border-radius(0,top);
   }
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -12,12 +12,12 @@
   &:first-child {
     .page-link {
       margin-left: 0;
-      @include border-radius($border-radius,left);
+      @include border-radius($border-radius, left);
     }
   }
   &:last-child {
     .page-link {
-      @include border-radius($border-radius,right);
+      @include border-radius($border-radius, right);
     }
   }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -12,12 +12,12 @@
   &:first-child {
     .page-link {
       margin-left: 0;
-      @include border-left-radius($border-radius);
+      @include border-radius($border-radius,left);
     }
   }
   &:last-child {
     .page-link {
-      @include border-right-radius($border-radius);
+      @include border-radius($border-radius,right);
     }
   }
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -109,7 +109,7 @@
   background-color: $popover-title-bg;
   border-bottom: $popover-border-width solid darken($popover-title-bg, 5%);
   $offset-border-width: ($border-width / $font-size-root);
-  @include border-radius(($border-radius-lg - $offset-border-width) ($border-radius-lg - $offset-border-width) 0 0);
+  @include border-radius(($border-radius-lg - $offset-border-width) top);
 }
 
 .popover-content {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -109,7 +109,7 @@
   background-color: $popover-title-bg;
   border-bottom: $popover-border-width solid darken($popover-title-bg, 5%);
   $offset-border-width: ($border-width / $font-size-root);
-  @include border-radius(($border-radius-lg - $offset-border-width) top);
+  @include border-radius(($border-radius-lg - $offset-border-width), top);
 }
 
 .popover-content {

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -37,18 +37,18 @@
 }
 .progress[value]::-moz-progress-bar {
   background-color: $progress-bar-color;
-  @include border-radius($border-radius,left);
+  @include border-radius($border-radius, left);
 }
 .progress[value]::-webkit-progress-value {
   background-color: $progress-bar-color;
-  @include border-radius($border-radius,left);
+  @include border-radius($border-radius, left);
 }
 // Tweaks for full progress bar
 .progress[value="100"]::-moz-progress-bar {
-  @include border-radius($border-radius,right);
+  @include border-radius($border-radius, right);
 }
 .progress[value="100"]::-webkit-progress-value {
-  @include border-radius($border-radius,right);
+  @include border-radius($border-radius, right);
 }
 
 // Unfilled portion of the bar
@@ -76,10 +76,10 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
     height: $spacer-y;
     text-indent: -999rem; // Simulate hiding of value as in native `<progress>`
     background-color: $progress-bar-color;
-    @include border-radius($border-radius,left);
+    @include border-radius($border-radius, left);
   }
   .progress[width="100%"] {
-    @include border-radius($border-radius,right);
+    @include border-radius($border-radius, right);
   }
 }
 

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -37,18 +37,18 @@
 }
 .progress[value]::-moz-progress-bar {
   background-color: $progress-bar-color;
-  @include border-left-radius($border-radius);
+  @include border-radius($border-radius,left);
 }
 .progress[value]::-webkit-progress-value {
   background-color: $progress-bar-color;
-  @include border-left-radius($border-radius);
+  @include border-radius($border-radius,left);
 }
 // Tweaks for full progress bar
 .progress[value="100"]::-moz-progress-bar {
-  @include border-right-radius($border-radius);
+  @include border-radius($border-radius,right);
 }
 .progress[value="100"]::-webkit-progress-value {
-  @include border-right-radius($border-radius);
+  @include border-radius($border-radius,right);
 }
 
 // Unfilled portion of the bar
@@ -76,10 +76,10 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
     height: $spacer-y;
     text-indent: -999rem; // Simulate hiding of value as in native `<progress>`
     background-color: $progress-bar-color;
-    @include border-left-radius($border-radius);
+    @include border-radius($border-radius,left);
   }
   .progress[width="100%"] {
-    @include border-right-radius($border-radius);
+    @include border-radius($border-radius,right);
   }
 }
 

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -1,35 +1,20 @@
 // Single side border-radius
+$radius-side-lists: (
+    all  : (true),
+    top  : (true, true, false, false),
+    bottom  : (false, false, true, true),
+    left  : (true, false, false, true),
+    right  : (false, true, true, false),
+);
 
-@mixin border-radius($radius: $border-radius) {
+// Defaults to all corners at $border-radius setting value with no arguments
+@mixin border-radius ( $size: $border-radius , $side: all ) {
   @if $enable-rounded {
-    border-radius: $radius;
-  }
-}
-
-@mixin border-top-radius($radius) {
-  @if $enable-rounded {
-    border-top-right-radius: $radius;
-    border-top-left-radius: $radius;
-  }
-}
-
-@mixin border-right-radius($radius) {
-  @if $enable-rounded {
-    border-bottom-right-radius: $radius;
-    border-top-right-radius: $radius;
-  }
-}
-
-@mixin border-bottom-radius($radius) {
-  @if $enable-rounded {
-    border-bottom-right-radius: $radius;
-    border-bottom-left-radius: $radius;
-  }
-}
-
-@mixin border-left-radius($radius) {
-  @if $enable-rounded {
-    border-bottom-left-radius: $radius;
-    border-top-left-radius: $radius;
+    $bools: map-get($radius-side-lists, $side);
+    $radius-list:;
+    @each $bool in $bools{
+      $radius-list: if($bool, append($radius-list,$size), append($radius-list,0px));
+    }
+    border-radius: $radius-list;
   }
 }

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -13,7 +13,7 @@ $radius-side-lists: (
     $bools: map-get($radius-side-lists, $side);
     $radius-list: null;
     @each $bool in $bools{
-      $radius-list: if($bool, append($radius-list,$size), append($radius-list,0px));
+      $radius-list: if($bool, append($radius-list, $size), append($radius-list, 0));
     }
     border-radius: $radius-list;
   }

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -8,11 +8,11 @@ $radius-side-lists: (
 );
 
 // Defaults to all corners at $border-radius setting value with no arguments
-@mixin border-radius ( $size: $border-radius , $side: all ) {
+@mixin border-radius ($size: $border-radius , $side: all){
   @if $enable-rounded {
     $bools: map-get($radius-side-lists, $side);
     $radius-list: null;
-    @each $bool in $bools{
+    @each $bool in $bools {
       $radius-list: if($bool, append($radius-list, $size), append($radius-list, 0));
     }
     border-radius: $radius-list;

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -11,7 +11,7 @@ $radius-side-lists: (
 @mixin border-radius ( $size: $border-radius , $side: all ) {
   @if $enable-rounded {
     $bools: map-get($radius-side-lists, $side);
-    $radius-list:;
+    $radius-list: null;
     @each $bool in $bools{
       $radius-list: if($bool, append($radius-list,$size), append($radius-list,0px));
     }

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -8,7 +8,7 @@ $radius-side-lists: (
 );
 
 // Defaults to all corners at $border-radius setting value with no arguments
-@mixin border-radius ($size: $border-radius , $side: all){
+@mixin border-radius ($size: $border-radius , $side: all) {
   @if $enable-rounded {
     $bools: map-get($radius-side-lists, $side);
     $radius-list: null;

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -10,12 +10,12 @@
   .page-item {
     &:first-child {
       .page-link {
-        @include border-left-radius($border-radius);
+        @include border-radius($border-radius,left);
       }
     }
     &:last-child {
       .page-link {
-        @include border-right-radius($border-radius);
+        @include border-radius($border-radius,right);
       }
     }
   }

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -10,12 +10,12 @@
   .page-item {
     &:first-child {
       .page-link {
-        @include border-radius($border-radius,left);
+        @include border-radius($border-radius, left);
       }
     }
     &:last-child {
       .page-link {
-        @include border-radius($border-radius,right);
+        @include border-radius($border-radius, right);
       }
     }
   }


### PR DESCRIPTION
I altered border radius mixin for my in house team. We do a lot of sass work and I wanted a single mixin to reference that would also reduce markup in v4-dev it only reduced the bootstrap.css codebase by 27 lines. My team uses it a lot in development so it the code reduction is greater.

I thought I would hand it over to the repository to see if it had any merit.

I removed the dist changes, and am resubmitting a new request... my apologies.
