### PR TITLE
fix distorted card images

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -160,6 +160,7 @@
 // Card image
 .card-img {
   // margin: -1.325rem;
+  width: 100%;
   @include border-radius($card-border-radius-inner);
 }
 .card-img-overlay {
@@ -175,9 +176,11 @@
 
 // Card image caps
 .card-img-top {
+  max-width: 100%;
   @include border-top-radius($card-border-radius-inner);
 }
 .card-img-bottom {
+  max-width: 100%;
   @include border-bottom-radius($card-border-radius-inner);
 }
 


### PR DESCRIPTION
Fixes #21650.

The image won't be stretched with the css in this PR.