### PR TITLE
v4: Update tooltip placement docs

### DIFF
--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -186,7 +186,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>string | function</td>
         <td>'top'</td>
         <td>
-          <p>How to position the tooltip - top | bottom | left | right | auto.<br>When "auto" is specified, it will dynamically reorient the tooltip. For example, if placement is "auto left", the tooltip will display to the left when possible, otherwise it will display right.</p>
+          <p>How to position the tooltip - top | bottom | left | right.</p>
           <p>When a function is used to determine the placement, it is called with the tooltip DOM node as its first argument and the triggering element DOM node as its second. The <code>this</code> context is set to the tooltip instance.</p>
         </td>
       </tr>

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -174,6 +174,10 @@ Dropped entirely for the new card component.
 - `.panel-warning` to `.card-warning` and `.card-inverse` (or use `.bg-warning` on `.card-header`)
 - `.panel-danger` to `.card-danger` and `.card-inverse` (or use `.bg-danger` on `.card-header`)
 
+### Tooltips
+
+- Removed support for `auto` placement options.
+
 ### Carousel
 
 - Renamed `.item` to `.carousel-item`.


### PR DESCRIPTION
Removes mention of `auto` as a valid option and adds a note to the migration docs.

Fixes #19796.
