### PR TITLE
Rename .in to .active to fix collapse

### DIFF
--- a/scss/_animation.scss
+++ b/scss/_animation.scss
@@ -2,26 +2,26 @@
   opacity: 0;
   transition: opacity .15s linear;
 
-  &.in {
+  &.active {
     opacity: 1;
   }
 }
 
 .collapse {
   display: none;
-  &.in {
+  &.active {
     display: block;
   }
 }
 
 tr {
-  &.collapse.in {
+  &.collapse.active {
     display: table-row;
   }
 }
 
 tbody {
-  &.collapse.in {
+  &.collapse.active {
     display: table-row-group;
   }
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -31,7 +31,7 @@
     transition: transform .3s ease-out;
     transform: translate(0, -25%);
   }
-  &.in .modal-dialog { transform: translate(0, 0); }
+  &.active .modal-dialog { transform: translate(0, 0); }
 }
 .modal-open .modal {
   overflow-x: hidden;
@@ -69,7 +69,7 @@
 
   // Fade for backdrop
   &.fade { opacity: 0; }
-  &.in { opacity: $modal-backdrop-opacity; }
+  &.active { opacity: $modal-backdrop-opacity; }
 }
 
 // Modal header


### PR DESCRIPTION
aa11f002182877fe545933d6ac6009cd5363072c is what most likely broke this. My screen recorder broke so I can't show any gifs to show what the bug was, but anything that relied on collapse stopped working.
