### PR TITLE
Updates .list-group-flush to not create a double border when placed inside a .card

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -70,6 +70,7 @@
 
 .list-group-flush {
   .list-group-item {
+    border-width: $list-group-border-width 0;
     border-radius: 0;
   }
 }


### PR DESCRIPTION
Resolves #20395 
