### PR TITLE
Add :dir() pseudo-class feature requests to Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -70,6 +70,16 @@
 
 -
   browser: >
+    Microsoft Edge
+  summary: >
+    Implement the `:dir()` pseudo-class from Selectors Level 4
+  upstream_bug: >
+    [Edge UserVoice idea #12299532](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12299532--dir)
+  origin: >
+    Bootstrap#19984
+
+-
+  browser: >
     Firefox
   summary: >
     `.table-bordered` with an empty `<tbody>` is missing borders.
@@ -220,6 +230,16 @@
 
 -
   browser: >
+    Chrome
+  summary: >
+    Implement the `:dir()` pseudo-class from Selectors Level 4
+  upstream_bug: >
+    Chromium#576815
+  origin: >
+    Bootstrap#19984
+
+-
+  browser: >
     Chrome (Windows & Linux)
   summary: >
     Animation glitch when returning to inactive tab after animations occurred while tab was hidden.
@@ -247,6 +267,16 @@
     WebKit#158340
   origin: >
     Bootstrap#20012
+
+-
+  browser: >
+    Safari
+  summary: >
+    Implement the `:dir()` pseudo-class from Selectors Level 4
+  upstream_bug: >
+    WebKit#64861
+  origin: >
+    Bootstrap#19984
 
 -
   browser: >


### PR DESCRIPTION
Since [`:dir()`](Refs https://developer.mozilla.org/en-US/docs/Web/CSS/:dir) would be very useful for RTL support, I propose adding these relevant browser feature request bugs to the Wall.

CC: @mdo 
