### PR TITLE
dropdown.js: Avoid calling jQuery('#')

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.4.0)
     colorator (0.1)
+    ffi (1.9.14)
     ffi (1.9.14-x64-mingw32)
     jekyll (3.1.6)
       colorator (~> 0.1)

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -29,7 +29,7 @@
       selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = selector && $(selector)
+    var $parent = $(selector === '#' ? [] : selector)
 
     return $parent && $parent.length ? $parent : $this.parent()
   }


### PR DESCRIPTION
Calling `jQuery('#')` is considered a syntax error in jQuery 3. [1]
This change avoids this issue, similar to the change in `alert.js`
introduced in #20019.

[1] https://jquery.com/upgrade-guide/3.0/#breaking-change-jquery-quot-quot-and-find-quot-quot-are-invalid-syntax