### PR TITLE
add new column for even screen split system usage

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -47,7 +47,7 @@
 
 .make-grid-columns();
 
-
+.make-grid-even-columns();
 // Extra small grid
 //
 // Columns, offsets, pushes, and pulls for extra small devices like


### PR DESCRIPTION
I've decided it would be better if we have opportunity to use grid system when we have to split screen in 10 parts , 5 parts , 2 parts and 3 parts,1 part and 4 parts , So I've several case when it was needed to split screen like this and I've made solution to extend bootstrap grid , so it can help others to save time who has that kind of cases which I had , I've called it column even so there are col-even-(xs, sm, md,lg )-(1,2,4,6,8,10)
