### PR TITLE
Add support for column class which automatically sizes flexbox columns

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -40,6 +40,10 @@
           flex-grow: 1;
           max-width: 100%;
         }
+       .col-#{$breakpoint}-auto {
+          width: auto;
+          flex: 0 0 auto;
+        }
       }
 
       @for $i from 1 through $columns {


### PR DESCRIPTION
Creates classes like `.col-xs-auto`, `.col-sm-auto`, etc.

These allow a column to automatically be sized based on its content at certain viewports, using the same cascade of the rest of the column sizing classes. They're useful for elements that you might want stacked on smaller screens, but normally lay out nicely on a horizontal at larger screens, without the need to be fixed to a specific grid at those sizes.
