### PR TITLE
Jumbotron sass: replace background-color with background

### DIFF
--- a/scss/_jumbotron.scss
+++ b/scss/_jumbotron.scss
@@ -1,7 +1,7 @@
 .jumbotron {
   padding: $jumbotron-padding ($jumbotron-padding / 2);
   margin-bottom: $jumbotron-padding;
-  background-color: $jumbotron-bg;
+  background: $jumbotron-bg;
   @include border-radius($border-radius-lg);
 
   @include media-breakpoint-up(sm) {


### PR DESCRIPTION
background-color: limits variable only to colors but jumbotron often is used with bg image.

background-color: X have same effect as background: X, however, now image can be set as jumbotron bg using variable.
