### PR TITLE
Remove hard-coded value in button-outline-variant

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -58,21 +58,21 @@
   }
 }
 
-@mixin button-outline-variant($color) {
+@mixin button-outline-variant($color, $color-hover: #fff) {
   color: $color;
   background-image: none;
   background-color: transparent;
   border-color: $color;
 
   @include hover {
-    color: #fff;
+    color: $color-hover;
     background-color: $color;
         border-color: $color;
   }
 
   &:focus,
   &.focus {
-    color: #fff;
+    color: $color-hover;
     background-color: $color;
         border-color: $color;
   }
@@ -80,14 +80,14 @@
   &:active,
   &.active,
   .open > &.dropdown-toggle {
-    color: #fff;
+    color: $color-hover;
     background-color: $color;
         border-color: $color;
 
     &:hover,
     &:focus,
     &.focus {
-      color: #fff;
+      color: $color-hover;
       background-color: darken($color, 17%);
           border-color: darken($color, 25%);
     }


### PR DESCRIPTION
Fixes #20609

PR #20641, another solution to this issue, hard-codes use of $body-color, which may not be the desired color for the text when hovering.
### Before

![before](https://cloud.githubusercontent.com/assets/28444/18599908/98e4774c-7c0f-11e6-9c49-c42cecdae63f.gif)

```
+button-outline-variant(white)
```
### After

![after](https://cloud.githubusercontent.com/assets/28444/18599946/c1614f9c-7c0f-11e6-9baa-374f7ddc6188.gif)

```
+button-outline-variant(white, $color-brand-teal)
```
