### PR TITLE
v4: Simplify button states

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -11,7 +11,6 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
-  cursor: pointer;
   user-select: none;
   border: $input-btn-border-width solid transparent;
   @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -17,15 +17,12 @@
   @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
   @include transition($btn-transition);
 
-  &,
-  &:active,
-  &.active {
-    &:focus,
-    &.focus {
-      @include tab-focus();
-    }
+  &:focus,
+  &.focus {
+    @include tab-focus();
   }
 
+  // Share hover and focus styles
   @include hover-focus {
     text-decoration: none;
   }
@@ -33,18 +30,19 @@
     text-decoration: none;
   }
 
-  &:active,
-  &.active {
-    background-image: none;
-    outline: 0;
-    @include box-shadow($btn-active-box-shadow);
-  }
-
+  // Disabled comes first so active can properly restyle
   &.disabled,
   &:disabled {
     cursor: $cursor-disabled;
     opacity: .65;
     @include box-shadow(none);
+  }
+
+  &:active,
+  &.active {
+    background-image: none;
+    outline: 0;
+    @include box-shadow($btn-active-box-shadow);
   }
 }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -23,7 +23,7 @@
   &:focus,
   &.focus {
     outline: 0;
-    box-shadow: 0 0 0 2px rgba($brand-primary, .25);
+    box-shadow: $btn-focus-box-shadow;
   }
 
   // Disabled comes first so active can properly restyle
@@ -37,7 +37,7 @@
   &:active,
   &.active {
     background-image: none;
-    @include box-shadow($btn-active-box-shadow);
+    @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
   }
 }
 

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -130,8 +130,9 @@ fieldset[disabled] a.btn {
     background-color: transparent;
   }
   &:disabled {
+    color: $btn-link-disabled-color;
+
     @include hover-focus {
-      color: $btn-link-disabled-color;
       text-decoration: none;
     }
   }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -17,17 +17,14 @@
   @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
   @include transition($btn-transition);
 
-  &:focus,
-  &.focus {
-    @include tab-focus();
-  }
-
   // Share hover and focus styles
   @include hover-focus {
     text-decoration: none;
   }
+  &:focus,
   &.focus {
-    text-decoration: none;
+    outline: 0;
+    box-shadow: 0 0 0 2px rgba($brand-primary, .25);
   }
 
   // Disabled comes first so active can properly restyle
@@ -41,7 +38,6 @@
   &:active,
   &.active {
     background-image: none;
-    outline: 0;
     @include box-shadow($btn-active-box-shadow);
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -367,6 +367,7 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -12,49 +12,34 @@
   border-color: $border;
   @include box-shadow($btn-box-shadow);
 
+  // Hover and focus styles are shared
   @include hover {
     color: $color;
     background-color: $active-background;
-        border-color: $active-border;
+    border-color: $active-border;
   }
-
   &:focus,
   &.focus {
     color: $color;
     background-color: $active-background;
-        border-color: $active-border;
+    border-color: $active-border;
+  }
+
+  // Disabled comes first so active can properly restyle
+  &.disabled,
+  &:disabled {
+    background-color: $background;
+    border-color: $border;
   }
 
   &:active,
   &.active,
-  .open > &.dropdown-toggle {
+  .show > &.dropdown-toggle {
     color: $color;
     background-color: $active-background;
-        border-color: $active-border;
-    // Remove the gradient for the pressed/active state
-    background-image: none;
+    border-color: $active-border;
+    background-image: none; // Remove the gradient for the pressed/active state
     @include box-shadow($btn-active-box-shadow);
-
-    &:hover,
-    &:focus,
-    &.focus {
-      color: $color;
-      background-color: darken($background, 17%);
-          border-color: darken($border, 25%);
-    }
-  }
-
-  &.disabled,
-  &:disabled {
-    &:focus,
-    &.focus {
-      background-color: $background;
-          border-color: $border;
-    }
-    @include hover {
-      background-color: $background;
-          border-color: $border;
-    }
   }
 }
 
@@ -67,41 +52,28 @@
   @include hover {
     color: $color-hover;
     background-color: $color;
-        border-color: $color;
+    border-color: $color;
   }
 
   &:focus,
   &.focus {
     color: $color-hover;
     background-color: $color;
-        border-color: $color;
-  }
-
-  &:active,
-  &.active,
-  .open > &.dropdown-toggle {
-    color: $color-hover;
-    background-color: $color;
-        border-color: $color;
-
-    &:hover,
-    &:focus,
-    &.focus {
-      color: $color-hover;
-      background-color: darken($color, 17%);
-          border-color: darken($color, 25%);
-    }
+    border-color: $color;
   }
 
   &.disabled,
   &:disabled {
-    &:focus,
-    &.focus {
-      border-color: lighten($color, 20%);
-    }
-    @include hover {
-      border-color: lighten($color, 20%);
-    }
+    color: $color;
+    background-color: transparent;
+  }
+
+  &:active,
+  &.active,
+  .show > &.dropdown-toggle {
+    color: $color-hover;
+    background-color: $color;
+    border-color: $color;
   }
 }
 

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -20,7 +20,12 @@
   }
   &:focus,
   &.focus {
-    box-shadow: 0 0 0 2px rgba($border, .5);
+    // Avoid using mixin so we can pass custom focus shadow properly
+    @if $enable-shadows {
+      box-shadow: $btn-box-shadow, 0 0 0 2px rgba($border, .5);
+    } @else {
+      box-shadow: 0 0 0 2px rgba($border, .5);
+    }
   }
 
   // Disabled comes first so active can properly restyle

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -20,9 +20,6 @@
   }
   &:focus,
   &.focus {
-    color: $color;
-    background-color: $active-background;
-    border-color: $active-border;
     box-shadow: 0 0 0 2px rgba($border, .5);
   }
 

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -37,8 +37,8 @@
   .show > &.dropdown-toggle {
     color: $color;
     background-color: $active-background;
-    border-color: $active-border;
     background-image: none; // Remove the gradient for the pressed/active state
+    border-color: $active-border;
     @include box-shadow($btn-active-box-shadow);
   }
 }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -23,6 +23,7 @@
     color: $color;
     background-color: $active-background;
     border-color: $active-border;
+    box-shadow: 0 0 0 2px rgba($border, .5);
   }
 
   // Disabled comes first so active can properly restyle
@@ -57,9 +58,7 @@
 
   &:focus,
   &.focus {
-    color: $color-hover;
-    background-color: $color;
-    border-color: $color;
+    box-shadow: 0 0 0 2px rgba($color, .5);
   }
 
   &.disabled,


### PR DESCRIPTION
This PR drastically simplifies our button states to address #19189, #21235, and #21415. My hope is we can simplify the selectors, reduce the number of selectors overall, and make it easier to customize our buttons. Here's a rundown of what's changed and why.

- **Moved active state after the disabled state.** This way, disabled *active* buttons automatically inherit the proper changes to visual styles and simply modifies the opacity. Previously we had to reset the `background-color` and `border-color` across all states.

- **Unchains the focus state from active state.** There's no need to add extra selectors to the original focus state within `&, &:active, &.active { ... }`—we just need to set the focus styles.

- **Removes all hover, focus, and disabled styles from the active states.** Now that active is after disabled in Sass, we can easily inherit the proper styles. Similarly, hover and focus will inherit automatically as well. This does remove the ability to see a hover on active, but I'm okay with that as it's more akin to native behaviors.

See the new CSS in action at https://output.jsbin.com/homiyos.

/cc @cvrebert @patrickhlauke 