### PR TITLE
Remove unused exec:npmUpdate Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -327,9 +327,6 @@ module.exports = function (grunt) {
     },
 
     exec: {
-      npmUpdate: {
-        command: 'npm update'
-      }
     },
 
     buildcontrol: {


### PR DESCRIPTION
We'll need to retain `grunt-exec` for the time being, to be the bridge between Grunt and the npm scripts until Grunt can be removed completely.
