### PR TITLE
Remove extra media queries for setting gutters

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -19,6 +19,19 @@
   @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
 }
 
+// Name of the previous breakpoint, or null for the first breakpoint.
+//
+//    >> breakpoint-prev(sm)
+//    xs
+//    >> breakpoint-prev(sm, (xs: 0, sm: 544px, md: 768px))
+//    xs
+//    >> breakpoint-prev(sm, $breakpoint-names: (xs sm md))
+//    xs
+@function breakpoint-prev($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
+  $n: index($breakpoint-names, $name);
+  @return if($n > 1, nth($breakpoint-names, $n - 1), null);
+}
+
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.
 //
 //    >> breakpoint-min(sm, (xs: 0, sm: 544px, md: 768px))

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,6 +2,21 @@
 //
 // Generate semantic grid columns with these mixins.
 
+@mixin validate-gutter-for($breakpoint, $gutters: $grid-gutter-widths) {
+  $prev-breakpoint: breakpoint-prev($breakpoint, $gutters);
+
+  @if $prev-breakpoint {
+    $prev-gutter: map-get($gutters, $prev-breakpoint);
+    $current-gutter: map-get($gutters, $breakpoint);
+
+    @if $prev-gutter != $current-gutter {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
 @mixin make-container($gutters: $grid-gutter-widths) {
   margin-left: auto;
   margin-right: auto;
@@ -10,10 +25,12 @@
   }
 
   @each $breakpoint in map-keys($gutters) {
-    @include media-breakpoint-up($breakpoint) {
-      $gutter: map-get($gutters, $breakpoint);
-      padding-right: ($gutter / 2);
-      padding-left:  ($gutter / 2);
+    @include validate-gutter-for($breakpoint, $gutters) {
+      @include media-breakpoint-up($breakpoint) {
+        $gutter: map-get($gutters, $breakpoint);
+        padding-right: ($gutter / 2);
+        padding-left:  ($gutter / 2);
+      }
     }
   }
 }
@@ -48,10 +65,12 @@
   }
 
   @each $breakpoint in map-keys($gutters) {
-    @include media-breakpoint-up($breakpoint) {
-      $gutter: map-get($gutters, $breakpoint);
-      margin-right: ($gutter / -2);
-      margin-left:  ($gutter / -2);
+    @include validate-gutter-for($breakpoint, $gutters) {
+      @include media-breakpoint-up($breakpoint) {
+        $gutter: map-get($gutters, $breakpoint);
+        margin-right: ($gutter / -2);
+        margin-left:  ($gutter / -2);
+      }
     }
   }
 }


### PR DESCRIPTION
Because we use `media-breakpoint-up` for setup the gutters we could validate if the previous gutter is the same of the current one don't add any media query.

I am wondering how many rules we could remove following the same concept 🤔 Every time we use `media-breakpoint-up` based on some map configuration we could validate the previous one like `make-container-max-widths` as well