### PR TITLE
Remove   filter: alpha(opacity = 0);

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -208,7 +208,6 @@
   max-width: 100%;
   height: $custom-file-height;
   margin: 0;
-  filter: alpha(opacity = 0);
   opacity: 0;
 
   &:focus ~ .custom-file-control {


### PR DESCRIPTION
Not needed (and all other old IE filter attributes have been removed from the CSS. This was the only one remaining