### PR TITLE
Remove redundant media queries

### DIFF
--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -8,15 +8,13 @@
     $min: breakpoint-min($breakpoint, $grid-breakpoints);
 
     @if $min {
-      @media (min-width: $min) {
-        .d-#{$breakpoint}-none { display: none !important; }
-        .d-#{$breakpoint}-inline { display: inline !important; }
-        .d-#{$breakpoint}-inline-block { display: inline-block !important; }
-        .d-#{$breakpoint}-block { display: block !important; }
-        .d-#{$breakpoint}-table { display: table !important; }
-        .d-#{$breakpoint}-table-cell { display: table-cell !important; }
-        .d-#{$breakpoint}-flex { display: flex !important; }
-      }
+      .d-#{$breakpoint}-none { display: none !important; }
+      .d-#{$breakpoint}-inline { display: inline !important; }
+      .d-#{$breakpoint}-inline-block { display: inline-block !important; }
+      .d-#{$breakpoint}-block { display: block !important; }
+      .d-#{$breakpoint}-table { display: table !important; }
+      .d-#{$breakpoint}-table-cell { display: table-cell !important; }
+      .d-#{$breakpoint}-flex { display: flex !important; }
     } @else {
       .d-none { display: none !important; }
       .d-inline { display: inline !important; }

--- a/scss/utilities/_float.scss
+++ b/scss/utilities/_float.scss
@@ -4,11 +4,9 @@
 
     @if $min {
       // everything else
-      @media (min-width: $min) {
-        .float-#{$breakpoint}-left { @include float-left; }
-        .float-#{$breakpoint}-right { @include float-right; }
-        .float-#{$breakpoint}-none { @include float-none; }
-      }
+      .float-#{$breakpoint}-left { @include float-left; }
+      .float-#{$breakpoint}-right { @include float-right; }
+      .float-#{$breakpoint}-none { @include float-none; }
     } @else {
       // xs
       .float-left { @include float-left; }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -21,20 +21,18 @@
 
         @if $min {
           // everything else
-          @media (min-width: $min) {
-            .#{$abbrev}-#{$breakpoint}-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
-            .#{$abbrev}t-#{$breakpoint}-#{$size} { #{$prop}-top:    $length-y !important; }
-            .#{$abbrev}r-#{$breakpoint}-#{$size} { #{$prop}-right:  $length-x !important; }
-            .#{$abbrev}b-#{$breakpoint}-#{$size} { #{$prop}-bottom: $length-y !important; }
-            .#{$abbrev}l-#{$breakpoint}-#{$size} { #{$prop}-left:   $length-x !important; }
-            .#{$abbrev}x-#{$breakpoint}-#{$size} {
-              #{$prop}-right:  $length-x !important;
-              #{$prop}-left:   $length-x !important;
-            }
-            .#{$abbrev}y-#{$breakpoint}-#{$size} {
-              #{$prop}-top:    $length-y !important;
-              #{$prop}-bottom: $length-y !important;
-            }
+          .#{$abbrev}-#{$breakpoint}-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
+          .#{$abbrev}t-#{$breakpoint}-#{$size} { #{$prop}-top:    $length-y !important; }
+          .#{$abbrev}r-#{$breakpoint}-#{$size} { #{$prop}-right:  $length-x !important; }
+          .#{$abbrev}b-#{$breakpoint}-#{$size} { #{$prop}-bottom: $length-y !important; }
+          .#{$abbrev}l-#{$breakpoint}-#{$size} { #{$prop}-left:   $length-x !important; }
+          .#{$abbrev}x-#{$breakpoint}-#{$size} {
+            #{$prop}-right:  $length-x !important;
+            #{$prop}-left:   $length-x !important;
+          }
+          .#{$abbrev}y-#{$breakpoint}-#{$size} {
+            #{$prop}-top:    $length-y !important;
+            #{$prop}-bottom: $length-y !important;
           }
         } @else {
           // xs


### PR DESCRIPTION
These media queries for min-width were unnecessary and produced stuff like
```css
@media (min-width: 576px) and (min-width: 576px) {
  /* Some CSS here */
}
```

Removing these queries fixes this.

P.S.: Lately, I've been noticing a lot of stuff weird/wrong with the code, so expect some PRs from me. I would like to do a giant PR with all of my fixes but that would be annoying to review, so I'm splitting it up into several different ones. With this method, it would also be easier to reject some changes by just closing the PR.