### PR TITLE
Remove https://bugzil.la/504622 from Wall of Browser Bugs

### DIFF
--- a/docs/_data/browser-bugs.yml
+++ b/docs/_data/browser-bugs.yml
@@ -162,16 +162,6 @@
   browser: >
     Firefox
   summary: >
-    `min-width: 0` has no effect on `<fieldset>`
-  upstream_bug: >
-    Mozilla#504622
-  origin: >
-    Bootstrap#12359
-
--
-  browser: >
-    Firefox
-  summary: >
     Layout with floated columns breaks when printing
   upstream_bug: >
     Mozilla#1315994


### PR DESCRIPTION
It's fixed in Firefox 53! https://bugzil.la/504622
Refs #12359.