### PR TITLE
Add media rules to nav items into toggleable navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -174,6 +174,20 @@
   }
 }
 
+// Navigation items into toggleable navbar
+.navbar-nav {
+  .nav-item {
+    @each $breakpoint in xs, sm, md {
+      .navbar-toggleable-#{$breakpoint} & {
+        @include media-breakpoint-down($breakpoint) {
+          float: none;
+          margin-left: 0;
+        }
+      }
+    }
+  }
+}
+
 // Dark links against a light background
 .navbar-light {
   .navbar-brand,


### PR DESCRIPTION
### PR to fix alignment of nav items into toggleable navbar

Here two _**before**_ states of items in mobile dropdown of navbar: 

![before-1](https://cloud.githubusercontent.com/assets/17578344/15825421/51595d00-2c0c-11e6-8e37-51d239592f45.png)

![before-2](https://cloud.githubusercontent.com/assets/17578344/15825424/5557dfd0-2c0c-11e6-9a0c-1fb6f67c5c6e.png)

And this is _**after**_ that I get with changes (in this PR):

![after](https://cloud.githubusercontent.com/assets/17578344/15825486/9b807a1c-2c0c-11e6-9b99-cec1208a4e84.png)
