### PR TITLE
Fix .input-group-btn overflowing its parent when Flexbox is enabled

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -25,7 +25,10 @@
       z-index: 3;
     }
     @if $enable-flex {
-      flex: 1;
+      flex: 1 1 auto;
+      // Add width 1% and flex-basis auto to ensure that button will not wrap out
+      // the column. Applies to IE Edge+ and Firefox. Chrome do not require this.
+      width: 1%;
     } @else {
       // IE9 fubars the placeholder attribute in text inputs and the arrows on
       // select elements in input groups. To fix it, we float the input. Details:


### PR DESCRIPTION
With $enable-flex: true;
Applies to Firefox and IE Edge.
http://codepen.io/zalog/pen/bpMJmv
