### PR TITLE
Drop the $small-font-size variable for the newer $font-size-sm one

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -60,7 +60,7 @@ hr {
 
 small,
 .small {
-  font-size: $small-font-size;
+  font-size: $font-size-sm;
   font-weight: normal;
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -205,8 +205,6 @@ $headings-color:         inherit !default;
 $lead-font-size:   1.25rem !default;
 $lead-font-weight: 300 !default;
 
-$small-font-size: 80% !default;
-
 $text-muted: $gray-light !default;
 
 $abbr-border-color: $gray-light !default;


### PR DESCRIPTION
Originally `$small-font-size` was added in v3 to set the `font-size` of the `<small>` element. Now that we have newer, global type variables, we can use those instead for these kind of things.

Fixes #20859
