### PR TITLE
Dropdown: remove dependency to role="menu", role="listbox" a and li elements => fix keyboard navigation

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -44,11 +44,9 @@ const Dropdown = (($) => {
     BACKDROP      : '.dropdown-backdrop',
     DATA_TOGGLE   : '[data-toggle="dropdown"]',
     FORM_CHILD    : '.dropdown form',
-    ROLE_MENU     : '[role="menu"]',
-    ROLE_LISTBOX  : '[role="listbox"]',
+    MENU          : '.dropdown-menu',
     NAVBAR_NAV    : '.navbar-nav',
-    VISIBLE_ITEMS : '[role="menu"] li:not(.disabled) a, '
-                  + '[role="listbox"] li:not(.disabled) a'
+    VISIBLE_ITEMS : '.dropdown-menu .dropdown-item:not(.disabled)'
   }
 
 
@@ -268,8 +266,7 @@ const Dropdown = (($) => {
 
   $(document)
     .on(Event.KEYDOWN_DATA_API, Selector.DATA_TOGGLE,  Dropdown._dataApiKeydownHandler)
-    .on(Event.KEYDOWN_DATA_API, Selector.ROLE_MENU,    Dropdown._dataApiKeydownHandler)
-    .on(Event.KEYDOWN_DATA_API, Selector.ROLE_LISTBOX, Dropdown._dataApiKeydownHandler)
+    .on(Event.KEYDOWN_DATA_API, Selector.MENU, Dropdown._dataApiKeydownHandler)
     .on(Event.CLICK_DATA_API, Dropdown._clearMenus)
     .on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, Dropdown.prototype.toggle)
     .on(Event.CLICK_DATA_API, Selector.FORM_CHILD, (e) => {


### PR DESCRIPTION
Per migration documentation in https://github.com/twbs/bootstrap/commit/4d8d8bdab4b0e2931fcf92ce30d772b05a989434:

> - Rebuilt dropdown styles and markup to provide easy, built-in support for `<a>` and `<button>` based dropdown items.
> - Dropdown items now require `.dropdown-item`.

Per https://github.com/twbs/bootstrap/issues/19034#issuecomment-179749958 role="menu" should have been dropped.

This PR:
- Remove the dependency to `role="menu"` or `role="listbox"` and rely on the class `dropdown-menu` instead
- Remove the dependency to the `a` element for the dropdown-item and rely on the class `dropdown-item` instead
- Remove the necessity to wrap dropdown-item in `li` elements

All this problems affected only the keyboard navigation in the dropdown.
With this modification the javascript now matches the markup in the documentation.
The keyboard navigation works again now in [dropdowns](http://v4-alpha.getbootstrap.com/components/dropdowns/).
