### PR TITLE
Hide popovers when their containing modal is closed.

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -224,6 +224,7 @@ const Tooltip = (($) => {
       $.removeData(this.element, this.constructor.DATA_KEY)
 
       $(this.element).off(this.constructor.EVENT_KEY)
+      $(this.element).closest('.modal').off('hide.bs.modal')
 
       if (this.tip) {
         $(this.tip).remove()
@@ -456,6 +457,11 @@ const Tooltip = (($) => {
               (event) => this._leave(event)
             )
         }
+
+        $(this.element).closest('.modal').on(
+          'hide.bs.modal',
+          () => this.hide()
+        )
       })
 
       if (this.config.selector) {


### PR DESCRIPTION
Fixes #19270 by detecting when the popover is inside a modal and listening for the modal close event. Will probably require a test case.

Fixes #20568 (dup).

/cc @mdo @cvrebert