### PR TITLE
v4: Remove tab-focus mixin

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -26,7 +26,6 @@
 @import "mixins/resize";
 @import "mixins/screen-reader";
 @import "mixins/size";
-@import "mixins/tab-focus";
 @import "mixins/reset-text";
 @import "mixins/text-emphasis";
 @import "mixins/text-hide";

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -166,10 +166,6 @@ a {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }
-
-  &:focus {
-    @include tab-focus();
-  }
 }
 
 // And undo these styles for placeholder links/named anchors (without href)
@@ -188,7 +184,7 @@ a:not([href]):not([tabindex]) {
   }
 
   &:focus {
-    outline: none;
+    outline: 0;
   }
 }
 

--- a/scss/mixins/_tab-focus.scss
+++ b/scss/mixins/_tab-focus.scss
@@ -1,9 +1,0 @@
-// WebKit-style focus
-
-@mixin tab-focus() {
-  // WebKit-specific. Other browsers will keep their default outline style.
-  // (Initially tried to also force default via `outline: initial`,
-  // but that seems to erroneously remove the outline in Firefox altogether.)
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}


### PR DESCRIPTION
Last remaining instance of this mixin was in Reboot (after the great button refactor of #21439 and more). Removing all that now and just letting `:focus` states do their thang.

Handles the last bits of #19708 I think.

/cc @patrickhlauke 