### PR TITLE
add mixin/custom.scss file to be able to overide easily bootstrap mixins

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -52,3 +52,7 @@
 @import "mixins/grid-framework";
 @import "mixins/grid";
 @import "mixins/pulls";
+
+// Custom (let this import at the end of the file).
+@import "mixins/custom";
+

--- a/scss/mixins/_custom.scss
+++ b/scss/mixins/_custom.scss
@@ -1,0 +1,4 @@
+// Bootstrap overrides
+//
+// Copy mixin from the folder mixins to this file to override default mixin
+// without modifying source files.


### PR DESCRIPTION
An empty custom file is available to override bootstrap's variables  without modifying source files. This pull request intend to allow user to be able to override mixin with a similar file.
