### PR TITLE
Use native font stack for button, input, select and textarea

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -311,8 +311,7 @@ input,
 button,
 select,
 textarea {
-  // Normalize includes `font: inherit;`, so `font-family`. `font-size`, etc are
-  // properly inherited. However, `line-height` isn't inherited there.
+  font: inherit;
   line-height: inherit;
 }
 


### PR DESCRIPTION
Fixes #21588, fixes #21652

Since Normalize 5.0.0 button, input, select and textarea, do not `font: inherit` and define `font-family: sans-serif`,`font-size: 100%`

necolas/normalize.css#649 once merged will remove `font-family: sans-serif`,`font-size: 100%` but do not restore `font: inherit`.

This PR define `font: inherit` in reboot and therefore permanently fix the issues #21588 and #21652 for wether we use Normalize 5.0.0 or 6.0.0 + necolas/normalize.css#649.

Ref necolas/normalize.css#642, necolas/normalize.css#649