### PR TITLE
Match the height of select.form-control with input.form-control

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -66,7 +66,8 @@
 
 select.form-control {
   &:not([size]):not([multiple]) {
-    height: $input-height;
+    $select-border-width: ($border-width * 2);
+    height: calc(#{$input-height} - #{$select-border-width});
   }
 
   &:focus::-ms-value {


### PR DESCRIPTION
Uses a local variable and some calc love to counteract the border-width (times 2) from the height of the select. Fixes #17194 and nullifies #19967.

Demo of the new CSS in effect with inputs, selects, and custom selects for good measure: https://jsbin.com/yitijo/.
