### PR TITLE
Document .small and .mark classes

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -134,6 +134,8 @@ Styling for common inline HTML5 elements.
 
 While not shown above, feel free to use `<b>` and `<i>` in HTML5. `<b>` is meant to highlight words or phrases without conveying additional importance while `<i>` is mostly for voice, technical terms, etc.
 
+Corresponding classes `.small` and `.mark` are also available and apply the respective styles without introducing additional semantics.
+
 ## Abbreviations
 
 Stylized implementation of HTML's `<abbr>` element for abbreviations and acronyms to show the expanded version on hover. Abbreviations with a `title` attribute have a light dotted bottom border and a help cursor on hover, providing additional context on hover and to users of assistive technologies.


### PR DESCRIPTION
These are available in `_type.scss` in `v4-dev` but not documented.  These classes are useful for styling without adding semantics.
