### PR TITLE
Add script to check for broken links in docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,6 +243,9 @@ module.exports = function (grunt) {
       },
       'uglify-docs': {
         command: 'npm run uglify-docs'
+      },
+      'check-broken-links': {
+        command: 'npm run check-broken-links'
       }
     },
 
@@ -347,6 +350,8 @@ module.exports = function (grunt) {
   grunt.registerTask('docs-js', ['exec:uglify-docs'])
   grunt.registerTask('docs', ['lint-docs-css', 'docs-css', 'docs-js', 'clean:docs', 'copy:docs'])
   grunt.registerTask('docs-github', ['jekyll:github'])
+  grunt.registerTask('check-broken-links', ['exec:check-broken-links'])
+  grunt.registerTask('lint-docs', ['docs', 'check-broken-links'])
 
   grunt.registerTask('prep-release', ['dist', 'docs', 'docs-github', 'compress'])
 

--- a/grunt/check-broken-links.js
+++ b/grunt/check-broken-links.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+'use strict'
+
+/*!
+ * Script to start a local http server and run broken-link-checker on the Bootstrap documentation site.
+ * Copyright 2017 The Bootstrap Authors
+ * Copyright 2017 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+var finalhandler = require('finalhandler')
+var http = require('http')
+var serveStatic = require('serve-static')
+var Blc = require('broken-link-checker/lib/cli')
+
+function main(args) {
+
+  if (args.length < 2) {
+    console.error('USAGE: check-broken-links <site dir> <port> <options>')
+    console.error('Got arguments:', args)
+    process.exit(1)
+  }
+
+  var directory = args[0]
+  var port = args[1]
+
+  var serve = serveStatic(directory)
+  var server = http.createServer(function onRequest(req, res) {
+    serve(req, res, finalhandler(req, res))
+  })
+
+  server.listen(port, function () {
+    new Blc().input(['http://localhost:' + port].concat(args.slice(2)))
+  })
+}
+
+main(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "uglify": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
     "uglify-docs": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --output docs/assets/js/docs.min.js docs/assets/js/vendor/anchor.min.js docs/assets/js/vendor/clipboard.min.js docs/assets/js/vendor/holder.min.js docs/assets/js/src/application.js",
     "update-shrinkwrap": "npm shrinkwrap --dev && shx mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
-    "test": "npm run eslint && grunt test"
+    "test": "npm run eslint && grunt test",
+    "check-broken-links": "node grunt/check-broken-links.js _gh_pages 3001 -rog"
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",
@@ -53,6 +54,7 @@
     "babel-eslint": "^7.1.1",
     "babel-plugin-transform-es2015-modules-strip": "^0.1.0",
     "babel-preset-es2015": "^6.18.0",
+    "broken-link-checker": "^0.7.4",
     "clean-css": "^3.4.23",
     "eslint": "^3.12.2",
     "grunt": "^1.0.1",
@@ -76,6 +78,7 @@
     "node-sass": "^4.1.1",
     "postcss-cli": "^2.6.0",
     "postcss-flexbugs-fixes": "^2.1.0",
+    "serve-static": "^1.11.1",
     "shelljs": "^0.7.5",
     "shx": "^0.2.1",
     "time-grunt": "^1.4.0",


### PR DESCRIPTION
Fixes #18568

This relies on [broken-link-checker](https://github.com/stevenvachon/broken-link-checker)
The check can be executed via `npm run check-broken-links` or `grunt check-broken-links`.