### PR TITLE
Use light color for toggler button for dark navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -199,7 +199,8 @@
 
 // White links against a dark background
 .navbar-dark {
-  .navbar-brand {
+  .navbar-brand,
+  .navbar-toggler {
     color: $navbar-dark-active-color;
 
     @include hover-focus {


### PR DESCRIPTION
Currently, the navbar toggler button used to display collapsed items
is always black, even if the navbar is dark themed (`.navbar-dark`).

With this commit, navbar-toggler uses the same colors as navbar-brand and
navbar-link.
