### PR TITLE
Reset the left and right border on list items for flush list groups

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -70,6 +70,8 @@
 
 .list-group-flush {
   .list-group-item {
+    border-right: 0;
+    border-left: 0;
     border-radius: 0;
   }
 }


### PR DESCRIPTION
Avoid the resetting of the already set values in #20397. Fixes #20395.
