### PR TITLE
Rename shrinkwrap-related npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "htmlhint": "htmlhint --config docs/.htmlhintrc _gh_pages/",
     "postcss": "postcss --config grunt/postcss.js --replace dist/css/*.css",
     "postcss-docs": "postcss --config grunt/postcss.js --no-map --replace docs/assets/css/docs.min.css && postcss --config grunt/postcss.js --no-map --replace docs/examples/**/*.css",
-    "shrinkwrap": "npm shrinkwrap --dev && shx mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
+    "update-shrinkwrap": "npm shrinkwrap --dev && shx mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
     "test": "npm run eslint && npm run jscs && grunt test"
   },
   "style": "dist/css/bootstrap.css",


### PR DESCRIPTION
To avoid infinite recursion in newer npm versions, which added a lifecycle script for `npm shrinkwrap`.
Refs https://github.com/npm/npm/issues/13253
Refs https://github.com/npm/npm/pull/12814
