### PR TITLE
Update tooltip.js

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -16,7 +16,7 @@ const Tooltip = (($) => {
    * Check for Tether dependency
    * Tether - http://github.hubspot.com/tether/
    */
-  if ('undefined' === typeof Tether) {
+  if (typeof Tether === 'undefined') {
     throw new Error('Bootstrap tooltips require Tether (http://github.hubspot.com/tether/)')
   }
 

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -16,7 +16,7 @@ const Tooltip = (($) => {
    * Check for Tether dependency
    * Tether - http://github.hubspot.com/tether/
    */
-  if (window.Tether === undefined) {
+  if ('undefined' === typeof Tether) {
     throw new Error('Bootstrap tooltips require Tether (http://github.hubspot.com/tether/)')
   }
 


### PR DESCRIPTION
Don't reference `Tether` via attachment to `window`, with the update one can import bootstrap providing the dependencies in webpack with:

``` js
new webpack.ProvidePlugin({
  $: 'jquery',
  jQuery: 'jquery',
  Tether: 'tether',
});
```

Then inside one's own bootstrap/globals, `import 'bootstrap';` will simply work, and $/jQuery can be used from there.

I had wanted to do this, but also expose jQuery, Tether, etc when in development build in my code, but if I provide `window.Tether`, I can't then expose it to the outside...
