### PR TITLE
Fix A11yUserVoice bugify rendering.

### DIFF
--- a/docs/_plugins/bugify.rb
+++ b/docs/_plugins/bugify.rb
@@ -4,8 +4,8 @@ module Jekyll
       upstream_map = {
         "Bootstrap" => "https://github.com/twbs/bootstrap/issues/",
         "Edge" => ["https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/", "Edge issue"],
-        "UserVoice" => ["https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/", "Edge UserVoice idea"],
         "A11yUserVoice" => ["https://microsoftaccessibility.uservoice.com/forums/307429-microsoft-accessibility-feedback/suggestions/", "Microsoft A11y UserVoice idea"],
+        "UserVoice" => ["https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/", "Edge UserVoice idea"],
         "Mozilla" => ["https://bugzilla.mozilla.org/show_bug.cgi?id=", "Mozilla bug"],
         "Chromium" => ["https://bugs.chromium.org/p/chromium/issues/detail?id=", "Chromium issue"],
         "WebKit" => ["https://bugs.webkit.org/show_bug.cgi?id=", "WebKit bug"],


### PR DESCRIPTION
The `A11yUserVoice` entry (added by #21107) needs to be before `UserVoice` as one is a substring of the other and the `UserVoice` regex replace currently executes first resulting in this:
<br>

![screen shot](https://cloud.githubusercontent.com/assets/1073681/20856328/5eed89e6-b960-11e6-9812-42a198f6981e.png)
