### PR TITLE
.input-group-addon line-height should be the same as .form-control

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -87,7 +87,7 @@
   padding: $input-padding-y $input-padding-x;
   font-size: $font-size-base;
   font-weight: normal;
-  line-height: 1.5;
+  line-height: $line-height;
   color: $input-color;
   text-align: center;
   background-color: $input-group-addon-bg;


### PR DESCRIPTION
When $line-height is changed the .form-control line height is increased, see https://github.com/twbs/bootstrap/blob/v4-dev/scss/_forms.scss#L12. But the line height of .input-group-addon was hard coded so it would not increase in size. The text .input-group-addon will not center vertical that way.

This change fixes that issue.

Found #17967 which looks similar, but am to big of a git nub to see that change probably
