### PR TITLE
.form-control:focus customization

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -329,7 +329,7 @@ $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
 $input-border-focus:             #66afe9 !default;
-$input-box-shadow-focus:         rgba(102,175,233,.6) !default;
+$input-box-shadow-focus:         $input-box-shadow, 0 0 8px rgba(102,175,233,.6) !default;
 $input-color-focus:              $input-color !default;
 
 $input-color-placeholder:        #999 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -327,10 +327,10 @@ $input-border-radius:            $border-radius !default;
 $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
-$input-bg-focus:                 $input-bg;
+$input-bg-focus:                 $input-bg !default;
 $input-border-focus:             #66afe9 !default;
 $input-box-shadow-focus:         rgba(102,175,233,.6) !default;
-$input-color-focus:              $input-color;
+$input-color-focus:              $input-color !default;
 
 $input-color-placeholder:        #999 !default;
 

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -60,8 +60,7 @@
     background-color: $input-bg-focus;
     border-color: $input-border-focus;
     outline: none;
-    $shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px $input-box-shadow-focus;
-    @include box-shadow($shadow);
+    @include box-shadow($input-box-shadow-focus);
   }
 }
 


### PR DESCRIPTION
Fix #20435 
1. Fix the ability to customize `.form-control:focus` background and color.
2. Better control and consistency for `box-shadow`.
