### PR TITLE
Use $custom-control-spacer-y variable for margin-top of custom-controls (#21278)

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -119,6 +119,7 @@
     clear: left;
 
     + .custom-control {
+      margin-top: $custom-control-spacer-y;
       margin-left: 0;
     }
   }


### PR DESCRIPTION
This merge request fixes issue #21278