### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",
-  "main": "./dist/js/npm",
+  "main": "dist/js/bootstrap",
   "repository": {
     "type": "git",
     "url": "https://github.com/twbs/bootstrap.git"


### PR DESCRIPTION
For example, `resolve` npm module can't resolve path to bootstrap.
