### PR TITLE
Add transitioncancel to Most Wanted list for Chrome, Safari, Edge

### DIFF
--- a/docs/_data/browser-features.yml
+++ b/docs/_data/browser-features.yml
@@ -30,6 +30,16 @@
 
 -
   browser: >
+    Microsoft Edge
+  summary: >
+    Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
+  upstream_bug: >
+    UserVoice#15939898
+  origin: >
+    Bootstrap#20618
+
+-
+  browser: >
     Firefox
   summary: >
     Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
@@ -62,6 +72,16 @@
   browser: >
     Chrome
   summary: >
+    Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
+  upstream_bug: >
+    Chromium#642487
+  origin: >
+    Chromium#437860
+
+-
+  browser: >
+    Chrome
+  summary: >
     Implement the [`of <selector-list>` clause](http://caniuse.com/#feat=css-nth-child-of) of the `:nth-child()` pseudo-class
   upstream_bug: >
     Chromium#304163
@@ -87,6 +107,16 @@
     Chromium#231752
   origin: >
     Bootstrap#17021
+
+-
+  browser: >
+    Safari
+  summary: >
+    Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
+  upstream_bug: >
+    WebKit#161535
+  origin: >
+    Bootstrap#20618
 
 -
   browser: >


### PR DESCRIPTION
Mozilla's bug is already on the list. Might as well be fair and ask the other browsers for it too:
- https://bugs.chromium.org/p/chromium/issues/detail?id=642487
- https://bugs.webkit.org/show_bug.cgi?id=161535

I would add an Edge UserVoice request, but I don't have any spare votes left there.

CC: @twbs/team for review
