### PR TITLE
Remove unused $size parameter

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -33,7 +33,7 @@
   margin-right: ($gutter / -2);
 }
 
-@mixin make-col-ready($size, $columns: $grid-columns, $gutter: $grid-gutter-width) {
+@mixin make-col-ready($columns: $grid-columns, $gutter: $grid-gutter-width) {
   position: relative;
   min-height: 1px; // Prevent collapsing
   padding-right: ($gutter / 2);


### PR DESCRIPTION
$size is not currently being used in the make-col-ready() mixin
