### PR TITLE
Set height on custom select

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -137,6 +137,8 @@
 .custom-select {
   display: inline-block;
   max-width: 100%;
+  $select-border-width: ($border-width * 2);
+  height: calc(#{$input-height} - #{$select-border-width});
   padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
   padding-right: $custom-select-padding-x \9;
   color: $custom-select-color;


### PR DESCRIPTION
Matches the changes from #20874 to the regular select element. This is really only necessary for IE and Edge near as I can tell. Fixes #20810.
