### PR TITLE
Add Wall of Browser Bugs entries for Selectors Level 4 :nth-child(An+B of S)

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -150,6 +150,16 @@
 
 -
   browser: >
+    Firefox
+  summary: >
+    Implement the `of <selector-list>` clause of the `:nth-child()` pseudo-class
+  upstream_bug: >
+    Mozilla#854148
+  origin: >
+    Bootstrap#20143
+
+-
+  browser: >
     Firefox (Windows)
   summary: >
     Right border of `<select>` menu is sometimes missing when screen is set to uncommon resolution
@@ -247,6 +257,16 @@
     Chromium#370155
   origin: >
     Bootstrap#12832
+
+-
+  browser: >
+    Chrome
+  summary: >
+    Implement the `of <selector-list>` clause of the `:nth-child()` pseudo-class
+  upstream_bug: >
+    Chromium#304163
+  origin: >
+    Bootstrap#20143
 
 -
   browser: >


### PR DESCRIPTION
I propose adding these on the grounds that the `of S` feature would allow us to make our widgets more robust. We've had several issue reports (e.g. #15684, #13825, #16540) where folks tried to put stuff like `<input type="hidden">` within `.input-group` or `.btn-group`, but this broke the `:first-child`/`:last-child`-based selectors we use to adjust rounded corners.
With this feature, we could restrict the children considered to only the relevant ones, thus ignoring other irrelevant elements. For example, we could use `:nth-child(1 of .btn)` in our `.btn-group` CSS to ignore non-`.btn` children and thus round the corners correctly in such cases.

Refs:
- http://caniuse.com/#feat=css-nth-child-of
- https://drafts.csswg.org/selectors-4/#the-nth-child-pseudo
- https://crbug.com/304163
- https://bugzil.la/854148

CC: @twbs/team for review
