### PR TITLE
Do not assume margin direction, harder to override

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -4,7 +4,7 @@
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
-  margin-bottom: $headings-margin-bottom;
+  margin: $headings-margin;
   font-family: $headings-font-family;
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -263,7 +263,7 @@ $font-size-h4: 1.5rem !default;
 $font-size-h5: 1.25rem !default;
 $font-size-h6: 1rem !default;
 
-$headings-margin-bottom: ($spacer / 2) !default;
+$headings-margin: 0 0 ($spacer / 2) 0 !default;
 $headings-font-family:   inherit !default;
 $headings-font-weight:   500 !default;
 $headings-line-height:   1.1 !default;


### PR DESCRIPTION
`margin-bottom` is an opinionated way of handling margin spacing. We can remove the dependency and use simple CSS shorthand to achieve the same result. Variable is much more configurable.