### PR TITLE
Visual example does not use this class

### DIFF
--- a/docs/_includes/css/forms.html
+++ b/docs/_includes/css/forms.html
@@ -625,7 +625,7 @@
     </form>
   </div><!-- /.bs-example -->
 {% highlight html %}
-<label class="sr-only" for="inputHelpBlock">Input with help text</label>
+<label for="inputHelpBlock">Input with help text</label>
 <input type="text" id="inputHelpBlock" class="form-control" aria-describedby="helpBlock">
 ...
 <span id="helpBlock" class="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>


### PR DESCRIPTION
The `.bs-example` version has a visible label, and does not use the `.sr-only` class