### PR TITLE
https://crbug.com/427994 has been fixed

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -182,16 +182,6 @@
   browser: >
     Chrome
   summary: >
-    `width: 1%` on nested table cell causes its table to hog horizontal space.
-  upstream_bug: >
-    Chromium#427994
-  origin: >
-    Bootstrap#16372
-
--
-  browser: >
-    Chrome
-  summary: >
     `table-cell` borders not overlapping despite `margin-right: -1px`
   upstream_bug: >
     Chromium#534750


### PR DESCRIPTION
So remove its entry from the Wall of Browser Bugs.
Refs https://crbug.com/427994
Refs #16372.

~~**Don't merge yet.** Need to verify the fix once it hits Chrome Canary.~~
