### PR TITLE
v4: Move `_custom.scss` after vars and mixins

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -27,7 +27,6 @@ html {
 // Variables
 //
 
-@import "custom";
 @import "variables";
 
 //
@@ -38,5 +37,7 @@ html {
 @import "mixins/breakpoints";
 @import "mixins/grid-framework";
 @import "mixins/grid";
+
+@import "custom";
 
 @import "grid";

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -3,8 +3,7 @@
 // Includes only Normalize and our custom Reboot reset.
 
 @import "variables";
-@import "mixins/hover";
-@import "mixins/tab-focus";
+@import "mixins";
 @import "custom";
 
 @import "normalize";

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -2,10 +2,10 @@
 //
 // Includes only Normalize and our custom Reboot reset.
 
-@import "custom";
 @import "variables";
 @import "mixins/hover";
 @import "mixins/tab-focus";
+@import "custom";
 
 @import "normalize";
 @import "reboot";

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -6,9 +6,9 @@
  */
 
 // Core variables and mixins
-@import "custom";
 @import "variables";
 @import "mixins";
+@import "custom";
 
 // Reset and dependencies
 @import "normalize";


### PR DESCRIPTION
Allows reuse of vars and mixins, while also allowing customization of vars. Fixes #21409.