### PR TITLE
Fix image in <figure> can exceeds container width on Firefox

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -29,7 +29,7 @@
 
 .figure {
   // Ensures the caption's text aligns with the image.
-  display: inline-block;
+  display: block;
 }
 
 .figure-img {


### PR DESCRIPTION
An image in `<figure class="figure">` wider than the container no longer exceeds it

fix #21886 