### PR TITLE
U can't use command from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com): `npm install bootstrap@4.0.0-alpha.5`
 - Install with [yarn](https://github.com/yarnpkg/yarn): `yarn add bootstrap@4.0.0-alpha.5`
-- Install with [Meteor](https://www.meteor.com): `meteor add twbs:bootstrap@=4.0.0-alpha.5`
+- Install with [Meteor](https://www.meteor.com): `Use npm npm install bootstrap@4.0.0-alpha.5`
 - Install with [Composer](https://getcomposer.org): `composer require twbs/bootstrap:4.0.0-alpha.5`
 - Install with [Bower](https://bower.io): `bower install bootstrap#v4.0.0-alpha.5`
 - Install with [NuGet](https://www.nuget.org): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com): `npm install bootstrap@4.0.0-alpha.5`
 - Install with [yarn](https://github.com/yarnpkg/yarn): `yarn add bootstrap@4.0.0-alpha.5`
-- Install with [Meteor](https://www.meteor.com): `Use npm npm install bootstrap@4.0.0-alpha.5`
+- Install with [Meteor](https://www.meteor.com): `Use npm install bootstrap@4.0.0-alpha.5`
 - Install with [Composer](https://getcomposer.org): `composer require twbs/bootstrap:4.0.0-alpha.5`
 - Install with [Bower](https://bower.io): `bower install bootstrap#v4.0.0-alpha.5`
 - Install with [NuGet](https://www.nuget.org): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).


### PR DESCRIPTION
meteor add twbs:bootstrap@=4.0.0-alpha.5 does not work.. So it is better to write the command that works, or remove meteor section completly?

see https://github.com/twbs/bootstrap/issues/20389