### PR TITLE
v4 : Making .tooltip('show') throw an error on elements with display:none

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -239,6 +239,9 @@ const Tooltip = (($) => {
     }
 
     show() {
+      if ($(this.element).css('display') === 'none') {
+        throw new Error('Please use show on visible elements')
+      }
       let showEvent = $.Event(this.constructor.Event.SHOW)
 
       if (this.isWithContent() && this._isEnabled) {

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -320,4 +320,16 @@ $(function () {
       .bootstrapPopover('show')
   })
 
+  QUnit.test('should throw an error when show is called on hidden elements', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+
+    try {
+      $('<div data-toggle="popover" data-title="some title" data-content="@Johann-S" style="display: none"/>').bootstrapPopover('show')
+    }
+    catch (err) {
+      assert.strictEqual(err.message, 'Please use show on visible elements')
+      done()
+    }
+  })
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -185,6 +185,19 @@ $(function () {
       .bootstrapTooltip('show')
   })
 
+  QUnit.test('should throw an error when show is called on hidden elements', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+
+    try {
+      $('<div title="tooltip title" style="display: none"/>').bootstrapTooltip('show')
+    }
+    catch (err) {
+      assert.strictEqual(err.message, 'Please use show on visible elements')
+      done()
+    }
+  })
+
   QUnit.test('should fire inserted event', function (assert) {
     assert.expect(2)
     var done = assert.async()


### PR DESCRIPTION
I made this PR for this feature request in https://github.com/twbs/bootstrap/pull/17021 : 

> Consider making .tooltip('show') throw an error when the target is display: none per #14155
