### PR TITLE
Fix container within navbar on smallest breakpoint

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -20,6 +20,12 @@
   display: flex;
   flex-direction: column;
   padding: $navbar-padding-y $navbar-padding-x;
+
+  // Prevent container to center conter on smallest breakpoint (due to no with set for xs)
+  > .container {
+    margin-right: 0;
+    margin-left: 0;
+  }
 }
 
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -21,7 +21,7 @@
   flex-direction: column;
   padding: $navbar-padding-y $navbar-padding-x;
 
-  // Prevent container to center conter on smallest breakpoint (due to no with set for xs)
+  // Prevent container to center content on smallest breakpoint (due to no with set for xs)
   > .container {
     margin-right: 0;
     margin-left: 0;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -21,10 +21,12 @@
   flex-direction: column;
   padding: $navbar-padding-y $navbar-padding-x;
 
-  // Prevent container to center content on smallest breakpoint (due to no with set for xs)
-  > .container {
-    margin-right: 0;
-    margin-left: 0;
+  @include media-breakpoint-down(nth(map-keys($grid-breakpoints), 1)) {
+    // Prevent container to collease content on smallest breakpoint on Chrome
+    > .container {
+      margin-right: 0;
+      margin-left: 0;
+    }
   }
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -22,7 +22,6 @@
   padding: $navbar-padding-y $navbar-padding-x;
 
   @include media-breakpoint-down(nth(map-keys($grid-breakpoints), 1)) {
-    // Prevent container to collease content on smallest breakpoint on Chrome
     > .container {
       margin-right: 0;
       margin-left: 0;


### PR DESCRIPTION
Fixes #21605 and fixes #21590.

At the smallest breakpoint the `container` has no `with` set. In the case of a `container` within a `navbar`, due to `margin-right: auto` and `margin-left: auto` the container content is coalesced toward the center.
This issue happen only in Chrome (see http://jsfiddle.net/rLqtw01t/ in chrome on xs viewport with and in another browser).

This PR set `margin-right: 0` and `margin-left: 0` for `container` within `navbar` under xs viewport  width to avoid the issue.