### PR TITLE
Fix carousel "load" event bound without any namespace

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -227,7 +227,7 @@
     .on('click.bs.carousel.data-api', '[data-slide]', clickHandler)
     .on('click.bs.carousel.data-api', '[data-slide-to]', clickHandler)
 
-  $(window).on('load', function () {
+  $(window).on('load.bs.carousel.data-api', function () {
     $('[data-ride="carousel"]').each(function () {
       var $carousel = $(this)
       Plugin.call($carousel, $carousel.data())


### PR DESCRIPTION
I was trying to do something like this
```js
$(window)
	.off('load.bs.carousel.data-api')
	.on('load.bs.carousel.data-api', function () {
		// something custom
	});
```
And it did not work because the `'load'` event was bound without usual bootstrap carousel data-API namespaces.