### PR TITLE
Card image fixes

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -644,7 +644,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
 {% example html %}
 <div class="card-columns">
   <div class="card">
-    <img class="card-img-top img-fluid" data-src="holder.js/100px160/" alt="Card image cap">
+    <img class="card-img-top" data-src="holder.js/100px160/" alt="Card image cap">
     <div class="card-block">
       <h4 class="card-title">Card title that wraps to a new line</h4>
       <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -661,7 +661,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
     </blockquote>
   </div>
   <div class="card">
-    <img class="card-img-top img-fluid" data-src="holder.js/100px160/" alt="Card image cap">
+    <img class="card-img-top" data-src="holder.js/100px160/" alt="Card image cap">
     <div class="card-block">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -686,7 +686,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
     </div>
   </div>
   <div class="card">
-    <img class="card-img img-fluid" data-src="holder.js/100px260/" alt="Card image">
+    <img class="card-img" data-src="holder.js/100px260/" alt="Card image">
   </div>
   <div class="card p-3 text-right">
     <blockquote class="card-blockquote">

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -355,8 +355,8 @@ Turn an image into a card background and overlay your card's text. Depending on 
 
 {% example html %}
 <div class="card card-inverse">
-  <img class="card-overlay-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
-  <div class="card-overlay">
+  <img class="card-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
+  <div class="card-img-overlay">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     <p class="card-text">Last updated 3 mins ago</p>

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -355,11 +355,11 @@ Turn an image into a card background and overlay your card's text. Depending on 
 
 {% example html %}
 <div class="card card-inverse">
-  <img class="card-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
-  <div class="card-img-overlay">
+  <img class="card-overlay-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
+  <div class="card-overlay">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+    <p class="card-text">Last updated 3 mins ago</p>
   </div>
 </div>
 {% endexample %}

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -158,7 +158,7 @@
 }
 
 // Card image
-.card-overlay {
+.card-img-overlay {
   position: absolute;
   top: 0;
   right: 0;
@@ -167,7 +167,7 @@
   padding: $card-img-overlay-padding;
 }
 
-.card-overlay-img {
+.card-img {
   width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
   @include border-radius($card-border-radius-inner);
 }

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -158,11 +158,7 @@
 }
 
 // Card image
-.card-img {
-  // margin: -1.325rem;
-  @include border-radius($card-border-radius-inner);
-}
-.card-img-overlay {
+.card-overlay {
   position: absolute;
   top: 0;
   right: 0;
@@ -171,13 +167,19 @@
   padding: $card-img-overlay-padding;
 }
 
-
+.card-overlay-img {
+  width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
+  @include border-radius($card-border-radius-inner);
+}
 
 // Card image caps
 .card-img-top {
+  width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
   @include border-top-radius($card-border-radius-inner);
 }
+
 .card-img-bottom {
+  width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
   @include border-bottom-radius($card-border-radius-inner);
 }
 


### PR DESCRIPTION
Closes #21857, fixes #21650, and closes #21885 (dupe of #21650).

The card image stretching affected `.card-img`, `.card-img-top`, and `.card-img-bottom` as we utilize flexbox and `flex-direction: column` on `.card`. Intrinsic image sizing is basically borked with flex due to the default `stretch` value for aligning the content. There's no real way around this it seems _other_ than `width: 100%;` as no other flex property will address the aspect ratio.