### PR TITLE
Add alert-margin-bottom variable

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -4,7 +4,7 @@
 
 .alert {
   padding: $alert-padding-y $alert-padding-x;
-  margin-bottom: $spacer-y;
+  margin-bottom: $alert-margin-bottom;
   border: $alert-border-width solid transparent;
   @include border-radius($alert-border-radius);
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -783,6 +783,7 @@ $modal-sm:                    300px !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
+$alert-margin-bottom:         $spacer-y !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;


### PR DESCRIPTION
I’d like to be able to set the alert margin (bottom) via variable, rather than new css rule.

Existing behaviour won't change.