### PR TITLE
v4: Miscellaneous states, flexbox, and docs cleanup

### DIFF
--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -5,7 +5,7 @@ description: Learn about Bootstrap's list group component for rendering series o
 group: components
 ---
 
-List groups are a flexible and powerful component for displaying not only simple lists of elements, but complex ones with custom content.
+List groups are a flexible and powerful component for displaying a series of content. List group items can be modified and extended to support just about any content within. They can also be used as navigation with the right modifier class.
 
 ## Contents
 
@@ -13,7 +13,7 @@ List groups are a flexible and powerful component for displaying not only simple
 {:toc}
 
 ## Basic example
-The most basic list group is simply an unordered list with list items, and the proper classes. Build upon it with the options that follow, or your own CSS as needed.
+The most basic list group is an unordered list with list items and the proper classes. Build upon it with the options that follow, or with your own CSS as needed.
 
 {% example html %}
 <ul class="list-group">
@@ -25,47 +25,37 @@ The most basic list group is simply an unordered list with list items, and the p
 </ul>
 {% endexample %}
 
-## Badge
+## Active items
 
-Add badges to any list group item to show unread counts, activity, and more with the help of some utilities. Note the [`justify-content-between` utility class]({{ site.baseurl }}/layout/grid/#horizontal-alignment), the badge's placement, and the lack of a float and margin utilities on the badges.
+Add `.active` to a `.list-group-item` to indicate the current active selection.
 
-{% highlight html %}
+{% example html %}
 <ul class="list-group">
-  <li class="list-group-item justify-content-between">
-    Cras justo odio
-    <span class="badge badge-default badge-pill">14</span>
-  </li>
-  <li class="list-group-item justify-content-between">
-    Dapibus ac facilisis in
-    <span class="badge badge-default badge-pill">2</span>
-  </li>
-  <li class="list-group-item justify-content-between">
-    Morbi leo risus
-    <span class="badge badge-default badge-pill">1</span>
-  </li>
+  <li class="list-group-item active">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+  <li class="list-group-item">Morbi leo risus</li>
+  <li class="list-group-item">Porta ac consectetur ac</li>
+  <li class="list-group-item">Vestibulum at eros</li>
 </ul>
-{% endhighlight %}
-
+{% endexample %}
 
 ## Disabled items
 
-Add `.disabled` to a `.list-group-item` to gray it out to appear disabled.
+Add `.disabled` to a `.list-group-item` to make it _appear_ disabled. Note that some elements with `.disabled` will also require custom JavaScript to fully disable their click events (e.g., links).
 
 {% example html %}
-<div class="list-group">
-  <a href="#" class="list-group-item disabled">
-    Cras justo odio
-  </a>
-  <a href="#" class="list-group-item">Dapibus ac facilisis in</a>
-  <a href="#" class="list-group-item">Morbi leo risus</a>
-  <a href="#" class="list-group-item">Porta ac consectetur ac</a>
-  <a href="#" class="list-group-item">Vestibulum at eros</a>
-</div>
+<ul class="list-group">
+  <li class="list-group-item disabled">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+  <li class="list-group-item">Morbi leo risus</li>
+  <li class="list-group-item">Porta ac consectetur ac</li>
+  <li class="list-group-item">Vestibulum at eros</li>
+</ul>
 {% endexample %}
 
-## Anchors and buttons
+## Links and buttons
 
-Use anchors or buttons to create actionable list group items with hover, disabled, and active states by adding `.list-group-item-action`. This separate class contains a few overrides to add compatibility for `<a>`s and `<button>`s, as well as the hover and focus states.
+Use `<a>`s or `<button>`s to create _actionable_ list group items with hover, disabled, and active states by adding `.list-group-item-action`. We separate these pseudo-classes to ensure list groups made of non-interactive elements (like `<li>`s or `<div>`s) don't provide a click or tap affordance.
 
 Be sure to **not use the standard `.btn` classes here**.
 
@@ -81,6 +71,8 @@ Be sure to **not use the standard `.btn` classes here**.
 </div>
 {% endexample %}
 
+With `<button>`s, you can also make use of the `disabled` attribute instead of the `.disabled` class. Sadly, `<a>`s don't support the disabled attribute.
+
 {% example html %}
 <div class="list-group">
   <button type="button" class="list-group-item list-group-item-action active">
@@ -89,7 +81,7 @@ Be sure to **not use the standard `.btn` classes here**.
   <button type="button" class="list-group-item list-group-item-action">Dapibus ac facilisis in</button>
   <button type="button" class="list-group-item list-group-item-action">Morbi leo risus</button>
   <button type="button" class="list-group-item list-group-item-action">Porta ac consectetur ac</button>
-  <button type="button" class="list-group-item list-group-item-action disabled">Vestibulum at eros</button>
+  <button type="button" class="list-group-item list-group-item-action" disabled>Vestibulum at eros</button>
 </div>
 {% endexample %}
 
@@ -109,6 +101,27 @@ Use contextual classes to style list items, default or linked. Also includes `.a
 {% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
 {{ callout-include | markdownify }}
 
+## With badges
+
+Add badges to any list group item to show unread counts, activity, and more with the help of some utilities. Note the [`justify-content-between` utility class]({{ site.baseurl }}/layout/grid/#horizontal-alignment) and the badge's placement.
+
+{% example html %}
+<ul class="list-group">
+  <li class="list-group-item justify-content-between">
+    Cras justo odio
+    <span class="badge badge-default badge-pill">14</span>
+  </li>
+  <li class="list-group-item justify-content-between">
+    Dapibus ac facilisis in
+    <span class="badge badge-default badge-pill">2</span>
+  </li>
+  <li class="list-group-item justify-content-between">
+    Morbi leo risus
+    <span class="badge badge-default badge-pill">1</span>
+  </li>
+</ul>
+{% endexample %}
+
 ## Custom content
 
 Add nearly any HTML within, even for linked list groups like the one below.
@@ -116,16 +129,16 @@ Add nearly any HTML within, even for linked list groups like the one below.
 {% example html %}
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-action active">
-    <h5 class="list-group-item-heading">List group item heading</h5>
-    <p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>
+    <h5 class="mt-0 mb-1">List group item heading</h5>
+    <small>Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</small>
   </a>
   <a href="#" class="list-group-item list-group-item-action">
-    <h5 class="list-group-item-heading">List group item heading</h5>
-    <p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>
+    <h5 class="mt-0 mb-1">List group item heading</h5>
+    <small>Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</small>
   </a>
   <a href="#" class="list-group-item list-group-item-action">
-    <h5 class="list-group-item-heading">List group item heading</h5>
-    <p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>
+    <h5 class="mt-0 mb-1">List group item heading</h5>
+    <small>Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</small>
   </a>
 </div>
 {% endexample %}

--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -87,10 +87,23 @@ With `<button>`s, you can also make use of the `disabled` attribute instead of t
 
 ## Contextual classes
 
-Use contextual classes to style list items, default or linked. Also includes `.active` state.
+Use contextual classes to style list items with a stateful background and color.
+
+{% example html %}
+<ul class="list-group">
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+  <li class="list-group-item list-group-item-success">Dapibus ac facilisis in</li>
+  <li class="list-group-item list-group-item-info">Cras sit amet nibh libero</li>
+  <li class="list-group-item list-group-item-warning">Porta ac consectetur ac</li>
+  <li class="list-group-item list-group-item-danger">Vestibulum at eros</li>
+</ul>
+{% endexample %}
+
+Contextual classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a contextual list group item.
 
 {% example html %}
 <div class="list-group">
+  <a href="#" class="list-group-item list-group-item-action">Dapibus ac facilisis in</a>
   <a href="#" class="list-group-item list-group-item-action list-group-item-success">Dapibus ac facilisis in</a>
   <a href="#" class="list-group-item list-group-item-action list-group-item-info">Cras sit amet nibh libero</a>
   <a href="#" class="list-group-item list-group-item-action list-group-item-warning">Porta ac consectetur ac</a>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -30,8 +30,12 @@ In addition, as pages likely have more than one such navigation section, it's ad
 </nav>
 {% endexample %}
 
+## Working with icons
+
+Looking to use an icon or symbol in place of text for some pagination links? Be sure to provide proper screen reader support with `aria` attributes and the `.sr-only` utility.
+
 {% example html %}
-<nav aria-label="Page navigation">
+<nav aria-label="Page navigation example">
   <ul class="pagination">
     <li class="page-item">
       <a class="page-link" href="#" aria-label="Previous">
@@ -42,8 +46,6 @@ In addition, as pages likely have more than one such navigation section, it's ad
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
-    <li class="page-item"><a class="page-link" href="#">4</a></li>
-    <li class="page-item"><a class="page-link" href="#">5</a></li>
     <li class="page-item">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -58,35 +58,23 @@ Looking to use an icon or symbol in place of text for some pagination links? Be 
 
 ## Disabled and active states
 
-Links are customizable for different circumstances. Use `.disabled` for unclickable links and `.active` to indicate the current page.
+Pagination links are customizable for different circumstances. Use `.disabled` for links that appear un-clickable and `.active` to indicate the current page.
 
-{% callout warning %}
-#### Link functionality caveat
-
-The `.disabled` class uses `pointer-events: none` to try to disable the link functionality of `<a>`s, but that CSS property is not yet standardized. In addition, even in browsers that do support `pointer-events: none`, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links. So to be safe, add a `tabindex="-1"` attribute on these links (to prevent them from receiving keyboard focus) and use custom JavaScript to disable their functionality.
-{% endcallout %}
+While the `.disabled` class uses `pointer-events: none` to _try_ to disable the link functionality of `<a>`s, that CSS property is not yet standardized and doesn't account for keyboard navigation. As such, you should always add `tabindex="-1"` on disabled links and use custom JavaScript to fully disable their functionality.
 
 {% example html %}
 <nav aria-label="...">
   <ul class="pagination">
     <li class="page-item disabled">
-      <a class="page-link" href="#" tabindex="-1" aria-label="Previous">
-        <span aria-hidden="true">&laquo;</span>
-        <span class="sr-only">Previous</span>
-      </a>
+      <a class="page-link" href="#" tabindex="-1">Previous</a>
     </li>
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item active">
-      <a class="page-link" href="#">1 <span class="sr-only">(current)</span></a>
+      <a class="page-link" href="#">2 <span class="sr-only">(current)</span></a>
     </li>
-    <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
-    <li class="page-item"><a class="page-link" href="#">4</a></li>
-    <li class="page-item"><a class="page-link" href="#">5</a></li>
     <li class="page-item">
-      <a class="page-link" href="#" aria-label="Next">
-        <span aria-hidden="true">&raquo;</span>
-        <span class="sr-only">Next</span>
-      </a>
+      <a class="page-link" href="#">Next</a>
     </li>
   </ul>
 </nav>
@@ -98,12 +86,19 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 <nav aria-label="...">
   <ul class="pagination">
     <li class="page-item disabled">
-      <span class="page-link" aria-label="Previous">
-        <span aria-hidden="true">&laquo;</span>
-        <span class="sr-only">Previous</span>
+      <span class="page-link">Previous</span>
+    </li>
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item active">
+      <span class="page-link">
+        2
+        <span class="sr-only">(current)</span>
       </span>
     </li>
-    <li class="page-item active"><span class="page-link">1 <span class="sr-only">(current)</span></span></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item">
+      <a class="page-link" href="#">Next</a>
+    </li>
   </ul>
 </nav>
 {% endexample %}

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -5,7 +5,7 @@ description: Documentation and examples for showing pagination links.
 group: components
 ---
 
-Provide pagination links for your site or app with the multi-page pagination component.
+Pagination links indicate a series of related content exists across multiple pages. Typically these are used where a multi-page approach to long lists of content improves general performance, such as in search results or inboxes.
 
 ## Contents
 

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -103,7 +103,6 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 </nav>
 {% endexample %}
 
-
 ## Sizing
 
 Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for additional sizes.

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -14,7 +14,21 @@ Pagination links indicate a series of related content exists across multiple pag
 
 ## Overview
 
-Simple pagination inspired by Rdio, great for apps and search results. The large block is hard to miss, easily scalable, and provides large click areas.
+We use a large block of connected links for our pagination, making links hard to miss and easily scalable—all while providing large hit areas. Pagination is built with list HTML elements so screen readers can announce the number of available links. Use a wrapping `<nav>` element to identify it as a navigation section to screen readers and other assistive technologies.
+
+In addition, as pages likely have more than one such navigation section, it's advisable to provide a descriptive `aria-label` for the `<nav>` to reflect its purpose. For example, if the pagination component is used to navigate between a set of search results, an appropriate label could be `aria-label="Search results pages"`.
+
+{% example html %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination">
+    <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item"><a class="page-link" href="#">Next</a></li>
+  </ul>
+</nav>
+{% endexample %}
 
 {% example html %}
 <nav aria-label="Page navigation">
@@ -39,12 +53,6 @@ Simple pagination inspired by Rdio, great for apps and search results. The large
   </ul>
 </nav>
 {% endexample %}
-
-{% callout info %}
-### Labelling the pagination component
-
-The pagination component should be wrapped in a `<nav>` element to identify it as a navigation section to screen readers and other assistive technologies. In addition, as a page is likely to have more than one such navigation section already (such as the primary navigation in the header, or a sidebar navigation), it is advisable to provide a descriptive `aria-label` for the `<nav>` which reflects its purpose. For example, if the pagination component is used to navigate between a set of search results, an appropriate label could be `aria-label="Search results pages"`.
-{% endcallout %}
 
 ## Disabled and active states
 

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -110,20 +110,14 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav aria-label="...">
   <ul class="pagination pagination-lg">
-    <li class="page-item">
-      <a class="page-link" href="#" aria-label="Previous">
-        <span aria-hidden="true">&laquo;</span>
-        <span class="sr-only">Previous</span>
-      </a>
+    <li class="page-item disabled">
+      <a class="page-link" href="#" tabindex="-1">Previous</a>
     </li>
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item">
-      <a class="page-link" href="#" aria-label="Next">
-        <span aria-hidden="true">&raquo;</span>
-        <span class="sr-only">Next</span>
-      </a>
+      <a class="page-link" href="#">Next</a>
     </li>
   </ul>
 </nav>
@@ -132,11 +126,18 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% example html %}
 <nav aria-label="...">
   <ul class="pagination pagination-sm">
+    <li class="page-item disabled">
+      <a class="page-link" href="#" tabindex="-1">Previous</a>
+    </li>
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item">
-      <a class="page-link" href="#" aria-label="Previous">
-        <span aria-hidden="true">&laquo;</span>
-        <span class="sr-only">Previous</span>
-      </a>
+      <a class="page-link" href="#">Next</a>
+    </li>
+  </ul>
+</nav>
+{% endexample %}
     </li>
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -138,15 +138,38 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
   </ul>
 </nav>
 {% endexample %}
+
+## Alignment
+
+Change the alignment of pagination components with [flexbox utilities]({{ site.baseurl }}/utilities/flexbox).
+
+{% example html %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination justify-content-center">
+    <li class="page-item disabled">
+      <a class="page-link" href="#" tabindex="-1">Previous</a>
     </li>
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item">
-      <a class="page-link" href="#" aria-label="Next">
-        <span aria-hidden="true">&raquo;</span>
-        <span class="sr-only">Next</span>
-      </a>
+      <a class="page-link" href="#">Next</a>
+    </li>
+  </ul>
+</nav>
+{% endexample %}
+
+{% example html %}
+<nav aria-label="Page navigation example">
+  <ul class="pagination justify-content-end">
+    <li class="page-item disabled">
+      <a class="page-link" href="#" tabindex="-1">Previous</a>
+    </li>
+    <li class="page-item"><a class="page-link" href="#">1</a></li>
+    <li class="page-item"><a class="page-link" href="#">2</a></li>
+    <li class="page-item"><a class="page-link" href="#">3</a></li>
+    <li class="page-item">
+      <a class="page-link" href="#">Next</a>
     </li>
   </ul>
 </nav>

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -81,30 +81,21 @@
     background-color: $dropdown-link-hover-bg;
   }
 
-  // Active state
-  &.active {
-    @include plain-hover-focus {
-      color: $dropdown-link-active-color;
-      text-decoration: none;
-      background-color: $dropdown-link-active-bg;
-      outline: 0;
-    }
+  &.active,
+  &:active {
+    color: $dropdown-link-active-color;
+    text-decoration: none;
+    background-color: $dropdown-link-active-bg;
   }
 
-  // Disabled state
-  //
-  // Gray out text and ensure the hover/focus state remains gray
-  &.disabled {
-    @include plain-hover-focus {
-      color: $dropdown-link-disabled-color;
-    }
-
-    // Nuke hover/focus effects
-    @include hover-focus {
-      text-decoration: none;
-      cursor: $cursor-disabled;
-      background-color: transparent;
-      background-image: none; // Remove CSS gradient
+  &.disabled,
+  &:disabled {
+    color: $dropdown-link-disabled-color;
+    cursor: $cursor-disabled;
+    background-color: transparent;
+    // Remove CSS gradients if they're enabled
+    @if $enable-gradients {
+      background-image: none;
     }
   }
 }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -12,6 +12,34 @@
 }
 
 
+// Interactive list items
+//
+// Use anchor or button elements instead of `li`s or `div`s to create interactive
+// list items. Includes an extra `.active` modifier class for selected items.
+
+.list-group-item-action {
+  width: 100%; // For `<button>`s (anchors become 100% by default though)
+  color: $list-group-link-color;
+  text-align: inherit; // For `<button>`s (anchors inherit)
+
+  .list-group-item-heading {
+    color: $list-group-link-heading-color;
+  }
+
+  // Hover state
+  @include hover-focus {
+    color: $list-group-link-hover-color;
+    text-decoration: none;
+    background-color: $list-group-hover-bg;
+  }
+
+  &:active {
+    color: $list-group-link-active-color;
+    background-color: $list-group-link-active-bg;
+  }
+}
+
+
 // Individual list items
 //
 // Use on `li`s or `div`s within the `.list-group` parent.
@@ -36,42 +64,50 @@
     @include border-bottom-radius($list-group-border-radius);
   }
 
-  &.disabled {
-    @include plain-hover-focus {
-      color: $list-group-disabled-color;
-      cursor: $cursor-disabled;
-      background-color: $list-group-disabled-bg;
+  @include hover-focus {
+    text-decoration: none;
+  }
 
-      // Force color to inherit for custom content
-      .list-group-item-heading {
-        color: inherit;
-      }
-      .list-group-item-text {
-        color: $list-group-disabled-text-color;
-      }
+  &.disabled,
+  &:disabled {
+    color: $list-group-disabled-color;
+    cursor: $cursor-disabled;
+    background-color: $list-group-disabled-bg;
+
+    // Force color to inherit for custom content
+    .list-group-item-heading {
+      color: inherit;
+    }
+    .list-group-item-text {
+      color: $list-group-disabled-text-color;
     }
   }
 
+  // Include both here for `<a>`s and `<button>`s
   &.active {
-    @include plain-hover-focus {
-      z-index: 2; // Place active items above their siblings for proper border styling
-      color: $list-group-active-color;
-      text-decoration: none; // Repeat here because it inherits global a:hover otherwise
-      background-color: $list-group-active-bg;
-      border-color: $list-group-active-border;
+    z-index: 2; // Place active items above their siblings for proper border styling
+    color: $list-group-active-color;
+    background-color: $list-group-active-bg;
+    border-color: $list-group-active-border;
 
-      // Force color to inherit for custom content
-      .list-group-item-heading,
-      .list-group-item-heading > small,
-      .list-group-item-heading > .small {
-        color: inherit;
-      }
-      .list-group-item-text {
-        color: $list-group-active-text-color;
-      }
+    // Force color to inherit for custom content
+    .list-group-item-heading,
+    .list-group-item-heading > small,
+    .list-group-item-heading > .small {
+      color: inherit;
+    }
+
+    .list-group-item-text {
+      color: $list-group-active-text-color;
     }
   }
 }
+
+
+// Flush list items
+//
+// Remove borders and border-radius to keep list group items edge-to-edge. Most
+// useful within other components (e.g., cards).
 
 .list-group-flush {
   .list-group-item {
@@ -94,29 +130,6 @@
 }
 
 
-// Interactive list items
-//
-// Use anchor or button elements instead of `li`s or `div`s to create interactive
-// list items. Includes an extra `.active` modifier class for selected items.
-
-.list-group-item-action {
-  width: 100%; // For `<button>`s (anchors become 100% by default though)
-  color: $list-group-link-color;
-  text-align: inherit; // For `<button>`s (anchors inherit)
-
-  .list-group-item-heading {
-    color: $list-group-link-heading-color;
-  }
-
-  // Hover state
-  @include hover-focus {
-    color: $list-group-link-hover-color;
-    text-decoration: none;
-    background-color: $list-group-hover-bg;
-  }
-}
-
-
 // Contextual variants
 //
 // Add modifier classes to change text and background color on individual items.
@@ -126,17 +139,3 @@
 @include list-group-item-variant(info, $state-info-bg, $state-info-text);
 @include list-group-item-variant(warning, $state-warning-bg, $state-warning-text);
 @include list-group-item-variant(danger, $state-danger-bg, $state-danger-text);
-
-
-// Custom content options
-//
-// Extra classes for creating well-formatted content within `.list-group-item`s.
-
-.list-group-item-heading {
-  margin-top: 0;
-  margin-bottom: $list-group-item-heading-margin-bottom;
-}
-.list-group-item-text {
-  margin-bottom: 0;
-  line-height: 1.3;
-}

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -53,7 +53,7 @@
   }
 
   .nav-link.active,
-  .nav-item.open .nav-link {
+  .nav-item.show .nav-link {
     color: $nav-tabs-active-link-hover-color;
     background-color: $nav-tabs-active-link-hover-bg;
     border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-bg;
@@ -78,7 +78,7 @@
   }
 
   .nav-link.active,
-  .nav-item.open .nav-link {
+  .nav-item.show .nav-link {
     color: $nav-pills-active-link-color;
     cursor: default;
     background-color: $nav-pills-active-link-bg;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -21,12 +21,7 @@
   // Disabled state lightens text and removes hover/tab effects
   &.disabled {
     color: $nav-disabled-link-color;
-
-    @include plain-hover-focus {
-      color: $nav-disabled-link-hover-color;
-      cursor: $cursor-disabled;
-      background-color: $nav-disabled-link-hover-bg;
-    }
+    cursor: $cursor-disabled;
   }
 }
 
@@ -51,21 +46,17 @@
     }
 
     &.disabled {
-      @include plain-hover-focus {
-        color: $nav-disabled-link-color;
-        background-color: transparent;
-        border-color: transparent;
-      }
+      color: $nav-disabled-link-color;
+      background-color: transparent;
+      border-color: transparent;
     }
   }
 
   .nav-link.active,
   .nav-item.open .nav-link {
-    @include plain-hover-focus {
-      color: $nav-tabs-active-link-hover-color;
-      background-color: $nav-tabs-active-link-hover-bg;
-      border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-bg;
-    }
+    color: $nav-tabs-active-link-hover-color;
+    background-color: $nav-tabs-active-link-hover-bg;
+    border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-bg;
   }
 
   .dropdown-menu {
@@ -88,11 +79,9 @@
 
   .nav-link.active,
   .nav-item.open .nav-link {
-    @include plain-hover-focus {
-      color: $nav-pills-active-link-color;
-      cursor: default;
-      background-color: $nav-pills-active-link-bg;
-    }
+    color: $nav-pills-active-link-color;
+    cursor: default;
+    background-color: $nav-pills-active-link-bg;
   }
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -165,9 +165,7 @@
     .active > .nav-link,
     .nav-link.open,
     .nav-link.active {
-      @include plain-hover-focus {
-        color: $navbar-light-active-color;
-      }
+      color: $navbar-light-active-color;
     }
   }
 
@@ -216,9 +214,7 @@
     .active > .nav-link,
     .nav-link.open,
     .nav-link.active {
-      @include plain-hover-focus {
-        color: $navbar-inverse-active-color;
-      }
+      color: $navbar-inverse-active-color;
     }
   }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -240,7 +240,6 @@
 // Custom override for collapse plugin in navbar.
 
 // Placed at the end of the file so it can override some CSS properties
-// scss-lint:disable ImportantRule
 .navbar-toggleable {
   @each $breakpoint in map-keys($grid-breakpoints) {
     $next: breakpoint-next($breakpoint, $grid-breakpoints);
@@ -272,10 +271,12 @@
           align-items: center;
         }
 
+        // scss-lint:disable ImportantRule
         .navbar-collapse {
           display: flex !important;
           width: 100%;
         }
+        // scss-lint:enable ImportantRule
 
         .nav-item {
           display: inline-block;
@@ -293,4 +294,3 @@
     }
   }
 }
-// scss-lint:enable ImportantRule

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,6 +1,4 @@
 .pagination {
-  margin-top: $spacer-y;
-  margin-bottom: $spacer-y;
   display: flex;
   // 1-2: Disable browser default list styles
   list-style: none; // 1

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,8 +1,10 @@
 .pagination {
-  padding-left: 0;
   margin-top: $spacer-y;
   margin-bottom: $spacer-y;
   display: flex;
+  // 1-2: Disable browser default list styles
+  list-style: none; // 1
+  padding-left: 0; // 2
   @include border-radius();
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -7,8 +7,6 @@
 }
 
 .page-item {
-  display: inline; // Remove list-style and block-level defaults
-
   &:first-child {
     .page-link {
       margin-left: 0;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,8 +1,8 @@
 .pagination {
-  display: inline-block;
   padding-left: 0;
   margin-top: $spacer-y;
   margin-bottom: $spacer-y;
+  display: flex;
   @include border-radius();
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -23,7 +23,6 @@
     @include plain-hover-focus {
       z-index: 2;
       color: $pagination-active-color;
-      cursor: default;
       background-color: $pagination-active-bg;
       border-color: $pagination-active-border;
     }

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,8 +1,8 @@
 .pagination {
   display: flex;
   // 1-2: Disable browser default list styles
-  list-style: none; // 1
-  padding-left: 0; // 2
+  padding-left: 0; // 1
+  list-style: none; // 2
   @include border-radius();
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -20,22 +20,18 @@
   }
 
   &.active .page-link {
-    @include plain-hover-focus {
-      z-index: 2;
-      color: $pagination-active-color;
-      background-color: $pagination-active-bg;
-      border-color: $pagination-active-border;
-    }
+    z-index: 2;
+    color: $pagination-active-color;
+    background-color: $pagination-active-bg;
+    border-color: $pagination-active-border;
   }
 
   &.disabled .page-link {
-    @include plain-hover-focus {
-      color: $pagination-disabled-color;
-      pointer-events: none;
-      background-color: $pagination-disabled-bg;
-      border-color: $pagination-disabled-border;
-    }
+    color: $pagination-disabled-color;
+    pointer-events: none;
     cursor: $cursor-disabled; // While `pointer-events: none` removes the cursor in modern browsers, we provide a disabled cursor as a fallback.
+    background-color: $pagination-disabled-bg;
+    border-color: $pagination-disabled-border;
   }
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -33,10 +33,10 @@
     @include plain-hover-focus {
       color: $pagination-disabled-color;
       pointer-events: none;
-      cursor: $cursor-disabled;
       background-color: $pagination-disabled-bg;
       border-color: $pagination-disabled-border;
     }
+    cursor: $cursor-disabled; // While `pointer-events: none` removes the cursor in modern browsers, we provide a disabled cursor as a fallback.
   }
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -37,7 +37,7 @@
 
 .page-link {
   position: relative;
-  float: left; // Collapse white-space
+  display: block;
   padding: $pagination-padding-y $pagination-padding-x;
   margin-left: -1px;
   line-height: $pagination-line-height;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -637,8 +637,6 @@ $nav-item-inline-spacer:        1rem !default;
 $nav-link-padding:              .5em 1em !default;
 $nav-link-hover-bg:             $gray-lighter !default;
 $nav-disabled-link-color:       $gray-light !default;
-$nav-disabled-link-hover-color: $gray-light !default;
-$nav-disabled-link-hover-bg:    transparent !default;
 
 $nav-tabs-border-color:                       #ddd !default;
 $nav-tabs-border-width:                       $border-width !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -865,28 +865,31 @@ $progress-bar-info-bg:        $brand-info !default;
 
 // List group
 
-$list-group-bg:                 $white !default;
-$list-group-border-color:       rgba($black,.125) !default;
-$list-group-border-width:       $border-width !default;
-$list-group-border-radius:      $border-radius !default;
+$list-group-color:               $body-color !default;
+$list-group-bg:                  $white !default;
+$list-group-border-color:        rgba($black,.125) !default;
+$list-group-border-width:        $border-width !default;
+$list-group-border-radius:       $border-radius !default;
 
-$list-group-hover-bg:           $gray-lightest !default;
-$list-group-active-color:       $component-active-color !default;
-$list-group-active-bg:          $component-active-bg !default;
-$list-group-active-border:      $list-group-active-bg !default;
-$list-group-active-text-color:  lighten($list-group-active-bg, 50%) !default;
+$list-group-item-padding-x:      1.25rem !default;
+$list-group-item-padding-y:      .75rem !default;
+
+$list-group-hover-bg:            $gray-lightest !default;
+$list-group-active-color:        $component-active-color !default;
+$list-group-active-bg:           $component-active-bg !default;
+$list-group-active-border:       $list-group-active-bg !default;
+$list-group-active-text-color:   lighten($list-group-active-bg, 50%) !default;
 
 $list-group-disabled-color:      $gray-light !default;
-$list-group-disabled-bg:         $gray-lighter !default;
+$list-group-disabled-bg:         $list-group-bg !default;
 $list-group-disabled-text-color: $list-group-disabled-color !default;
 
-$list-group-link-color:         $gray !default;
-$list-group-link-hover-color:   $list-group-link-color !default;
-$list-group-link-heading-color: $gray-dark !default;
+$list-group-link-color:          $gray !default;
+$list-group-link-heading-color:  $gray-dark !default;
+$list-group-link-hover-color:    $list-group-link-color !default;
 
-$list-group-item-padding-x:             1.25rem !default;
-$list-group-item-padding-y:             .75rem !default;
-$list-group-item-heading-margin-bottom: 5px !default;
+$list-group-link-active-color:   $list-group-color !default;
+$list-group-link-active-bg:      $gray-lighter !default;
 
 
 // Image thumbnails

--- a/scss/mixins/_list-group.scss
+++ b/scss/mixins/_list-group.scss
@@ -20,11 +20,9 @@
     }
 
     &.active {
-      @include plain-hover-focus {
-        color: #fff;
-        background-color: $color;
-        border-color: $color;
-      }
+      color: #fff;
+      background-color: $color;
+      border-color: $color;
     }
   }
 }


### PR DESCRIPTION
This started out as a general cleanup of our pseudo-classes (to simplify our CSS output), but quickly turned into a smorgasbord of commits. At a high level, this affects navs, navbars, pagination, and list groups, but here's a small rundown of the highlights:

- Removes `plain-hover-focus` mixins from navs, navbar navs, pagination, and list groups. As noted in #21439, these things often don't need to be reset for the active/disabled states. This really helps to reduce the compiled CSS selectors.

- Overhauls the list group a bit to provide better docs, improve Sass variable indentation, cleans up some styles for lighter output.

- Updates pagination to use flexbox instead of floats and what not. Fixes #20029 in the process.

- Revamps pagination docs to include simpler examples, incorporate accessibility notes into the core of the docs instead of as callouts, and provide examples of using flex alignment.

- Fixes some instances of `.open` which was recently changed to `.show` for toggling dropdowns.

My biggest question in this is, do still need these hover mixins for this stuff? @cvrebertc, hoping we can perhaps delete the `plain-hover-focus` one since that should be shied away from anyway.