### PR TITLE
v4: Disable important flag on Sass linter

### DIFF
--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -89,7 +89,7 @@ linters:
     enabled: true
 
   ImportantRule:
-    enabled: true
+    enabled: false
 
   ImportPath:
     enabled: true

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -214,7 +214,6 @@
 //
 // Custom override for collapse plugin in navbar.
 
-// scss-lint:disable ImportantRule
 .navbar-toggleable {
   &-xs {
     @include clearfix;
@@ -255,4 +254,3 @@
     }
   }
 }
-// scss-lint:enable ImportantRule

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -1,4 +1,4 @@
-// scss-lint:disable ImportantRule, QualifyingElement
+// scss-lint:disable QualifyingElement
 
 // Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -1,4 +1,4 @@
-// scss-lint:disable ImportantRule, QualifyingElement, DuplicateProperty
+// scss-lint:disable QualifyingElement, DuplicateProperty
 
 // Reboot
 //

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -184,7 +184,6 @@
     }
   }
 
-  // scss-lint:disable ImportantRule
   tr {
     float: left;
 
@@ -194,5 +193,4 @@
       border: $table-border-width solid $table-border-color;
     }
   }
-  // scss-lint:enable ImportantRule
 }

--- a/scss/utilities/_visibility.scss
+++ b/scss/utilities/_visibility.scss
@@ -1,5 +1,3 @@
-// scss-lint:disable ImportantRule
-
 //
 // Visibility utilities
 //


### PR DESCRIPTION
Using it too much on utilities and more.
