### PR TITLE
Add Wall of Browser Bugs entry for #16915

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -1,5 +1,15 @@
 -
   browser: >
+    Microsoft Edge
+  summary: >
+    Edge renders an SVG `<img>` with `max-width:100%;` too small
+  upstream_bug: >
+    IE#2274240
+  origin: >
+    Bootstrap#16915
+
+-
+  browser: >
     Internet Explorer 11 & Microsoft Edge
   summary: >
     Hovered element still remains in `:hover` state after scrolling away.


### PR DESCRIPTION
https://connect.microsoft.com/IE/feedback/details/2274240/edge-edge-renders-an-svg-img-with-max-width-100-too-small
Refs #16915
