### PR TITLE
Allow defining navbar font and color

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -6,6 +6,9 @@
 .navbar {
   position: relative;
   padding: $navbar-padding-y $navbar-padding-x;
+  font-family: $navbar-font-family;
+  font-weight: $navbar-font-weight;
+
   @include clearfix;
 
   @include media-breakpoint-up(sm) {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -174,7 +174,7 @@
   }
 
   .navbar-divider {
-    background-color: rgba(0,0,0,.075);
+    background-color: $navbar-light-bg;
   }
 }
 
@@ -208,7 +208,7 @@
   }
 
   .navbar-divider {
-    background-color: rgba(255,255,255,.075);
+    background-color: $navbar-dark-bg;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -478,6 +478,8 @@ $zindex-modal:             1050 !default;
 
 // Navbar
 
+$navbar-font-family:                inherit !default;
+$navbar-font-weight:                inherit !default;
 $navbar-border-radius:              $border-radius !default;
 $navbar-padding-x:                  $spacer !default;
 $navbar-padding-y:                  ($spacer / 2) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -485,11 +485,13 @@ $navbar-padding-x:                  $spacer !default;
 $navbar-padding-y:                  ($spacer / 2) !default;
 $navbar-brand-padding-y:            .25rem !default;
 
+$navbar-dark-bg:                    rgba(255,255,255,.075) !default;
 $navbar-dark-color:                 rgba(255,255,255,.5) !default;
 $navbar-dark-hover-color:           rgba(255,255,255,.75) !default;
 $navbar-dark-active-color:          rgba(255,255,255,1) !default;
 $navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
 
+$navbar-light-bg:                   rgba(0,0,0,.075) !default;
 $navbar-light-color:                rgba(0,0,0,.3) !default;
 $navbar-light-hover-color:          rgba(0,0,0,.6) !default;
 $navbar-light-active-color:         rgba(0,0,0,.8) !default;


### PR DESCRIPTION
This is helpful for people customizing their Bootstrap stylesheets.

I ran into this usecase while making a Solarized colorscheme for
Bootstrap.
