### PR TITLE
v4 Docs: Update composer require command

### DIFF
--- a/docs/getting-started/download.md
+++ b/docs/getting-started/download.md
@@ -78,7 +78,7 @@ $ meteor add twbs:bootstrap@={{ site.current_version }}
 You can also install and manage Bootstrap's Sass and JavaScript using [Composer](https://getcomposer.org):
 
 {% highlight bash %}
-$ composer require twbs/bootstrap
+$ composer require twbs/bootstrap:{{ site.current_version }}
 {% endhighlight %}
 
 ### Bower


### PR DESCRIPTION
Updated `composer require` command to download current v4-alpha version, to match the commands for npm/bower/meteor/etc.
