### PR TITLE
Add spacer mixin, refactor utility class generation

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -23,6 +23,7 @@
 @import "mixins/resize";
 @import "mixins/screen-reader";
 @import "mixins/size";
+@import "mixins/spacer";
 @import "mixins/tab-focus";
 @import "mixins/reset-text";
 @import "mixins/text-emphasis";

--- a/scss/mixins/_spacer.scss
+++ b/scss/mixins/_spacer.scss
@@ -1,14 +1,14 @@
-@mixin spacer( $abbrev: 'p', $sides: '', $size: 1, $important: false ) {
+@mixin spacer( $abbrev: "p", $sides: "", $size: 1, $important: false ) {
 
-  @if ( $sides == 'x' ) {
+  @if ( $sides == "x" ) {
 
-    @include spacer( $abbrev, 'r', $size, $important );
-    @include spacer( $abbrev, 'l', $size, $important );
+    @include spacer( $abbrev, "r", $size, $important );
+    @include spacer( $abbrev, "l", $size, $important );
 
-  } @else if ( $sides == 'y' ) {
+  } @else if ( $sides == "y" ) {
 
-    @include spacer( $abbrev, 't', $size, $important );
-    @include spacer( $abbrev, 'b', $size, $important );
+    @include spacer( $abbrev, "t", $size, $important );
+    @include spacer( $abbrev, "b", $size, $important );
 
   } @else {
 
@@ -17,47 +17,47 @@
     $length-x:   map-get( $lengths, x );
     $length-y:   map-get( $lengths, y );
 
-    $prop:      'padding';
+    $prop:      "padding";
 
-    @if ( $abbrev == 'm' ) {
+    @if ( $abbrev == "m" ) {
 
-      $prop: 'margin';
+      $prop: "margin";
 
     }
 
-    $prop-sides: '';
+    $prop-sides: "";
     $length:     $length-y $length-x;
 
     @if ( $length-x == $length-y ) {
       $length: $length-x;
     }
 
-    @if ( $sides == 't' ) {
+    @if ( $sides == "t" ) {
 
-      $prop-sides:  '-top';
+      $prop-sides:  "-top";
       $length:      $length-y;
 
-    } @else if ( $sides == 'r' ) {
+    } @else if ( $sides == "r" ) {
 
-      $prop-sides:  '-right';
+      $prop-sides:  "-right";
       $length:      $length-x;
 
-    } @else if ( $sides == 'b' ) {
+    } @else if ( $sides == "b" ) {
 
-      $prop-sides:  '-bottom';
+      $prop-sides:  "-bottom";
       $length:      $length-y;
 
-    } @else if ( $sides == 'l' ) {
+    } @else if ( $sides == "l" ) {
 
-      $prop-sides:  '-left';
+      $prop-sides:  "-left";
       $length:      $length-x;
 
     }
 
-    $_important: '';
+    $_important: "";
 
     @if ( $important ) {
-      $_important: ' !important';
+      $_important: " !important";
     }
 
     #{$prop}#{$prop-sides}: $length#{$_important};

--- a/scss/mixins/_spacer.scss
+++ b/scss/mixins/_spacer.scss
@@ -1,25 +1,25 @@
-@mixin spacer( $abbrev: "p", $sides: "", $size: 1, $important: false ) {
+@mixin spacer($abbrev: "p", $sides: "", $size: 1, $important: false) {
 
-  @if ( $sides == "x" ) {
+  @if ($sides == "x") {
 
-    @include spacer( $abbrev, "r", $size, $important );
-    @include spacer( $abbrev, "l", $size, $important );
+    @include spacer($abbrev, "r", $size, $important);
+    @include spacer($abbrev, "l", $size, $important);
 
-  } @else if ( $sides == "y" ) {
+  } @else if ($sides == "y") {
 
-    @include spacer( $abbrev, "t", $size, $important );
-    @include spacer( $abbrev, "b", $size, $important );
+    @include spacer($abbrev, "t", $size, $important);
+    @include spacer($abbrev, "b", $size, $important);
 
   } @else {
 
-    $lengths:    map-get( $spacers, $size );
+    $lengths:    map-get($spacers, $size);
 
-    $length-x:   map-get( $lengths, x );
-    $length-y:   map-get( $lengths, y );
+    $length-x:   map-get($lengths, x);
+    $length-y:   map-get($lengths, y);
 
     $prop:      "padding";
 
-    @if ( $abbrev == "m" ) {
+    @if ($abbrev == "m") {
 
       $prop: "margin";
 
@@ -28,26 +28,26 @@
     $prop-sides: "";
     $length:     $length-y $length-x;
 
-    @if ( $length-x == $length-y ) {
+    @if ($length-x == $length-y) {
       $length: $length-x;
     }
 
-    @if ( $sides == "t" ) {
+    @if ($sides == "t") {
 
       $prop-sides:  "-top";
       $length:      $length-y;
 
-    } @else if ( $sides == "r" ) {
+    } @else if ($sides == "r") {
 
       $prop-sides:  "-right";
       $length:      $length-x;
 
-    } @else if ( $sides == "b" ) {
+    } @else if ($sides == "b") {
 
       $prop-sides:  "-bottom";
       $length:      $length-y;
 
-    } @else if ( $sides == "l" ) {
+    } @else if ($sides == "l") {
 
       $prop-sides:  "-left";
       $length:      $length-x;
@@ -56,7 +56,7 @@
 
     $_important: "";
 
-    @if ( $important ) {
+    @if ($important) {
       $_important: " !important";
     }
 

--- a/scss/mixins/_spacer.scss
+++ b/scss/mixins/_spacer.scss
@@ -1,0 +1,67 @@
+@mixin spacer( $abbrev: 'p', $sides: '', $size: 1, $important: false ) {
+
+  @if ( $sides == 'x' ) {
+
+    @include spacer( $abbrev, 'r', $size, $important );
+    @include spacer( $abbrev, 'l', $size, $important );
+
+  } @else if ( $sides == 'y' ) {
+
+    @include spacer( $abbrev, 't', $size, $important );
+    @include spacer( $abbrev, 'b', $size, $important );
+
+  } @else {
+
+    $lengths:    map-get( $spacers, $size );
+
+    $length-x:   map-get( $lengths, x );
+    $length-y:   map-get( $lengths, y );
+
+    $prop:      'padding';
+
+    @if ( $abbrev == 'm' ) {
+
+      $prop: 'margin';
+
+    }
+
+    $prop-sides: '';
+    $length:     $length-y $length-x;
+
+    @if ( $length-x == $length-y ) {
+      $length: $length-x;
+    }
+
+    @if ( $sides == 't' ) {
+
+      $prop-sides:  '-top';
+      $length:      $length-y;
+
+    } @else if ( $sides == 'r' ) {
+
+      $prop-sides:  '-right';
+      $length:      $length-x;
+
+    } @else if ( $sides == 'b' ) {
+
+      $prop-sides:  '-bottom';
+      $length:      $length-y;
+
+    } @else if ( $sides == 'l' ) {
+
+      $prop-sides:  '-left';
+      $length:      $length-x;
+
+    }
+
+    $_important: '';
+
+    @if ( $important ) {
+      $_important: ' !important';
+    }
+
+    #{$prop}#{$prop-sides}: $length#{$_important};
+
+  }
+
+}

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -12,8 +12,8 @@
 
 @each $prop, $abbrev in (margin: m, padding: p) {
   @each $size, $lengths in $spacers {
-    @each $side in ( '', 'x', 'y', 't', 'r', 'b', 'l') {
-      .#{$abbrev}#{$side}-#{$size} { @include spacer( $abbrev, $side, $size, true ); }
+    @each $side in ("", "x", "y", "t", "r", "b", "l") {
+      .#{$abbrev}#{$side}-#{$size} { @include spacer($abbrev, $side, $size, true); }
     }
   }
 }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -12,23 +12,8 @@
 
 @each $prop, $abbrev in (margin: m, padding: p) {
   @each $size, $lengths in $spacers {
-    $length-x:   map-get($lengths, x);
-    $length-y:   map-get($lengths, y);
-
-    .#{$abbrev}-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
-    .#{$abbrev}t-#{$size} { #{$prop}-top:    $length-y !important; }
-    .#{$abbrev}r-#{$size} { #{$prop}-right:  $length-x !important; }
-    .#{$abbrev}b-#{$size} { #{$prop}-bottom: $length-y !important; }
-    .#{$abbrev}l-#{$size} { #{$prop}-left:   $length-x !important; }
-
-    // Axes
-    .#{$abbrev}x-#{$size} {
-      #{$prop}-right:  $length-x !important;
-      #{$prop}-left:   $length-x !important;
-    }
-    .#{$abbrev}y-#{$size} {
-      #{$prop}-top:    $length-y !important;
-      #{$prop}-bottom: $length-y !important;
+    @each $side in ( '', 'x', 'y', 't', 'r', 'b', 'l') {
+      .#{$abbrev}#{$side}-#{$size} { @include spacer( $abbrev, $side, $size, true ); }
     }
   }
 }


### PR DESCRIPTION
I found myself trying to extend the spacing utility classes within media queries. As this is not supported by Sass I decided to write a mixin so you can reuse defined spacers in code.
