### PR TITLE
renamed modal-title-padding to modal-header-padding

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -75,7 +75,7 @@
 // Modal header
 // Top section of the modal w/ title and dismiss
 .modal-header {
-  padding: $modal-title-padding;
+  padding: $modal-header-padding;
   border-bottom: $modal-header-border-width solid $modal-header-border-color;
   @include clearfix;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -756,7 +756,6 @@ $modal-inner-padding:         15px !default;
 $modal-dialog-margin:         10px !default;
 $modal-dialog-sm-up-margin-y: 30px !default;
 
-$modal-title-padding:         15px !default;
 $modal-title-line-height:     $line-height-base !default;
 
 $modal-content-bg:               #fff !default;
@@ -771,6 +770,7 @@ $modal-header-border-color:   #e5e5e5 !default;
 $modal-footer-border-color:   $modal-header-border-color !default;
 $modal-header-border-width:   $modal-content-border-width !default;
 $modal-footer-border-width:   $modal-header-border-width !default;
+$modal-header-padding:        15px !default;
 
 $modal-lg:                    900px !default;
 $modal-md:                    600px !default;


### PR DESCRIPTION
From: Modal title padding named wrong #21080

I have changed the variable name and moved it to be with other modal-header variables