### PR TITLE
Move box-shadow and transition mixins out of the main mixins file

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -2,22 +2,6 @@
 //
 // Used in conjunction with global variables to enable certain theme features.
 
-@mixin box-shadow($shadow...) {
-  @if $enable-shadows {
-    box-shadow: $shadow;
-  }
-}
-
-@mixin transition($transition...) {
-  @if $enable-transitions {
-    @if length($transition) == 0 {
-      transition: $transition-base;
-    } @else {
-      transition: $transition;
-    }
-  }
-}
-
 // Utilities
 @import "mixins/breakpoints";
 @import "mixins/hover";
@@ -47,7 +31,9 @@
 // // Skins
 @import "mixins/background-variant";
 @import "mixins/border-radius";
+@import "mixins/box-shadow";
 @import "mixins/gradients";
+@import "mixins/transition";
 
 // // Layout
 @import "mixins/clearfix";

--- a/scss/mixins/_box-shadow.scss
+++ b/scss/mixins/_box-shadow.scss
@@ -1,0 +1,5 @@
+@mixin box-shadow($shadow...) {
+  @if $enable-shadows {
+    box-shadow: $shadow;
+  }
+}

--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -1,0 +1,9 @@
+@mixin transition($transition...) {
+  @if $enable-transitions {
+    @if length($transition) == 0 {
+      transition: $transition-base;
+    } @else {
+      transition: $transition;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #22012, closes #22013.

This avoids the addition of a "core" mixins file as suggested in #22013 and instead moves each mixin to it's own file..