### PR TITLE
Alphabetized carousel options & added "ride" to it

### DIFF
--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -157,22 +157,28 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
        <td>The amount of time to delay between automatically cycling an item. If false, carousel will not automatically cycle.</td>
      </tr>
      <tr>
+       <td>keyboard</td>
+       <td>boolean</td>
+       <td>true</td>
+       <td>Whether the carousel should react to keyboard events.</td>
+     </tr>
+     <tr>
        <td>pause</td>
        <td>string</td>
        <td>"hover"</td>
        <td>Pauses the cycling of the carousel on mouseenter and resumes the cycling of the carousel on mouseleave.</td>
      </tr>
      <tr>
+       <td>ride</td>
+       <td>string</td>
+       <td>false</td>
+       <td>Autoplays the carousel after the user manually cycles the first item. If "carousel", autoplays the carousel on load.</td>
+     </tr>
+     <tr>
        <td>wrap</td>
        <td>boolean</td>
        <td>true</td>
        <td>Whether the carousel should cycle continuously or have hard stops.</td>
-     </tr>
-     <tr>
-       <td>keyboard</td>
-       <td>boolean</td>
-       <td>true</td>
-       <td>Whether the carousel should react to keyboard events.</td>
      </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This PR adds "ride" documentation to the carousel options at:
http://v4-alpha.getbootstrap.com/components/carousel/

The "ride" values are:
- **"carousel"**: autoplays the carousel on load
- **false**: autoplays the carousel after the user manually cycles the first item

Additionally, the options table was in a seemingly random order so I alphabatized it. If this order was intentional please let me know and I'll restore the original order and add the "ride" entry at the bottom of the table.
