### PR TITLE
Made modal.dispose work at any point in modal's lifecycle, prevented crashes if multiple modals are alive

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -442,14 +442,23 @@ Manually toggles a modal. **Returns to the caller before the modal has actually 
 #### `.modal('show')`
 
 Manually opens a modal. **Returns to the caller before the modal has actually been shown** (i.e. before the `shown.bs.modal` event occurs).
+Showing a modal that is transitioning out cancels the `hidden.bs.modal` event.
 
 {% highlight js %}$('#myModal').modal('show'){% endhighlight %}
 
 #### `.modal('hide')`
 
 Manually hides a modal. **Returns to the caller before the modal has actually been hidden** (i.e. before the `hidden.bs.modal` event occurs).
+Hiding a modal that is transitioning in cancels the `shown.bs.modal` event.
 
 {% highlight js %}$('#myModal').modal('hide'){% endhighlight %}
+
+#### `.modal('dispose')`
+
+Hides and deactivates an element's modal. Does not fire a hide or hidden event, and if the modal was transitioning
+in or out, the `shown.bs.modal` or `hidden.bs.modal` events will be cancelled.
+
+{% highlight js %}$('#element').modal('dispose'){% endhighlight %}
 
 ### Events
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -131,7 +131,15 @@ const Modal = (($) => {
       }
 
       this._isShown = true
-
+      
+      // When the open class does not exist and the refcount is 1 is an invalid
+      // state, caused by manual removal of the modal open class. It's safe to fix
+      // the refcount in this case. (but not if the refcount is > 1, that'll prevent
+      // multiple simultanious modals from working)
+      if (!$(document.body).hasClass(ClassName.OPEN) && this._addRefcount(0) === 1) {
+          this._addRefcount(-1)
+      }
+      
       if (!this._hasRefcountItem) {
         this._hasRefcountItem = true
         let refCount = this._addRefcount(1)
@@ -243,7 +251,7 @@ const Modal = (($) => {
     // private
 
     _addRefcount(increment) {
-      let refCount = (Number($(document.body).data(REFCOUNT_KEY)) || 0) + increment
+      let refCount = Math.max(0, (Number($(document.body).data(REFCOUNT_KEY)) || 0) + increment)
       $(document.body).data(REFCOUNT_KEY, refCount)
       if (refCount === 0) {
         $(document.body).removeData(REFCOUNT_KEY)

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -93,6 +93,7 @@ const Modal = (($) => {
       this._scrollbarWidth      = 0
       this._resizeHandler       = null
       this._focusHandler        = null
+      this._isDisposed          = false
 
       this._showTimeout         = null
       this._hideTimeout         = null
@@ -125,7 +126,7 @@ const Modal = (($) => {
 
       $(this._element).trigger(showEvent)
 
-      if (this._isShown || showEvent.isDefaultPrevented()) {
+      if (this._isDisposed || this._isShown || showEvent.isDefaultPrevented()) {
         return
       }
 
@@ -209,6 +210,7 @@ const Modal = (($) => {
 
     dispose() {
       this._element.style.display = 'none'
+      this._isDisposed = true
 
       let refs = this._addRefcount(this._hasRefcountItem ? -1 : 0)
       if (refs === 0) {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -70,13 +70,11 @@ const Util = (($) => {
       called = true
     })
 
-    setTimeout(() => {
+    return setTimeout(() => {
       if (!called) {
         Util.triggerTransitionEnd(this)
       }
     }, duration)
-
-    return this
   }
 
   function setTransitionEndSupport() {

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -15,10 +15,10 @@ $(function () {
     },
     afterEach: function (assert) {
       if ($(document.body).data('bs.modal.refcount') !== undefined) {
-        throw new Error('bs.modal.refcount must not be set')  
+        throw new Error('bs.modal.refcount must not be set')
       }
       if ($(document.body).hasClass('modal-open')) {
-        throw new Error('body must not have .modal-open')  
+        throw new Error('body must not have .modal-open')
       }
       $.fn.modal = $.fn.bootstrapModal
       delete $.fn.bootstrapModal

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -137,17 +137,53 @@
     </div>
   </div>
 
+  <div id="myModal3" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel3">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <h4 class="modal-title" id="myModalLabel3">Race Condition Test</h4>
+        </div>
+        <div class="modal-body">
+          You should see a lot of modals created and destroyed. Afterwards, the page should be in an ok state (code below
+          should print trues). Some modals will flicker (destroyed before completing their animations) and numbers displayed
+          on the modals will not be in order. This test should work multiple times without refreshing the page.
+          <br/>
+          <small><code><pre>/* Close all modals first. */ console.log(!$(document.body).hasClass('modal-open'),!$(document.body).data('bs.modal.refcount'))</pre></code></small>
+          <br/>
+          <button id="race-condition-test-1" class="btn btn-lg">show/hide</button>
+          <button id="race-condition-test-2" class="btn btn-lg">show/hide/dispose</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div id="raceModal0" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 0 </div></div></div></div>
+  <div id="raceModal1" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 1 </div></div></div></div>
+  <div id="raceModal2" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 2 </div></div></div></div>
+  <div id="raceModal3" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 3 </div></div></div></div>
+  <div id="raceModal4" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 4 </div></div></div></div>
+  <div id="raceModal5" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 5 </div></div></div></div>
+  <div id="raceModal6" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 6 </div></div></div></div>
+  <div id="raceModal7" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 7 </div></div></div></div>
+  <div id="raceModal8" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 8 </div></div></div></div>
+  <div id="raceModal9" class="modal fade" tabindex="-1" role="dialog"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"> Race Modal 9 </div></div></div></div>
+    
+
   <button class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
     Launch demo modal
   </button>
 
   <button id="tall-toggle" class="btn btn-default">Toggle tall &lt;body&gt; content</button>
-  <br><br>
+  <br/><br/>
   <button class="btn btn-secondary btn-lg" data-toggle="modal" data-target="#myModal2">
     Launch Firefox bug test modal
   </button>
   (<a href="https://github.com/twbs/bootstrap/issues/18365">See Issue #18365</a>)
-  <br><br>
+  <br/><br/>
+  <button class="btn btn-secondary btn-lg" data-toggle="modal" data-target="#myModal3">
+    Launch race condition test
+  </button>
+  <br/><br/>
   <div id="tall" style="display: none;">
     Tall body content to force the page to have a scrollbar.
   </div>
@@ -193,6 +229,43 @@ $(function () {
     $('#ff-bug-input').on('focus', function () {
       reportFirefoxTestResult(true)
     })
+  })
+  function doTest(fn, speed, count) {
+    setTimeout(function () {
+      if (count === 10) return
+      fn(count)
+      doTest(fn, speed, count + 1)
+    }, speed)
+  }
+  function raceTest(start, speed, hide, dispose) {
+    setTimeout(doTest.bind(this, function (i) {
+      $("#raceModal" + i).modal("show")
+      if (hide !== undefined) {
+        setTimeout(function () {
+          $("#raceModal" + i).modal("hide")
+        }, hide);
+      }
+      if (dispose !== undefined) {
+        setTimeout(function () {
+          $("#raceModal" + i).modal("dispose")
+        }, dispose)
+      }
+    }, speed, 0), start)
+  }
+  $('#race-condition-test-1').click(function () {
+    var interval = 400
+    $("#myModal3").modal("dispose")
+    raceTest(0, interval * 1.0, interval * 0.5)
+    raceTest(0, interval * 1.6, interval * 1.5)
+    raceTest(0, interval * 2.1, interval * 1.2)
+  })
+  $('#race-condition-test-2').click(function () {
+    var interval = 400
+    $("#myModal3").modal("dispose")
+    raceTest(0, interval * 1.0, interval * 0.5, interval * 1.5)
+    raceTest(0, interval * 1.6, interval * 1.5, interval * 1.5)
+    raceTest(0, interval * 1.7, interval * 0.9, interval * 0.9)
+    raceTest(0, interval * 1.9, interval * 1.2, interval * 0.7)
   })
 })
 </script>


### PR DESCRIPTION
The current implementation of dispose does not work correctly when any modal is opening, open, or closing (including the one being disposed).

To fix this, modals need to know the state of the currently open modal. I've done this by maintaining a global counter which is incremented when a modal starts showing and decrements when it is done hiding or is disposed. The counter is stored in `$('body').data('bs.modal.refcount')`. I chose this approach because it also prevents the whole page from locking up if multiple modals are alive at once.

Additionally, some events needed to be cleaned up when dispose is called during or immediately after a transition. If they aren't, the backdrop, modal-open class, or resize event can be leaked or prematurely removed. It could also crash in several places. The events that have to be cleaned up are:
- Transition end handlers
- Hide/show timeouts
- Focus event
- Resize event

Support for manual removal of modals (i.e. `$(".modal, .modal-backdrop").remove()` and `$("body").removeClass("modal-open")`) is retained even if the user is not aware of the refcount, because manual removal leads to a state that can never be reached normally. This state can be detected and fixed.

I've added assertions afterEach test to check that there are no modals still alive. I've added new tests for dispose and for multiple open modals, and I added a test to the visual tests file for more aggressive testing of transitions in combination with dispose.

I wasn't sure about a few things:
- I needed the timeout id from emulateTransitionEnd, so I made it return it. Do you care about backwards compatibility for that method?
- Should disposing a modal add the "area-hidden" attribute?
- In the tests afterEach block, should I use assertions or throw? If I use assertions, I have to change all the `asserts.expect` calls.
