### PR TITLE
Use correct value for xs and sm breakpoints in documentation

### DIFF
--- a/docs/layout/responsive-utilities.md
+++ b/docs/layout/responsive-utilities.md
@@ -28,11 +28,11 @@ Try to use these on a limited basis and avoid creating entirely different versio
       <th></th>
       <th>
         Extra small devices
-        <small>Portrait phones (&lt;544px)</small>
+        <small>Portrait phones (&lt;576px)</small>
       </th>
       <th>
         Small devices
-        <small>Landscape phones (&ge;544px - &lt;768px)</small>
+        <small>Landscape phones (&ge;576px - &lt;768px)</small>
       </th>
       <th>
         Medium devices


### PR DESCRIPTION
The documentation on the available responsive utility classes includes an incorrect value for the `xs` max-width and `sm` min-width. This corrects the value and brings the available classes table values in line with the values elsewhere in the documentation (c.f. [Responsive Breakpoints](http://v4-alpha.getbootstrap.com/layout/overview/#responsive-breakpoints)) and with the functionality of the classes themselves.