### PR TITLE
Container padding uses per-breakpoint gutter sizes, fixes #19304.

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,13 +2,19 @@
 //
 // Generate semantic grid columns with these mixins.
 
-@mixin make-container($gutter: $grid-gutter-width-base) {
+@mixin make-container($gutters: $grid-gutter-widths) {
   margin-left: auto;
   margin-right: auto;
-  padding-left:  ($gutter / 2);
-  padding-right: ($gutter / 2);
   @if not $enable-flex {
     @include clearfix();
+  }
+
+  @each $breakpoint in map-keys($gutters) {
+    @include media-breakpoint-up($breakpoint) {
+      $gutter: map-get($gutters, $breakpoint);
+      padding-right: ($gutter / 2);
+      padding-left:  ($gutter / 2);
+    }
   }
 }
 


### PR DESCRIPTION
Hoping this is what was intended by issue #19304. I'm re-using the per-breakpoint setting for gutters as the padding base for containers.
