### PR TITLE
Processing mobile touch events for plugin Carousel (swiping left/right)

### DIFF
--- a/docs/_includes/js/carousel.html
+++ b/docs/_includes/js/carousel.html
@@ -5,7 +5,7 @@
 
   <h2 id="carousel-examples">Examples</h2>
   <div class="bs-example" data-example-id="simple-carousel">
-    <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+    <div id="carousel-example-generic" class="carousel slide" data-ride="carousel" data-touch="true">
       <ol class="carousel-indicators">
         <li data-target="#carousel-example-generic" data-slide-to="0" class="active"></li>
         <li data-target="#carousel-example-generic" data-slide-to="1"></li>
@@ -33,7 +33,7 @@
     </div>
   </div><!-- /example -->
 {% highlight html %}
-<div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+<div id="carousel-example-generic" class="carousel slide" data-ride="carousel" data-touch="true">
   <!-- Indicators -->
   <ol class="carousel-indicators">
     <li data-target="#carousel-example-generic" data-slide-to="0" class="active"></li>
@@ -93,7 +93,7 @@
   <h3>Optional captions</h3>
   <p>Add captions to your slides easily with the <code>.carousel-caption</code> element within any <code>.item</code>. Place just about any optional HTML within there and it will be automatically aligned and formatted.</p>
   <div class="bs-example" data-example-id="carousel-with-captions">
-    <div id="carousel-example-captions" class="carousel slide" data-ride="carousel">
+    <div id="carousel-example-captions" class="carousel slide" data-ride="carousel" data-touch="true">
       <ol class="carousel-indicators">
         <li data-target="#carousel-example-captions" data-slide-to="0" class="active"></li>
         <li data-target="#carousel-example-captions" data-slide-to="1"></li>
@@ -188,12 +188,24 @@ $('.carousel').carousel()
          <td>true</td>
          <td>Whether the carousel should cycle continuously or have hard stops.</td>
        </tr>
-       <tr>
-         <td>keyboard</td>
-         <td>boolean</td>
-         <td>true</td>
-         <td>Whether the carousel should react to keyboard events.</td>
-       </tr>
+	   <tr>
+		   <td>keyboard</td>
+		   <td>boolean</td>
+		   <td>true</td>
+		   <td>Whether the carousel should react to keyboard events.</td>
+	   </tr>
+	   <tr>
+		   <td>touch</td>
+		   <td>boolean</td>
+		   <td>false</td>
+		   <td>Whether the carousel should react to touch events (swiping left/right).</td>
+	   </tr>
+	   <tr>
+		   <td>touch-dist</td>
+		   <td>number</td>
+		   <td>60</td>
+		   <td>Minimal distance of touch swipe to activate sliding.</td>
+	   </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/docs/_includes/js/carousel.html
+++ b/docs/_includes/js/carousel.html
@@ -188,24 +188,24 @@ $('.carousel').carousel()
          <td>true</td>
          <td>Whether the carousel should cycle continuously or have hard stops.</td>
        </tr>
-	   <tr>
-		   <td>keyboard</td>
-		   <td>boolean</td>
-		   <td>true</td>
-		   <td>Whether the carousel should react to keyboard events.</td>
-	   </tr>
-	   <tr>
-		   <td>touch</td>
-		   <td>boolean</td>
-		   <td>false</td>
-		   <td>Whether the carousel should react to touch events (swiping left/right).</td>
-	   </tr>
-	   <tr>
-		   <td>touch-dist</td>
-		   <td>number</td>
-		   <td>60</td>
-		   <td>Minimal distance of touch swipe to activate sliding.</td>
-	   </tr>
+       <tr>
+         <td>keyboard</td>
+         <td>boolean</td>
+         <td>true</td>
+         <td>Whether the carousel should react to keyboard events.</td>
+       </tr>
+       <tr>
+         <td>touch</td>
+         <td>boolean</td>
+         <td>false</td>
+         <td>Whether the carousel should react to touch events (swiping left/right).</td>
+       </tr>
+       <tr>
+         <td>touch-dist</td>
+         <td>number</td>
+         <td>60</td>
+         <td>Minimal distance of touch swipe to activate sliding.</td>
+       </tr>
       </tbody>
     </table>
   </div><!-- /.table-responsive -->

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -28,6 +28,33 @@
     this.options.pause == 'hover' && !('ontouchstart' in document.documentElement) && this.$element
       .on('mouseenter.bs.carousel', $.proxy(this.pause, this))
       .on('mouseleave.bs.carousel', $.proxy(this.cycle, this))
+
+	if(this.options.touch){
+		  var touchStartX = 0, distRequired = 60;
+		  if( this.options.touchDist && !isNaN( parseInt( this.options.touchDist ) ) ){
+			  distRequired = Math.abs(parseInt(this.options.touchDist))
+		  }
+		  this.$element.on('touchstart.bs.carousel', $.proxy(
+			  function(e){
+				  touchStartX = e.originalEvent.touches[0].pageX;
+			  },
+			  this
+		  ));
+		  this.$element.on('touchmove.bs.carousel', $.proxy(
+			  function(e){
+				  var dist = touchStartX - e.originalEvent.touches[0].pageX;
+				  if(Math.abs(dist) < distRequired) return false;
+				  if(dist < 0){
+					  // move right, slide to prev
+					  this.prev();
+				  }else{
+					  // move left, slide to next
+					  this.next();
+				  }
+			  },
+			  this
+		  ));
+	}
   }
 
   Carousel.VERSION  = '3.3.6'


### PR DESCRIPTION
To enable touch add 'data-touch="true"' to carousel element.
Also there is available attribute 'data-touch-dist="60"' that defines minimal distance of touch swipe to activate sliding (default 60px).
