### PR TITLE
Tests: Switch from .then to .done to get synchronous operation

### DIFF
--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -371,7 +371,7 @@ $(function () {
     }
 
     $.when(testOffsetMethod('js'))
-      .then(function () { testOffsetMethod('data') })
+      .done(function () { testOffsetMethod('data') })
   })
 
   QUnit.test('should allow passed in option offset method: position', function (assert) {
@@ -414,7 +414,7 @@ $(function () {
     }
 
     $.when(testOffsetMethod('js'))
-      .then(function () { testOffsetMethod('data') })
+      .done(function () { testOffsetMethod('data') })
   })
 
 })


### PR DESCRIPTION
This is the only failure I found in the test suite with jQuery 3.0 and it's easily fixed. :pizza: 

jQuery 3.0 uses Promise/A+ compliant `.then` method which is always async. The older .done and .fail methods are still sync. Ref: https://jquery.com/upgrade-guide/3.0/

It's not clear why these two tests use Deferred at all since they appear to be completely synchronous. The giveaway is that there is no QUnit `assert.async()` call in the test, which you would need if there was any async component.
