### PR TITLE
Change .navbar-toggler color

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -187,8 +187,7 @@
 
 // Dark links against a light background
 .navbar-light {
-  .navbar-brand,
-  .navbar-toggler {
+  .navbar-brand {
     color: $navbar-light-active-color;
 
     @include hover-focus {
@@ -218,6 +217,7 @@
   }
 
   .navbar-toggler {
+    color: $navbar-light-color;
     border-color: $navbar-light-toggler-border;
   }
 
@@ -232,8 +232,7 @@
 
 // White links against a dark background
 .navbar-inverse {
-  .navbar-brand,
-  .navbar-toggler {
+  .navbar-brand {
     color: $navbar-inverse-active-color;
 
     @include hover-focus {
@@ -263,6 +262,7 @@
   }
 
   .navbar-toggler {
+    color: $navbar-inverse-color;
     border-color: $navbar-inverse-toggler-border;
   }
 


### PR DESCRIPTION
Change the `.navbar-toggler` to default contextual `.navbar-*-color` in case we use some other custom icons like `.navbar-toggler-icon.fa.fa-search`.
Please take a look at this demo: http://codepen.io/zalog/pen/MJLZOE/ - you must resize down the viewport.

Being on mobile, I'm not sure if we need a hover-focus mixin for `.navbar-toggler`, but if we do, please let me know.