### PR TITLE
v4: Miscellaneous color changes

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -5,13 +5,13 @@
   line-height: 1;
   color: $close-color;
   text-shadow: $close-text-shadow;
-  opacity: .2;
+  opacity: .5;
 
   @include hover-focus {
     color: $close-color;
     text-decoration: none;
     cursor: pointer;
-    opacity: .5;
+    opacity: .75;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -92,9 +92,9 @@
 //
 // Grayscale and brand colors for use across Bootstrap.
 
-$gray-dark:                 #373a3c !default;
-$gray:                      #55595c !default;
-$gray-light:                #818a91 !default;
+$gray-dark:                 #292b2c !default;
+$gray:                      #464a4c !default;
+$gray-light:                #636c72 !default;
 $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -829,7 +829,7 @@ $list-group-hover-bg:           #f5f5f5 !default;
 $list-group-active-color:       $component-active-color !default;
 $list-group-active-bg:          $component-active-bg !default;
 $list-group-active-border:      $list-group-active-bg !default;
-$list-group-active-text-color:  lighten($list-group-active-bg, 40%) !default;
+$list-group-active-text-color:  lighten($list-group-active-bg, 50%) !default;
 
 $list-group-disabled-color:      $gray-light !default;
 $list-group-disabled-bg:         $gray-lighter !default;


### PR DESCRIPTION
This branch addresses a handful of color changes and contrast improvements. It doesn't solve everything from #19693, but I'm okay with that since the `$brand-` color changes aren't very good looking to me. We'll deal with that later.

- Darkens the close icon colors via `opacity` changes.
- Fixes #20952 by darkening the `$gray-light` value.
- In concert with the above fix, darkened `$gray` and `$gray-dark` to keep the color scheme intact.
- Darken the opacity of text in active list group items.

/cc @patrickhlauke 