### PR TITLE
v4 disabled navbar links

### DIFF
--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -44,7 +44,7 @@ Here's an example of all the sub-components included in a default, non-responsiv
       <a class="nav-link" href="#">Link</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="#">Link</a>
+      <a class="nav-link disabled" href="#">Disabled</a>
     </li>
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" href="http://example.com" id="supportedContentDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Dropdown</a>
@@ -118,7 +118,7 @@ Active states—with `.active`—to indicate the current page can be applied dir
       <a class="nav-link" href="#">Pricing</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="#">About</a>
+      <a class="nav-link disabled" href="#">Disabled</a>
     </li>
   </ul>
 </nav>
@@ -132,7 +132,7 @@ And because we use classes for our navs, you can avoid the list-based approach e
     <a class="nav-item nav-link active" href="#">Home <span class="sr-only">(current)</span></a>
     <a class="nav-item nav-link" href="#">Features</a>
     <a class="nav-item nav-link" href="#">Pricing</a>
-    <a class="nav-item nav-link" href="#">About</a>
+    <a class="nav-item nav-link disabled" href="#">Disabled</a>
   </div>
 </nav>
 {% endexample %}

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -206,6 +206,10 @@
       @include hover-focus {
         color: $navbar-light-hover-color;
       }
+
+      &.disabled {
+        color: $navbar-light-disabled-color;
+      }
     }
 
     .open > .nav-link,
@@ -249,6 +253,10 @@
 
       @include hover-focus {
         color: $navbar-dark-hover-color;
+      }
+
+      &.disabled {
+        color: $navbar-dark-disabled-color;
       }
     }
 


### PR DESCRIPTION
Alternate to #18634, which didn't use Sass nesting (small style preference) and didn't make awesome use of the docs for showing disabled link examples.