### PR TITLE
v4: Simpler modal footer buttons

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -101,20 +101,6 @@
   text-align: right; // right align buttons
   border-top: 1px solid $modal-footer-border-color;
   @include clearfix(); // clear it in case folks use .pull-* classes on buttons
-
-  // Properly space out buttons
-  .btn + .btn {
-    margin-bottom: 0; // account for input[type="submit"] which gets the bottom margin like all other inputs
-    margin-left: 5px;
-  }
-  // but override that for button groups
-  .btn-group .btn + .btn {
-    margin-left: -1px;
-  }
-  // and override it for block buttons as well
-  .btn-block + .btn-block {
-    margin-left: 0;
-  }
 }
 
 // Measure scrollbar width for padding body during modal show/hide


### PR DESCRIPTION
Fixes #18949 by outright removing the CSS that caused it. The example modal in the docs looks just fine right now—if folks want something else, utilities and custom CSS can accomplish the rest.
