### PR TITLE
Make top & bottom .label padding the same

### DIFF
--- a/less/labels.less
+++ b/less/labels.less
@@ -4,7 +4,7 @@
 
 .label {
   display: inline;
-  padding: .2em .6em .3em;
+  padding: .3em .6em;
   font-size: 75%;
   font-weight: bold;
   line-height: 1;


### PR DESCRIPTION
Use to look like this:
![a](https://cloud.githubusercontent.com/assets/9902336/14065569/941c6eb2-f42f-11e5-9161-4565045f635e.PNG)

`padding: .2em .6em .3em`

| top | horizontal | bottom |
| --- | --- | --- |
| .2em | .6em | .3em |

---

Now looks like this:
![b](https://cloud.githubusercontent.com/assets/9902336/14065570/96088602-f42f-11e5-825e-707542a9455c.PNG)

`padding: .3em .6em;`

| vertical | horizontal |
| --- | --- |
| .3em | .6em |
