### PR TITLE
Move Travis builds to container-based infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-sudo: required
-dist: trusty
+sudo: false
 language: node_js
 git:
-  depth: 10
+  depth: 1
 node_js:
   - "4"
   - "6"
 before_install:
   # Remove ./node_modules/.bin from PATH so node-which doesn't replace Unix which and cause RVM to barf. See https://github.com/travis-ci/travis-ci/issues/5092
   - export PATH=$(python -c 'from sys import argv;from collections import OrderedDict as od;print(":".join(od((p,None) for p in argv[1].split(":") if p.startswith("/")).keys()))' "$PATH")
-  - rvm install 2.2
-  - rvm use 2.2 --fuzzy
-  - npm install -g npm@3
+  - rvm install 2.3.1
+  - rvm use 2.3.1
+  - export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
   - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""
   - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip validator\]'; export TWBS_DO_VALIDATOR=$?; true
   - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip sauce\]'; export TWBS_DO_SAUCE=$?; true
@@ -22,7 +21,6 @@ install:
   - npm install
 cache:
   directories:
-    - node_modules
     - vendor/bundle
     - "$HOME/google-cloud-sdk"
 env:


### PR DESCRIPTION
Testing fix for #17163. So far this is green on Node v6, but there are issues with `htmllint` needing Java 8 and Node v4 trying to install `fsevents` (a clearly Mac OS X related package.json).
