### PR TITLE
Enhance hiding dropdowns

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -40,20 +40,21 @@
     $(toggle).each(function () {
       var $this         = $(this)
       var $parent       = getParent($this)
-      var relatedTarget = { relatedTarget: this }
+      var related = { relatedTarget: this, relatedEvent: e }
 
       if (!$parent.hasClass('open')) return
 
       if (e && e.type == 'click' && /input|textarea/i.test(e.target.tagName) && $.contains($parent[0], e.target)) return
 
-      $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
+      $parent.trigger(e = $.Event('hide.bs.dropdown', related))
 
       if (e.isDefaultPrevented()) return
 
       $this.attr('aria-expanded', 'false')
-      $parent.removeClass('open').trigger($.Event('hidden.bs.dropdown', relatedTarget))
+      $parent.removeClass('open').trigger($.Event('hidden.bs.dropdown', related))
     })
   }
+  Dropdown.clearMenus = clearMenus
 
   Dropdown.prototype.toggle = function (e) {
     var $this = $(this)


### PR DESCRIPTION
Enhance hiding logic of dropdowns to allow more flexible customization.
- Pass the `click` event which is about to hide the dropdowns to `hide.bs.dropdown` event parameters as `relatedEvent`, so developers can decide to hide or not using for example `e.relatedEvent.target`.
- Expose `clearMenus` as a static method of `Dropdown` so it can be overridden by developers just as prototype methods
