### PR TITLE
Add :empty to .custom-file-control selector

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -229,7 +229,7 @@
   @include box-shadow($custom-file-box-shadow);
 
   @each $lang, $text in map-get($custom-file-text, placeholder) {
-    &:lang(#{$lang})::after {
+    &:lang(#{$lang}):empty::after {
       content: $text;
     }
   }


### PR DESCRIPTION
![screen shot 2017-03-13 at 09 26 05](https://cloud.githubusercontent.com/assets/150607/23861256/1df435ee-07cf-11e7-8fd2-10ed0a23f755.png)

`<label class="custom-file"><input type="file" class="custom-file-input" /><span class="custom-file-control">test.txt</span></label>`

![screen shot 2017-03-13 at 09 24 17](https://cloud.githubusercontent.com/assets/150607/23861176/e66cf390-07ce-11e7-82c5-5e0941a77741.png)


vs

![screen shot 2017-03-13 at 09 24 35](https://cloud.githubusercontent.com/assets/150607/23861181/eaa8897e-07ce-11e7-9d21-2e0d388e4ddb.png)
