### PR TITLE
Prevent margin-bottom on vertical button groups

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -164,6 +164,7 @@
     float: none;
     width: 100%;
     max-width: 100%;
+    margin-bottom: 0;
   }
 
   // Clear floats so dropdown menus can be properly placed


### PR DESCRIPTION
This will override the margin-bottom on labels when they're in a vertical button group.

Fixes #20298
