### PR TITLE
fix tooltips margins

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -15,11 +15,10 @@
 
   &.tooltip-top,
   &.bs-tether-element-attached-bottom {
-    padding: $tooltip-arrow-width 0;
-    margin-top: -$tooltip-margin;
+    padding: $tooltip-arrow-width + $tooltip-margin 0;
 
     .tooltip-inner::before {
-      bottom: 0;
+      bottom: $tooltip-margin;
       left: 50%;
       margin-left: -$tooltip-arrow-width;
       content: "";
@@ -29,12 +28,11 @@
   }
   &.tooltip-right,
   &.bs-tether-element-attached-left {
-    padding: 0 $tooltip-arrow-width;
-    margin-left: $tooltip-margin;
+    padding: 0 $tooltip-arrow-width + $tooltip-margin;
 
     .tooltip-inner::before {
       top: 50%;
-      left: 0;
+      left: $tooltip-margin;
       margin-top: -$tooltip-arrow-width;
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
@@ -43,11 +41,10 @@
   }
   &.tooltip-bottom,
   &.bs-tether-element-attached-top {
-    padding: $tooltip-arrow-width 0;
-    margin-top: $tooltip-margin;
+    padding: $tooltip-arrow-width + $tooltip-margin 0;
 
     .tooltip-inner::before {
-      top: 0;
+      top: $tooltip-margin;
       left: 50%;
       margin-left: -$tooltip-arrow-width;
       content: "";
@@ -57,12 +54,11 @@
   }
   &.tooltip-left,
   &.bs-tether-element-attached-right {
-    padding: 0 $tooltip-arrow-width;
-    margin-left: -$tooltip-margin;
+    padding: 0 $tooltip-arrow-width + $tooltip-margin;
 
     .tooltip-inner::before {
       top: 50%;
-      right: 0;
+      right: $tooltip-margin;
       margin-top: -$tooltip-arrow-width;
       content: "";
       border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;


### PR DESCRIPTION
## Summary:
As described in #21146 and #22300, and [shown here](http://jsbin.com/gopevakala/edit?html,output), left and top tooltips exhibit inconsistencies in regards to margins.

## before
Top and left tooltips sometimes ignore margins

## After
All tooltips now use padding instead of margin

## Technical 
[As shown here](https://www.diffchecker.com/kyilr4EM), **top** and **left** tooltips switches between _absolute_ and _fixed_ positions. No doubt this is what causes the inconsistencies, but I admit the logic behind this switch, and the reason it differs from **bottom** or **right** tooltips remains an enigma to me. [It happens here](https://github.com/HubSpot/tether/blob/3d7119e590661f8c9e9e566c8a7640c189687215/src/js/tether.js#L734), but since it's deep inside tether's logic, I tried looking for a workaround in bootstrap's code. Since the margins seems to be what causes the issue, i've successfully replaced them with paddings, while preserving the spacing by adding it to the arrow position. 

Example of fix available here -
http://jsbin.com/noyitof/edit?html,css,js,output