### PR TITLE
Prevent double border on list-group in cards with no .card-block.

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -294,3 +294,10 @@
     }
   }
 }
+
+// Prevent double border on list-group in cards with no .card-block
+
+.card > .card-header + .list-group > .list-group-item:first-child,
+.card > .list-group + .card-footer {
+  border-top: 0;
+}


### PR DESCRIPTION
Fixes #19047.
Removes double border when list-group is adjacent to .card-header and .card-footer with .card-block missing.
