### PR TITLE
v4: Move Reboot's input border-radius override to .form-control

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -18,8 +18,16 @@
   background-image: none;
   background-clip: padding-box;
   border: $input-btn-border-width solid $input-border-color;
+
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
-  @include border-radius($input-border-radius);
+  @if $enable-rounded {
+    // Manually use the if/else instead of the mixin to account for iOS override
+    border-radius: $input-border-radius;
+  } @else {
+    // Otherwise undo the iOS default
+    border-radius: 0;
+  }
+
   @include box-shadow($input-box-shadow);
   @include transition(border-color ease-in-out .15s, box-shadow ease-in-out .15s);
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -318,8 +318,6 @@ textarea {
   // properly inherited. However, `line-height` isn't addressed there. Using this
   // ensures we don't need to unnecessarily redeclare the global font stack.
   line-height: inherit;
-  // iOS adds rounded borders by default
-  border-radius: 0;
 }
 
 input[type="radio"],


### PR DESCRIPTION
Addresses #20247, but without the super specific selector. Still need to verify the bug and fix.
