### PR TITLE
Fixed incorrect instructions: "Press ⌘ to copy"

### DIFF
--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -73,7 +73,7 @@
     })
 
     clipboard.on('error', function (e) {
-      var fallbackMsg = /Mac/i.test(navigator.userAgent) ? 'Press \u2318 to copy' : 'Press Ctrl-C to copy'
+      var fallbackMsg = /Mac/i.test(navigator.userAgent) ? 'Press \u2318C to copy' : 'Press Ctrl-C to copy'
 
       $(e.trigger)
         .attr('title', fallbackMsg)

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -73,8 +73,8 @@
     })
 
     clipboard.on('error', function (e) {
-      const modifierKey = /Mac/i.test(navigator.userAgent) ? '\u2318' : 'Ctrl-';
-      let fallbackMsg = 'Press ' + modifierKey + 'C to copy';
+      const modifierKey = /Mac/i.test(navigator.userAgent) ? '\u2318' : 'Ctrl-'
+      let fallbackMsg = 'Press ' + modifierKey + 'C to copy'
 
       $(e.trigger)
         .attr('title', fallbackMsg)

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -73,7 +73,7 @@
     })
 
     clipboard.on('error', function (e) {
-      var fallbackMsg = /Mac/i.test(navigator.userAgent) ? 'Press \u2318C to copy' : 'Press Ctrl-C to copy'
+      var fallbackMsg = /Mac/i.test(navigator.userAgent) ? 'Press \u2318' + 'C to copy' : 'Press Ctrl-C to copy'
 
       $(e.trigger)
         .attr('title', fallbackMsg)

--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -73,7 +73,8 @@
     })
 
     clipboard.on('error', function (e) {
-      var fallbackMsg = /Mac/i.test(navigator.userAgent) ? 'Press \u2318' + 'C to copy' : 'Press Ctrl-C to copy'
+      const modifierKey = /Mac/i.test(navigator.userAgent) ? '\u2318' : 'Ctrl-';
+      let fallbackMsg = 'Press ' + modifierKey + 'C to copy';
 
       $(e.trigger)
         .attr('title', fallbackMsg)


### PR DESCRIPTION
Changed to "Press ⌘C to copy"
