### PR TITLE
Custom check margin change

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -14,11 +14,8 @@
   display: inline-block;
   min-height: (1rem * $line-height-base);
   padding-left: $custom-control-gutter;
+  margin-right: $custom-control-spacer-x;
   cursor: pointer;
-
-  + .custom-control {
-    margin-left: $custom-control-spacer-x;
-  }
 }
 
 .custom-control-input {


### PR DESCRIPTION
Fixes #20999.

Move margin from adjacent selector to right on the .custom-control for better responsive rendering.