### PR TITLE
Remove iOS virtual keyboard bug section from docs

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -34,7 +34,7 @@ Always try to place a modal's HTML code in a top-level position in your document
 {% callout warning %}
 #### Mobile device caveats
 
-There are some caveats regarding using modals on mobile devices. [See our browser support docs]({{ site.baseurl }}/getting-started/browsers-devices/#modals-navbars-and-virtual-keyboards) for details.
+There are some caveats regarding using modals on mobile devices. [See our browser support docs]({{ site.baseurl }}/getting-started/browsers-devices/#modals-and-dropdowns-on-mobile) for details.
 {% endcallout %}
 
 ### Static example

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -191,15 +191,11 @@ For more information and usage guidelines, read [Windows Phone 8 and Device-Widt
 
 As a heads up, we include this in all of Bootstrap's documentation and examples as a demonstration.
 
-## Modals, navbars, and virtual keyboards
+## Modals and dropdowns on mobile
 
 ### Overflow and scrolling
 
 Support for `overflow: hidden;` on the `<body>` element is quite limited in iOS and Android. To that end, when you scroll past the top or bottom of a modal in either of those devices' browsers, the `<body>` content will begin to scroll. See [Chrome bug #175502](https://bugs.chromium.org/p/chromium/issues/detail?id=175502) (fixed in Chrome v40) and [WebKit bug #153852](https://bugs.webkit.org/show_bug.cgi?id=153852).
-
-### Virtual keyboards
-
-Also, note that if you're using a fixed navbar or using inputs within a modal, iOS has a rendering bug that doesn't update the position of fixed elements when the virtual keyboard is triggered. A few workarounds for this include transforming your elements to `position: absolute;` or invoking a timer on focus to try to correct the positioning manually. This is not handled by Bootstrap, so it is up to you to decide which solution is best for your application.
 
 ### Navbar Dropdowns
 


### PR DESCRIPTION
The modal backdrop positioning bug related to iOS' virtual keyboard (#9023) doesn't seem to reproduce in iOS 8.0+ (possibly as a side-effect of https://bugs.webkit.org/show_bug.cgi?id=153224 ).
Testcase: http://output.jsbin.com/cacido/quiet
