### PR TITLE
Make text align right for .col-form-label

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -98,6 +98,7 @@ select.form-control {
   padding-top: calc(#{$input-padding-y} - #{$input-btn-border-width} * 2);
   padding-bottom: calc(#{$input-padding-y} - #{$input-btn-border-width} * 2);
   margin-bottom: 0; // Override the `<label>` default
+  text-align: right;
 }
 
 .col-form-label-lg {


### PR DESCRIPTION
This PR tries to right align `.col-form-label` as described in #20643.

I personally like right-aligned label very much from Bootstrap 3 and would love to see the same in Bootstrap 4.

This is my first PR to a front end development framework so if I missed anything, please let me know and I will be glad to fix it.
