### PR TITLE
Minor changes to "Sticky Footer" and "Sticky Footer Nav" examples

### DIFF
--- a/docs/examples/sticky-footer-navbar/sticky-footer-navbar.css
+++ b/docs/examples/sticky-footer-navbar/sticky-footer-navbar.css
@@ -9,7 +9,7 @@ body {
   margin-bottom: 60px;
 }
 .footer {
-  position: absolute;
+  position: static;
   bottom: 0;
   width: 100%;
   /* Set the fixed height of the footer here */

--- a/docs/examples/sticky-footer/sticky-footer.css
+++ b/docs/examples/sticky-footer/sticky-footer.css
@@ -9,7 +9,7 @@ body {
   margin-bottom: 60px;
 }
 .footer {
-  position: absolute;
+  position: static;
   bottom: 0;
   width: 100%;
   /* Set the fixed height of the footer here */


### PR DESCRIPTION
I've changed position attribute from 'absolute' to 'static' to ensure better integration of footer to a web page. This is a minor change to the example files.
I had the issue of footer sticking to one point of the page when I scrolled, and the footer did not stick to the bottom of the page all the time. This change fixed mine.
