### PR TITLE
V4: Add old .hidden-* classes to visibility utilities

### DIFF
--- a/scss/utilities/_visibility.scss
+++ b/scss/utilities/_visibility.scss
@@ -11,6 +11,11 @@
 // Responsive visibility utilities
 
 @each $bp in map-keys($grid-breakpoints) {
+  .hidden-#{$bp} {
+    @include media-breakpoint-only($bp) {
+      display: none !important;
+    }
+  }
   .hidden-#{$bp}-up {
     @include media-breakpoint-up($bp) {
       display: none !important;


### PR DESCRIPTION
For better and simpler hiding an element on one specific breakpoint, adding the old .hidden-\* classes
