### PR TITLE
Remove tab-focus mixin and add surgical `outline: none` where appropriate

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -22,7 +22,7 @@
   &.active {
     &:focus,
     &.focus {
-      @include tab-focus();
+      outline: none;
     }
   }
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -23,7 +23,6 @@
 @import "mixins/resize";
 @import "mixins/screen-reader";
 @import "mixins/size";
-@import "mixins/tab-focus";
 @import "mixins/reset-text";
 @import "mixins/text-emphasis";
 @import "mixins/text-hide";

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -71,6 +71,10 @@
       border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
     }
 
+    &:focus {
+      outline-offset: -2px;
+    }
+
     &.disabled {
       @include plain-hover-focus {
         color: $nav-disabled-link-color;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -56,6 +56,7 @@
     color: $pagination-hover-color;
     background-color: $pagination-hover-bg;
     border-color: $pagination-hover-border;
+    outline: none;
   }
 }
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -165,10 +165,6 @@ a {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }
-
-  &:focus {
-    @include tab-focus();
-  }
 }
 
 // And undo these styles for placeholder links/named anchors (without href).
@@ -183,10 +179,6 @@ a:not([href]) {
   @include hover-focus {
     color: inherit;
     text-decoration: none;
-  }
-
-  &:focus {
-    outline: none;
   }
 }
 

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -5,7 +5,6 @@
 @import "custom";
 @import "variables";
 @import "mixins/hover";
-@import "mixins/tab-focus";
 
 @import "normalize";
 @import "reboot";

--- a/scss/mixins/_tab-focus.scss
+++ b/scss/mixins/_tab-focus.scss
@@ -1,9 +1,0 @@
-// WebKit-style focus
-
-@mixin tab-focus() {
-  // Default
-  outline: thin dotted;
-  // WebKit
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}


### PR DESCRIPTION
Explicitly setting a particular outline (e.g. the default `outline: thin dotted`) overrides heuristics in some modern browsers (such as Firefox) that automagically suppress `outline` as a result of mouse/tap interaction (while retaining it for keyboard interaction).

This removes the generic `tab-focus` mixin (mostly leaving outline handling up to the browser and its own heuristics), but also adds explicit `outline: none` in cases where it's deemed "safe", i.e. where sufficiently clear focus indication is provided (`.btn` elements, pagination links)

Fixes https://github.com/twbs/bootstrap/issues/18650 / https://github.com/twbs/bootstrap/issues/17006 and the Firefox focus part of https://github.com/twbs/bootstrap/issues/19398
