### PR TITLE
numeric strings raise typecheck exception in tooltips

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -53,7 +53,7 @@ const Tooltip = (($) => {
   const DefaultType = {
     animation   : 'boolean',
     template    : 'string',
-    title       : '(string|element|function)',
+    title       : '(number|string|element|function)',
     trigger     : 'string',
     delay       : '(number|object)',
     html        : 'boolean',


### PR DESCRIPTION
Creating a tooltip with only numeric values in the string:
<a href="#" data-title="123" data-toggle="tooltip">Tooltip</a> 

raises a typeCheck exception since the string is evaluated into a number
 