### PR TITLE
Update js docs overview blurb about accessing a plugin instance

### DIFF
--- a/docs/_includes/js/overview.html
+++ b/docs/_includes/js/overview.html
@@ -45,7 +45,7 @@ $('#myModal').modal({ keyboard: false })   // initialized with no keyboard
 $('#myModal').modal('show')                // initializes and invokes show immediately
 {% endhighlight %}
 
-  <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[rel="popover"]').data('bs.popover')</code>.</p>
+  <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[data-toggle="popover"]').data('bs.popover')</code>.</p>
 
   <h4>Default settings</h4>
   <p>You can change the default settings for a plugin by modifying the plugin's <code>Constructor.DEFAULTS</code> object:</p>

--- a/docs/_includes/js/overview.html
+++ b/docs/_includes/js/overview.html
@@ -45,7 +45,7 @@ $('#myModal').modal({ keyboard: false })   // initialized with no keyboard
 $('#myModal').modal('show')                // initializes and invokes show immediately
 {% endhighlight %}
 
-  <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[rel="popover"]').data('popover')</code>.</p>
+  <p>Each plugin also exposes its raw constructor on a <code>Constructor</code> property: <code>$.fn.popover.Constructor</code>. If you'd like to get a particular plugin instance, retrieve it directly from an element: <code>$('[rel="popover"]').data('bs.popover')</code>.</p>
 
   <h4>Default settings</h4>
   <p>You can change the default settings for a plugin by modifying the plugin's <code>Constructor.DEFAULTS</code> object:</p>


### PR DESCRIPTION
The docs haven't been updated to mention you need to use the `bs` data namespace to access a plugin instance on an element. Additionally, it's still mentioning using `[rel="popover"]` instead of `[data-toggle="popover"]`.
