### PR TITLE
Add alert divider (<hr>) example in docs

### DIFF
--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -61,7 +61,7 @@ Alerts can also contain additional HTML elements like headings, paragraphs and d
 <div class="alert alert-success" role="alert">
   <h4 class="alert-heading">Well done!</h4>
   <p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
-  <hr/>
+  <hr>
   <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
 </div>
 {% endexample %}

--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -55,12 +55,13 @@ Use the `.alert-link` utility class to quickly provide matching colored links wi
 
 ### Additional content
 
-Alerts can also contain additional HTML elements like headings and paragraphs.
+Alerts can also contain additional HTML elements like headings, paragraphs and dividers.
 
 {% example html %}
 <div class="alert alert-success" role="alert">
   <h4 class="alert-heading">Well done!</h4>
   <p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
+  <hr/>
   <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
 </div>
 {% endexample %}


### PR DESCRIPTION
There is styling present [there](https://github.com/twbs/bootstrap/blob/v4-dev/scss/mixins/_alert.scss#L8)  so we might rather include and example in the docs!