### PR TITLE
Update _screen-reader.scss

### DIFF
--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -9,7 +9,7 @@
   height: 1px;
   padding: 0;
   margin: -1px;
-  overflow: hidden;  
+  overflow: hidden;
   clip: rect(0,0,0,0);
   white-space: nowrap;
   clip-path: inset(50%);
@@ -29,7 +29,7 @@
     width: auto;
     height: auto;
     margin: 0;
-    overflow: visible;    
+    overflow: visible; 
     clip: auto;
     white-space: normal;
     clip-path: none;

--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -29,7 +29,7 @@
     width: auto;
     height: auto;
     margin: 0;
-    overflow: visible; 
+    overflow: visible;
     clip: auto;
     white-space: normal;
     clip-path: none;

--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -1,6 +1,7 @@
 // Only display content to screen readers
 //
 // See: http://a11yproject.com/posts/how-to-hide-content
+// See: http://hugogiraudel.com/2016/10/13/css-hide-and-seek/
 
 @mixin sr-only {
   position: absolute;
@@ -9,7 +10,9 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  white-space: nowrap;
   clip: rect(0,0,0,0);
+  clip-path: inset(50%);
   border: 0;
 }
 
@@ -27,6 +30,8 @@
     height: auto;
     margin: 0;
     overflow: visible;
+    white-space: normal;
     clip: auto;
+    clip-path: none;
   }
 }

--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -8,7 +8,6 @@
   width: 1px;
   height: 1px;
   padding: 0;
-  margin: -1px;
   overflow: hidden;
   clip: rect(0,0,0,0);
   white-space: nowrap;
@@ -28,7 +27,6 @@
     position: static;
     width: auto;
     height: auto;
-    margin: 0;
     overflow: visible;
     clip: auto;
     white-space: normal;

--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -9,9 +9,9 @@
   height: 1px;
   padding: 0;
   margin: -1px;
-  overflow: hidden;
-  white-space: nowrap;
+  overflow: hidden;  
   clip: rect(0,0,0,0);
+  white-space: nowrap;
   clip-path: inset(50%);
   border: 0;
 }
@@ -29,9 +29,9 @@
     width: auto;
     height: auto;
     margin: 0;
-    overflow: visible;
-    white-space: normal;
+    overflow: visible;    
     clip: auto;
+    white-space: normal;
     clip-path: none;
   }
 }


### PR DESCRIPTION
Small improvements that could be important:
* `clip` [is deprecated](https://www.w3.org/TR/css-masking-1/#clip-property). Adding `clip-path` as progressive enhancement; the shorter notation came from @ryuran 's [suggestion](https://twitter.com/ryuran78/status/778943389819604992);
* [J. Renée Beach warned about single pixel with interfering with screen readers vocalisation](https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe#.vcd5xlpgg) solved with `white-space`.

See [the detailed post on Hugo Giraudel's blog](http://hugogiraudel.com/2016/10/13/css-hide-and-seek/).

Also kinda related to issue #20732 :)

Please let me know if you find any trouble with this technique. Thanks a lot!