### PR TITLE
Update print styles borrowed from h5bp

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -14,7 +14,10 @@
     *::before,
     *::after,
     *::first-letter,
-    *::first-line {
+    p::first-line,
+    div::first-line,
+    blockquote::first-line,
+    li::first-line {
       // Bootstrap specific; comment out `color` and `background`
       //color: #000 !important; // Black prints faster:
                                 //   http://www.sanbeiji.com/archives/953
@@ -24,7 +27,7 @@
     }
 
     a,
-    a:visited {
+    a::visited {
       text-decoration: underline;
     }
 
@@ -44,10 +47,13 @@
     //
 
     //a[href^="#"]::after,
-    //a[href^="javascript:"]::after {
-    //  content: "";
+    //a[href^="javascript:"]:after {
+    //    content: "";
     //}
 
+    pre {
+      white-space: pre-wrap !important;
+    }
     pre,
     blockquote {
       border: $border-width solid #999;   // Bootstrap custom code; using `$border-width` instead of 1px


### PR DESCRIPTION
Fixes #20814 - print/print preview crash in IE11 (caused by `*:first-line`
selector)
