### PR TITLE
Remove reference to "loaded.bs.modal" event

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -480,10 +480,6 @@ Bootstrap's modal class exposes a few events for hooking into modal functionalit
        <td>hidden.bs.modal</td>
        <td>This event is fired when the modal has finished being hidden from the user (will wait for CSS transitions to complete).</td>
      </tr>
-     <tr>
-       <td>loaded.bs.modal</td>
-       <td>This event is fired when the modal has loaded content using the <code>remote</code> option.</td>
-     </tr>
     </tbody>
   </table>
 </div>

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -123,7 +123,10 @@ New to Bootstrap 4 is the Reboot, a new stylesheet that builds on Normalize with
 ### List groups
 
 - Replaced `a.list-group-item` with an explicit class, `.list-group-item-action`, for styling link and button versions of list group items.
--
+
+### Modal
+
+- The `remote` option (which could be used to automatically load and inject external content into a modal) and the correspending `loaded.bs.modal` event were removed. We recommend instead using client-side templating or a data binding framework, or calling [jQuery.load](http://api.jquery.com/load/) yourself.
 
 ### Navs
 


### PR DESCRIPTION
Since the "remote" option is no longer available in v4 the reference to the "loaded.bs.modal" event is no longer needed, too.
