### PR TITLE
Custom Forms: Allow Chrome/Firefox feature that lets the user drag and drop into file inputs

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -210,8 +210,7 @@
 .custom-file-input {
   min-width: $custom-file-width;
   max-width: 100%;
-  padding-top: $custom-file-padding-y;
-  padding-bottom: $custom-file-padding-y;
+  height: $custom-file-height;
   margin: 0;
   filter: alpha(opacity = 0);
   opacity: 0;

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -210,6 +210,8 @@
 .custom-file-input {
   min-width: $custom-file-width;
   max-width: 100%;
+  padding-top: $custom-file-padding-y;
+  padding-bottom: $custom-file-padding-y;
   margin: 0;
   filter: alpha(opacity = 0);
   opacity: 0;
@@ -229,6 +231,7 @@
   padding: $custom-file-padding-x $custom-file-padding-y;
   line-height: $custom-file-line-height;
   color: $custom-file-color;
+  pointer-events: none;
   user-select: none;
   background-color: $custom-file-bg;
   border: $custom-file-border-width solid $custom-file-border-color;


### PR DESCRIPTION
Chrome (among other browsers) allows you to drag and drop files from the desktop into `<input type="file">` form elements. Bootstrap 4's custom file input covers up the base input, so drag and drop doesn't work.

This patch disables `pointer-events` on the custom element so dropped files pass through to the invisible, full-height input behind it. Normal clicks work just as they did.
