### PR TITLE
changed order of  _variables.scss and _custom.scss call in bootstrap.scss

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -52,8 +52,8 @@ $grid-gutter-width:          1.875rem !default; // 30px
 // Grid mixins
 //
 
-@import "custom";
 @import "variables";
+@import "custom";
 
 @import "mixins/clearfix";
 @import "mixins/breakpoints";

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -2,8 +2,8 @@
 //
 // Includes only Normalize and our custom Reboot reset.
 
-@import "custom";
 @import "variables";
+@import "custom";
 @import "mixins/hover";
 @import "mixins/tab-focus";
 

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -5,8 +5,8 @@
  */
 
 // Core variables and mixins
-@import "custom";
 @import "variables";
+@import "custom";
 @import "mixins";
 
 // Reset and dependencies

--- a/scss/utilities/_clearfix.scss
+++ b/scss/utilities/_clearfix.scss
@@ -1,11 +1,3 @@
 .clearfix {
   @include clearfix();
 }
-
-@each $breakpoint in map-keys($grid-breakpoints) {
-  @include media-breakpoint-only($breakpoint) {
-    .clearfix-#{$breakpoint} {
-      @include clearfix();
-    }
-  }
-}

--- a/scss/utilities/_clearfix.scss
+++ b/scss/utilities/_clearfix.scss
@@ -1,3 +1,11 @@
 .clearfix {
   @include clearfix();
 }
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-only($breakpoint) {
+    .clearfix-#{$breakpoint} {
+      @include clearfix();
+    }
+  }
+}


### PR DESCRIPTION
because `_custom.scss` can refer to variables from `_variables.scss`, but a error will be thrown if `custom` is called before `variables`
