### PR TITLE
Remove list-group-item-heading and list-group-item-text

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -22,10 +22,6 @@
   color: $list-group-link-color;
   text-align: inherit; // For `<button>`s (anchors inherit)
 
-  .list-group-item-heading {
-    color: $list-group-link-heading-color;
-  }
-
   // Hover state
   @include hover-focus {
     color: $list-group-link-hover-color;
@@ -73,14 +69,6 @@
     color: $list-group-disabled-color;
     cursor: $cursor-disabled;
     background-color: $list-group-disabled-bg;
-
-    // Force color to inherit for custom content
-    .list-group-item-heading {
-      color: inherit;
-    }
-    .list-group-item-text {
-      color: $list-group-disabled-text-color;
-    }
   }
 
   // Include both here for `<a>`s and `<button>`s
@@ -89,17 +77,6 @@
     color: $list-group-active-color;
     background-color: $list-group-active-bg;
     border-color: $list-group-active-border;
-
-    // Force color to inherit for custom content
-    .list-group-item-heading,
-    .list-group-item-heading > small,
-    .list-group-item-heading > .small {
-      color: inherit;
-    }
-
-    .list-group-item-text {
-      color: $list-group-active-text-color;
-    }
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -871,14 +871,11 @@ $list-group-hover-bg:            $gray-lightest !default;
 $list-group-active-color:        $component-active-color !default;
 $list-group-active-bg:           $component-active-bg !default;
 $list-group-active-border:       $list-group-active-bg !default;
-$list-group-active-text-color:   lighten($list-group-active-bg, 50%) !default;
 
 $list-group-disabled-color:      $gray-light !default;
 $list-group-disabled-bg:         $list-group-bg !default;
-$list-group-disabled-text-color: $list-group-disabled-color !default;
 
 $list-group-link-color:          $gray !default;
-$list-group-link-heading-color:  $gray-dark !default;
 $list-group-link-hover-color:    $list-group-link-color !default;
 
 $list-group-link-active-color:   $list-group-color !default;

--- a/scss/mixins/_list-group.scss
+++ b/scss/mixins/_list-group.scss
@@ -10,10 +10,6 @@
   button.list-group-item-#{$state} {
     color: $color;
 
-    .list-group-item-heading {
-      color: inherit;
-    }
-
     @include hover-focus {
       color: $color;
       background-color: darken($background, 5%);


### PR DESCRIPTION
https://github.com/twbs/bootstrap/commit/f228802fd0ea6914da982bdab7d8f9c9364d1bc3 removes the classes `list-group-item-heading` and `list-group-item-text` from the docs.
The commit makes those classes obsolete and they don't seems to achieve any purpose.