### PR TITLE
Add Wall of Browser Bugs entry for #12359

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -150,6 +150,16 @@
 
 -
   browser: >
+    Firefox
+  summary: >
+    `min-width: 0` has no effect on `<fieldset>`
+  upstream_bug: >
+    Mozilla#504622
+  origin: >
+    Bootstrap#12359
+
+-
+  browser: >
     Firefox (Windows)
   summary: >
     Right border of `<select>` menu is sometimes missing when screen is set to uncommon resolution


### PR DESCRIPTION
This adds https://bugzilla.mozilla.org/show_bug.cgi?id=504622 to the Wall, on the grounds that we've had to add documentation (http://getbootstrap.com/css/#callout-tables-responsive-ff-fieldset) to specifically address this instance of standards-non-compliance.
Refs #12359.
CC: @twbs/team for review
