### PR TITLE
resolved textual utility classes broken link

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -5,7 +5,7 @@ description: Documentation and examples for Bootstrap typography, including glob
 group: content
 ---
 
-Bootstrap includes simple and easily customized typography for headings, body text, lists, and more. For even more control, check out the [textual utility classes]({{ site.baseurl }}/utilities/typography).
+Bootstrap includes simple and easily customized typography for headings, body text, lists, and more. For even more control, check out the [textual utility classes]({{ site.baseurl }}/utilities/typography/#text-alignment).
 
 ## Contents
 


### PR DESCRIPTION
"textual utility classes" link at the top of the typography page is broken. This resolves the broken link.