### PR TITLE
Update Bower URL (HTTP to HTTPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Several quick start options are available:
 - Install with [npm](https://www.npmjs.com): `npm install bootstrap@4.0.0-alpha.4`
 - Install with [Meteor](https://www.meteor.com): `meteor add twbs:bootstrap@=4.0.0-alpha.4`
 - Install with [Composer](https://getcomposer.org): `composer require twbs/bootstrap`
-- Install with [Bower](http://bower.io): `bower install bootstrap#v4.0.0-alpha.4`
+- Install with [Bower](https://bower.io): `bower install bootstrap#v4.0.0-alpha.4`
 - Install with [NuGet](https://www.nuget.org): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).
 
 Read the [Getting started page](http://getbootstrap.com/getting-started/) for information on the framework contents, templates and examples, and more.


### PR DESCRIPTION
Bower homepage is available in [HTTPS](https://bower.io/).
