### PR TITLE
Example pages: Remove usages of defunct .page-header class

### DIFF
--- a/docs/examples/dashboard/dashboard.css
+++ b/docs/examples/dashboard/dashboard.css
@@ -80,9 +80,6 @@ body {
     padding-left: 40px;
   }
 }
-.main .page-header {
-  margin-top: 0;
-}
 
 
 /*

--- a/docs/examples/dashboard/index.html
+++ b/docs/examples/dashboard/index.html
@@ -64,7 +64,7 @@
           </ul>
         </div>
         <div class="col-sm-9 offset-sm-3 col-md-10 offset-md-2 main">
-          <h1 class="page-header">Dashboard</h1>
+          <h1>Dashboard</h1>
 
           <div class="row placeholders">
             <div class="col-xs-6 col-sm-3 placeholder">

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -21,10 +21,8 @@
   <body>
     <div class="container">
 
-      <div class="page-header">
-        <h1>Bootstrap grid examples</h1>
-        <p class="lead">Basic grid layouts to get you familiar with building within the Bootstrap grid system.</p>
-      </div>
+      <h1>Bootstrap grid examples</h1>
+      <p class="lead">Basic grid layouts to get you familiar with building within the Bootstrap grid system.</p>
 
       <h3>Five grid tiers</h3>
       <p>There are five tiers to the Bootstrap grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>

--- a/docs/examples/sticky-footer-navbar/index.html
+++ b/docs/examples/sticky-footer-navbar/index.html
@@ -56,7 +56,7 @@
 
     <!-- Begin page content -->
     <div class="container">
-      <div class="page-header m-t-1">
+      <div class="m-t-1">
         <h1>Sticky footer with fixed navbar</h1>
       </div>
       <p class="lead">Pin a fixed-height footer to the bottom of the viewport in desktop browsers with this custom HTML and CSS. A fixed navbar has been added with <code>padding-top: 60px;</code> on the <code>body > .container</code>.</p>

--- a/docs/examples/sticky-footer/index.html
+++ b/docs/examples/sticky-footer/index.html
@@ -22,7 +22,7 @@
 
     <!-- Begin page content -->
     <div class="container">
-      <div class="page-header m-t-1">
+      <div class="m-t-1">
         <h1>Sticky footer</h1>
       </div>
       <p class="lead">Pin a fixed-height footer to the bottom of the viewport in desktop browsers with this custom HTML and CSS.</p>


### PR DESCRIPTION
Refs #19338.

Note: The selector in `dashboard.css` that used `.page-header` was superfluous because the margin that it zeroed was already zero even without that declaration.
