### PR TITLE
Add container to tooltip options

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -47,7 +47,8 @@ const Tooltip = (($) => {
     selector    : false,
     placement   : 'top',
     offset      : '0 0',
-    constraints : []
+    constraints : [],
+    container   : false
   }
 
   const DefaultType = {
@@ -60,7 +61,8 @@ const Tooltip = (($) => {
     selector    : '(string|boolean)',
     placement   : '(string|function)',
     offset      : 'string',
-    constraints : 'array'
+    constraints : 'array',
+    container   : '(string|boolean)'
   }
 
   const AttachmentMap = {
@@ -272,9 +274,11 @@ const Tooltip = (($) => {
 
         let attachment = this._getAttachment(placement)
 
+        let container = (this.config.container === false) ? document.body : $(this.config.container)
+
         $(tip)
           .data(this.constructor.DATA_KEY, this)
-          .appendTo(document.body)
+          .appendTo(container)
 
         $(this.element).trigger(this.constructor.Event.INSERTED)
 


### PR DESCRIPTION
Fixes #17755 by adding the already documented `container` option for tooltips and popovers.
