### PR TITLE
Fixed #20897 by changing btn-default to btn-secondary in docs for V4

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -298,7 +298,7 @@ To take advantage of the Bootstrap grid system within a modal, just nest `.conta
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
         <button type="button" class="btn btn-primary">Save changes</button>
       </div>
     </div>


### PR DESCRIPTION
The modal documentation page for V4 was using `btn-default` in the "Using the grid system" example.

I changed it to the new correct class of `btn-secondary`.
