### PR TITLE
Wrap .fade and .collapsing transition properties in $enable-transitions

### DIFF
--- a/scss/_animation.scss
+++ b/scss/_animation.scss
@@ -1,6 +1,9 @@
 .fade {
   opacity: 0;
-  transition: opacity .15s linear;
+
+  @if $enable-transitions {
+    transition: opacity .15s linear;
+  }
 
   &.active {
     opacity: 1;
@@ -30,7 +33,10 @@ tbody {
   position: relative;
   height: 0;
   overflow: hidden;
-  transition-timing-function: ease;
-  transition-duration: .35s;
-  transition-property: height;
+
+  @if $enable-transitions {
+    transition-timing-function: ease;
+    transition-duration: .35s;
+    transition-property: height;
+  }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -114,7 +114,7 @@ $enable-flex:               false !default;
 $enable-rounded:            true !default;
 $enable-shadows:            false !default;
 $enable-gradients:          false !default;
-$enable-transitions:        false !default;
+$enable-transitions:        true !default;
 $enable-hover-media-query:  false !default;
 $enable-grid-classes:       true !default;
 $enable-print-styles:       true !default;


### PR DESCRIPTION
Peeping #18127 reminded me that this needed doing. Probably going to enable the transitions by default, too, to ensure collapse and fade examples in the docs work as intended.