### PR TITLE
Add @supports query for 3D transforms on carousel

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -22,26 +22,11 @@
 
     // WebKit CSS3 transforms for supported devices
     @media all and (transform-3d), (-webkit-transform-3d) {
-      transition: transform .6s ease-in-out;
-      backface-visibility: hidden;
-      perspective: 1000px;
+      @include carousel-css3-transforms;
+    }
 
-      &.next,
-      &.active.right {
-        left: 0;
-        transform: translate3d(100%, 0, 0);
-      }
-      &.prev,
-      &.active.left {
-        left: 0;
-        transform: translate3d(-100%, 0, 0);
-      }
-      &.next.left,
-      &.prev.right,
-      &.active {
-        left: 0;
-        transform: translate3d(0, 0, 0);
-      }
+    @supports (transform: translate3d(0,0,0)) {
+      @include carousel-css3-transforms;
     }
   }
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -33,6 +33,7 @@
 @import "mixins/alert";
 @import "mixins/buttons";
 @import "mixins/cards";
+@import "mixins/carousel";
 @import "mixins/pagination";
 @import "mixins/lists";
 @import "mixins/list-group";

--- a/scss/mixins/_carousel.scss
+++ b/scss/mixins/_carousel.scss
@@ -1,0 +1,22 @@
+@mixin carousel-css3-transforms {
+  transition: transform .6s ease-in-out;
+  backface-visibility: hidden;
+  perspective: 1000px;
+
+  &.next,
+  &.active.right {
+    left: 0;
+    transform: translate3d(100%, 0, 0);
+  }
+  &.prev,
+  &.active.left {
+    left: 0;
+    transform: translate3d(-100%, 0, 0);
+  }
+  &.next.left,
+  &.prev.right,
+  &.active {
+    left: 0;
+    transform: translate3d(0, 0, 0);
+  }
+}


### PR DESCRIPTION
Addresses #15534

Really just a Sass version of @cvrebert's v3 fix: https://github.com/twbs/bootstrap/commit/18e1bfa66250a4593cc36a9adb3b9231e5646f82

Explored using placeholder, but they don't behave well with @media/@supports queries. So a mixin was used.
