### PR TITLE
jspm updates package information

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "LICENSE"
   ],
   "jspm": {
-    "main": "js/bootstrap",
+    "main": "dist/js/bootstrap",
     "shim": {
       "js/bootstrap": {
         "deps": "jquery",
@@ -81,9 +81,9 @@
       }
     },
     "files": [
-      "css",
-      "fonts",
-      "js"
+      "dist/css",
+      "dist/fonts",
+      "dist/js"
     ]
   }
 }


### PR DESCRIPTION
Doing a  `jspm install npm:bootstrap` did not give back the dist-folder. so no css is included, and no bootstrap.js (only source js files)
