### PR TITLE
v4: Flexbox carousel options

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -61,6 +61,10 @@
   position: absolute;
   top: 0;
   bottom: 0;
+  // Use flex for alignment (1-3)
+  display: flex; // 1. allow flex styles
+  justify-content: center; // 2. horizontally center contents
+  align-items: center; // 3. vertically center contents
   width: $carousel-control-width;
   color: $carousel-control-color;
   text-align: center;
@@ -86,26 +90,16 @@
 // Icons for within
 .carousel-control-prev-icon,
 .carousel-control-next-icon {
-  position: absolute;
-  top: 50%;
-  z-index: 5;
   display: inline-block;
   width: $carousel-control-icon-width;
   height: $carousel-control-icon-width;
-  margin-top: -($carousel-control-icon-width / 2);
-  font-family: serif;
-  line-height: 1;
   background: transparent no-repeat center center;
   background-size: 100% 100%;
 }
 .carousel-control-prev-icon {
-  left: 50%;
-  margin-left: -($carousel-control-icon-width / 2);
   background-image: $carousel-control-prev-icon-bg;
 }
 .carousel-control-next-icon {
-  right: 50%;
-  margin-right: -($carousel-control-icon-width / 2);
   background-image: $carousel-control-next-icon-bg;
 }
 

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -63,8 +63,8 @@
   bottom: 0;
   // Use flex for alignment (1-3)
   display: flex; // 1. allow flex styles
-  justify-content: center; // 2. horizontally center contents
-  align-items: center; // 3. vertically center contents
+  align-items: center; // 2. vertically center contents
+  justify-content: center; // 3. horizontally center contents
   width: $carousel-control-width;
   color: $carousel-control-color;
   text-align: center;

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -121,7 +121,6 @@
   // Use the .carousel-control's width as margin so we don't overlay those
   margin-right: $carousel-control-width;
   margin-left: $carousel-control-width;
-  text-align: center;
   list-style: none;
 
   li {

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -24,7 +24,7 @@
 .carousel-item.active,
 .carousel-item-next,
 .carousel-item-prev {
-  display: block;
+  display: flex;
 }
 
 .carousel-item-next,

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -121,6 +121,8 @@
   bottom: 10px;
   left: 0;
   z-index: 15;
+  display: flex;
+  justify-content: center;
   padding-left: 0; // override <ul> default
   // Use the .carousel-control's width as margin so we don't overlay those
   margin-right: $carousel-control-width;
@@ -130,9 +132,11 @@
 
   li {
     position: relative;
-    display: inline-block;
-    width: $carousel-indicator-width;
+    flex: 1 0 auto;
+    max-width: $carousel-indicator-width;
     height: $carousel-indicator-height;
+    margin-right: $carousel-indicator-spacer;
+    margin-left: $carousel-indicator-spacer;
     text-indent: -999px;
     cursor: pointer;
     background-color: rgba($carousel-indicator-active-bg, .5);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -912,6 +912,7 @@ $carousel-control-opacity:                    .5 !default;
 
 $carousel-indicator-width:                    30px !default;
 $carousel-indicator-height:                   3px !default;
+$carousel-indicator-spacer:                   3px !default;
 $carousel-indicator-active-bg:                #fff !default;
 
 $carousel-caption-width:                      70% !default;


### PR DESCRIPTION
Following up on #21389, this implements flexbox into **some aspects of the carousel**. The entire thing isn't flexbox (yet?) as I think that might require a rethinking of the JS approach. (Compare our JS methods to https://blog.madewithenvy.com/the-order-property-flexbox-carousels-87a168567820#.7vubbda6s, for example.)

However, this does make the following changes:

- Sets `display: flex` instead of `block` on active carousel items. There's no visual different here, but if folks want to get creative, this might make it a bit easier.

- Rebuilds carousel controls (the left and right click areas) with flexbox. They're still absolutely positioned themselves, but the icons within are now aligned via flexbox. Far simpler styling overall.

- Rebuilds carousel indicators with flexbox. Instead of a fixed `width`, we're now using a `max-width` and some flexbox styling to scale to *n* number of indicators quite easily. This required adding some new horizontal `margin` (`display: flex` doesn't "suffer" from the same HTML space as `inline-block`); I've added a new variable to help customize that here.

- Removed some unused CSS that was left in since the move back to SVGs for icons and more.

Fixes #21305.