### PR TITLE
Fix `.list-group-item` buttons focus outline overlap

### DIFF
--- a/less/list-group.less
+++ b/less/list-group.less
@@ -63,6 +63,10 @@ button.list-group-item {
 button.list-group-item {
   width: 100%;
   text-align: left;
+  
+  &:focus {
+    z-index: 2; // Place focused buttons above their siblings to prevent outline overlap
+  }
 }
 
 .list-group-item {


### PR DESCRIPTION
When list group buttons are focused, their bottom outline is overlapped by the next list button (this seems to be an issue with outlines in general)

![screen shot 2017-01-04 at 9 20 23 pm](https://cloud.githubusercontent.com/assets/5196925/21653051/4b374494-d2d5-11e6-8971-7fc20eefc752.png)

Active list items were already placed above their siblings. This pull request does the same with a focused button to prevent the outline overlap. The recent pull request #16215 for list-group buttons made it easy to include the focus style. Hope it is according to coding standards.