### PR TITLE
v4: Couple popover fixes

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -112,6 +112,10 @@
   border-bottom: $popover-border-width solid darken($popover-title-bg, 5%);
   $offset-border-width: ($border-width / $font-size-root);
   @include border-radius(($border-radius-lg - $offset-border-width) ($border-radius-lg - $offset-border-width) 0 0);
+
+  &:empty {
+    display: none;
+  }
 }
 
 .popover-content {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -5,7 +5,7 @@
   z-index: $zindex-popover;
   display: block;
   max-width: $popover-max-width;
-  padding: 1px;
+  padding: $popover-inner-padding;
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -606,6 +606,7 @@ $tooltip-arrow-color:         $tooltip-bg !default;
 
 // Popovers
 
+$popover-inner-padding:               1px !default;
 $popover-bg:                          #fff !default;
 $popover-max-width:                   276px !default;
 $popover-border-width:                $border-width !default;


### PR DESCRIPTION
Two small fixes:
- Alternate fix to #19006: Add a single variable for controlling that inner 1px padding on `.popover`.
- Restore hiding of the `.popover-title` with `:empty`
