### PR TITLE
Added note about async tooltip('destroy')

### DIFF
--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -232,7 +232,7 @@ $('#example').tooltip(options)
   {% highlight js %}$('#element').tooltip('toggle'){% endhighlight %}
 
   <h4><code>.tooltip('destroy')</code></h4>
-  <p>Hides and destroys an element's tooltip. Tooltips that use delegation (which are created using <a href="#tooltips-options">the <code>selector</code> option</a>) cannot be individually destroyed on descendant trigger elements.</p>
+  <p>Hides and destroys an element's tooltip. <strong>Returns to the caller before the tooltip has actually been hidden or destroyed</strong> (i.e. before the element is removed from the DOM). Tooltips that use delegation (which are created using <a href="#tooltips-options">the <code>selector</code> option</a>) cannot be individually destroyed on descendant trigger elements.</p>
   {% highlight js %}$('#element').tooltip('destroy'){% endhighlight %}
 
   <h3 id="tooltips-events">Events</h3>


### PR DESCRIPTION
Added a note to the `destroy` blurb similar to the ones on `hide`, `show`, and `toggle`.

The tooltip method `tooltip('destroy')` returns before removing the tooltip element from the DOM, which can lead to some unexpected behaviour (particularly when trying to change the tooltip on an element by removing it and then adding a new one).

Since that behaviour is indicated on the other methods, a reader could take its absence here to mean that the `destroy` method is not asynchronous.