### PR TITLE
v4: Fix row-based <dl>

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -232,7 +232,7 @@ Align terms and descriptions horizontally by using our grid system's predefined 
 
   <dt class="col-sm-3">Euismod</dt>
   <dd class="col-sm-9">Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.</dd>
-  <dd class="col-sm-9 col-sm-offset-3">Donec id elit non mi porta gravida at eget metus.</dd>
+  <dd class="col-sm-9 offset-sm-3">Donec id elit non mi porta gravida at eget metus.</dd>
 
   <dt class="col-sm-3">Malesuada porta</dt>
   <dd class="col-sm-9">Etiam porta sem malesuada magna mollis euismod.</dd>
@@ -243,8 +243,8 @@ Align terms and descriptions horizontally by using our grid system's predefined 
   <dt class="col-sm-3">Nesting</dt>
   <dd class="col-sm-9">
     <dl class="row">
-      <dt class="col-sm-3">Nested definition list</dt>
-      <dd class="col-sm-9">Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc.</dd>
+      <dt class="col-sm-4">Nested definition list</dt>
+      <dd class="col-sm-8">Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc.</dd>
     </dl>
   </dd>
 </dl>

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -138,11 +138,13 @@ mark,
   }
 }
 
-// Clean up some horizontal `<dl>`s built with grids
-// scss-lint:disable QualifyingElement
-dl.row {
-  > dd + dt {
-    clear: left;
+@if not $enable-flex {
+  // Clean up some horizontal `<dl>`s built with grids
+  // scss-lint:disable QualifyingElement
+  dl.row {
+    > dd + dt {
+      clear: left;
+    }
   }
+  // scss-lint:enable QualifyingElement
 }
-// scss-lint:enable QualifyingElement

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -137,3 +137,12 @@ mark,
     content: "\00A0 \2014"; // nbsp, em dash
   }
 }
+
+// Clean up some horizontal `<dl>`s built with grids
+// scss-lint:disable QualifyingElement
+dl.row {
+  > dd + dt {
+    clear: left;
+  }
+}
+// scss-lint:enable QualifyingElement


### PR DESCRIPTION
For non-flex grids, the multiple columns need to be cleared. This adds some (admittedly not great) styles to auto clear things. Fixes #17969.
