### PR TITLE
Fix progress doc markup

### DIFF
--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -122,7 +122,7 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
   <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
 <div class="progress">
-  <div class="progress-bar progress-bar-striped bg-warning" role="progressbar"style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" ></div>
+  <div class="progress-bar progress-bar-striped bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
 <div class="progress">
   <div class="progress-bar progress-bar-striped bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>


### PR DESCRIPTION
Fix a missing space that create problem with the doc generation.
Before:

![2017-01-04_12-02-29](https://cloud.githubusercontent.com/assets/3250552/21651279/068a016a-d276-11e6-80a2-b106e079026e.png)

After:
![2017-01-04_12-03-05](https://cloud.githubusercontent.com/assets/3250552/21651284/0f4fb704-d276-11e6-8e28-72461b63149c.png)
