### PR TITLE
Fix cards cut of when in columns

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -314,6 +314,7 @@
     column-gap: $card-columns-sm-up-column-gap;
 
     .card {
+      display: inline-block;
       width: 100%; // Don't let them exceed the column width
     }
   }


### PR DESCRIPTION
This changes the cards to use `display: inline-block` when in columns to stop them
wrapping when in columns and therefore stopping them getting cut off.

<img width="865" alt="screen shot 2016-09-07 at 09 43 40" src="https://cloud.githubusercontent.com/assets/741068/18305459/9b81e37c-74df-11e6-9ddf-4ed085ed4847.png">

Fixes #20654
