### PR TITLE
Removed 'gossip' and 'awesome music videos' words

### DIFF
--- a/docs/_includes/getting-started/community.html
+++ b/docs/_includes/getting-started/community.html
@@ -9,5 +9,5 @@
     <li>Developers should use the keyword <code>bootstrap</code> on packages which modify or add to the functionality of Bootstrap when distributing through <a href="https://www.npmjs.com/browse/keyword/bootstrap">npm</a> or similar delivery mechanisms for maximum discoverability.</li>
     <li>Find inspiring examples of people building with Bootstrap at the <a href="http://expo.getbootstrap.com">Bootstrap Expo</a>.</li>
   </ul>
-  <p>You can also follow <a href="https://twitter.com/getbootstrap">@getbootstrap on Twitter</a> for the latest gossip and awesome music videos.</p>
+  <p>You can also follow <a href="https://twitter.com/getbootstrap">@getbootstrap on Twitter</a> for the latest news and updates.</p>
 </div>


### PR DESCRIPTION
Remove 'gossip' and 'awesome music videos' terminology on community.html. People will not follow @getbootstrap for gossip or music videos. Replace 'gossip' and 'awesome music videos' terminology with 'latest news and updates'.
