### PR TITLE
Use vanilla npm shrinkwrap instead of uber/npm-shrinkwrap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,6 @@ module.exports = function (grunt) {
 
   var fs = require('fs');
   var path = require('path');
-  var npmShrinkwrap = require('npm-shrinkwrap');
   var generateGlyphiconsData = require('./grunt/bs-glyphicons-data-generator.js');
   var BsLessdocParser = require('./grunt/bs-lessdoc-parser.js');
   var getLessVarsData = function () {
@@ -493,20 +492,4 @@ module.exports = function (grunt) {
   grunt.registerTask('docs-github', ['jekyll:github', 'htmlmin']);
 
   grunt.registerTask('prep-release', ['dist', 'docs', 'docs-github', 'compress']);
-
-  // Task for updating the cached npm packages used by the Travis build (which are controlled by test-infra/npm-shrinkwrap.json).
-  // This task should be run and the updated file should be committed whenever Bootstrap's dependencies change.
-  grunt.registerTask('update-shrinkwrap', ['exec:npmUpdate', '_update-shrinkwrap']);
-  grunt.registerTask('_update-shrinkwrap', function () {
-    var done = this.async();
-    npmShrinkwrap({ dev: true, dirname: __dirname }, function (err) {
-      if (err) {
-        grunt.fail.warn(err);
-      }
-      var dest = 'grunt/npm-shrinkwrap.json';
-      fs.renameSync('npm-shrinkwrap.json', dest);
-      grunt.log.writeln('File ' + dest.cyan + ' updated.');
-      done();
-    });
-  });
 };

--- a/grunt/npm-shrinkwrap.json
+++ b/grunt/npm-shrinkwrap.json
@@ -1,4170 +1,3752 @@
 {
   "name": "bootstrap",
   "version": "3.3.6",
-  "npm-shrinkwrap-version": "200.4.0",
-  "node-version": "v5.9.0",
   "dependencies": {
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-    },
     "abbrev": {
       "version": "1.0.7",
+      "from": "abbrev@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
     },
     "accepts": {
       "version": "1.2.13",
+      "from": "accepts@>=1.2.13 <1.3.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
     },
     "acorn": {
       "version": "2.7.0",
+      "from": "acorn@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
     },
     "acorn-globals": {
       "version": "1.0.9",
+      "from": "acorn-globals@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
     },
     "adm-zip": {
       "version": "0.4.4",
+      "from": "adm-zip@0.4.4",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
     },
     "align-text": {
       "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "alter": {
       "version": "0.2.0",
+      "from": "alter@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
+      "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-regex": {
       "version": "1.1.1",
+      "from": "ansi-regex@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
     },
     "ansi-styles": {
       "version": "2.2.0",
+      "from": "ansi-styles@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz"
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
     },
     "archiver": {
       "version": "0.21.0",
+      "from": "archiver@>=0.21.0 <0.22.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.21.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.5.0 <1.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "glob": {
           "version": "6.0.4",
+          "from": "glob@>=6.0.0 <6.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.0 <3.11.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "archiver-utils": {
       "version": "0.3.0",
+      "from": "archiver-utils@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-0.3.0.tgz",
       "dependencies": {
         "glob": {
           "version": "6.0.4",
+          "from": "glob@>=6.0.0 <6.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.0 <3.11.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "argparse": {
       "version": "0.1.16",
+      "from": "argparse@>=0.1.11 <0.2.0",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
       "dependencies": {
         "underscore.string": {
           "version": "2.4.0",
+          "from": "underscore.string@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
         }
       }
     },
     "array-differ": {
       "version": "1.0.0",
+      "from": "array-differ@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-    },
-    "array-find": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
+      "from": "array-find-index@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-union": {
       "version": "1.0.1",
+      "from": "array-union@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
+      "from": "array-uniq@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "arrify": {
       "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
       "version": "1.0.0",
+      "from": "asap@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
     },
     "asn1": {
       "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "ast-traverse": {
       "version": "0.1.1",
+      "from": "ast-traverse@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
     },
     "ast-types": {
       "version": "0.8.12",
+      "from": "ast-types@0.8.12",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
     },
     "async": {
       "version": "0.1.22",
+      "from": "async@>=0.1.22 <0.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
     },
     "autoprefixer-core": {
       "version": "5.2.1",
+      "from": "autoprefixer-core@>=5.1.7 <6.0.0",
       "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz"
     },
     "aws-sign": {
       "version": "0.3.0",
+      "from": "aws-sign@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.3.2",
+      "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
       "dependencies": {
         "lru-cache": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz"
+          "version": "4.0.1",
+          "from": "lru-cache@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
         }
       }
     },
     "babel-core": {
-      "version": "5.8.35",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
+      "version": "5.8.38",
+      "from": "babel-core@>=5.8.3 <5.9.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
+          "from": "minimatch@>=2.0.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "path-exists": {
           "version": "1.0.0",
+          "from": "path-exists@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "repeating": {
           "version": "1.1.3",
+          "from": "repeating@>=1.1.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
         },
         "source-map": {
           "version": "0.5.3",
+          "from": "source-map@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "babel-jscs": {
       "version": "2.0.5",
+      "from": "babel-jscs@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/babel-jscs/-/babel-jscs-2.0.5.tgz"
     },
     "babel-plugin-constant-folding": {
       "version": "1.0.1",
+      "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
     },
     "babel-plugin-dead-code-elimination": {
       "version": "1.0.2",
+      "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
     },
     "babel-plugin-eval": {
       "version": "1.0.1",
+      "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
     },
     "babel-plugin-inline-environment-variables": {
       "version": "1.0.1",
+      "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
     },
     "babel-plugin-jscript": {
       "version": "1.0.4",
+      "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
     },
     "babel-plugin-member-expression-literals": {
       "version": "1.0.1",
+      "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
     },
     "babel-plugin-property-literals": {
       "version": "1.0.1",
+      "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
     },
     "babel-plugin-proto-to-assign": {
       "version": "1.0.4",
+      "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.9.3 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "babel-plugin-react-constant-elements": {
       "version": "1.0.3",
+      "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
     },
     "babel-plugin-react-display-name": {
       "version": "1.0.3",
+      "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
     },
     "babel-plugin-remove-console": {
       "version": "1.0.1",
+      "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
     },
     "babel-plugin-remove-debugger": {
       "version": "1.0.1",
+      "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
     },
     "babel-plugin-runtime": {
       "version": "1.0.7",
+      "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
     },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
+      "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
     },
     "babel-plugin-undefined-to-void": {
       "version": "1.1.6",
+      "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
     },
     "babylon": {
-      "version": "5.8.35",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
+      "version": "5.8.38",
+      "from": "babylon@>=5.8.38 <6.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
     },
     "balanced-match": {
       "version": "0.3.0",
+      "from": "balanced-match@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
     },
     "basic-auth": {
       "version": "1.0.3",
+      "from": "basic-auth@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
     },
     "batch": {
       "version": "0.5.3",
+      "from": "batch@0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
     "bl": {
       "version": "1.1.2",
+      "from": "bl@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
     },
     "bluebird": {
       "version": "2.10.2",
+      "from": "bluebird@>=2.9.33 <3.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "body-parser": {
       "version": "1.14.2",
+      "from": "body-parser@>=1.14.0 <1.15.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "qs": {
           "version": "5.2.0",
+          "from": "qs@5.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
         }
       }
     },
     "boom": {
       "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.3",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
     },
     "breakable": {
       "version": "1.0.0",
+      "from": "breakable@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
+      "from": "browserify-zlib@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
       "version": "0.4.0",
+      "from": "browserslist@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
     },
     "btoa": {
       "version": "1.1.2",
+      "from": "btoa@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz"
     },
     "buffer-crc32": {
       "version": "0.2.5",
+      "from": "buffer-crc32@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
       "version": "2.2.0",
+      "from": "bytes@2.2.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
     },
     "camel-case": {
       "version": "1.2.2",
+      "from": "camel-case@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
     },
     "camelcase": {
       "version": "2.1.1",
+      "from": "camelcase@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
+      "from": "camelcase-keys@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
-    "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
-    },
     "caniuse-db": {
-      "version": "1.0.30000433",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000433.tgz"
-    },
-    "cardinal": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz"
+      "version": "1.0.30000436",
+      "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000436.tgz"
     },
     "caseless": {
       "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
       "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chalk": {
       "version": "1.0.0",
+      "from": "chalk@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz"
     },
     "change-case": {
       "version": "2.3.1",
+      "from": "change-case@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz"
     },
     "character-parser": {
       "version": "1.2.1",
+      "from": "character-parser@1.2.1",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
     },
     "charenc": {
       "version": "0.0.1",
+      "from": "charenc@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.1.tgz"
     },
     "clean-css": {
       "version": "3.4.10",
+      "from": "clean-css@>=3.4.2 <3.5.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz"
     },
     "cli": {
       "version": "0.11.2",
+      "from": "cli@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.2.tgz",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
+          "from": "glob@>=5.0.10 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        }
-      }
-    },
-    "cli-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz"
         }
       }
     },
     "cli-table": {
       "version": "0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "dependencies": {
         "colors": {
           "version": "1.0.3",
+          "from": "colors@1.0.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         }
       }
     },
     "cliui": {
       "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
     },
     "coffee-script": {
       "version": "1.3.3",
+      "from": "coffee-script@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
     },
     "color-convert": {
       "version": "1.0.0",
+      "from": "color-convert@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
     },
     "colors": {
       "version": "0.6.2",
+      "from": "colors@>=0.6.2 <0.7.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.8.1",
+      "from": "commander@>=2.8.0 <2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
     },
     "comment-parser": {
       "version": "0.3.1",
+      "from": "comment-parser@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz"
     },
     "commoner": {
       "version": "0.10.4",
+      "from": "commoner@>=0.10.3 <0.11.0",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
+          "from": "glob@>=5.0.15 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "iconv-lite": {
           "version": "0.4.13",
+          "from": "iconv-lite@>=0.4.5 <0.5.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         }
       }
     },
     "compress-commons": {
       "version": "0.4.2",
+      "from": "compress-commons@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.4.2.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
+      "from": "concat-map@0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.1",
+      "from": "concat-stream@>=1.4.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "config-chain": {
       "version": "1.1.10",
+      "from": "config-chain@>=1.1.8 <1.2.0",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz"
     },
     "connect": {
       "version": "3.4.1",
+      "from": "connect@>=3.4.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz"
     },
     "connect-livereload": {
       "version": "0.5.4",
+      "from": "connect-livereload@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz"
     },
     "console-browserify": {
       "version": "1.1.0",
+      "from": "console-browserify@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
     "constant-case": {
       "version": "1.1.2",
+      "from": "constant-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
     },
     "constantinople": {
       "version": "3.0.2",
+      "from": "constantinople@>=3.0.1 <3.1.0",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz"
     },
     "content-type": {
       "version": "1.0.1",
+      "from": "content-type@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
     },
     "convert-source-map": {
       "version": "1.2.0",
+      "from": "convert-source-map@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
     },
     "cookie-jar": {
       "version": "0.3.0",
+      "from": "cookie-jar@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
     },
     "core-js": {
       "version": "1.2.6",
+      "from": "core-js@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "crc32-stream": {
       "version": "0.4.0",
+      "from": "crc32-stream@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.4.0.tgz"
     },
     "crypt": {
       "version": "0.0.1",
+      "from": "crypt@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.1.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "css": {
       "version": "1.0.8",
+      "from": "css@>=1.0.8 <1.1.0",
       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz"
     },
     "css-parse": {
       "version": "1.0.4",
+      "from": "css-parse@1.0.4",
       "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
     },
     "css-stringify": {
       "version": "1.0.5",
+      "from": "css-stringify@1.0.5",
       "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
     },
     "csscomb": {
       "version": "3.1.8",
+      "from": "csscomb@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/csscomb/-/csscomb-3.1.8.tgz",
       "dependencies": {
         "commander": {
           "version": "2.0.0",
+          "from": "commander@2.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
         }
       }
     },
     "csscomb-core": {
       "version": "3.0.0-3.1",
+      "from": "csscomb-core@3.0.0-3.1",
       "resolved": "https://registry.npmjs.org/csscomb-core/-/csscomb-core-3.0.0-3.1.tgz",
       "dependencies": {
         "minimatch": {
           "version": "0.2.12",
+          "from": "minimatch@0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.12.tgz"
         }
       }
     },
     "csslint": {
       "version": "0.10.0",
+      "from": "csslint@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz"
     },
     "ctype": {
       "version": "0.5.3",
+      "from": "ctype@0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
     },
     "cycle": {
       "version": "1.0.3",
+      "from": "cycle@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "d": {
       "version": "0.1.1",
+      "from": "d@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.13.0",
+      "from": "dashdash@>=1.10.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
+      "from": "date-now@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "date-time": {
       "version": "1.0.0",
+      "from": "date-time@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
+      "from": "dateformat@1.0.2-1.2.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
     },
     "debug": {
       "version": "2.2.0",
+      "from": "debug@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
+      "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-equal": {
       "version": "1.0.1",
+      "from": "deep-equal@*",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "defined": {
       "version": "1.0.0",
+      "from": "defined@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
     },
     "defs": {
       "version": "1.1.1",
+      "from": "defs@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
+          "from": "camelcase@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0"
         },
         "window-size": {
           "version": "0.1.4",
+          "from": "window-size@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
         },
         "yargs": {
           "version": "3.27.0",
+          "from": "yargs@>=3.27.0 <3.28.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depd": {
       "version": "1.1.0",
+      "from": "depd@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "destroy": {
       "version": "1.0.4",
+      "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "detect-indent": {
       "version": "3.0.1",
+      "from": "detect-indent@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "dependencies": {
         "repeating": {
           "version": "1.1.3",
+          "from": "repeating@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
         }
       }
     },
     "detective": {
       "version": "4.3.1",
+      "from": "detective@>=4.3.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
         }
       }
     },
     "diff": {
       "version": "1.3.2",
+      "from": "diff@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
-    },
-    "difflib": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
+      "from": "dom-serializer@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         },
         "entities": {
           "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
+      "from": "domelementtype@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
+      "from": "domhandler@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
+      "from": "domutils@>=1.5.0 <1.6.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "dot-case": {
       "version": "1.1.2",
+      "from": "dot-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
-    },
-    "dreamopt": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
+      "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "end-of-stream": {
       "version": "1.1.0",
+      "from": "end-of-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "entities": {
       "version": "1.0.0",
+      "from": "entities@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
     },
     "errno": {
       "version": "0.1.4",
+      "from": "errno@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
-    },
-    "error": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
+      "from": "error-ex@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
+      "from": "es5-ext@>=0.10.8 <0.11.0",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
+      "from": "es6-iterator@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.3",
+      "from": "es6-map@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
     },
     "es6-promise": {
       "version": "2.3.0",
+      "from": "es6-promise@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
     },
     "es6-set": {
       "version": "0.1.4",
+      "from": "es6-set@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
       "version": "3.0.2",
+      "from": "es6-symbol@>=3.0.1 <3.1.0",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
+      "from": "escape-html@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escope": {
       "version": "3.6.0",
+      "from": "escope@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "esprima": {
       "version": "1.0.4",
+      "from": "esprima@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
+      "from": "esrecurse@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
+          "from": "estraverse@>=4.1.0 <4.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
+      "from": "estraverse@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
+      "from": "esutils@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
       "version": "1.7.0",
+      "from": "etag@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
+      "from": "event-emitter@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "eventemitter2": {
       "version": "0.4.14",
+      "from": "eventemitter2@>=0.4.13 <0.5.0",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
     },
     "exit": {
       "version": "0.1.2",
+      "from": "exit@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "extend": {
       "version": "3.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "eyes": {
       "version": "0.1.8",
+      "from": "eyes@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "faye-websocket": {
       "version": "0.10.0",
+      "from": "faye-websocket@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fg-lodash": {
       "version": "0.0.2",
+      "from": "fg-lodash@0.0.2",
       "resolved": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "underscore.string": {
           "version": "2.3.3",
+          "from": "underscore.string@>=2.3.3 <2.4.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
         }
       }
     },
     "figures": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+      "version": "1.5.0",
+      "from": "figures@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
     },
     "file-sync-cmp": {
       "version": "0.1.1",
+      "from": "file-sync-cmp@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
     },
     "finalhandler": {
       "version": "0.4.1",
+      "from": "finalhandler@0.4.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
+      "from": "find-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "findup-sync": {
       "version": "0.1.3",
+      "from": "findup-sync@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
+          "from": "glob@>=3.2.9 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
         },
         "lodash": {
           "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "forever-agent": {
       "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.0-rc4",
+      "from": "form-data@>=1.0.0-rc3 <1.1.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "fresh": {
       "version": "0.3.0",
+      "from": "fresh@0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "fs-extra": {
       "version": "0.23.1",
+      "from": "fs-extra@>=0.23.1 <0.24.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         }
       }
     },
     "fs-readdir-recursive": {
       "version": "0.1.2",
+      "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
     },
     "gaze": {
       "version": "1.0.0",
+      "from": "gaze@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.0.0.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getobject": {
       "version": "0.1.0",
+      "from": "getobject@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
     },
     "glob": {
       "version": "7.0.3",
+      "from": "glob@>=7.0.3 <7.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
     },
     "globals": {
       "version": "6.4.1",
+      "from": "globals@>=6.4.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
     },
     "globule": {
       "version": "0.2.0",
+      "from": "globule@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
+          "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "gonzales-pe": {
       "version": "3.0.0-28",
+      "from": "gonzales-pe@3.0.0-28",
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.0.0-28.tgz"
     },
     "graceful-fs": {
       "version": "1.2.3",
+      "from": "graceful-fs@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "grunt": {
       "version": "0.4.5",
+      "from": "grunt@>=0.4.5 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "glob": {
           "version": "3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
         },
         "inherits": {
           "version": "1.0.2",
+          "from": "inherits@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "grunt-autoprefixer": {
       "version": "3.0.4",
+      "from": "grunt-autoprefixer@>=3.0.4 <3.1.0",
       "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz"
     },
     "grunt-contrib-clean": {
       "version": "1.0.0",
+      "from": "grunt-contrib-clean@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "rimraf": {
           "version": "2.5.2",
+          "from": "rimraf@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         }
       }
     },
     "grunt-contrib-compress": {
       "version": "1.1.1",
+      "from": "grunt-contrib-compress@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.1.1.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "grunt-contrib-concat": {
       "version": "1.0.0",
+      "from": "grunt-contrib-concat@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.0.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.3",
+          "from": "source-map@>=0.5.3 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "grunt-contrib-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-1.0.0.tgz",
+      "version": "1.0.1",
+      "from": "grunt-contrib-connect@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-1.0.1.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
+      "from": "grunt-contrib-copy@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "grunt-contrib-csslint": {
       "version": "1.0.0",
+      "from": "grunt-contrib-csslint@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-csslint/-/grunt-contrib-csslint-1.0.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "grunt-contrib-cssmin": {
       "version": "1.0.1",
+      "from": "grunt-contrib-cssmin@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-1.0.1.tgz"
     },
     "grunt-contrib-htmlmin": {
       "version": "1.1.0",
+      "from": "grunt-contrib-htmlmin@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-1.1.0.tgz"
     },
     "grunt-contrib-jade": {
       "version": "1.0.0",
+      "from": "grunt-contrib-jade@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jade/-/grunt-contrib-jade-1.0.0.tgz"
     },
     "grunt-contrib-jshint": {
       "version": "1.0.0",
+      "from": "grunt-contrib-jshint@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "grunt-contrib-less": {
       "version": "1.2.0",
+      "from": "grunt-contrib-less@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-1.2.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "grunt-contrib-qunit": {
       "version": "0.7.0",
+      "from": "grunt-contrib-qunit@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-0.7.0.tgz"
     },
     "grunt-contrib-uglify": {
       "version": "1.0.1",
+      "from": "grunt-contrib-uglify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.6.1",
+          "from": "lodash@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
         }
       }
     },
     "grunt-contrib-watch": {
       "version": "1.0.0",
+      "from": "grunt-contrib-watch@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.5.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "grunt-csscomb": {
       "version": "3.1.0",
+      "from": "grunt-csscomb@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/grunt-csscomb/-/grunt-csscomb-3.1.0.tgz"
     },
     "grunt-exec": {
       "version": "0.4.6",
+      "from": "grunt-exec@>=0.4.6 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-0.4.6.tgz"
     },
     "grunt-html": {
       "version": "6.0.0",
+      "from": "grunt-html@>=6.0.0 <6.1.0",
       "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-6.0.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "async": {
           "version": "1.5.1",
+          "from": "async@1.5.1",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@1.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "grunt-jekyll": {
       "version": "0.4.4",
+      "from": "grunt-jekyll@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-jekyll/-/grunt-jekyll-0.4.4.tgz"
     },
     "grunt-jscs": {
       "version": "2.8.0",
+      "from": "grunt-jscs@>=2.8.0 <2.9.0",
       "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-2.8.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.6.1",
+          "from": "lodash@>=4.6.1 <4.7.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
         }
       }
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
+      "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "underscore.string": {
           "version": "2.3.3",
+          "from": "underscore.string@>=2.3.3 <2.4.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
         }
       }
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
+      "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "underscore.string": {
           "version": "2.3.3",
+          "from": "underscore.string@>=2.3.3 <2.4.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
         }
       }
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
+      "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
     },
     "grunt-lib-phantomjs": {
       "version": "0.6.0",
+      "from": "grunt-lib-phantomjs@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.6.0.tgz",
       "dependencies": {
         "semver": {
           "version": "1.0.14",
+          "from": "semver@>=1.0.14 <1.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
         }
       }
     },
     "grunt-saucelabs": {
       "version": "8.6.2",
+      "from": "grunt-saucelabs@>=8.6.2 <8.7.0",
       "resolved": "https://registry.npmjs.org/grunt-saucelabs/-/grunt-saucelabs-8.6.2.tgz",
       "dependencies": {
         "colors": {
           "version": "1.0.3",
+          "from": "colors@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
         },
         "lodash": {
           "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         },
         "q": {
           "version": "1.3.0",
+          "from": "q@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.3.0.tgz"
         }
       }
     },
     "gzip-size": {
       "version": "1.0.0",
+      "from": "gzip-size@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz"
     },
     "har-validator": {
       "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "has-ansi": {
       "version": "1.0.3",
+      "from": "has-ansi@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz"
     },
     "has-color": {
       "version": "0.1.7",
+      "from": "has-color@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "hawk": {
       "version": "3.1.3",
+      "from": "hawk@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-    },
-    "heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz"
     },
     "hoek": {
       "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hooker": {
       "version": "0.2.3",
+      "from": "hooker@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.4",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "html-minifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.3.0.tgz"
+      "version": "1.3.1",
+      "from": "html-minifier@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.3.1.tgz"
     },
     "htmlparser2": {
       "version": "3.8.3",
+      "from": "htmlparser2@>=3.8.0 <3.9.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "http-errors": {
       "version": "1.3.1",
+      "from": "http-errors@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-signature": {
       "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "http2": {
       "version": "3.3.2",
-      "from": "http2@git://github.com/gruntjs/node-http2.git#f1fc002c1aef9b4e871c808fc5ddacdeb1a5cd94",
-      "resolved": "git://github.com/gruntjs/node-http2.git#f1fc002c1aef9b4e871c808fc5ddacdeb1a5cd94"
+      "from": "git+https://github.com/gruntjs/node-http2.git#fix-return-value",
+      "resolved": "git+https://github.com/gruntjs/node-http2.git#f1fc002c1aef9b4e871c808fc5ddacdeb1a5cd94"
     },
     "i": {
       "version": "0.3.4",
+      "from": "i@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.4.tgz"
     },
     "iconv-lite": {
       "version": "0.2.11",
+      "from": "iconv-lite@>=0.2.11 <0.3.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
     },
     "image-size": {
       "version": "0.4.0",
+      "from": "image-size@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.4.0.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
+      "from": "indent-string@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "inflight": {
       "version": "1.0.4",
+      "from": "inflight@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
     },
     "inherit": {
       "version": "2.2.3",
+      "from": "inherit@>=2.2.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
     },
     "inherits": {
       "version": "2.0.1",
+      "from": "inherits@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
+      "from": "ini@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
+      "from": "invert-kv@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
+      "from": "is-arrayish@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.3",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
+      "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-integer": {
       "version": "1.0.6",
+      "from": "is-integer@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
     },
     "is-lower-case": {
       "version": "1.1.3",
+      "from": "is-lower-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
     },
     "is-my-json-valid": {
       "version": "2.13.1",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-promise": {
       "version": "2.1.0",
+      "from": "is-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-upper-case": {
       "version": "1.1.2",
+      "from": "is-upper-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
+      "from": "is-utf8@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
+      "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "1.11.0",
+      "from": "jade@>=1.11.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
       "dependencies": {
         "commander": {
           "version": "2.6.0",
+          "from": "commander@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-base64": {
       "version": "2.1.9",
+      "from": "js-base64@>=2.1.8 <2.2.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
     },
     "js-tokens": {
       "version": "1.0.1",
+      "from": "js-tokens@1.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
     },
     "js-yaml": {
       "version": "2.0.5",
+      "from": "js-yaml@>=2.0.5 <2.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz"
     },
     "jsbn": {
       "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jscs": {
       "version": "2.11.0",
+      "from": "jscs@>=2.11.0 <2.12.0",
       "resolved": "https://registry.npmjs.org/jscs/-/jscs-2.11.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "argparse": {
           "version": "1.0.7",
+          "from": "argparse@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
         },
         "chalk": {
           "version": "1.1.1",
+          "from": "chalk@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@>=2.9.0 <2.10.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "esprima": {
           "version": "2.7.2",
+          "from": "esprima@>=2.7.0 <2.8.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "glob": {
           "version": "5.0.15",
+          "from": "glob@>=5.0.1 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "js-yaml": {
           "version": "3.4.6",
+          "from": "js-yaml@>=3.4.0 <3.5.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz"
         },
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.0 <3.11.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "vow": {
           "version": "0.4.12",
+          "from": "vow@>=0.4.8 <0.5.0",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.12.tgz"
         },
         "vow-fs": {
           "version": "0.3.4",
+          "from": "vow-fs@>=0.3.4 <0.4.0",
           "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
           "dependencies": {
             "glob": {
               "version": "4.5.3",
+              "from": "glob@>=4.3.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
             }
           }
         },
         "vow-queue": {
           "version": "0.4.2",
+          "from": "vow-queue@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
         }
       }
     },
     "jscs-jsdoc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.1.tgz"
+      "version": "1.3.2",
+      "from": "jscs-jsdoc@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-1.3.2.tgz"
     },
     "jscs-preset-wikimedia": {
       "version": "1.0.0",
+      "from": "jscs-preset-wikimedia@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz"
     },
     "jsdoctypeparser": {
       "version": "1.2.0",
+      "from": "jsdoctypeparser@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.7.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "jsesc": {
       "version": "0.5.0",
+      "from": "jsesc@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "jshint": {
       "version": "2.9.1",
+      "from": "jshint@>=2.9.1 <2.10.0",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
       "dependencies": {
         "cli": {
           "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz"
         },
         "glob": {
           "version": "3.2.11",
+          "from": "glob@>=3.2.1 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "shelljs": {
           "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         }
       }
     },
-    "json-diff": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz"
-    },
     "json-schema": {
       "version": "0.2.2",
+      "from": "json-schema@0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json5": {
       "version": "0.4.0",
+      "from": "json5@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonfile": {
       "version": "2.2.3",
+      "from": "jsonfile@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
     },
     "jsonlint": {
       "version": "1.6.2",
+      "from": "jsonlint@>=1.6.2 <1.7.0",
       "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
+      "from": "jsonpointer@2.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
+      "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
     },
     "jstransformer": {
       "version": "0.0.2",
+      "from": "jstransformer@0.0.2",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz"
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "from": "JSV@>=4.0.0",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
     },
     "kew": {
       "version": "0.4.0",
+      "from": "kew@0.4.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
     },
     "kind-of": {
       "version": "3.0.2",
+      "from": "kind-of@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
     },
     "lazy-cache": {
       "version": "1.0.3",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
     },
     "lazystream": {
       "version": "0.1.0",
+      "from": "lazystream@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
+          "from": "readable-stream@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
+      "from": "lcid@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-    },
-    "left-pad": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
     },
     "less": {
       "version": "2.6.1",
+      "from": "less@>=2.6.0 <2.7.0",
       "resolved": "https://registry.npmjs.org/less/-/less-2.6.1.tgz",
       "dependencies": {
         "asap": {
           "version": "2.0.3",
+          "from": "asap@>=2.0.3 <2.1.0",
           "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
         },
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "promise": {
           "version": "7.1.1",
+          "from": "promise@>=7.1.1 <8.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
         },
         "source-map": {
           "version": "0.5.3",
+          "from": "source-map@>=0.5.3 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "leven": {
       "version": "1.0.2",
+      "from": "leven@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-    },
-    "line-numbers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
     },
     "linkify-it": {
       "version": "1.2.0",
+      "from": "linkify-it@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.0.tgz"
     },
     "livereload-js": {
       "version": "2.2.2",
+      "from": "livereload-js@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
     },
     "load-grunt-tasks": {
       "version": "3.4.1",
+      "from": "load-grunt-tasks@>=3.4.1 <3.5.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.4.1.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
+      "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         }
       }
     },
     "lodash": {
       "version": "0.9.2",
+      "from": "lodash@>=0.9.2 <0.10.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._createassigner": {
       "version": "3.1.1",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash.assign": {
       "version": "3.2.0",
+      "from": "lodash.assign@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.8",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "longest": {
       "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loud-rejection": {
       "version": "1.3.0",
+      "from": "loud-rejection@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz"
     },
     "lower-case": {
       "version": "1.1.3",
+      "from": "lower-case@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
     },
     "lower-case-first": {
       "version": "1.0.2",
+      "from": "lower-case-first@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
     },
     "lru-cache": {
       "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
+      "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "markdown-it": {
       "version": "6.0.0",
+      "from": "markdown-it@>=6.0.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.0.tgz",
       "dependencies": {
         "argparse": {
           "version": "1.0.7",
+          "from": "argparse@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
         },
         "entities": {
           "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
-    "marked": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
-    },
     "maxmin": {
       "version": "1.1.0",
+      "from": "maxmin@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
       "dependencies": {
         "pretty-bytes": {
           "version": "1.0.4",
+          "from": "pretty-bytes@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz"
         }
       }
     },
     "md5": {
       "version": "2.0.0",
+      "from": "md5@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.0.0.tgz",
       "dependencies": {
         "is-buffer": {
           "version": "1.0.2",
+          "from": "is-buffer@>=1.0.2 <1.1.0",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
         }
       }
     },
     "mdurl": {
       "version": "1.0.1",
+      "from": "mdurl@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
+      "from": "media-typer@0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "meow": {
       "version": "3.7.0",
+      "from": "meow@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "mime": {
       "version": "1.3.4",
+      "from": "mime@1.3.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
       "version": "1.22.0",
+      "from": "mime-db@>=1.22.0 <1.23.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
     },
     "mime-types": {
       "version": "2.1.10",
+      "from": "mime-types@>=2.1.9 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
     },
     "minimatch": {
       "version": "3.0.0",
+      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
     },
     "minimist": {
       "version": "1.2.0",
+      "from": "minimist@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "morgan": {
       "version": "1.7.0",
+      "from": "morgan@>=1.6.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
+      "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-    },
-    "msee": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
-        },
-        "nopt": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz"
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
-        }
-      }
     },
     "multimatch": {
       "version": "2.1.0",
+      "from": "multimatch@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz"
     },
     "mute-stream": {
       "version": "0.0.6",
+      "from": "mute-stream@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
     },
     "natural-compare": {
       "version": "1.2.2",
+      "from": "natural-compare@>=1.2.2 <1.3.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz"
     },
     "ncname": {
       "version": "1.0.0",
+      "from": "ncname@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz"
     },
     "ncp": {
       "version": "0.4.2",
+      "from": "ncp@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
     },
     "negotiator": {
       "version": "0.5.3",
+      "from": "negotiator@0.5.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "node-int64": {
       "version": "0.4.0",
+      "from": "node-int64@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nomnom": {
       "version": "1.8.1",
+      "from": "nomnom@>=1.5.0",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
+          "from": "ansi-styles@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
         },
         "chalk": {
           "version": "0.4.0",
+          "from": "chalk@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
         },
         "strip-ansi": {
           "version": "0.1.1",
+          "from": "strip-ansi@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
         },
         "underscore": {
           "version": "1.6.0",
+          "from": "underscore@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "nopt": {
       "version": "1.0.10",
+      "from": "nopt@>=1.0.10 <1.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
+      "from": "normalize-package-data@>=2.3.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
+      "from": "normalize-path@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
-    },
-    "npm": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.1.tgz",
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "ansi": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz"
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
-        },
-        "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "async-some": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz"
-        },
-        "block-stream": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-        },
-        "char-spinner": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
-        },
-        "chmodr": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
-        },
-        "cmd-shim": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz"
-        },
-        "columnify": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "dependencies": {
-            "wcwidth": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-          "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-            }
-          }
-        },
-        "dezalgo": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-          "dependencies": {
-            "asap": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
-            }
-          }
-        },
-        "editor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz"
-        },
-        "fs-vacuum": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.7.tgz"
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
-          "dependencies": {
-            "iferr": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-        },
-        "fstream-npm": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.0.7.tgz",
-          "dependencies": {
-            "fstream-ignore": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz"
-            }
-          }
-        },
-        "github-url-from-git": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
-        },
-        "github-url-from-username-repo": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz"
-        },
-        "glob": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dependencies": {
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-        },
-        "hosted-git-info": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-        },
-        "inflight": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-        },
-        "init-package-json": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.3.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dependencies": {
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
-            }
-          }
-        },
-        "lockfile": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
-        },
-        "lru-cache": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.1.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "node-gyp": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "2.0.10",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                }
-              }
-            },
-            "path-array": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-              "dependencies": {
-                "array-index": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.0.2",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                      "dependencies": {
-                        "d": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                        },
-                        "es5-ext": {
-                          "version": "0.10.11",
-                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-        },
-        "normalize-git-url": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.1.tgz"
-        },
-        "normalize-package-data": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz"
-        },
-        "npm-install-checks": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz"
-        },
-        "npm-package-arg": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz"
-        },
-        "npm-registry-client": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.1.0.tgz",
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                }
-              }
-            },
-            "retry": {
-              "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz"
-            }
-          }
-        },
-        "npm-user-validate": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz"
-        },
-        "npmlog": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz",
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                }
-              }
-            },
-            "gauge": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
-              "dependencies": {
-                "has-unicode": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                },
-                "lodash._createpadding": {
-                  "version": "3.6.1",
-                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                },
-                "lodash.pad": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.2.2.tgz"
-                },
-                "lodash.padleft": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-                },
-                "lodash.padright": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                },
-                "lodash.repeat": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._root": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-        },
-        "opener": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz"
-        },
-        "osenv": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
-            },
-            "os-tmpdir": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-        },
-        "read": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-            }
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "dependencies": {
-            "debuglog": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz"
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz"
-            },
-            "util-extend": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
-            }
-          }
-        },
-        "read-package-json": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.3.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dependencies": {
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "json-parse-helpfulerror": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "dependencies": {
-                "jju": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            }
-          }
-        },
-        "realize-package-specifier": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz"
-        },
-        "request": {
-          "version": "2.69.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                }
-              }
-            },
-            "bl": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.12.4",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.3",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.12.2",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.3",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.9",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-            },
-            "qs": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            }
-          }
-        },
-        "retry": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz"
-        },
-        "rimraf": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-              "dependencies": {
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-        },
-        "sha": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "slide": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-        },
-        "sorted-object": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
-        },
-        "spdx-license-ids": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-        },
-        "umask": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz"
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "dependencies": {
-            "spdx-correct": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-              "dependencies": {
-                "spdx-exceptions": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-          "dependencies": {
-            "builtins": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
-            }
-          }
-        },
-        "which": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                }
-              }
-            },
-            "isexe": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz"
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-        },
-        "write-file-atomic": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
-        }
-      }
-    },
-    "npm-shrinkwrap": {
-      "version": "200.4.0",
-      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-200.4.0.tgz",
-      "dependencies": {
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        }
-      }
     },
     "npmconf": {
       "version": "2.1.1",
+      "from": "npmconf@2.1.1",
       "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
+          "from": "nopt@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "semver": {
           "version": "4.3.6",
+          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "num2fraction": {
       "version": "1.2.2",
+      "from": "num2fraction@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
       "version": "0.8.1",
+      "from": "oauth-sign@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
     },
     "object-assign": {
       "version": "4.0.1",
+      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-    },
-    "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
+      "from": "on-finished@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "on-headers": {
       "version": "1.0.1",
+      "from": "on-headers@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
     "once": {
       "version": "1.3.3",
+      "from": "once@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "opn": {
       "version": "4.0.1",
+      "from": "opn@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.1.tgz"
     },
     "optimist": {
       "version": "0.3.7",
+      "from": "optimist@>=0.3.5 <0.4.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
+      "from": "os-homedir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
+      "from": "os-locale@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
+      "from": "os-tmpdir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "osenv": {
       "version": "0.1.3",
+      "from": "osenv@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
     "output-file-sync": {
       "version": "1.1.1",
+      "from": "output-file-sync@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
     },
     "package": {
       "version": "1.0.1",
+      "from": "package@>=1.0.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
     },
     "pako": {
       "version": "0.2.8",
+      "from": "pako@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
     },
     "param-case": {
       "version": "1.1.2",
+      "from": "param-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
+      "from": "parse-json@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse-ms": {
       "version": "1.0.1",
+      "from": "parse-ms@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz"
     },
     "parserlib": {
       "version": "0.2.5",
+      "from": "parserlib@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
+      "from": "parseurl@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "pascal-case": {
       "version": "1.1.2",
+      "from": "pascal-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
     },
     "path-case": {
       "version": "1.1.2",
+      "from": "path-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
     },
     "path-exists": {
       "version": "2.1.0",
+      "from": "path-exists@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-type": {
       "version": "1.1.0",
+      "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         }
       }
     },
     "pathval": {
       "version": "0.1.1",
+      "from": "pathval@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
     },
     "phantomjs": {
       "version": "1.9.19",
+      "from": "phantomjs@>=1.9.0-1 <1.10.0",
       "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.19.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
+          "from": "asn1@0.1.11",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
         },
         "assert-plus": {
           "version": "0.1.5",
+          "from": "assert-plus@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "async": {
           "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "aws-sign2": {
           "version": "0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "bl": {
           "version": "0.9.5",
+          "from": "bl@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
         },
         "boom": {
           "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
         },
         "caseless": {
           "version": "0.6.0",
+          "from": "caseless@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
+          "from": "combined-stream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
         "cryptiles": {
           "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
         },
         "delayed-stream": {
           "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.1.4",
+          "from": "form-data@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz"
         },
         "hawk": {
           "version": "1.1.1",
+          "from": "hawk@1.1.1",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
         },
         "hoek": {
           "version": "0.9.1",
+          "from": "hoek@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
+          "from": "mime-types@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "oauth-sign": {
           "version": "0.4.0",
+          "from": "oauth-sign@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
         },
         "qs": {
           "version": "1.2.2",
+          "from": "qs@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
+          "from": "readable-stream@>=1.0.26 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         },
         "request": {
           "version": "2.42.0",
+          "from": "request@2.42.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz"
         },
         "sntp": {
           "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
         }
       }
     },
     "pify": {
       "version": "2.3.0",
+      "from": "pify@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.0",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "pkg-up": {
       "version": "1.0.0",
+      "from": "pkg-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
     },
     "pkginfo": {
       "version": "0.4.0",
+      "from": "pkginfo@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
     },
     "plur": {
       "version": "1.0.0",
+      "from": "plur@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
     },
     "portscanner": {
       "version": "1.0.0",
+      "from": "portscanner@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.15",
+          "from": "async@0.1.15",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
         }
       }
     },
     "postcss": {
       "version": "4.1.16",
+      "from": "postcss@>=4.1.11 <5.0.0",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz"
     },
     "pretty-bytes": {
       "version": "3.0.1",
+      "from": "pretty-bytes@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz"
     },
     "pretty-ms": {
       "version": "2.1.0",
+      "from": "pretty-ms@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz"
     },
     "private": {
       "version": "0.1.6",
+      "from": "private@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.6",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
     },
     "progress": {
       "version": "1.1.8",
+      "from": "progress@1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "6.1.0",
+      "from": "promise@>=6.0.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz"
     },
     "prompt": {
       "version": "0.2.14",
+      "from": "prompt@>=0.2.14 <0.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz"
     },
     "proto-list": {
       "version": "1.2.4",
+      "from": "proto-list@>=1.2.1 <1.3.0",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
     },
     "prr": {
       "version": "0.0.0",
+      "from": "prr@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
+      "from": "pseudomap@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "q": {
       "version": "1.4.1",
+      "from": "q@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
       "version": "6.0.2",
+      "from": "qs@>=6.0.2 <6.1.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
     },
     "range-parser": {
       "version": "1.0.3",
+      "from": "range-parser@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "raw-body": {
       "version": "2.1.6",
+      "from": "raw-body@>=2.1.5 <2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.3.0",
+          "from": "bytes@2.3.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
         },
         "iconv-lite": {
           "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         }
       }
     },
     "read": {
       "version": "1.0.7",
+      "from": "read@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
-    },
-    "read-json": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/read-json/-/read-json-0.1.0.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
+      "from": "read-pkg@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
+      "from": "read-pkg-up@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "2.0.6",
+      "from": "readable-stream@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "recast": {
       "version": "0.10.33",
+      "from": "recast@0.10.33",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0"
         },
         "source-map": {
           "version": "0.5.3",
+          "from": "source-map@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "redent": {
       "version": "1.0.0",
+      "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
-    },
-    "redeyed": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
-      "dependencies": {
-        "esprima-fb": {
-          "version": "12001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
-        }
-      }
     },
     "regenerate": {
       "version": "1.2.1",
+      "from": "regenerate@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
     },
     "regenerator": {
       "version": "0.8.40",
+      "from": "regenerator@0.8.40",
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
         }
       }
     },
     "regexpu": {
       "version": "1.3.0",
+      "from": "regexpu@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
+          "from": "esprima@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         }
       }
     },
     "regjsgen": {
       "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
       "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "relateurl": {
       "version": "0.2.6",
+      "from": "relateurl@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
     },
     "repeat-string": {
       "version": "1.5.4",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "2.0.0",
+      "from": "repeating@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
     },
     "request": {
       "version": "2.69.0",
+      "from": "request@>=2.51.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
       "dependencies": {
         "bl": {
           "version": "1.0.3",
+          "from": "bl@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
         }
       }
     },
     "request-progress": {
       "version": "0.3.1",
+      "from": "request-progress@0.3.1",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz"
     },
     "requestretry": {
       "version": "1.2.2",
+      "from": "requestretry@>=1.2.2 <1.3.0",
       "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
+          "from": "asn1@0.1.11",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
         },
         "assert-plus": {
           "version": "0.1.5",
+          "from": "assert-plus@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "async": {
           "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "aws-sign2": {
           "version": "0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "bl": {
           "version": "0.9.5",
+          "from": "bl@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
         },
         "boom": {
           "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
         },
         "caseless": {
           "version": "0.8.0",
+          "from": "caseless@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
+          "from": "combined-stream@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
         "cryptiles": {
           "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
         },
         "delayed-stream": {
           "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.2.0",
+          "from": "form-data@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.0.14",
+              "from": "mime-types@>=2.0.3 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
             }
           }
         },
         "hawk": {
           "version": "1.1.1",
+          "from": "hawk@1.1.1",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
         },
         "hoek": {
           "version": "0.9.1",
+          "from": "hoek@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
         },
         "mime-db": {
           "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
+          "from": "mime-types@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "oauth-sign": {
           "version": "0.5.0",
+          "from": "oauth-sign@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
         },
         "qs": {
           "version": "2.3.3",
+          "from": "qs@>=2.3.1 <2.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
+          "from": "readable-stream@>=1.0.26 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         },
         "request": {
           "version": "2.51.0",
+          "from": "request@>=2.51.0 <2.52.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz"
         },
         "sntp": {
           "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
         }
       }
     },
     "reserved-words": {
       "version": "0.1.1",
+      "from": "reserved-words@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz"
     },
     "resolve": {
       "version": "1.1.7",
+      "from": "resolve@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
+      "from": "resolve-from@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
     },
     "resolve-pkg": {
       "version": "0.1.0",
+      "from": "resolve-pkg@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz"
     },
     "revalidator": {
       "version": "0.1.8",
+      "from": "revalidator@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
     },
     "right-align": {
       "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.2.8",
+      "from": "rimraf@>=2.2.8 <2.3.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-    },
-    "run-parallel": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.5.tgz"
-    },
-    "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
-    },
-    "safe-json-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz"
     },
     "sauce-tunnel": {
       "version": "2.3.0",
+      "from": "sauce-tunnel@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/sauce-tunnel/-/sauce-tunnel-2.3.0.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
+          "from": "asn1@0.1.11",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
         },
         "assert-plus": {
           "version": "0.1.2",
+          "from": "assert-plus@0.1.2",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
         },
         "async": {
           "version": "0.2.10",
+          "from": "async@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "boom": {
           "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
+              "from": "hoek@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             }
           }
         },
         "combined-stream": {
           "version": "0.0.7",
+          "from": "combined-stream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
         "cryptiles": {
           "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
         },
         "ctype": {
           "version": "0.5.2",
+          "from": "ctype@0.5.2",
           "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
         },
         "delayed-stream": {
           "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.0.8",
+          "from": "form-data@0.0.8",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz"
         },
         "hawk": {
           "version": "0.13.1",
+          "from": "hawk@>=0.13.0 <0.14.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz"
         },
         "hoek": {
           "version": "0.8.5",
+          "from": "hoek@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.8.5.tgz"
         },
         "http-signature": {
           "version": "0.9.11",
+          "from": "http-signature@>=0.9.11 <0.10.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.9.11.tgz"
         },
         "json-stringify-safe": {
           "version": "4.0.0",
+          "from": "json-stringify-safe@>=4.0.0 <4.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz"
         },
         "mime": {
           "version": "1.2.11",
+          "from": "mime@>=1.2.9 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "oauth-sign": {
           "version": "0.3.0",
+          "from": "oauth-sign@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "qs": {
           "version": "0.6.6",
+          "from": "qs@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "request": {
           "version": "2.21.0",
+          "from": "request@>=2.21.0 <2.22.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz"
         },
         "sntp": {
           "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
+              "from": "hoek@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.3.0",
+          "from": "tunnel-agent@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
         }
       }
     },
     "saucelabs": {
       "version": "0.1.1",
+      "from": "saucelabs@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
     },
     "semver": {
       "version": "5.1.0",
+      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "send": {
       "version": "0.13.1",
+      "from": "send@0.13.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz"
     },
     "sentence-case": {
       "version": "1.1.3",
+      "from": "sentence-case@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
     },
     "serve-index": {
       "version": "1.7.3",
+      "from": "serve-index@>=1.7.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz"
     },
     "serve-static": {
       "version": "1.10.2",
+      "from": "serve-static@>=1.10.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.6.0",
+      "from": "shelljs@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "2.1.2",
+      "from": "signal-exit@>=2.1.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "simple-fmt": {
       "version": "0.1.0",
+      "from": "simple-fmt@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
     },
     "simple-is": {
       "version": "0.2.0",
+      "from": "simple-is@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
     },
     "slash": {
       "version": "1.0.0",
+      "from": "slash@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "snake-case": {
       "version": "1.1.2",
+      "from": "snake-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
     },
     "sntp": {
       "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-    },
-    "sorted-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
     },
     "source-map": {
       "version": "0.4.4",
+      "from": "source-map@>=0.4.2 <0.5.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
+      "from": "source-map-support@>=0.2.10 <0.3.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
+          "from": "source-map@0.1.32",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "spdx-correct": {
       "version": "1.0.2",
+      "from": "spdx-correct@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
+      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.2",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.0",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
     },
     "split": {
       "version": "0.3.3",
+      "from": "split@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.7.4",
+      "from": "sshpk@>=1.7.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
     },
     "stable": {
       "version": "0.1.5",
+      "from": "stable@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
     },
     "stack-trace": {
       "version": "0.0.9",
+      "from": "stack-trace@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "statuses": {
       "version": "1.2.1",
+      "from": "statuses@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
     },
     "stream-buffers": {
       "version": "2.2.0",
+      "from": "stream-buffers@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "stringmap": {
       "version": "0.2.2",
+      "from": "stringmap@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
     },
     "stringset": {
       "version": "0.2.1",
+      "from": "stringset@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "2.0.1",
+      "from": "strip-ansi@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
+      "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
+      "from": "strip-indent@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "supports-color": {
       "version": "1.3.1",
+      "from": "supports-color@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
     },
     "swap-case": {
       "version": "1.1.2",
+      "from": "swap-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
     },
     "tar-stream": {
       "version": "1.3.2",
+      "from": "tar-stream@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.2.tgz"
     },
     "temporary": {
       "version": "0.0.8",
+      "from": "temporary@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz"
     },
     "text-table": {
       "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "throttleit": {
       "version": "0.0.2",
+      "from": "throttleit@>=0.0.2 <0.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
     },
     "through": {
       "version": "2.3.8",
+      "from": "through@>=2.3.8 <2.4.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "time-grunt": {
       "version": "1.3.0",
+      "from": "time-grunt@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz"
     },
     "tiny-lr": {
       "version": "0.2.1",
+      "from": "tiny-lr@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "dependencies": {
         "qs": {
           "version": "5.1.0",
+          "from": "qs@>=5.1.0 <5.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         }
       }
     },
     "title-case": {
       "version": "1.1.2",
+      "from": "title-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
     },
     "tmp": {
       "version": "0.0.28",
+      "from": "tmp@>=0.0.28 <0.0.29",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
     },
     "to-double-quotes": {
       "version": "2.0.0",
+      "from": "to-double-quotes@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz"
     },
     "to-fast-properties": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "to-fast-properties@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "to-single-quotes": {
       "version": "2.0.0",
+      "from": "to-single-quotes@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz"
     },
     "tough-cookie": {
       "version": "2.2.2",
+      "from": "tough-cookie@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "transformers": {
       "version": "2.1.0",
+      "from": "transformers@2.1.0",
       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
       "dependencies": {
         "is-promise": {
           "version": "1.0.1",
+          "from": "is-promise@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
         },
         "promise": {
           "version": "2.0.0",
+          "from": "promise@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz"
         },
         "source-map": {
           "version": "0.1.43",
+          "from": "source-map@>=0.1.7 <0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         },
         "uglify-js": {
           "version": "2.2.5",
+          "from": "uglify-js@>=2.2.5 <2.3.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz"
         }
       }
     },
     "trim-newlines": {
       "version": "1.0.0",
+      "from": "trim-newlines@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "trim-right": {
       "version": "1.0.1",
+      "from": "trim-right@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
     },
     "try-resolve": {
       "version": "1.0.1",
+      "from": "try-resolve@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
     },
     "tryor": {
       "version": "0.1.2",
+      "from": "tryor@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.2",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tweetnacl": {
       "version": "0.14.1",
+      "from": "tweetnacl@>=0.13.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.1.tgz"
     },
     "type-is": {
       "version": "1.6.12",
+      "from": "type-is@>=1.6.10 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
+      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uc.micro": {
       "version": "1.0.0",
+      "from": "uc.micro@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz"
     },
     "uglify-js": {
       "version": "2.6.2",
+      "from": "uglify-js@>=2.6.0 <2.7.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
           "version": "0.5.3",
+          "from": "source-map@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "uid-number": {
       "version": "0.0.5",
+      "from": "uid-number@0.0.5",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
     },
     "underscore": {
       "version": "1.7.0",
+      "from": "underscore@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "underscore.string": {
       "version": "2.2.1",
+      "from": "underscore.string@>=2.2.1 <2.3.0",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
+      "from": "unpipe@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "upper-case": {
       "version": "1.1.3",
+      "from": "upper-case@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
     },
     "upper-case-first": {
       "version": "1.1.2",
+      "from": "upper-case-first@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
     },
     "uri-path": {
       "version": "1.0.0",
+      "from": "uri-path@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz"
     },
     "user-home": {
       "version": "1.1.1",
+      "from": "user-home@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utile": {
       "version": "0.2.1",
+      "from": "utile@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
     },
     "utils-merge": {
       "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
+      "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "void-elements": {
       "version": "2.0.1",
+      "from": "void-elements@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
     "vow": {
       "version": "0.4.4",
+      "from": "vow@0.4.4",
       "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.4.tgz"
     },
     "vow-fs": {
       "version": "0.3.2",
+      "from": "vow-fs@0.3.2",
       "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.2.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.8",
+          "from": "glob@3.2.8",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "node-uuid": {
           "version": "1.4.0",
+          "from": "node-uuid@1.4.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz"
         }
       }
     },
     "vow-queue": {
       "version": "0.3.1",
+      "from": "vow-queue@0.3.1",
       "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.3.1.tgz"
     },
     "websocket-driver": {
       "version": "0.6.4",
+      "from": "websocket-driver@>=0.5.1",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz"
     },
     "websocket-extensions": {
       "version": "0.1.1",
+      "from": "websocket-extensions@>=0.1.1",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
     "which": {
       "version": "1.0.9",
+      "from": "which@>=1.0.5 <1.1.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
     },
     "window-size": {
       "version": "0.1.0",
+      "from": "window-size@0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "winston": {
       "version": "0.8.3",
+      "from": "winston@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "pkginfo": {
           "version": "0.3.1",
+          "from": "pkginfo@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
         }
       }
     },
     "with": {
       "version": "4.0.3",
+      "from": "with@>=4.0.0 <4.1.0",
       "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
+          "from": "acorn@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
         }
       }
     },
     "wordwrap": {
       "version": "0.0.2",
+      "from": "wordwrap@0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
     },
     "wrappy": {
       "version": "1.0.1",
+      "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "xml-char-classes": {
       "version": "1.0.0",
+      "from": "xml-char-classes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
     },
     "xmlbuilder": {
       "version": "3.1.0",
+      "from": "xmlbuilder@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.5.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "xtend": {
       "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.1",
+      "from": "y18n@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
       "version": "2.0.0",
+      "from": "yallist@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
       "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         }
       }
     },
     "zip-stream": {
       "version": "0.8.0",
+      "from": "zip-stream@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.8.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <3.11.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Twitter, Inc.",
   "scripts": {
     "change-version": "node grunt/change-version.js",
+    "shrinkwrap": "npm shrinkwrap --dev && mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
     "test": "grunt test"
   },
   "style": "dist/css/bootstrap.css",
@@ -55,7 +56,6 @@
     "grunt-saucelabs": "~8.6.2",
     "load-grunt-tasks": "~3.4.1",
     "markdown-it": "^6.0.0",
-    "npm-shrinkwrap": "^200.4.0",
     "shelljs": "^0.6.0",
     "time-grunt": "^1.3.0"
   },


### PR DESCRIPTION
Ports #19604 to v3.
Fixes #18559 for v3.
