### PR TITLE
Overwrite margin-bottom on form-control-static

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -346,7 +346,7 @@ select.form-control-lg {
     // Make static controls behave like regular ones
     .form-control-static {
       display: inline-block;
-      margin-bottom: 0px;
+      margin-bottom: 0;
     }
 
     .input-group {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -346,6 +346,7 @@ select.form-control-lg {
     // Make static controls behave like regular ones
     .form-control-static {
       display: inline-block;
+      margin-bottom: 0px;
     }
 
     .input-group {


### PR DESCRIPTION
In the documentation the `.form-control-static` class has been used on a `p` element.
On the regular vertical form the margin bottom of the `p` element gets overwritten by a `.mb-0` class.
In the inline form example this class hasn't been applied, therefore the `p` element gets a `margin-bottom`.

To prevent this behavior we can add a `margin-bottom` of `0`.