### PR TITLE
Add position:sticky to Most Wanted features

### DIFF
--- a/docs/_data/browser-features.yml
+++ b/docs/_data/browser-features.yml
@@ -10,6 +10,16 @@
 
 -
   browser: >
+    Microsoft Edge
+  summary: >
+    Implement [sticky positioning](http://html5please.com/#position:sticky) from CSS Positioned Layout Level 3
+  upstream_bug: >
+    UserVoice#6263621
+  origin: >
+    Bootstrap#17021
+
+-
+  browser: >
     Firefox
   summary: >
     Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
@@ -57,6 +67,16 @@
     Chromium#576815
   origin: >
     Bootstrap#19984
+
+-
+  browser: >
+    Chrome
+  summary: >
+    Implement [sticky positioning](http://html5please.com/#position:sticky) from CSS Positioned Layout Level 3
+  upstream_bug: >
+    Chromium#231752
+  origin: >
+    Bootstrap#17021
 
 -
   browser: >


### PR DESCRIPTION
On the grounds that it's what we're advising former Affix users to migrate to in v4, and it would be great if polyfills for it stopped being necessary.

Refs https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6263621-position-sticky
Refs https://crbug.com/231752

CC: @twbs/team for review
