### PR TITLE
Popover inside modal

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -304,7 +304,7 @@ const Tooltip = (($) => {
             this._leave(null, this)
           }
 
-          if ($(this.element).parents('.modal').length > 0){
+          if ($(this.element).parents('.modal').length > 0) {
             $(tip).appendTo($(this.element).parents('.modal').get(0))
           }
         }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -303,6 +303,10 @@ const Tooltip = (($) => {
           if (prevHoverState === HoverState.OUT) {
             this._leave(null, this)
           }
+
+          if ($(this.element).parents('.modal').length > 0){
+            $(tip).appendTo($(this.element).parents('.modal').get(0))
+          }
         }
 
         if (Util.supportsTransitionEnd() && $(this.tip).hasClass(ClassName.FADE)) {


### PR DESCRIPTION
This fix allows popovers inside modals to be hidden when a modal is dismissed. This resolves #20093.
