### PR TITLE
Remove duplication in `flexbox.md`

### DIFF
--- a/docs/_plugins/highlight_alt.rb
+++ b/docs/_plugins/highlight_alt.rb
@@ -63,10 +63,10 @@ eos
 
         # Find holder.js images and replace the `data-src` with `src="..."`
         code = code.gsub(/data-src="holder.js.+?"/, 'src="..."')
-        # Find tags with the attribue `bd-hide` and remove all attributes after it
-        code = code.gsub(/\ *bd-hide.*?(?=\>)/, "")
-        # Find tags with the attribute `bd-remove` and replace the tag with `...`
-        code = code.gsub(/\<(.+?)\ +.*?bd-remove.*?\>.*?\<\/\1\>/, "...")
+        # Find tags with the attribue `data-bd-hide` and remove all attributes after it
+        code = code.gsub(/\ *data-bd-hide.*?(?=\>)/, "")
+        # Find tags with the attribute `data-bd-remove` and replace the tag with `...`
+        code = code.gsub(/\<(.+?)\ +.*?data-bd-remove.*?\>.*?\<\/\1\>/, "...")
         # We don't need multiple lines of `...`, so only use one `...`.
         code = code.gsub(/(?!\<\w+.*?\>)\s*(?:\.{3,}\s*)+(?=\<\/\w+\>)/, "...")
         # Find `bd-` classes and any class after it and remove them.

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -69,19 +69,19 @@ Use `justify-content` utilities on flexbox containers to change the alignment of
 
 {% example html %}
 <div class="d-flex justify-content-start bd-highlight mb-3">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 <div class="d-flex justify-content-end bd-highlight mb-3">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 <div class="d-flex justify-content-center bd-highlight mb-3">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 <div class="d-flex justify-content-between bd-highlight mb-3">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 <div class="d-flex justify-content-around bd-highlight">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
@@ -99,20 +99,20 @@ Responsive variations also exist for `justify-content`.
 Use `align-items` utilities on flexbox containers to change the alignment of flex items on the cross axis (the y-axis to start, x-axis if `flex-direction: column`). Choose from `start`, `end`, `center`, `baseline`, or `stretch` (browser default).
 
 {% example html %}
-<div class="d-flex align-items-start bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-items-start bd-highlight mb-3" data-bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-<div class="d-flex align-items-end bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-items-end bd-highlight mb-3" data-bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-<div class="d-flex align-items-center bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-items-center bd-highlight mb-3" data-bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-<div class="d-flex align-items-baseline bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-items-baseline bd-highlight mb-3" data-bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-<div class="d-flex align-items-stretch bd-highlight" bd-hide style="height: 100px">{% for i in (1..3) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-items-stretch bd-highlight" data-bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
@@ -201,13 +201,13 @@ Easily move all flex items to one side, but keep another on the opposite end by 
 Similarly, move one flex item to the top or bottom of a container by mixing `align-items`, `flex-direction: column`, and `margin-top: auto` or `margin-bottom: auto`.
 
 {% example html %}
-<div class="d-flex align-items-start flex-column bd-highlight mb-3" bd-hide style="height: 200px;">
+<div class="d-flex align-items-start flex-column bd-highlight mb-3" data-bd-hide style="height: 200px;">
   <div class="mb-auto bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
 </div>
 
-<div class="d-flex align-items-end flex-column bd-highlight mb-3" bd-hide style="height: 200px;">
+<div class="d-flex align-items-end flex-column bd-highlight mb-3" data-bd-hide style="height: 200px;">
   <div class="bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
   <div class="mt-auto bd-highlight p-2">Flex item</div>
@@ -220,19 +220,19 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 
 {% example html %}
 <div class="d-flex flex-nowrap bd-highlight">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
 <div class="d-flex flex-wrap bd-highlight">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
 <div class="d-flex flex-wrap-reverse bd-highlight">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
 {% endexample %}
 
@@ -269,38 +269,38 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 **Heads up!** This property has no affect on single rows of flex items.
 
 {% example html %}
-<div class="d-flex align-content-start flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-start flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
-<div class="d-flex align-content-end flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-end flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
-<div class="d-flex align-content-center flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-center flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
-<div class="d-flex align-content-between flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-between flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
-<div class="d-flex align-content-around flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-around flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 
 {% example html %}
-<div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
-  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+<div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" data-bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div data-bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
 {% endexample %}
 

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -67,31 +67,23 @@ Responsive variations also exist for `flex-direction`.
 
 Use `justify-content` utilities on flexbox containers to change the alignment of flex items on the main axis (the x-axis to start, y-axis if `flex-direction: column`). Choose from `start` (browser default), `end`, `center`, `between`, or `around`.
 
-<div class="bd-example">
-  <div class="d-flex justify-content-start bd-highlight mb-3">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex justify-content-end bd-highlight mb-3">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex justify-content-center bd-highlight mb-3">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex justify-content-between bd-highlight mb-3">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex justify-content-around bd-highlight">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex justify-content-start bd-highlight mb-3">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-
-{% highlight html %}
-<div class="d-flex justify-content-start">...</div>
-<div class="d-flex justify-content-end">...</div>
-<div class="d-flex justify-content-center">...</div>
-<div class="d-flex justify-content-between">...</div>
-<div class="d-flex justify-content-around">...</div>
-{% endhighlight %}
+<div class="d-flex justify-content-end bd-highlight mb-3">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex justify-content-center bd-highlight mb-3">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex justify-content-between bd-highlight mb-3">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex justify-content-around bd-highlight">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+{% endexample %}
 
 Responsive variations also exist for `justify-content`.
 
@@ -106,31 +98,23 @@ Responsive variations also exist for `justify-content`.
 
 Use `align-items` utilities on flexbox containers to change the alignment of flex items on the cross axis (the y-axis to start, x-axis if `flex-direction: column`). Choose from `start`, `end`, `center`, `baseline`, or `stretch` (browser default).
 
-<div class="bd-example">
-  <div class="d-flex align-items-start bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex align-items-end bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex align-items-center bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex align-items-baseline bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-  <div class="d-flex align-items-stretch bd-highlight" style="height: 100px">{% for i in (1..3) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-items-start bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-
-{% highlight html %}
-<div class="d-flex align-items-start">...</div>
-<div class="d-flex align-items-end">...</div>
-<div class="d-flex align-items-center">...</div>
-<div class="d-flex align-items-baseline">...</div>
-<div class="d-flex align-items-stretch">...</div>
-{% endhighlight %}
+<div class="d-flex align-items-end bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex align-items-center bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex align-items-baseline bd-highlight mb-3" bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+<div class="d-flex align-items-stretch bd-highlight" bd-hide style="height: 100px">{% for i in (1..3) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
+</div>
+{% endexample %}
 
 Responsive variations also exist for `align-items`.
 
@@ -217,13 +201,13 @@ Easily move all flex items to one side, but keep another on the opposite end by 
 Similarly, move one flex item to the top or bottom of a container by mixing `align-items`, `flex-direction: column`, and `margin-top: auto` or `margin-bottom: auto`.
 
 {% example html %}
-<div class="d-flex align-items-start flex-column bd-highlight mb-3" style="height: 200px;">
+<div class="d-flex align-items-start flex-column bd-highlight mb-3" bd-hide style="height: 200px;">
   <div class="mb-auto bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
 </div>
 
-<div class="d-flex align-items-end flex-column bd-highlight mb-3" style="height: 200px;">
+<div class="d-flex align-items-end flex-column bd-highlight mb-3" bd-hide style="height: 200px;">
   <div class="bd-highlight p-2">Flex item</div>
   <div class="bd-highlight p-2">Flex item</div>
   <div class="mt-auto bd-highlight p-2">Flex item</div>
@@ -234,41 +218,22 @@ Similarly, move one flex item to the top or bottom of a container by mixing `ali
 
 Change how flex items wrap in a flex container. Choose from no wrapping at all (the browser default) with `.flex-nowrap`, wrapping with `.flex-wrap`, or reverse wrapping with `.flex-wrap-reverse`.
 
-<div class="bd-example">
-  <div class="d-flex flex-nowrap bd-highlight">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex flex-nowrap bd-highlight">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex flex-nowrap">
-  ...
-</div>
-{% endhighlight %}
-
-<div class="bd-example">
-  <div class="d-flex flex-wrap bd-highlight">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-</div>
-{% highlight html %}
-<div class="d-flex flex-wrap">
-  ...
-</div>
-{% endhighlight %}
-
-<div class="bd-example">
-  <div class="d-flex flex-wrap-reverse bd-highlight">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
-</div>
-{% highlight html %}
-<div class="d-flex flex-wrap-reverse">
-  ...
-</div>
-{% endhighlight %}
-
+{% endexample %}
 
 {% example html %}
+<div class="d-flex flex-wrap bd-highlight">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="d-flex flex-wrap-reverse bd-highlight">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
+</div>
 {% endexample %}
 
 Responsive variations also exist for `flex-wrap`.
@@ -303,61 +268,41 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 
 **Heads up!** This property has no affect on single rows of flex items.
 
-<div class="bd-example">
-  <div class="d-flex align-content-start flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-start flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-start flex-wrap">
-  ...
-</div>
-{% endhighlight %}
+{% endexample %}
 
-<div class="bd-example">
-  <div class="d-flex align-content-end flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-end flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-end flex-wrap">...</div>
-{% endhighlight %}
+{% endexample %}
 
-<div class="bd-example">
-  <div class="d-flex align-content-center flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-center flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-center flex-wrap">...</div>
-{% endhighlight %}
+{% endexample %}
 
-<div class="bd-example">
-  <div class="d-flex align-content-between flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-between flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-between flex-wrap">...</div>
-{% endhighlight %}
+{% endexample %}
 
-<div class="bd-example">
-  <div class="d-flex align-content-around flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-around flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-around flex-wrap">...</div>
-{% endhighlight %}
+{% endexample %}
 
-<div class="bd-example">
-  <div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
-    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
-  </div>
+{% example html %}
+<div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" bd-hide style="height: 200px">{% for i in (1..15) %}
+  <div bd-remove class="bd-highlight p-2">Flex item</div>{% endfor %}
 </div>
-{% highlight html %}
-<div class="d-flex align-content-stretch flex-wrap">...</div>
-{% endhighlight %}
+{% endexample %}
 
 Responsive variations also exist for `align-content`.
 

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -36,30 +36,22 @@ Set the direction of flex items in a flex container with direction utilities. In
 Use `.flex-row` to set a horizontal direction (the browser default), or `.flex-row-reverse` to start the horizontal direction from the opposite side.
 
 {% example html %}
-<div class="d-flex flex-row bd-highlight mb-3">
-  <div class="p-2 bd-highlight">Flex item 1</div>
-  <div class="p-2 bd-highlight">Flex item 2</div>
-  <div class="p-2 bd-highlight">Flex item 3</div>
+<div class="d-flex flex-row bd-highlight mb-3">{% for i in (1..3) %}
+  <div class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
-<div class="d-flex flex-row-reverse bd-highlight">
-  <div class="p-2 bd-highlight">Flex item 1</div>
-  <div class="p-2 bd-highlight">Flex item 2</div>
-  <div class="p-2 bd-highlight">Flex item 3</div>
+<div class="d-flex flex-row-reverse bd-highlight">{% for i in (1..3) %}
+  <div class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
 {% endexample %}
 
 Use `.flex-column` to set a vertical direction, or `.flex-column-reverse`  to start the vertical direction from the opposite side.
 
 {% example html %}
-<div class="d-flex flex-column bd-highlight mb-3">
-  <div class="p-2 bd-highlight">Flex item 1</div>
-  <div class="p-2 bd-highlight">Flex item 2</div>
-  <div class="p-2 bd-highlight">Flex item 3</div>
+<div class="d-flex flex-column bd-highlight mb-3">{% for i in (1..3) %}
+  <div class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
-<div class="d-flex flex-column-reverse bd-highlight">
-  <div class="p-2 bd-highlight">Flex item 1</div>
-  <div class="p-2 bd-highlight">Flex item 2</div>
-  <div class="p-2 bd-highlight">Flex item 3</div>
+<div class="d-flex flex-column-reverse bd-highlight">{% for i in (1..3) %}
+  <div class="bd-highlight p-2">Flex item {{ i }}</div>{% endfor %}
 </div>
 {% endexample %}
 
@@ -76,30 +68,20 @@ Responsive variations also exist for `flex-direction`.
 Use `justify-content` utilities on flexbox containers to change the alignment of flex items on the main axis (the x-axis to start, y-axis if `flex-direction: column`). Choose from `start` (browser default), `end`, `center`, `between`, or `around`.
 
 <div class="bd-example">
-  <div class="d-flex justify-content-start bd-highlight mb-3">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex justify-content-start bd-highlight mb-3">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex justify-content-end bd-highlight mb-3">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex justify-content-end bd-highlight mb-3">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex justify-content-center bd-highlight mb-3">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex justify-content-center bd-highlight mb-3">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex justify-content-between bd-highlight mb-3">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex justify-content-between bd-highlight mb-3">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex justify-content-around bd-highlight">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex justify-content-around bd-highlight">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 
@@ -125,30 +107,20 @@ Responsive variations also exist for `justify-content`.
 Use `align-items` utilities on flexbox containers to change the alignment of flex items on the cross axis (the y-axis to start, x-axis if `flex-direction: column`). Choose from `start`, `end`, `center`, `baseline`, or `stretch` (browser default).
 
 <div class="bd-example">
-  <div class="d-flex align-items-start bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-items-start bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex align-items-end bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-items-end bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex align-items-center bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-items-center bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex align-items-baseline bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-items-baseline bd-highlight mb-3" style="height: 100px">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
-  <div class="d-flex align-items-stretch bd-highlight" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-items-stretch bd-highlight" style="height: 100px">{% for i in (1..3) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 
@@ -263,22 +235,8 @@ Similarly, move one flex item to the top or bottom of a container by mixing `ali
 Change how flex items wrap in a flex container. Choose from no wrapping at all (the browser default) with `.flex-nowrap`, wrapping with `.flex-wrap`, or reverse wrapping with `.flex-wrap-reverse`.
 
 <div class="bd-example">
-  <div class="d-flex flex-nowrap bd-highlight">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex flex-nowrap bd-highlight">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -288,22 +246,8 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex flex-wrap bd-highlight">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex flex-wrap bd-highlight">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -313,22 +257,8 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex flex-wrap-reverse bd-highlight">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex flex-wrap-reverse bd-highlight">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -374,22 +304,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 **Heads up!** This property has no affect on single rows of flex items.
 
 <div class="bd-example">
-  <div class="d-flex align-content-start flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-start flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -399,22 +315,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex align-content-end flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-end flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -422,22 +324,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex align-content-center flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-center flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -445,22 +333,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex align-content-between flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-between flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -468,22 +342,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex align-content-around flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-around flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}
@@ -491,22 +351,8 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 {% endhighlight %}
 
 <div class="bd-example">
-  <div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" style="height: 200px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+  <div class="d-flex align-content-stretch flex-wrap bd-highlight mb-3" style="height: 200px">{% for i in (1..15) %}
+    <div class="bd-highlight p-2">Flex item</div>{% endfor %}
   </div>
 </div>
 {% highlight html %}

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -16,11 +16,11 @@ Quickly manage the layout, alignment, and sizing of grid columns, navigation, co
 Apply `display` utilities to create a flexbox container and transform **direct children elements** into flex items. Flex containers and items are able to be modified further with additional flex properties.
 
 {% example html %}
-<div class="d-flex p-2 bd-highlight">I'm a flexbox container!</div>
+<div class="d-flex bd-highlight p-2">I'm a flexbox container!</div>
 {% endexample %}
 
 {% example html %}
-<div class="d-inline-flex p-2 bd-highlight">I'm an inline flexbox container!</div>
+<div class="d-inline-flex bd-highlight p-2">I'm an inline flexbox container!</div>
 {% endexample %}
 
 Responsive variations also exist for `.d-flex` and `.d-inline-flex`.
@@ -147,29 +147,29 @@ Use `align-self` utilities on flexbox items to individually change their alignme
 
 <div class="bd-example">
   <div class="d-flex bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="align-self-start p-2 bd-highlight">Aligned flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
+    <div class="align-self-start bd-highlight p-2">Aligned flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
   </div>
   <div class="d-flex bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="align-self-end p-2 bd-highlight">Aligned flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
+    <div class="align-self-end bd-highlight p-2">Aligned flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
   </div>
   <div class="d-flex bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="align-self-center p-2 bd-highlight">Aligned flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
+    <div class="align-self-center bd-highlight p-2">Aligned flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
   </div>
   <div class="d-flex bd-highlight mb-3" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="align-self-baseline p-2 bd-highlight">Aligned flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
+    <div class="align-self-baseline bd-highlight p-2">Aligned flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
   </div>
   <div class="d-flex bd-highlight" style="height: 100px">
-    <div class="p-2 bd-highlight">Flex item</div>
-    <div class="align-self-stretch p-2 bd-highlight">Aligned flex item</div>
-    <div class="p-2 bd-highlight">Flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
+    <div class="align-self-stretch bd-highlight p-2">Aligned flex item</div>
+    <div class="bd-highlight p-2">Flex item</div>
   </div>
 </div>
 
@@ -200,15 +200,15 @@ Easily move all flex items to one side, but keep another on the opposite end by 
 
 {% example html %}
 <div class="d-flex justify-content-end bd-highlight mb-3">
-  <div class="mr-auto p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="mr-auto bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
 </div>
 
 <div class="d-flex justify-content-start bd-highlight">
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="ml-auto p-2 bd-highlight">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="ml-auto bd-highlight p-2">Flex item</div>
 </div>
 {% endexample %}
 
@@ -218,15 +218,15 @@ Similarly, move one flex item to the top or bottom of a container by mixing `ali
 
 {% example html %}
 <div class="d-flex align-items-start flex-column bd-highlight mb-3" style="height: 200px;">
-  <div class="mb-auto p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
+  <div class="mb-auto bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
 </div>
 
 <div class="d-flex align-items-end flex-column bd-highlight mb-3" style="height: 200px;">
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="p-2 bd-highlight">Flex item</div>
-  <div class="mt-auto p-2 bd-highlight">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="bd-highlight p-2">Flex item</div>
+  <div class="mt-auto bd-highlight p-2">Flex item</div>
 </div>
 {% endexample %}
 
@@ -284,9 +284,9 @@ Change the _visual_ order of specific flex items with a handful of `order` utili
 
 {% example html %}
 <div class="d-flex flex-nowrap bd-highlight">
-  <div class="flex-last p-2 bd-highlight">First flex item</div>
-  <div class="p-2 bd-highlight">Second flex item</div>
-  <div class="flex-first p-2 bd-highlight">Third flex item</div>
+  <div class="flex-last bd-highlight p-2">First flex item</div>
+  <div class="bd-highlight p-2">Second flex item</div>
+  <div class="flex-first bd-highlight p-2">Third flex item</div>
 </div>
 {% endexample %}
 


### PR DESCRIPTION
First commit removes a lot of duplication by using loops. In fact, I can reduce the duplication even more by using `{% cycle %}` but then it starts looking like code-golf, so I'm not going to do that.

The second commit just puts the `bd-highlight` class in front of the `p-2` class, so when it parses, it will hide the `p-2` class. A lot of this is pointless because it'll get replaced with `...` later.

The third commit merges the 2 functions we had before (`remove_holderjs` and `remove_example_classes`) and puts it into a new function called `cleanup_highlighted_code`. The TODO comment was when I realized [that regex does not parse HTML](http://stackoverflow.com/a/1732454) and should be replaced by something better.
The 2 new features that I've also added in this commit are:
- The `data-bd-hide` attribute, which hides the attributes that follow it.
  - `<div class="d-flex" data-bd-hide style="height: 100px;">` =>  `<div class="d-flex">`
- The `data-bd-remove` attribute, which replaces the entire element with `...`
  - `<div data-bd-remove class="d-flex">` => `...`

Please note that these are not going to work 100% of the time, because of the way HTML and regex work.

The fourth commit uses the stuff that I added in the previous commit. I plan to do this to every single file, but I first need to fix the TODO.

For people that want to see what this changes, I've made a build of the docs here: https://bootstrap-tests.starsam80.net/more-bd/utilities/flexbox/