### PR TITLE
Fix tab border in IE11 & Edge

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -64,7 +64,7 @@
     @include plain-hover-focus {
       color: $nav-tabs-active-link-hover-color;
       background-color: $nav-tabs-active-link-hover-bg;
-      border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color transparent;
+      border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-bg;
     }
   }
 


### PR DESCRIPTION
Uses an explicit hex value (given to us by the `$nav-tabs-active-link-hover-bg` variable) to match the bottom border to the background color. The use of `transparent` apparently isn't so good for IE11 and Edge, but the solid hex is just dandy in my VMs.

Fixes #18228.

/cc @hansmaad @cvrebert 