### PR TITLE
css: make .container-fluid 100% width

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -11,11 +11,12 @@
 
 // Fluid container
 //
-// Utilizes the mixin meant for fixed width containers, but without any defined
-// width for fluid, full width layouts.
+// Utilizes the mixin meant for fixed width containers, but with 100% width for
+// fluid, full width layouts.
 
 @if $enable-grid-classes {
   .container-fluid {
+    width: 100%;
     @include make-container();
   }
 }


### PR DESCRIPTION
Force .container-fluid to be 100% width no matter if the parent is flex, or not.

Pen: http://codepen.io/zalog/pen/yMwyGr