### PR TITLE
Make container `position: relative`

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -3,6 +3,7 @@
 // Generate semantic grid columns with these mixins.
 
 @mixin make-container($gutters: $grid-gutter-widths) {
+  position: relative;
   margin-left: auto;
   margin-right: auto;
 


### PR DESCRIPTION
Allows for better/easier positioning of elements within (e.g., a toggler in a navbar). Alternative is to add a relative positioning utility, but I think this is more intuitive.