### PR TITLE
Add $mark-bg so <mark>'s background-color can be customized independently of $state-warning-bg

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -67,7 +67,7 @@ small,
 mark,
 .mark {
   padding: .2em;
-  background-color: $state-warning-bg;
+  background-color: $mark-bg;
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -549,6 +549,7 @@ $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #8a6d3b !default;
 $state-warning-bg:               #fcf8e3 !default;
+$mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #a94442 !default;


### PR DESCRIPTION
CC: @mdo for review
