### PR TITLE
Docs: Correct arg `offsets` to `offset` in tooltips & popovers

### DIFF
--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -265,7 +265,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>An array of constraints - passed through to Tether. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#constraints">constraint docs</a>.</td>
       </tr>
       <tr>
-        <td>offsets</td>
+        <td>offset</td>
         <td>string</td>
         <td>'0 0'</td>
         <td>Offset of the popover relative to its target. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#offset">offset docs</a>.</td>

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -229,7 +229,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>An array of constraints - passed through to Tether. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#constraints">constraint docs</a>.</td>
       </tr>
       <tr>
-        <td>offsets</td>
+        <td>offset</td>
         <td>string</td>
         <td>'0 0'</td>
         <td>Offset of the popover relative to its target. For more information refer to Tether's <a href="http://github.hubspot.com/tether/#constraints">offset docs</a>.</td>


### PR DESCRIPTION
Tooltips & Popovers accept `offset` as arg, not `offsets`.
