### PR TITLE
Add Wall of Browser Bugs entry for https://webkit.org/b/153852

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -342,6 +342,16 @@
 
 -
   browser: >
+    Safari (iOS)
+  summary: >
+    `<body>` with `overflow:hidden` CSS is scrollable on iOS
+  upstream_bug: >
+    WebKit#153852
+  origin: >
+    Bootstrap#14839
+
+-
+  browser: >
     Safari (iPad Pro)
   summary: >
     Rendering of descendants of `position: fixed` element gets clipped on iPad Pro in Landscape orientation


### PR DESCRIPTION
See https://webkit.org/b/153852
Refs http://getbootstrap.com/getting-started/#overflow-and-scrolling
Refs #14839.
