### PR TITLE
Modal : Pass remote response data to 'loaded' event

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -28,7 +28,7 @@
       this.$element
         .find('.modal-content')
         .load(this.options.remote, $.proxy(function (data, textStatus, response) {
-          this.$element.trigger('loaded.bs.modal', {data: data, textStatus: textStatus, response: response})
+          this.$element.trigger('loaded.bs.modal', {data: data, textStatus: textStatus, response: response} )
         }, this))
     }
   }

--- a/js/modal.js
+++ b/js/modal.js
@@ -27,8 +27,8 @@
     if (this.options.remote) {
       this.$element
         .find('.modal-content')
-        .load(this.options.remote, $.proxy(function () {
-          this.$element.trigger('loaded.bs.modal')
+        .load(this.options.remote, $.proxy(function (data, textStatus, response) {
+          this.$element.trigger('loaded.bs.modal', {data: data, textStatus: textStatus, response: response})
         }, this))
     }
   }


### PR DESCRIPTION
```
Modal : Pass remote response data to 'loaded' event  …
```

Pass response data from remote loading to the 'loaded' event so we can handle them.
- data : data from the response
- textStatus : Status of the response (cf. JQuery documentation : "success", "notmodified", "nocontent", "error", "timeout", "abort", or "parsererror")
- response : The whole response object

This would be very useful for many of us who load content throught the data-api and would like to handle stuff from time to time.
