### PR TITLE
Restyle code elements in links

### DIFF
--- a/scss/_code.scss
+++ b/scss/_code.scss
@@ -16,9 +16,9 @@ code {
 
   // Streamline the style when inside anchors to avoid broken underline and more
   a > & {
+    padding: 0;
     color: inherit;
     background-color: inherit;
-    padding: 0;
   }
 }
 

--- a/scss/_code.scss
+++ b/scss/_code.scss
@@ -13,6 +13,13 @@ code {
   color: $code-color;
   background-color: $code-bg;
   @include border-radius($border-radius);
+
+  // Streamline the style when inside anchors to avoid broken underline and more
+  a > & {
+    color: inherit;
+    background-color: inherit;
+    padding: 0;
+  }
 }
 
 // User input typically entered via keyboard


### PR DESCRIPTION
Fixes #21259. Removes the background, color, and padding on code elements within anchors.