### PR TITLE
v4: Dropdown units 

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -140,8 +140,8 @@
 // Dropdown section headers
 .dropdown-header {
   display: block;
-  margin-bottom: 0; // for use with heading elements
   padding: $dropdown-padding-y $dropdown-item-padding-x;
+  margin-bottom: 0; // for use with heading elements
   font-size: $font-size-sm;
   color: $dropdown-header-color;
   white-space: nowrap; // as with > li > a

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -140,6 +140,7 @@
 // Dropdown section headers
 .dropdown-header {
   display: block;
+  margin-bottom: 0; // for use with heading elements
   padding: $dropdown-padding-y $dropdown-item-padding-x;
   font-size: $font-size-sm;
   color: $dropdown-header-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -437,14 +437,14 @@ $form-icon-danger: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www
 //
 // Dropdown menu container and contents.
 
-$dropdown-min-width:             160px !default;
-$dropdown-padding-y:             5px !default;
-$dropdown-margin-top:            2px !default;
+$dropdown-min-width:             10rem !default;
+$dropdown-padding-y:             .5rem !default;
+$dropdown-margin-top:            .125rem !default;
 $dropdown-bg:                    #fff !default;
 $dropdown-border-color:          rgba(0,0,0,.15) !default;
 $dropdown-border-width:          $border-width !default;
 $dropdown-divider-bg:            #e5e5e5 !default;
-$dropdown-box-shadow:            0 6px 12px rgba(0,0,0,.175) !default;
+$dropdown-box-shadow:            0 .5rem 1rem rgba(0,0,0,.175) !default;
 
 $dropdown-link-color:            $gray-dark !default;
 $dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
@@ -455,7 +455,7 @@ $dropdown-link-active-bg:        $component-active-bg !default;
 
 $dropdown-link-disabled-color:   $gray-light !default;
 
-$dropdown-item-padding-x:        20px !default;
+$dropdown-item-padding-x:        1.5rem !default;
 
 $dropdown-header-color:          $gray-light !default;
 


### PR DESCRIPTION
Fixes #19784. Move from pixels to rems, add a `margin-bottom: 0;` to keep things aligned.
