### PR TITLE
missing jquery dependency on npm (package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/twbs/bootstrap/issues"
   },
   "license": "MIT",
+  "dependencies": {
+    "jquery": "1.9.1 - 3"
+  },
   "devDependencies": {
     "btoa": "~1.1.2",
     "glob": "~7.0.3",


### PR DESCRIPTION
Hi guys!

When you install bootstrap by npm install, the jquery does not install like a dependency of bootstrap, like bower installs. So i put the dependency on package.json to solve this issue. 

If my PR has anything wrong, please tell me.