### PR TITLE
Fixes #20975: navbar-text on navbar-dark and bg-inverse is invisible

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -226,6 +226,10 @@
   .navbar-divider {
     background-color: rgba(0,0,0,.075);
   }
+  
+  .navbar-text {
+    color: $navbar-light-color;
+  }
 }
 
 // White links against a dark background
@@ -265,6 +269,10 @@
 
   .navbar-divider {
     background-color: rgba(255,255,255,.075);
+  }
+  
+  .navbar-text {
+    color: $navbar-dark-color;
   }
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -270,7 +270,7 @@
   .navbar-divider {
     background-color: rgba(255,255,255,.075);
   }
-  
+
   .navbar-text {
     color: $navbar-dark-color;
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -226,7 +226,7 @@
   .navbar-divider {
     background-color: rgba(0,0,0,.075);
   }
-  
+
   .navbar-text {
     color: $navbar-light-color;
   }


### PR DESCRIPTION
Made navbar-text color on navbar-dark equal to non-hovered link color.

![navbar-dark](https://cloud.githubusercontent.com/assets/2943658/19838954/b5cc7776-9eea-11e6-9cc1-2bfb5eabd07a.png)
