### PR TITLE
Add align self to navbar brand

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -29,6 +29,7 @@
 
 .navbar-brand {
   display: inline-block;
+  align-self: flex-start;
   padding-top: .25rem;
   padding-bottom: .25rem;
   margin-right: $navbar-padding-x;


### PR DESCRIPTION
This PR fixes navbar brand width. Problem is that after navbar collapsed, link become full width:

![width](https://cloud.githubusercontent.com/assets/17578344/21775201/d865874c-d69d-11e6-9dce-8384e5367147.png)

![hover](https://cloud.githubusercontent.com/assets/17578344/21775220/e420623c-d69d-11e6-9f08-865bf28b027b.gif)

So, after adding `align-self: flex-start;` to `.navbar-brand` it will have its normal width:

![after](https://cloud.githubusercontent.com/assets/17578344/21775296/3019888a-d69e-11e6-9a60-d303ed77e332.png)

Fixes #21621.
