### PR TITLE
Allow flex on per-mixin-use basis

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -39,8 +39,8 @@
   }
 }
 
-@mixin make-row($gutters: $grid-gutter-widths) {
-  @if $enable-flex {
+@mixin make-row($gutters: $grid-gutter-widths, $flex: $enable-flex) {
+  @if $flex {
     display: flex;
     flex-wrap: wrap;
   } @else {


### PR DESCRIPTION
I would like to be able to use flex rows in some places but traditional rows in others. Adding a flex variable here lets you disable $enable-flex (the default) but have a custom row class that makes use of the same mixin but with flex support.