### PR TITLE
Body font weight variable

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -72,6 +72,7 @@ body {
   // Make the `body` use the `font-size-root`
   font-family: $font-family-base;
   font-size: $font-size-base;
+  font-weight: $font-weight-base;
   line-height: $line-height-base;
   // Go easy on the eyes and use something other than `#000` for text
   color: $body-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -193,6 +193,8 @@ $font-size-lg:   1.25rem !default;
 $font-size-sm:   .875rem !default;
 $font-size-xs:   .75rem !default;
 
+$font-weight-base: normal !default;
+
 $line-height-base: 1.5 !default;
 
 $font-size-h1: 2.5rem !default;


### PR DESCRIPTION
I’d like to be able to set body font-weight via variable, rather than new css rule.

300 looks really nice with 16px font size and new font-family rule.
