### PR TITLE
cache selectors

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -447,17 +447,18 @@ const Modal = (($) => {
 
     static _jQueryInterface(config, relatedTarget) {
       return this.each(function () {
-        let data    = $(this).data(DATA_KEY)
+        let $this = $(this);
+        let data    = $this.data(DATA_KEY)
         let _config = $.extend(
           {},
           Modal.Default,
-          $(this).data(),
+          $this.data(),
           typeof config === 'object' && config
         )
 
         if (!data) {
           data = new Modal(this, _config)
-          $(this).data(DATA_KEY, data)
+          $this.data(DATA_KEY, data)
         }
 
         if (typeof config === 'string') {
@@ -487,28 +488,30 @@ const Modal = (($) => {
     if (selector) {
       target = $(selector)[0]
     }
+    
+    let $target = $(target);
 
-    let config = $(target).data(DATA_KEY) ?
-      'toggle' : $.extend({}, $(target).data(), $(this).data())
+    let config = $target.data(DATA_KEY) ?
+      'toggle' : $.extend({}, $target.data(), $(this).data())
 
     if (this.tagName === 'A') {
       event.preventDefault()
     }
 
-    let $target = $(target).one(Event.SHOW, (showEvent) => {
+    $target.one(Event.SHOW, (showEvent) => {
       if (showEvent.isDefaultPrevented()) {
         // only register focus restorer if modal will actually get shown
         return
       }
 
       $target.one(Event.HIDDEN, () => {
-        if ($(this).is(':visible')) {
+        if ($target.is(':visible')) {
           this.focus()
         }
       })
     })
 
-    Modal._jQueryInterface.call($(target), config, this)
+    Modal._jQueryInterface.call($target, config, this)
   })
 
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -447,7 +447,7 @@ const Modal = (($) => {
 
     static _jQueryInterface(config, relatedTarget) {
       return this.each(function () {
-        let $this = $(this);
+        let $this = $(this)
         let data    = $this.data(DATA_KEY)
         let _config = $.extend(
           {},
@@ -488,8 +488,8 @@ const Modal = (($) => {
     if (selector) {
       target = $(selector)[0]
     }
-    
-    let $target = $(target);
+
+    let $target = $(target)
 
     let config = $target.data(DATA_KEY) ?
       'toggle' : $.extend({}, $target.data(), $(this).data())


### PR DESCRIPTION
isn't better to cache selectors where possible?

for instance  `$this = $(this)` and `$target = $(target)` instead of calling jQuery every time to wrap the element.

what about `$(this._element)` in the `_showBackdrop` method? wouldn't be good to set `this._$element = $(this._element)` in the Modal constructor?
