### PR TITLE
package.json main reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",
-  "main": "./dist/js/npm",
+  "main": "./dist/js/bootstrap",
   "repository": {
     "type": "git",
     "url": "https://github.com/twbs/bootstrap.git"


### PR DESCRIPTION
Hi!
It seems to me as if the main module is incorrectly defined as when I install 4.0.0-alpha.2 or 4.0.0-alpha.3 it incorrectly points to dist/js/npm as main entry point and that file does not exist.
