### PR TITLE
Documentation: Correct prefix for flexbox order classes

### DIFF
--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -360,12 +360,12 @@ Change the _visual_ order of specific flex items with a handful of `order` utili
 </div>
 {% endexample %}
 
-Responsive variations also exist for `order`.
+Responsive variations also exist for `flex`.
 
 {% for bp in site.data.breakpoints %}
-- `.order{{ bp.abbr }}-first`
-- `.order{{ bp.abbr }}-last`
-- `.order{{ bp.abbr }}-unordered`{% endfor %}
+- `.flex{{ bp.abbr }}-first`
+- `.flex{{ bp.abbr }}-last`
+- `.flex{{ bp.abbr }}-unordered`{% endfor %}
 
 ## Align content
 


### PR DESCRIPTION
… they are called `flex-…`, not `order-…`, as [it can be seen in the source](https://github.com/twbs/bootstrap/blob/8167682deb6146e1949cb49baf6e87d350befe3d/scss/utilities/_flex.scss#L9-L11).