### PR TITLE
Fix Modal documentation about _handleUpdate method + move to public scope

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -575,6 +575,12 @@ Manually hides a modal. **Returns to the caller before the modal has actually be
 
 {% highlight js %}$('#myModal').modal('hide'){% endhighlight %}
 
+#### `.modal('handleUpdate')`
+
+Manually readjust the modal's position if the height of a modal changes while it is open (i.e. in case a scrollbar appears).
+
+{% highlight js %}$('#myModal').modal('handleUpdate'){% endhighlight %}
+
 ### Events
 
 Bootstrap's modal class exposes a few events for hooking into modal functionality. All modal events are fired at the modal itself (i.e. at the `<div class="modal">`).

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -410,7 +410,7 @@ For modals that simply appear rather than fade in to view, remove the `.fade` cl
 
 ### Dynamic heights
 
-If the height of a modal changes while it is open, you should call `$('#myModal').data('bs.modal')._handleUpdate()` or `$('#myModal').modal('_handleUpdate')` to readjust the modal's position in case a scrollbar appears.
+If the height of a modal changes while it is open, you should call `$('#myModal').data('bs.modal').handleUpdate()` or `$('#myModal').modal('handleUpdate')` to readjust the modal's position in case a scrollbar appears.
 
 ### Accessibility
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -410,7 +410,7 @@ For modals that simply appear rather than fade in to view, remove the `.fade` cl
 
 ### Dynamic heights
 
-If the height of a modal changes while it is open, you should call `$('#myModal').data('bs.modal').handleUpdate()` to readjust the modal's position in case a scrollbar appears.
+If the height of a modal changes while it is open, you should call `$('#myModal').data('bs.modal')._handleUpdate()` or `$('#myModal').modal('_handleUpdate')` to readjust the modal's position in case a scrollbar appears.
 
 ### Accessibility
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -215,6 +215,9 @@ const Modal = (($) => {
       this._scrollbarWidth      = null
     }
 
+    handleUpdate() {
+      this._adjustDialog()
+    }
 
     // private
 
@@ -296,7 +299,7 @@ const Modal = (($) => {
 
     _setResizeEvent() {
       if (this._isShown) {
-        $(window).on(Event.RESIZE, (event) => this._handleUpdate(event))
+        $(window).on(Event.RESIZE, (event) => this.handleUpdate(event))
       } else {
         $(window).off(Event.RESIZE)
       }
@@ -400,10 +403,6 @@ const Modal = (($) => {
     // the following methods are used to handle overflowing modals
     // todo (fat): these should probably be refactored out of modal.js
     // ----------------------------------------------------------------------
-
-    _handleUpdate() {
-      this._adjustDialog()
-    }
 
     _adjustDialog() {
       const isModalOverflowing =


### PR DESCRIPTION
Update the way to call ``_handleUpdate`` method

IMO this method should move to the public scope

Close : #21868