### PR TITLE
Fixed progress bar color variables

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -132,14 +132,14 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
 //
 
 .progress-success {
-  @include progress-variant($progress-bar-success-bg);
+  @include progress-variant($progress-bar-success-color);
 }
 .progress-info {
-  @include progress-variant($progress-bar-info-bg);
+  @include progress-variant($progress-bar-info-color);
 }
 .progress-warning {
-  @include progress-variant($progress-bar-warning-bg);
+  @include progress-variant($progress-bar-warning-color);
 }
 .progress-danger {
-  @include progress-variant($progress-bar-danger-bg);
+  @include progress-variant($progress-bar-danger-color);
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -712,15 +712,14 @@ $alert-danger-border:         $state-danger-border !default;
 // Progress bars
 
 $progress-bg:                 #eee !default;
-$progress-bar-color:          #0074d9 !default;
 $progress-border-radius:      $border-radius !default;
 $progress-box-shadow:         inset 0 .1rem .1rem rgba(0,0,0,.1) !default;
 
-$progress-bar-bg:             $brand-primary !default;
-$progress-bar-success-bg:     $brand-success !default;
-$progress-bar-warning-bg:     $brand-warning !default;
-$progress-bar-danger-bg:      $brand-danger !default;
-$progress-bar-info-bg:        $brand-info !default;
+$progress-bar-color:             $brand-primary !default;
+$progress-bar-success-color:     $brand-success !default;
+$progress-bar-warning-color:     $brand-warning !default;
+$progress-bar-danger-color:      $brand-danger !default;
+$progress-bar-info-color:        $brand-info !default;
 
 
 // List group


### PR DESCRIPTION
I think there are two issues with the current implementation of the progress bar:
- the global `$brand-primary` color doesn't effect the color of the default progress bar (it's color is still the default blue)
- the naming of the color variables for the progress bar is confusing, because their names end on '-bg' (for example `$progress-bar-success-bg`) although they change the (foreground) color of the progress bar
