### PR TITLE
Remove Meteor install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com): `npm install bootstrap@4.0.0-alpha.5`
 - Install with [yarn](https://github.com/yarnpkg/yarn): `yarn add bootstrap@4.0.0-alpha.5`
-- Install with [Meteor](https://www.meteor.com): `meteor add twbs:bootstrap@=4.0.0-alpha.5`
 - Install with [Composer](https://getcomposer.org): `composer require twbs/bootstrap:4.0.0-alpha.5`
 - Install with [Bower](https://bower.io): `bower install bootstrap#v4.0.0-alpha.5`
 - Install with [NuGet](https://www.nuget.org): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).

--- a/docs/getting-started/download.md
+++ b/docs/getting-started/download.md
@@ -71,12 +71,6 @@ gem install bootstrap -v 4.0.0.alpha5
 
 [See the gem's README](https://github.com/twbs/bootstrap-rubygem/blob/master/README.md) for further details.
 
-### Meteor
-
-{% highlight bash %}
-meteor add twbs:bootstrap@={{ site.current_version }}
-{% endhighlight %}
-
 ### Composer
 
 You can also install and manage Bootstrap's Sass and JavaScript using [Composer](https://getcomposer.org):


### PR DESCRIPTION
As per #20389, Bootstrap's Atmosphere package is no longer supported.

_Note to self: I still need to look at if we can remove `package.js`, the badge in `README.md `, and a reference in  `docs/index.html`._