### PR TITLE
Adds Sidebar Drawer Option On Modal

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -11,6 +11,10 @@
   .modal {
     overflow-x: hidden;
     overflow-y: auto;
+
+    &.drawer {
+      overflow-y: hidden;
+    }
   }
 }
 
@@ -30,6 +34,60 @@
   // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
   // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
   // See also https://github.com/twbs/bootstrap/issues/17695
+
+  &.drawer {
+    &.show {
+      .modal-dialog {
+        transform: translateX(0);
+      }
+    }
+
+    &.left {
+      .modal-dialog {
+        left: 0;
+        transform: translateX(-100%);
+      }
+
+      &.show {
+        .modal-dialog {
+          transform: translateX(0);
+        }
+      }
+    }
+
+    .modal-dialog {
+      position: absolute;
+      right: 0;
+      width: $modal-drawer-width;
+      height: 100%;
+      margin: 0;
+      transform: translateX(100%);
+
+      .modal-content {
+        height: 100%;
+        border: 0;
+
+        // Just in case the modal-body is longer than 100vh
+        .modal-body {
+          max-height: calc(100vh - #{$modal-drawer-header-height});
+          padding-bottom: $modal-drawer-header-height;
+          overflow-y: auto;
+        }
+      }
+    }
+
+    .modal-content {
+      border-radius: 0;
+    }
+
+    .modal-footer {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      border: 0;
+      border-radius: 0;
+    }
+  }
 }
 
 // Shell div to position the modal with bottom padding

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -896,6 +896,9 @@ $modal-fade-transform:              translate(0, -50px) !default;
 $modal-show-transform:              none !default;
 $modal-transition:                  transform .3s ease-out !default;
 
+$modal-drawer-width:          16rem !default;
+$modal-drawer-header-height:  4.25rem !default;
+
 
 // Alerts
 //

--- a/site/docs/4.1/components/modal.md
+++ b/site/docs/4.1/components/modal.md
@@ -605,6 +605,96 @@ Our default modal without modifier class constitutes the "medium" size modal.
   </div>
 </div>
 
+## Drawer Variety
+
+Modals can also be displayed as a drawer that slides out from the right or left, available by adding the modifier class `.drawer` after `.modal`. To accommodate the use as an off-canvas navigation, you can have the drawer display from the left side by just adding `.left` after `.drawer`.
+
+<div class="bd-example">
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-drawer-left">Drawer left</button>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-drawer">Drawer right</button>
+</div>
+
+{% highlight html %}
+<!-- Drawer Left -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-drawer-left">Drawer left</button>
+
+<div class="modal fade drawer left bd-example-modal-drawer-left" tabindex="-1" role="dialog" aria-labelledby="myDrawerLeftModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+
+<!-- Drawer Right -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-drawer">Drawer right</button>
+
+<div class="modal fade drawer bd-example-modal-drawer" tabindex="-1" role="dialog" aria-labelledby="myDrawerModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+{% endhighlight %}
+
+<div class="modal fade drawer left bd-example-modal-drawer-left" tabindex="-1" role="dialog" aria-labelledby="myDrawerLeftModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="myDrawerLeftModalLabel">Drawer Left</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer bg-faded">
+        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade drawer bd-example-modal-drawer" tabindex="-1" role="dialog" aria-labelledby="myDrawerModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="myDrawerModalLabel">Drawer Right</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+      </div>
+      <div class="modal-footer bg-faded">
+        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Usage
 
 The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.


### PR DESCRIPTION
Per this comment https://github.com/twbs/bootstrap/pull/21390#issuecomment-268703161 regarding adding a drawer to the framework, I thought I'd offer up the solution that we have been using in prod on V4 for a while. 

This attaches the Drawer to the `.modal` rather than the `.collapse` to take advantage of the modal backdrop. It can be used as an alternative look to the regular modal dialog and as an option for those looking for an off-canvas nav. 

![drawer](https://cloud.githubusercontent.com/assets/4511852/21662524/eb352098-d28e-11e6-8124-ee4eaa284d39.gif)
