### PR TITLE
[Docs] Add missing :focus styles

### DIFF
--- a/docs/assets/scss/_footer.scss
+++ b/docs/assets/scss/_footer.scss
@@ -13,7 +13,8 @@
     font-weight: 500;
     color: $gray;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: $link-color;
     }
   }

--- a/docs/assets/scss/_masthead.scss
+++ b/docs/assets/scss/_masthead.scss
@@ -39,7 +39,8 @@
     color: $bd-yellow;
     border-color: $bd-yellow;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: $bd-graphite;
       background-color: $bd-yellow;
       border-color: $bd-yellow;

--- a/docs/assets/scss/_team.scss
+++ b/docs/assets/scss/_team.scss
@@ -6,8 +6,12 @@
     color: #555;
   }
 
-  .team-member:hover {
+  .team-member:hover,
+  .team-member:focus {
     color: #333;
+  }
+
+  .team-member:hover {
     text-decoration: none;
   }
 


### PR DESCRIPTION
Double up `:hover` styles to also apply on `:focus` (particularly the masthead button needs this, as otherwise it gives no visible indication of being focused)