### PR TITLE
Travis: Upgrade Node.js from v5 to v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
   depth: 10
 node_js:
   - "4"
-  - "5"
+  - "6"
 before_install:
   # Remove ./node_modules/.bin from PATH so node-which doesn't replace Unix which and cause RVM to barf. See https://github.com/travis-ci/travis-ci/issues/5092
   - export PATH=$(python -c 'from sys import argv;from collections import OrderedDict as od;print(":".join(od((p,None) for p in argv[1].split(":") if p.startswith("/")).keys()))' "$PATH")


### PR DESCRIPTION
v6 is the current stable version and will be an LTS version.
v5 is not an LTS version.

Refs https://github.com/nodejs/LTS

CC: @XhmikosR @hnrch02 
