### PR TITLE
Jank card borders were too janky

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -9,8 +9,7 @@
   background-color: $card-bg;
   // border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
-  // Doesn't use mixin so that cards always have a "border"
-  box-shadow: inset 0 0 0 $card-border-width $card-border-color;
+  border: $card-border-width solid $card-border-color;
 }
 
 .card-block {


### PR DESCRIPTION
- Drops the experiment I had going for `box-shadow`-powered borders
- Reinstates regular `border` using existing variables

Fixes  #19097 and #19143. Nullifies #19828.
