### PR TITLE
Fix modal being too wide on small devices

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -113,7 +113,7 @@
 }
 
 // Scale up the modal
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-up(md) {
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     max-width: $modal-md;


### PR DESCRIPTION
$modal-md's default value is wider than the sm media breakpoint, thus making standard modals wider than the viewport on small devices.  Adjust the media query to use the md breakpoint instead.
