### PR TITLE
Adding distribution CSS file in "main".

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   "moduleType": "globals",
   "main": [
     "less/bootstrap.less",
+    "dist/css/bootstrap.css",
     "dist/js/bootstrap.js"
   ],
   "ignore": [


### PR DESCRIPTION
In some cases developers just need to pull in the distribution CSS file inside their projects just with a <link> tag.  But if we want to take advantage of resources like : [wiredep](https://www.npmjs.com/package/wiredep), and pull in the CSS automatically, we can't because that file is missing in the list of "main"  files. #
