### PR TITLE
Fix pagination underline

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -48,12 +48,12 @@
   padding: $pagination-padding-y $pagination-padding-x;
   margin-left: -1px;
   color: $pagination-color;
-  text-decoration: none;
   background-color: $pagination-bg;
   border: $pagination-border-width solid $pagination-border-color;
 
   @include hover-focus {
     color: $pagination-hover-color;
+    text-decoration: none;
     background-color: $pagination-hover-bg;
     border-color: $pagination-hover-border;
   }


### PR DESCRIPTION
Moves text-decoration from the default link state to the hover/focus state of the `.page-link` so it can override the global styles properly.

Fixes #21094.