### PR TITLE
Fixed tether requirement for UMD.

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -1,5 +1,6 @@
 /* global Tether */
 
+import Tether from 'tether'
 import Util from './util'
 
 
@@ -16,7 +17,7 @@ const Tooltip = (($) => {
    * Check for Tether dependency
    * Tether - http://github.hubspot.com/tether/
    */
-  if (window.Tether === undefined) {
+  if (window.Tether === undefined && Tether === undefined) {
     throw new Error('Bootstrap tooltips require Tether (http://github.hubspot.com/tether/)')
   }
 


### PR DESCRIPTION
It does not seem possible to use tooltips withing UMD environment because of hard windows.Tether check. I've added proper import of tether, which should eliminate the problem.
