### PR TITLE
button.js: Set disabled property in addition to disabled attribute

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -41,10 +41,10 @@
 
       if (state == 'loadingText') {
         this.isLoading = true
-        $el.addClass(d).attr(d, d)
+        $el.addClass(d).attr(d, d).prop(d, true)
       } else if (this.isLoading) {
         this.isLoading = false
-        $el.removeClass(d).removeAttr(d)
+        $el.removeClass(d).removeAttr(d).prop(d, false)
       }
     }, this), 0)
   }


### PR DESCRIPTION
So as to preserve the existing behavior when running under jQuery 3.

This code ought to have used `.prop` instead of `.attr` in the first place, but we can't get rid of the attr manipulation now, due to backward compatibility constraints.

This addresses the only warning that the jQuery Migrate Plugin emitted.

Refs https://github.com/jquery/jquery-migrate/blob/3.0.0/warnings.md#jqmigrate-jqueryfnremoveattr-no-longer-sets-boolean-properties
Refs #16834.

No v4 port is necessary here, since the relevant feature has already been excised from v4's buttons plugin.

CC: @XhmikosR @hnrch02 for review
