### PR TITLE
update click state when hiding so can be shown again by trigger

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -340,6 +340,7 @@ const Tooltip = (($) => {
       }
 
       $(tip).removeClass(ClassName.IN)
+      this._activeTrigger.click = false
 
       if (Util.supportsTransitionEnd() &&
          ($(this.tip).hasClass(ClassName.FADE))) {

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -805,4 +805,20 @@ $(function () {
     })
   })
 
+  QUnit.test('should show on first trigger after hide', function (assert) {
+    assert.expect(3)
+
+    var $el = $('<a href="#" rel="tooltip" title="Test tooltip"/>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip({ trigger: 'click' })
+
+    $el.trigger('click')
+    assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
+
+    $el.bootstrapTooltip('hide')
+    assert.ok($('.tooltip').not('.fade.in'), 'tooltip was faded out')
+
+    $el.trigger('click')
+    assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in again')
+  })
 })


### PR DESCRIPTION
fixes #16732 by applying [@markbao's suggestion](https://github.com/twbs/bootstrap/issues/16732#issuecomment-232138662) when the tooltip is hidden. addresses issue demonstrated here https://jsbin.com/bapohu/edit?html,js,output. I couldn't reproduce the other 2 scenarios with v4 outlined in #16732 
