### PR TITLE
use align-items on .form-inline to keep items from growing too much

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -299,7 +299,7 @@ select.form-control-lg {
   display: flex;
   flex-flow: row wrap;
   align-items: center; // Prevent shorter elements from growing to same height as others (e.g., small buttons growing to normal sized button height)
-  
+
   // Because we use flex, the initial sizing of checkboxes is collapsed and
   // doesn't occupy the full-width (which is what we want for xs grid tier),
   // so we force that here.

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -308,7 +308,7 @@ select.form-control-lg {
   }
 
   // Kick in the inline
-  @include media-breakpoint-up(sm) {    
+  @include media-breakpoint-up(sm) {
     label {
       display: flex;
       align-items: center;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -298,7 +298,8 @@ select.form-control-lg {
 .form-inline {
   display: flex;
   flex-flow: row wrap;
-
+  align-items: center; // Prevent shorter elements from growing to same height as others (e.g., small buttons growing to normal sized button height)
+  
   // Because we use flex, the initial sizing of checkboxes is collapsed and
   // doesn't occupy the full-width (which is what we want for xs grid tier),
   // so we force that here.
@@ -307,7 +308,7 @@ select.form-control-lg {
   }
 
   // Kick in the inline
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-up(sm) {    
     label {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Avoids this issue:

<img width="795" alt="screen shot 2016-12-28 at 4 45 35 pm" src="https://cloud.githubusercontent.com/assets/98681/21534506/15def99e-cd1d-11e6-9529-0a2bc56b2c64.png">
