### PR TITLE
Collapse - do not prevent event for input

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -363,7 +363,9 @@ const Collapse = (($) => {
    */
 
   $(document).on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
-    event.preventDefault()
+    if (/input|textarea/i.test(event.target.tagName)) {
+      event.preventDefault()
+    }
 
     const target = Collapse._getTargetFromElement(this)
     const data   = $(target).data(DATA_KEY)

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -513,4 +513,20 @@ $(function () {
     })
     $target.trigger($.Event('click'))
   })
+
+  QUnit.test('should not prevent event for input', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+    var $target = $('<input type="checkbox" data-toggle="collapse" data-target="#collapsediv1" />').appendTo('#qunit-fixture')
+
+    $('<div id="collapsediv1"/>')
+      .appendTo('#qunit-fixture')
+      .on('shown.bs.collapse', function () {
+        assert.ok($target.attr('aria-expanded') === 'true')
+        assert.ok($target.prop('checked'))
+        done()
+      })
+
+    $target.trigger($.Event('click'))
+  })
 })


### PR DESCRIPTION
Stop preventing event for input in Collapse

/CC @mdo and @bardiharborow 

Fixes #22049, fixes #21079