### PR TITLE
V4: Allow for background options on a card

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -6,7 +6,7 @@
   position: relative;
   display: block;
   margin-bottom: $card-spacer-y;
-  background-color: $card-bg;
+  background: $card-bg;
   // border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
   border: $card-border-width solid $card-border-color;


### PR DESCRIPTION
`$card-bg` implies to me I can use the background options available, ie images. But currently it only allows colors

In a standard `<div class="card"></div>`, there are no other `background` attributes so this change should not break any other thing.
