### PR TITLE
update click state when hiding so can be shown again by trigger

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -358,6 +358,10 @@ const Tooltip = (($) => {
 
       $(tip).removeClass(ClassName.SHOW)
 
+      this._activeTrigger[Trigger.CLICK] = false
+      this._activeTrigger[Trigger.FOCUS] = false
+      this._activeTrigger[Trigger.HOVER] = false
+
       if (Util.supportsTransitionEnd() &&
           $(this.tip).hasClass(ClassName.FADE)) {
         this._isTransitioning = true

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -818,4 +818,25 @@ $(function () {
     })
   })
 
+  QUnit.test('should show on first trigger after hide', function (assert) {
+    assert.expect(3)
+    var $el = $('<a href="#" rel="tooltip" title="Test tooltip"/>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip({ trigger: 'click hover focus', animation: false })
+
+    var tooltip = $el.data('bs.tooltip')
+    var $tooltip = $(tooltip.getTipElement())
+
+    function showingTooltip() { return $tooltip.hasClass('show') || tooltip._hoverState === 'show' }
+
+    $el.trigger('click')
+    assert.ok(showingTooltip(), 'tooltip is faded in')
+
+    $el.bootstrapTooltip('hide')
+    assert.ok(!showingTooltip(), 'tooltip was faded out')
+
+    $el.trigger('click')
+    assert.ok(showingTooltip(), 'tooltip is faded in again')
+  })
+
 })


### PR DESCRIPTION
fixes #16732 by applying [@markbao's suggestion](https://github.com/twbs/bootstrap/issues/16732#issuecomment-232138662) based on [@bardiharborow's review](https://github.com/twbs/bootstrap/pull/20463#event-903792763) when the tooltip is hidden. addresses issue demonstrated here https://jsbin.com/bapohu/edit?html,js,output

updated version of #20463