### PR TITLE
Fixes #20609

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -65,14 +65,22 @@
   border-color: $color;
 
   @include hover {
-    color: #fff;
+    @if (lightness($color) > 50) {
+      color: #fff;
+    }@else{
+      color: $body-color;
+    }
     background-color: $color;
         border-color: $color;
   }
 
   &:focus,
   &.focus {
-    color: #fff;
+    @if (lightness($color) > 50) {
+      color: #fff;
+    }@else{
+      color: $body-color;
+    }
     background-color: $color;
         border-color: $color;
   }
@@ -80,14 +88,22 @@
   &:active,
   &.active,
   .open > &.dropdown-toggle {
-    color: #fff;
+    @if (lightness($color) > 50) {
+      color: #fff;
+    }@else{
+      color: $body-color;
+    }
     background-color: $color;
         border-color: $color;
 
     &:hover,
     &:focus,
     &.focus {
+      @if (lightness($color) > 50) {
       color: #fff;
+    }@else{
+      color: $body-color;
+    }
       background-color: darken($color, 17%);
           border-color: darken($color, 25%);
     }


### PR DESCRIPTION
The hover/active color is defaulted to white. If the user adds a lightly coloured button (such as yellow), then the white text gets lost. This conditionally checks the color passed to return either white, or the $body-color. Fixes #20609
