### PR TITLE
bower.json: Add Bowerder's `browser` field for minified JS & CSS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,10 @@
     "less/bootstrap.less",
     "dist/js/bootstrap.js"
   ],
+  "browser": [
+    "dist/css/bootstrap.min.css",
+    "dist/js/bootstrap.min.js",
+  ],
   "ignore": [
     "/.*",
     "_config.yml",


### PR DESCRIPTION
> because development files (ex: `.scss`, `.coffee`, ...)  isn't actually good for browsers to digest.

useful for project which behavior [like this one](https://github.com/tnga/bowerder); considering this conversation bower/bower#2312
