### PR TITLE
Don't show `.bd-*` classes to the user

### DIFF
--- a/docs/_plugins/highlight_alt.rb
+++ b/docs/_plugins/highlight_alt.rb
@@ -63,7 +63,12 @@ eos
       end
 
       def remove_example_classes(code)
+        # Find `bd-` classes and remove them from the highlighted code. Because of how this regex works, it will also
+        # remove classes that are after the `bd-` class. While this is a bug, I left it because it can be helpful too.
+        # To fix the bug, replace `(?=")` with `(?=("|\ ))`.
         code = code.gsub(/(?!class=".)\ *?bd-.+?(?=")/, "")
+        # Find empty class attributes after the previous regex and remove those too.
+        code = code.gsub(/\ class=""/, "")
       end
 
       def render_rouge(code)

--- a/docs/_plugins/highlight_alt.rb
+++ b/docs/_plugins/highlight_alt.rb
@@ -57,9 +57,13 @@ eos
       def example(output)
         "<div class=\"bd-example\" data-example-id=\"#{@options[:id]}\">\n#{output}\n</div>"
       end
-    
+
       def remove_holderjs(code)
         code = code.gsub(/data-src="holder.js.+?"/, 'src="..."')
+      end
+
+      def remove_example_classes(code)
+        code = code.gsub(/(?!class=".)\ *?bd-.+?(?=")/, "")
       end
 
       def render_rouge(code)
@@ -67,6 +71,7 @@ eos
         formatter = Rouge::Formatters::HTML.new(line_numbers: @options[:linenos], wrap: false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         code = remove_holderjs(code)
+        code = remove_example_classes(code)
         code = formatter.format(lexer.lex(code))
         "<div class=\"highlight\"><pre>#{code}</pre></div>"
       end


### PR DESCRIPTION
I think screenshots show this change the best:
Before: ![Before](http://i.imgur.com/5CchMjU.png)
After: ![After](http://i.imgur.com/PUh3lfG.png)

`.bd-*` classes aren't in the regular bootstrap css, so when people copy these class names, they aren't going to do anything.

A small bug (but can be used as a feature) I noticed is when other class names appear after the `bd-*` class and they disappear as well, so something like `<div class="d-flex bd-highlight p-2">` would display as `<div class="d-flex">`