### PR TITLE
Docs for text-truncate and text-nowrap

### DIFF
--- a/docs/utilities/typography.md
+++ b/docs/utilities/typography.md
@@ -19,14 +19,6 @@ Easily realign text to components with text alignment classes.
 <p class="text-justify">Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit amet fermentum. Donec sed odio operae, eu vulputate felis rhoncus. Praeterea iter est quasdam res quas ex communi. At nos hinc posthac, sitientis piros Afros. Petierunt uti sibi concilium totius Galliae in diem certam indicere. Cras mattis iudicium purus sit amet fermentum.</p>
 {% endexample %}
 
-{% example html %}
-<div class="card">
-  <div class="card-block text-nowrap">
-    Curabitur blandit tempus ardua ridiculus sed magna.
-  </div>
-</div>
-{% endexample %}
-
 For left, right, and center alignment, responsive classes are available that use the same viewport width breakpoints as the grid system.
 
 {% example html %}
@@ -38,6 +30,31 @@ For left, right, and center alignment, responsive classes are available that use
 <p class="text-md-left">Left aligned text on viewports sized MD (medium) or wider.</p>
 <p class="text-lg-left">Left aligned text on viewports sized LG (large) or wider.</p>
 <p class="text-xl-left">Left aligned text on viewports sized XL (extra-large) or wider.</p>
+{% endexample %}
+
+## Text wrapping and overflow
+
+Prevent text from wrapping with a `.text-nowrap` class.
+
+{% example html %}
+<div class="row">
+  <div class="col-1 text-nowrap">
+    Curabitur blandit tempus ardua ridiculus sed magna.
+  </div>
+  <div class="col-11">
+    <img data-src="holder.js/50x50" alt="An image to show the text doesn't wrap">
+  </div>
+</div>
+{% endexample %}
+
+For longer content, you can add a `.text-truncate` class to truncate the text with an ellipsis.
+
+{% example html %}
+<div class="row">
+  <div class="col-2 text-truncate">
+    Praeterea iter est quasdam res quas ex communi.
+  </div>
+</div>
 {% endexample %}
 
 ## Text transform


### PR DESCRIPTION
Adding `text-truncate` and extending on the example added for `text-nowrap`

I'm not 100% happy about the example for `text-nowrap` though it does sufficiently get the point across.