### PR TITLE
Zero out the default margin-bottom on label.custom-file

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -204,6 +204,7 @@
   display: inline-block;
   max-width: 100%;
   height: $custom-file-height;
+  margin-bottom: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Reset the `margin-bottom: 0.5rem` from `<label>`.

![screen-shot-05-16-16-at-04 59-pm](https://cloud.githubusercontent.com/assets/985838/15291865/d7f17878-1b88-11e6-8370-e994d360bf1c.png)
