### PR TITLE
Change .tag print styles to .badge.

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -101,7 +101,7 @@
         border-top-color: #000 !important;
       }
     }
-    .tag {
+    .badge {
       border: $border-width solid #000;
     }
 


### PR DESCRIPTION
We missed the print styles when renaming `.tag` to `.badge`.