### PR TITLE
Remove https://webkit.org/b/128489 from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -232,16 +232,6 @@
   browser: >
     Safari (OS X)
   summary: >
-    Scrollbar clipped in `select[multiple]` with padding.
-  upstream_bug: >
-    WebKit#128489, Safari#19208483
-  origin: >
-    Bootstrap#12536
-
--
-  browser: >
-    Safari (OS X)
-  summary: >
     Weird button behavior with some `<input type="number">` elements.
   upstream_bug: >
     WebKit#137269, Safari#18834768


### PR DESCRIPTION
Refs https://webkit.org/b/128489
Refs #12536.
