### PR TITLE
Prevents overflow visible on <select multiple>

### DIFF
--- a/scss/_normalize.scss
+++ b/scss/_normalize.scss
@@ -274,7 +274,7 @@ optgroup {
 
 button,
 input, // 1
-select { // 2
+select:not([multiple]) { // 2
   overflow: visible;
 }
 


### PR DESCRIPTION
I had a bug when upgrading from alpha.2 to alpha.3 with a select multiple tag : the options where displayed with forced overflow visible, which renders all options even out of the select tag.
![capture du 2016-08-17 11-16-28](https://cloud.githubusercontent.com/assets/667482/17731338/2531bf30-646d-11e6-8c46-b85736388c3a.png)
