### PR TITLE
Add extra styles for focused/hovered active outline buttons

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -64,19 +64,33 @@
   background-color: transparent;
   border-color: $color;
 
+  @include hover {
+    color: #fff;
+    background-color: $color;
+        border-color: $color;
+  }
+
   &:focus,
-  &.focus,
+  &.focus {
+    color: #fff;
+    background-color: $color;
+        border-color: $color;
+  }
+
   &:active,
   &.active,
   .open > &.dropdown-toggle {
     color: #fff;
     background-color: $color;
         border-color: $color;
-  }
-  @include hover {
-    color: #fff;
-    background-color: $color;
-        border-color: $color;
+
+    &:hover,
+    &:focus,
+    &.focus {
+      color: #fff;
+      background-color: darken($color, 17%);
+          border-color: darken($color, 25%);
+    }
   }
 
   &.disabled,


### PR DESCRIPTION
Ports the same approach from https://github.com/twbs/bootstrap/commit/1f153b640de55a4fff1aca3cf7331e9b7e3a408f#diff-edb9cd89b66120ef946a81de31f6bb06 (originally https://github.com/twbs/bootstrap/pull/16154 in v3) to outline buttons as well

Fixes https://github.com/twbs/bootstrap/issues/19199
