### PR TITLE
Replace renamed classes in push/pull example

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -442,7 +442,7 @@ To nest your content with the default grid, add a new `.row` and set of `.col-sm
 
 ### Example: Column ordering
 
-Easily change the order of our built-in grid columns with `.col-md-push-*` and `.col-md-pull-*` modifier classes.
+Easily change the order of our built-in grid columns with `.push-md-*` and `.pull-md-*` modifier classes.
 
 <div class="bd-example-row">
 {% example html %}


### PR DESCRIPTION
The example for column ordering still referenced the old push/pull class names.
