### PR TITLE
Only fix grid column collapsing when the column is empty

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -14,9 +14,11 @@
           flex-basis: 0;
           flex-grow: 1;
           max-width: 100%;
-          min-height: 1px;
           padding-right: ($gutter / 2);
           padding-left:  ($gutter / 2);
+        }
+        .col-#{$breakpoint}:empty {
+          min-height: 1px;
         }
       }
 

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -16,9 +16,11 @@
           max-width: 100%;
           padding-right: ($gutter / 2);
           padding-left:  ($gutter / 2);
-        }
-        .col-#{$breakpoint}:empty {
-          min-height: 1px;
+
+          // Prevent columns from collapsing when empty
+          &:empty {
+            min-height: 1px;
+          }
         }
       }
 


### PR DESCRIPTION
`min-height: 1px`  prevents a column from collapsing when there is no content inside of it ([empty](https://developer.mozilla.org/en-US/docs/Web/CSS/:empty)). This PR makes this rule applied specifically to the case of the bug that it's fixing. 

Currently `min-height` creates undesirable behavior when animating an element's `height` to or from `0`. 
Example of annoying behavior:  http://codepen.io/FranDias/pen/YWqayO (granted this is on `float`  grid but the behavior is the same on `flex` grid)

Support for [`:empty`](http://caniuse.com/#search=empty) has good parity with [flexbox](http://caniuse.com/#search=flexbox)
