### PR TITLE
Fix issue select[multiple] overflowing container

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -344,6 +344,7 @@ input[type="checkbox"] {
   textarea.form-control,
   select[multiple].form-control {
     height: auto;
+    overflow: scroll;
   }
   .form-control-static {
     height: @input-height-small;


### PR DESCRIPTION
Added `overflow: scroll` to `select[multiple].form-control` class to fix options overflowing container.

Before

<img width="547" alt="screen shot 2016-08-31 at 10 07 06 pm" src="https://cloud.githubusercontent.com/assets/1802050/18156089/545cc208-6fc8-11e6-936e-b7468321dcff.png">

After

<img width="523" alt="screen shot 2016-08-31 at 10 07 20 pm" src="https://cloud.githubusercontent.com/assets/1802050/18156094/5ca12e18-6fc8-11e6-95a0-0837bacf23ba.png">
