### PR TITLE
Fix #20548

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -16,7 +16,7 @@
 //    md
 @function breakpoint-next($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
   $n: index($breakpoint-names, $name);
-  @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
+  @return if($n, if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null), null);
 }
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.


### PR DESCRIPTION
Fixes #20548 
Add a null check in breakpoint-next.
As a result, the content of `@include media-breakpoint-down(XX)` or `@include media-breakpoint-up(XX)` will be generated only if the breakpoint exist in `$grid-breakpoints`.
