### PR TITLE
Inverse card improvements

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -314,7 +314,7 @@ Turn an image into a card background and overlay your card's text. Depending on 
 
 ## Inverted text
 
-Cards include a class for quickly toggling **the text color**. By default, cards use dark text and assume a light background. **Add `.card-inverse` for white text** and specify the `background-color` and `border-color` to go with it.
+By default, cards use dark text and assume a light background. You can reverse that by toggling the `color` of text within, as well as that of the card's subcomponents, with `.card-inverse`. Then, specify a dark `background-color` and `border-color` to go with it.
 
 You can also use `.card-inverse` with the [contextual backgrounds variants](#background-variants).
 

--- a/scss/mixins/_cards.scss
+++ b/scss/mixins/_cards.scss
@@ -20,6 +20,8 @@
 //
 
 @mixin card-inverse {
+  color: rgba(255,255,255,.65);
+
   .card-header,
   .card-footer {
     background-color: transparent;


### PR DESCRIPTION
Fixes #21164.

Updates the docs to better articulate how the `.card-inverse` works, and also improve the class itself to apply a `color` to the entirely of the `.card-inverse` so it works with more content.