### PR TITLE
Button focus should apply same colours as hover

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -18,8 +18,11 @@
     background-color: $active-background;
     border-color: $active-border;
   }
+
   &:focus,
   &.focus {
+    color: $color;
+
     // Avoid using mixin so we can pass custom focus shadow properly
     @if $enable-shadows {
       box-shadow: $btn-box-shadow, 0 0 0 2px rgba($border, .5);
@@ -52,15 +55,16 @@
   background-color: transparent;
   border-color: $color;
 
+  &:focus,
+  &.focus {
+    color: $color;
+    box-shadow: 0 0 0 2px rgba($color, .5);
+  }
+
   @include hover {
     color: $color-hover;
     background-color: $color;
     border-color: $color;
-  }
-
-  &:focus,
-  &.focus {
-    box-shadow: 0 0 0 2px rgba($color, .5);
   }
 
   &.disabled,


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/21843

Since this change https://github.com/twbs/bootstrap/commit/a9bee8b6c8c31455dfba029434fad88b862c3846 buttons rendered with `<a>` have been inheriting their focus colour from reboot instead of overriding it with the button style.

### Before
![image](https://cloud.githubusercontent.com/assets/1628558/22646342/c7f96e7e-ec63-11e6-9e79-8e3ed3ebfdee.png)
![image](https://cloud.githubusercontent.com/assets/1628558/22646346/ccec0568-ec63-11e6-9ea2-d7085cf67ea2.png)

### After
![image](https://cloud.githubusercontent.com/assets/1628558/22646295/8d4b905e-ec63-11e6-91aa-f72f724599e9.png)
