### PR TITLE
v4: Compile flex, grid, and Reboot dist stylesheets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -385,7 +385,7 @@ module.exports = function (grunt) {
     require('./grunt/bs-sass-compile/' + sassCompilerName + '.js')(grunt);
   })(process.env.TWBS_SASS || 'libsass');
   // grunt.registerTask('sass-compile', ['sass:core', 'sass:extras', 'sass:docs']);
-  grunt.registerTask('sass-compile', ['sass:core', 'sass:docs']);
+  grunt.registerTask('sass-compile', ['sass:core', 'sass:extras', 'sass:docs']);
 
   grunt.registerTask('dist-css', ['sass-compile', 'exec:postcss', 'cssmin:core', 'cssmin:docs']);
 


### PR DESCRIPTION
Fixes #18292.

While the lines changed here is super small, this adds a significant amount of CSS to our code base. We're essentially doubling the amount of compiled CSS (default and flex), and then some (grid and reboot only options).

<img width="837" alt="screen shot 2016-09-08 at 9 33 07 pm" src="https://cloud.githubusercontent.com/assets/98681/18375538/18c90b80-760c-11e6-81e0-04032e970bf2.png">

I don't think that's a huge issue, but I do want to call it out. Anyone have any strong opinions?

/cc @twbs/team
