### PR TITLE
Remove random cursor: default from pill nav

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -81,7 +81,6 @@
   .nav-link.active,
   .nav-item.show .nav-link {
     color: $nav-pills-active-link-color;
-    cursor: default;
     background-color: $nav-pills-active-link-bg;
   }
 }


### PR DESCRIPTION
Fixes #21560. Pretty sure this wasn't intentional, so should be fine to remove.