### PR TITLE
Remove border-bottom from <abbr>

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -154,7 +154,7 @@ Change text alignment, transform, style, weight, and color with our [text utilit
 
 ## Abbreviations
 
-Stylized implementation of HTML's `<abbr>` element for abbreviations and acronyms to show the expanded version on hover. Abbreviations with a `title` attribute have a light dotted bottom border and a help cursor on hover, providing additional context on hover and to users of assistive technologies.
+Stylized implementation of HTML's `<abbr>` element for abbreviations and acronyms to show the expanded version on hover. Abbreviations have a default underline from Normalize.css and gain a help cursor to provide additional context on hover and to users of assistive technologies.
 
 Add `.initialism` to an abbreviation for a slightly smaller font-size.
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -112,12 +112,11 @@ p {
   margin-bottom: 1rem;
 }
 
-// Abbreviations and acronyms
+// Abbreviations
 abbr[title],
 // Add data-* attribute to help out our tooltip plugin, per https://github.com/twbs/bootstrap/issues/5257
 abbr[data-original-title] {
   cursor: help;
-  border-bottom: 1px dotted $abbr-border-color;
 }
 
 address {


### PR DESCRIPTION
Remove the border-bottom from abbr elements since that's covered with an underline in Normalize.css. Updates the docs to match and tweaks some code comments, too.

Fixes #20908.