### PR TITLE
Invalid visible items selector for dropdowns prevents arrow keys from working

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -51,7 +51,7 @@ const Dropdown = (($) => {
     ROLE_MENU     : '[role="menu"]',
     ROLE_LISTBOX  : '[role="listbox"]',
     NAVBAR_NAV    : '.navbar-nav',
-    VISIBLE_ITEMS : '[role="menu"] li:not(.disabled) a, '
+    VISIBLE_ITEMS : '.dropdown-menu .dropdown-item:not(.disabled), '
                   + '[role="listbox"] li:not(.disabled) a'
   }
 


### PR DESCRIPTION
The keys up/down do not work with Bootstrap 4 dropdowns. The selectors in Javascript require nodes which are not present in BS4 markup. The attached patch seem to solve the problem I was facing.