### PR TITLE
Add native title tooltip IE11/Edge bug to wall of browser bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -2,6 +2,16 @@
   browser: >
     Internet Explorer 11 & Microsoft Edge
   summary: >
+    Native browser tooltip for `title` shows on first keyboard focus (in addition to custom tooltip component)
+  upstream_bug: >
+    IE#2445370
+  origin: >
+    Bootstrap#18692
+
+-
+  browser: >
+    Internet Explorer 11 & Microsoft Edge
+  summary: >
     Hovered element still remains in `:hover` state after scrolling away.
   upstream_bug: >
     IE#926665


### PR DESCRIPTION
See https://connect.microsoft.com/IE/feedback/details/2445370
Cherry-pick from v4 https://github.com/twbs/bootstrap/pull/19434
