### PR TITLE
Workaround dividers thickness inconsistent when decimal zoom

### DIFF
--- a/scss/mixins/_nav-divider.scss
+++ b/scss/mixins/_nav-divider.scss
@@ -3,7 +3,7 @@
 // Dividers (basically an hr) within dropdowns and nav lists
 
 @mixin nav-divider($color: #e5e5e5) {
-  height: 0px;
+  height: 0;
   border-top: 1px solid $color;
   margin: ($spacer-y / 2) 0;
   overflow: hidden;

--- a/scss/mixins/_nav-divider.scss
+++ b/scss/mixins/_nav-divider.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 0px;
-  border-top: 1px solid @color;
+  border-top: 1px solid $color;
   margin: ($spacer-y / 2) 0;
   overflow: hidden;
   background-color: $color;

--- a/scss/mixins/_nav-divider.scss
+++ b/scss/mixins/_nav-divider.scss
@@ -3,7 +3,8 @@
 // Dividers (basically an hr) within dropdowns and nav lists
 
 @mixin nav-divider($color: #e5e5e5) {
-  height: 1px;
+  height: 0px;
+  border-top: 1px solid @color;
   margin: ($spacer-y / 2) 0;
   overflow: hidden;
   background-color: $color;


### PR DESCRIPTION
When decimal zoom, due to browser pixel rounding, the dividers look like this:
<img width="151" alt="2017-02-09 01_30_46-bootply - the bootstrap playground" src="https://cloud.githubusercontent.com/assets/15178410/22755103/b2f6a076-ee7c-11e6-98dc-6816d782160c.png">

But `border` won't be rounding, so workaround this:
<img width="154" alt="2017-02-09 01_31_32-bootply - the bootstrap playground" src="https://cloud.githubusercontent.com/assets/15178410/22755306/8f4db956-ee7d-11e6-8722-80078c183bf7.png">

And I just fixed v4, please fix v3 too.