### PR TITLE
Enable EmptyLineBetweenBlocks linter

### DIFF
--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -64,7 +64,7 @@ linters:
     style: same_line # or 'new_line'
 
   EmptyLineBetweenBlocks:
-    enabled: false
+    enabled: true
     ignore_single_line_blocks: true
 
   EmptyRule:

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -44,12 +44,15 @@
 .alert-success {
   @include alert-variant($alert-success-bg, $alert-success-border, $alert-success-text);
 }
+
 .alert-info {
   @include alert-variant($alert-info-bg, $alert-info-border, $alert-info-text);
 }
+
 .alert-warning {
   @include alert-variant($alert-warning-bg, $alert-warning-border, $alert-warning-text);
 }
+
 .alert-danger {
   @include alert-variant($alert-danger-bg, $alert-danger-border, $alert-danger-text);
 }

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -25,12 +25,14 @@
   //
   // To trick IE into suppressing the underline, we give the pseudo-element an
   // underline and then immediately remove it.
+  // scss-lint:disable EmptyLineBetweenBlocks
   + .breadcrumb-item:hover::before {
     text-decoration: underline;
   }
   + .breadcrumb-item:hover::before {
     text-decoration: none;
   }
+  // scss-lint:enable EmptyLineBetweenBlocks
 
   &.active {
     color: $breadcrumb-active-color;

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -16,6 +16,7 @@
     @include hover {
       z-index: 2;
     }
+
     &:focus,
     &:active,
     &.active {
@@ -64,15 +65,18 @@
 .btn-group > .btn-group {
   float: left;
 }
+
 .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
+
 .btn-group > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
     @include border-right-radius(0);
   }
 }
+
 .btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
   @include border-left-radius(0);
 }
@@ -156,22 +160,27 @@
   &:not(:first-child):not(:last-child) {
     border-radius: 0;
   }
+
   &:first-child:not(:last-child) {
     @include border-bottom-radius(0);
   }
+
   &:last-child:not(:first-child) {
     @include border-top-radius(0);
   }
 }
+
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0;
 }
+
 .btn-group-vertical > .btn-group:first-child:not(:last-child) {
   > .btn:last-child,
   > .dropdown-toggle {
     @include border-bottom-radius(0);
   }
 }
+
 .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
   @include border-top-radius(0);
 }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -20,6 +20,7 @@
   @include hover-focus {
     text-decoration: none;
   }
+
   &:focus,
   &.focus {
     outline: 0;
@@ -55,18 +56,23 @@ fieldset[disabled] a.btn {
 .btn-primary {
   @include button-variant($btn-primary-color, $btn-primary-bg, $btn-primary-border);
 }
+
 .btn-secondary {
   @include button-variant($btn-secondary-color, $btn-secondary-bg, $btn-secondary-border);
 }
+
 .btn-info {
   @include button-variant($btn-info-color, $btn-info-bg, $btn-info-border);
 }
+
 .btn-success {
   @include button-variant($btn-success-color, $btn-success-bg, $btn-success-border);
 }
+
 .btn-warning {
   @include button-variant($btn-warning-color, $btn-warning-bg, $btn-warning-border);
 }
+
 .btn-danger {
   @include button-variant($btn-danger-color, $btn-danger-bg, $btn-danger-border);
 }
@@ -75,18 +81,23 @@ fieldset[disabled] a.btn {
 .btn-outline-primary {
   @include button-outline-variant($btn-primary-bg);
 }
+
 .btn-outline-secondary {
   @include button-outline-variant($btn-secondary-border);
 }
+
 .btn-outline-info {
   @include button-outline-variant($btn-info-bg);
 }
+
 .btn-outline-success {
   @include button-outline-variant($btn-success-bg);
 }
+
 .btn-outline-warning {
   @include button-outline-variant($btn-warning-bg);
 }
+
 .btn-outline-danger {
   @include button-outline-variant($btn-danger-bg);
 }
@@ -109,19 +120,23 @@ fieldset[disabled] a.btn {
     background-color: transparent;
     @include box-shadow(none);
   }
+
   &,
   &:focus,
   &:active {
     border-color: transparent;
   }
+
   @include hover {
     border-color: transparent;
   }
+
   @include hover-focus {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
     background-color: transparent;
   }
+
   &:disabled {
     color: $btn-link-disabled-color;
 
@@ -140,6 +155,7 @@ fieldset[disabled] a.btn {
   // line-height: ensure even-numbered height of button next to large input
   @include button-size($btn-padding-y-lg, $btn-padding-x-lg, $font-size-lg, $btn-border-radius-lg);
 }
+
 .btn-sm {
   // line-height: ensure proper height of button next to small input
   @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $font-size-sm, $btn-border-radius-sm);

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -106,15 +106,19 @@
 .card-primary {
   @include card-variant($brand-primary, $brand-primary);
 }
+
 .card-success {
   @include card-variant($brand-success, $brand-success);
 }
+
 .card-info {
   @include card-variant($brand-info, $brand-info);
 }
+
 .card-warning {
   @include card-variant($brand-warning, $brand-warning);
 }
+
 .card-danger {
   @include card-variant($brand-danger, $brand-danger);
 }
@@ -123,18 +127,23 @@
 .card-outline-primary {
   @include card-outline-variant($btn-primary-bg);
 }
+
 .card-outline-secondary {
   @include card-outline-variant($btn-secondary-border);
 }
+
 .card-outline-info {
   @include card-outline-variant($btn-info-bg);
 }
+
 .card-outline-success {
   @include card-outline-variant($btn-success-bg);
 }
+
 .card-outline-warning {
   @include card-outline-variant($btn-warning-bg);
 }
+
 .card-outline-danger {
   @include card-outline-variant($btn-danger-bg);
 }
@@ -162,6 +171,7 @@
   // margin: -1.325rem;
   @include border-radius($card-border-radius-inner);
 }
+
 .card-img-overlay {
   position: absolute;
   top: 0;
@@ -177,6 +187,7 @@
 .card-img-top {
   @include border-top-radius($card-border-radius-inner);
 }
+
 .card-img-bottom {
   @include border-bottom-radius($card-border-radius-inner);
 }
@@ -229,16 +240,19 @@
           .card-img-top {
             border-top-right-radius: 0;
           }
+
           .card-img-bottom {
             border-bottom-right-radius: 0;
           }
         }
+
         &:last-child {
           @include border-left-radius(0);
 
           .card-img-top {
             border-top-left-radius: 0;
           }
+
           .card-img-bottom {
             border-bottom-left-radius: 0;
           }

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -80,9 +80,11 @@
     opacity: .9;
   }
 }
+
 .carousel-control-prev {
   left: 0;
 }
+
 .carousel-control-next {
   right: 0;
 }
@@ -96,9 +98,11 @@
   background: transparent no-repeat center center;
   background-size: 100% 100%;
 }
+
 .carousel-control-prev-icon {
   background-image: $carousel-control-prev-icon-bg;
 }
+
 .carousel-control-next-icon {
   background-image: $carousel-control-next-icon-bg;
 }
@@ -144,6 +148,7 @@
       height: 10px;
       content: "";
     }
+
     &::after {
       position: absolute;
       bottom: -10px;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -356,9 +356,11 @@ select.form-control-lg {
       margin-top: 0;
       margin-bottom: 0;
     }
+
     .form-check-label {
       padding-left: 0;
     }
+
     .form-check-input {
       position: relative;
       margin-top: 0;
@@ -373,6 +375,7 @@ select.form-control-lg {
       justify-content: center;
       padding-left: 0;
     }
+
     .custom-control-indicator {
       position: static;
       display: inline-block;

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -55,6 +55,7 @@
 .input-group-lg > .input-group-btn > .btn {
   @extend .form-control-lg;
 }
+
 .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
 .input-group-sm > .input-group-btn > .btn {
@@ -84,6 +85,7 @@
     font-size: $font-size-sm;
     @include border-radius($input-border-radius-sm);
   }
+
   &.form-control-lg {
     padding: $input-padding-y-lg $input-padding-x-lg;
     font-size: $font-size-lg;
@@ -113,9 +115,11 @@
 .input-group-btn:not(:first-child) > .btn-group:not(:last-child) > .btn {
   @include border-right-radius(0);
 }
+
 .input-group-addon:not(:last-child) {
   border-right: 0;
 }
+
 .input-group .form-control:not(:first-child),
 .input-group-addon:not(:first-child),
 .input-group-btn:not(:first-child) > .btn,
@@ -125,6 +129,7 @@
 .input-group-btn:not(:last-child) > .btn-group:not(:first-child) > .btn {
   @include border-left-radius(0);
 }
+
 .form-control + .input-group-addon:not(:first-child) {
   border-left: 0;
 }
@@ -164,6 +169,7 @@
       margin-right: (-$input-btn-border-width);
     }
   }
+
   &:not(:first-child) {
     > .btn,
     > .btn-group {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -31,8 +31,10 @@
     @include transition($modal-transition);
     transform: translate(0, -25%);
   }
+
   &.show .modal-dialog { transform: translate(0, 0); }
 }
+
 .modal-open .modal {
   overflow-x: hidden;
   overflow-y: auto;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -113,6 +113,7 @@
   > .tab-pane {
     display: none;
   }
+
   > .active {
     display: block;
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -109,6 +109,7 @@
   position: absolute;
   left: $navbar-padding-x;
 }
+
 .navbar-toggler-right {
   position: absolute;
   right: $navbar-padding-x;

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -13,6 +13,7 @@
       @include border-left-radius($border-radius);
     }
   }
+
   &:last-child {
     .page-link {
       @include border-right-radius($border-radius);

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -165,6 +165,7 @@
   content: "";
   border-width: $popover-arrow-outer-width;
 }
+
 .popover::after {
   content: "";
   border-width: $popover-arrow-width;

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -57,6 +57,7 @@
     pre {
       white-space: pre-wrap !important;
     }
+
     pre,
     blockquote {
       border: $border-width solid #999;   // Bootstrap custom code; using `$border-width` instead of 1px
@@ -95,6 +96,7 @@
     .navbar {
       display: none;
     }
+
     .badge {
       border: $border-width solid #000;
     }
@@ -107,6 +109,7 @@
         background-color: #fff !important;
       }
     }
+
     .table-bordered {
       th,
       td {

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -14,6 +14,7 @@
   background-color: $progress-bg;
   @include border-radius($progress-border-radius);
 }
+
 .progress-bar {
   height: $progress-height;
   color: $progress-bar-color;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -27,6 +27,7 @@
       border-top-color: $tooltip-arrow-color;
     }
   }
+
   &.tooltip-right,
   &.bs-tether-element-attached-left {
     padding: 0 $tooltip-arrow-width;
@@ -41,6 +42,7 @@
       border-right-color: $tooltip-arrow-color;
     }
   }
+
   &.tooltip-bottom,
   &.bs-tether-element-attached-top {
     padding: $tooltip-arrow-width 0;
@@ -55,6 +57,7 @@
       border-bottom-color: $tooltip-arrow-color;
     }
   }
+
   &.tooltip-left,
   &.bs-tether-element-attached-right {
     padding: 0 $tooltip-arrow-width;

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -9,6 +9,7 @@
 
 .collapse {
   display: none;
+
   &.show {
     display: block;
   }

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -29,16 +29,19 @@ h6, .h6 { font-size: $font-size-h6; }
   font-weight: $display1-weight;
   line-height: $display-line-height;
 }
+
 .display-2 {
   font-size: $display2-size;
   font-weight: $display2-weight;
   line-height: $display-line-height;
 }
+
 .display-3 {
   font-size: $display3-size;
   font-weight: $display3-weight;
   line-height: $display-line-height;
 }
+
 .display-4 {
   font-size: $display4-size;
   font-weight: $display4-weight;
@@ -87,6 +90,7 @@ mark,
 .list-inline {
   @include list-unstyled;
 }
+
 .list-inline-item {
   display: inline-block;
 
@@ -137,6 +141,7 @@ mark,
   &::before {
     content: "";
   }
+
   &::after {
     content: "\00A0 \2014"; // nbsp, em dash
   }


### PR DESCRIPTION
Hi,

I know this is a quite invasive PR and is highly opinionated.

I've noticed some inconsistent styling in the sources.

The use of empty line between blocks was quite inconsistent, this linter
will increase the uniformity of the code.

Examples:
- badge has empty lines between colored variants https://github.com/twbs/bootstrap/blob/v4-dev/scss/_badge.scss#L58 while alert hasn't https://github.com/twbs/bootstrap/blob/v4-dev/scss/_alert.scss#L47
- card has both empty lines and not empty lines between `*-child` selectors https://github.com/twbs/bootstrap/blob/v4-dev/scss/_card.scss#L50 https://github.com/twbs/bootstrap/blob/v4-dev/scss/_card.scss#L236
- popover has both empty lines and not empty lines between `::before` and `::after` selectors https://github.com/twbs/bootstrap/blob/v4-dev/scss/_popover.scss#L39 https://github.com/twbs/bootstrap/blob/v4-dev/scss/_popover.scss#L168
- dropdown has empty lines between `-left` and `-right` variants https://github.com/twbs/bootstrap/blob/v4-dev/scss/_dropdown.scss#L124 while navbar hasn't https://github.com/twbs/bootstrap/blob/v4-dev/scss/_navbar.scss#L112