### PR TITLE
Remove -webkit-overflow-scrolling:touch; due to an iOS Safari bug

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -22,7 +22,9 @@
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;
-  -webkit-overflow-scrolling: touch;
+  // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
+  // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
+  // See also https://github.com/twbs/bootstrap/issues/17695
 
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {


### PR DESCRIPTION
Fixes #17695.
Refs https://bugs.webkit.org/show_bug.cgi?id=158342
CC: @twbs/team for review
