### PR TITLE
Remove `cursor: pointer;`

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -33,7 +33,6 @@ a.badge {
   @include hover-focus {
     color: $badge-link-hover-color;
     text-decoration: none;
-    cursor: pointer;
   }
 }
 // scss-lint:enable QualifyingElement

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -131,7 +131,6 @@
     margin-right: $carousel-indicator-spacer;
     margin-left: $carousel-indicator-spacer;
     text-indent: -999px;
-    cursor: pointer;
     background-color: rgba($carousel-indicator-active-bg, .5);
 
     // Use pseudo classes to increase the hit area by 10px on top and bottom.

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -10,7 +10,6 @@
   @include hover-focus {
     color: $close-color;
     text-decoration: none;
-    cursor: pointer;
     opacity: .75;
   }
 }
@@ -23,7 +22,6 @@
 // scss-lint:disable QualifyingElement
 button.close {
   padding: 0;
-  cursor: pointer;
   background: transparent;
   border: 0;
   -webkit-appearance: none;

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -15,7 +15,6 @@
   min-height: (1rem * $line-height-base);
   padding-left: $custom-control-gutter;
   margin-right: $custom-control-spacer-x;
-  cursor: pointer;
 }
 
 .custom-control-input {
@@ -200,7 +199,6 @@
   max-width: 100%;
   height: $custom-file-height;
   margin-bottom: 0;
-  cursor: pointer;
 }
 
 .custom-file-input {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -216,7 +216,6 @@ select.form-control-lg {
 .form-check-label {
   padding-left: $form-check-input-gutter;
   margin-bottom: 0; // Override default `<label>` bottom margin
-  cursor: pointer;
 }
 
 .form-check-input {

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -260,17 +260,6 @@ svg:not(:root) {
 }
 
 
-// iOS "clickable elements" fix for role="button"
-//
-// Fixes "clickability" issue (and more generally, the firing of events such as focus as well)
-// for traditionally non-focusable elements with role="button"
-// see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
-
-[role="button"] {
-  cursor: pointer;
-}
-
-
 // Avoid 300ms click delay on touch devices that support the `touch-action` CSS property.
 //
 // In particular, unlike most other browsers, IE11+Edge on Windows 10 on touch devices and IE Mobile 10-11


### PR DESCRIPTION
Turns out using `cursor: pointer` on actions (e.g., buttons) is incorrect. I removed the `cursor: pointer` from our buttons in Alpha 6 knowing this, but I left the rest of the properties throughout the codebase for another time. This PR aims to finish that work, removing nearly all the remaining `cursor: pointer` properties from our CSS.

I still need to figure out the `role="button"` one for iOS click-ability though.

This would also fix #21781.

---
#### References

From the [W3C spec](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor):

> **pointer**
> The cursor is a pointer that indicates a link.

From [Microsoft's design guidelines](https://msdn.microsoft.com/en-us/library/windows/desktop/dn742466%28v=vs.85%29.aspx):

> **To avoid confusion, it is imperative not to use the hand pointer for other purposes.** For example, command buttons already have a strong affordance, so they don't need a hand pointer. The hand pointer must mean "this target is a link" and nothing else.

Regarding the cursor pointer from [Apple's HIG](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/Pointers.html):

> The content is a URL link.