### PR TITLE
v4: Drop .center-block for new-ish .m-x-auto 

### DIFF
--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -60,8 +60,19 @@ Here are some representative examples of these classes:
 }
 {% endhighlight %}
 
-Additionally, Bootstrap also includes an `.m-x-auto` class which sets the horizontal margins to `auto`.
+Additionally, Bootstrap also includes an `.m-x-auto` class for centering fixed-width block level content by setting the horizontal margins to `auto`.
 
+<div class="bd-example">
+  <div class="m-x-auto" style="width: 200px; background-color: rgba(86,61,124,.15);">
+    Centered element
+  </div>
+</div>
+
+{% highlight html %}
+<div class="m-x-auto" style="width: 200px;"">
+  Centered element
+</div>
+{% endhighlight %}
 
 ## Text alignment
 
@@ -191,27 +202,7 @@ Two similar non-responsive mixins (`pull-left` and `pull-right`) are also availa
 }
 {% endhighlight %}
 
-## Center content
-
-Set an element to `display: block;` and center via `margin`. Available as a mixin and class.
-
-{% example html %}
-<div class="center-block">Centered block</div>
-{% endexample %}
-
-{% highlight scss %}
-// Class
-.center-block {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-// Usage as a mixin
-.element {
-  @include center-block;
-}
-{% endhighlight %}
+## Clearfix
 
 Easily clear `float`s by adding `.clearfix` **to the parent element**. Utilizes [the micro clearfix](http://nicolasgallagher.com/micro-clearfix-hack/) as popularized by Nicolas Gallagher. Can also be used as a mixin.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -154,8 +154,9 @@ Dropped entirely for the new card component.
 
 ### Utilities
 
-- Added `.pull-{xs,sm,md,lg,xl}-{left,right,none}` classes for responsive floats
-- Removed `.pull-left` and `.pull-right` since they're redundant to `.pull-xs-left` and `.pull-xs-right`
+- Added `.pull-{xs,sm,md,lg,xl}-{left,right,none}` classes for responsive floats.
+- Removed `.pull-left` and `.pull-right` since they're redundant to `.pull-xs-left` and `.pull-xs-right`.
+- Dropped `.center-block` for the new `.m-x-auto` class.
 
 ### Vendor prefix mixins
 Bootstrap 3's [vendor prefix](http://webdesign.about.com/od/css/a/css-vendor-prefixes.htm) mixins, which were deprecated in v3.2.0, have been removed in Bootstrap 4. Since we use [Autoprefixer](https://github.com/postcss/autoprefixer), they're no longer necessary.

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -48,7 +48,6 @@
 
 // // Layout
 @import "mixins/clearfix";
-@import "mixins/center-block";
 // @import "mixins/navbar-align";
 @import "mixins/grid-framework";
 @import "mixins/grid";

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1,5 +1,4 @@
 @import "utilities/background";
-@import "utilities/center-block";
 @import "utilities/clearfix";
 @import "utilities/pulls";
 @import "utilities/screenreaders";

--- a/scss/mixins/_center-block.scss
+++ b/scss/mixins/_center-block.scss
@@ -1,7 +1,0 @@
-// Center-align a block level element
-
-@mixin center-block() {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}

--- a/scss/utilities/_center-block.scss
+++ b/scss/utilities/_center-block.scss
@@ -1,3 +1,0 @@
-.center-block {
-  @include center-block();
-}


### PR DESCRIPTION
This drops the `.center-block` mixin and class from v4 in favor of the relatively new `.m-x-auto`. The former includes an explicit `display: block;` while the latter is only `margin-left/right: auto`. In the interest of keeping things lean, I'm voting `.center-block` off the island.

This adds some minor docs tweaks to include an example, as well as a note to the migration docs.
