### PR TITLE
v4: Grid adjustments

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -64,11 +64,11 @@ See how aspects of the Bootstrap grid system work across multiple devices with a
         <th></th>
         <th class="text-xs-center">
           Extra small<br>
-          <small>&lt;544px</small>
+          <small>&lt;576px</small>
         </th>
         <th class="text-xs-center">
           Small<br>
-          <small>&ge;544px</small>
+          <small>&ge;576px</small>
         </th>
         <th class="text-xs-center">
           Medium<br>
@@ -93,9 +93,9 @@ See how aspects of the Bootstrap grid system work across multiple devices with a
       <tr>
         <th class="text-nowrap" scope="row">Container width</th>
         <td>None (auto)</td>
-        <td>576px</td>
+        <td>540px</td>
         <td>720px</td>
-        <td>940px</td>
+        <td>960px</td>
         <td>1140px</td>
       </tr>
       <tr>
@@ -154,7 +154,7 @@ $grid-breakpoints: (
   // Extra small screen / phone
   xs: 0,
   // Small screen / phone
-  sm: 544px,
+  sm: 576px,
   // Medium screen / tablet
   md: 768px,
   // Large screen / desktop
@@ -164,9 +164,9 @@ $grid-breakpoints: (
 );
 
 $container-max-widths: (
-  sm: 576px,
+  sm: 540px,
   md: 720px,
-  lg: 940px,
+  lg: 960px,
   xl: 1140px
 );
 {% endhighlight %}
@@ -512,7 +512,7 @@ $grid-breakpoints: (
 $container-max-widths: (
   sm: 420px,
   md: 720px,
-  lg: 940px
+  lg: 960px
 );
 {% endhighlight %}
 

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -112,7 +112,7 @@ See how aspects of the Bootstrap grid system work across multiple devices with a
       </tr>
       <tr>
         <th class="text-nowrap" scope="row">Gutter width</th>
-        <td colspan="5">1.875rem / 30px (15px on each side of a column)</td>
+        <td colspan="5">30px (15px on each side of a column)</td>
       </tr>
       <tr>
         <th class="text-nowrap" scope="row">Nestable</th>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -140,7 +140,7 @@ $grid-breakpoints: (
 $container-max-widths: (
   sm: 540px,
   md: 720px,
-  lg: 940px,
+  lg: 960px,
   xl: 1140px
 ) !default;
 @include _assert-ascending($container-max-widths, "$container-max-widths");

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -125,7 +125,7 @@ $link-hover-decoration: underline !default;
 
 $grid-breakpoints: (
   xs: 0,
-  sm: 544px,
+  sm: 576px,
   md: 768px,
   lg: 992px,
   xl: 1200px
@@ -138,7 +138,7 @@ $grid-breakpoints: (
 // Define the maximum width of `.container` for different screen sizes.
 
 $container-max-widths: (
-  sm: 576px,
+  sm: 540px,
   md: 720px,
   lg: 940px,
   xl: 1140px

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -17,7 +17,8 @@
 @mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
   @each $breakpoint, $container-max-width in $max-widths {
     @include media-breakpoint-up($breakpoint, $breakpoints) {
-      max-width: $container-max-width;
+      width: $container-max-width;
+      max-width: 100%;
     }
   }
 }


### PR DESCRIPTION
Grouping a handful of CSS and docs changes related to the grid:
- **Moves from `max-width` containers to `width`, with a `max-width: 100%`.** This corrects inconsistencies between browsers and default/flexbox grid implementations; previously some containers wouldn't occupy their full `max-width`. Fixes #20681.
- **Changes the values of the `sm` breakpoint and container.** Now the breakpoint is wider than the container (this was a longstanding bug from me, sorry about that :grin:). Fixes #18054.
- **Changes the large grid breakpoint's value from `940px` to `960px`** so that every grid tier, in it's max width, is cleanly divisible by 12. Fixes #18510.
- Update grid docs to match all the above changes.
