### PR TITLE
Update SCSS-Lint dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ group :development, :test do
   gem 'jekyll', '~> 3.1.2'
   gem 'jekyll-redirect-from', '~> 0.10.0'
   gem 'jekyll-sitemap', '~> 0.10.0'
-  gem 'scss_lint', '~> 0.48.0'
+  gem 'scss_lint', '~> 0.49.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,9 @@ GEM
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    scss_lint (0.48.0)
+    scss_lint (0.49.0)
       rake (>= 0.9, < 12)
-      sass (~> 3.4.15)
+      sass (~> 3.4.20)
 
 PLATFORMS
   ruby
@@ -45,7 +45,7 @@ DEPENDENCIES
   jekyll (~> 3.1.2)
   jekyll-redirect-from (~> 0.10.0)
   jekyll-sitemap (~> 0.10.0)
-  scss_lint (~> 0.48.0)
+  scss_lint (~> 0.49.0)
 
 BUNDLED WITH
    1.12.5

--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -457,7 +457,7 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
+    allowed_shorthands: [1, 2, 3, 4]
 
   SingleLinePerProperty:
     enabled: false


### PR DESCRIPTION
SCSS-Lint 0.49.0 modifies Shorthand linter to report lint if a shorthand
of a length not specified in the allowed_shorthands option is used.

New defaults include "4" in the list of allowed shorthands, so we are changing our configuration accordingly.

Ref: https://github.com/brigade/scss-lint/commit/e283d1689699f581561fea344df3168128c46d7b
