### PR TITLE
Avoid using $.offset() on SVGs since it gives incorrect results in jQuery 3

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -364,7 +364,10 @@
       // width and height are missing in IE8, so compute them manually; see https://github.com/twbs/bootstrap/issues/14093
       elRect = $.extend({}, elRect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top })
     }
-    var elOffset  = isBody ? { top: 0, left: 0 } : $element.offset()
+    var isSvg = window.SVGElement && el instanceof window.SVGElement
+    // Avoid using $.offset() on SVGs since it gives incorrect results in jQuery 3.
+    // See https://github.com/twbs/bootstrap/issues/20280
+    var elOffset  = isBody ? { top: 0, left: 0 } : (isSvg ? null : $element.offset())
     var scroll    = { scroll: isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.scrollTop() }
     var outerDims = isBody ? { width: $(window).width(), height: $(window).height() } : null
 


### PR DESCRIPTION
Fixes #20280.
Refs https://github.com/jquery/jquery/issues/3137
CC: @XhmikosR @hnrch02 @patrickhlauke 
