### PR TITLE
_custom.scss should be the first include

### DIFF
--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -6,9 +6,9 @@
  */
 
 // Core variables and mixins
+@import "custom";
 @import "variables";
 @import "mixins";
-@import "custom";
 
 // Reset and dependencies
 @import "normalize";


### PR DESCRIPTION
Custom include should be at the top of the file. This prevents issues where for example reassigning $brand-primary would not affect any of the other variables using $brand-primary.