### PR TITLE
Update iOS temporal input types support comment

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -181,7 +181,7 @@ input[type="search"] {
 // set a pixel line-height that matches the given height of the input, but only
 // for Safari. See https://bugs.webkit.org/show_bug.cgi?id=139848
 //
-// Note that as of 8.3, iOS doesn't support `datetime` or `week`.
+// Note that as of 9.3, iOS doesn't support `week`.
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   input[type="date"],


### PR DESCRIPTION
- `<input type="datetime">` no longer exists, per https://github.com/whatwg/html/issues/336
- iOS 9.3.2 still doesn't support `<input type="week">`
