### PR TITLE
Fix data-pause documentation for carousel

### DIFF
--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -208,9 +208,9 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
    </tr>
    <tr>
      <td>pause</td>
-     <td>string | null</td>
+     <td>string | boolean</td>
      <td>"hover"</td>
-     <td>If set to <code>"hover"</code>, pauses the cycling of the carousel on <code>mouseenter</code> and resumes the cycling of the carousel on <code>mouseleave</code>. If set to <code>null</code>, hovering over the carousel won't pause it.</td>
+     <td>If set to <code>"hover"</code>, pauses the cycling of the carousel on <code>mouseenter</code> and resumes the cycling of the carousel on <code>mouseleave</code>. If set to <code>false</code>, hovering over the carousel won't pause it.</td>
    </tr>
    <tr>
      <td>ride</td>


### PR DESCRIPTION
Carousel option data-pause expects boolean “false”. “null” causes js error!