### PR TITLE
Make hound fail on violations

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,3 +3,4 @@ javascript:
   enabled: true
 scss:
   enabled: false
+fail_on_violations: true


### PR DESCRIPTION
This makes Hound set the pull request status via the GitHub API whenever it finds a violation of code style
