### PR TITLE
remove unnecessary `/` in reference url

### DIFF
--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -1,6 +1,6 @@
 // Only display content to screen readers
 //
-// See: http://a11yproject.com/posts/how-to-hide-content/
+// See: http://a11yproject.com/posts/how-to-hide-content
 
 @mixin sr-only {
   position: absolute;


### PR DESCRIPTION
https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.2/scss%2Fmixins%2F_screen-reader.scss#L3

current reference URL of `@mixin sr-only` is 404

> http://a11yproject.com/posts/how-to-hide-content/

Just remove unnecessary `/` in the end.
http://a11yproject.com/posts/how-to-hide-content
