### PR TITLE
Navbar improvements: dropdown support, margin/padding variables for navbar items, calculated spacer for body for fixed navbars

### DIFF
--- a/docs/examples/navbar-dropdown/index.html
+++ b/docs/examples/navbar-dropdown/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" href="../../favicon.ico">
+
+    <title>navbar with dropdown example for Bootstrap 4</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../../dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom styles for this template -->
+    <link href="navbar-dropdown.css" rel="stylesheet">
+</head>
+
+<body>
+
+<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+    <a class="navbar-brand" href="#">Logo</a>
+
+    <ul class="nav navbar-nav">
+        <li class="nav-item active">
+            <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#">Products</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="#">About us</a>
+        </li>
+    </ul>
+
+    <ul class="nav navbar-nav pull-xs-right">
+        <li class="nav-item">
+            <a class="nav-link" href="#">Admin panel</a>
+        </li>
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                User
+            </a>
+            <div class="dropdown-menu dropdown-menu-right app-nav-dropdown" aria-labelledby="dropdown">
+                <a class="dropdown-item" href="#">My profile</a>
+                <a class="dropdown-item" href="#">Edit settings</a>
+                <a class="dropdown-item" href="#">Friends</a>
+                <a class="dropdown-item" href="#">Logout</a>
+            </div>
+        </li>
+    </ul>
+</nav>
+
+<div class="jumbotron">
+    <h1>Navbar with dropdown, inverse, right align example</h1>
+    <p>
+        <a class="btn btn-lg btn-primary" href="../../components/navbar" role="button">View navbar docs &raquo;</a>
+    </p>
+</div>
+
+
+<!-- Bootstrap core JavaScript
+================================================== -->
+<!-- Placed at the end of the document so the pages load faster -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js" integrity="sha384-8gBf6Y4YYq7Jx97PIqmTwLPin4hxIzQw5aDmUg/DDhul9fFpbbLcLh3nTIIDJKhx" crossorigin="anonymous"></script>
+<script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.1.1/js/tether.min.js" integrity="sha384-MWq1Lnqj72tmjGdOKuNBn3E0gj3vWfy/1EmR5TVL8d8nGvwgy32YkCpKpTUhwBVv" crossorigin="anonymous"></script>
+<script src="../../dist/js/bootstrap.min.js"></script>
+<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+<script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
+</body>
+</html>

--- a/docs/examples/navbar-dropdown/index.html
+++ b/docs/examples/navbar-dropdown/index.html
@@ -39,10 +39,10 @@
             <a class="nav-link" href="#">Admin panel</a>
         </li>
         <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" id="nav_user_dropdown" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                 User
             </a>
-            <div class="dropdown-menu dropdown-menu-right app-nav-dropdown" aria-labelledby="dropdown">
+            <div class="dropdown-menu dropdown-menu-right app-nav-dropdown" aria-labelledby="nav_user_dropdown">
                 <a class="dropdown-item" href="#">My profile</a>
                 <a class="dropdown-item" href="#">Edit settings</a>
                 <a class="dropdown-item" href="#">Friends</a>

--- a/docs/examples/navbar-dropdown/index.html
+++ b/docs/examples/navbar-dropdown/index.html
@@ -39,10 +39,10 @@
             <a class="nav-link" href="#">Admin panel</a>
         </li>
         <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" id="nav_user_dropdown" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" id="navUserDropdown" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                 User
             </a>
-            <div class="dropdown-menu dropdown-menu-right app-nav-dropdown" aria-labelledby="nav_user_dropdown">
+            <div class="dropdown-menu dropdown-menu-right app-nav-dropdown" aria-labelledby="navUserDropdown">
                 <a class="dropdown-item" href="#">My profile</a>
                 <a class="dropdown-item" href="#">Edit settings</a>
                 <a class="dropdown-item" href="#">Friends</a>

--- a/docs/examples/navbar-dropdown/navbar-dropdown.css
+++ b/docs/examples/navbar-dropdown/navbar-dropdown.css
@@ -1,0 +1,4 @@
+body {
+  min-height: 75rem;
+  padding-top: 6rem;
+}

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -69,8 +69,8 @@
 
 .navbar-brand {
   float: left;
-  padding-top:    .25rem;
-  padding-bottom: .25rem;
+  padding-top: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
+  padding-bottom: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
   margin-right: 1rem;
   font-size: $font-size-lg;
 
@@ -144,6 +144,8 @@
 .navbar-nav {
   .nav-item {
     float: left;
+    margin: $navbar-item-margin-y $navbar-item-margin-x;
+    padding: $navbar-item-padding-y $navbar-item-padding-x;
   }
 
   .nav-link {
@@ -152,12 +154,19 @@
     padding-bottom: .425rem;
 
     + .nav-link {
-      margin-left: 1rem;
+      margin-left: 0;
     }
   }
 
   .nav-item + .nav-item {
-    margin-left: 1rem;
+    margin-left: 0;
+  }
+  
+  .dropdown-menu {
+    margin-top: $navbar-padding-y;
+    border-top: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -72,8 +72,8 @@
   padding-top: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
   padding-bottom: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
   margin-top: $navbar-item-margin-y;
-  margin-bottom: $navbar-item-margin-y;
   margin-right: 1rem;
+  margin-bottom: $navbar-item-margin-y;
   font-size: $font-size-lg;
 
   @include hover-focus {
@@ -146,8 +146,8 @@
 .navbar-nav {
   .nav-item {
     float: left;
-    margin: $navbar-item-margin-y $navbar-item-margin-x;
     padding: $navbar-item-padding-y $navbar-item-padding-x;
+    margin: $navbar-item-margin-y $navbar-item-margin-x;
   }
 
   .nav-link {
@@ -166,7 +166,7 @@
 
   .dropdown-menu {
     margin-top: $navbar-padding-y + $navbar-item-margin-y;
-    border-top: none;
+    border-top: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -71,6 +71,8 @@
   float: left;
   padding-top: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
   padding-bottom: (($navbar-item-padding-y + 0.425rem) / $font-size-lg) + rem;
+  margin-top: $navbar-item-margin-y;
+  margin-bottom: $navbar-item-margin-y;
   margin-right: 1rem;
   font-size: $font-size-lg;
 
@@ -161,9 +163,9 @@
   .nav-item + .nav-item {
     margin-left: 0;
   }
-  
+
   .dropdown-menu {
-    margin-top: $navbar-padding-y;
+    margin-top: $navbar-padding-y + $navbar-item-margin-y;
     border-top: none;
     border-top-left-radius: 0;
     border-top-right-radius: 0;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -62,6 +62,13 @@
   }
 }
 
+.body-navbar-top-spacer {
+  margin-top: ($navbar-item-padding-y + 0.425rem + $navbar-item-margin-y) * 2 + $line-height;
+}
+
+.body-navbar-bottom-spacer {
+  margin-bottom: ($navbar-item-padding-y + 0.425rem + $navbar-item-margin-y) * 2 + $line-height;
+}
 
 //
 // Brand/project name

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -441,7 +441,7 @@ $zindex-modal:             1050 !default;
 
 $navbar-border-radius:              $border-radius !default;
 $navbar-padding-x:                  $spacer !default;
-$navbar-padding-y:                  ($spacer / 2) !default;
+$navbar-padding-y:                  0 !default;
 
 $navbar-dark-color:                 rgba(255,255,255,.5) !default;
 $navbar-dark-hover-color:           rgba(255,255,255,.75) !default;
@@ -452,6 +452,11 @@ $navbar-light-color:                rgba(0,0,0,.3) !default;
 $navbar-light-hover-color:          rgba(0,0,0,.6) !default;
 $navbar-light-active-color:         rgba(0,0,0,.8) !default;
 $navbar-light-disabled-color:       rgba(0,0,0,.15) !default;
+
+$navbar-item-padding-y:             0.5rem;
+$navbar-item-padding-x:             1rem;
+$navbar-item-margin-y:              0;
+$navbar-item-margin-x:              0;
 
 
 // Navs


### PR DESCRIPTION
Fixes: #17532: Dropdowns in navbar navs? from #18467
1. Padding in navbar removed to allow bg color on :hover on nav-item. Margin in nav-item now can be used instead.
2. Added padding and margin to navbar nav-items configurable via 4 new variables:
   - $navbar-item-padding-y: 0.5rem;
   - $navbar-item-padding-x: 1rem;
   - $navbar-item-margin-y: 0;
   - $navbar-item-margin-x: 0;
3. Fixed navbar-brand to position correctly
4. Added dropdown support in navbar.
5. Added example navbar-dropdown with bg-inverse, right align and fixed navbar.
6. Added two new classes for body to add calculated margin if fixed navbar used:
   - `.body-navbar-top-spacer`
   - `.body-navbar-bottom-spacer`
