### PR TITLE
Update bootstrap-grid.scss to include box-sizing and responsive changes

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -3,6 +3,25 @@
 // Includes relevant variables and mixins for the regular (non-flexbox) grid
 // system, as well as the generated predefined classes (e.g., `.col-4-sm`).
 
+//
+// Box sizing, responsive, and more
+//
+
+@at-root {
+  @-ms-viewport { width: device-width; }
+}
+
+html {
+  box-sizing: border-box;
+  -ms-overflow-style: scrollbar;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
 
 //
 // Variables


### PR DESCRIPTION
This fixes #17982 I think—judging by the issue's screenshots, it was missing some box-sizing. Alongside that, since this is a responsive grid, I figured we'd need those responsive changes from Reboot as well.

/cc @Restuta