### PR TITLE
Fix heights of `<select>` elements to match `<inputs>` when using `.form-control`

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -322,14 +322,19 @@ Because of this, you may need to manually address the width and alignment of ind
 {% example html %}
 <form class="form-inline">
   <div class="form-group">
-    <label class="sr-only" for="exampleInputAmount">Amount (in dollars)</label>
+    <label class="sr-only" for="exampleSelectCurrency">Currency</label>
+    <select class="form-control" id="exampleSelectCurrency">
+      <option>USD ($)</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label class="sr-only" for="exampleInputAmount">Amount</label>
     <div class="input-group">
-      <div class="input-group-addon">$</div>
       <input type="text" class="form-control" id="exampleInputAmount" placeholder="Amount">
       <div class="input-group-addon">.00</div>
     </div>
   </div>
-  <button type="submit" class="btn btn-primary">Transfer cash</button>
+  <button type="submit" class="btn btn-primary">Convert</button>
 </form>
 {% endexample %}
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -110,7 +110,7 @@
   font-size: $font-size-base;
   background-color: $popover-title-bg;
   border-bottom: $popover-border-width solid darken($popover-title-bg, 5%);
-  $offset-border-width: ($border-width / $font-size-root);
+  $offset-border-width: ($border-width / $font-size-base);
   @include border-radius(($border-radius-lg - $offset-border-width) ($border-radius-lg - $offset-border-width) 0 0);
 
   &:empty {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -93,7 +93,7 @@ $spacers: (
     y: ($spacer-y * 3)
   )
 ) !default;
-$border-width: 1px !default;
+$border-width: .0625rem !default;
 
 
 // Body

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -336,9 +336,9 @@ $input-padding-y-sm:             .25rem !default;
 $input-padding-x-lg:             1.5rem !default;
 $input-padding-y-lg:             .75rem !default;
 
-$input-height:                   (($font-size-base * $line-height-base) + ($input-padding-y * 2)) !default;
-$input-height-lg:                (($font-size-lg * $line-height-lg) + ($input-padding-y-lg * 2)) !default;
-$input-height-sm:                (($font-size-sm * $line-height-sm) + ($input-padding-y-sm * 2)) !default;
+$input-height:                   (($font-size-base * $input-line-height) + ($input-padding-y * 2) + ($input-btn-border-width * 2)) !default;
+$input-height-lg:                (($font-size-lg * $input-line-height) + ($input-padding-y-lg * 2) + ($input-btn-border-width * 2)) !default;
+$input-height-sm:                (($font-size-sm * $input-line-height) + ($input-padding-y-sm * 2) + ($input-btn-border-width * 2)) !default;
 
 $form-group-margin-bottom:       $spacer-y !default;
 


### PR DESCRIPTION
This fixes `select.form-control` heights not matching `input.form-control` referenced in #17194 

![screen shot 2016-05-25 at 11 52 51](https://cloud.githubusercontent.com/assets/6179889/15537592/4a3a12b8-226f-11e6-9119-5fa92d4abdff.png)

Note: to do this, I've had to change `$border-width` to use `rem` units instead of `px`
