### PR TITLE
add overflow hidden to dropdown menu

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -105,6 +105,7 @@
   // Show the menu
   > .dropdown-menu {
     display: block;
+    overflow: hidden;
   }
 
   // Remove the outline when :focus is triggered


### PR DESCRIPTION
This fixes the issue that when a dropdown has no vertical margins (`$dropdown-padding-y: 0`), the hover state has no rounded corners.

![before](https://cloud.githubusercontent.com/assets/288516/22541492/d810a2f4-e926-11e6-8b15-3db8067bb329.png)

![after](https://cloud.githubusercontent.com/assets/288516/22541493/dbd9acf0-e926-11e6-8c56-83b5ce6c4187.png)
