### PR TITLE
Calculcate the top offset for custom control indicators

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -61,7 +61,7 @@
 
 .custom-control-indicator {
   position: absolute;
-  top: .25rem;
+  top: (($line-height-base - $custom-control-indicator-size) / 2);
   left: 0;
   display: block;
   width: $custom-control-indicator-size;


### PR DESCRIPTION
Fixes #21023.

Uses some math functions to determine what the offset should be. This is helpful for those who customize the size of their indicators and still want them vertically centered.
