### PR TITLE
Remove classes at one time

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -353,15 +353,10 @@ const Carousel = (($) => {
         $(activeElement)
           .one(Util.TRANSITION_END, () => {
             $(nextElement)
-              .removeClass(directionalClassName)
-              .removeClass(direction)
+              .removeClass(directionalClassName + ' ' + direction)
+              .addClass(ClassName.ACTIVE)
 
-            $(nextElement).addClass(ClassName.ACTIVE)
-
-            $(activeElement)
-              .removeClass(ClassName.ACTIVE)
-              .removeClass(direction)
-              .removeClass(directionalClassName)
+            $(activeElement).removeClass(ClassName.ACTIVE + ' ' + direction + ' ' + directionalClassName)
 
             this._isSliding = false
 

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -353,10 +353,10 @@ const Carousel = (($) => {
         $(activeElement)
           .one(Util.TRANSITION_END, () => {
             $(nextElement)
-              .removeClass(directionalClassName + ' ' + direction)
+              .removeClass(`${directionalClassName} ${direction}`)
               .addClass(ClassName.ACTIVE)
 
-            $(activeElement).removeClass(ClassName.ACTIVE + ' ' + direction + ' ' + directionalClassName)
+            $(activeElement).removeClass(`${ClassName.ACTIVE} ${direction} ${directionalClassName}`)
 
             this._isSliding = false
 

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -119,9 +119,7 @@ const Popover = (($) => {
       this.setElementContent($tip.find(Selector.TITLE), this.getTitle())
       this.setElementContent($tip.find(Selector.CONTENT), this._getContent())
 
-      $tip
-        .removeClass(ClassName.FADE)
-        .removeClass(ClassName.IN)
+      $tip.removeClass(`${ClassName.FADE} ${ClassName.IN}`)
 
       this.cleanupTether()
     }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -371,9 +371,7 @@ const Tooltip = (($) => {
 
       this.setElementContent($tip.find(Selector.TOOLTIP_INNER), this.getTitle())
 
-      $tip
-        .removeClass(ClassName.FADE)
-        .removeClass(ClassName.IN)
+      $tip.removeClass(`${ClassName.FADE} ${ClassName.IN}`)
 
       this.cleanupTether()
     }


### PR DESCRIPTION
Based on [jQuery API Document](https://api.jquery.com/removeclass/), we can remove multiple classes at one time by using space-separated classes.
