### PR TITLE
Add mixin to build button with params

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -5,47 +5,7 @@
 //
 
 .btn {
-  display: inline-block;
-  font-weight: $btn-font-weight;
-  line-height: $btn-line-height;
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: middle;
-  cursor: pointer;
-  user-select: none;
-  border: $input-btn-border-width solid transparent;
-  @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
-  @include transition(all .2s ease-in-out);
-
-  &,
-  &:active,
-  &.active {
-    &:focus,
-    &.focus {
-      @include tab-focus();
-    }
-  }
-
-  @include hover-focus {
-    text-decoration: none;
-  }
-  &.focus {
-    text-decoration: none;
-  }
-
-  &:active,
-  &.active {
-    background-image: none;
-    outline: 0;
-    @include box-shadow($btn-active-box-shadow);
-  }
-
-  &.disabled,
-  &:disabled {
-    cursor: $cursor-disabled;
-    opacity: .65;
-    @include box-shadow(none);
-  }
+  @include button($btn-line-height, $btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
 }
 
 // Future-proof disabling of clicks on `<a>` elements

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -3,6 +3,50 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
+@mixin button($line-height: $btn-line-height, $padding-y: $btn-padding-y, $padding-x: $btn-padding-x, $font-size: $font-size-base, $radius: $btn-border-radius) {
+  display: inline-block;
+  font-weight: $btn-font-weight;
+  line-height: $line-height;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  border: $input-btn-border-width solid transparent;
+  @include button-size($padding-y, $padding-x, $font-size, $radius);
+  @include transition(all .2s ease-in-out);
+
+  &,
+  &:active,
+  &.active {
+    &:focus,
+    &.focus {
+      @include tab-focus();
+    }
+  }
+
+  @include hover-focus {
+    text-decoration: none;
+  }
+  &.focus {
+    text-decoration: none;
+  }
+
+  &:active,
+  &.active {
+    background-image: none;
+    outline: 0;
+    @include box-shadow($btn-active-box-shadow);
+  }
+
+  &.disabled,
+  &:disabled {
+    cursor: $cursor-disabled;
+    opacity: .65;
+    @include box-shadow(none);
+  }
+}
+
 @mixin button-variant($color, $background, $border) {
   $active-background: darken($background, 10%);
   $active-border: darken($border, 12%);


### PR DESCRIPTION
This pull request adds a new mixin for building a button with the following params:
- Line height
- Padding y
- Padding x
- Font size
- Radius

In case you want to create a different type of basic button (a rounded button for instance) this is more scalable because you can create a new CSS class for this new button with that mixin.
