### PR TITLE
JS Mangle private properties => reduce minified JS by 11.9% (4.8% gzipped)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sass-docs": "node-sass --output-style expanded --source-map true --precision 6 docs/assets/scss/docs.scss docs/assets/css/docs.min.css",
     "scss-lint": "bundle exec scss-lint --config scss/.scss-lint.yml --exclude scss/_normalize.scss scss/*.scss",
     "scss-lint-docs": "bundle exec scss-lint --config scss/.scss-lint.yml --exclude docs/assets/scss/docs.scss docs/assets/scss/*.scss",
-    "uglify": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
+    "uglify": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --mangle-props 2 --mangle-regex '/^_/' --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
     "uglify-docs": "uglifyjs --compress warnings=false --mangle --comments '/^!/' --output docs/assets/js/docs.min.js docs/assets/js/vendor/anchor.min.js docs/assets/js/vendor/clipboard.min.js docs/assets/js/vendor/holder.min.js docs/assets/js/src/application.js",
     "update-shrinkwrap": "npm shrinkwrap --dev && shx mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
     "test": "npm run eslint && grunt test"


### PR DESCRIPTION
All the private attribute (variables or function) in Bootstrap JS modules starts with `_` so we can easily configure Uglify to mandle them and produce a small minified JS file.

|   | Minified size | Minified gain | Minified + zip size | Minified + zip gain |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Before  | 46,653b | - | 12,648b | - |
| After  | 41,059b | 11.9% | 12,063b | 4.8% |

In addition, this size reductions cumulate with #21711