### PR TITLE
Scrollspy test: Allow for async .then() in jQuery 3

### DIFF
--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -314,21 +314,21 @@ $(function () {
     var testElementIsActiveAfterScroll = function (element, target) {
       var deferred = $.Deferred()
       var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top)
-      var done = assert.async()
       $content.one('scroll', function () {
         assert.ok($(element).hasClass('active'), 'target:' + target + ', element: ' + element)
-        done()
         deferred.resolve()
       })
       $content.scrollTop(scrollHeight)
       return deferred.promise()
     }
 
+   var done = assert.async()
     $.when(testElementIsActiveAfterScroll('#li-100-5', '#div-100-5'))
       .then(function () { return testElementIsActiveAfterScroll('#li-100-4', '#div-100-4') })
       .then(function () { return testElementIsActiveAfterScroll('#li-100-3', '#div-100-3') })
       .then(function () { return testElementIsActiveAfterScroll('#li-100-2', '#div-100-2') })
       .then(function () { return testElementIsActiveAfterScroll('#li-100-1', '#div-100-1') })
+      .then(function () { done() })
   })
 
   QUnit.test('should allow passed in option offset method: offset', function (assert) {


### PR DESCRIPTION
Instead of doing a new assert.async(), just do a single one for the entire test and let the .then() be async as well. Fixes #20182.
