### PR TITLE
Add border width to input height variables

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -135,8 +135,7 @@
 .custom-select {
   display: inline-block;
   max-width: 100%;
-  $select-border-width: ($custom-select-border-width * 2);
-  height: calc(#{$input-height} + #{$select-border-width});
+  height: $input-height;
   padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
   line-height: $custom-select-line-height;
   color: $custom-select-color;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -66,8 +66,7 @@
 
 select.form-control {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height} + #{$select-border-width});
+    height: $input-height;
   }
 
   &:focus::-ms-value {
@@ -165,8 +164,7 @@ select.form-control {
 
 select.form-control-sm {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height-sm} + #{$select-border-width});
+    height: $input-height-sm;
   }
 }
 
@@ -179,8 +177,7 @@ select.form-control-sm {
 
 select.form-control-lg {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height-lg} + #{$select-border-width});
+    height: $input-height-lg;
   }
 }
 

--- a/scss/_helper-functions.scss
+++ b/scss/_helper-functions.scss
@@ -1,0 +1,3 @@
+@import "helper-functions/strip-unit";
+@import "helper-functions/px-to-rem";
+@import "helper-functions/rem-to-px";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -412,9 +412,9 @@ $input-color-focus:              $input-color !default;
 
 $input-color-placeholder:        $gray-light !default;
 
-$input-height:                   (($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2)) !default;
-$input-height-lg:                (($font-size-lg * $input-btn-line-height-lg) + ($input-btn-padding-y-lg * 2)) !default;
-$input-height-sm:                (($font-size-sm * $input-btn-line-height-sm) + ($input-btn-padding-y-sm * 2)) !default;
+$input-height:                   (rem-to-px(($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2)) + ($input-btn-border-width * 2)) !default;
+$input-height-lg:                (rem-to-px(($font-size-lg * $input-btn-line-height-lg) + ($input-btn-padding-y-lg * 2)) + ($input-btn-border-width * 2)) !default;
+$input-height-sm:                (rem-to-px(($font-size-sm * $input-btn-line-height-sm) + ($input-btn-padding-y-sm * 2)) + ($input-btn-border-width * 2)) !default;
 
 $input-transition:               border-color ease-in-out .15s, box-shadow ease-in-out .15s !default;
 

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -22,6 +22,7 @@ html {
   box-sizing: inherit;
 }
 
+@import "helper-functions";
 @import "custom";
 @import "variables";
 

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -2,6 +2,7 @@
 //
 // Includes only Normalize and our custom Reboot reset.
 
+@import "helper-functions";
 @import "custom";
 @import "variables";
 @import "mixins";

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -6,6 +6,7 @@
  */
 
 // Core variables and mixins
+@import "helper-functions";
 @import "custom";
 @import "variables";
 @import "mixins";

--- a/scss/helper-functions/_px-to-rem.scss
+++ b/scss/helper-functions/_px-to-rem.scss
@@ -1,0 +1,5 @@
+// Convert a value in `px` to `rem`
+
+@function px-to-rem($value) {
+  @return (strip-unit($value) / 16) * 1rem;
+}

--- a/scss/helper-functions/_rem-to-px.scss
+++ b/scss/helper-functions/_rem-to-px.scss
@@ -1,0 +1,5 @@
+// Convert a value in `rem` to `px`
+
+@function rem-to-px($value) {
+  @return strip-unit($value) * 16px;
+}

--- a/scss/helper-functions/_strip-unit.scss
+++ b/scss/helper-functions/_strip-unit.scss
@@ -1,0 +1,5 @@
+// Strip the unit from a value
+
+@function strip-unit($value) {
+  @return $value / ($value * 0 + 1);
+}


### PR DESCRIPTION
This commit adds the border width (top + bottom) to the input height variables by default. This makes IMHO much more sense because every element is set to `box-sizing: border-box`, so the border height should count to the total element height.

This commit introduces some handy helper functions to convert `rem` units to `px` and vice versa. This is required to calculate the total input height because the border width is defined in `px` and the other height related variables (`padding`, `font-size` etc.) are defined in `rem`.