### PR TITLE
v4: Fix card columns

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -314,6 +314,7 @@
     column-gap: $card-columns-sm-up-column-gap;
 
     .card {
+      display: inline-block; // Don't let them vertically span multiple columns
       width: 100%; // Don't let them exceed the column width
     }
   }


### PR DESCRIPTION
Fixes #20654 by reverting #20447. Cards must be `inline-block` in columns, otherwise they can get split across columns.
