### PR TITLE
Add Wall of Browser Bugs entries for <dialog>

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -72,16 +72,6 @@
   browser: >
     Microsoft Edge
   summary: >
-    Implement the `:dir()` pseudo-class from Selectors Level 4
-  upstream_bug: >
-    UserVoice#12299532
-  origin: >
-    Bootstrap#19984
-
--
-  browser: >
-    Microsoft Edge
-  summary: >
     Hovering over descendant SVG element fires `mouseleave` event at ancestor
   upstream_bug: >
     Edge#7787318
@@ -122,16 +112,6 @@
   browser: >
     Firefox
   summary: >
-    Fire `transitioncancel` event when a transition is canceled
-  upstream_bug: >
-    Mozilla#1264125
-  origin: >
-    Mozilla#1182856
-
--
-  browser: >
-    Firefox
-  summary: >
     Wide floated table doesn't wrap onto new line
   upstream_bug: >
     Mozilla#1277782
@@ -147,16 +127,6 @@
     Mozilla#577785
   origin: >
     Bootstrap#19670
-
--
-  browser: >
-    Firefox
-  summary: >
-    Implement the `of <selector-list>` clause of the `:nth-child()` pseudo-class
-  upstream_bug: >
-    Mozilla#854148
-  origin: >
-    Bootstrap#20143
 
 -
   browser: >
@@ -252,31 +222,11 @@
   browser: >
     Chrome
   summary: >
-    Implement the `:dir()` pseudo-class from Selectors Level 4
-  upstream_bug: >
-    Chromium#576815
-  origin: >
-    Bootstrap#19984
-
--
-  browser: >
-    Chrome
-  summary: >
     Don't make `:hover` sticky on touch-friendly webpages
   upstream_bug: >
     Chromium#370155
   origin: >
     Bootstrap#12832
-
--
-  browser: >
-    Chrome
-  summary: >
-    Implement the `of <selector-list>` clause of the `:nth-child()` pseudo-class
-  upstream_bug: >
-    Chromium#304163
-  origin: >
-    Bootstrap#20143
 
 -
   browser: >
@@ -297,16 +247,6 @@
     WebKit#156684
   origin: >
     Bootstrap#17403
-
--
-  browser: >
-    Safari
-  summary: >
-    Implement the `:dir()` pseudo-class from Selectors Level 4
-  upstream_bug: >
-    WebKit#64861
-  origin: >
-    Bootstrap#19984
 
 -
   browser: >

--- a/docs/_data/browser-features.yml
+++ b/docs/_data/browser-features.yml
@@ -30,6 +30,16 @@
 
 -
   browser: >
+    Firefox
+  summary: >
+    Implement the HTML5 [`<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+  upstream_bug: >
+    Mozilla#840640
+  origin: >
+    Bootstrap#20175
+
+-
+  browser: >
     Chrome
   summary: >
     Implement the [`of <selector-list>` clause](http://caniuse.com/#feat=css-nth-child-of) of the `:nth-child()` pseudo-class
@@ -57,3 +67,13 @@
     WebKit#64861
   origin: >
     Bootstrap#19984
+
+-
+  browser: >
+    Safari
+  summary: >
+    Implement the HTML5 [`<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+  upstream_bug: >
+    WebKit#84635
+  origin: >
+    Bootstrap#20175

--- a/docs/_data/browser-features.yml
+++ b/docs/_data/browser-features.yml
@@ -1,0 +1,59 @@
+-
+  browser: >
+    Microsoft Edge
+  summary: >
+    Implement the [`:dir()` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:dir) from Selectors Level 4
+  upstream_bug: >
+    UserVoice#12299532
+  origin: >
+    Bootstrap#19984
+
+-
+  browser: >
+    Firefox
+  summary: >
+    Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
+  upstream_bug: >
+    Mozilla#1264125
+  origin: >
+    Mozilla#1182856
+
+-
+  browser: >
+    Firefox
+  summary: >
+    Implement the [`of <selector-list>` clause](http://caniuse.com/#feat=css-nth-child-of) of the `:nth-child()` pseudo-class
+  upstream_bug: >
+    Mozilla#854148
+  origin: >
+    Bootstrap#20143
+
+-
+  browser: >
+    Chrome
+  summary: >
+    Implement the [`of <selector-list>` clause](http://caniuse.com/#feat=css-nth-child-of) of the `:nth-child()` pseudo-class
+  upstream_bug: >
+    Chromium#304163
+  origin: >
+    Bootstrap#20143
+
+-
+  browser: >
+    Chrome
+  summary: >
+    Implement the [`:dir()` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:dir) from Selectors Level 4
+  upstream_bug: >
+    Chromium#576815
+  origin: >
+    Bootstrap#19984
+
+-
+  browser: >
+    Safari
+  summary: >
+    Implement the [`:dir()` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:dir) from Selectors Level 4
+  upstream_bug: >
+    WebKit#64861
+  origin: >
+    Bootstrap#19984

--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -38,3 +38,32 @@ See also:
     </tbody>
   </table>
 </div>
+
+# Most wanted features
+
+There are several features specified in Web standards which would allow us to make Bootstrap more robust, elegant, or performant, but aren't yet implemented in certain browsers, thus preventing us from taking advantage of them.
+
+We publicly list these "most wanted" feature requests here, in the hopes of expediting the process of getting them implemented.
+
+<div class="table-responsive">
+  <table class="bd-browser-bugs table table-bordered table-hover">
+    <thead>
+      <tr>
+        <th>Browser(s)</th>
+        <th>Summary of feature</th>
+        <th>Upstream issue(s)</th>
+        <th>Bootstrap issue(s)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for feat in site.data.browser-features %}
+      <tr>
+        <td>{{ feat.browser }}</td>
+        <td>{{ feat.summary | markdownify | bugify }}</td>
+        <td>{{ feat.upstream_bug | bugify }}</td>
+        <td>{{ feat.origin | bugify }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
I propose adding these on the grounds that `<dialog>` would make it much easier and less hacky to implement modals. In particular, accomplishing the "disablement" of the underlying page, so that the modal is actually modal, is currently pretty painful.

Refs:
- https://bugzil.la/840640
- https://webkit.org/b/84635
- http://caniuse.com/#feat=dialog
- https://html.spec.whatwg.org/multipage/forms.html#the-dialog-element

CC: @twbs/team for review
