### PR TITLE
Travis build infrastructure refresh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,33 @@
-sudo: required
+sudo: false
 dist: trusty
 language: node_js
 git:
-  depth: 10
+  depth: 3
 node_js:
   - "4"
   - "6"
 before_install:
-  # Remove ./node_modules/.bin from PATH so node-which doesn't replace Unix which and cause RVM to barf. See https://github.com/travis-ci/travis-ci/issues/5092
-  - export PATH=$(python -c 'from sys import argv;from collections import OrderedDict as od;print(":".join(od((p,None) for p in argv[1].split(":") if p.startswith("/")).keys()))' "$PATH")
-  - rvm install 2.2
-  - rvm use 2.2 --fuzzy
-  - npm install -g npm@3
-  - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""
+  - if [[ `npm -v` != 3* ]]; then npm install -g npm@3; fi
+  - "export TRAVIS_COMMIT_MSG=\"`git log --format=%B --no-merges -n 1`\""
   - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip validator\]'; export TWBS_DO_VALIDATOR=$?; true
   - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip sauce\]'; export TWBS_DO_SAUCE=$?; true
   - if [ "$TRAVIS_REPO_SLUG" = twbs-savage/bootstrap ]; then export TWBS_DO_VALIDATOR=0; fi
 install:
-  - bundle install --deployment --jobs=3
+  - bundle install --deployment --jobs=3 --retry=3
   - cp grunt/npm-shrinkwrap.json ./
   - npm install
+after_success:
+  - if [ "$TWBS_TEST" = sauce-js-unit ]; then grunt/upload-preview.sh; fi
 cache:
   directories:
     - node_modules
     - vendor/bundle
     - "$HOME/google-cloud-sdk"
 env:
-  global:
-    - NPM_CONFIG_PROGRESS="false"
-  matrix:
-    - TWBS_TEST=core
-    - TWBS_TEST=validate-html
-    - TWBS_TEST=sauce-js-unit
+  - TWBS_TEST=core
+  - TWBS_TEST=validate-html
+  - TWBS_TEST=sauce-js-unit
 matrix:
-  fast_finish: true
   exclude:
     - node_js: "4"
       env: TWBS_TEST=validate-html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,9 +283,6 @@ module.exports = function (grunt) {
       },
       htmlhint: {
         command: 'npm run htmlhint'
-      },
-      'upload-preview': {
-        command: './grunt/upload-preview.sh'
       }
     },
 
@@ -361,7 +358,7 @@ module.exports = function (grunt) {
   if (typeof process.env.SAUCE_ACCESS_KEY !== 'undefined' &&
       // Skip Sauce if running a different subset of the test suite
       runSubset('sauce-js-unit')) {
-    testSubtasks = testSubtasks.concat(['dist', 'docs-css', 'docs-js', 'clean:docs', 'copy:docs', 'exec:upload-preview']);
+    testSubtasks = testSubtasks.concat(['dist', 'docs-css', 'docs-js', 'clean:docs', 'copy:docs']);
     // Skip Sauce on Travis when [skip sauce] is in the commit message
     if (isUndefOrNonZero(process.env.TWBS_DO_SAUCE)) {
       testSubtasks.push('connect');


### PR DESCRIPTION
Resolves #17163. Ubuntu Trusty containers are [now available](https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/) on Travis, removing the last obstacle stopping us moving to the container based environment. This cuts build times by about 15 seconds.

Regarding the other changes: Ruby 2.3.1 comes preinstalled on the new images, so I have removed the install directive. The npm install directive has been made conditional as only the Node 4.x environment will have npm 2.x. `--retry=3` has been added to the bundler command to bring it in line with Travis' default and to provide greater network stability. `NPM_CONFIG_PROGRESS="false"` has been removed as npm/npm#11283 seems to be fixed. Git `--depth` has been lowered.

Coming soon in another PR, is switching to using the Travis [apt addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-with-the-APT-Addon) to download the Google Cloud SDK (blocked on travis-ci/apt-package-whitelist#3515) and switching to using the Travis [sauce_connect addon](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-Sauce-Labs) rather than using grunt-saucelabs (blocked on further investigation).