### PR TITLE
Remove unused $variables in grid mixins

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -45,7 +45,7 @@
 
       @for $i from 1 through $columns {
         .col-#{$breakpoint}-#{$i} {
-          @include make-col($i, $columns, $gutter);
+          @include make-col($i, $columns);
         }
       }
 

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -33,7 +33,7 @@
   margin-right: ($gutter / -2);
 }
 
-@mixin make-col-ready($columns: $grid-columns, $gutter: $grid-gutter-width) {
+@mixin make-col-ready($gutter: $grid-gutter-width) {
   position: relative;
   min-height: 1px; // Prevent collapsing
   padding-right: ($gutter / 2);
@@ -47,7 +47,7 @@
   }
 }
 
-@mixin make-col($size, $columns: $grid-columns, $gutter: $grid-gutter-width) {
+@mixin make-col($size, $columns: $grid-columns) {
   @if $enable-flex {
     flex: 0 0 percentage($size / $columns);
     // Add a `max-width` to ensure content within each column does not blow out


### PR DESCRIPTION
As I recently commented on #20413
The variable `$columns` in `make-col-ready()` and `$gutter` in `make-col()`, aren't being used and aren't necessary.
