### PR TITLE
custom-control spacing

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -12,7 +12,7 @@
 .custom-control {
   position: relative;
   display: inline;
-  padding-left: $custom-control-gutter;
+  padding-left: $custom-control-indicator-size;
   cursor: pointer;
 
   + .custom-control {
@@ -73,6 +73,12 @@
   background-position: center center;
   background-size: $custom-control-indicator-bg-size;
   @include box-shadow($custom-control-indicator-box-shadow);
+}
+
+// Custom description
+
+.custom-control-description {
+  padding-left: ($custom-control-gutter - $custom-control-indicator-size);
 }
 
 // Checkboxes


### PR DESCRIPTION
If we don't have `.custom-control-indicator` remains some extra padding:
http://codepen.io/zalog/pen/oLBzBq
