### PR TITLE
Docs : Removed border from GitHub button

### DIFF
--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -8,7 +8,7 @@
 
 /*
  * Bootstrap Documentation
- * Special styles for presenting Bootstrap's documentation and code examples.
+ * Special styles for presenting Bootstrap's documentation andgit code examples.
  */
 
 
@@ -822,6 +822,7 @@ h1[id] {
   width: 180px;
   height: 20px;
   margin-top: 6px;
+  border: none;
 }
 .bs-team img {
   float: left;

--- a/docs/assets/css/src/docs.css
+++ b/docs/assets/css/src/docs.css
@@ -8,7 +8,7 @@
 
 /*
  * Bootstrap Documentation
- * Special styles for presenting Bootstrap's documentation andgit code examples.
+ * Special styles for presenting Bootstrap's documentation and code examples.
  */
 
 


### PR DESCRIPTION
At the [core team page](http://getbootstrap.com/about/#team-core) of the documentation, the GitHub buttons have an ugly border. I fixed that.

![Before, after](https://cloud.githubusercontent.com/assets/7029582/14011683/cf6c80f6-f1a0-11e5-83bf-fd953733d21c.png)
