### PR TITLE
Remove http://bugzil.la/1060131 from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -72,16 +72,6 @@
   browser: >
     Firefox
   summary: >
-    Button elements with `width: 100%` become cropped in long tables.
-  upstream_bug: >
-    Mozilla#1060131
-  origin: >
-    Bootstrap#14320
-
--
-  browser: >
-    Firefox
-  summary: >
     If the disabled state of a form control is changed via JavaScript, the normal state doesn't return after refreshing the page.
   upstream_bug: >
     Mozilla#654072


### PR DESCRIPTION
http://bugzil.la/1060131 has been fixed by http://bugzil.la/823483 which should land in Firefox 46.
Refs #14320
