### PR TITLE
Use .attr() instead of .prop() to get attribute

### DIFF
--- a/js/button.js
+++ b/js/button.js
@@ -55,11 +55,11 @@
 
     if ($parent.length) {
       var $input = this.$element.find('input')
-      if ($input.prop('type') == 'radio') {
+      if ($input.attr('type') == 'radio') {
         if ($input.prop('checked')) changed = false
         $parent.find('.active').removeClass('active')
         this.$element.addClass('active')
-      } else if ($input.prop('type') == 'checkbox') {
+      } else if ($input.attr('type') == 'checkbox') {
         if (($input.prop('checked')) !== this.$element.hasClass('active')) changed = false
         this.$element.toggleClass('active')
       }


### PR DESCRIPTION
Quotes from [jQuery API Docs](http://api.jquery.com/attr/):

> To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the [.prop()](http://api.jquery.com/prop/) method.
> 
> As of jQuery 1.6, the [.prop()](http://api.jquery.com/prop/) method provides a way to explicitly retrieve property values, while [.attr()](http://api.jquery.com/attr/) retrieves attributes.
> 
> For example, `selectedIndex`, `tagName`, `nodeName`, `nodeType`, `ownerDocument`, `defaultChecked`, and `defaultSelected` should be retrieved and set with the `.prop()` method. Prior to jQuery 1.6, these properties were retrievable with the `.attr()` method, but this was not within the scope of attr. These do not have corresponding attributes and are only properties.

So, I think the `.attr()` method will be better to get the type attribute from the input :D
