### PR TITLE
Remove forced default focus outline

### DIFF
--- a/less/mixins/tab-focus.less
+++ b/less/mixins/tab-focus.less
@@ -1,9 +1,9 @@
 // WebKit-style focus
 
 .tab-focus() {
-  // Default
-  outline: thin dotted;
-  // WebKit
+  // WebKit-specific - other browser will keep their default outline style
+  // (initially tried to also force default via `outline: initial`
+  // but this seems to erroneously remove the outline in Firefox altogether)
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }


### PR DESCRIPTION
the current `outline: thin dotted` that is forced as "default" is not in fact default in Firefox/OS X; forcing it leads to unsightly dotted outline that's non-standard for the browser/platform.

removing it seems to have no adverse effect in other all situations where this mixin is used (buttons, scaffolding for general link styles, and the case of forms). attempted to use `outline: initial` at first, but this seems somehow broken in Firefox (ends up removing standard Firefox dotted outline on links).

This is mostly a bug-fix, rather than a new feature (hence targetting it for v3)

Closes https://github.com/twbs/bootstrap/issues/19933
