### PR TITLE
Added breakpoint classes for margin and padding spacing

### DIFF
--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -9,25 +9,29 @@
   margin-left:  auto !important;
 }
 
-@each $prop, $abbrev in (margin: m, padding: p) {
-  @each $size, $lengths in $spacers {
-    $length-x:   map-get($lengths, x);
-    $length-y:   map-get($lengths, y);
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-down($breakpoint) {
+    @each $prop, $abbrev in (margin: m, padding: p) {
+      @each $size, $lengths in $spacers {
+        $length-x:   map-get($lengths, x);
+        $length-y:   map-get($lengths, y);
 
-    .#{$abbrev}-a-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
-    .#{$abbrev}-t-#{$size} { #{$prop}-top:    $length-y !important; }
-    .#{$abbrev}-r-#{$size} { #{$prop}-right:  $length-x !important; }
-    .#{$abbrev}-b-#{$size} { #{$prop}-bottom: $length-y !important; }
-    .#{$abbrev}-l-#{$size} { #{$prop}-left:   $length-x !important; }
+        .#{$abbrev}-a-#{$breakpoint}-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
+        .#{$abbrev}-t-#{$breakpoint}-#{$size} { #{$prop}-top:    $length-y !important; }
+        .#{$abbrev}-r-#{$breakpoint}-#{$size} { #{$prop}-right:  $length-x !important; }
+        .#{$abbrev}-b-#{$breakpoint}-#{$size} { #{$prop}-bottom: $length-y !important; }
+        .#{$abbrev}-l-#{$breakpoint}-#{$size} { #{$prop}-left:   $length-x !important; }
 
-    // Axes
-    .#{$abbrev}-x-#{$size} {
-      #{$prop}-right:  $length-x !important;
-      #{$prop}-left:   $length-x !important;
-    }
-    .#{$abbrev}-y-#{$size} {
-      #{$prop}-top:    $length-y !important;
-      #{$prop}-bottom: $length-y !important;
+        // Axes
+        .#{$abbrev}-x-#{$breakpoint}-#{$size} {
+          #{$prop}-right:  $length-x !important;
+          #{$prop}-left:   $length-x !important;
+        }
+        .#{$abbrev}-y-#{$breakpoint}-#{$size} {
+          #{$prop}-top:    $length-y !important;
+          #{$prop}-bottom: $length-y !important;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Currently spacing classes (padding and margin) can only be applied without breakpoints. It's currently not possible to add spacing only at certain breakpoints (xl, lg, md, sm, xs), I added the breakpoints wrapper function so it becomes possible.

It's now possible to use 
`{spacing-type}-{side}-{breakpoint}-{size}` (i.e. `m-t-xs-2`)
