### PR TITLE
Remove 'hover' from nav-tabs-active-link-hover-color et al

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -55,9 +55,9 @@
 
   .nav-link.active,
   .nav-item.show .nav-link {
-    color: $nav-tabs-active-link-hover-color;
-    background-color: $nav-tabs-active-link-hover-bg;
-    border-color: $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-border-color $nav-tabs-active-link-hover-bg;
+    color: $nav-tabs-active-link-color;
+    background-color: $nav-tabs-active-link-bg;
+    border-color: $nav-tabs-active-link-border-color $nav-tabs-active-link-border-color $nav-tabs-active-link-bg;
   }
 
   .dropdown-menu {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -621,9 +621,9 @@ $nav-tabs-border-color:                       #ddd !default;
 $nav-tabs-border-width:                       $border-width !default;
 $nav-tabs-border-radius:                      $border-radius !default;
 $nav-tabs-link-hover-border-color:            $gray-lighter !default;
-$nav-tabs-active-link-hover-color:            $gray !default;
-$nav-tabs-active-link-hover-bg:               $body-bg !default;
-$nav-tabs-active-link-hover-border-color:     #ddd !default;
+$nav-tabs-active-link-color:            $gray !default;
+$nav-tabs-active-link-bg:               $body-bg !default;
+$nav-tabs-active-link-border-color:     #ddd !default;
 
 $nav-pills-border-radius:     $border-radius !default;
 $nav-pills-active-link-color: $component-active-color !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -621,9 +621,9 @@ $nav-tabs-border-color:                       #ddd !default;
 $nav-tabs-border-width:                       $border-width !default;
 $nav-tabs-border-radius:                      $border-radius !default;
 $nav-tabs-link-hover-border-color:            $gray-lighter !default;
-$nav-tabs-active-link-color:            $gray !default;
-$nav-tabs-active-link-bg:               $body-bg !default;
-$nav-tabs-active-link-border-color:     #ddd !default;
+$nav-tabs-active-link-color:                  $gray !default;
+$nav-tabs-active-link-bg:                     $body-bg !default;
+$nav-tabs-active-link-border-color:           #ddd !default;
 
 $nav-pills-border-radius:     $border-radius !default;
 $nav-pills-active-link-color: $component-active-color !default;


### PR DESCRIPTION
Addressing the issue:

Remove 'hover' from nav-tabs-active-link-hover-color et al #22073