### PR TITLE
Update _custom.scss imports in other builds

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -22,22 +22,15 @@ html {
   box-sizing: inherit;
 }
 
-
-//
-// Variables
-//
-
+@import "custom";
 @import "variables";
 
 //
 // Grid mixins
 //
 
-@import "mixins/clearfix";
 @import "mixins/breakpoints";
 @import "mixins/grid-framework";
 @import "mixins/grid";
-
-@import "custom";
 
 @import "grid";

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -2,8 +2,8 @@
 //
 // Includes only Normalize and our custom Reboot reset.
 
+@import "custom";
 @import "variables";
 @import "mixins";
-@import "custom";
 
 @import "reboot";


### PR DESCRIPTION
- Correctly places the _custom.scss file first in the other two buids.
- Also removes the clearfix mixin from the grid build because flexbox yo.

Fixes #21682.