### PR TITLE
v4: Avoid shorthand border-radius for list groups in cards

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -53,13 +53,15 @@
   .card {
     > .list-group:first-child {
       .list-group-item:first-child {
-        border-radius: $card-border-radius $card-border-radius 0 0;
+        border-top-left-radius: $card-border-radius;
+        border-top-right-radius: $card-border-radius;
       }
     }
 
     > .list-group:last-child {
       .list-group-item:last-child {
-        border-radius: 0 0 $card-border-radius $card-border-radius;
+        border-bottom-left-radius: $card-border-radius;
+        border-bottom-right-radius: $card-border-radius;
       }
     }
   }


### PR DESCRIPTION
Fixes #18940.

Uses specific `border-radius` properties when changing the corners of list groups in cards to avoid overriding combo first-/last-child items.
