### PR TITLE
Fix input box-shadow on focus state

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -423,7 +423,7 @@ $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
 $input-border-focus:             lighten($brand-primary, 25%) !default;
-$input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
+$input-box-shadow-focus:         $input-box-shadow, 0 0 8px rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
 $input-color-placeholder:        $gray-light !default;


### PR DESCRIPTION
The variable `$input-box-shadow-focus` is currently defined as `$input-box-shadow, rgba($input-border-focus, .6) !default` that generate the invalid css `box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), rgba(92, 179, 253, 0.6);`

This PR add the missing `h-shadow`, `v-shadow` and `blur`. I set the default variable with the same value as the one defined for Bootstrap v3 [here](https://github.com/twbs/bootstrap/blob/master/less/mixins/forms.less#L60).

