### PR TITLE
Docs Tooltip Static Demo uses v3 class names

### DIFF
--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -49,25 +49,25 @@ Hover over the links below to see tooltips:
 Four options are available: top, right, bottom, and left aligned.
 
 <div class="bd-example bd-example-tooltip-static">
-  <div class="tooltip top" role="tooltip">
+  <div class="tooltip tooltip-top" role="tooltip">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner">
       Tooltip on the top
     </div>
   </div>
-  <div class="tooltip right" role="tooltip">
+  <div class="tooltip tooltip-right" role="tooltip">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner">
       Tooltip on the right
     </div>
   </div>
-  <div class="tooltip bottom" role="tooltip">
+  <div class="tooltip tooltip-bottom" role="tooltip">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner">
       Tooltip on the bottom
     </div>
   </div>
-  <div class="tooltip left" role="tooltip">
+  <div class="tooltip tooltip-left" role="tooltip">
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner">
       Tooltip on the left
@@ -128,7 +128,7 @@ You should only add tooltips to HTML elements that are traditionally keyboard-fo
 <a href="#" data-toggle="tooltip" title="Some tooltip text!">Hover over me</a>
 
 <!-- Generated markup by the plugin -->
-<div class="tooltip top" role="tooltip">
+<div class="tooltip tooltip-top" role="tooltip">
   <div class="tooltip-arrow"></div>
   <div class="tooltip-inner">
     Some tooltip text!


### PR DESCRIPTION
Tooltip Static Demo doesn't show tooltip-arrow.
<img width="878" alt="tooltip-static-demo" src="https://cloud.githubusercontent.com/assets/788266/17036451/3422f27a-4f41-11e6-9e7c-ff704bc5e56d.png">
