### PR TITLE
Added $card-cap-color variable in .card-header and .card-footer

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -75,6 +75,7 @@
   padding: $card-spacer-y $card-spacer-x;
   margin-bottom: 0; // Removes the default margin-bottom of <hN>
   background-color: $card-cap-bg;
+  color: $card-cap-color;
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
@@ -88,6 +89,7 @@
   }
   padding: $card-spacer-y $card-spacer-x;
   background-color: $card-cap-bg;
+  color: $card-cap-color;
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -677,6 +677,7 @@ $card-border-width:        1px !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba(0,0,0,.125) !default;
 $card-border-radius-inner: calc(#{$card-border-radius} - #{$card-border-width}) !default;
+$card-cap-color:           $gray-dark !default;
 $card-cap-bg:              $gray-lightest !default;
 $card-bg:                  #fff !default;
 


### PR DESCRIPTION
If the theme is light, and header is dark, it is unreadable. Give the
opportunity to change the text color.