### PR TITLE
Update _navbar.scss to fix navbar items in wrong position when in state "collapse in", with any navbar-toggleable-*

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -222,6 +222,7 @@
       .navbar-nav .nav-item {
         float: none;
         margin-left: 0;
+        clear: both;
       }
     }
     @include media-breakpoint-up(sm) {
@@ -235,6 +236,7 @@
       .navbar-nav .nav-item {
         float: none;
         margin-left: 0;
+        clear: both;
       }
     }
     @include media-breakpoint-up(md) {
@@ -248,6 +250,7 @@
       .navbar-nav .nav-item {
         float: none;
         margin-left: 0;
+        clear: both;
       }
     }
     @include media-breakpoint-up(lg) {


### PR DESCRIPTION
Little modification to fix the alignment problem with the nav items and the navbar-brand when viewing collapsed menu.

It's my first try at PR's so please don't be rude. If I made mistakes, I will be happy to learn from them. 

Reference issue: #20392 
