### PR TITLE
Use "latest" version specifier (when applicable) in Sauce tests

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -1,5 +1,5 @@
 [
-  # Docs: https://saucelabs.com/docs/platforms/webdriver
+  # Docs: https://wiki.saucelabs.com/display/DOCS/Platform+Configurator
 
   {
     browserName: "safari",
@@ -7,18 +7,21 @@
   },
   {
     browserName: "chrome",
-    platform: "OS X 10.11"
+    platform: "OS X 10.11",
+    version: "latest"
   },
   {
     browserName: "firefox",
-    platform: "OS X 10.11"
+    platform: "OS X 10.11",
+    version: "latest"
   },
 
   # Mac Opera not currently supported by Sauce Labs
 
   {
     browserName: "MicrosoftEdge",
-    platform: "Windows 10"
+    platform: "Windows 10",
+    version: "latest"
   },
   {
     browserName: "internet explorer",
@@ -38,11 +41,13 @@
 
   {
     browserName: "chrome",
-    platform: "Windows 10"
+    platform: "Windows 10",
+    version: "latest"
   },
   {
     browserName: "firefox",
-    platform: "Windows 10"
+    platform: "Windows 10",
+    version: "latest"
   },
 
   # Win Opera 15+ not currently supported by Sauce Labs
@@ -50,7 +55,7 @@
   {
     browserName: "iphone",
     platform: "OS X 10.10",
-    version: "9.2"
+    version: "latest"
   },
 
   # iOS Chrome not currently supported by Sauce Labs
@@ -58,11 +63,13 @@
   # Linux (unofficial)
   {
     browserName: "chrome",
-    platform: "Linux"
+    platform: "Linux",
+    version: "latest"
   },
   {
     browserName: "firefox",
-    platform: "Linux"
+    platform: "Linux",
+    version: "latest"
   }
 
   # Android Chrome not currently supported by Sauce Labs


### PR DESCRIPTION
Refs http://sauceio.com/index.php/2016/03/new-browser-version-shortcuts/
