### PR TITLE
Make modal front transparent

### DIFF
--- a/less/modals.less
+++ b/less/modals.less
@@ -23,6 +23,7 @@
   left: 0;
   z-index: @zindex-modal;
   -webkit-overflow-scrolling: touch;
+  background-color: transparent;
 
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.


### PR DESCRIPTION
Hi there,

I found some website set `background-color` on `.modal`. I think we always expect `transparent` on this `.modal`  to use it with `.modal-backdrop`.
Could you consider to merge this fix?
