### PR TITLE
Change SauceLabs iPhone test to use Appium.

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -53,9 +53,10 @@
   # Win Opera 15+ not currently supported by Sauce Labs
 
   {
-    browserName: "iphone",
-    platform: "OS X 10.10",
-    version: "latest"
+    browserName: "Safari",
+    deviceName: "iPhone Simulator",
+    platformVersion: "9.3",
+    platformName: "iOS"
   },
 
   # iOS Chrome not currently supported by Sauce Labs


### PR DESCRIPTION
Fixes #20914. I believe this is correct based on the [SauceLabs docs](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Appium-SpecificOptions), but I am unable to test this as any changes to the build system will cause Savage to bail on testing.
