### PR TITLE
Switch to separate vars for alert vertical/horizontal padding

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -3,7 +3,7 @@
 //
 
 .alert {
-  padding: $alert-padding;
+  padding: $alert-padding-y $alert-padding-x;
   margin-bottom: $spacer-y;
   border: $alert-border-width solid transparent;
   @include border-radius($alert-border-radius);
@@ -26,13 +26,13 @@
 // Expand the right padding and account for the close button's positioning.
 
 .alert-dismissible {
-  padding-right: ($alert-padding * 2);
+  padding-right: ($alert-padding-x * 2);
 
   // Adjust close link position
   .close {
     position: relative;
     top: -.125rem;
-    right: -$alert-padding;
+    right: -$alert-padding-x;
     color: inherit;
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -701,7 +701,8 @@ $modal-sm:                    300px !default;
 //
 // Define alert colors, border radius, and padding.
 
-$alert-padding:               1rem !default;
+$alert-padding-x:             1.25rem !default;
+$alert-padding-y:             .75rem !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      bold !default;
 $alert-border-width:          $border-width !default;


### PR DESCRIPTION
`1rem` all around was too much, so this cleans that up and offers more customization to folks. Also happens to fix #20931.
