### PR TITLE
v4 - production's files for browsers (bower.json)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,10 @@
     "scss/bootstrap.scss",
     "dist/js/bootstrap.js"
   ],
+  "browser": [
+    "dist/css/bootstrap.min.css",
+    "dist/js/bootstrap.min.js",
+  ],
   "ignore": [
     "/.*",
     "_config.yml",


### PR DESCRIPTION
> because development files (ex: `.scss`, `.coffee`, ...)  isn't actually good for browsers to digest.

useful for project which behavior [like this one](https://github.com/tnga/bowerder); considering this conversation bower/bower#2312
