### PR TITLE
Dropdown focus

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -17,11 +17,6 @@
     border-right: $caret-width solid transparent;
     border-left: $caret-width solid transparent;
   }
-
-  // Prevent the focus on the dropdown toggle when closing dropdowns
-  &:focus {
-    outline: 0;
-  }
 }
 
 .dropup {


### PR DESCRIPTION
Removes the custom `outline: 0` override from dropdown toggles. Fixes #17573.

We keep the focus everywhere, and in many cases now customize it's appearance for a better look. Removing it for one subset of our components (this only affects some buttons) seems wrong now.