### PR TITLE
css: table as block issues (corresponding to #21677)

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -142,7 +142,6 @@
 
 .table-responsive {
   display: block;
-  width: 100%;
   overflow-x: auto;
   -ms-overflow-style: -ms-autohiding-scrollbar; // See https://github.com/twbs/bootstrap/pull/10057
 


### PR DESCRIPTION
Removed 100% width as in combination with block, it will break the float in grids and alignments and always clear the preceding. Also the .table-responsive cannot be applied to the `<table>` as display: block; breaks the automatic column width resizing. It should be applied to a wrapping div for overflow and above problems to work correctly