### PR TITLE
Allow a <label> for .input-group-addon by removing margin

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -85,6 +85,7 @@
 
 .input-group-addon {
   padding: $input-padding-y $input-padding-x;
+  margin: 0;
   font-size: $font-size-base;
   font-weight: normal;
   line-height: 1.5;
@@ -93,7 +94,6 @@
   background-color: $input-group-addon-bg;
   border: $input-btn-border-width solid $input-group-addon-border-color;
   @include border-radius($border-radius);
-  margin: 0;
 
   // Sizing
   &.form-control-sm {

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -93,6 +93,7 @@
   background-color: $input-group-addon-bg;
   border: $input-btn-border-width solid $input-group-addon-border-color;
   @include border-radius($border-radius);
+  margin: 0;
 
   // Sizing
   &.form-control-sm {


### PR DESCRIPTION
When using a label as input-group-addon there will be a default margin-bottom of .5rem via the reboot, https://github.com/twbs/bootstrap/blob/v4-dev/scss/_reboot.scss#L280.

This will lead to undesirable white space below the label and the input will scall bigger then needed. By removing the margin, it will play nice with label elements
