### PR TITLE
Remove broken links

### DIFF
--- a/docs/_data/translations.yml
+++ b/docs/_data/translations.yml
@@ -6,7 +6,7 @@
 - name: Chinese
   code: zh
   description: Bootstrap 4 中文文档教程
-  url: http://boot4.com/
+  url: http://wiki.jikexueyuan.com/project/bootstrap4/
 
 - name: Japanese
   code: ja

--- a/docs/_data/translations.yml
+++ b/docs/_data/translations.yml
@@ -3,6 +3,11 @@
   description: Bootstrap 中文文档
   url: http://v4.bootcss.com/
 
+- name: Chinese
+  code: zh
+  description: Bootstrap 4 中文文档教程
+  url: http://boot4.com/
+
 - name: Japanese
   code: ja
   description: Bootstrap 4 日本語リファレンス

--- a/docs/_data/translations.yml
+++ b/docs/_data/translations.yml
@@ -3,11 +3,6 @@
   description: Bootstrap 中文文档
   url: http://v4.bootcss.com/
 
-- name: Chinese
-  code: zh
-  description: Bootstrap 4 中文文档教程
-  url: http://boot4.com/
-
 - name: Japanese
   code: ja
   description: Bootstrap 4 日本語リファレンス

--- a/docs/getting-started/build-tools.md
+++ b/docs/getting-started/build-tools.md
@@ -43,7 +43,7 @@ Our Gruntfile includes the following commands and tasks:
 
 Bootstrap uses [Autoprefixer][autoprefixer] (included in our Gruntfile and build process) to automatically add vendor prefixes to some CSS properties at build time. Doing so saves us time and code by allowing us to write key parts of our CSS a single time while eliminating the need for vendor mixins like those found in v3.
 
-We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [`/grunt/postcss.js`](https://github.com/twbs/bootstrap/blob/master/grunt/postcss.js) for details.
+We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [`/grunt/postcss.js`](https://github.com/twbs/bootstrap/blob/v4-dev/grunt/postcss.js) for details.
 
 ## Local documentation
 


### PR DESCRIPTION
Fix link to postcss.js (link to v4-dev instead of master)
Remove the link to http://boot4.com/ as the site is down

All the other links are verified (with script from #21695)