### PR TITLE
Update migration documentation for renamed image classes

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -72,6 +72,8 @@ New to Bootstrap 4 is the Reboot, a new stylesheet that builds on Normalize with
 ### Images
 
 - Renamed `.img-responsive` to `.img-fluid`.
+- Renamed `.img-rounded` to `.rounded`
+- Renamed `.img-circle` to `.rounded-circle`
 
 ### Tables
 


### PR DESCRIPTION
As mentioned in the Alpha5 release, several image classes were renamed but were not updated migration docs. https://github.com/twbs/bootstrap/issues/20630

V3 Docs: https://getbootstrap.com/css/#images
