### PR TITLE
Change remaining .in references to .active.

### DIFF
--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -111,7 +111,7 @@ Note that closing an alert will remove it from the DOM.
 | Method | Description |
 | --- | --- |
 | `$().alert()` | Makes an alert listen for click events on descendant elements which have the `data-dismiss="alert"` attribute. (Not necessary when using the data-api's auto-initialization.) |
-| `$().alert('close')` | Closes an alert by removing it from the DOM. If the `.fade` and `.in` classes are present on the element, the alert will fade out before it is removed. |
+| `$().alert('close')` | Closes an alert by removing it from the DOM. If the `.fade` and `.active` classes are present on the element, the alert will fade out before it is removed. |
 
 {% highlight js %}$(".alert").alert('close'){% endhighlight %}
 

--- a/docs/components/navs.md
+++ b/docs/components/navs.md
@@ -302,7 +302,7 @@ $('#myTab li:eq(2) a').tab('show') // Select third tab (0-indexed)
 
 ### Fade effect
 
-To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must also have `.in` to make the initial content visible.
+To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must also have `.active` to make the initial content visible.
 
 {% highlight html %}
 <div class="tab-content">


### PR DESCRIPTION
Looks like we missed a few. Refs #20982.