### PR TITLE
Change scope of docs anchor preventDefault to include modals.

### DIFF
--- a/docs/assets/js/src/application.js
+++ b/docs/assets/js/src/application.js
@@ -33,7 +33,7 @@
     $('.bd-example-indeterminate [type="checkbox"]').prop('indeterminate', true)
 
     // Disable empty links in docs examples
-    $('.bd-example [href="#"]').click(function (e) {
+    $('.bd-content [href="#"]').click(function (e) {
       e.preventDefault()
     })
 


### PR DESCRIPTION
Fixes #20093 (the first point, the second being a duplicate of #19270). Needs sanity check to ensure I'm not breaking any other behavior.