### PR TITLE
Docs correction to change .pull to .float on Card docs

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -226,7 +226,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 
 ## Header nav
 
-Use Bootstrap's nav pills or tabs within a card header. Be sure to always include a `.pull-*-*` utility class for proper alignment.
+Use Bootstrap's nav pills or tabs within a card header. Be sure to always include a `.float-*-*` utility class for proper alignment.
 
 {% example html %}
 <div class="card text-xs-center">


### PR DESCRIPTION
Fixing a reference to the old `.pull-*-*` in the Card docs located here: http://v4-alpha.getbootstrap.com/components/card/#header-nav

![screen shot 2016-10-27 at 10 19 06 am](https://cloud.githubusercontent.com/assets/4511852/19777873/0ae968ea-9c2f-11e6-9601-46de721d89b1.png)
