### PR TITLE
v4: Enable flexbox CSS on flexbox grid page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,8 +184,15 @@ module.exports = function (grunt) {
         ]
       },
       docs: {
-        src: 'docs/assets/css/docs.min.css',
-        dest: 'docs/assets/css/docs.min.css'
+        files: [
+          {
+            expand: true,
+            cwd: 'docs/assets/css',
+            src: ['*.css', '!*.min.css'],
+            dest: 'docs/assets/css',
+            ext: '.min.css'
+          }
+        ]
       }
     },
 

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -15,6 +15,9 @@
 <!-- Bootstrap core CSS -->
 {% if site.github %}
   <link href="{{ site.baseurl }}/dist/css/bootstrap.min.css" rel="stylesheet">
+  {% if page.title == "Flexbox grid system" %}
+    <link href="{{ site.baseurl }}/assets/css/docs-flexbox.min.css" rel="stylesheet">
+  {% endif %}
 {% else %}
   <link href="{{ site.baseurl }}/dist/css/bootstrap.css" rel="stylesheet">
 {% endif %}

--- a/docs/assets/scss/flex-grid.scss
+++ b/docs/assets/scss/flex-grid.scss
@@ -1,7 +1,4 @@
-// Bootstrap Grid only
-//
-// Includes relevant variables and mixins for the regular (non-flexbox) grid
-// system, as well as the generated predefined classes (e.g., `.col-4-sm`).
+// Bootstrap flexbox grid for our docs page
 
 
 //
@@ -10,6 +7,10 @@
 
 @import "custom";
 @import "variables";
+
+// Override for flexbox mode
+$enable-flex: true;
+
 
 //
 // Grid mixins

--- a/docs/layout/flexbox-grid.md
+++ b/docs/layout/flexbox-grid.md
@@ -9,7 +9,7 @@ Fancy a more modern grid system? [Enable flexbox support in Bootstrap](/getting-
 Bootstrap's flexbox grid includes support for every feature from our [default grid system](/layout/grid), and then some. Please read the [default grid system docs](/layout/grid) before proceeding through this page. Features that are covered there are only summarized here. Please note that **Internet Explorer 9 does not support flexbox**, so proceed with caution when enabling it.
 
 {% callout warning %}
-**Heads up!** The flexbox grid documentation is only functional when flexbox support is explicitly enabled.
+**Heads up!** This flexbox grid documentation is powered by an additional CSS file that overrides our default grid system's CSS. This is only available in our hosted docs and is disabled in development.
 {% endcallout %}
 
 ## Contents

--- a/grunt/bs-sass-compile/libsass.js
+++ b/grunt/bs-sass-compile/libsass.js
@@ -25,7 +25,8 @@ module.exports = function configureLibsass(grunt) {
       },
       docs: {
         files: {
-          'docs/assets/css/docs.min.css': 'docs/assets/scss/docs.scss'
+          'docs/assets/css/docs.min.css': 'docs/assets/scss/docs.scss',
+          'docs/assets/css/docs-flexbox.min.css': 'docs/assets/scss/flex-grid.scss'
         }
       }
     }

--- a/grunt/bs-sass-compile/sass.js
+++ b/grunt/bs-sass-compile/sass.js
@@ -29,7 +29,8 @@ module.exports = function configureRubySass(grunt) {
       docs: {
         options: options,
         files: {
-          'docs/assets/css/docs.min.css': 'docs/assets/scss/docs.scss'
+          'docs/assets/css/docs.min.css': 'docs/assets/scss/docs.scss',
+          'docs/assets/css/docs-flexbox.min.css': 'docs/assets/scss/flex-grid.scss'
         }
       }
     }


### PR DESCRIPTION
This PR is a last minute addition to Alpha 3 that enables our flexbox CSS as a separate, override stylesheet for our hosted docs. I've disabled it for local development only because my process for testing flexbox support is universal for all our docs (e.g., enable it and work). I've modified the Gruntfile and created a new Sass file to build this override from.

As part of this, I've updated the warning callout to communicate the flexbox enablement to docs visitors, as well as tweaking the `bootstrap-grid.scss` file to remove the dupe variables.
