### PR TITLE
Fix docs for new naming of .btn-outline

### DIFF
--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -61,7 +61,7 @@ When using button classes on `<a>` elements that are used to trigger in-page fun
 
 ## Outline buttons
 
-In need of a button, but not the hefty background colors they bring? Replace the default modifier classes with the `.btn-*-outline` ones to remove all background images and colors on any button.
+In need of a button, but not the hefty background colors they bring? Replace the default modifier classes with the `.btn-outline-*` ones to remove all background images and colors on any button.
 
 {% example html %}
 <button type="button" class="btn btn-outline-primary">Primary</button>


### PR DESCRIPTION
This one was overlooked at edit

See #17719 and #19199
