### PR TITLE
Fix for dropdown-right alignment being incorrect

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -129,8 +129,9 @@
 // Add extra class to `.dropdown-menu` to flip the alignment of the dropdown
 // menu with the parent.
 .dropdown-menu-right {
-  right: 0;
+	display: inline-block;
   left: auto; // Reset the default from `.dropdown-menu`
+  right: 0;
 }
 
 .dropdown-menu-left {

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -129,9 +129,9 @@
 // Add extra class to `.dropdown-menu` to flip the alignment of the dropdown
 // menu with the parent.
 .dropdown-menu-right {
-	display: inline-block;
-  left: auto; // Reset the default from `.dropdown-menu`
   right: 0;
+  left: auto; // Reset the default from `.dropdown-menu`
+  display: inline-block; //Make sure width doesnt stretch to fill container.
 }
 
 .dropdown-menu-left {


### PR DESCRIPTION
Changed display property for class .dropdown-menu-right to fix this issue: https://github.com/twbs/bootstrap/issues/18852

I opted to change the display property for dropdown-menu-right instead of dropdown-menu, because this issue is specific to the dropdown-menu-right class. Changing the display property for dropdown-menu class could have unforeseen consequences.,
