### PR TITLE
Prevent nested carousel items from being updated

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -115,7 +115,8 @@
   }
 
   Carousel.prototype.slide = function (type, next) {
-    var $active   = this.$element.children('.carousel-inner').children('.item.active')
+    var $inner    = this.$element.children('.carousel-inner')
+    var $active   = $inner.children('.item.active')
     var $next     = next || this.getItemForDirection(type, $active)
     var isCycling = this.interval
     var direction = type == 'next' ? 'left' : 'right'

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -115,7 +115,7 @@
   }
 
   Carousel.prototype.slide = function (type, next) {
-    var $active   = this.$element.find('.item.active')
+    var $active   = this.$element.children('.carousel-inner').children('.item.active')
     var $next     = next || this.getItemForDirection(type, $active)
     var isCycling = this.interval
     var direction = type == 'next' ? 'left' : 'right'


### PR DESCRIPTION
As it's noted in/since #14441 nested carousel's are not supported.
Anyways this fix will prevent inherit carousel item's from being updated from a parent carousel.