### PR TITLE
added variables to fix card-outline-*

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -584,6 +584,7 @@ $card-deck-margin:         .625rem !default;
 
 $card-columns-sm-up-column-gap: 1.25rem !default;
 
+$card-border-style:         solid !default;
 
 // Tooltips
 

--- a/scss/mixins/_cards.scss
+++ b/scss/mixins/_cards.scss
@@ -8,6 +8,8 @@
 @mixin card-outline-variant($color) {
   background-color: transparent;
   border-color: $color;
+  border-style: $card-border-style;
+  border-width: $card-border-width;
 }
 
 //


### PR DESCRIPTION
added

 border-style: $card-border-style;
 border-width: $card-border-width;

 to @mixin card-outline-variant

 added

 $card-border-style:   solid !default;

 to _variables.scss

 so card-outline-\* would work

@mdo this fixes https://github.com/twbs/bootstrap/issues/19097
