### PR TITLE
Adding zoom callout for .form-control-sm

### DIFF
--- a/docs/components/forms.md
+++ b/docs/components/forms.md
@@ -609,6 +609,12 @@ Add the `readonly` boolean attribute on an input to prevent modification of the 
 
 Set heights using classes like `.form-control-lg`, and set widths using grid column classes like `.col-lg-*`.
 
+{% callout warning %}
+#### Caveat about `.form-control-sm`
+
+When a form control is focused, most mobile browsers will zoom on the control if its font size is less than 16px. By default, these browsers will render a `.form-control-sm` element with a font size of 14px, which will cause the page to zoom when the control is focused.  If this behavior is undesirable, avoid using the small control size.
+{% endcallout %}
+
 {% example html %}
 <input class="form-control form-control-lg" type="text" placeholder=".form-control-lg">
 <input class="form-control" type="text" placeholder="Default input">


### PR DESCRIPTION
After I noticed my page zooming, I searched for how to prevent it and found this:
http://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone

If there was a callout, I probably would have avoided ever attempting to use .form-control-sm.

In the callout itself, I was unsure whether I should present a single recommended solution, or if I should present all possible solutions.  In this case, the other solutions are to prevent zoom onFocus with custom Javascript or to prevent zoom altogether with a viewport restriction.  Since both impact accessibility, I decided to only present the option of avoiding use.