### PR TITLE
Fix modal documentation

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -63,7 +63,7 @@ Below is a _static_ modal example (meaning its `position` and `display` have bee
 </div>
 
 {% highlight html %}
-<div class="modal fade">
+<div class="modal">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
The example code has the class `"modal fade"`, but the visible example has the class `"modal"`. `"fade"` appears to not work for modals that you do not intend to animate onto the page