### PR TITLE
Disable Hound on test cases.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -10,6 +10,7 @@ javascript:
 eslint:
   enabled: true
   config_file: js/.eslintrc.json
+  ignore_file: .houndignore
 
 jscs:
   enabled: true

--- a/.houndignore
+++ b/.houndignore
@@ -1,0 +1,4 @@
+**/*.min.js
+**/vendor/*
+**/dist/*
+js/tests/*


### PR DESCRIPTION
Until houndci/hound#889 is fixed, Hound isn't going to support the multiple ESLint configs we use to correctly lint the main code and test cases. This PR disables Hound on test cases for now. Fixes #20466.