### PR TITLE
Favor text-decoration over border-bottom where supported

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -123,6 +123,14 @@ abbr[data-original-title] {
   cursor: help;
   border-bottom: 1px dotted $abbr-border-color;
 }
+// Avoid double underline in Firefox 40+; see https://github.com/twbs/bootstrap/issues/16574
+@supports (text-decoration: underline dotted) {
+  abbr[title],
+  abbr[data-original-title] {
+    text-decoration: underline dotted $abbr-border-color;
+    border-bottom: 0;
+  }
+}
 
 address {
   margin-bottom: 1rem;


### PR DESCRIPTION
Fixes #16574.
See also https://github.com/necolas/normalize.css/pull/468
Given Normalize's relatively slow pace of development, I propose we stop waiting on them for a fix.
CC: @mdo 
