### PR TITLE
Progress bar:fix use variable progress-border-radius instead of border-radius

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -26,7 +26,7 @@
   // Reset the default appearance
   appearance: none;
   // Set overall border radius
-  @include border-radius($border-radius);
+  @include border-radius($progress-border-radius);
 }
 
 // Filled-in portion of the bar
@@ -37,30 +37,30 @@
 }
 .progress[value]::-moz-progress-bar {
   background-color: $progress-bar-color;
-  @include border-left-radius($border-radius);
+  @include border-left-radius($progress-border-radius);
 }
 .progress[value]::-webkit-progress-value {
   background-color: $progress-bar-color;
-  @include border-left-radius($border-radius);
+  @include border-left-radius($progress-border-radius);
 }
 // Tweaks for full progress bar
 .progress[value="100"]::-moz-progress-bar {
-  @include border-right-radius($border-radius);
+  @include border-right-radius($progress-border-radius);
 }
 .progress[value="100"]::-webkit-progress-value {
-  @include border-right-radius($border-radius);
+  @include border-right-radius($progress-border-radius);
 }
 
 // Unfilled portion of the bar
 .progress[value]::-webkit-progress-bar {
   background-color: $progress-bg;
-  @include border-radius($border-radius);
+  @include border-radius($progress-border-radius);
   @include box-shadow($progress-box-shadow);
 }
 base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make these styles Firefox-only
 .progress[value] {
   background-color: $progress-bg;
-  @include border-radius($border-radius);
+  @include border-radius($progress-border-radius);
   @include box-shadow($progress-box-shadow);
 }
 
@@ -68,7 +68,7 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
 @media screen and (min-width:0\0) {
   .progress {
     background-color: $progress-bg;
-    @include border-radius($border-radius);
+    @include border-radius($progress-border-radius);
     @include box-shadow($progress-box-shadow);
   }
   .progress-bar {
@@ -76,10 +76,10 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
     height: $spacer-y;
     text-indent: -999rem; // Simulate hiding of value as in native `<progress>`
     background-color: $progress-bar-color;
-    @include border-left-radius($border-radius);
+    @include border-left-radius($progress-border-radius);
   }
   .progress[width="100%"] {
-    @include border-right-radius($border-radius);
+    @include border-right-radius($progress-border-radius);
   }
 }
 


### PR DESCRIPTION
In v4-dev branch, the border-radius for progress bar component is applying `$border-radius` variable. 

So currently we cannot customize the border-radius for progress bar without affecting other components which apply `$border-radius` variable as well . While there is a customizable variable `$progress-border-radius` not being in use at all (#18623).

This commit changes to use `$progress-border-radius` to replace `$border-radius` for progress bar to make it work properly.
