### PR TITLE
Bump Normalize so we can remove Reboot's input[type=search] box-sizing override

### DIFF
--- a/scss/_normalize.scss
+++ b/scss/_normalize.scss
@@ -1,4 +1,4 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css commit fe56763 | MIT License | github.com/necolas/normalize.css */
 
 //
 // 1. Set default font family to sans-serif.
@@ -37,7 +37,6 @@ figcaption,
 figure,
 footer,
 header,
-hgroup,
 main,
 menu,
 nav,
@@ -353,13 +352,11 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 //
-// 1. Address `appearance` set to `searchfield` in Safari and Chrome.
-// 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+// Address `appearance` set to `searchfield` in Safari and Chrome.
 //
 
 input[type="search"] {
-  -webkit-appearance: textfield; // 1
-  box-sizing: content-box; //2
+  -webkit-appearance: textfield;
 }
 
 //

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -331,8 +331,6 @@ legend {
 }
 
 input[type="search"] {
-  // Undo Normalize's default here to match our global overrides.
-  box-sizing: inherit;
   // This overrides the extra rounded corners on search inputs in iOS so that our
   // `.form-control` class can properly style them. Note that this cannot simply
   // be added to `.form-control` as it's not specific enough. For details, see


### PR DESCRIPTION
Given Normalize's relatively slow development pace, it's not clear whether there'll be a new packaged release any time soon. I propose that we don't wait around for one.
CC: @mdo 
(Hat tip to @patrickhlauke for driving the Normalize.css side of this forward)
