### PR TITLE
http://bugzil.la/924068 closed as duplicate of http://bugzil.la/545685

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -114,7 +114,7 @@
   summary: >
     Right border of `<select>` menu is sometimes missing when screen is set to uncommon resolution
   upstream_bug: >
-    Mozilla#924068
+    Mozilla#545685
   origin: >
     Bootstrap#15990
 


### PR DESCRIPTION
Update the Wall of Browser Bugs entry accordingly.
Refs #15990
Refs http://bugzil.la/924068
