### PR TITLE
v4: Flex media redux

### DIFF
--- a/docs/layout/media-object.md
+++ b/docs/layout/media-object.md
@@ -5,50 +5,53 @@ description: Documentation and examples for Bootstrap's media object to construc
 group: layout
 ---
 
-The [media object](http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/) is an abstract element used as the basis for building more complex and repetitive components (like blog comments, Tweets, etc). Included is support for left and right aligned content, content alignment options, nesting, and more.
+The [media object](http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/) helps build complex and repetitive components where some media is positioned alongside content that doesn't wrap around said media. Plus, it does this with only two required classes thanks to flexbox.
 
 ## Contents
 
 * Will be replaced with the ToC, excluding the "Contents" header
 {:toc}
 
-## Default media
+## Example
 
-The default media allow to float a media object (images, video, audio) to the left or right of a content block.
+Below is an example of a single media object. Only two classes are required—the wrapping `.media` and the `.media-body` around your content. Optional padding and margin can be controlled through [spacing utilities]({{ site.baseurl }}/utilities/spacing/).
 
 {% example html %}
 <div class="media">
-  <a class="media-left" href="#">
-    <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-  </a>
+  <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
-    <h4 class="media-heading">Media heading</h4>
-    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+    <h5 class="mt-0">Media heading</h5>
+    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
   </div>
 </div>
 {% endexample %}
 
+{% callout warning %}
+##### Flexbug #12: Inline elements aren't treated as flex items
+
+Internet Explorer 10-11 do not render inline elements like links or images (or `::before` and `::after` pseudo-elements) as flex items. The only workaround is to set a non-inline `display` value (e.g., `block`, `inline-block`, or `flex`). We suggest using `.d-flex`, one of our [display utilities]({{ site.baseurl }}/utilities/display-property/), as an easy fix.
+
+**Source:** [Flexbugs on GitHub](https://github.com/philipwalton/flexbugs#12-inline-elements-are-not-treated-as-flex-items)
+{% endcallout %}
+
 ## Nesting
 
-Media components can also be nested.
+Media objects can be infinitely nested, though we suggest you stop at some point. Place nested `.media` within the `.media-body` of a parent media object.
 
 {% example html %}
 <div class="media">
-  <div class="media-left">
-    <a href="#">
-      <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-    </a>
-  </div>
+  <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
-    <h4 class="media-heading">Media heading</h4>
-    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+    <h5 class="mt-0">Media heading</h5>
+    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+
     <div class="media mt-3">
-      <a class="media-left" href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
+      <a class="d-flex pr-3" href="#">
+        <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">
-        <h4 class="media-heading">Nested media heading</h4>
-        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+        <h5 class="mt-0">Media heading</h5>
+        Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
       </div>
     </div>
   </div>
@@ -57,18 +60,14 @@ Media components can also be nested.
 
 ## Alignment
 
-The images or other media can be aligned top, middle, or bottom. The default is top aligned.
+Media in a media object can be aligned with flexbox utilities to the top (default), middle, or end of your `.media-body` content.
 
 {% example html %}
 <div class="media">
-  <div class="media-left">
-    <a href="#">
-      <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-    </a>
-  </div>
+  <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
-    <h4 class="media-heading">Top aligned media</h4>
-    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
+    <h5 class="mt-0">Top-aligned media</h5>
+    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
     <p>Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
   </div>
 </div>
@@ -76,94 +75,65 @@ The images or other media can be aligned top, middle, or bottom. The default is 
 
 {% example html %}
 <div class="media">
-  <div class="media-left media-middle">
-    <a href="#">
-      <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-    </a>
-  </div>
+  <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
-    <h4 class="media-heading">Middle aligned media</h4>
-    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
-    <p>Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+    <h5 class="mt-0">Center-aligned media</h5>
+    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
+    <p class="mb-0">Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
   </div>
 </div>
 {% endexample %}
 
 {% example html %}
 <div class="media">
-  <div class="media-left media-bottom">
-    <a href="#">
-      <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-    </a>
-  </div>
+  <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
-    <h4 class="media-heading">Bottom aligned media</h4>
-    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
-    <p>Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+    <h5 class="mt-0">Bottom-aligned media</h5>
+    <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
+    <p class="mb-0">Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
   </div>
+</div>
+{% endexample %}
+
+## Order
+
+Change the order of content in media objects by modifying the HTML itself, or by adding some custom flexbox CSS to set the `order` property (to an integer of your choosing).
+
+{% example html %}
+<div class="media">
+  <div class="media-body">
+    <h5 class="mt-0 mb-1">Media object</h5>
+    Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+  </div>
+  <img class="d-flex ml-3" data-src="holder.js/64x64" alt="Generic placeholder image">
 </div>
 {% endexample %}
 
 ## Media list
 
-With a bit of extra markup, you can use media inside list (useful for comment threads or articles lists).
+Because the media object has so few structural requirements, you can also use these classes on list HTML elements. On your `<ul>` or `<ol>`, add the `.list-unstyled` to remove any browser default list styles, and then apply `.media` to your `<li>`s. As always, use spacing utilities wherever needed to fine tune.
 
 {% example html %}
-<ul class="media-list">
+<ul class="list-unstyled">
   <li class="media">
-    <div class="media-left">
-      <a href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
-    </div>
+    <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
     <div class="media-body">
-      <h4 class="media-heading">Media heading</h4>
-      <p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.</p>
-      <!-- Nested media object -->
-      <div class="media mt-3">
-        <a class="media-left" href="#">
-          <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-        </a>
-        <div class="media-body">
-          <h4 class="media-heading">Nested media heading</h4>
-          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
-          <!-- Nested media object -->
-          <div class="media mt-3">
-            <div class="media-left">
-              <a href="#">
-                <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-              </a>
-            </div>
-            <div class="media-body">
-              <h4 class="media-heading">Nested media heading</h4>
-              Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
-            </div>
-          </div>
-        </div>
-      </div>
-      <!-- Nested media object -->
-      <div class="media mt-3">
-        <div class="media-left">
-          <a href="#">
-            <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-          </a>
-        </div>
-        <div class="media-body">
-          <h4 class="media-heading">Nested media heading</h4>
-          Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
-        </div>
-      </div>
+      <h5 class="mt-0 mb-1">List-based media object</h5>
+      Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
     </div>
   </li>
-  <li class="media mt-3">
+  <li class="media my-4">
+    <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
     <div class="media-body">
-      <h4 class="media-heading">Media heading</h4>
-      Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin commodo. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis.
+      <h5 class="mt-0 mb-1">List-based media object</h5>
+      Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
     </div>
-    <div class="media-right">
-      <a href="#">
-        <img class="media-object" data-src="holder.js/64x64" alt="Generic placeholder image">
-      </a>
+  </li>
+  <li class="media">
+    <img class="d-flex mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
+    <div class="media-body">
+      <h5 class="mt-0 mb-1">List-based media object</h5>
+      Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
     </div>
   </li>
 </ul>

--- a/scss/_media.scss
+++ b/scss/_media.scss
@@ -1,59 +1,8 @@
 .media {
   display: flex;
+  align-items: flex-start;
 }
+
 .media-body {
   flex: 1;
-}
-.media-middle {
-  align-self: center;
-}
-.media-bottom {
-  align-self: flex-end;
-}
-
-
-//
-// Images/elements as the media anchor
-//
-
-.media-object {
-  display: block;
-
-  // Fix collapse in webkit from max-width: 100% and display: table-cell.
-  &.img-thumbnail {
-    max-width: none;
-  }
-}
-
-
-//
-// Alignment
-//
-
-.media-right {
-  padding-left: $media-alignment-padding-x;
-}
-
-.media-left {
-  padding-right: $media-alignment-padding-x;
-}
-
-
-//
-// Headings
-//
-
-.media-heading {
-  margin-top: 0;
-  margin-bottom: $media-heading-margin-bottom;
-}
-
-
-//
-// Media list variation
-//
-
-.media-list {
-  padding-left: 0;
-  list-style: none;
 }

--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -14,5 +14,6 @@
     .d#{$infix}-table        { display: table !important; }
     .d#{$infix}-table-cell   { display: table-cell !important; }
     .d#{$infix}-flex         { display: flex !important; }
+    .d#{$infix}-flex-inline  { display: inline-flex !important; }
   }
 }


### PR DESCRIPTION
This PR overhauls the `.media` component by reducing it to only two required classes, `.media` and `.media-body`. Everything else can be accomplished with utility classes for padding, margin, and alignment. This also overhauls the docs to improve copy, add more examples, and improve existing examples with the new markup and utils usage guidelines.

While working on this, I took a look at #20408. Turns out that's a known bug with inline flex items not being counted in IE10-11. I've added a docs warning for that.

_As an aside, I'll likely be tackling some flex utils name changes and docs updates in a follow-up PR. We're missing some key flex utils and the class names could use a small change for consistency with our other property-value utils (e.g., `d-flex`)._