### PR TITLE
v4: Mixing auto margins with flexbox

### DIFF
--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -59,69 +59,6 @@ Responsive variations also exist for `.flex-row` and `.flex-column`.
 - `.flex{{ bp.abbr }}-row`
 - `.flex{{ bp.abbr }}-column`{% endfor %}
 
-## Auto margins
-
-Flexbox can do some pretty awesome things when you mix `justify-content` with `margin-right: auto` or `margin-left: auto` on a particular flex item. For example, we can move all flex items to the right, but keep one on the left like so.
-
-{% example html %}
-<div class="d-flex justify-content-end bd-highlight">
-  <div class="mr-auto p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-</div>
-{% endexample %}
-
-
-## Wrap
-
-Change how flex items wrap in a flex container. Choose from no wrapping at all (the browser default) with `.flex-nowrap`, or enable wrapping with `.flex-wrap`.
-
-{% example html %}
-<div class="d-flex flex-nowrap bd-highlight">
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-</div>
-{% endexample %}
-
-{% example html %}
-<div class="d-flex flex-wrap bd-highlight">
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-</div>
-{% endexample %}
-
-Responsive variations also exist for `.flex-nowrap` and `.flex-wrap`.
-
-{% for bp in site.data.breakpoints %}
-- `.flex{{ bp.abbr }}-nowrap`
-- `.flex{{ bp.abbr }}-wrap`{% endfor %}
-
 ## Justify content
 
 Use `justify-content` utilities on flexbox containers to change the alignment of flex items on the main axis (the x-axis to start, y-axis if `flex-direction: column`). Choose from `start` (browser default), `end`, `center`, `between`, or `around`.
@@ -241,6 +178,68 @@ Use `align-self` utilities on flexbox items to individually change their alignme
 <div class="align-self-baseline">Aligned flex item</div>
 <div class="align-self-stretch">Aligned flex item</div>
 {% endhighlight %}
+
+## Auto margins
+
+Flexbox can do some pretty awesome things when you mix `justify-content` with `margin-right: auto` or `margin-left: auto` on a particular flex item. For example, we can move all flex items to the right, but keep one on the left like so.
+
+{% example html %}
+<div class="d-flex justify-content-end bd-highlight">
+  <div class="mr-auto p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+</div>
+{% endexample %}
+
+## Wrap
+
+Change how flex items wrap in a flex container. Choose from no wrapping at all (the browser default) with `.flex-nowrap`, or enable wrapping with `.flex-wrap`.
+
+{% example html %}
+<div class="d-flex flex-nowrap bd-highlight">
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="d-flex flex-wrap bd-highlight">
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+</div>
+{% endexample %}
+
+Responsive variations also exist for `.flex-nowrap` and `.flex-wrap`.
+
+{% for bp in site.data.breakpoints %}
+- `.flex{{ bp.abbr }}-nowrap`
+- `.flex{{ bp.abbr }}-wrap`{% endfor %}
 
 ## Order
 

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -59,6 +59,19 @@ Responsive variations also exist for `.flex-row` and `.flex-column`.
 - `.flex{{ bp.abbr }}-row`
 - `.flex{{ bp.abbr }}-column`{% endfor %}
 
+## Auto margins
+
+Flexbox can do some pretty awesome things when you mix `justify-content` with `margin-right: auto` or `margin-left: auto` on a particular flex item. For example, we can move all flex items to the right, but keep one on the left like so.
+
+{% example html %}
+<div class="d-flex justify-content-end bd-highlight">
+  <div class="mr-auto p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+</div>
+{% endexample %}
+
+
 ## Wrap
 
 Change how flex items wrap in a flex container. Choose from no wrapping at all (the browser default) with `.flex-nowrap`, or enable wrapping with `.flex-wrap`.

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -181,13 +181,41 @@ Use `align-self` utilities on flexbox items to individually change their alignme
 
 ## Auto margins
 
-Flexbox can do some pretty awesome things when you mix `justify-content` with `margin-right: auto` or `margin-left: auto` on a particular flex item. For example, we can move all flex items to the right, but keep one on the left like so.
+Flexbox can do some pretty awesome things when you mix flex alignments with auto margins.
+
+### With justify-content
+
+Easily move all flex items to one side, but keep another on the opposite end by mixing `justify-content` with `margin-right: auto` or `margin-left: auto`.
 
 {% example html %}
-<div class="d-flex justify-content-end bd-highlight">
+<div class="d-flex justify-content-end bd-highlight mb-3">
   <div class="mr-auto p-2 bd-highlight">Flex item</div>
   <div class="p-2 bd-highlight">Flex item</div>
   <div class="p-2 bd-highlight">Flex item</div>
+</div>
+
+<div class="d-flex justify-content-start bd-highlight">
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="ml-auto p-2 bd-highlight">Flex item</div>
+</div>
+{% endexample %}
+
+### With align-items
+
+Similarly, move one flex item to the top or bottom of a container by mixing `align-items`, `flex-direction: column`, and `margin-top: auto` or `margin-bottom: auto`.
+
+{% example html %}
+<div class="d-flex align-items-start flex-column bd-highlight mb-3" style="height: 200px;">
+  <div class="mb-auto p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+</div>
+
+<div class="d-flex align-items-end flex-column bd-highlight mb-3" style="height: 200px;">
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="mt-auto p-2 bd-highlight">Flex item</div>
 </div>
 {% endexample %}
 

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -44,7 +44,7 @@
   // Some special margin utils
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-    
+
     .m#{$infix}-auto { margin: auto !important; }
     .mx#{$infix}-auto {
       margin-right: auto !important;

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -44,6 +44,7 @@
   // Some special margin utils
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    
     .m#{$infix}-auto { margin: auto !important; }
     .mx#{$infix}-auto {
       margin-right: auto !important;

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -44,9 +44,14 @@
   // Some special margin utils
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    .m#{$infix}-auto { margin: auto !important; }
     .mx#{$infix}-auto {
       margin-right: auto !important;
       margin-left:  auto !important;
+    }
+    .my#{$infix}-auto {
+      margin-top: auto !important;
+      margin-bottom:  auto !important;
     }
     .mt#{$infix}-auto { margin-top: auto !important; }
     .mr#{$infix}-auto { margin-right: auto !important; }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -15,14 +15,6 @@
 
 // Margin and Padding
 
-.mx-auto {
-  margin-right: auto !important;
-  margin-left:  auto !important;
-}
-
-.mr-auto { margin-right: auto !important; }
-.ml-auto { margin-left: auto !important; }
-
 @each $breakpoint in map-keys($grid-breakpoints) {
   @each $prop, $abbrev in (margin: m, padding: p) {
     @each $size, $lengths in $spacers {
@@ -47,6 +39,19 @@
         }
       }
     }
+  }
+
+  // Some special margin utils
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    .mx#{$infix}-auto {
+      margin-right: auto !important;
+      margin-left:  auto !important;
+    }
+    .mt#{$infix}-auto { margin-top: auto !important; }
+    .mr#{$infix}-auto { margin-right: auto !important; }
+    .mb#{$infix}-auto { margin-bottom: auto !important; }
+    .ml#{$infix}-auto { margin-left: auto !important; }
   }
 }
 

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -20,6 +20,9 @@
   margin-left:  auto !important;
 }
 
+.mr-auto { margin-right: auto !important; }
+.ml-auto { margin-left: auto !important; }
+
 @each $breakpoint in map-keys($grid-breakpoints) {
   @each $prop, $abbrev in (margin: m, padding: p) {
     @each $size, $lengths in $spacers {


### PR DESCRIPTION
<img width="888" alt="screen shot 2016-12-24 at 6 11 21 pm" src="https://cloud.githubusercontent.com/assets/98681/21469471/cea35040-ca04-11e6-970b-235051784c20.png">

Turns out auto margins and flexbox make an amazing team. I discovered this while working on #21425 and really wanted to put something together for it. Using `margin-{direction}: auto` on a flex item will automatically place it on the opposite end of the flex items (when mixed with `justify-content` or `align-items`, at least). This makes for some awesome layout opportunities that are perfect for grids, modal footers, cards, and more.
