### PR TITLE
v4: Fix npm JS directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "files": [
     "dist",
     "grunt",
-    "js/*.js",
+    "js/**/*.js",
     "scss/**/*.scss",
     "Gruntfile.js",
     "LICENSE"


### PR DESCRIPTION
Fixes #20385 with recursive glob action to ensure `js` directory is copied over via npm. Verified in a local directory with dummy `package.json` pointing to the commit this PR includes.

/cc @cvrebert for sanity check

![screen shot 2016-07-30 at 10 46 32 am](https://cloud.githubusercontent.com/assets/98681/17272116/0bb79d32-5643-11e6-80a5-cdaea1088ca0.png)
