### PR TITLE
Add Wall of Browser Bugs entries for #12832

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -250,6 +250,16 @@
 
 -
   browser: >
+    Chrome
+  summary: >
+    Don't make `:hover` sticky on touch-friendly webpages
+  upstream_bug: >
+    Chromium#370155
+  origin: >
+    Bootstrap#12832
+
+-
+  browser: >
     Chrome (Windows & Linux)
   summary: >
     Animation glitch when returning to inactive tab after animations occurred while tab was hidden.
@@ -439,6 +449,16 @@
     WebKit#158342
   origin: >
     Bootstrap#17695
+
+-
+  browser: >
+    Safari (iOS)
+  summary: >
+    Don't make `:hover` sticky on touch-friendly webpages
+  upstream_bug: >
+    WebKit#158517
+  origin: >
+    Bootstrap#12832
 
 -
   browser: >


### PR DESCRIPTION
Refs #12832
Refs http://getbootstrap.com/getting-started/#support-sticky-hover-mobile
Refs https://bugs.chromium.org/p/chromium/issues/detail?id=370155
Refs https://bugs.webkit.org/show_bug.cgi?id=158517
