### PR TITLE
Larger alert dismiss icon

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -26,13 +26,12 @@
 // Expand the right padding and account for the close button's positioning.
 
 .alert-dismissible {
-  padding-right: ($alert-padding-x * 2);
-
   // Adjust close link position
   .close {
     position: relative;
-    top: -.125rem;
+    top: -$alert-padding-y;
     right: -$alert-padding-x;
+    padding: $alert-padding-y $alert-padding-x;
     color: inherit;
   }
 }


### PR DESCRIPTION
Add padding to dismiss button for alerts and use position to place it. Removes extra padding on .alert-dismissible's right side, too. We could probably further simplify these things in the future as well.

Fix #20013, nullify #21112