### PR TITLE
Ensure input groups behavior appropriately in inline forms

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -330,6 +330,7 @@ select.form-control-lg {
 
     .input-group {
       display: inline-table;
+      width: auto;
       vertical-align: middle;
 
       .input-group-addon,


### PR DESCRIPTION
Overrides the default width: 100% with an auto. Fixes #20752.
