### PR TITLE
Remove margin-bottom from last .form-group

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -188,6 +188,10 @@ select.form-control-lg {
 
 .form-group {
   margin-bottom: $form-group-margin-bottom;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 }
 
 .form-text {


### PR DESCRIPTION
I like to have, eg, my submit/reset buttons inside `.form-group`s to group my form elements. But since every `.form-group` has `margin-bottom: $form-group-margin-bottom`, which is set to 1rem by default in v4 (and 15px in v3), it adds unwanted pixels in form of margin to the layout. See picture below where the unwanted pixels are marked with orange.

![bootstrap-form-group.jpg](https://dev.moso.io/twbs/bootstrap-form-group.jpg)

However, with a simple `&:last-of-type` that removes the `margin-bottom` on the last `.form-group`, one can get rid of the unwanted addition of pixels.