### PR TITLE
Remove duplicate jQuery browser bug link.

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -8,8 +8,6 @@ Bootstrap currently works around several outstanding browser bugs in major brows
 
 We publicly list browser bugs that are impacting us here, in the hopes of expediting the process of fixing them. For information on Bootstrap's browser compatibility, [see our browser compatibility docs]({{ site.baseurl }}/getting-started/browsers-devices/#supported-browsers).
 
-Also see [jQuery's browser bug workarounds](https://docs.google.com/document/d/1LPaPA30bLUB_publLIMF0RlhdnPx_ePXm7oW02iiT6o).
-
 See also:
 
 * [Chromium issue 536263: [meta] Issues affecting Bootstrap](https://code.google.com/p/chromium/issues/detail?id=536263)


### PR DESCRIPTION
The link is already in the `See also` section.