### PR TITLE
Fix keyboard navigation for toggle buttons (checkbox, radio, single toggle) following a mouse click

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -114,7 +114,7 @@
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
         e.preventDefault()
         // The target component still receive the focus
-        $btn.find('input').focus()
+        $btn.find('input:visible,button:visible').first().focus()
       }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {

--- a/js/button.js
+++ b/js/button.js
@@ -113,10 +113,10 @@
       Plugin.call($btn, 'toggle')
       if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) {
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
-        e.preventDefault();
+        e.preventDefault()
         
         // The target component still receive the focus
-        $(e.target).focus();
+        $(e.target).focus()
       }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {

--- a/js/button.js
+++ b/js/button.js
@@ -114,7 +114,6 @@
       if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) {
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
         e.preventDefault()
-        
         // The target component still receive the focus
         $(e.target).focus()
       }

--- a/js/button.js
+++ b/js/button.js
@@ -108,8 +108,7 @@
 
   $(document)
     .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-      var $btn = $(e.target)
-      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
+      var $btn = $(e.target).closest('.btn')
       Plugin.call($btn, 'toggle')
       if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) {
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes

--- a/js/button.js
+++ b/js/button.js
@@ -114,8 +114,8 @@
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
         e.preventDefault()
         // The target component still receive the focus
-        if ($btn.is('input,button')) $btn.focus()
-        else $btn.find('input:visible,button:visible').first().focus()
+        if ($btn.is('input,button')) $btn.trigger('focus')
+        else $btn.find('input:visible,button:visible').first().trigger('focus')
       }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {

--- a/js/button.js
+++ b/js/button.js
@@ -114,7 +114,8 @@
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
         e.preventDefault()
         // The target component still receive the focus
-        $btn.find('input:visible,button:visible').first().focus()
+        if ($btn.is('input,button')) $btn.focus()
+        else $btn.find('input:visible,button:visible').first().focus()
       }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {

--- a/js/button.js
+++ b/js/button.js
@@ -111,7 +111,13 @@
       var $btn = $(e.target)
       if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
       Plugin.call($btn, 'toggle')
-      if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) e.preventDefault()
+      if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) {
+        // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
+        e.preventDefault();
+        
+        // The target component still receive the focus
+        $(e.target).focus();
+      }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
       $(e.target).closest('.btn').toggleClass('focus', /^focus(in)?$/.test(e.type))

--- a/js/button.js
+++ b/js/button.js
@@ -115,7 +115,7 @@
         // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
         e.preventDefault()
         // The target component still receive the focus
-        $(e.target).focus()
+        $btn.find('input').focus()
       }
     })
     .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {


### PR DESCRIPTION
#16226 has fixed #16223 but also has broken the keyboard navigation.

This PR, still fixes #16226, but also restores the keyboard navigation broken by #16223.

3.3.6 status : 
![image](https://cloud.githubusercontent.com/assets/579170/13034982/24fdda86-d344-11e5-8ec2-9a3457075d39.png)
jsfiddle (look the console) : http://jsfiddle.net/vjjmj4da/9/

3.3.6+PR status :
![image](https://cloud.githubusercontent.com/assets/579170/13034983/2ac8df56-d344-11e5-8143-eba3764deb8a.png)

jsfiddle (look the console) : http://jsfiddle.net/vjjmj4da/13/
