### PR TITLE
Fix selectable disabled toggle radio buttons

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -24,7 +24,8 @@ const Button = (($) => {
   const ClassName = {
     ACTIVE : 'active',
     BUTTON : 'btn',
-    FOCUS  : 'focus'
+    FOCUS  : 'focus',
+    DISABLED: 'disabled'
   }
 
   const Selector = {
@@ -74,7 +75,9 @@ const Button = (($) => {
         const input = $(this._element).find(Selector.INPUT)[0]
 
         if (input) {
-          if (input.type === 'radio') {
+          if (input.disabled || $(this._element).hasClass(ClassName.DISABLED)) {
+            triggerChangeEvent = false
+          } else if (input.type === 'radio') {
             if (input.checked &&
               $(this._element).hasClass(ClassName.ACTIVE)) {
               triggerChangeEvent = false

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -138,4 +138,39 @@ $(function () {
     assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
   })
 
+  QUnit.test('shouldn\'t check disabled radio inputs', function (assert) {
+    assert.expect(12)
+    var groupHTML = '<div class="btn-group" data-toggle="buttons">'
+      + '<label class="btn btn-primary active">'
+      + '<input type="radio" name="options" id="option1" checked="true"> Option 1'
+      + '</label>'
+      + '<label class="btn btn-primary">'
+      + '<input type="radio" name="options" disabled="true" id="option2"> Option 2'
+      + '</label>'
+      + '<label class="btn btn-primary disabled">'
+      + '<input type="radio" name="options" id="option3"> Option 3'
+      + '</label>'
+      + '</div>'
+    var $group = $(groupHTML).appendTo('#qunit-fixture')
+
+    var $btn1 = $group.children().eq(0)
+    var $btn2 = $group.children().eq(1)
+    var $btn3 = $group.children().eq(2)
+
+    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
+    assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
+    assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
+    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
+    $btn2.find('input').trigger('click')
+    assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
+    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
+    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
+    assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
+    $btn3.find('input').trigger('click')
+    assert.ok(!$btn3.hasClass('active'), 'btn3 does not have active class')
+    assert.ok(!$btn3.find('input').prop('checked'), 'btn3 is not checked')
+    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
+    assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
+  })
+
 })


### PR DESCRIPTION
Currently, if when using a toggle button radio group with disabled Inputs or Label input container, despite having the correct cursor and styling, those inputs are still selectable

This pull request makes it so disabled radio toggle button is not selectable
They can be disabled either by
- adding a disabled class on Label container
- decorating the Input with a disabled attribute

