### PR TITLE
JS constant rework => reduce minified JS by 7.5% (6.3% gzipped)

### DIFF
--- a/js/src/alert.js
+++ b/js/src/alert.js
@@ -25,22 +25,15 @@ const Alert = (($) => {
   const JQUERY_NO_CONFLICT  = $.fn[NAME]
   const TRANSITION_DURATION = 150
 
-  const Selector = {
-    DISMISS : '[data-dismiss="alert"]'
-  }
+  const SELECTOR_DISMISS = '[data-dismiss="alert"]'
 
-  const Event = {
-    CLOSE          : `close${EVENT_KEY}`,
-    CLOSED         : `closed${EVENT_KEY}`,
-    CLICK_DATA_API : `click${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_CLOSE = `close${EVENT_KEY}`
+  const EVENT_CLOSED = `closed${EVENT_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    ALERT : 'alert',
-    FADE  : 'fade',
-    SHOW  : 'show'
-  }
-
+  const CLASS_NAME_ALERT = 'alert'
+  const CLASS_NAME_FADE = 'fade'
+  const CLASS_NAME_SHOW = 'show'
 
   /**
    * ------------------------------------------------------------------------
@@ -94,24 +87,24 @@ const Alert = (($) => {
       }
 
       if (!parent) {
-        parent = $(element).closest(`.${ClassName.ALERT}`)[0]
+        parent = $(element).closest(`.${CLASS_NAME_ALERT}`)[0]
       }
 
       return parent
     }
 
     _triggerCloseEvent(element) {
-      const closeEvent = $.Event(Event.CLOSE)
+      const closeEvent = $.Event(EVENT_CLOSE)
 
       $(element).trigger(closeEvent)
       return closeEvent
     }
 
     _removeElement(element) {
-      $(element).removeClass(ClassName.SHOW)
+      $(element).removeClass(CLASS_NAME_SHOW)
 
       if (!Util.supportsTransitionEnd() ||
-          !$(element).hasClass(ClassName.FADE)) {
+          !$(element).hasClass(CLASS_NAME_FADE)) {
         this._destroyElement(element)
         return
       }
@@ -124,7 +117,7 @@ const Alert = (($) => {
     _destroyElement(element) {
       $(element)
         .detach()
-        .trigger(Event.CLOSED)
+        .trigger(EVENT_CLOSED)
         .remove()
     }
 
@@ -167,8 +160,8 @@ const Alert = (($) => {
    */
 
   $(document).on(
-    Event.CLICK_DATA_API,
-    Selector.DISMISS,
+    EVENT_CLICK_DATA_API,
+    SELECTOR_DISMISS,
     Alert._handleDismiss(new Alert())
   )
 

--- a/js/src/button.js
+++ b/js/src/button.js
@@ -21,26 +21,18 @@ const Button = (($) => {
   const DATA_API_KEY        = '.data-api'
   const JQUERY_NO_CONFLICT  = $.fn[NAME]
 
-  const ClassName = {
-    ACTIVE : 'active',
-    BUTTON : 'btn',
-    FOCUS  : 'focus'
-  }
+  const CLASS_NAME_ACTIVE = 'active'
+  const CLASS_NAME_BUTTON = 'btn'
+  const CLASS_NAME_FOCUS = 'focus'
 
-  const Selector = {
-    DATA_TOGGLE_CARROT : '[data-toggle^="button"]',
-    DATA_TOGGLE        : '[data-toggle="buttons"]',
-    INPUT              : 'input',
-    ACTIVE             : '.active',
-    BUTTON             : '.btn'
-  }
+  const SELECTOR_DATA_TOGGLE_CARROT = '[data-toggle^="button"]'
+  const SELECTOR_DATA_TOGGLE = '[data-toggle="buttons"]'
+  const SELECTOR_INPUT = 'input'
+  const SELECTOR_ACTIVE = '.active'
+  const SELECTOR_BUTTON = '.btn'
 
-  const Event = {
-    CLICK_DATA_API      : `click${EVENT_KEY}${DATA_API_KEY}`,
-    FOCUS_BLUR_DATA_API : `focus${EVENT_KEY}${DATA_API_KEY} `
-                        + `blur${EVENT_KEY}${DATA_API_KEY}`
-  }
-
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+  const EVENT_FOCUS_BLUR_DATA_API = `focus${EVENT_KEY}${DATA_API_KEY} blur${EVENT_KEY}${DATA_API_KEY}`
 
   /**
    * ------------------------------------------------------------------------
@@ -67,29 +59,29 @@ const Button = (($) => {
     toggle() {
       let triggerChangeEvent = true
       const rootElement      = $(this._element).closest(
-        Selector.DATA_TOGGLE
+        SELECTOR_DATA_TOGGLE
       )[0]
 
       if (rootElement) {
-        const input = $(this._element).find(Selector.INPUT)[0]
+        const input = $(this._element).find(SELECTOR_INPUT)[0]
 
         if (input) {
           if (input.type === 'radio') {
             if (input.checked &&
-              $(this._element).hasClass(ClassName.ACTIVE)) {
+              $(this._element).hasClass(CLASS_NAME_ACTIVE)) {
               triggerChangeEvent = false
 
             } else {
-              const activeElement = $(rootElement).find(Selector.ACTIVE)[0]
+              const activeElement = $(rootElement).find(SELECTOR_ACTIVE)[0]
 
               if (activeElement) {
-                $(activeElement).removeClass(ClassName.ACTIVE)
+                $(activeElement).removeClass(CLASS_NAME_ACTIVE)
               }
             }
           }
 
           if (triggerChangeEvent) {
-            input.checked = !$(this._element).hasClass(ClassName.ACTIVE)
+            input.checked = !$(this._element).hasClass(CLASS_NAME_ACTIVE)
             $(input).trigger('change')
           }
 
@@ -99,10 +91,10 @@ const Button = (($) => {
       }
 
       this._element.setAttribute('aria-pressed',
-        !$(this._element).hasClass(ClassName.ACTIVE))
+        !$(this._element).hasClass(CLASS_NAME_ACTIVE))
 
       if (triggerChangeEvent) {
-        $(this._element).toggleClass(ClassName.ACTIVE)
+        $(this._element).toggleClass(CLASS_NAME_ACTIVE)
       }
     }
 
@@ -139,20 +131,20 @@ const Button = (($) => {
    */
 
   $(document)
-    .on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE_CARROT, (event) => {
+    .on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE_CARROT, (event) => {
       event.preventDefault()
 
       let button = event.target
 
-      if (!$(button).hasClass(ClassName.BUTTON)) {
-        button = $(button).closest(Selector.BUTTON)
+      if (!$(button).hasClass(CLASS_NAME_BUTTON)) {
+        button = $(button).closest(SELECTOR_BUTTON)
       }
 
       Button._jQueryInterface.call($(button), 'toggle')
     })
-    .on(Event.FOCUS_BLUR_DATA_API, Selector.DATA_TOGGLE_CARROT, (event) => {
-      const button = $(event.target).closest(Selector.BUTTON)[0]
-      $(button).toggleClass(ClassName.FOCUS, /^focus(in)?$/.test(event.type))
+    .on(EVENT_FOCUS_BLUR_DATA_API, SELECTOR_DATA_TOGGLE_CARROT, (event) => {
+      const button = $(event.target).closest(SELECTOR_BUTTON)[0]
+      $(button).toggleClass(CLASS_NAME_FOCUS, /^focus(in)?$/.test(event.type))
     })
 
 

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -43,43 +43,34 @@ const Carousel = (($) => {
     wrap     : 'boolean'
   }
 
-  const Direction = {
-    NEXT     : 'next',
-    PREV     : 'prev',
-    LEFT     : 'left',
-    RIGHT    : 'right'
-  }
+  const DIRECTION_NEXT = 'next'
+  const DIRECTION_PREV = 'prev'
+  const DIRECTION_LEFT = 'left'
+  const DIRECTION_RIGHT = 'right'
 
-  const Event = {
-    SLIDE          : `slide${EVENT_KEY}`,
-    SLID           : `slid${EVENT_KEY}`,
-    KEYDOWN        : `keydown${EVENT_KEY}`,
-    MOUSEENTER     : `mouseenter${EVENT_KEY}`,
-    MOUSELEAVE     : `mouseleave${EVENT_KEY}`,
-    LOAD_DATA_API  : `load${EVENT_KEY}${DATA_API_KEY}`,
-    CLICK_DATA_API : `click${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_SLIDE = `slide${EVENT_KEY}`
+  const EVENT_SLID = `slid${EVENT_KEY}`
+  const EVENT_KEYDOWN = `keydown${EVENT_KEY}`
+  const EVENT_MOUSEENTER = `mouseenter${EVENT_KEY}`
+  const EVENT_MOUSELEAVE = `mouseleave${EVENT_KEY}`
+  const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    CAROUSEL : 'carousel',
-    ACTIVE   : 'active',
-    SLIDE    : 'slide',
-    RIGHT    : 'carousel-item-right',
-    LEFT     : 'carousel-item-left',
-    NEXT     : 'carousel-item-next',
-    PREV     : 'carousel-item-prev',
-    ITEM     : 'carousel-item'
-  }
+  const CLASS_NAME_CAROUSEL = 'carousel'
+  const CLASS_NAME_ACTIVE = 'active'
+  const CLASS_NAME_SLIDE = 'slide'
+  const CLASS_NAME_RIGHT = 'carousel-item-right'
+  const CLASS_NAME_LEFT = 'carousel-item-left'
+  const CLASS_NAME_NEXT = 'carousel-item-next'
+  const CLASS_NAME_PREV = 'carousel-item-prev'
 
-  const Selector = {
-    ACTIVE      : '.active',
-    ACTIVE_ITEM : '.active.carousel-item',
-    ITEM        : '.carousel-item',
-    NEXT_PREV   : '.carousel-item-next, .carousel-item-prev',
-    INDICATORS  : '.carousel-indicators',
-    DATA_SLIDE  : '[data-slide], [data-slide-to]',
-    DATA_RIDE   : '[data-ride="carousel"]'
-  }
+  const SELECTOR_ACTIVE = '.active'
+  const SELECTOR_ACTIVE_ITEM = '.active.carousel-item'
+  const SELECTOR_ITEM = '.carousel-item'
+  const SELECTOR_NEXT_PREV = '.carousel-item-next, .carousel-item-prev'
+  const SELECTOR_INDICATORS = '.carousel-indicators'
+  const SELECTOR_DATA_SLIDE = '[data-slide], [data-slide-to]'
+  const SELECTOR_DATA_RIDE = '[data-ride="carousel"]'
 
 
   /**
@@ -100,7 +91,7 @@ const Carousel = (($) => {
 
       this._config            = this._getConfig(config)
       this._element           = $(element)[0]
-      this._indicatorsElement = $(this._element).find(Selector.INDICATORS)[0]
+      this._indicatorsElement = $(this._element).find(SELECTOR_INDICATORS)[0]
 
       this._addEventListeners()
     }
@@ -123,7 +114,7 @@ const Carousel = (($) => {
       if (this._isSliding) {
         throw new Error('Carousel is sliding')
       }
-      this._slide(Direction.NEXT)
+      this._slide(DIRECTION_NEXT)
     }
 
     nextWhenVisible() {
@@ -137,7 +128,7 @@ const Carousel = (($) => {
       if (this._isSliding) {
         throw new Error('Carousel is sliding')
       }
-      this._slide(Direction.PREVIOUS)
+      this._slide(DIRECTION_PREV)
     }
 
     pause(event) {
@@ -145,7 +136,7 @@ const Carousel = (($) => {
         this._isPaused = true
       }
 
-      if ($(this._element).find(Selector.NEXT_PREV)[0] &&
+      if ($(this._element).find(SELECTOR_NEXT_PREV)[0] &&
         Util.supportsTransitionEnd()) {
         Util.triggerTransitionEnd(this._element)
         this.cycle(true)
@@ -174,7 +165,7 @@ const Carousel = (($) => {
     }
 
     to(index) {
-      this._activeElement = $(this._element).find(Selector.ACTIVE_ITEM)[0]
+      this._activeElement = $(this._element).find(SELECTOR_ACTIVE_ITEM)[0]
 
       const activeIndex = this._getItemIndex(this._activeElement)
 
@@ -183,7 +174,7 @@ const Carousel = (($) => {
       }
 
       if (this._isSliding) {
-        $(this._element).one(Event.SLID, () => this.to(index))
+        $(this._element).one(EVENT_SLID, () => this.to(index))
         return
       }
 
@@ -194,8 +185,8 @@ const Carousel = (($) => {
       }
 
       const direction = index > activeIndex ?
-        Direction.NEXT :
-        Direction.PREVIOUS
+        DIRECTION_NEXT :
+        DIRECTION_PREV
 
       this._slide(direction, this._items[index])
     }
@@ -226,14 +217,14 @@ const Carousel = (($) => {
     _addEventListeners() {
       if (this._config.keyboard) {
         $(this._element)
-          .on(Event.KEYDOWN, (event) => this._keydown(event))
+          .on(EVENT_KEYDOWN, (event) => this._keydown(event))
       }
 
       if (this._config.pause === 'hover' &&
         !('ontouchstart' in document.documentElement)) {
         $(this._element)
-          .on(Event.MOUSEENTER, (event) => this.pause(event))
-          .on(Event.MOUSELEAVE, (event) => this.cycle(event))
+          .on(EVENT_MOUSEENTER, (event) => this.pause(event))
+          .on(EVENT_MOUSELEAVE, (event) => this.cycle(event))
       }
     }
 
@@ -257,13 +248,13 @@ const Carousel = (($) => {
     }
 
     _getItemIndex(element) {
-      this._items = $.makeArray($(element).parent().find(Selector.ITEM))
+      this._items = $.makeArray($(element).parent().find(SELECTOR_ITEM))
       return this._items.indexOf(element)
     }
 
     _getItemByDirection(direction, activeElement) {
-      const isNextDirection = direction === Direction.NEXT
-      const isPrevDirection = direction === Direction.PREVIOUS
+      const isNextDirection = direction === DIRECTION_NEXT
+      const isPrevDirection = direction === DIRECTION_PREV
       const activeIndex     = this._getItemIndex(activeElement)
       const lastItemIndex   = this._items.length - 1
       const isGoingToWrap   = isPrevDirection && activeIndex === 0 ||
@@ -273,7 +264,7 @@ const Carousel = (($) => {
         return activeElement
       }
 
-      const delta     = direction === Direction.PREVIOUS ? -1 : 1
+      const delta     = direction === DIRECTION_PREV ? -1 : 1
       const itemIndex = (activeIndex + delta) % this._items.length
 
       return itemIndex === -1 ?
@@ -282,7 +273,7 @@ const Carousel = (($) => {
 
 
     _triggerSlideEvent(relatedTarget, eventDirectionName) {
-      const slideEvent = $.Event(Event.SLIDE, {
+      const slideEvent = $.Event(EVENT_SLIDE, {
         relatedTarget,
         direction: eventDirectionName
       })
@@ -295,21 +286,21 @@ const Carousel = (($) => {
     _setActiveIndicatorElement(element) {
       if (this._indicatorsElement) {
         $(this._indicatorsElement)
-          .find(Selector.ACTIVE)
-          .removeClass(ClassName.ACTIVE)
+          .find(SELECTOR_ACTIVE)
+          .removeClass(CLASS_NAME_ACTIVE)
 
         const nextIndicator = this._indicatorsElement.children[
           this._getItemIndex(element)
         ]
 
         if (nextIndicator) {
-          $(nextIndicator).addClass(ClassName.ACTIVE)
+          $(nextIndicator).addClass(CLASS_NAME_ACTIVE)
         }
       }
     }
 
     _slide(direction, element) {
-      const activeElement = $(this._element).find(Selector.ACTIVE_ITEM)[0]
+      const activeElement = $(this._element).find(SELECTOR_ACTIVE_ITEM)[0]
       const nextElement   = element || activeElement &&
         this._getItemByDirection(direction, activeElement)
 
@@ -319,17 +310,17 @@ const Carousel = (($) => {
       let orderClassName
       let eventDirectionName
 
-      if (direction === Direction.NEXT) {
-        directionalClassName = ClassName.LEFT
-        orderClassName = ClassName.NEXT
-        eventDirectionName = Direction.LEFT
+      if (direction === DIRECTION_NEXT) {
+        directionalClassName = CLASS_NAME_LEFT
+        orderClassName = CLASS_NAME_NEXT
+        eventDirectionName = DIRECTION_LEFT
       } else {
-        directionalClassName = ClassName.RIGHT
-        orderClassName = ClassName.PREV
-        eventDirectionName = Direction.RIGHT
+        directionalClassName = CLASS_NAME_RIGHT
+        orderClassName = CLASS_NAME_PREV
+        eventDirectionName = DIRECTION_RIGHT
       }
 
-      if (nextElement && $(nextElement).hasClass(ClassName.ACTIVE)) {
+      if (nextElement && $(nextElement).hasClass(CLASS_NAME_ACTIVE)) {
         this._isSliding = false
         return
       }
@@ -352,13 +343,13 @@ const Carousel = (($) => {
 
       this._setActiveIndicatorElement(nextElement)
 
-      const slidEvent = $.Event(Event.SLID, {
+      const slidEvent = $.Event(EVENT_SLID, {
         relatedTarget: nextElement,
         direction: eventDirectionName
       })
 
       if (Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.SLIDE)) {
+        $(this._element).hasClass(CLASS_NAME_SLIDE)) {
 
         $(nextElement).addClass(orderClassName)
 
@@ -371,9 +362,9 @@ const Carousel = (($) => {
           .one(Util.TRANSITION_END, () => {
             $(nextElement)
               .removeClass(`${directionalClassName} ${orderClassName}`)
-              .addClass(ClassName.ACTIVE)
+              .addClass(CLASS_NAME_ACTIVE)
 
-            $(activeElement).removeClass(`${ClassName.ACTIVE} ${orderClassName} ${directionalClassName}`)
+            $(activeElement).removeClass(`${CLASS_NAME_ACTIVE} ${orderClassName} ${directionalClassName}`)
 
             this._isSliding = false
 
@@ -383,8 +374,8 @@ const Carousel = (($) => {
           .emulateTransitionEnd(TRANSITION_DURATION)
 
       } else {
-        $(activeElement).removeClass(ClassName.ACTIVE)
-        $(nextElement).addClass(ClassName.ACTIVE)
+        $(activeElement).removeClass(CLASS_NAME_ACTIVE)
+        $(nextElement).addClass(CLASS_NAME_ACTIVE)
 
         this._isSliding = false
         $(this._element).trigger(slidEvent)
@@ -437,7 +428,7 @@ const Carousel = (($) => {
 
       const target = $(selector)[0]
 
-      if (!target || !$(target).hasClass(ClassName.CAROUSEL)) {
+      if (!target || !$(target).hasClass(CLASS_NAME_CAROUSEL)) {
         return
       }
 
@@ -467,10 +458,10 @@ const Carousel = (($) => {
    */
 
   $(document)
-    .on(Event.CLICK_DATA_API, Selector.DATA_SLIDE, Carousel._dataApiClickHandler)
+    .on(EVENT_CLICK_DATA_API, SELECTOR_DATA_SLIDE, Carousel._dataApiClickHandler)
 
-  $(window).on(Event.LOAD_DATA_API, () => {
-    $(Selector.DATA_RIDE).each(function () {
+  $(window).on(EVENT_LOAD_DATA_API, () => {
+    $(SELECTOR_DATA_RIDE).each(function () {
       const $carousel = $(this)
       Carousel._jQueryInterface.call($carousel, $carousel.data())
     })

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -35,30 +35,22 @@ const Collapse = (($) => {
     parent : 'string'
   }
 
-  const Event = {
-    SHOW           : `show${EVENT_KEY}`,
-    SHOWN          : `shown${EVENT_KEY}`,
-    HIDE           : `hide${EVENT_KEY}`,
-    HIDDEN         : `hidden${EVENT_KEY}`,
-    CLICK_DATA_API : `click${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_SHOW = `show${EVENT_KEY}`
+  const EVENT_SHOWN = `shown${EVENT_KEY}`
+  const EVENT_HIDE = `hide${EVENT_KEY}`
+  const EVENT_HIDDEN = `hidden${EVENT_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    SHOW       : 'show',
-    COLLAPSE   : 'collapse',
-    COLLAPSING : 'collapsing',
-    COLLAPSED  : 'collapsed'
-  }
+  const CLASS_NAME_SHOW = 'show'
+  const CLASS_NAME_COLLAPSE = 'collapse'
+  const CLASS_NAME_COLLAPSING = 'collapsing'
+  const CLASS_NAME_COLLAPSED = 'collapsed'
 
-  const Dimension = {
-    WIDTH  : 'width',
-    HEIGHT : 'height'
-  }
+  const WIDTH = 'width'
+  const HEIGHT = 'height'
 
-  const Selector = {
-    ACTIVES     : '.card > .show, .card > .collapsing',
-    DATA_TOGGLE : '[data-toggle="collapse"]'
-  }
+  const SELECTOR_ACTIVES = '.card > .show, .card > .collapsing'
+  const SELECTOR_DATA_TOGGLE = '[data-toggle="collapse"]'
 
 
   /**
@@ -104,7 +96,7 @@ const Collapse = (($) => {
     // public
 
     toggle() {
-      if ($(this._element).hasClass(ClassName.SHOW)) {
+      if ($(this._element).hasClass(CLASS_NAME_SHOW)) {
         this.hide()
       } else {
         this.show()
@@ -116,7 +108,7 @@ const Collapse = (($) => {
         throw new Error('Collapse is transitioning')
       }
 
-      if ($(this._element).hasClass(ClassName.SHOW)) {
+      if ($(this._element).hasClass(CLASS_NAME_SHOW)) {
         return
       }
 
@@ -124,7 +116,7 @@ const Collapse = (($) => {
       let activesData
 
       if (this._parent) {
-        actives = $.makeArray($(this._parent).find(Selector.ACTIVES))
+        actives = $.makeArray($(this._parent).find(SELECTOR_ACTIVES))
         if (!actives.length) {
           actives = null
         }
@@ -137,7 +129,7 @@ const Collapse = (($) => {
         }
       }
 
-      const startEvent = $.Event(Event.SHOW)
+      const startEvent = $.Event(EVENT_SHOW)
       $(this._element).trigger(startEvent)
       if (startEvent.isDefaultPrevented()) {
         return
@@ -153,15 +145,15 @@ const Collapse = (($) => {
       const dimension = this._getDimension()
 
       $(this._element)
-        .removeClass(ClassName.COLLAPSE)
-        .addClass(ClassName.COLLAPSING)
+        .removeClass(CLASS_NAME_COLLAPSE)
+        .addClass(CLASS_NAME_COLLAPSING)
 
       this._element.style[dimension] = 0
       this._element.setAttribute('aria-expanded', true)
 
       if (this._triggerArray.length) {
         $(this._triggerArray)
-          .removeClass(ClassName.COLLAPSED)
+          .removeClass(CLASS_NAME_COLLAPSED)
           .attr('aria-expanded', true)
       }
 
@@ -169,15 +161,15 @@ const Collapse = (($) => {
 
       const complete = () => {
         $(this._element)
-          .removeClass(ClassName.COLLAPSING)
-          .addClass(ClassName.COLLAPSE)
-          .addClass(ClassName.SHOW)
+          .removeClass(CLASS_NAME_COLLAPSING)
+          .addClass(CLASS_NAME_COLLAPSE)
+          .addClass(CLASS_NAME_SHOW)
 
         this._element.style[dimension] = ''
 
         this.setTransitioning(false)
 
-        $(this._element).trigger(Event.SHOWN)
+        $(this._element).trigger(EVENT_SHOWN)
       }
 
       if (!Util.supportsTransitionEnd()) {
@@ -200,18 +192,18 @@ const Collapse = (($) => {
         throw new Error('Collapse is transitioning')
       }
 
-      if (!$(this._element).hasClass(ClassName.SHOW)) {
+      if (!$(this._element).hasClass(CLASS_NAME_SHOW)) {
         return
       }
 
-      const startEvent = $.Event(Event.HIDE)
+      const startEvent = $.Event(EVENT_HIDE)
       $(this._element).trigger(startEvent)
       if (startEvent.isDefaultPrevented()) {
         return
       }
 
       const dimension       = this._getDimension()
-      const offsetDimension = dimension === Dimension.WIDTH ?
+      const offsetDimension = dimension === WIDTH ?
         'offsetWidth' : 'offsetHeight'
 
       this._element.style[dimension] = `${this._element[offsetDimension]}px`
@@ -219,15 +211,15 @@ const Collapse = (($) => {
       Util.reflow(this._element)
 
       $(this._element)
-        .addClass(ClassName.COLLAPSING)
-        .removeClass(ClassName.COLLAPSE)
-        .removeClass(ClassName.SHOW)
+        .addClass(CLASS_NAME_COLLAPSING)
+        .removeClass(CLASS_NAME_COLLAPSE)
+        .removeClass(CLASS_NAME_SHOW)
 
       this._element.setAttribute('aria-expanded', false)
 
       if (this._triggerArray.length) {
         $(this._triggerArray)
-          .addClass(ClassName.COLLAPSED)
+          .addClass(CLASS_NAME_COLLAPSED)
           .attr('aria-expanded', false)
       }
 
@@ -236,9 +228,9 @@ const Collapse = (($) => {
       const complete = () => {
         this.setTransitioning(false)
         $(this._element)
-          .removeClass(ClassName.COLLAPSING)
-          .addClass(ClassName.COLLAPSE)
-          .trigger(Event.HIDDEN)
+          .removeClass(CLASS_NAME_COLLAPSING)
+          .addClass(CLASS_NAME_COLLAPSE)
+          .trigger(EVENT_HIDDEN)
       }
 
       this._element.style[dimension] = ''
@@ -278,8 +270,8 @@ const Collapse = (($) => {
     }
 
     _getDimension() {
-      const hasWidth = $(this._element).hasClass(Dimension.WIDTH)
-      return hasWidth ? Dimension.WIDTH : Dimension.HEIGHT
+      const hasWidth = $(this._element).hasClass(WIDTH)
+      return hasWidth ? WIDTH : HEIGHT
     }
 
     _getParent() {
@@ -299,12 +291,12 @@ const Collapse = (($) => {
 
     _addAriaAndCollapsedClass(element, triggerArray) {
       if (element) {
-        const isOpen = $(element).hasClass(ClassName.SHOW)
+        const isOpen = $(element).hasClass(CLASS_NAME_SHOW)
         element.setAttribute('aria-expanded', isOpen)
 
         if (triggerArray.length) {
           $(triggerArray)
-            .toggleClass(ClassName.COLLAPSED, !isOpen)
+            .toggleClass(CLASS_NAME_COLLAPSED, !isOpen)
             .attr('aria-expanded', isOpen)
         }
       }
@@ -356,7 +348,7 @@ const Collapse = (($) => {
    * ------------------------------------------------------------------------
    */
 
-  $(document).on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
+  $(document).on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
     event.preventDefault()
 
     const target = Collapse._getTargetFromElement(this)

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -28,34 +28,26 @@ const Dropdown = (($) => {
   const ARROW_DOWN_KEYCODE       = 40 // KeyboardEvent.which value for down arrow key
   const RIGHT_MOUSE_BUTTON_WHICH = 3 // MouseEvent.which value for the right button (assuming a right-handed mouse)
 
-  const Event = {
-    HIDE             : `hide${EVENT_KEY}`,
-    HIDDEN           : `hidden${EVENT_KEY}`,
-    SHOW             : `show${EVENT_KEY}`,
-    SHOWN            : `shown${EVENT_KEY}`,
-    CLICK            : `click${EVENT_KEY}`,
-    CLICK_DATA_API   : `click${EVENT_KEY}${DATA_API_KEY}`,
-    FOCUSIN_DATA_API : `focusin${EVENT_KEY}${DATA_API_KEY}`,
-    KEYDOWN_DATA_API : `keydown${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_HIDE = `hide${EVENT_KEY}`
+  const EVENT_HIDDEN = `hidden${EVENT_KEY}`
+  const EVENT_SHOW = `show${EVENT_KEY}`
+  const EVENT_SHOWN = `shown${EVENT_KEY}`
+  const EVENT_CLICK = `click${EVENT_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
+  const EVENT_FOCUSIN_DATA_API = `focusin${EVENT_KEY}${DATA_API_KEY}`
+  const EVENT_KEYDOWN_DATA_API = `keydown${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    BACKDROP : 'dropdown-backdrop',
-    DISABLED : 'disabled',
-    SHOW     : 'show'
-  }
+  const CLASS_NAME_BACKDROP = 'dropdown-backdrop'
+  const CLASS_NAME_DISABLED = 'disabled'
+  const CLASS_NAME_SHOW = 'show'
 
-  const Selector = {
-    BACKDROP      : '.dropdown-backdrop',
-    DATA_TOGGLE   : '[data-toggle="dropdown"]',
-    FORM_CHILD    : '.dropdown form',
-    ROLE_MENU     : '[role="menu"]',
-    ROLE_LISTBOX  : '[role="listbox"]',
-    NAVBAR_NAV    : '.navbar-nav',
-    VISIBLE_ITEMS : '[role="menu"] li:not(.disabled) a, '
-                  + '[role="listbox"] li:not(.disabled) a'
-  }
-
+  const SELECTOR_BACKDROP = '.dropdown-backdrop'
+  const SELECTOR_DATA_TOGGLE = '[data-toggle="dropdown"]'
+  const SELECTOR_FORM_CHILD = '.dropdown form'
+  const SELECTOR_ROLE_MENU = '[role="menu"]'
+  const SELECTOR_ROLE_LISTBOX = '[role="listbox"]'
+  const SELECTOR_NAVBAR_NAV = '.navbar-nav'
+  const SELECTOR_VISIBLE_ITEMS = '[role="menu"] li:not(.disabled) a, [role="listbox"] li:not(.disabled) a'
 
   /**
    * ------------------------------------------------------------------------
@@ -82,12 +74,12 @@ const Dropdown = (($) => {
     // public
 
     toggle() {
-      if (this.disabled || $(this).hasClass(ClassName.DISABLED)) {
+      if (this.disabled || $(this).hasClass(CLASS_NAME_DISABLED)) {
         return false
       }
 
       const parent   = Dropdown._getParentFromElement(this)
-      const isActive = $(parent).hasClass(ClassName.SHOW)
+      const isActive = $(parent).hasClass(CLASS_NAME_SHOW)
 
       Dropdown._clearMenus()
 
@@ -96,11 +88,11 @@ const Dropdown = (($) => {
       }
 
       if ('ontouchstart' in document.documentElement &&
-         !$(parent).closest(Selector.NAVBAR_NAV).length) {
+         !$(parent).closest(SELECTOR_NAVBAR_NAV).length) {
 
         // if mobile we use a backdrop because click events don't delegate
         const dropdown     = document.createElement('div')
-        dropdown.className = ClassName.BACKDROP
+        dropdown.className = CLASS_NAME_BACKDROP
         $(dropdown).insertBefore(this)
         $(dropdown).on('click', Dropdown._clearMenus)
       }
@@ -108,7 +100,7 @@ const Dropdown = (($) => {
       const relatedTarget = {
         relatedTarget : this
       }
-      const showEvent     = $.Event(Event.SHOW, relatedTarget)
+      const showEvent     = $.Event(EVENT_SHOW, relatedTarget)
 
       $(parent).trigger(showEvent)
 
@@ -119,8 +111,8 @@ const Dropdown = (($) => {
       this.focus()
       this.setAttribute('aria-expanded', true)
 
-      $(parent).toggleClass(ClassName.SHOW)
-      $(parent).trigger($.Event(Event.SHOWN, relatedTarget))
+      $(parent).toggleClass(CLASS_NAME_SHOW)
+      $(parent).trigger($.Event(EVENT_SHOWN, relatedTarget))
 
       return false
     }
@@ -135,7 +127,7 @@ const Dropdown = (($) => {
     // private
 
     _addEventListeners() {
-      $(this._element).on(Event.CLICK, this.toggle)
+      $(this._element).on(EVENT_CLICK, this.toggle)
     }
 
 
@@ -164,12 +156,12 @@ const Dropdown = (($) => {
         return
       }
 
-      const backdrop = $(Selector.BACKDROP)[0]
+      const backdrop = $(SELECTOR_BACKDROP)[0]
       if (backdrop) {
         backdrop.parentNode.removeChild(backdrop)
       }
 
-      const toggles = $.makeArray($(Selector.DATA_TOGGLE))
+      const toggles = $.makeArray($(SELECTOR_DATA_TOGGLE))
 
       for (let i = 0; i < toggles.length; i++) {
         const parent        = Dropdown._getParentFromElement(toggles[i])
@@ -177,7 +169,7 @@ const Dropdown = (($) => {
           relatedTarget : toggles[i]
         }
 
-        if (!$(parent).hasClass(ClassName.SHOW)) {
+        if (!$(parent).hasClass(CLASS_NAME_SHOW)) {
           continue
         }
 
@@ -187,7 +179,7 @@ const Dropdown = (($) => {
           continue
         }
 
-        const hideEvent = $.Event(Event.HIDE, relatedTarget)
+        const hideEvent = $.Event(EVENT_HIDE, relatedTarget)
         $(parent).trigger(hideEvent)
         if (hideEvent.isDefaultPrevented()) {
           continue
@@ -196,8 +188,8 @@ const Dropdown = (($) => {
         toggles[i].setAttribute('aria-expanded', 'false')
 
         $(parent)
-          .removeClass(ClassName.SHOW)
-          .trigger($.Event(Event.HIDDEN, relatedTarget))
+          .removeClass(CLASS_NAME_SHOW)
+          .trigger($.Event(EVENT_HIDDEN, relatedTarget))
       }
     }
 
@@ -221,18 +213,18 @@ const Dropdown = (($) => {
       event.preventDefault()
       event.stopPropagation()
 
-      if (this.disabled || $(this).hasClass(ClassName.DISABLED)) {
+      if (this.disabled || $(this).hasClass(CLASS_NAME_DISABLED)) {
         return
       }
 
       const parent   = Dropdown._getParentFromElement(this)
-      const isActive = $(parent).hasClass(ClassName.SHOW)
+      const isActive = $(parent).hasClass(CLASS_NAME_SHOW)
 
       if (!isActive && event.which !== ESCAPE_KEYCODE ||
            isActive && event.which === ESCAPE_KEYCODE) {
 
         if (event.which === ESCAPE_KEYCODE) {
-          const toggle = $(parent).find(Selector.DATA_TOGGLE)[0]
+          const toggle = $(parent).find(SELECTOR_DATA_TOGGLE)[0]
           $(toggle).trigger('focus')
         }
 
@@ -240,7 +232,7 @@ const Dropdown = (($) => {
         return
       }
 
-      const items = $(parent).find(Selector.VISIBLE_ITEMS).get()
+      const items = $(parent).find(SELECTOR_VISIBLE_ITEMS).get()
 
       if (!items.length) {
         return
@@ -273,12 +265,12 @@ const Dropdown = (($) => {
    */
 
   $(document)
-    .on(Event.KEYDOWN_DATA_API, Selector.DATA_TOGGLE,  Dropdown._dataApiKeydownHandler)
-    .on(Event.KEYDOWN_DATA_API, Selector.ROLE_MENU,    Dropdown._dataApiKeydownHandler)
-    .on(Event.KEYDOWN_DATA_API, Selector.ROLE_LISTBOX, Dropdown._dataApiKeydownHandler)
-    .on(`${Event.CLICK_DATA_API} ${Event.FOCUSIN_DATA_API}`, Dropdown._clearMenus)
-    .on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, Dropdown.prototype.toggle)
-    .on(Event.CLICK_DATA_API, Selector.FORM_CHILD, (e) => {
+    .on(EVENT_KEYDOWN_DATA_API, SELECTOR_DATA_TOGGLE,  Dropdown._dataApiKeydownHandler)
+    .on(EVENT_KEYDOWN_DATA_API, SELECTOR_ROLE_MENU,    Dropdown._dataApiKeydownHandler)
+    .on(EVENT_KEYDOWN_DATA_API, SELECTOR_ROLE_LISTBOX, Dropdown._dataApiKeydownHandler)
+    .on(`${EVENT_CLICK_DATA_API} ${EVENT_FOCUSIN_DATA_API}`, Dropdown._clearMenus)
+    .on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, Dropdown.prototype.toggle)
+    .on(EVENT_CLICK_DATA_API, SELECTOR_FORM_CHILD, (e) => {
       e.stopPropagation()
     })
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -41,34 +41,28 @@ const Modal = (($) => {
     show     : 'boolean'
   }
 
-  const Event = {
-    HIDE              : `hide${EVENT_KEY}`,
-    HIDDEN            : `hidden${EVENT_KEY}`,
-    SHOW              : `show${EVENT_KEY}`,
-    SHOWN             : `shown${EVENT_KEY}`,
-    FOCUSIN           : `focusin${EVENT_KEY}`,
-    RESIZE            : `resize${EVENT_KEY}`,
-    CLICK_DISMISS     : `click.dismiss${EVENT_KEY}`,
-    KEYDOWN_DISMISS   : `keydown.dismiss${EVENT_KEY}`,
-    MOUSEUP_DISMISS   : `mouseup.dismiss${EVENT_KEY}`,
-    MOUSEDOWN_DISMISS : `mousedown.dismiss${EVENT_KEY}`,
-    CLICK_DATA_API    : `click${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_HIDE = `hide${EVENT_KEY}`
+  const EVENT_HIDDEN = `hidden${EVENT_KEY}`
+  const EVENT_SHOW = `show${EVENT_KEY}`
+  const EVENT_SHOWN = `shown${EVENT_KEY}`
+  const EVENT_FOCUSIN = `focusin${EVENT_KEY}`
+  const EVENT_RESIZE = `resize${EVENT_KEY}`
+  const EVENT_CLICK_DISMISS = `click.dismiss${EVENT_KEY}`
+  const EVENT_KEYDOWN_DISMISS = `keydown.dismiss${EVENT_KEY}`
+  const EVENT_MOUSEUP_DISMISS = `mouseup.dismiss${EVENT_KEY}`
+  const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    SCROLLBAR_MEASURER : 'modal-scrollbar-measure',
-    BACKDROP           : 'modal-backdrop',
-    OPEN               : 'modal-open',
-    FADE               : 'fade',
-    SHOW               : 'show'
-  }
+  const CLASS_NAME_SCROLLBAR_MEASURER = 'modal-scrollbar-measure'
+  const CLASS_NAME_BACKDROP = 'modal-backdrop'
+  const CLASS_NAME_OPEN = 'modal-open'
+  const CLASS_NAME_FADE = 'fade'
+  const CLASS_NAME_SHOW = 'show'
 
-  const Selector = {
-    DIALOG             : '.modal-dialog',
-    DATA_TOGGLE        : '[data-toggle="modal"]',
-    DATA_DISMISS       : '[data-dismiss="modal"]',
-    FIXED_CONTENT      : '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
-  }
+  const SELECTOR_DIALOG = '.modal-dialog'
+  const SELECTOR_DATA_TOGGLE = '[data-toggle="modal"]'
+  const SELECTOR_DATA_DISMISS = '[data-dismiss="modal"]'
+  const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 
 
   /**
@@ -82,7 +76,7 @@ const Modal = (($) => {
     constructor(element, config) {
       this._config              = this._getConfig(config)
       this._element             = element
-      this._dialog              = $(element).find(Selector.DIALOG)[0]
+      this._dialog              = $(element).find(SELECTOR_DIALOG)[0]
       this._backdrop            = null
       this._isShown             = false
       this._isBodyOverflowing   = false
@@ -116,10 +110,10 @@ const Modal = (($) => {
       }
 
       if (Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.FADE)) {
+        $(this._element).hasClass(CLASS_NAME_FADE)) {
         this._isTransitioning = true
       }
-      const showEvent = $.Event(Event.SHOW, {
+      const showEvent = $.Event(EVENT_SHOW, {
         relatedTarget
       })
 
@@ -134,19 +128,19 @@ const Modal = (($) => {
       this._checkScrollbar()
       this._setScrollbar()
 
-      $(document.body).addClass(ClassName.OPEN)
+      $(document.body).addClass(CLASS_NAME_OPEN)
 
       this._setEscapeEvent()
       this._setResizeEvent()
 
       $(this._element).on(
-        Event.CLICK_DISMISS,
-        Selector.DATA_DISMISS,
+        EVENT_CLICK_DISMISS,
+        SELECTOR_DATA_DISMISS,
         (event) => this.hide(event)
       )
 
-      $(this._dialog).on(Event.MOUSEDOWN_DISMISS, () => {
-        $(this._element).one(Event.MOUSEUP_DISMISS, (event) => {
+      $(this._dialog).on(EVENT_MOUSEDOWN_DISMISS, () => {
+        $(this._element).one(EVENT_MOUSEUP_DISMISS, (event) => {
           if ($(event.target).is(this._element)) {
             this._ignoreBackdropClick = true
           }
@@ -166,12 +160,12 @@ const Modal = (($) => {
       }
 
       const transition = Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.FADE)
+        $(this._element).hasClass(CLASS_NAME_FADE)
       if (transition) {
         this._isTransitioning = true
       }
 
-      const hideEvent = $.Event(Event.HIDE)
+      const hideEvent = $.Event(EVENT_HIDE)
       $(this._element).trigger(hideEvent)
 
       if (!this._isShown || hideEvent.isDefaultPrevented()) {
@@ -183,12 +177,12 @@ const Modal = (($) => {
       this._setEscapeEvent()
       this._setResizeEvent()
 
-      $(document).off(Event.FOCUSIN)
+      $(document).off(EVENT_FOCUSIN)
 
-      $(this._element).removeClass(ClassName.SHOW)
+      $(this._element).removeClass(CLASS_NAME_SHOW)
 
-      $(this._element).off(Event.CLICK_DISMISS)
-      $(this._dialog).off(Event.MOUSEDOWN_DISMISS)
+      $(this._element).off(EVENT_CLICK_DISMISS)
+      $(this._dialog).off(EVENT_MOUSEDOWN_DISMISS)
 
       if (transition) {
         $(this._element)
@@ -226,7 +220,7 @@ const Modal = (($) => {
 
     _showElement(relatedTarget) {
       const transition = Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.FADE)
+        $(this._element).hasClass(CLASS_NAME_FADE)
 
       if (!this._element.parentNode ||
          this._element.parentNode.nodeType !== Node.ELEMENT_NODE) {
@@ -242,13 +236,13 @@ const Modal = (($) => {
         Util.reflow(this._element)
       }
 
-      $(this._element).addClass(ClassName.SHOW)
+      $(this._element).addClass(CLASS_NAME_SHOW)
 
       if (this._config.focus) {
         this._enforceFocus()
       }
 
-      const shownEvent = $.Event(Event.SHOWN, {
+      const shownEvent = $.Event(EVENT_SHOWN, {
         relatedTarget
       })
 
@@ -271,8 +265,8 @@ const Modal = (($) => {
 
     _enforceFocus() {
       $(document)
-        .off(Event.FOCUSIN) // guard against infinite focus loop
-        .on(Event.FOCUSIN, (event) => {
+        .off(EVENT_FOCUSIN) // guard against infinite focus loop
+        .on(EVENT_FOCUSIN, (event) => {
           if (document !== event.target &&
               this._element !== event.target &&
               !$(this._element).has(event.target).length) {
@@ -283,22 +277,22 @@ const Modal = (($) => {
 
     _setEscapeEvent() {
       if (this._isShown && this._config.keyboard) {
-        $(this._element).on(Event.KEYDOWN_DISMISS, (event) => {
+        $(this._element).on(EVENT_KEYDOWN_DISMISS, (event) => {
           if (event.which === ESCAPE_KEYCODE) {
             this.hide()
           }
         })
 
       } else if (!this._isShown) {
-        $(this._element).off(Event.KEYDOWN_DISMISS)
+        $(this._element).off(EVENT_KEYDOWN_DISMISS)
       }
     }
 
     _setResizeEvent() {
       if (this._isShown) {
-        $(window).on(Event.RESIZE, (event) => this._handleUpdate(event))
+        $(window).on(EVENT_RESIZE, (event) => this._handleUpdate(event))
       } else {
-        $(window).off(Event.RESIZE)
+        $(window).off(EVENT_RESIZE)
       }
     }
 
@@ -307,10 +301,10 @@ const Modal = (($) => {
       this._element.setAttribute('aria-hidden', 'true')
       this._isTransitioning = false
       this._showBackdrop(() => {
-        $(document.body).removeClass(ClassName.OPEN)
+        $(document.body).removeClass(CLASS_NAME_OPEN)
         this._resetAdjustments()
         this._resetScrollbar()
-        $(this._element).trigger(Event.HIDDEN)
+        $(this._element).trigger(EVENT_HIDDEN)
       })
     }
 
@@ -322,14 +316,14 @@ const Modal = (($) => {
     }
 
     _showBackdrop(callback) {
-      const animate = $(this._element).hasClass(ClassName.FADE) ?
-        ClassName.FADE : ''
+      const animate = $(this._element).hasClass(CLASS_NAME_FADE) ?
+        CLASS_NAME_FADE : ''
 
       if (this._isShown && this._config.backdrop) {
         const doAnimate = Util.supportsTransitionEnd() && animate
 
         this._backdrop = document.createElement('div')
-        this._backdrop.className = ClassName.BACKDROP
+        this._backdrop.className = CLASS_NAME_BACKDROP
 
         if (animate) {
           $(this._backdrop).addClass(animate)
@@ -337,7 +331,7 @@ const Modal = (($) => {
 
         $(this._backdrop).appendTo(document.body)
 
-        $(this._element).on(Event.CLICK_DISMISS, (event) => {
+        $(this._element).on(EVENT_CLICK_DISMISS, (event) => {
           if (this._ignoreBackdropClick) {
             this._ignoreBackdropClick = false
             return
@@ -356,7 +350,7 @@ const Modal = (($) => {
           Util.reflow(this._backdrop)
         }
 
-        $(this._backdrop).addClass(ClassName.SHOW)
+        $(this._backdrop).addClass(CLASS_NAME_SHOW)
 
         if (!callback) {
           return
@@ -372,7 +366,7 @@ const Modal = (($) => {
           .emulateTransitionEnd(BACKDROP_TRANSITION_DURATION)
 
       } else if (!this._isShown && this._backdrop) {
-        $(this._backdrop).removeClass(ClassName.SHOW)
+        $(this._backdrop).removeClass(CLASS_NAME_SHOW)
 
         const callbackRemove = () => {
           this._removeBackdrop()
@@ -382,7 +376,7 @@ const Modal = (($) => {
         }
 
         if (Util.supportsTransitionEnd() &&
-           $(this._element).hasClass(ClassName.FADE)) {
+           $(this._element).hasClass(CLASS_NAME_FADE)) {
           $(this._backdrop)
             .one(Util.TRANSITION_END, callbackRemove)
             .emulateTransitionEnd(BACKDROP_TRANSITION_DURATION)
@@ -430,7 +424,7 @@ const Modal = (($) => {
 
     _setScrollbar() {
       const bodyPadding = parseInt(
-        $(Selector.FIXED_CONTENT).css('padding-right') || 0,
+        $(SELECTOR_FIXED_CONTENT).css('padding-right') || 0,
         10
       )
 
@@ -448,7 +442,7 @@ const Modal = (($) => {
 
     _getScrollbarWidth() { // thx d.walsh
       const scrollDiv = document.createElement('div')
-      scrollDiv.className = ClassName.SCROLLBAR_MEASURER
+      scrollDiv.className = CLASS_NAME_SCROLLBAR_MEASURER
       document.body.appendChild(scrollDiv)
       const scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth
       document.body.removeChild(scrollDiv)
@@ -493,7 +487,7 @@ const Modal = (($) => {
    * ------------------------------------------------------------------------
    */
 
-  $(document).on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
+  $(document).on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
     let target
     const selector = Util.getSelectorFromElement(this)
 
@@ -508,13 +502,13 @@ const Modal = (($) => {
       event.preventDefault()
     }
 
-    const $target = $(target).one(Event.SHOW, (showEvent) => {
+    const $target = $(target).one(EVENT_SHOW, (showEvent) => {
       if (showEvent.isDefaultPrevented()) {
         // only register focus restorer if modal will actually get shown
         return
       }
 
-      $target.one(Event.HIDDEN, () => {
+      $target.one(EVENT_HIDDEN, () => {
         if ($(this).is(':visible')) {
           this.focus()
         }

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -42,19 +42,6 @@ const Popover = (($) => {
   const SELECTOR_TITLE = '.popover-title'
   const SELECTOR_CONTENT = '.popover-content'
 
-  const Event = {
-    HIDE       : `hide${EVENT_KEY}`,
-    HIDDEN     : `hidden${EVENT_KEY}`,
-    SHOW       : `show${EVENT_KEY}`,
-    SHOWN      : `shown${EVENT_KEY}`,
-    INSERTED   : `inserted${EVENT_KEY}`,
-    CLICK      : `click${EVENT_KEY}`,
-    FOCUSIN    : `focusin${EVENT_KEY}`,
-    FOCUSOUT   : `focusout${EVENT_KEY}`,
-    MOUSEENTER : `mouseenter${EVENT_KEY}`,
-    MOUSELEAVE : `mouseleave${EVENT_KEY}`
-  }
-
 
   /**
    * ------------------------------------------------------------------------
@@ -83,8 +70,8 @@ const Popover = (($) => {
       return DATA_KEY
     }
 
-    static get Event() {
-      return Event
+    static getEvent(eventName) {
+      return `${eventName}${EVENT_KEY}`
     }
 
     static get EVENT_KEY() {

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -36,15 +36,11 @@ const Popover = (($) => {
     content : '(string|element|function)'
   })
 
-  const ClassName = {
-    FADE : 'fade',
-    SHOW : 'show'
-  }
+  const CLASS_NAME_FADE = 'fade'
+  const CLASS_NAME_SHOW = 'show'
 
-  const Selector = {
-    TITLE   : '.popover-title',
-    CONTENT : '.popover-content'
-  }
+  const SELECTOR_TITLE = '.popover-title'
+  const SELECTOR_CONTENT = '.popover-content'
 
   const Event = {
     HIDE       : `hide${EVENT_KEY}`,
@@ -114,10 +110,10 @@ const Popover = (($) => {
       const $tip = $(this.getTipElement())
 
       // we use append for html objects to maintain js events
-      this.setElementContent($tip.find(Selector.TITLE), this.getTitle())
-      this.setElementContent($tip.find(Selector.CONTENT), this._getContent())
+      this.setElementContent($tip.find(SELECTOR_TITLE), this.getTitle())
+      this.setElementContent($tip.find(SELECTOR_CONTENT), this._getContent())
 
-      $tip.removeClass(`${ClassName.FADE} ${ClassName.SHOW}`)
+      $tip.removeClass(`${CLASS_NAME_FADE} ${CLASS_NAME_SHOW}`)
 
       this.cleanupTether()
     }

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -36,36 +36,23 @@ const ScrollSpy = (($) => {
     target : '(string|element)'
   }
 
-  const Event = {
-    ACTIVATE      : `activate${EVENT_KEY}`,
-    SCROLL        : `scroll${EVENT_KEY}`,
-    LOAD_DATA_API : `load${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_ACTIVATE = `activate${EVENT_KEY}`
+  const EVENT_SCROLL = `scroll${EVENT_KEY}`
+  const EVENT_LOAD_DATA_API = `load${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    DROPDOWN_ITEM : 'dropdown-item',
-    DROPDOWN_MENU : 'dropdown-menu',
-    NAV_LINK      : 'nav-link',
-    NAV           : 'nav',
-    ACTIVE        : 'active'
-  }
+  const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item'
+  const CLASS_NAME_ACTIVE = 'active'
 
-  const Selector = {
-    DATA_SPY        : '[data-spy="scroll"]',
-    ACTIVE          : '.active',
-    LIST_ITEM       : '.list-item',
-    LI              : 'li',
-    LI_DROPDOWN     : 'li.dropdown',
-    NAV_LINKS       : '.nav-link',
-    DROPDOWN        : '.dropdown',
-    DROPDOWN_ITEMS  : '.dropdown-item',
-    DROPDOWN_TOGGLE : '.dropdown-toggle'
-  }
+  const SELECTOR_DATA_SPY = '[data-spy="scroll"]'
+  const SELECTOR_ACTIVE = '.active'
+  const SELECTOR_LI = 'li'
+  const SELECTOR_NAV_LINKS = '.nav-link'
+  const SELECTOR_DROPDOWN = '.dropdown'
+  const SELECTOR_DROPDOWN_ITEMS = '.dropdown-item'
+  const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
 
-  const OffsetMethod = {
-    OFFSET   : 'offset',
-    POSITION : 'position'
-  }
+  const METHOD_OFFSET = 'offset'
+  const METHOD_POSITION = 'position'
 
 
   /**
@@ -80,14 +67,14 @@ const ScrollSpy = (($) => {
       this._element       = element
       this._scrollElement = element.tagName === 'BODY' ? window : element
       this._config        = this._getConfig(config)
-      this._selector      = `${this._config.target} ${Selector.NAV_LINKS},`
-                          + `${this._config.target} ${Selector.DROPDOWN_ITEMS}`
+      this._selector      = `${this._config.target} ${SELECTOR_NAV_LINKS},`
+                          + `${this._config.target} ${SELECTOR_DROPDOWN_ITEMS}`
       this._offsets       = []
       this._targets       = []
       this._activeTarget  = null
       this._scrollHeight  = 0
 
-      $(this._scrollElement).on(Event.SCROLL, (event) => this._process(event))
+      $(this._scrollElement).on(EVENT_SCROLL, (event) => this._process(event))
 
       this.refresh()
       this._process()
@@ -109,12 +96,12 @@ const ScrollSpy = (($) => {
 
     refresh() {
       const autoMethod = this._scrollElement !== this._scrollElement.window ?
-        OffsetMethod.POSITION : OffsetMethod.OFFSET
+        METHOD_POSITION : METHOD_OFFSET
 
       const offsetMethod = this._config.method === 'auto' ?
         autoMethod : this._config.method
 
-      const offsetBase = offsetMethod === OffsetMethod.POSITION ?
+      const offsetBase = offsetMethod === METHOD_POSITION ?
         this._getScrollTop() : 0
 
       this._offsets = []
@@ -252,22 +239,22 @@ const ScrollSpy = (($) => {
 
       const $link = $(queries.join(','))
 
-      if ($link.hasClass(ClassName.DROPDOWN_ITEM)) {
-        $link.closest(Selector.DROPDOWN).find(Selector.DROPDOWN_TOGGLE).addClass(ClassName.ACTIVE)
-        $link.addClass(ClassName.ACTIVE)
+      if ($link.hasClass(CLASS_NAME_DROPDOWN_ITEM)) {
+        $link.closest(SELECTOR_DROPDOWN).find(SELECTOR_DROPDOWN_TOGGLE).addClass(CLASS_NAME_ACTIVE)
+        $link.addClass(CLASS_NAME_ACTIVE)
       } else {
         // todo (fat) this is kinda sus...
         // recursively add actives to tested nav-links
-        $link.parents(Selector.LI).find(`> ${Selector.NAV_LINKS}`).addClass(ClassName.ACTIVE)
+        $link.parents(SELECTOR_LI).find(`> ${SELECTOR_NAV_LINKS}`).addClass(CLASS_NAME_ACTIVE)
       }
 
-      $(this._scrollElement).trigger(Event.ACTIVATE, {
+      $(this._scrollElement).trigger(EVENT_ACTIVATE, {
         relatedTarget: target
       })
     }
 
     _clear() {
-      $(this._selector).filter(Selector.ACTIVE).removeClass(ClassName.ACTIVE)
+      $(this._selector).filter(SELECTOR_ACTIVE).removeClass(CLASS_NAME_ACTIVE)
     }
 
 
@@ -302,8 +289,8 @@ const ScrollSpy = (($) => {
    * ------------------------------------------------------------------------
    */
 
-  $(window).on(Event.LOAD_DATA_API, () => {
-    const scrollSpys = $.makeArray($(Selector.DATA_SPY))
+  $(window).on(EVENT_LOAD_DATA_API, () => {
+    const scrollSpys = $.makeArray($(SELECTOR_DATA_SPY))
 
     for (let i = scrollSpys.length; i--;) {
       const $spy = $(scrollSpys[i])

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -25,34 +25,26 @@ const Tab = (($) => {
   const JQUERY_NO_CONFLICT  = $.fn[NAME]
   const TRANSITION_DURATION = 150
 
-  const Event = {
-    HIDE           : `hide${EVENT_KEY}`,
-    HIDDEN         : `hidden${EVENT_KEY}`,
-    SHOW           : `show${EVENT_KEY}`,
-    SHOWN          : `shown${EVENT_KEY}`,
-    CLICK_DATA_API : `click${EVENT_KEY}${DATA_API_KEY}`
-  }
+  const EVENT_HIDE = `hide${EVENT_KEY}`
+  const EVENT_HIDDEN = `hidden${EVENT_KEY}`
+  const EVENT_SHOW = `show${EVENT_KEY}`
+  const EVENT_SHOWN = `shown${EVENT_KEY}`
+  const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-  const ClassName = {
-    DROPDOWN_MENU : 'dropdown-menu',
-    ACTIVE        : 'active',
-    DISABLED      : 'disabled',
-    FADE          : 'fade',
-    SHOW          : 'show'
-  }
+  const CLASS_NAME_DROPDOWN_MENU = 'dropdown-menu'
+  const CLASS_NAME_ACTIVE = 'active'
+  const CLASS_NAME_DISABLED = 'disabled'
+  const CLASS_NAME_FADE = 'fade'
+  const CLASS_NAME_SHOW = 'show'
 
-  const Selector = {
-    A                     : 'a',
-    LI                    : 'li',
-    DROPDOWN              : '.dropdown',
-    LIST                  : 'ul:not(.dropdown-menu), ol:not(.dropdown-menu), nav:not(.dropdown-menu)',
-    FADE_CHILD            : '> .nav-item .fade, > .fade',
-    ACTIVE                : '.active',
-    ACTIVE_CHILD          : '> .nav-item > .active, > .active',
-    DATA_TOGGLE           : '[data-toggle="tab"], [data-toggle="pill"]',
-    DROPDOWN_TOGGLE       : '.dropdown-toggle',
-    DROPDOWN_ACTIVE_CHILD : '> .dropdown-menu .active'
-  }
+  const SELECTOR_DROPDOWN = '.dropdown'
+  const SELECTOR_LIST = 'ul:not(.dropdown-menu), ol:not(.dropdown-menu), nav:not(.dropdown-menu)'
+  const SELECTOR_FADE_CHILD = '> .nav-item .fade, > .fade'
+  const SELECTOR_ACTIVE = '.active'
+  const SELECTOR_ACTIVE_CHILD = '> .nav-item > .active, > .active'
+  const SELECTOR_DATA_TOGGLE = '[data-toggle="tab"], [data-toggle="pill"]'
+  const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
+  const SELECTOR_DROPDOWN_ACTIVE_CHILD = '> .dropdown-menu .active'
 
 
   /**
@@ -80,26 +72,26 @@ const Tab = (($) => {
     show() {
       if (this._element.parentNode &&
           this._element.parentNode.nodeType === Node.ELEMENT_NODE &&
-          $(this._element).hasClass(ClassName.ACTIVE) ||
-          $(this._element).hasClass(ClassName.DISABLED)) {
+          $(this._element).hasClass(CLASS_NAME_ACTIVE) ||
+          $(this._element).hasClass(CLASS_NAME_DISABLED)) {
         return
       }
 
       let target
       let previous
-      const listElement = $(this._element).closest(Selector.LIST)[0]
+      const listElement = $(this._element).closest(SELECTOR_LIST)[0]
       const selector    = Util.getSelectorFromElement(this._element)
 
       if (listElement) {
-        previous = $.makeArray($(listElement).find(Selector.ACTIVE))
+        previous = $.makeArray($(listElement).find(SELECTOR_ACTIVE))
         previous = previous[previous.length - 1]
       }
 
-      const hideEvent = $.Event(Event.HIDE, {
+      const hideEvent = $.Event(EVENT_HIDE, {
         relatedTarget: this._element
       })
 
-      const showEvent = $.Event(Event.SHOW, {
+      const showEvent = $.Event(EVENT_SHOW, {
         relatedTarget: previous
       })
 
@@ -124,11 +116,11 @@ const Tab = (($) => {
       )
 
       const complete = () => {
-        const hiddenEvent = $.Event(Event.HIDDEN, {
+        const hiddenEvent = $.Event(EVENT_HIDDEN, {
           relatedTarget: this._element
         })
 
-        const shownEvent = $.Event(Event.SHOWN, {
+        const shownEvent = $.Event(EVENT_SHOWN, {
           relatedTarget: previous
         })
 
@@ -152,11 +144,11 @@ const Tab = (($) => {
     // private
 
     _activate(element, container, callback) {
-      const active          = $(container).find(Selector.ACTIVE_CHILD)[0]
+      const active          = $(container).find(SELECTOR_ACTIVE_CHILD)[0]
       const isTransitioning = callback
         && Util.supportsTransitionEnd()
-        && (active && $(active).hasClass(ClassName.FADE)
-           || Boolean($(container).find(Selector.FADE_CHILD)[0]))
+        && (active && $(active).hasClass(CLASS_NAME_FADE)
+           || Boolean($(container).find(SELECTOR_FADE_CHILD)[0]))
 
       const complete = () => this._transitionComplete(
         element,
@@ -175,41 +167,41 @@ const Tab = (($) => {
       }
 
       if (active) {
-        $(active).removeClass(ClassName.SHOW)
+        $(active).removeClass(CLASS_NAME_SHOW)
       }
     }
 
     _transitionComplete(element, active, isTransitioning, callback) {
       if (active) {
-        $(active).removeClass(ClassName.ACTIVE)
+        $(active).removeClass(CLASS_NAME_ACTIVE)
 
         const dropdownChild = $(active.parentNode).find(
-          Selector.DROPDOWN_ACTIVE_CHILD
+          SELECTOR_DROPDOWN_ACTIVE_CHILD
         )[0]
 
         if (dropdownChild) {
-          $(dropdownChild).removeClass(ClassName.ACTIVE)
+          $(dropdownChild).removeClass(CLASS_NAME_ACTIVE)
         }
 
         active.setAttribute('aria-expanded', false)
       }
 
-      $(element).addClass(ClassName.ACTIVE)
+      $(element).addClass(CLASS_NAME_ACTIVE)
       element.setAttribute('aria-expanded', true)
 
       if (isTransitioning) {
         Util.reflow(element)
-        $(element).addClass(ClassName.SHOW)
+        $(element).addClass(CLASS_NAME_SHOW)
       } else {
-        $(element).removeClass(ClassName.FADE)
+        $(element).removeClass(CLASS_NAME_FADE)
       }
 
       if (element.parentNode &&
-          $(element.parentNode).hasClass(ClassName.DROPDOWN_MENU)) {
+          $(element.parentNode).hasClass(CLASS_NAME_DROPDOWN_MENU)) {
 
-        const dropdownElement = $(element).closest(Selector.DROPDOWN)[0]
+        const dropdownElement = $(element).closest(SELECTOR_DROPDOWN)[0]
         if (dropdownElement) {
-          $(dropdownElement).find(Selector.DROPDOWN_TOGGLE).addClass(ClassName.ACTIVE)
+          $(dropdownElement).find(SELECTOR_DROPDOWN_TOGGLE).addClass(CLASS_NAME_ACTIVE)
         }
 
         element.setAttribute('aria-expanded', true)
@@ -252,7 +244,7 @@ const Tab = (($) => {
    */
 
   $(document)
-    .on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
+    .on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
       event.preventDefault()
       Tab._jQueryInterface.call($(this), 'show')
     })

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -74,18 +74,16 @@ const Tooltip = (($) => {
   const HOVER_STATE_SHOW = 'show'
   const HOVER_STATE_OUT = 'out'
 
-  const Event = {
-    HIDE       : `hide${EVENT_KEY}`,
-    HIDDEN     : `hidden${EVENT_KEY}`,
-    SHOW       : `show${EVENT_KEY}`,
-    SHOWN      : `shown${EVENT_KEY}`,
-    INSERTED   : `inserted${EVENT_KEY}`,
-    CLICK      : `click${EVENT_KEY}`,
-    FOCUSIN    : `focusin${EVENT_KEY}`,
-    FOCUSOUT   : `focusout${EVENT_KEY}`,
-    MOUSEENTER : `mouseenter${EVENT_KEY}`,
-    MOUSELEAVE : `mouseleave${EVENT_KEY}`
-  }
+  const EVENT_HIDE = 'hide'
+  const EVENT_HIDDEN = 'hidden'
+  const EVENT_SHOW = 'show'
+  const EVENT_SHOWN = 'shown'
+  const EVENT_INSERTED = 'inserted'
+  const EVENT_CLICK = 'click'
+  const EVENT_FOCUSIN = 'focusin'
+  const EVENT_FOCUSOUT = 'focusout'
+  const EVENT_MOUSEENTER = 'mouseenter'
+  const EVENT_MOUSELEAVE = 'mouseleave'
 
   const CLASS_NAME_FADE = 'fade'
   const CLASS_NAME_SHOW = 'show'
@@ -149,8 +147,8 @@ const Tooltip = (($) => {
       return DATA_KEY
     }
 
-    static get Event() {
-      return Event
+    static getEvent(eventName) {
+      return `${eventName}${EVENT_KEY}`
     }
 
     static get EVENT_KEY() {
@@ -238,7 +236,7 @@ const Tooltip = (($) => {
         throw new Error('Please use show on visible elements')
       }
 
-      const showEvent = $.Event(this.constructor.Event.SHOW)
+      const showEvent = $.Event(this.constructor.getEvent(EVENT_SHOW))
       if (this.isWithContent() && this._isEnabled) {
         if (this._isTransitioning) {
           throw new Error('Tooltip is transitioning')
@@ -278,7 +276,7 @@ const Tooltip = (($) => {
           .data(this.constructor.DATA_KEY, this)
           .appendTo(container)
 
-        $(this.element).trigger(this.constructor.Event.INSERTED)
+        $(this.element).trigger(this.constructor.getEvent(EVENT_INSERTED))
 
         this._tether = new Tether({
           attachment,
@@ -301,7 +299,7 @@ const Tooltip = (($) => {
           this._hoverState   = null
           this._isTransitioning = false
 
-          $(this.element).trigger(this.constructor.Event.SHOWN)
+          $(this.element).trigger(this.constructor.getEvent(EVENT_SHOWN))
 
           if (prevHoverState === HOVER_STATE_OUT) {
             this._leave(null, this)
@@ -322,7 +320,7 @@ const Tooltip = (($) => {
 
     hide(callback) {
       const tip       = this.getTipElement()
-      const hideEvent = $.Event(this.constructor.Event.HIDE)
+      const hideEvent = $.Event(this.constructor.getEvent(EVENT_HIDE))
       if (this._isTransitioning) {
         throw new Error('Tooltip is transitioning')
       }
@@ -332,7 +330,7 @@ const Tooltip = (($) => {
         }
 
         this.element.removeAttribute('aria-describedby')
-        $(this.element).trigger(this.constructor.Event.HIDDEN)
+        $(this.element).trigger(this.constructor.getEvent(EVENT_HIDDEN))
         this._isTransitioning = false
         this.cleanupTether()
 
@@ -435,18 +433,18 @@ const Tooltip = (($) => {
       triggers.forEach((trigger) => {
         if (trigger === 'click') {
           $(this.element).on(
-            this.constructor.Event.CLICK,
+            this.constructor.getEvent(EVENT_CLICK),
             this.config.selector,
             (event) => this.toggle(event)
           )
 
         } else if (trigger !== TRIGGER_MANUAL) {
           const eventIn  = trigger === TRIGGER_HOVER ?
-            this.constructor.Event.MOUSEENTER :
-            this.constructor.Event.FOCUSIN
+            this.constructor.getEvent(EVENT_MOUSEENTER) :
+            this.constructor.getEvent(EVENT_FOCUSIN)
           const eventOut = trigger === TRIGGER_HOVER ?
-            this.constructor.Event.MOUSELEAVE :
-            this.constructor.Event.FOCUSOUT
+            this.constructor.getEvent(EVENT_MOUSELEAVE) :
+            this.constructor.getEvent(EVENT_FOCUSOUT)
 
           $(this.element)
             .on(

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -71,10 +71,8 @@ const Tooltip = (($) => {
     LEFT   : 'middle right'
   }
 
-  const HoverState = {
-    SHOW : 'show',
-    OUT  : 'out'
-  }
+  const HOVER_STATE_SHOW = 'show'
+  const HOVER_STATE_OUT = 'out'
 
   const Event = {
     HIDE       : `hide${EVENT_KEY}`,
@@ -89,27 +87,20 @@ const Tooltip = (($) => {
     MOUSELEAVE : `mouseleave${EVENT_KEY}`
   }
 
-  const ClassName = {
-    FADE : 'fade',
-    SHOW : 'show'
-  }
+  const CLASS_NAME_FADE = 'fade'
+  const CLASS_NAME_SHOW = 'show'
 
-  const Selector = {
-    TOOLTIP       : '.tooltip',
-    TOOLTIP_INNER : '.tooltip-inner'
-  }
+  const SELECTOR_TOOLTIP_INNER = '.tooltip-inner'
 
   const TetherClass = {
     element : false,
     enabled : false
   }
 
-  const Trigger = {
-    HOVER  : 'hover',
-    FOCUS  : 'focus',
-    CLICK  : 'click',
-    MANUAL : 'manual'
-  }
+  const TRIGGER_HOVER = 'hover'
+  const TRIGGER_FOCUS = 'focus'
+  const TRIGGER_CLICK = 'click'
+  const TRIGGER_MANUAL = 'manual'
 
 
   /**
@@ -208,7 +199,7 @@ const Tooltip = (($) => {
 
       } else {
 
-        if ($(this.getTipElement()).hasClass(ClassName.SHOW)) {
+        if ($(this.getTipElement()).hasClass(CLASS_NAME_SHOW)) {
           this._leave(null, this)
           return
         }
@@ -272,7 +263,7 @@ const Tooltip = (($) => {
         this.setContent()
 
         if (this.config.animation) {
-          $(tip).addClass(ClassName.FADE)
+          $(tip).addClass(CLASS_NAME_FADE)
         }
 
         const placement  = typeof this.config.placement === 'function' ?
@@ -303,7 +294,7 @@ const Tooltip = (($) => {
         Util.reflow(tip)
         this._tether.position()
 
-        $(tip).addClass(ClassName.SHOW)
+        $(tip).addClass(CLASS_NAME_SHOW)
 
         const complete = () => {
           const prevHoverState = this._hoverState
@@ -312,12 +303,12 @@ const Tooltip = (($) => {
 
           $(this.element).trigger(this.constructor.Event.SHOWN)
 
-          if (prevHoverState === HoverState.OUT) {
+          if (prevHoverState === HOVER_STATE_OUT) {
             this._leave(null, this)
           }
         }
 
-        if (Util.supportsTransitionEnd() && $(this.tip).hasClass(ClassName.FADE)) {
+        if (Util.supportsTransitionEnd() && $(this.tip).hasClass(CLASS_NAME_FADE)) {
           this._isTransitioning = true
           $(this.tip)
             .one(Util.TRANSITION_END, complete)
@@ -336,7 +327,7 @@ const Tooltip = (($) => {
         throw new Error('Tooltip is transitioning')
       }
       const complete  = () => {
-        if (this._hoverState !== HoverState.SHOW && tip.parentNode) {
+        if (this._hoverState !== HOVER_STATE_SHOW && tip.parentNode) {
           tip.parentNode.removeChild(tip)
         }
 
@@ -356,14 +347,14 @@ const Tooltip = (($) => {
         return
       }
 
-      $(tip).removeClass(ClassName.SHOW)
+      $(tip).removeClass(CLASS_NAME_SHOW)
 
-      this._activeTrigger[Trigger.CLICK] = false
-      this._activeTrigger[Trigger.FOCUS] = false
-      this._activeTrigger[Trigger.HOVER] = false
+      this._activeTrigger[TRIGGER_CLICK] = false
+      this._activeTrigger[TRIGGER_FOCUS] = false
+      this._activeTrigger[TRIGGER_HOVER] = false
 
       if (Util.supportsTransitionEnd() &&
-          $(this.tip).hasClass(ClassName.FADE)) {
+          $(this.tip).hasClass(CLASS_NAME_FADE)) {
         this._isTransitioning = true
         $(tip)
           .one(Util.TRANSITION_END, complete)
@@ -390,9 +381,9 @@ const Tooltip = (($) => {
     setContent() {
       const $tip = $(this.getTipElement())
 
-      this.setElementContent($tip.find(Selector.TOOLTIP_INNER), this.getTitle())
+      this.setElementContent($tip.find(SELECTOR_TOOLTIP_INNER), this.getTitle())
 
-      $tip.removeClass(`${ClassName.FADE} ${ClassName.SHOW}`)
+      $tip.removeClass(`${CLASS_NAME_FADE} ${CLASS_NAME_SHOW}`)
 
       this.cleanupTether()
     }
@@ -449,11 +440,11 @@ const Tooltip = (($) => {
             (event) => this.toggle(event)
           )
 
-        } else if (trigger !== Trigger.MANUAL) {
-          const eventIn  = trigger === Trigger.HOVER ?
+        } else if (trigger !== TRIGGER_MANUAL) {
+          const eventIn  = trigger === TRIGGER_HOVER ?
             this.constructor.Event.MOUSEENTER :
             this.constructor.Event.FOCUSIN
-          const eventOut = trigger === Trigger.HOVER ?
+          const eventOut = trigger === TRIGGER_HOVER ?
             this.constructor.Event.MOUSELEAVE :
             this.constructor.Event.FOCUSOUT
 
@@ -513,19 +504,19 @@ const Tooltip = (($) => {
 
       if (event) {
         context._activeTrigger[
-          event.type === 'focusin' ? Trigger.FOCUS : Trigger.HOVER
+          event.type === 'focusin' ? TRIGGER_FOCUS : TRIGGER_HOVER
         ] = true
       }
 
-      if ($(context.getTipElement()).hasClass(ClassName.SHOW) ||
-         context._hoverState === HoverState.SHOW) {
-        context._hoverState = HoverState.SHOW
+      if ($(context.getTipElement()).hasClass(CLASS_NAME_SHOW) ||
+         context._hoverState === HOVER_STATE_SHOW) {
+        context._hoverState = HOVER_STATE_SHOW
         return
       }
 
       clearTimeout(context._timeout)
 
-      context._hoverState = HoverState.SHOW
+      context._hoverState = HOVER_STATE_SHOW
 
       if (!context.config.delay || !context.config.delay.show) {
         context.show()
@@ -533,7 +524,7 @@ const Tooltip = (($) => {
       }
 
       context._timeout = setTimeout(() => {
-        if (context._hoverState === HoverState.SHOW) {
+        if (context._hoverState === HOVER_STATE_SHOW) {
           context.show()
         }
       }, context.config.delay.show)
@@ -554,7 +545,7 @@ const Tooltip = (($) => {
 
       if (event) {
         context._activeTrigger[
-          event.type === 'focusout' ? Trigger.FOCUS : Trigger.HOVER
+          event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER
         ] = false
       }
 
@@ -564,7 +555,7 @@ const Tooltip = (($) => {
 
       clearTimeout(context._timeout)
 
-      context._hoverState = HoverState.OUT
+      context._hoverState = HOVER_STATE_OUT
 
       if (!context.config.delay || !context.config.delay.hide) {
         context.hide()
@@ -572,7 +563,7 @@ const Tooltip = (($) => {
       }
 
       context._timeout = setTimeout(() => {
-        if (context._hoverState === HoverState.OUT) {
+        if (context._hoverState === HOVER_STATE_OUT) {
           context.hide()
         }
       }, context.config.delay.hide)


### PR DESCRIPTION
Fixes #20011

Improve JS minification:

|   | Minified size | Minified gain | Minified + zip size | Minified + zip gain |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Before  | 46,653b | - | 12,648b | - |
| After  | 43,121b | 7.5% | 11,851 | 6.3% |
| With #21715  | 37,526b | 19.5% | 11,278 | 10.8% |

In addition it allows the JS linter to detect unused variables. For example [this variable](https://github.com/twbs/bootstrap/blob/v4-dev/js/src/tab.js#L45) is defined but not used and the linter cannot detect it.