### PR TITLE
Add Gitter badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Bootstrap](http://getbootstrap.com)
 
 [![Slack](https://bootstrap-slack.herokuapp.com/badge.svg)](https://bootstrap-slack.herokuapp.com)
+[![Gitter](https://badges.gitter.im/twbs/bootstrap.svg)](https://gitter.im/twbs/bootstrap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 ![Bower version](https://img.shields.io/bower/v/bootstrap.svg)
 [![npm version](https://img.shields.io/npm/v/bootstrap.svg)](https://www.npmjs.com/package/bootstrap)
 [![Gem version](https://img.shields.io/gem/v/bootstrap.svg)](https://rubygems.org/gems/bootstrap)


### PR DESCRIPTION
I've noticed [a Gitter room](https://gitter.im/twbs/bootstrap) has been made for twbs/bootstrap, too. An useful service which doesn't require anything other than GitHub account surely deserves its place in badges.

Should it be added in community section of README, too? I can amend it to the commit if needed.

—
p.s. @mdo or @cvrebert I have some issue with logging on Slack, please reach me out so I  can solve it
