### PR TITLE
Fix #20566

### DIFF
--- a/scss/_animation.scss
+++ b/scss/_animation.scss
@@ -9,12 +9,21 @@
 
 .collapse {
   display: none;
-
   &.in {
     display: block;
   }
-  // tr&.in    { display: table-row; }
-  // tbody&.in { display: table-row-group; }
+}
+
+tr {
+  &.collapse.in {
+    display: table-row;
+  }
+}
+
+tbody {
+  &.collapse.in {
+    display: table-row-group;
+  }
 }
 
 .collapsing {


### PR DESCRIPTION
The tr and trbody tags were commented out within the .collapse class. Additionally, when uncommented, they generated incorrect css when compiled. Restructed. Fixes #20566 
