### PR TITLE
Changed Display Utilities classnames

### DIFF
--- a/docs/_includes/nav-docs.html
+++ b/docs/_includes/nav-docs.html
@@ -1,4 +1,4 @@
-<form class="bd-search d-none d-sm-block">
+<form class="bd-search display-none display-sm-block">
   <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
   <div class="dropdown-menu bd-search-results" id="search-results"></div>
 </form>

--- a/docs/_includes/nav-home.html
+++ b/docs/_includes/nav-home.html
@@ -25,7 +25,7 @@
     </nav>
     {% endcomment %}
 
-    <div class="d-flex justify-content-between d-lg-none">
+    <div class="display-flex justify-content-between display-lg-none">
       <a class="navbar-brand" href="{{ site.baseurl }}/">
         Bootstrap
       </a>

--- a/docs/examples/dashboard/index.html
+++ b/docs/examples/dashboard/index.html
@@ -19,7 +19,7 @@
   <body>
     <nav class="navbar navbar-expand-md navbar-inverse fixed-top bg-inverse">
       <a class="navbar-brand" href="#">Dashboard</a>
-      <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler display-lg-none" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 
@@ -47,7 +47,7 @@
 
     <div class="container-fluid">
       <div class="row">
-        <nav class="col-sm-3 col-md-2 d-none d-sm-block bg-faded sidebar">
+        <nav class="col-sm-3 col-md-2 display-none display-sm-block bg-faded sidebar">
           <ul class="nav nav-pills flex-column">
             <li class="nav-item">
               <a class="nav-link active" href="#">Overview <span class="sr-only">(current)</span></a>

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -143,7 +143,7 @@
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
         <!-- Add the extra clearfix for only the required viewport -->
-        <div class="clearfix d-sm-none"></div>
+        <div class="clearfix display-sm-none"></div>
 
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>

--- a/docs/examples/offcanvas/index.html
+++ b/docs/examples/offcanvas/index.html
@@ -56,7 +56,7 @@
       <div class="row row-offcanvas row-offcanvas-right">
 
         <div class="col-12 col-md-9">
-          <p class="float-right d-md-none">
+          <p class="float-right display-md-none">
             <button type="button" class="btn btn-primary btn-sm" data-toggle="offcanvas">Toggle nav</button>
           </p>
           <div class="jumbotron">

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -480,7 +480,7 @@ With the handful of grid tiers available, you're bound to run into issues where,
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
   <!-- Add the extra clearfix for only the required viewport -->
-  <div class="clearfix d-none d-sm-block"></div>
+  <div class="clearfix display-none display-sm-block"></div>
 
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>

--- a/docs/layout/utilities-for-layout.md
+++ b/docs/layout/utilities-for-layout.md
@@ -20,7 +20,7 @@ Use our `display` utilities for responsively toggling common values of the `disp
 
 Bootstrap 4 is built with flexbox, but not every element's `display` has been changed to `display: flex` as this would add many unnecessary overrides and unexpectedly change key browser behaviors. Most of [our components](/components/) are built with flexbox enabled.
 
-Should you need to add `display: flex` to an element, do so with `.d-flex` or one of the responsive variants (e.g., `.d-sm-flex`). You'll need this class or `display` value to allow the use of our extra [flexbox utilities](/utilities/flexbox/) for sizing, alignment, spacing, and more.
+Should you need to add `display: flex` to an element, do so with `.display-flex` or one of the responsive variants (e.g., `.display-sm-flex`). You'll need this class or `display` value to allow the use of our extra [flexbox utilities](/utilities/flexbox/) for sizing, alignment, spacing, and more.
 
 ## Margin and padding
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -216,7 +216,7 @@ Dropped entirely for the new card component.
 
 ### Utilities
 
-- Made display utilities responsive (e.g., `.d-none` and `d-{sm,md,lg,xl}-none`).
+- Made display utilities responsive (e.g., `.display-none` and `display-{sm,md,lg,xl}-none`).
 - Added `.float-{sm,md,lg,xl}-{left,right,none}` classes for responsive floats and removed `.pull-left` and `.pull-right` since they're redundant to `.float-left` and `.float-right`.
 - Added responsive variations to our text alignment classes `.text-{sm,md,lg,xl}-{left,center,right}`.
 - Added new margin auto utilities for all sides, plus vertical and horizontal shorthands.
@@ -249,11 +249,11 @@ Our responsive utility classes have largely been removed in favor of explicit `d
 - All `.hidden-` classes have been removed, save for the print utilities which have been renamed.
   - Removed from v3: `.hidden-xs` `.hidden-sm` `.hidden-md` `.hidden-lg` `.visible-xs-block` `.visible-xs-inline` `.visible-xs-inline-block` `.visible-sm-block` `.visible-sm-inline` `.visible-sm-inline-block` `.visible-md-block` `.visible-md-inline` `.visible-md-inline-block` `.visible-lg-block` `.visible-lg-inline` `.visible-lg-inline-block`
   - Removed from v4 alphas: `.hidden-xs-up` `.hidden-xs-down` `.hidden-sm-up` `.hidden-sm-down` `.hidden-md-up` `.hidden-md-down` `.hidden-lg-up` `.hidden-lg-down`
-- Print utilities no longer start with `.hidden-` or `.visible-`, but with `.d-print-`.
+- Print utilities no longer start with `.hidden-` or `.visible-`, but with `.display-print-`.
   - Old names: `.visible-print-block`, `.visible-print-inline`, `.visible-print-inline-block`, `.hidden-print`
-  - New classes: `.d-print-block`, `.d-print-inline`, `.d-print-inline-block`, `.d-print-none`
+  - New classes: `.display-print-block`, `.display-print-inline`, `.display-print-inline-block`, `.display-print-none`
 
-Rather than using explicit `.visible-*` classes, you make an element visible by simply not hiding it at that screen size. You can combine one `.d-*-none` class with one `.d-*-block` class to show an element only on a given interval of screen sizes (e.g. `.d-none.d-md-block.d-lg-none` shows the element only on medium and large devices).
+Rather than using explicit `.visible-*` classes, you make an element visible by simply not hiding it at that screen size. You can combine one `.display-*-none` class with one `.display-*-block` class to show an element only on a given interval of screen sizes (e.g. `.display-none.display-md-block.display-lg-none` shows the element only on medium and large devices).
 
 Note that the changes to the grid breakpoints in v4 means that you'll need to go one breakpoint larger to achieve the same results. The new responsive utility classes don't attempt to accommodate less common cases where an element's visibility can't be expressed as a single contiguous range of viewport sizes; you will instead need to use custom CSS in such cases.
 

--- a/docs/utilities/display.md
+++ b/docs/utilities/display.md
@@ -15,42 +15,42 @@ Quickly and responsively toggle the `display` value of components and more with 
 
 The [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display) accepts a handful of values and we support many of them with utility classes. We purposefully don't provide every value as a utility, so here's what we support:
 
-- `.d-none`
-- `.d-inline`
-- `.d-inline-block`
-- `.d-block`
-- `.d-table`
-- `.d-table-cell`
-- `.d-flex`
-- `.d-inline-flex`
+- `.display-none`
+- `.display-inline`
+- `.display-inline-block`
+- `.display-block`
+- `.display-table`
+- `.display-table-cell`
+- `.display-flex`
+- `.display-inline-flex`
 
 Put them to use by applying any of the classes to an element of your choice. For example, here's how you could use the inline, block, or inline-block utilities (the same applies to the other classes).
 
 {% example html %}
-<div class="d-inline bg-success">d-inline</div>
-<div class="d-inline bg-success">d-inline</div>
+<div class="display-inline bg-success">display-inline</div>
+<div class="display-inline bg-success">display-inline</div>
 {% endexample %}
 
 {% example html %}
-<span class="d-block bg-primary">d-block</span>
+<span class="display-block bg-primary">display-block</span>
 {% endexample %}
 
 {% example html %}
-<div class="d-inline-block bg-warning">d-inline-block</div>
-<div class="d-inline-block bg-warning">d-inline-block</div>
+<div class="display-inline-block bg-warning">display-inline-block</div>
+<div class="display-inline-block bg-warning">display-inline-block</div>
 {% endexample %}
 
 Responsive variations also exist for every single utility mentioned above.
 
 {% for bp in site.data.breakpoints %}
-- `.d{{ bp.abbr }}-none`
-- `.d{{ bp.abbr }}-inline`
-- `.d{{ bp.abbr }}-inline-block`
-- `.d{{ bp.abbr }}-block`
-- `.d{{ bp.abbr }}-table`
-- `.d{{ bp.abbr }}-table-cell`
-- `.d{{ bp.abbr }}-flex`
-- `.d{{ bp.abbr }}-inline-flex`{% endfor %}
+- `.display{{ bp.abbr }}-none`
+- `.display{{ bp.abbr }}-inline`
+- `.display{{ bp.abbr }}-inline-block`
+- `.display{{ bp.abbr }}-block`
+- `.display{{ bp.abbr }}-table`
+- `.display{{ bp.abbr }}-table-cell`
+- `.display{{ bp.abbr }}-flex`
+- `.display{{ bp.abbr }}-inline-flex`{% endfor %}
 
 ## Display in print
 
@@ -58,7 +58,7 @@ Change the `display` value of elements when printing with our print display util
 
 | Class | Print style |
 | --- | --- |
-| `.d-print-block` | Applies `display: block` to the element when printing |
-| `.d-print-inline` | Applies `display: inline` to the element when printing |
-| `.d-print-inline-block` | Applies `display: inline-block` to the element when printing |
-| `.d-print-none` | Applies `display: none` to the element when printing |
+| `.display-print-block` | Applies `display: block` to the element when printing |
+| `.display-print-inline` | Applies `display: inline` to the element when printing |
+| `.display-print-inline-block` | Applies `display: inline-block` to the element when printing |
+| `.display-print-none` | Applies `display: none` to the element when printing |

--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -6,14 +6,14 @@
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    .d#{$infix}-none         { display: none !important; }
-    .d#{$infix}-inline       { display: inline !important; }
-    .d#{$infix}-inline-block { display: inline-block !important; }
-    .d#{$infix}-block        { display: block !important; }
-    .d#{$infix}-table        { display: table !important; }
-    .d#{$infix}-table-cell   { display: table-cell !important; }
-    .d#{$infix}-flex         { display: flex !important; }
-    .d#{$infix}-inline-flex  { display: inline-flex !important; }
+    .display#{$infix}-none         { display: none !important; }
+    .display#{$infix}-inline       { display: inline !important; }
+    .display#{$infix}-inline-block { display: inline-block !important; }
+    .display#{$infix}-block        { display: block !important; }
+    .display#{$infix}-table        { display: table !important; }
+    .display#{$infix}-table-cell   { display: table-cell !important; }
+    .display#{$infix}-flex         { display: flex !important; }
+    .display#{$infix}-inline-flex  { display: inline-flex !important; }
   }
 }
 
@@ -22,7 +22,7 @@
 // Utilities for toggling `display` in print
 //
 
-.d-print-block {
+.display-print-block {
   display: none !important;
 
   @media print {
@@ -30,7 +30,7 @@
   }
 }
 
-.d-print-inline {
+.display-print-inline {
   display: none !important;
 
   @media print {
@@ -38,7 +38,7 @@
   }
 }
 
-.d-print-inline-block {
+.display-print-inline-block {
   display: none !important;
 
   @media print {
@@ -46,7 +46,7 @@
   }
 }
 
-.d-print-none {
+.display-print-none {
   @media print {
     display: none !important;
   }


### PR DESCRIPTION
I personally think names should be as much descriptive as possible and that applies for classes as well. I don't fancy naming display class names as `.d*` so I changed it to `.display*`.

`.d*` reminded me my old ways of programming like naming variable containing User object as  `$u` instead of `$user` or even worse UserModel as `$um` instead of `$userModel` The problem with this usually becomes when there's another object with same first letters. eg. UserManager and UserModel. Someone resolves it with `$um` and `$um2` which is not the best way to solve it :)

So IMO class name should say what it does. `.display-sm-none` says it very well I think. For `.d-sm-none` I would have to search the docs if I'm user not familiar with Boostrap.