### PR TITLE
fix segmented buttons

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -30,8 +30,8 @@
 .input-group .form-control {
   // Vertically centers the content of the addons within the input group
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
+  align-items: center;
 
   &:not(:first-child):not(:last-child) {
     @include border-radius(0);
@@ -144,8 +144,6 @@
   // element above the siblings.
   > .btn {
     position: relative;
-    // Vertically stretch the button and center its content
-    flex: 1;
 
     + .btn {
       margin-left: (-$input-btn-border-width);

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -30,7 +30,6 @@
 .input-group .form-control {
   // Vertically centers the content of the addons within the input group
   display: flex;
-  flex-direction: row;
   align-items: center;
 
   &:not(:first-child):not(:last-child) {


### PR DESCRIPTION
Fixes #21593 and fixes #21651.

changed flex-direction to row
centering is now done by align-items instead of justify-content

this way there is no need for flex property on the .btn inside .btn-group