### PR TITLE
v4 table updates

### DIFF
--- a/docs/assets/scss/_content.scss
+++ b/docs/assets/scss/_content.scss
@@ -6,11 +6,15 @@
 
 .bd-content {
   > table {
-    display: block;
     width: 100%;
     max-width: 100%;
     margin-bottom: 1rem;
-    overflow-y: auto;
+
+    @include media-breakpoint-down(md) {
+      display: block;
+      overflow-x: auto;
+      -ms-overflow-style: -ms-autohiding-scrollbar; // See https://github.com/twbs/bootstrap/pull/10057
+    }
 
     // Cells
     > thead,

--- a/docs/content/tables.md
+++ b/docs/content/tables.md
@@ -442,50 +442,13 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 
 Use contextual classes to color table rows or individual cells.
 
-<table class="table table-bordered table-striped table-responsive">
-  <colgroup>
-    <col class="col-1">
-    <col class="col-7">
-  </colgroup>
-  <thead>
-    <tr>
-      <th>Class</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">
-        <code>.table-active</code>
-      </th>
-      <td>Applies the hover color to a particular row or cell</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-success</code>
-      </th>
-      <td>Indicates a successful or positive action</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-info</code>
-      </th>
-      <td>Indicates a neutral informative change or action</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-warning</code>
-      </th>
-      <td>Indicates a warning that might need attention</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-danger</code>
-      </th>
-      <td>Indicates a dangerous or potentially negative action</td>
-    </tr>
-  </tbody>
-</table>
+| Class | Description |
+| --- | --- |
+| `.table-active` | Applies the hover color to a particular row or cell |
+| `.table-success` | Indicates a successful or positive action |
+| `.table-info` | Indicates a neutral informative change or action |
+| `.table-warning` | Indicates a warning that might need attention |
+| `.table-danger` | Indicates a dangerous or potentially negative action |
 
 <div class="bd-example">
   <table class="table">

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -99,8 +99,8 @@
 
 .nav-justified {
   .nav-item {
-    flex-grow: 1;
     flex-basis: 0;
+    flex-grow: 1;
     text-align: center;
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -142,13 +142,15 @@
 // will display normally.
 
 .table-responsive {
-  display: block;
-  width: 100%;
-  overflow-x: auto;
-  -ms-overflow-style: -ms-autohiding-scrollbar; // See https://github.com/twbs/bootstrap/pull/10057
+  @include media-breakpoint-down(md) {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -ms-overflow-style: -ms-autohiding-scrollbar; // See https://github.com/twbs/bootstrap/pull/10057
 
-  // Prevent double border on horizontal scroll due to use of `display: block;`
-  &.table-bordered {
-    border: 0;
+    // Prevent double border on horizontal scroll due to use of `display: block;`
+    &.table-bordered {
+      border: 0;
+    }
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -125,7 +125,7 @@
   th,
   td,
   thead th {
-    border-color: $body-bg;
+    border-color: $table-inverse-border;
   }
 
   &.table-bordered {

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -131,6 +131,20 @@
   &.table-bordered {
     border: 0;
   }
+
+  &.table-striped {
+    tbody tr:nth-of-type(odd) {
+      background-color: $table-inverse-bg-accent;
+    }
+  }
+
+  &.table-hover {
+    tbody tr {
+      @include hover {
+        background-color: $table-inverse-bg-hover;
+      }
+    }
+  }
 }
 
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -134,7 +134,6 @@
 }
 
 
-
 // Responsive tables
 //
 // Add `.table-responsive` to `.table`s and we'll make them mobile friendly by

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -316,20 +316,19 @@ $table-cell-padding:            .75rem !default;
 $table-sm-cell-padding:         .3rem !default;
 
 $table-bg:                      transparent !default;
-
-$table-inverse-bg:              $gray-dark !default;
-$table-inverse-border:          lighten($gray-dark, 7.5%) !default;
-$table-inverse-color:           $body-bg !default;
-
 $table-bg-accent:               rgba($black,.05) !default;
 $table-bg-hover:                rgba($black,.075) !default;
 $table-bg-active:               $table-bg-hover !default;
 
+$table-border-width:            $border-width !default;
+$table-border-color:            $gray-lighter !default;
+
 $table-head-bg:                 $gray-lighter !default;
 $table-head-color:              $gray !default;
 
-$table-border-width:            $border-width !default;
-$table-border-color:            $gray-lighter !default;
+$table-inverse-bg:              $gray-dark !default;
+$table-inverse-border:          lighten($gray-dark, 7.5%) !default;
+$table-inverse-color:           $body-bg !default;
 
 
 // Buttons

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -327,6 +327,9 @@ $table-head-bg:                 $gray-lighter !default;
 $table-head-color:              $gray !default;
 
 $table-inverse-bg:              $gray-dark !default;
+$table-inverse-bg-accent:       rgba($white, .05) !default;
+$table-inverse-bg-hover:        rgba($white, .075) !default;
+$table-inverse-bg-active:       $table-inverse-bg-hover !default;
 $table-inverse-border:          lighten($gray-dark, 7.5%) !default;
 $table-inverse-color:           $body-bg !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -318,6 +318,7 @@ $table-sm-cell-padding:         .3rem !default;
 $table-bg:                      transparent !default;
 
 $table-inverse-bg:              $gray-dark !default;
+$table-inverse-border:          lighten($gray-dark, 7.5%) !default;
 $table-inverse-color:           $body-bg !default;
 
 $table-bg-accent:               rgba($black,.05) !default;


### PR DESCRIPTION
Few table updates:

- Fixes the inverse table's border color. Adds a new variable that lightens the inverse table's background color a bit instead of using `$body-bg`.
- Fixes the responsive table behavior. Instead of using a parent class again, this scopes (as the comment above it indicates) the styles to under 768px.

---

Fixes part of #21585
Fixes #21577 (/cc @pmsaue0 as credit for the fix)
Closes #21677, closes #21678, and closes #21676 as they're no longer needed.
