### PR TITLE
Use card-spacer-y for vertical padding

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -14,7 +14,7 @@
 
 .card-block {
   @include clearfix;
-  padding: $card-spacer-x;
+  padding: $card-spacer-y $card-spacer-x;
 }
 
 .card-title {


### PR DESCRIPTION
.card-block should use $card-spacer-y for vertical padding, just like .card-header and .card-footer, right?
