### PR TITLE
Revert #18700 but discourage using <a>s for disabled pagination items

### DIFF
--- a/docs/_includes/components/pagination.html
+++ b/docs/_includes/components/pagination.html
@@ -77,7 +77,7 @@
   </ul>
 </nav>
 {% endhighlight %}
-  <p>You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</code>, or omit the anchor in the case of the previous/next arrows, to remove click functionality while retaining intended styles.</p>
+  <p>We recommend that you swap out active or disabled anchors for <code>&lt;span&gt;</code>, or omit the anchor in the case of the previous/next arrows, to remove click functionality while retaining intended styles.</p>
 {% highlight html %}
 <nav aria-label="...">
   <ul class="pagination">

--- a/less/pager.less
+++ b/less/pager.less
@@ -49,7 +49,6 @@
       color: @pager-disabled-color;
       background-color: @pager-bg;
       cursor: @cursor-disabled;
-      pointer-events: none; // Future-proof disabling of clicks on `<a>` elements
     }
   }
 }

--- a/less/pagination.less
+++ b/less/pagination.less
@@ -71,7 +71,6 @@
       background-color: @pagination-disabled-bg;
       border-color: @pagination-disabled-border;
       cursor: @cursor-disabled;
-      pointer-events: none; // Future-proof disabling of clicks on `<a>` elements
     }
   }
 }


### PR DESCRIPTION
Reverts #18700 per the discussion in that commit.
I would make the docs stronger than "we recommend", but we're under a time crunch and removing the examples of the recommended-against way without further explanation seems like it'd be confusing.
