### PR TITLE
Title attribute should never be an empty string

### DIFF
--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -40,7 +40,7 @@ $(function () {
   QUnit.test('should empty title attribute', function (assert) {
     assert.expect(1)
     var $trigger = $('<a href="#" rel="tooltip" title="Another tooltip"/>').bootstrapTooltip()
-    assert.strictEqual($trigger.attr('title'), '', 'title attribute was emptied')
+    assert.strictEqual($trigger.attr('title'), undefined, 'title attribute was removed')
   })
 
   QUnit.test('should add data attribute for referencing original title', function (assert) {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -343,7 +343,7 @@
   Tooltip.prototype.fixTitle = function () {
     var $e = this.$element
     if ($e.attr('title') || typeof $e.attr('data-original-title') != 'string') {
-      $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
+      $e.attr('data-original-title', $e.attr('title') || '').removeAttr('title')
     }
   }
 


### PR DESCRIPTION
After storing the original `title` attribute, the `title` attribute should not be replaced with an empty string, which would result in an accessibility violation on elements, like `input`, that may use the title for a label. This seems to have been improperly translated from the source material: https://github.com/jaz303/tipsy/blob/master/src/javascripts/jquery.tipsy.js#L94.
