### PR TITLE
Dropdown perf - on keyboard nav, search for active item in the current dropdown rather than the whole document

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -230,11 +230,7 @@ const Dropdown = (($) => {
         return
       }
 
-      let items = $.makeArray($(Selector.VISIBLE_ITEMS))
-
-      items = items.filter((item) => {
-        return item.offsetWidth || item.offsetHeight
-      })
+      let items = $(parent).find(Selector.VISIBLE_ITEMS).get()
 
       if (!items.length) {
         return


### PR DESCRIPTION
Currently when navigating a dropdown with the keyboard, in order to determine the current index, this [selector](https://github.com/twbs/bootstrap/blob/v4-dev/js/src/dropdown.js#L233) is used to find the active elements on the whole document.
All the dropdown-items on the page are retrieved and looped on with a call to `item.offsetWidth` and `item.offsetHeight` to determine if they are currently visible.

With this PR the active items are searched only under the parent dropdown.
In addition it avoid the necessity to call `item.offsetWidth` and `item.offsetHeight`.

On a side note, the keyboard navigation currently doesn't work in v4 as there is a discrepancy between the html markup (from the documentation) and the javascript. See #19864 for the fix.
