### PR TITLE
Fixes #21449

### DIFF
--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -202,7 +202,8 @@ Place various form controls and components within a navbar with `.form-inline`.
 Align the contents of your inline forms with utilities as needed.
 
 {% example html %}
-<nav class="navbar navbar-light bg-faded justify-content-end">
+<nav class="navbar navbar-light bg-faded justify-content-between">
+  <a class="navbar-brand">Navbar</a>
   <form class="form-inline">
     <input class="form-control mr-sm-2" type="text" placeholder="Search">
     <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -5,6 +5,7 @@
 
 .navbar {
   position: relative;
+  display: flex;
   padding: $navbar-padding-y $navbar-padding-x;
 }
 


### PR DESCRIPTION
As reported by @quy, this inline form navbar example was broken. The utility wasn't applying as I totally forgot to add `display: flex` to the `.navbar`. This PR fixes that and updates the docs example that was reported broken with a different utility.

Fixes #21449.