### PR TITLE
Fix .embed-responsive class in flex container

### DIFF
--- a/scss/_responsive-embed.scss
+++ b/scss/_responsive-embed.scss
@@ -3,9 +3,14 @@
 .embed-responsive {
   position: relative;
   display: block;
-  height: 0;
+  width: 100%;
   padding: 0;
   overflow: hidden;
+
+  &::before {
+    display: block;
+    content: "";
+  }
 
   .embed-responsive-item,
   iframe,
@@ -23,17 +28,25 @@
 }
 
 .embed-responsive-21by9 {
-  padding-bottom: percentage(9 / 21);
+  &::before {
+    padding-top: percentage(9 / 21);
+  }
 }
 
 .embed-responsive-16by9 {
-  padding-bottom: percentage(9 / 16);
+  &::before {
+    padding-top: percentage(9 / 16);
+  }
 }
 
 .embed-responsive-4by3 {
-  padding-bottom: percentage(3 / 4);
+  &::before {
+    padding-top: percentage(3 / 4);
+  }
 }
 
 .embed-responsive-1by1 {
-  padding-bottom: percentage(1 / 1);
+  &::before {
+    padding-top: percentage(1 / 1);
+  }
 }


### PR DESCRIPTION
Firefox have trouble displaying `.embed-responsive` in a `flex` container. Firefox developer said that Firefox has the correct implementation, and other browsers which show `.embed-responsive` normally were wrong.

This RP fixes the problem regardless of browsers' implementation by move padding into pseudo class `::before`, as the padding in pseudo class will be resolved against block `.embed-responsive` instead of flex parent.

Spec: http://dev.w3.org/csswg/css-flexbox/#item-margins

> For blocks in CSS, % padding values are always resolved against the containing block width -- but in flexbox, they're resolved against the length of the containing block's corresponding dimension (width or height).
> 
> Authors should avoid using percentages in paddings or margins on flex items entirely, as they will get different behavior in different browsers.

Safari / WebKit: https://bugs.webkit.org/show_bug.cgi?id=113519
Chrome / Blink: https://bugs.chromium.org/p/chromium/issues/detail?id=229568
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=958714
