### PR TITLE
remove unnecessary loop

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -174,17 +174,15 @@
   // ==========================
 
   function Plugin(option) {
-    return this.each(function () {
-      var $this   = $(this)
-      var data    = $this.data('bs.carousel')
-      var options = $.extend({}, Carousel.DEFAULTS, $this.data(), typeof option == 'object' && option)
-      var action  = typeof option == 'string' ? option : options.slide
+    var $this   = $(this)
+    var data    = $this.data('bs.carousel')
+    var options = $.extend({}, Carousel.DEFAULTS, $this.data(), typeof option == 'object' && option)
+    var action  = typeof option == 'string' ? option : options.slide
 
-      if (!data) $this.data('bs.carousel', (data = new Carousel(this, options)))
-      if (typeof option == 'number') data.to(option)
-      else if (action) data[action]()
-      else if (options.interval) data.pause().cycle()
-    })
+    if (!data) $this.data('bs.carousel', (data = new Carousel(this, options)))
+    if (typeof option == 'number') data.to(option)
+    else if (action) data[action]()
+    else if (options.interval) data.pause().cycle()
   }
 
   var old = $.fn.carousel


### PR DESCRIPTION
the `each` in Plugin function is unnecessary. the following code had do the job:

```
    $('[data-ride="carousel"]').each(function () {
      var $carousel = $(this)
      Plugin.call($carousel, $carousel.data())
    })
```
