### PR TITLE
Add https://webkit.org/b/138201 back to the Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -284,6 +284,16 @@
   browser: >
     Safari (iOS)
   summary: >
+    Text input's cursor doesn't move while scrolling the page.
+  upstream_bug: >
+    WebKit#138201, Safari#18819624
+  origin: >
+    Bootstrap#14708
+
+-
+  browser: >
+    Safari (iOS)
+  summary: >
     Can't move cursor to start of text after entering long string of text into `<input type="text">`
   upstream_bug: >
     WebKit#148061, Safari#22299624


### PR DESCRIPTION
Reverts #19119.
A commenter gave a new example where the bug still repros:
https://bugs.webkit.org/show_bug.cgi?id=138201#c6
