### PR TITLE
Remove print-specific img max-width:100%; style so that Google Maps etc. print correctly

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -37,10 +37,6 @@
     page-break-inside: avoid;
   }
 
-  img {
-    max-width: 100% !important;
-  }
-
   p,
   h2,
   h3 {


### PR DESCRIPTION
See https://github.com/h5bp/html5-boilerplate/issues/1741
X-Ref: #1506
