### PR TITLE
Update nuspec to support jquery v1.9.1 - v3.x

### DIFF
--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>bootstrap</id>
-    <version>4.0.0-alpha.3</version>
+    <version>4.0.0</version>
     <title>Bootstrap CSS</title>
     <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
@@ -16,9 +16,9 @@
     <copyright>Copyright 2017</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="jQuery" version="3.0.0.1" />
+      <dependency id="jQuery" version="[1.9.1,4)" />
     </dependencies>
-    <tags>css js less mobile-first responsive front-end framework web</tags>
+    <tags>css mobile-first responsive front-end framework web</tags>
   </metadata>
   <files>
     <file src="dist\css\*.*" target="content\Content" />

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>bootstrap.sass</id>
-    <version>4.0.0-alpha.3</version>
+    <version>4.0.0</version>
     <title>Bootstrap Sass</title>
     <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
@@ -16,9 +16,9 @@
     <copyright>Copyright 2017</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="jQuery" version="3.0.0.1" />
+      <dependency id="jQuery" version="[1.9.1,4)" />
     </dependencies>
-    <tags>css js less mobile-first responsive front-end framework web</tags>
+    <tags>css sass mobile-first responsive front-end framework web</tags>
   </metadata>
   <files>
     <file src="scss\**\*.scss" target="content\Content\bootstrap" />


### PR DESCRIPTION
@DavidDeSloovere emailed about the latest NuGet package requiring jquery v3.0.0.1, this will update the nuspec to match the bower.json file and require jquery to be at least v1.9.1 and less than v4.0.0

Also updates 
- the version to plain 4.0.0 (it's set on publishing to match the package.json file)
- the `tags` to match `keywords` of package.json
