### PR TITLE
Fix border width calculation for custom-select

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -135,7 +135,7 @@
 .custom-select {
   display: inline-block;
   max-width: 100%;
-  $select-border-width: ($border-width * 2);
+  $select-border-width: ($custom-select-border-width * 2);
   height: calc(#{$input-height} + #{$select-border-width});
   padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
   line-height: $custom-select-line-height;


### PR DESCRIPTION
In addition to #22011 and #21994 also a fix for the custom-select border width. Now it respects the set variable. Fixes #22011.