### PR TITLE
Visibility mixin

### DIFF
--- a/_visibility.scss
+++ b/_visibility.scss
@@ -1,0 +1,5 @@
+// Visibility
+
+@mixin invisible {
+  visibility: hidden !important;
+}

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -28,6 +28,7 @@
 @import "mixins/text-emphasis";
 @import "mixins/text-hide";
 @import "mixins/text-truncate";
+@import "mixins/visibility";
 
 // // Components
 @import "mixins/alert";

--- a/scss/utilities/_visibility.scss
+++ b/scss/utilities/_visibility.scss
@@ -5,7 +5,7 @@
 //
 
 .invisible {
-  visibility: hidden !important;
+  @include invisible();
 }
 
 // Responsive visibility utilities


### PR DESCRIPTION
The [docs](http://v4-alpha.getbootstrap.com/components/utilities/#invisible-content) mention an invisible @mixin which is not present in the source scss files.

This adds a visibility mixins file, and references it in the utilities file.
