### PR TITLE
Add media type "all" to media queries to fix them for IE9

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -202,7 +202,7 @@
 //
 // Reiterate per navbar.less and the modified component alignment there.
 
-@media (min-width: @grid-float-breakpoint) {
+@media all and (min-width: @grid-float-breakpoint) {
   .navbar-right {
     .dropdown-menu {
       .dropdown-menu-right();

--- a/less/forms.less
+++ b/less/forms.less
@@ -474,7 +474,7 @@ input[type="checkbox"] {
 .form-inline {
 
   // Kick in the inline
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     // Inline-block all the things for "inline"
     .form-group {
       display: inline-block;
@@ -574,7 +574,7 @@ input[type="checkbox"] {
 
   // Reset spacing and right align labels, but scope to media queries so that
   // labels on narrow viewports stack the same as a default form example.
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     .control-label {
       text-align: right;
       margin-bottom: 0;
@@ -595,7 +595,7 @@ input[type="checkbox"] {
   // Quick utility class for applying `.input-lg` and `.input-sm` styles to the
   // inputs and labels within a `.form-group`.
   .form-group-lg {
-    @media (min-width: @screen-sm-min) {
+    @media all and (min-width: @screen-sm-min) {
       .control-label {
         padding-top: (@padding-large-vertical + 1);
         font-size: @font-size-large;
@@ -603,7 +603,7 @@ input[type="checkbox"] {
     }
   }
   .form-group-sm {
-    @media (min-width: @screen-sm-min) {
+    @media all and (min-width: @screen-sm-min) {
       .control-label {
         padding-top: (@padding-small-vertical + 1);
         font-size: @font-size-small;

--- a/less/grid.less
+++ b/less/grid.less
@@ -10,13 +10,13 @@
 .container {
   .container-fixed();
 
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     width: @container-sm;
   }
-  @media (min-width: @screen-md-min) {
+  @media all and (min-width: @screen-md-min) {
     width: @container-md;
   }
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     width: @container-lg;
   }
 }
@@ -61,7 +61,7 @@
 // Columns, offsets, pushes, and pulls for the small device range, from phones
 // to tablets.
 
-@media (min-width: @screen-sm-min) {
+@media all and (min-width: @screen-sm-min) {
   .make-grid(sm);
 }
 
@@ -70,7 +70,7 @@
 //
 // Columns, offsets, pushes, and pulls for the desktop device range.
 
-@media (min-width: @screen-md-min) {
+@media all and (min-width: @screen-md-min) {
   .make-grid(md);
 }
 
@@ -79,6 +79,6 @@
 //
 // Columns, offsets, pushes, and pulls for the large desktop device range.
 
-@media (min-width: @screen-lg-min) {
+@media all and (min-width: @screen-lg-min) {
   .make-grid(lg);
 }

--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -44,23 +44,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-offset(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-push(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-sm-column-pull(@columns) {
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     right: percentage((@columns / @grid-columns));
   }
 }
@@ -72,23 +72,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-md-min) {
+  @media all and (min-width: @screen-md-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-offset(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media all and (min-width: @screen-md-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-push(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media all and (min-width: @screen-md-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-md-column-pull(@columns) {
-  @media (min-width: @screen-md-min) {
+  @media all and (min-width: @screen-md-min) {
     right: percentage((@columns / @grid-columns));
   }
 }
@@ -100,23 +100,23 @@
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
 
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-offset(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     margin-left: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-push(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     left: percentage((@columns / @grid-columns));
   }
 }
 .make-lg-column-pull(@columns) {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     right: percentage((@columns / @grid-columns));
   }
 }

--- a/less/modals.less
+++ b/less/modals.less
@@ -131,7 +131,7 @@
 }
 
 // Scale up the modal
-@media (min-width: @screen-sm-min) {
+@media all and (min-width: @screen-sm-min) {
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     width: @modal-md;
@@ -145,6 +145,6 @@
   .modal-sm { width: @modal-sm; }
 }
 
-@media (min-width: @screen-md-min) {
+@media all and (min-width: @screen-md-min) {
   .modal-lg { width: @modal-lg; }
 }

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -17,7 +17,7 @@
   // Prevent floats from breaking the navbar
   &:extend(.clearfix all);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     border-radius: @navbar-border-radius;
   }
 }
@@ -31,7 +31,7 @@
 .navbar-header {
   &:extend(.clearfix all);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     float: left;
   }
 }
@@ -60,7 +60,7 @@
     overflow-y: auto;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     width: auto;
     border-top: 0;
     box-shadow: none;
@@ -92,7 +92,7 @@
   .navbar-collapse {
     max-height: @navbar-collapse-max-height;
 
-    @media (max-device-width: @screen-xs-min) and (orientation: landscape) {
+    @media all and (max-device-width: @screen-xs-min) and (orientation: landscape) {
       max-height: 200px;
     }
   }
@@ -110,7 +110,7 @@
     margin-right: -@navbar-padding-horizontal;
     margin-left:  -@navbar-padding-horizontal;
 
-    @media (min-width: @grid-float-breakpoint) {
+    @media all and (min-width: @grid-float-breakpoint) {
       margin-right: 0;
       margin-left:  0;
     }
@@ -129,7 +129,7 @@
   z-index: @zindex-navbar;
   border-width: 0 0 1px;
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     border-radius: 0;
   }
 }
@@ -143,7 +143,7 @@
   z-index: @zindex-navbar-fixed;
 
   // Undo the rounded corners
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     border-radius: 0;
   }
 }
@@ -176,7 +176,7 @@
     display: block;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     .navbar > .container &,
     .navbar > .container-fluid & {
       margin-left: -@navbar-padding-horizontal;
@@ -218,7 +218,7 @@
     margin-top: 4px;
   }
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     display: none;
   }
 }
@@ -238,7 +238,7 @@
     line-height: @line-height-computed;
   }
 
-  @media (max-width: @grid-float-breakpoint-max) {
+  @media all and (max-width: @grid-float-breakpoint-max) {
     // Dropdowns get custom display when collapsed
     .open .dropdown-menu {
       position: static;
@@ -263,7 +263,7 @@
   }
 
   // Uncollapse the nav
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     float: left;
     margin: 0;
 
@@ -296,7 +296,7 @@
   .form-inline();
 
   .form-group {
-    @media (max-width: @grid-float-breakpoint-max) {
+    @media all and (max-width: @grid-float-breakpoint-max) {
       margin-bottom: 5px;
 
       &:last-child {
@@ -309,7 +309,7 @@
   .navbar-vertical-align(@input-height-base);
 
   // Undo 100% width for pull classes
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     width: auto;
     border: 0;
     margin-left: 0;
@@ -359,7 +359,7 @@
 .navbar-text {
   .navbar-vertical-align(@line-height-computed);
 
-  @media (min-width: @grid-float-breakpoint) {
+  @media all and (min-width: @grid-float-breakpoint) {
     float: left;
     margin-left: @navbar-padding-horizontal;
     margin-right: @navbar-padding-horizontal;
@@ -375,7 +375,7 @@
 //
 // Declared after the navbar components to ensure more specificity on the margins.
 
-@media (min-width: @grid-float-breakpoint) {
+@media all and (min-width: @grid-float-breakpoint) {
   .navbar-left  { .pull-left(); }
   .navbar-right {
     .pull-right();
@@ -465,7 +465,7 @@
       }
     }
 
-    @media (max-width: @grid-float-breakpoint-max) {
+    @media all and (max-width: @grid-float-breakpoint-max) {
       // Dropdowns get custom display when collapsed
       .open .dropdown-menu {
         > li > a {
@@ -599,7 +599,7 @@
       }
     }
 
-    @media (max-width: @grid-float-breakpoint-max) {
+    @media all and (max-width: @grid-float-breakpoint-max) {
       // Dropdowns get custom display
       .open .dropdown-menu {
         > .dropdown-header {

--- a/less/navs.less
+++ b/less/navs.less
@@ -173,7 +173,7 @@
     left: auto;
   }
 
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     > li {
       display: table-cell;
       width: 1%;
@@ -202,7 +202,7 @@
     border: 1px solid @nav-tabs-justified-link-border-color;
   }
 
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     > li > a {
       border-bottom: 1px solid @nav-tabs-justified-link-border-color;
       border-radius: @border-radius-base @border-radius-base 0 0;

--- a/less/responsive-utilities.less
+++ b/less/responsive-utilities.less
@@ -48,106 +48,106 @@
 }
 
 .visible-xs {
-  @media (max-width: @screen-xs-max) {
+  @media all and (max-width: @screen-xs-max) {
     .responsive-visibility();
   }
 }
 .visible-xs-block {
-  @media (max-width: @screen-xs-max) {
+  @media all and (max-width: @screen-xs-max) {
     display: block !important;
   }
 }
 .visible-xs-inline {
-  @media (max-width: @screen-xs-max) {
+  @media all and (max-width: @screen-xs-max) {
     display: inline !important;
   }
 }
 .visible-xs-inline-block {
-  @media (max-width: @screen-xs-max) {
+  @media all and (max-width: @screen-xs-max) {
     display: inline-block !important;
   }
 }
 
 .visible-sm {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media all and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     .responsive-visibility();
   }
 }
 .visible-sm-block {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media all and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: block !important;
   }
 }
 .visible-sm-inline {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media all and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: inline !important;
   }
 }
 .visible-sm-inline-block {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media all and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     display: inline-block !important;
   }
 }
 
 .visible-md {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media all and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     .responsive-visibility();
   }
 }
 .visible-md-block {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media all and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: block !important;
   }
 }
 .visible-md-inline {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media all and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: inline !important;
   }
 }
 .visible-md-inline-block {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media all and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     display: inline-block !important;
   }
 }
 
 .visible-lg {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     .responsive-visibility();
   }
 }
 .visible-lg-block {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     display: block !important;
   }
 }
 .visible-lg-inline {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     display: inline !important;
   }
 }
 .visible-lg-inline-block {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     display: inline-block !important;
   }
 }
 
 .hidden-xs {
-  @media (max-width: @screen-xs-max) {
+  @media all and (max-width: @screen-xs-max) {
     .responsive-invisibility();
   }
 }
 .hidden-sm {
-  @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  @media all and (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
     .responsive-invisibility();
   }
 }
 .hidden-md {
-  @media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  @media all and (min-width: @screen-md-min) and (max-width: @screen-md-max) {
     .responsive-invisibility();
   }
 }
 .hidden-lg {
-  @media (min-width: @screen-lg-min) {
+  @media all and (min-width: @screen-lg-min) {
     .responsive-invisibility();
   }
 }

--- a/less/theme.less
+++ b/less/theme.less
@@ -171,7 +171,7 @@
 }
 
 // Fix active state of dropdown items in collapsed mode
-@media (max-width: @grid-float-breakpoint-max) {
+@media all and (max-width: @grid-float-breakpoint-max) {
   .navbar .navbar-nav .open .dropdown-menu > .active > a {
     &,
     &:hover,

--- a/less/type.less
+++ b/less/type.less
@@ -65,7 +65,7 @@ p {
   font-weight: 300;
   line-height: 1.4;
 
-  @media (min-width: @screen-sm-min) {
+  @media all and (min-width: @screen-sm-min) {
     font-size: (@font-size-base * 1.5);
   }
 }
@@ -211,7 +211,7 @@ dd {
     &:extend(.clearfix all); // Clear the floated `dt` if an empty `dd` is present
   }
 
-  @media (min-width: @dl-horizontal-breakpoint) {
+  @media all and (min-width: @dl-horizontal-breakpoint) {
     dt {
       float: left;
       width: (@dl-horizontal-offset - 20);


### PR DESCRIPTION
Writing @media (max-width: something) will break in IE9, as the media type is not defined. This is easily fixed by simply rewriting all media queries with e.g. @media all and (max-width: something).
