### PR TITLE
scrollspy: fix wrong activation of all nested links

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -252,7 +252,7 @@ const ScrollSpy = (($) => {
       } else {
         // todo (fat) this is kinda sus...
         // recursively add actives to tested nav-links
-        $link.parents(Selector.LI).find('> ' + Selector.NAV_LINKS).addClass(ClassName.ACTIVE)
+        $link.parents(Selector.LI).find(`> ${Selector.NAV_LINKS}`).addClass(ClassName.ACTIVE)
       }
 
       $(this._scrollElement).trigger(Event.ACTIVATE, {

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -252,7 +252,7 @@ const ScrollSpy = (($) => {
       } else {
         // todo (fat) this is kinda sus...
         // recursively add actives to tested nav-links
-        $link.parents(Selector.LI).find(Selector.NAV_LINKS).addClass(ClassName.ACTIVE)
+        $link.parents(Selector.LI).find('> ' + Selector.NAV_LINKS).addClass(ClassName.ACTIVE)
       }
 
       $(this._scrollElement).trigger(Event.ACTIVATE, {


### PR DESCRIPTION
if the scrollspy applied to hierarchical navigation, then too many nav-links are activated.
Example markup:

```
      <ul id="toc" class="nav nav-pills nav-stacked">
        <li>
          <a href="#v1" class="nav-link">Volume 1</a>
          <ul class="nav">
            <li>
              <a href="#ch-1-1" class="nav-link">Chapter 1.1</a>
            </li>
            <li>
              <a href="#ch-1-2" class="nav-link">Chapter 1.2</a>
            </li>
            <li>
              <a href="#ch-1-3" class="nav-link">Chapter 1.3</a>
            </li>
          </ul>
        </li>
        <li>
          <a href="#v2" class="nav-link">Volume 2</a>
          <ul class="nav">
            <li>
              <a href="#ch-2-1" class="nav-link">Chapter 2.1</a>
            </li>
            <li>
              <a href="#ch-2-2" class="nav-link">Chapter 2.2</a>
            </li>
          </ul>
        </li>
      </ul>
```

on activation of "Chapter 1.2" all siblings ("Chapter 1.1" and "Chapter 1.3") are also activated, because the selector

```
$('.nav-link[href="#ch-1-2"]').parents('li').find('.nav-links')
```

matches all ".nav-link"s under "#v1", so the correct selector should be

```
$('.nav-link[href="#ch-1-2"]').parents('li').find('> .nav-links')
                                                   ^
                                      only direct children of li
```

The illustration of this problem can be found on [JSFiddle](https://jsfiddle.net/8bd158ra/2/), and the solution (just patched version of bootstrap.min.js) is [here](https://jsfiddle.net/8bd158ra/3/).
