### PR TITLE
Update tables.md

### DIFF
--- a/docs/content/tables.md
+++ b/docs/content/tables.md
@@ -765,7 +765,9 @@ Responsive tables make use of `overflow-y: hidden`, which clips off any content 
 </div>
 
 {% highlight html %}
-<table class="table table-responsive">
-  ...
-</table>
+<div class="table-responsive">
+  <table class="table">
+    ...
+  </table>
+</div>
 {% endhighlight %}


### PR DESCRIPTION
corresponding docs to: table-responsive change:
removed 100% width in combination with block, it will break the float in grids and alignments and always clear the preceding. Also the .table-responsive cannot be applied to the `<table>` as display: block; breaks the automatic column width resizing. It should be applied to a wrapping div for overflow and above problems to work correctly