### PR TITLE
Fixes 20614

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -70,7 +70,7 @@
 .card-header {
   @include clearfix;
   padding: $card-spacer-y $card-spacer-x;
-  background-color: $card-cap-bg;
+  background-color: darken($card-bg, $card-cap-bg-percent);
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
@@ -81,7 +81,7 @@
 .card-footer {
   @include clearfix;
   padding: $card-spacer-y $card-spacer-x;
-  background-color: $card-cap-bg;
+  background-color: darken($card-bg, $card-cap-bg-percent);
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -582,7 +582,7 @@ $card-border-width:        1px !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba(0,0,0,.125) !default;
 $card-border-radius-inner: $card-border-radius !default;
-$card-cap-bg:              #f5f5f5 !default;
+$card-cap-bg-percent:      4% !default;
 $card-bg:                  #fff !default;
 
 $card-link-hover-color:    #fff !default;

--- a/scss/mixins/_cards.scss
+++ b/scss/mixins/_cards.scss
@@ -6,7 +6,7 @@
 
   .card-header,
   .card-footer {
-    background-color: transparent;
+    background-color: darken($background, $card-cap-bg-percent);
   }
 }
 


### PR DESCRIPTION
Standard card headers/footers are 4% darker than the body. This PR
mimics that % to the background variants to add consistency. This
resolves #20614
