### PR TITLE
Fix gaps between vertical grouped buttons when using labels (#21793)

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -10,6 +10,7 @@
   > .btn {
     position: relative;
     flex: 0 1 auto;
+    margin-bottom: 0;
 
     // Bring the hover, focused, and "active" buttons to the fron to overlay
     // the borders properly


### PR DESCRIPTION
Fix #21793 