### PR TITLE
Popover + Tooltip - fix error when content or title is a number

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -605,6 +605,10 @@ const Tooltip = (($) => {
         }
       }
 
+      if (config.title && typeof config.title === 'number') {
+        config.title = config.title.toString()
+      }
+
       if (config.content && typeof config.content === 'number') {
         config.content = config.content.toString()
       }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -605,6 +605,10 @@ const Tooltip = (($) => {
         }
       }
 
+      if (config.content && typeof config.content === 'number') {
+        config.content = config.content.toString()
+      }
+
       Util.typeCheckConfig(
         NAME,
         config,

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -365,7 +365,7 @@ $(function () {
       .modal('show')
   })
 
-  QUnit.test('should convert number content to string without error', function (assert) {
+  QUnit.test('should convert number to string without error for content and title', function (assert) {
     assert.expect(2)
     var done = assert.async()
     var $popover = $('<a href="#">@mdo</a>')

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -364,4 +364,24 @@ $(function () {
       })
       .modal('show')
   })
+
+  QUnit.test('should convert number content to string without error', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+    var $popover = $('<a href="#">@mdo</a>')
+      .appendTo('#qunit-fixture')
+      .bootstrapPopover({
+        title: function () {
+          return '@Johann-S'
+        },
+        content: 7
+      })
+      .on('shown.bs.popover', function () {
+        assert.strictEqual($('.popover .popover-title').text(), '@Johann-S')
+        assert.strictEqual($('.popover .popover-content').text(), '7', 'content correctly converted')
+        done()
+      })
+
+    $popover.bootstrapPopover('show')
+  })
 })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -371,14 +371,12 @@ $(function () {
     var $popover = $('<a href="#">@mdo</a>')
       .appendTo('#qunit-fixture')
       .bootstrapPopover({
-        title: function () {
-          return '@Johann-S'
-        },
+        title: 5,
         content: 7
       })
       .on('shown.bs.popover', function () {
-        assert.strictEqual($('.popover .popover-title').text(), '@Johann-S')
-        assert.strictEqual($('.popover .popover-content').text(), '7', 'content correctly converted')
+        assert.strictEqual($('.popover .popover-title').text(), '5')
+        assert.strictEqual($('.popover .popover-content').text(), '7')
         done()
       })
 

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -886,4 +886,20 @@ $(function () {
 
     $el.bootstrapTooltip('hide')
   })
+
+  QUnit.test('should convert number in title to string', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var $el = $('<a href="#" rel="tooltip" title="7"/>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip('show')
+      .on('shown.bs.tooltip', function () {
+        var tooltip = $el.data('bs.tooltip')
+        var $tooltip = $(tooltip.getTipElement())
+        assert.strictEqual($tooltip.children().text(), '7')
+        done()
+      })
+
+    $el.bootstrapTooltip('show')
+  })
 })


### PR DESCRIPTION
As @cvrebert suggest (https://github.com/twbs/bootstrap/pull/20210#issuecomment-229783242) convert content and title to string

Close #20193