### PR TITLE
v4: Flex forms cleanup

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -675,7 +675,7 @@ Inline text can use any typical inline HTML element (be it a `<small>`, `<span>`
 <form class="form-inline">
   <div class="form-group">
     <label for="inputPassword4">Password</label>
-    <input type="password" id="inputPassword4" class="form-control" aria-describedby="passwordHelpInline">
+    <input type="password" id="inputPassword4" class="form-control mx-sm-3" aria-describedby="passwordHelpInline">
     <small id="passwordHelpInline" class="text-muted">
       Must be 8-20 characters long.
     </small>

--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -544,7 +544,7 @@ When you need to place plain text next to a form label within a form, use the `.
     <label class="sr-only">Email</label>
     <p class="form-control-static">email@example.com</p>
   </div>
-  <div class="form-group">
+  <div class="form-group mx-sm-3">
     <label for="inputPassword2" class="sr-only">Password</label>
     <input type="password" class="form-control" id="inputPassword2" placeholder="Password">
   </div>

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -11,7 +11,7 @@
 
 .custom-control {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
   min-height: (1rem * $line-height-base);
   padding-left: $custom-control-gutter;
   margin-right: $custom-control-spacer-x;

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -114,10 +114,11 @@
 // set. Use these optional classes to tweak the layout.
 
 .custom-controls-stacked {
+  display: flex;
+  flex-direction: column;
+
   .custom-control {
-    float: left;
     margin-bottom: $custom-control-spacer-y;
-    clear: left;
 
     + .custom-control {
       margin-left: 0;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -135,6 +135,7 @@ select.form-control {
 .form-control-static {
   padding-top: $input-padding-y;
   padding-bottom: $input-padding-y;
+  margin-bottom: 0; // match inputs if this class comes on inputs with default margins
   line-height: $input-line-height;
   border: solid transparent;
   border-width: 1px 0;
@@ -338,7 +339,6 @@ select.form-control-lg {
     // Make static controls behave like regular ones
     .form-control-static {
       display: inline-block;
-      margin-bottom: 0;
     }
 
     .input-group {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -324,6 +324,7 @@ select.form-control-lg {
       display: flex;
       flex: 0 0 auto;
       flex-flow: row wrap;
+      align-items: center;
       margin-bottom: 0;
     }
 

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -95,20 +95,20 @@ select.form-control {
 // For use with horizontal and inline forms, when you need the label text to
 // align with the form controls.
 .col-form-label {
-  padding-top: $input-padding-y;
-  padding-bottom: $input-padding-y;
+  padding-top: calc(#{$input-padding-y} - #{$input-btn-border-width} * 2);
+  padding-bottom: calc(#{$input-padding-y} - #{$input-btn-border-width} * 2);
   margin-bottom: 0; // Override the `<label>` default
 }
 
 .col-form-label-lg {
-  padding-top: $input-padding-y-lg;
-  padding-bottom: $input-padding-y-lg;
+  padding-top: calc(#{$input-padding-y-lg} - #{$input-btn-border-width} * 2);
+  padding-bottom: calc(#{$input-padding-y-lg} - #{$input-btn-border-width} * 2);
   font-size: $font-size-lg;
 }
 
 .col-form-label-sm {
-  padding-top: $input-padding-y-sm;
-  padding-bottom: $input-padding-y-sm;
+  padding-top: calc(#{$input-padding-y-sm} - #{$input-btn-border-width} * 2);
+  padding-bottom: calc(#{$input-padding-y-sm} - #{$input-btn-border-width} * 2);
   font-size: $font-size-sm;
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -466,7 +466,7 @@ $custom-control-checked-indicator-color:      $white !default;
 $custom-control-checked-indicator-bg:         $brand-primary !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 .075rem $body-bg, 0 0 0 .2rem $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
 
 $custom-control-active-indicator-color:      $white !default;
 $custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;


### PR DESCRIPTION
Fixing a handful of issues across our docs with the flexbox move.

- Fixes #20586 where the "outline" on custom controls was misaligned.
- Replaces #21270 with a fix for all `.form-control-static`s, not just inline ones.
- Fixes #21280 by moving stacked custom controls to flexbox.
- Fixes misaligned items in inline form groups with `align-items: center`.
- Fixes #21135 by moving `.col-form-label` padding settings to a `calc` function.

Might have a few more still to come.