### PR TITLE
Fix wrapping card decks

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -188,17 +188,15 @@
   .card-deck {
     display: flex;
     flex-flow: row wrap;
+    margin-left: -$card-deck-margin;
+    margin-right: -$card-deck-margin;
 
     .card {
       display: flex;
       flex: 1 0 0;
       flex-direction: column;
-
-      // Selectively apply horizontal margins to cards to avoid doing the
-      // negative margin dance like our grid. This differs from the grid
-      // due to the use of margins as gutters instead of padding.
-      &:not(:first-child) { margin-left: $card-deck-margin; }
-      &:not(:last-child) { margin-right: $card-deck-margin; }
+      margin-left: $card-deck-margin;
+      margin-right: $card-deck-margin;
     }
   }
 }

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -188,15 +188,15 @@
   .card-deck {
     display: flex;
     flex-flow: row wrap;
-    margin-left: -$card-deck-margin;
     margin-right: -$card-deck-margin;
+    margin-left: -$card-deck-margin;
 
     .card {
       display: flex;
       flex: 1 0 0;
       flex-direction: column;
-      margin-left: $card-deck-margin;
       margin-right: $card-deck-margin;
+      margin-left: $card-deck-margin;
     }
   }
 }


### PR DESCRIPTION
Fixes #22007 and fixes #21976 by changing margin strategy for card deck gutters. Note this doesn't apply any vertical `margin` to the cards; it only fixes the wrapping issue.