### PR TITLE
v4: Remove focus styles from anchors in Reboot

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -164,7 +164,7 @@ a {
   color: $link-color;
   text-decoration: $link-decoration;
 
-  @include hover-focus {
+  @include hover {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }


### PR DESCRIPTION
Fixes #21625, closes #21539.

We don't need to apply the hover styles to the focus state for links; they'll get the browser defaults here. Doing so was causing issues with link-based buttons having a bug with the focused color changing, so this avoids it entirely.