### PR TITLE
Flex utility classes shouldn't depend on $enable-grid-classes

### DIFF
--- a/scss/utilities/_flex.scss
+++ b/scss/utilities/_flex.scss
@@ -2,7 +2,7 @@
 //
 // Custom styles for additional flex alignment options.
 
-@if $enable-flex and $enable-grid-classes {
+@if $enable-flex {
   @each $breakpoint in map-keys($grid-breakpoints) {
     // Flex column reordering
     @include media-breakpoint-up($breakpoint) {


### PR DESCRIPTION
Since these are no longer part of the grid system per se.
CC: @mdo 
