### PR TITLE
Have same margin for <hN> as a <div> on .card-headers

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -71,7 +71,7 @@
 .card-header {
   @include clearfix;
   padding: $card-spacer-y $card-spacer-x;
-  margin-bottom: 0; // Removes the default margin-bottom of <hN> 
+  margin-bottom: 0; // Removes the default margin-bottom of <hN>
   background-color: $card-cap-bg;
   border-bottom: $card-border-width solid $card-border-color;
 

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -71,6 +71,7 @@
 .card-header {
   @include clearfix;
   padding: $card-spacer-y $card-spacer-x;
+  margin-bottom: 0; // Removes the default margin-bottom of <hN> 
   background-color: $card-cap-bg;
   border-bottom: $card-border-width solid $card-border-color;
 


### PR DESCRIPTION
Related #18726

When you use a `<hN>` as `.card-header` there is `margin-bottom: .5rem` added. The changes set the margin-bottom to 0
