### PR TITLE
Match height of select.form-control-sm, input.form-control-sm, and .btn-sm

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -137,11 +137,10 @@ fieldset[disabled] a.btn {
 //
 
 .btn-lg {
-  // line-height: ensure even-numbered height of button next to large input
   @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $font-size-lg, $btn-border-radius-lg);
 }
 .btn-sm {
-  // line-height: ensure proper height of button next to small input
+  line-height: $line-height-sm; // ensure proper height of button next to small input
   @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $font-size-sm, $btn-border-radius-sm);
 }
 

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -159,12 +159,14 @@ select.form-control {
 .form-control-sm {
   padding: $input-padding-y-sm $input-padding-x-sm;
   font-size: $font-size-sm;
+  line-height: $line-height-sm;
   @include border-radius($input-border-radius-sm);
 }
 
 select.form-control-sm {
   &:not([size]):not([multiple]) {
-    height: $input-height-sm;
+    $select-border-width: ($border-width * 2);
+    height: calc(#{$input-height-sm} + #{$select-border-width});
   }
 }
 


### PR DESCRIPTION
This commit shares line-height across these form elements, and adds the same height calculation to `select.form-control-sm` that we have for `select.form-control`.

For issue #21587 

Relevant commits:

https://github.com/twbs/bootstrap/commit/8e455ff56105e210cd313786c23532b7b81d01c9
https://github.com/twbs/bootstrap/pull/20874/commits/0c467e7b29e2dd601e51b2af161c0546a79d432c
https://github.com/twbs/bootstrap/commit/6993db1840561e89dd772302d5b3d567bc92f033