### PR TITLE
Progress line height

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -1,10 +1,8 @@
-// Progress animations
 @keyframes progress-bar-stripes {
   from { background-position: $progress-height 0; }
   to { background-position: 0 0; }
 }
 
-// Basic progress bar
 .progress {
   display: flex;
   overflow: hidden; // force rounded corners by cropping it
@@ -14,19 +12,18 @@
   background-color: $progress-bg;
   @include border-radius($progress-border-radius);
 }
+
 .progress-bar {
   height: $progress-height;
   color: $progress-bar-color;
   background-color: $progress-bar-bg;
 }
 
-// Striped
 .progress-bar-striped {
   @include gradient-striped();
   background-size: $progress-height $progress-height;
 }
 
-// Animated
 .progress-bar-animated {
   animation: progress-bar-stripes $progress-bar-animation-timing;
 }

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -15,6 +15,7 @@
 
 .progress-bar {
   height: $progress-height;
+  line-height: $progress-height;
   color: $progress-bar-color;
   background-color: $progress-bar-bg;
 }


### PR DESCRIPTION
Proper fix for #21801.

Can't use flex options for this since inner text of an element doesn't count as a flex item. Using the `line-height` and `height` match is the same approach from v3 and should suffice for most folks.