### PR TITLE
Fix link (a element) buttons color when focused

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -12,7 +12,6 @@
   border-color: $border;
   @include box-shadow($btn-box-shadow);
 
-  // Hover and focus styles are shared
   @include hover {
     color: $color;
     background-color: $active-background;
@@ -20,6 +19,8 @@
   }
   &:focus,
   &.focus {
+    // In case of link button (a element) overwrite focus color set in reboot
+    color: $color;
     // Avoid using mixin so we can pass custom focus shadow properly
     @if $enable-shadows {
       box-shadow: $btn-box-shadow, 0 0 0 2px rgba($border, .5);


### PR DESCRIPTION
This has been introduced in https://github.com/twbs/bootstrap/commit/a9bee8b6c8c31455dfba029434fad88b862c3846

Reboot set the focused color for `a` elements.
The button-variant mixin has to set the proper variant color in order for link button to display properly when focused.

Before:
![2017-01-04_16-56-02](https://cloud.githubusercontent.com/assets/3250552/21661034/22d580b8-d2a0-11e6-98dd-86ba02e90b4a.png)

After:
![2017-01-04_17-01-16](https://cloud.githubusercontent.com/assets/3250552/21661043/28767f7c-d2a0-11e6-8508-1084b77b796a.png)

Fixes #21625.