### PR TITLE
Fix small grammatical mistakes

### DIFF
--- a/docs/_includes/getting-started/translations.html
+++ b/docs/_includes/getting-started/translations.html
@@ -7,6 +7,6 @@
       <li><a href="{{ language.url }}" hreflang="{{ language.code }}">{{ language.description }} ({{ language.name }})</a></li>
     {% endfor %}
   </ul>
-  <p><strong class="text-danger">We don't help organize or host translations, we just link to them.</strong></p>
-  <p>Finished a new or better translation? Open a pull request to add it to our list.</p>
+  <p><strong class="text-danger">We don't help organize or host translations; we only link to them.</strong></p>
+  <p>Have you finished a new or better translation? Open a pull request to add it to our list.</p>
 </div>


### PR DESCRIPTION
- Linked two closely related ideas "We don't help..." and "We just link to them."
- Replaced "just" with "only" to indicate a singular item, i.e. "We only link to them."
- Added "Have you" before the question to make it proper, i.e. "Have you finished...?" vs. just "Finished...?"
