### PR TITLE
Change sticky order

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -581,8 +581,8 @@ $dropdown-header-color:          $gray-light !default;
 
 $zindex-dropdown-backdrop:  990 !default;
 $zindex-dropdown:           1000 !default;
+$zindex-sticky:             1020 !default;
 $zindex-fixed:              1030 !default;
-$zindex-sticky:             1030 !default;
 $zindex-modal-backdrop:     1040 !default;
 $zindex-modal:              1050 !default;
 $zindex-popover:            1060 !default;


### PR DESCRIPTION
Problem: when we set a `.fixed-top` navbar, and we need to set some other `.sticky-*` in page, the sticky's element stays on top of the fixed navbar.
Demo: http://codepen.io/zalog/pen/jyoyoR