### PR TITLE
fix 'all sides' utility class documentation

### DIFF
--- a/docs/utilities/spacing.md
+++ b/docs/utilities/spacing.md
@@ -21,7 +21,7 @@ Where *sides* is one of:
 * `r` - for classes that set `margin-right` or `padding-right`
 * `x` - for classes that set both `*-left` and `*-right`
 * `y` - for classes that set both `*-top` and `*-bottom`
-* `a` - for classes that set a `margin` or `padding` on all 4 sides of the element
+* omit sides value for classes that set a `margin` or `padding` on all 4 sides of the element
 
 Where *size* is one of:
 


### PR DESCRIPTION
if i'm not mistaken, it looks like the new syntax is to omit the `a` value.

ex: `m-1` vs `ma-1`
