### PR TITLE
Change $input-border-color to HEX color value

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -396,7 +396,7 @@ $input-bg:                       $white !default;
 $input-bg-disabled:              $gray-lighter !default;
 
 $input-color:                    $gray !default;
-$input-border-color:             rgba($black,.15) !default;
+$input-border-color:             #ccc !default;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
 $input-box-shadow:               inset 0 1px 1px rgba($black,.075) !default;
 


### PR DESCRIPTION
This PR fixes two problems with input groups.

First is hover change of middle (not rounded) border color of input because of input & button borders overlay:

![search-hover](https://cloud.githubusercontent.com/assets/17578344/21005020/e6197068-bd3b-11e6-8d89-85cf77180230.gif)

Second one is that now input color is not compatible with dark background:

![hex-border-color-before](https://cloud.githubusercontent.com/assets/17578344/21005203/868536c2-bd3c-11e6-8dac-82f11a599d75.png)

after this PR:

![hex-border-color-after](https://cloud.githubusercontent.com/assets/17578344/21005211/8ed0954c-bd3c-11e6-8065-bdac88d8bc97.png)

Sorry if I didn't get why now `$input-border-color` has RGBA value. But it will be great to fix this issues without changing z-indexes logic or any other major changes. Thanks!