### PR TITLE
Fix docs asset file paths in /grunt/configBridge.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
 
   Object.keys(configBridge.paths).forEach(function (key) {
     configBridge.paths[key].forEach(function (val, i, arr) {
-      arr[i] = path.join('./docs/assets', val);
+      arr[i] = path.join('./docs', val);
     });
   });
 

--- a/grunt/configBridge.json
+++ b/grunt/configBridge.json
@@ -1,10 +1,10 @@
 {
   "paths": {
     "docsJs": [
-      "../assets/js/vendor/anchor.min.js",
-      "../assets/js/vendor/clipboard.min.js",
-      "../assets/js/vendor/holder.min.js",
-      "../assets/js/src/application.js"
+      "assets/js/vendor/anchor.min.js",
+      "assets/js/vendor/clipboard.min.js",
+      "assets/js/vendor/holder.min.js",
+      "assets/js/src/application.js"
     ]
   }
 }


### PR DESCRIPTION
Previously, when running the docs locally, the site, rooted at:
    `http://localhost:9001/`
would reference docs assets using relative URLs such as:
    `/../assets/js/vendor/anchor.min.js`
which is equivalent to:
    `http://localhost:9001/../assets/js/vendor/anchor.min.js`
which is nonsense, since the root directory has no parent directory.
Apparently browsers silently ignore this extra `..`, hence why this wasn't noticed until now.
But if you adjust Jekyll's `baseurl` setting, this mistake causes incorrect URLs to get generated.

This PR corrects the problem by removing the extra `../` from the paths.

These paths are also referenced in the Gruntfile, where the fix actually allows us to simplify the code.
Previously, in the Gruntfile, we were doing, e.g.:
    `path.join('./docs/assets', '../assets/js/vendor/anchor.min.js')`
which calculates to:
    `./docs/assets/../assets/js/vendor/anchor.min.js`
which can be simplified to:
    `./docs/assets/js/vendor/anchor.min.js`

So we can remove the `/assets` suffix from the left argument
and the `../` prefix from the right argument
and still obtain the same result.

/fyi @hnrch02 @XhmikosR @juthilo 
