### PR TITLE
Enhance Positioning Options for Tooltips & Popovers

### DIFF
--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -218,6 +218,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>'right'</td>
       <td>
         <p>How to position the popover - top | bottom | left | right.</p>
+        <p>You may pass a secondary alignment, separated with a space. Example: <code>'top left'</code> or <code>'right bottom'</code>. if secondary alignment is not supplied, popover will be aligned to the target's center.</p>
         <p>When a function is used to determine the placement, it is called with the popover DOM node as its first argument and the triggering element DOM node as its second. The <code>this</code> context is set to the popover instance.</p>
       </td>
     </tr>

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -196,6 +196,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>'top'</td>
       <td>
         <p>How to position the tooltip - top | bottom | left | right.</p>
+        <p>You may pass a secondary alignment, separated with a space. Example: <code>'top left'</code> or <code>'right bottom'</code>. if secondary alignment is not supplied, tooltip will be aligned to the target's center.</p>
         <p>When a function is used to determine the placement, it is called with the tooltip DOM node as its first argument and the triggering element DOM node as its second. The <code>this</code> context is set to the tooltip instance.</p>
       </td>
     </tr>

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -65,11 +65,23 @@ const Tooltip = (($) => {
     container   : '(string|element|boolean)'
   }
 
+  // Mapping attachment-point of tooltip element and target element, respectively
   const AttachmentMap = {
-    TOP    : 'bottom center',
-    RIGHT  : 'middle left',
-    BOTTOM : 'top center',
-    LEFT   : 'middle right'
+    TOP             : ['bottom center', 'top center'],
+    'TOP LEFT'      : ['bottom left', 'top left'],
+    'TOP RIGHT'     : ['bottom right', 'top right'],
+
+    RIGHT           : ['middle left', 'middle right'],
+    'RIGHT TOP'     : ['top left', 'top right'],
+    'RIGHT BOTTOM'  : ['bottom left', 'bottom right'],
+
+    BOTTOM          : ['top center', 'bottom center'],
+    'BOTTOM LEFT'   : ['top left', 'bottom left'],
+    'BOTTOM RIGHT'  : ['top right', 'bottom right'],
+
+    LEFT            : ['middle right', 'middle left'],
+    'LEFT TOP'      : ['top right', 'top left'],
+    'LEFT BOTTOM'   : ['bottom right', 'bottom left']
   }
 
   const HoverState = {
@@ -289,7 +301,8 @@ const Tooltip = (($) => {
         $(this.element).trigger(this.constructor.Event.INSERTED)
 
         this._tether = new Tether({
-          attachment,
+          attachment      : attachment.tooltipElement,
+          targetAttachment: attachment.targetElement,
           element         : tip,
           target          : this.element,
           classes         : TetherClass,
@@ -444,7 +457,12 @@ const Tooltip = (($) => {
     // private
 
     _getAttachment(placement) {
-      return AttachmentMap[placement.toUpperCase()]
+      const mapping = AttachmentMap[placement.toUpperCase()]
+
+      return {
+        tooltipElement: mapping[0],
+        targetElement: mapping[1]
+      }
     }
 
     _cleanTipClass() {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -22,7 +22,7 @@
   // Popover directions
 
   &.popover-top,
-  &.bs-tether-element-attached-bottom {
+  &.bs-tether-element-attached-bottom.bs-tether-target-attached-top {
     margin-top: -$popover-arrow-width;
 
     &::before,
@@ -42,10 +42,28 @@
       margin-left: -$popover-arrow-width;
       border-top-color: $popover-arrow-color;
     }
+
+    &.bs-tether-element-attached-left {
+      &::before,
+      &::after {
+        left: $popover-arrow-outer-width * 2;
+      }
+    }
+
+    &.bs-tether-element-attached-right {
+      &::before {
+        right: $popover-arrow-outer-width - 1;
+        left: initial;
+      }
+      &::after {
+        right: $popover-arrow-outer-width;
+        left: initial;
+      }
+    }
   }
 
   &.popover-right,
-  &.bs-tether-element-attached-left {
+  &.bs-tether-element-attached-left.bs-tether-target-attached-right {
     margin-left: $popover-arrow-width;
 
     &::before,
@@ -65,10 +83,29 @@
       margin-top: -($popover-arrow-outer-width - 1);
       border-right-color: $popover-arrow-color;
     }
+
+    &.bs-tether-element-attached-top {
+      &::before,
+      &::after {
+        top: $popover-arrow-outer-width * 2;
+      }
+    }
+
+    &.bs-tether-element-attached-bottom {
+      &::before {
+        top: initial;
+        bottom: $popover-arrow-outer-width - 1;
+      }
+      &::after {
+        top: initial;
+        bottom: $popover-arrow-outer-width;
+      }
+    }
+
   }
 
   &.popover-bottom,
-  &.bs-tether-element-attached-top {
+  &.bs-tether-element-attached-top.bs-tether-target-attached-bottom {
     margin-top: $popover-arrow-width;
 
     &::before,
@@ -89,6 +126,24 @@
       border-bottom-color: $popover-arrow-color;
     }
 
+    &.bs-tether-element-attached-left {
+      &::before,
+      &::after {
+        left: $popover-arrow-outer-width * 2;
+      }
+    }
+
+    &.bs-tether-element-attached-right {
+      &::before {
+        right: $popover-arrow-outer-width - 1;
+        left: initial;
+      }
+      &::after {
+        right: $popover-arrow-outer-width;
+        left: initial;
+      }
+    }
+
     // This will remove the popover-title's border just below the arrow
     .popover-title::before {
       position: absolute;
@@ -103,7 +158,7 @@
   }
 
   &.popover-left,
-  &.bs-tether-element-attached-right {
+  &.bs-tether-element-attached-right.bs-tether-target-attached-left {
     margin-left: -$popover-arrow-width;
 
     &::before,
@@ -122,6 +177,24 @@
       right: -($popover-arrow-outer-width - 1);
       margin-top: -($popover-arrow-outer-width - 1);
       border-left-color: $popover-arrow-color;
+    }
+
+    &.bs-tether-element-attached-top {
+      &::before,
+      &::after {
+        top: $popover-arrow-outer-width * 2;
+      }
+    }
+
+    &.bs-tether-element-attached-bottom {
+      &::before {
+        top: initial;
+        bottom: $popover-arrow-outer-width - 1;
+      }
+      &::after {
+        top: initial;
+        bottom: $popover-arrow-outer-width;
+      }
     }
   }
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -14,7 +14,7 @@
   &.show { opacity: $tooltip-opacity; }
 
   &.tooltip-top,
-  &.bs-tether-element-attached-bottom {
+  &.bs-tether-element-attached-bottom.bs-tether-target-attached-top {
     padding: $tooltip-arrow-width 0;
     margin-top: -$tooltip-margin;
 
@@ -26,9 +26,20 @@
       border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
       border-top-color: $tooltip-arrow-color;
     }
+
+    &.bs-tether-element-attached {
+      &-left .tooltip-inner::before {
+        left: $tooltip-arrow-width * 3;
+      }
+
+      &-right .tooltip-inner::before {
+        right: $tooltip-arrow-width * 2;
+        left: inherit;
+      }
+    }
   }
   &.tooltip-right,
-  &.bs-tether-element-attached-left {
+  &.bs-tether-element-attached-left.bs-tether-target-attached-right {
     padding: 0 $tooltip-arrow-width;
     margin-left: $tooltip-margin;
 
@@ -40,9 +51,20 @@
       border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
       border-right-color: $tooltip-arrow-color;
     }
+
+    &.bs-tether-element-attached {
+      &-top .tooltip-inner::before {
+        top: $tooltip-arrow-width * 3;
+      }
+
+      &-bottom .tooltip-inner::before {
+        top: inherit;
+        bottom: $tooltip-arrow-width * 2;
+      }
+    }
   }
   &.tooltip-bottom,
-  &.bs-tether-element-attached-top {
+  &.bs-tether-element-attached-top.bs-tether-target-attached-bottom {
     padding: $tooltip-arrow-width 0;
     margin-top: $tooltip-margin;
 
@@ -54,9 +76,21 @@
       border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-bottom-color: $tooltip-arrow-color;
     }
+
+    &.bs-tether-element-attached {
+      &-left .tooltip-inner::before {
+        left: $tooltip-arrow-width * 3;
+      }
+
+      &-right .tooltip-inner::before {
+        right: $tooltip-arrow-width * 2;
+        left: inherit;
+      }
+    }
   }
+
   &.tooltip-left,
-  &.bs-tether-element-attached-right {
+  &.bs-tether-element-attached-right.bs-tether-target-attached-left {
     padding: 0 $tooltip-arrow-width;
     margin-left: -$tooltip-margin;
 
@@ -67,6 +101,17 @@
       content: "";
       border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-left-color: $tooltip-arrow-color;
+    }
+
+    &.bs-tether-element-attached {
+      &-top .tooltip-inner::before {
+        top: $tooltip-arrow-width * 3;
+      }
+
+      &-bottom .tooltip-inner::before {
+        top: inherit;
+        bottom: $tooltip-arrow-width * 2;
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary:
Add more positioning options to the **tooltip** component, using _tether_'s native [attachment options](http://tether.io/#attachment). As requested in #17759 and #19921, and inspired by [semantic UI tooltips](https://semantic-ui.com/modules/popup.html#tooltip). No breaking changes, still fully support previous params. Docs updated accordingly.

### Before:
Tooltips supported only 4 positioning options: top | right | bottom | left

### After:
Tooltips now have an **optional** secondary alignment option, for example `top left` or `right bottom`, summing up in 12 positioning options.