### PR TITLE
Color contrast tweaks for V4

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -5,13 +5,13 @@
   line-height: 1;
   color: $close-color;
   text-shadow: $close-text-shadow;
-  opacity: .2;
+  opacity: .42;
 
   @include hover-focus {
     color: $close-color;
     text-decoration: none;
     cursor: pointer;
-    opacity: .5;
+    opacity: .65;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -45,9 +45,9 @@ $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 
 $brand-primary:             #0275d8 !default;
-$brand-success:             #5cb85c !default;
-$brand-info:                #5bc0de !default;
-$brand-warning:             #f0ad4e !default;
+$brand-success:             #00ac07 !default;
+$brand-info:                #17a0d3 !default;
+$brand-warning:             #d58000 !default;
 $brand-danger:              #d9534f !default;
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -40,7 +40,7 @@
 
 $gray-dark:                 #373a3c !default;
 $gray:                      #55595c !default;
-$gray-light:                #818a91 !default;
+$gray-light:                #70787d !default;
 $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -269,7 +269,7 @@ $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
 $btn-secondary-bg:               #fff !default;
-$btn-secondary-border:           #ccc !default;
+$btn-secondary-border:           $gray !default;
 
 $btn-info-color:                 #fff !default;
 $btn-info-bg:                    $brand-info !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -722,7 +722,7 @@ $list-group-hover-bg:           #f5f5f5 !default;
 $list-group-active-color:       $component-active-color !default;
 $list-group-active-bg:          $component-active-bg !default;
 $list-group-active-border:      $list-group-active-bg !default;
-$list-group-active-text-color:  lighten($list-group-active-bg, 40%) !default;
+$list-group-active-text-color:  lighten($list-group-active-bg, 50%) !default;
 
 $list-group-disabled-color:      $gray-light !default;
 $list-group-disabled-bg:         $gray-lighter !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -758,7 +758,7 @@ $breadcrumb-padding-y:          .75rem !default;
 $breadcrumb-padding-x:          1rem !default;
 $breadcrumb-item-padding:       .5rem !default;
 
-$breadcrumb-bg:                 $gray-lighter !default;
+$breadcrumb-bg:                 $gray-lightest !default;
 $breadcrumb-divider-color:      $gray-light !default;
 $breadcrumb-active-color:       $gray-light !default;
 $breadcrumb-divider:            "/" !default;


### PR DESCRIPTION
A series of (hopefully non-controversial) tweaks to some common color contrast issues that V4 inherited from V3.

Some of these tweaks aim for the full 4.5:1 color contrast ratio recommended by WCAG 2.0, while others (notably the success, info and warning tweaks) go for the slightly more relaxed 3:1 (which is really for large text, so still not ideal in all situations...but a slightly more achievable goal, particularly for vibrant colors).

Not all possible combinations have been tried out, but most tweaks seem to move towards a more positive result judging purely by the documentation examples.
