### PR TITLE
DOCS - Fix a link in popover for v4

### DIFF
--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -268,7 +268,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>offsets</td>
         <td>string</td>
         <td>'0 0'</td>
-        <td>Offset of the popover relative to its target. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#constraints">offset docs</a>.</td>
+        <td>Offset of the popover relative to its target. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#offset">offset docs</a>.</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This is a fix for a bad link in the documentation for for v4.
