### PR TITLE
Custom modal backdrop

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -190,7 +190,7 @@
       var doAnimate = $.support.transition && animate
 
 	  if(this.options.customBackdrop){
-    	  this.$backdrop = $(this.options.customBackdrop)
+    	  this.$backdrop = $("#" + this.options.customBackdrop)
           .addClass('modal-backdrop ' + animate)
       }else{
     	  this.$backdrop = $(document.createElement('div'))

--- a/js/modal.js
+++ b/js/modal.js
@@ -189,8 +189,8 @@
     if (this.isShown && this.options.backdrop) {
       var doAnimate = $.support.transition && animate
 
-	  if(this.options.custom-modal-backdrop){
-    	  this.$backdrop = this.custom-modal-backdrop
+	  if(this.options.customBackdrop){
+    	  this.$backdrop = $(this.options.customBackdrop)
           .addClass('modal-backdrop ' + animate)
       }else{
     	  this.$backdrop = $(document.createElement('div'))

--- a/js/modal.js
+++ b/js/modal.js
@@ -189,8 +189,8 @@
     if (this.isShown && this.options.backdrop) {
       var doAnimate = $.support.transition && animate
 
-	  if(this.options.customBackdrop){
-    	  this.$backdrop = $("#" + this.options.customBackdrop)
+	  if(this.options.customBackdrop && $(this.options.customBackdrop)){
+    	  this.$backdrop = $(this.options.customBackdrop)
           .addClass('modal-backdrop ' + animate)
       }else{
     	  this.$backdrop = $(document.createElement('div'))

--- a/js/modal.js
+++ b/js/modal.js
@@ -189,9 +189,14 @@
     if (this.isShown && this.options.backdrop) {
       var doAnimate = $.support.transition && animate
 
-      this.$backdrop = $(document.createElement('div'))
-        .addClass('modal-backdrop ' + animate)
-        .appendTo(this.$body)
+	  if(this.options.custom-modal-backdrop){
+    	  this.$backdrop = this.custom-modal-backdrop
+          .addClass('modal-backdrop ' + animate)
+      }else{
+    	  this.$backdrop = $(document.createElement('div'))
+          .addClass('modal-backdrop ' + animate)
+          .appendTo(this.$body)
+      }
 
       this.$element.on('click.dismiss.bs.modal', $.proxy(function (e) {
         if (this.ignoreBackdropClick) {


### PR DESCRIPTION
Modified the Modal object for accept a new option's paramenter, the customBackdrop. 
When a modal will opened, it will use your backdrop.
This is usefull when you want an unclickable area in a specific div, instead all the screen. For examble, I have 2 columns, one for the menu and one for the content. I want the dialog only in the content. so the the backdrop is relative of his parent (the div "content").

For use this feauture just declare an empty div inside the content (or wherever you want) and add the  id to the option's modal:

var myCustomBackdrop = "#myShadow";
$("#popup-loading").modal({
    customBackdrop: myCustomBackdrop
});

N.B.:
The content div must have position:relative

![cattura](https://cloud.githubusercontent.com/assets/6776297/14324480/3b5236a6-fc25-11e5-9e1d-ba9ebfac9674.PNG)
