### PR TITLE
Fixes #21057, fixes utilities link on typography documentation page

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -5,7 +5,7 @@ description: Documentation and examples for Bootstrap typography, including glob
 group: content
 ---
 
-Bootstrap includes simple and easily customized typography for headings, body text, lists, and more. For even more control, check out the [textual utility classes]({{ site.baseurl }}/utilities/).
+Bootstrap includes simple and easily customized typography for headings, body text, lists, and more. For even more control, check out the [textual utility classes]({{ site.baseurl }}/utilities/typography).
 
 ## Contents
 


### PR DESCRIPTION
Added /typography subpath to the link, fixing it.