### PR TITLE
Add text-justify to responsive alignment classes

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -4,7 +4,6 @@
 
 // Alignment
 
-.text-justify        { text-align: justify !important; }
 .text-nowrap         { white-space: nowrap !important; }
 .text-truncate       { @include text-truncate; }
 
@@ -12,9 +11,10 @@
 
 @each $breakpoint in map-keys($grid-breakpoints) {
   @include media-breakpoint-up($breakpoint) {
-    .text-#{$breakpoint}-left   { text-align: left !important; }
-    .text-#{$breakpoint}-right  { text-align: right !important; }
-    .text-#{$breakpoint}-center { text-align: center !important; }
+    .text-#{$breakpoint}-left     { text-align: left !important; }
+    .text-#{$breakpoint}-right    { text-align: right !important; }
+    .text-#{$breakpoint}-center   { text-align: center !important; }
+    .text-#{$breakpoint}-justify  { text-align: justify !important; }
   }
 }
 


### PR DESCRIPTION
Hello,
Is there any reason why `.text-justify` isn't part of the responsive alignment classes?

It's also an alignment class, has the **same** CSS property and has `!important`, if you get to use, you'll not be able to adapt it.
