### PR TITLE
Remove the margin-bottom from <label>s in .btn-groups

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -10,6 +10,7 @@
   > .btn {
     position: relative;
     float: left;
+    margin-bottom: 0;
 
     // Bring the "active" button to the front
     &:focus,


### PR DESCRIPTION
- Fixes #20298 for vertical button group spacing
- Fixes #20784 for horizontal (default) button group spacing
- Alternate fix to #20823 which only applied a fix for vertical button groups
