### PR TITLE
Fixes #16516

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -71,7 +71,7 @@
         $(document.createElement('div'))
           .addClass('dropdown-backdrop')
           .insertAfter($(this))
-          .on('click', clearMenus)
+          .on('touchend', clearMenus)
       }
 
       var relatedTarget = { relatedTarget: this }


### PR DESCRIPTION
This change, just make sure the dropdown-backdrop which was introduced during "touchstart" gets its event handler for "touchend" event, rather than "click" one (which is broken due to delegation bug anyway). When the event is bound on "click", once all dropdowns are closed, it triggers the original initiator again and dropdown gets reopened. With my solution, backdrop is removed successfully and dropdowns close fine.

I realize you guys stopped supporting TWBS 3: please consider accepting this fix in, as I have a project with uses v3 and has unpredictable situation with touch-events. Dropdowns just remain open.

https://github.com/silviomoreto/bootstrap-select/issues/1558

Apparently, the related line in the code was put into ```if``` conditional with commit ```f37b351288883cca4ea435827b10fe6d8475dc6e```, but while doing so, whereas the condition contains ```ontouchstart``` rule, event itself wasn't updated to some touch-event, it remained as ```click```.