### PR TITLE
Fix for .navbar-toggleable-* > .container-fluid

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -116,7 +116,7 @@
 .navbar-toggler-left {
   position: absolute;
   left: $navbar-padding-x;
-  
+
   .container > &,
   .container-fluid > & {
     left: 0;
@@ -125,7 +125,7 @@
 .navbar-toggler-right {
   position: absolute;
   right: $navbar-padding-x;
-  
+
   .container > &,
   .container-fluid > & {
     right: 0;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -116,10 +116,20 @@
 .navbar-toggler-left {
   position: absolute;
   left: $navbar-padding-x;
+  
+  .container > &,
+  .container-fluid > & {
+    left: 0;
+  }
 }
 .navbar-toggler-right {
   position: absolute;
   right: $navbar-padding-x;
+  
+  .container > &,
+  .container-fluid > & {
+    right: 0;
+  }
 }
 
 // Generate series of `.navbar-toggleable-*` responsive classes for configuring

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -138,7 +138,8 @@
           }
         }
 
-        > .container {
+        > .container,
+        > .container-fluid {
           padding-right: 0;
           padding-left: 0;
         }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -159,7 +159,8 @@
         }
 
         // For nesting containers, have to redeclare for alignment purposes
-        > .container {
+        > .container,
+        > .container-fluid {
           display: flex;
           flex-wrap: nowrap;
           align-items: center;


### PR DESCRIPTION
Problems:
- childrens inside `.navbar-toggleable-* > .container-fluid` are not staying on the same line. You can see this on bigger viewports than `*`.
- when `.container|.container-fluid > .navbar-toggler-*` left/right position is relative to `.container` and not `.navbar` itself. That means that the positioning will be doubled by the padding of the `.navbar`.

We need to set `display: flex` on `.container-fluid` and reset the `.container|.container-fluid > .navbar-toggler-*` position.

Please look at this example: http://codepen.io/zalog/pen/PWRvrJ

Later edit: In my example I've used `.container-fluid.w-100` and I think we need to set `.container-fluid` 100% width by default. Please let me know if so.