### PR TITLE
Recursive copy of fonts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -276,7 +276,7 @@ module.exports = function (grunt) {
     copy: {
       fonts: {
         expand: true,
-        src: 'fonts/*',
+        src: 'fonts/**',
         dest: 'dist/'
       },
       docs: {


### PR DESCRIPTION
I created subfolder in fonts to separate my fonts, but when doing grunt dist, it only copy an empty folder.

We should use `fonts/**` to allow recursive copy of all fonts.
