### PR TITLE
add new column for even screen split system

### DIFF
--- a/less/mixins/grid-framework.less
+++ b/less/mixins/grid-framework.less
@@ -2,7 +2,28 @@
 //
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `@grid-columns`.
-
+.make-grid-even-columns() {
+  // Common styles for all sizes of grid columns, widths 1-10
+  .col-even(@index) { // initial
+    @item: ~".col-even-xs-@{index}, .col-even-sm-@{index}, .col-even-md-@{index}, .col-even-lg-@{index}";
+    .col-even((@index + 2), @item);
+  }
+  .col-even(@index, @list) when (@index =< @grid-columns) { // general; "=<" isn't a typo
+    @item:  ~".col-even-xs-@{index}, .col-even-sm-@{index}, .col-even-md-@{index}, .col-even-lg-@{index}";
+    .col-even((@index + 2), ~"@{list}, @{item}");
+  }
+  .col-even(@index, @list) when (@index > @grid-columns) { // terminal
+    @{list} {
+      position: relative;
+      // Prevent columns from collapsing when empty
+      min-height: 1px;
+      // Inner gutter via padding
+      padding-left:  ceil((@grid-gutter-width / 2));
+      padding-right: floor((@grid-gutter-width / 2));
+    }
+  }
+  .col(2); // kickstart it
+}
 .make-grid-columns() {
   // Common styles for all sizes of grid columns, widths 1-12
   .col(@index) { // initial


### PR DESCRIPTION
I've decided it would be better if we have opportunity to use grid system when we have to split screen in 10 parts , 5 parts , 2 parts and 3 parts,1 part and 4 parts , So I've several case when it was needed to split screen like this and I've made solution to extend bootstrap grid , so it can help others to save time who has that kind of cases which I had , I've called it column even so there are col-even-(xs, sm, md,lg )-(1,2,4,6,8,10)
