### PR TITLE
Remove `.float-left` from card header nav docs

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -226,12 +226,12 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 
 ## Header nav
 
-Use Bootstrap's nav pills or tabs within a card header. Be sure to always include a `.float-*-*` utility class for proper alignment.
+Use Bootstrap's nav pills or tabs within a card header.
 
 {% example html %}
 <div class="card text-center">
   <div class="card-header">
-    <ul class="nav nav-tabs card-header-tabs float-left">
+    <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
         <a class="nav-link active" href="#">Active</a>
       </li>
@@ -254,7 +254,7 @@ Use Bootstrap's nav pills or tabs within a card header. Be sure to always includ
 {% example html %}
 <div class="card text-center">
   <div class="card-header">
-    <ul class="nav nav-pills card-header-pills float-left">
+    <ul class="nav nav-pills card-header-pills">
       <li class="nav-item">
         <a class="nav-link active" href="#">Active</a>
       </li>


### PR DESCRIPTION
The docs say that we have to include a float utility class for proper alignment, but this must have changed recently. In my testing, removing `.float-left` not only [fixed the header nav when flex was enabled](http://i.imgur.com/w4cGPUB.png) (we were floating in a element without clearfix because of [this line](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_card.scss#L72)), but also made no difference when flex was disabled.