### PR TITLE
Add .tag-outline-* classes

### DIFF
--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -32,6 +32,19 @@ Add any of the below mentioned modifier classes to change the appearance of a ta
 <span class="tag tag-danger">Danger</span>
 {% endexample %}
 
+## Outline tags
+
+Match the `.btn-outline-*` classes with the `.tag-outline-*` variations to remove all background images and colors on any tag.
+
+{% example html %}
+<span class="tag tag-outline-default">Default</span>
+<span class="tag tag-outline-primary">Primary</span>
+<span class="tag tag-outline-success">Success</span>
+<span class="tag tag-outline-info">Info</span>
+<span class="tag tag-outline-warning">Warning</span>
+<span class="tag tag-outline-danger">Danger</span>
+{% endexample %}
+
 {% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
 {{ callout-include | markdownify }}
 

--- a/scss/_tags.scss
+++ b/scss/_tags.scss
@@ -75,3 +75,24 @@ a.tag {
 .tag-danger {
   @include tag-variant($tag-danger-bg);
 }
+
+// Outline variations (change color and border to $color and background to none/transparent)
+
+.tag-outline-default {
+  @include tag-outline-variant($tag-default-bg);
+}
+.tag-outline-primary {
+  @include tag-outline-variant($tag-primary-bg);
+}
+.tag-outline-info {
+  @include tag-outline-variant($tag-info-bg);
+}
+.tag-outline-success {
+  @include tag-outline-variant($tag-success-bg);
+}
+.tag-outline-warning {
+  @include tag-outline-variant($tag-warning-bg);
+}
+.tag-outline-danger {
+  @include tag-outline-variant($tag-danger-bg);
+}

--- a/scss/mixins/_tag.scss
+++ b/scss/mixins/_tag.scss
@@ -9,3 +9,17 @@
     }
   }
 }
+
+@mixin tag-outline-variant($color) {
+  background-image: none;
+  background-color: transparent;
+  border-color: $color;
+  color: $color;
+
+  &[href] {
+    @include hover-focus {
+      color: #fff;
+      background-color: $color;
+    }
+  }
+}

--- a/scss/mixins/_tag.scss
+++ b/scss/mixins/_tag.scss
@@ -14,6 +14,8 @@
   background-image: none;
   background-color: transparent;
   border-color: $color;
+  border-style: solid;
+  border-width: 1px;
   color: $color;
 
   &[href] {


### PR DESCRIPTION
This is a very simple PR - just emulating the button outline classes with labels.  My team is using the `.btn-outline-*` for buttons as well as just simply displaying data which is semantically strange to me.  It will allow for style matching when sites are using the buttons with outlines.

<img width="366" alt="screen shot 2016-09-09 at 3 09 57 pm" src="https://cloud.githubusercontent.com/assets/4600728/18399562/8d06a7b2-769f-11e6-9d79-9f02da9fac90.png">
