### PR TITLE
v4: Restore flexbox grid .col-{bp} class for auto layout

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -30,6 +30,19 @@
     }
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {
+      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
+      @if $enable-flex {
+        .col-#{$breakpoint} {
+          position: relative;
+          flex-basis: 0;
+          flex-grow: 1;
+          max-width: 100%;
+          min-height: 1px;
+          padding-right: ($grid-gutter-width / 2);
+          padding-left:  ($grid-gutter-width / 2);
+        }
+      }
+
       @for $i from 1 through $columns {
         .col-#{$breakpoint}-#{$i} {
           @include make-col($i, $columns, $gutter);


### PR DESCRIPTION
This follows up #19099 and #20349 to restore the auto-layout grid class generation for the flexbox grid system.

<img width="887" alt="screen shot 2016-07-25 at 5 22 36 pm" src="https://cloud.githubusercontent.com/assets/98681/17122011/b9dc2492-528c-11e6-8cf5-37edafd9b3a3.png">
