### PR TITLE
Modal: Remove IE8-specific window.innerWidth workaround

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -408,13 +408,7 @@ const Modal = (($) => {
     }
 
     _checkScrollbar() {
-      let fullWindowWidth = window.innerWidth
-      if (!fullWindowWidth) { // workaround for missing window.innerWidth in IE8
-        let documentElementRect = document.documentElement.getBoundingClientRect()
-        fullWindowWidth =
-          documentElementRect.right - Math.abs(documentElementRect.left)
-      }
-      this._isBodyOverflowing = document.body.clientWidth < fullWindowWidth
+      this._isBodyOverflowing = document.body.clientWidth < window.innerWidth
       this._scrollbarWidth = this._getScrollbarWidth()
     }
 


### PR DESCRIPTION
v4 no longer supports IE8.
CC: @XhmikosR @patrickhlauke 
