### PR TITLE
v4: Fix card variables

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -581,7 +581,7 @@ $card-spacer-y:            .75rem !default;
 $card-border-width:        1px !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba(0,0,0,.125) !default;
-$card-border-radius-inner: calc($card-border-radius - 1px) !default;
+$card-border-radius-inner: calc(#{$card-border-radius} - #{$card-border-width}) !default;
 $card-cap-bg:              #f5f5f5 !default;
 $card-bg:                  #fff !default;
 


### PR DESCRIPTION
I didn't interpolate the card variables when I changed this in #20667, so this addresses that. Without this, Sass compiled the variable names as literal strings instead of the variable values.
