### PR TITLE
adds a .custom-select-lg and makes .custom-select-sm use proper vars

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -184,14 +184,19 @@
 }
 
 .custom-select-sm {
-  padding-top: $custom-select-padding-y;
-  padding-bottom: $custom-select-padding-y;
+  padding-top: $custom-select-sm-padding-y;
+  padding-bottom: $custom-select-sm-padding-y;
   font-size: $custom-select-sm-font-size;
 
   // &:not([multiple]) {
   //   height: 26px;
   //   min-height: 26px;
   // }
+}
+.custom-select-lg {
+  padding-top: $custom-select-lg-padding-y;
+  padding-bottom: $custom-select-lg-padding-y;
+  font-size: $custom-select-lg-font-size;
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -401,6 +401,8 @@ $custom-select-focus-box-shadow:   inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 5px 
 
 $custom-select-sm-padding-y: .2rem !default;
 $custom-select-sm-font-size: 75% !default;
+$custom-select-lg-padding-y: .5rem !default;
+$custom-select-lg-font-size: 125% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;


### PR DESCRIPTION
This PR does two things.
1. Adds a `.custom-select-lg` and corresponding variables to Resolve #20316 
2. Makes the pre-existing `.custom-select-sm` class use the pre-existing `$custom-select-sm-padding-y` and `$custom-select-sm-font-size` which were added to the `_variables.scss` in https://github.com/twbs/bootstrap/commit/6b318ef176f894ed1ed8f81dd892319701ff0dcf#diff-d8ee409a461718bfb6240710c8c73382R373 but never referenced anywhere.
