### PR TITLE
Add "text-top" vertical align

### DIFF
--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -5,9 +5,12 @@
 .d-block {
   display: block !important;
 }
+
 .d-inline-block {
   display: inline-block !important;
+  vertical-align: text-top;
 }
+
 .d-inline {
   display: inline !important;
 }


### PR DESCRIPTION
# Issue

Placing two inline-blocked divs next to each other will cause the second div to align in the middle of the first one, resulting in a step-like alignment of divs.
# Reason

The next div in the inline-block'ed elements will inherit the `vertical-align` of the div previous to it, which is usually `middle`. resulting in this step-like alignment.
# Solution

Adding "text-top" to the `.d-inline-block` class will solve this issue, as all divs placed by each other will take from this inline-block.
# Side note

Although this issue is usually avoided by using bootstrap's grid system, sometimes developers need to place two elements next to each other without the grid system (or inside it) hence this will solve a kind of mysterious behavior for most developers.
# Example

http://jsfiddle.net/bLcqLo5L/
