### PR TITLE
v4: Native system font stack for sans-serif

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable QualifyingElement
+
 //
 // Grid examples
 //

--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -32,6 +32,30 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 - The `<body>` also sets a global `font-family` and `line-height`. This is inherited later by some form elements to prevent font inconsistencies.
 - For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
 
+## Native font stack
+
+The default web (Helvetica Neue, Helvetica, and Arial) fonts have been dropped in Bootstrap 4 and replaced with a "native font stack" for optimum text rendering on every device and OS. Read more about [native font stacks in this Smashing Magazine article](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/).
+
+{% highlight sass %}
+$font-family-sans-serif:
+  // Safari for OS X and iOS (San Francisco)
+  -apple-system,
+  // Chrome for OS X (San Francisco) and Windows (Segoe UI)
+  BlinkMacSystemFont,
+  // Windows
+  "Segoe UI",
+  // Android
+  "Roboto",
+  // Linux distros
+  "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+  // Older Android
+  "Droid Sans",
+  // Basic web fallback
+  "Helvetica Neue", Arial, sans-serif !default;
+{% endhighlight %}
+
+This `font-family` is applied to the `<body>` and automatically inherited globally throughout Bootstrap. To switch the global `font-family`, update `$font-family-base` and recompile Bootstrap.
+
 ## Headings and paragraphs
 
 All heading elements—e.g., `<h1>`—and `<p>` are reset to have their `margin-top` removed. Headings have `margin-bottom: .5rem` added and paragraphs `margin-bottom: 1rem` for easy spacing.

--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -15,9 +15,10 @@ Bootstrap includes simple and easily customized typography for headings, body te
 
 Bootstrap sets basic global display, typography, and link styles. Specifically, we:
 
-- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default)
-- Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base
-- Set the global link color via `$link-color` and apply link underlines only on `:hover`
+- Use a [native font stack](/content/reboot/#native-font-stack) that selects the best `font-family` for each OS and device.
+- Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
+- Set the global link color via `$link-color` and apply link underlines only on `:hover`.
+- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
 
 These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`.
 

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -51,7 +51,7 @@
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
       .col-#{$breakpoint}-first { order: -1; }
-      .col-#{$breakpoint}-last  { order: 1; }
+      .col-#{$breakpoint}-last { order: 1; }
     }
   }
 
@@ -59,7 +59,7 @@
 
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
-      .row-#{$breakpoint}-top    { align-items: flex-start; }
+      .row-#{$breakpoint}-top { align-items: flex-start; }
       .row-#{$breakpoint}-center { align-items: center; }
       .row-#{$breakpoint}-bottom { align-items: flex-end; }
     }
@@ -69,7 +69,7 @@
 
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
-      .col-#{$breakpoint}-top    { align-self: flex-start; }
+      .col-#{$breakpoint}-top { align-self: flex-start; }
       .col-#{$breakpoint}-center { align-self: center; }
       .col-#{$breakpoint}-bottom { align-self: flex-end; }
     }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -137,7 +137,7 @@ $grid-gutter-width: 1.875rem !default; // 30px
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", Arial, sans-serif !default;
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif !default;
 $font-family-serif:      Georgia, "Times New Roman", Times, serif !default;
 $font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:       $font-family-sans-serif !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -137,10 +137,10 @@ $grid-gutter-width: 1.875rem !default; // 30px
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", Arial, sans-serif !default;
 $font-family-serif:      Georgia, "Times New Roman", Times, serif !default;
 $font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
-$font-family-base: $font-family-sans-serif !default;
+$font-family-base:       $font-family-sans-serif !default;
 
 // Pixel value used to responsively scale all typography. Applied to the `<html>` element.
 $font-size-root: 16px !default;


### PR DESCRIPTION
To date, we've used a singular font stack for all browsers and OSes. Across the board, none of the fonts currently in use are the (preferred and well designed) system fonts. This PR drops the old font stack for a new native system-based one. Essentially, every OS will have it's own `font-family` with this new stack.

As an example, on OS X (Safari, Chrome, and Firefox) and iOS, the font will now be Apple's San Francisco. On the latest versions of Windows, it'll be Segoe UI. On Linux, well, you get whatever flavor of Linux you get 😆.

I took a quick look at our buttons as an example (as they tend to give us the most trouble) on Win7 IE9 and Win8 IE11 and things look a _tad_ out of alignment in IE9. IE11 looks just dandy.

<img width="660" alt="screen shot 2016-02-05 at 10 45 42 pm" src="https://cloud.githubusercontent.com/assets/98681/12865227/ac62fcbc-cc5b-11e5-9d94-0c898af41a48.png">

<img width="650" alt="screen shot 2016-02-05 at 10 49 58 pm" src="https://cloud.githubusercontent.com/assets/98681/12865226/ac470c6e-cc5b-11e5-89f4-827d0a2c8a3a.png">

For full details on what font is shown where, please head to https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/#details-of-approach-b.

Overall, I'm pretty stoked about this. Would love to hear what others are thinking.

**Sources:**
- http://furbo.org/2015/07/09/i-left-my-system-fonts-in-san-francisco/
- https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/#details-of-approach-a
