### PR TITLE
Use multi-selector to remove the same event handler

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -188,10 +188,7 @@ const Modal = (($) => {
     dispose() {
       $.removeData(this._element, DATA_KEY)
 
-      $(window).off(EVENT_KEY)
-      $(document).off(EVENT_KEY)
-      $(this._element).off(EVENT_KEY)
-      $(this._backdrop).off(EVENT_KEY)
+      $(window, document, this._element, this._backdrop).off(EVENT_KEY)
 
       this._config              = null
       this._element             = null


### PR DESCRIPTION
Use [multiple selector](https://api.jquery.com/multiple-selector/) instead of remove the same event handler multiple times.
