### PR TITLE
Mention contributors in License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2016 Twitter, Inc.
+Copyright (c) 2011-2016 Twitter, Inc. and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I am not a lawyer but adding `Contributors` to License because Twitter Inc isn't the only entity owning the copyright. The copyright is collectively owned by all contributors, or more precisely: every contributor owns a copyright on the code they have contributed.

The only way to retain full copyright over code is to ask for signing contributor's agreement before merging in changes. This is, in fact, what some companies who license free software commercially do.

As I mentioned, I am not an expert in this domain. Any opinion from people who are more well-versed with this subject (Copyright and Intellectual Property Rights) would be of great help

If this has already been discussed, then I apologize for bringing it up again as I couldn't find it via the issue tracker
