### PR TITLE
Reset CSS position property when unpinning Affix

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -87,7 +87,10 @@
     var affix = this.getState(scrollHeight, height, offsetTop, offsetBottom)
 
     if (this.affixed != affix) {
-      if (this.unpin != null) this.$element.css('top', '')
+      if (this.unpin != null) {
+        this.$element.css('top', '')
+        this.$element.css('position', '')
+      }
 
       var affixType = 'affix' + (affix ? '-' + affix : '')
       var e         = $.Event(affixType + '.bs.affix')


### PR DESCRIPTION
Fixes a bug in which css property "position: relative" wasn't properly cleared when component transfers (back) from affix-bottom to affix state.
