### PR TITLE
Add "The Bootstrap Authors" to copyright notices

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /*!
  * Bootstrap's Gruntfile
  * http://getbootstrap.com
+ * Copyright 2013-2016 The Bootstrap Authors
  * Copyright 2013-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2011-2016 Twitter, Inc.
+Copyright (c) 2011-2016 The Bootstrap Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ See [the Releases section of our GitHub project](https://github.com/twbs/bootstr
 
 ## Copyright and license
 
-Code and documentation copyright 2011-2016 Twitter, Inc. Code released under [the MIT license](https://github.com/twbs/bootstrap/blob/master/LICENSE). Docs released under [Creative Commons](https://github.com/twbs/bootstrap/blob/master/docs/LICENSE).
+Code and documentation copyright 2011-2016 the Bootstrap Authors and Twitter, Inc. Code released under [the MIT license](https://github.com/twbs/bootstrap/blob/master/LICENSE). Docs released under [Creative Commons](https://github.com/twbs/bootstrap/blob/master/docs/LICENSE).

--- a/docs/assets/js/ie-emulation-modes-warning.js
+++ b/docs/assets/js/ie-emulation-modes-warning.js
@@ -2,6 +2,7 @@
 // IT'S JUST JUNK FOR OUR DOCS!
 // ++++++++++++++++++++++++++++++++++++++++++
 /*!
+ * Copyright 2014-2015 The Bootstrap Authors
  * Copyright 2014-2015 Twitter, Inc.
  *
  * Licensed under the Creative Commons Attribution 3.0 Unported License. For

--- a/docs/assets/js/ie10-viewport-bug-workaround.js
+++ b/docs/assets/js/ie10-viewport-bug-workaround.js
@@ -1,5 +1,6 @@
 /*!
  * IE10 viewport hack for Surface/desktop Windows 8 bug
+ * Copyright 2014-2015 The Bootstrap Authors
  * Copyright 2014-2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -4,6 +4,7 @@
 
 /*!
  * JavaScript for Bootstrap's docs (http://getbootstrap.com)
+ * Copyright 2011-2016 The Bootstrap Authors
  * Copyright 2011-2016 Twitter, Inc.
  * Licensed under the Creative Commons Attribution 3.0 Unported License. For
  * details, see https://creativecommons.org/licenses/by/3.0/.

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -1,5 +1,6 @@
 /*!
  * Bootstrap Docs (http://getbootstrap.com)
+ * Copyright 2011-2016 The Bootstrap Authors
  * Copyright 2011-2016 Twitter, Inc.
  * Licensed under the Creative Commons Attribution 3.0 Unported License. For
  * details, see https://creativecommons.org/licenses/by/3.0/.

--- a/docs/getting-started/browsers-devices.md
+++ b/docs/getting-started/browsers-devices.md
@@ -174,6 +174,7 @@ See [this StackOverflow question](https://stackoverflow.com/questions/6771258/wh
 Internet Explorer 10 in Windows Phone 8 versions older than [Update 3 (a.k.a. GDR3)](http://blogs.windows.com/windows_phone/b/wpdev/archive/2013/10/14/introducing-windows-phone-preview-for-developers.aspx) doesn't differentiate **device width** from **viewport width** in `@-ms-viewport` at-rules, and thus doesn't properly apply the media queries in Bootstrap's CSS. To address this, you'll need to **include the following JavaScript to work around the bug**.
 
 {% highlight js %}
+// Copyright 2014-2015 The Bootstrap Authors
 // Copyright 2014-2015 Twitter, Inc.
 // Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
 if (navigator.userAgent.match(/IEMobile\/10\.0/)) {

--- a/grunt/bs-commonjs-generator.js
+++ b/grunt/bs-commonjs-generator.js
@@ -1,6 +1,7 @@
 /*!
  * Bootstrap Grunt task for the CommonJS module generation
  * http://getbootstrap.com
+ * Copyright 2014-2015 The Bootstrap Authors
  * Copyright 2014-2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/grunt/change-version.js
+++ b/grunt/change-version.js
@@ -3,6 +3,7 @@
 
 /*!
  * Script to update version number references in the project.
+ * Copyright 2015 The Bootstrap Authors
  * Copyright 2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -4,7 +4,7 @@
     <id>bootstrap</id>
     <version>4.0.0-alpha</version>
     <title>Bootstrap CSS</title>
-    <authors>Twitter, Inc.</authors>
+    <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
 	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
 	<releaseNotes>http://blog.getbootstrap.com</releaseNotes>

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -4,7 +4,7 @@
     <id>bootstrap.sass</id>
     <version>4.0.0-alpha</version>
     <title>Bootstrap Sass</title>
-    <authors>Twitter, Inc.</authors>
+    <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
 	<description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>http://blog.getbootstrap.com</releaseNotes>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "web"
   ],
   "homepage": "http://getbootstrap.com",
-  "author": "Twitter, Inc.",
+  "author": "The Bootstrap Authors (https://github.com/twbs/bootstrap/graphs/contributors)",
+  "contributors": ["Twitter, Inc."],
   "scripts": {
     "change-version": "node grunt/change-version.js",
     "shrinkwrap": "npm shrinkwrap --dev && mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,5 +1,6 @@
 /*!
  * Bootstrap v4.0.0-alpha.2 (http://getbootstrap.com)
+ * Copyright 2011-2016 The Bootstrap Authors
  * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */


### PR DESCRIPTION
Disclaimer: I am not a lawyer. This is not legal advice.
- Since we don't have a CLA, Twitter most likely doesn't have copyright on the contributions of non-Twitter contributors; the contributors or their employers most likely have copyright on their contributions.
- So the current copyright notice is outdated/inaccurate, in that it does not acknowledge these contributors. Due to the large number of contributors, it's common to refer to them using a group noun rather than listing them all individually directly in such copyright notices.
- It's my new employer's policy to suggest rectifying this type of inaccuracy when contributing to a project. Hence this PR.

CC: @twbs/team 
