### PR TITLE
Fix: border removal affecting child tables

### DIFF
--- a/less/panels.less
+++ b/less/panels.less
@@ -167,8 +167,8 @@
   > .table-responsive + .panel-body {
     border-top: 1px solid @table-border-color;
   }
-  > .table > tbody:first-child > tr:first-child th,
-  > .table > tbody:first-child > tr:first-child td {
+  > .table > tbody:first-child > tr:first-child > th,
+  > .table > tbody:first-child > tr:first-child > td {
     border-top: 0;
   }
   > .table-bordered,


### PR DESCRIPTION
This rule is supposed to remove the top border of the first row of a table in a panel (as its direct child).

However, it also affects all rows in tables which are children of this first row.

Adding the "direct child" selector fixes this issue.

I believe this rule could be further modified to prevent the repetition of `> .table > tbody:first-child > tr:first-child`, but I have no knowledge of LESS therefore I'll leave that to someone more seasoned.
