### PR TITLE
Fix IE11 table layout issue with flexbox

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -27,7 +27,7 @@ html {
 .container {
   table,
   tbody,
-  td, 
+  td,
   th {
     display: block;
   }

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -22,6 +22,16 @@ html {
   box-sizing: inherit;
 }
 
+//http://stackoverflow.com/questions/35451371/flex-css-property-in-table-doesnt-work-on-ie-and-firefox
+//Not sure what the best way to do this is since someone may want a table outside of the flex grid
+.container {
+  table,
+  tbody,
+  td, 
+  th {
+    display: block;
+  }
+}
 
 //
 // Variables


### PR DESCRIPTION
When applying flexbox to a table in IE, the table cells have strange widths. This is because IE11 sets TD to display: table-cell even when the parent has display: flex. The solution is to manual set the TDs to display: block. There are also wrapping issues that mean table and tbody also need display: block. That bug limits our ability to be more specific by saying "tr.row > td".