### PR TITLE
Fix incorrect select height calculation

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -67,7 +67,7 @@
 select.form-control {
   &:not([size]):not([multiple]) {
     $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height} - #{$select-border-width});
+    height: calc(#{$input-height} + #{$select-border-width});
   }
 
   &:focus::-ms-value {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -416,7 +416,7 @@ $input-padding-y-sm:             .25rem !default;
 $input-padding-x-lg:             1.5rem !default;
 $input-padding-y-lg:             .75rem !default;
 
-$input-height:                   (($font-size-base * $line-height-base) + ($input-padding-y * 2)) !default;
+$input-height:                   (($font-size-base * $input-line-height) + ($input-padding-y * 2)) !default;
 $input-height-lg:                (($font-size-lg * $line-height-lg) + ($input-padding-y-lg * 2)) !default;
 $input-height-sm:                (($font-size-sm * $line-height-sm) + ($input-padding-y-sm * 2)) !default;
 


### PR DESCRIPTION
This fixes a bug where the height of the select element was calculated incorrectly when using a $line-height-base with a value other that 1.5 (which is the current default).

Fixes #20977.