### PR TITLE
Fix Collapse JS class not respecting the configured parent element

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -121,7 +121,7 @@ const Collapse = (($) => {
       let activesData
 
       if (this._parent) {
-        actives = $.makeArray($(Selector.ACTIVES))
+        actives = $.makeArray($(this._parent).find(Selector.ACTIVES))
         if (!actives.length) {
           actives = null
         }


### PR DESCRIPTION
- Collapse will now find any active panels within the configured parent element using jQuery find
