### PR TITLE
Collapse plugin not finding trigger when targeting a class or multipl…

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -18,7 +18,7 @@
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
     this.$trigger      = $('[data-toggle="collapse"][href="#' + element.id + '"],' +
-                           '[data-toggle="collapse"][data-target="' + (options.target || ("#" + element.id)) + '"]')
+                           '[data-toggle="collapse"][data-target="' + (options.target || ('#' + element.id)) + '"]')
     this.transitioning = null
 
     if (this.options.parent) {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -18,7 +18,7 @@
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
     this.$trigger      = $('[data-toggle="collapse"][href="#' + element.id + '"],' +
-                           '[data-toggle="collapse"][data-target="#' + element.id + '"]')
+                           '[data-toggle="collapse"][data-target="' + (options.target || ("#" + element.id)) + '"]')
     this.transitioning = null
 
     if (this.options.parent) {


### PR DESCRIPTION
When a collapse panel is targeting either a class or a comma separated list of ids, the trigger's class and aria attributes are not updated.

Use case 1, "class":

``` html
<ul>
   <li>item</li>
   <li>item</li>
   <li>item</li>
   <li class="mylist collapse">item</li>
   <li class="mylist collapse">item</li>
   <li class="mylist collapse">item</li>
</ul>
<button type="button" data-toggle="collapse" data-target=".mylist">show/hide</button>
```

Use case 2, "multliple ids":

``` html
<ul id="mylist1">
   <li>item</li>
   <li>item</li>
   <li>item</li>
</ul>
<ul id="mylist2">
   <li>item</li>
   <li>item</li>
   <li>item</li>
</ul>
<button type="button" data-toggle="collapse" data-target="#mylist1,#mylist2">show/hide all</button>
```
