### PR TITLE
Update variable usage for input group addon

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -90,18 +90,18 @@
   text-align: center;
   background-color: $input-group-addon-bg;
   border: $input-btn-border-width solid $input-group-addon-border-color;
-  @include border-radius($border-radius);
+  @include border-radius($input-border-radius);
 
   // Sizing
   &.form-control-sm {
     padding: $input-padding-y-sm $input-padding-x-sm;
     font-size: $font-size-sm;
-    @include border-radius($border-radius-sm);
+    @include border-radius($input-border-radius-sm);
   }
   &.form-control-lg {
     padding: $input-padding-y-lg $input-padding-x-lg;
     font-size: $font-size-lg;
-    @include border-radius($border-radius-lg);
+    @include border-radius($input-border-radius-lg);
   }
 
   // scss-lint:disable QualifyingElement


### PR DESCRIPTION
Instead of the regular border-radius var, use the input ones to match sizing with their associated controls.

Fixes #20291.
