### PR TITLE
Remove unnecessary position and padding for alert close button

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -22,16 +22,8 @@
 
 
 // Dismissible alerts
-//
-// Expand the right padding and account for the close button's positioning.
-
 .alert-dismissible {
-  // Adjust close link position
   .close {
-    position: relative;
-    top: -$alert-padding-y;
-    right: -$alert-padding-x;
-    padding: $alert-padding-y $alert-padding-x;
     color: inherit;
   }
 }


### PR DESCRIPTION
This fixes #21889 where extra whitespace is appearing below an alert button with no bottom margin.

https://jsbin.com/xivoyufadi/1/edit?html,css,output
https://jsfiddle.net/kpyh492r/2/