### PR TITLE
Add "number" to popover content DefaultType

### DIFF
--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -34,7 +34,7 @@ const Popover = (($) => {
   })
 
   const DefaultType = $.extend({}, Tooltip.DefaultType, {
-    content : '(string|element|function)'
+    content : '(string|element|function|number)'
   })
 
   const ClassName = {


### PR DESCRIPTION
A fix for #20193 
It seems like adding another type is safe in this case
