### PR TITLE
[Docs v3] Typo in Modal Example

### DIFF
--- a/docs/_includes/js/modal.html
+++ b/docs/_includes/js/modal.html
@@ -160,7 +160,7 @@ $('#myModal').on('shown.bs.modal', function () {
 <!-- Large modal -->
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bs-example-modal-lg">Large modal</button>
 
-<div class="modal fade bs-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+<div class="modal fade modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       ...
@@ -171,7 +171,7 @@ $('#myModal').on('shown.bs.modal', function () {
 <!-- Small modal -->
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bs-example-modal-sm">Small modal</button>
 
-<div class="modal fade bs-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel">
+<div class="modal fade modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel">
   <div class="modal-dialog modal-sm" role="document">
     <div class="modal-content">
       ...


### PR DESCRIPTION
Hello,

i found an "typo" in the Docs for v3.3.7.

In the example is the class: "bs-example-modal-lg" (and "bs-example-modal-sm") used. If you copy & paste this example, it doesn't work. The right classes are "modal-lg" and "modal-sm".