### PR TITLE
v4 - Add methods for determining if elements are shown, visible, expanded

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -123,12 +123,13 @@ const Tooltip = (($) => {
     constructor(element, config) {
 
       // private
-      this._isEnabled        = true
-      this._timeout          = 0
-      this._hoverState       = ''
-      this._activeTrigger    = {}
-      this._isTransitioning  = false
-      this._tether           = null
+      this._isEnabled         = true
+      this._timeout           = 0
+      this._hoverState        = ''
+      this._activeTrigger     = {}
+      this._tether            = null
+      this._isTransitioning   = false
+      this._isShown           = false
 
       // protected
       this.element = element
@@ -181,6 +182,10 @@ const Tooltip = (($) => {
       this._isEnabled = false
     }
 
+    isShown() {
+      return this._isShown
+    }
+
     toggleEnabled() {
       this._isEnabled = !this._isEnabled
     }
@@ -231,11 +236,12 @@ const Tooltip = (($) => {
         $(this.tip).remove()
       }
 
-      this._isEnabled     = null
-      this._timeout       = null
-      this._hoverState    = null
-      this._activeTrigger = null
-      this._tether        = null
+      this._isEnabled      = null
+      this._timeout        = null
+      this._hoverState     = null
+      this._activeTrigger  = null
+      this._tether         = null
+      this._isShown        = false
 
       this.element = null
       this.config  = null
@@ -311,6 +317,7 @@ const Tooltip = (($) => {
           this._isTransitioning = false
 
           $(this.element).trigger(this.constructor.Event.SHOWN)
+          this._isShown = true
 
           if (prevHoverState === HoverState.OUT) {
             this._leave(null, this)
@@ -342,7 +349,9 @@ const Tooltip = (($) => {
 
         this.element.removeAttribute('aria-describedby')
         $(this.element).trigger(this.constructor.Event.HIDDEN)
+
         this._isTransitioning = false
+        this._isShown = false
         this.cleanupTether()
 
         if (callback) {
@@ -630,6 +639,24 @@ const Tooltip = (($) => {
     // static
 
     static _jQueryInterface(config) {
+      if (config === 'isShown') {
+        try {
+          this.each(function () {
+            let data   = $(this).data(DATA_KEY)
+            if (!data) {
+              const _config = typeof config === 'object' ? config : null
+              data = new Tooltip(this, _config)
+              $(this).data(DATA_KEY, data)
+            }
+            if (!data[config]()) {
+              throw new Error('Not shown')
+            }
+          })
+        } catch (e) {
+          return false
+        }
+        return true
+      }
       return this.each(function () {
         let data      = $(this).data(DATA_KEY)
         const _config = typeof config === 'object' && config

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -869,4 +869,28 @@ $(function () {
       })
       .modal('show')
   })
+
+  QUnit.test('call to "isShown" method should return false when a tooltip is not shown', function (assert) {
+    assert.expect(2)
+
+    var $tooltip = $('<span data-toggle="tooltip" title="some tip">some text</span>')
+      .appendTo('#qunit-fixture')
+
+    // on init
+    assert.strictEqual($tooltip.bootstrapTooltip('isShown'), false)
+
+    // on hide called
+    $tooltip.bootstrapTooltip('hide')
+    assert.strictEqual($tooltip.bootstrapTooltip('isShown'), false)
+  })
+
+  QUnit.test('call to "isShown" method should return true when show method is called', function (assert) {
+    assert.expect(1)
+
+    var $tooltip = $('<span data-toggle="tooltip" title="some tip">some text</span>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip('show')
+
+    assert.strictEqual($tooltip.bootstrapTooltip('isShown'), true)
+  })
 })


### PR DESCRIPTION
I made this PR for this feature request in #17021 :

> Add methods for determining if elements are shown. visible, expanded, etc #15573

- [x] Tooltips
- [ ] Collapse
- [ ] Modal
- [ ] Documentation

They are a lots of work to do but if I can have some feedbacks from maybe @fat, @bardiharborow and @mdo It would be great 😄 because I'm not sure if I chose the best way to do this