### PR TITLE
Remove http://bugzil.la/975632 from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -72,16 +72,6 @@
   browser: >
     Firefox
   summary: >
-    `max-width: 100%;` doesn't work inside tables.
-  upstream_bug: >
-    Mozilla#975632
-  origin: >
-    Bootstrap#10690
-
--
-  browser: >
-    Firefox
-  summary: >
     Button elements with `width: 100%` become cropped in long tables.
   upstream_bug: >
     Mozilla#1060131


### PR DESCRIPTION
http://bugzil.la/975632 has been fixed by http://bugzil.la/823483 which should land in Firefox 46.
Refs #10690
