### PR TITLE
Remove borders on the top and/or bottom when .list-group-flush is the first and/or last child

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -74,6 +74,18 @@
     border-left: 0;
     border-radius: 0;
   }
+
+  &:first-child {
+    .list-group-item:first-child {
+      border-top: 0;
+    }
+  }
+
+  &:last-child {
+    .list-group-item:last-child {
+      border-bottom: 0;
+    }
+  }
 }
 
 


### PR DESCRIPTION
Fully fixes #20395

Before: 
![screenshot2](https://cloud.githubusercontent.com/assets/4411333/19413095/a11176e8-92e1-11e6-83d9-eb4bb8decb8b.png)

After: 
![screenshot3](https://cloud.githubusercontent.com/assets/4411333/19413097/a57dbdea-92e1-11e6-806f-183a67d9f10c.png)
