### PR TITLE
Add http://bugzil.la/1264125 to Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -100,6 +100,16 @@
 
 -
   browser: >
+    Firefox
+  summary: >
+    Fire `transitioncancel` event when a transition is canceled
+  upstream_bug: >
+    Mozilla#1264125
+  origin: >
+    Mozilla#1182856
+
+-
+  browser: >
     Firefox (Windows)
   summary: >
     Right border of `<select>` menu is sometimes missing when screen is set to uncommon resolution


### PR DESCRIPTION
Due to the lack of this feature in browsers, we currently have to implement an annoying `setTimeout`-based workaround, which adds an extra layer of complication and probably slightly impacts performance:
https://github.com/twbs/bootstrap/blob/e391fcb953cc959ddd88fb676b68f49eef85ef06/js/src/util.js#L63-L77

See also https://bugs.chromium.org/p/chromium/issues/detail?id=437860
