### PR TITLE
Fix alignment of progress-bar text

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -20,6 +20,10 @@
   background-color: $progress-bar-bg;
 }
 
+.progress-bar > span {
+  vertical-align: middle;
+}
+  
 // Striped
 .progress-bar-striped {
   @include gradient-striped();


### PR DESCRIPTION
When the height of a .progress/.progress-bar is changed, the text within it does not appear to vertically align properly. Adding vertical-align: middle to the <span> elements within the .progress-bar should fix alignment issues.