### PR TITLE
Focus (visually hidden) input radio/checkbox

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -92,7 +92,10 @@ const Button = (($) => {
             input.checked = !$(this._element).hasClass(ClassName.ACTIVE)
             $(this._element).trigger('change')
           }
+
+          $(input).trigger('focus')
         }
+
       } else {
         this._element.setAttribute('aria-pressed',
           !$(this._element).hasClass(ClassName.ACTIVE))


### PR DESCRIPTION
This allows for keyboard navigation (e.g. arrow keys left/right to trigger different radio buttons) following an initial mouse click interaction on a radio button or checkbox

A simplified port of https://github.com/twbs/bootstrap/pull/19192 to the new v4 code base
