### PR TITLE
Add variables for transitions

### DIFF
--- a/docs/assets/scss/_anchor.scss
+++ b/docs/assets/scss/_anchor.scss
@@ -10,7 +10,7 @@
 
 *:hover > .anchorjs-link {
   opacity: .75;
-  transition: color .16s linear;
+  transition: color $transition-duration-short $transition-timing-secondary;
 }
 
 *:hover > .anchorjs-link:hover,

--- a/scss/_animation.scss
+++ b/scss/_animation.scss
@@ -1,7 +1,7 @@
 .fade {
   opacity: 0;
 
-  @include transition(opacity .15s linear);
+  @include transition(opacity $transition-duration-short $transition-timing-secondary);
 
   &.active {
     opacity: 1;
@@ -32,5 +32,5 @@ tbody {
   height: 0;
   overflow: hidden;
 
-  @include transition(height .35s ease);
+  @include transition(height $transition-duration-base ease);
 }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -15,7 +15,7 @@
   user-select: none;
   border: $input-btn-border-width solid transparent;
   @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
-  @include transition(all .2s ease-in-out);
+  @include transition($transition-property-primary $transition-duration-short $transition-timing-primary);
 
   &,
   &:active,

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -15,7 +15,7 @@
   width: 100%;
 
   @include if-supports-3d-transforms() {
-    @include transition(transform .6s ease-in-out);
+    @include transition($transition-property-secondary $transition-duration-long $transition-timing-primary);
     backface-visibility: hidden;
     perspective: 1000px;
   }

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -29,7 +29,7 @@
   }
 
   @include box-shadow($input-box-shadow);
-  @include transition(border-color ease-in-out .15s, box-shadow ease-in-out .15s);
+  @include transition(border-color $transition-timing-primary $transition-delay-base, box-shadow $transition-timing-primary $transition-delay-base);
 
   // Unstyle the caret on `<select>`s in IE10+.
   &::-ms-expand {

--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -16,7 +16,7 @@
   background-color: $thumbnail-bg;
   border: $thumbnail-border-width solid $thumbnail-border-color;
   @include border-radius($thumbnail-border-radius);
-  @include transition(all .2s ease-in-out);
+  @include transition($transition-property-primary $transition-duration-short $transition-timing-primary);
   @include box-shadow($thumbnail-box-shadow);
 
   // Keep them at most 100% wide

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -10,7 +10,11 @@
 
 @mixin transition($transition...) {
   @if $enable-transitions {
-    transition: $transition;
+    @if length($transition) == 0 {
+      transition: $transition-base;
+    } @else {
+      transition: $transition;
+    }
   }
 }
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -28,7 +28,7 @@
 
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {
-    @include transition(transform .3s ease-out);
+    @include transition($transition-property-secondary $transition-duration-base $transition-timing-primary);
     transform: translate(0, -25%);
   }
   &.active .modal-dialog { transform: translate(0, 0); }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -41,6 +41,7 @@
 // 33. Carousel
 // 34. Close
 // 35. Code
+// 36. Transitions
 
 @mixin _assert-ascending($map, $map-name) {
   $prev-key: null;
@@ -921,3 +922,20 @@ $pre-bg:                      $gray-lightest !default;
 $pre-color:                   $gray-dark !default;
 $pre-border-color:            #ccc !default;
 $pre-scrollable-max-height:   340px !default;
+
+
+// 36. Transitions
+
+$transition-property-primary:      all !default;
+$transition-property-secondary:    transform !default;
+
+$transition-duration-short:        .15s !default;
+$transition-duration-base:         .3s !default;
+$transition-duration-long:         .6s !default;
+
+$transition-timing-primary:        ease-in-out !default;
+$transition-timing-secondary:      linear !default;
+
+$transition-delay-base:            .15s !default;
+
+$transition-base:                  $transition-property-primary $transition-duration-base $transition-timing-primary !default;


### PR DESCRIPTION
- The transition shorthand was split up into the single properties to ensure flexibility
- Durations were unified to reduce the amount of different values (`0.2s` => `0.15s`)
- Duration naming scheme differs in general, because time shouldn't be named like `sm` or `lg`
- The two most used timing functions and transition properties were implemented as variables, because other current use cases depend on the behaviour of a specific component, e.g. `height` on `.collapsing`
- The base transition shorthand `$transition-base` (`all .3s ease-in-out`) is used if no parameters were passed to the mixin

See #21266 