### PR TITLE
Updates docs to match Tooltip type checking

### DIFF
--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -179,7 +179,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>container</td>
-      <td>string | false</td>
+      <td>string | element | boolean</td>
       <td>false</td>
       <td>
         <p>Appends the popover to a specific element. Example: <code>container: 'body'</code>. This option is particularly useful in that it allows you to position the popover in the flow of the document near the triggering element - which will prevent the popover from floating away from the triggering element during a window resize.</p>
@@ -221,7 +221,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>selector</td>
-      <td>string</td>
+      <td>string | boolean</td>
       <td>false</td>
       <td>If a selector is provided, popover objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://jsbin.com/zopod/1/edit">an informative example</a>.</td>
     </tr>

--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -179,7 +179,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>container</td>
-      <td>string | element | boolean</td>
+      <td>string | element | false</td>
       <td>false</td>
       <td>
         <p>Appends the popover to a specific element. Example: <code>container: 'body'</code>. This option is particularly useful in that it allows you to position the popover in the flow of the document near the triggering element - which will prevent the popover from floating away from the triggering element during a window resize.</p>
@@ -221,7 +221,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>selector</td>
-      <td>string | boolean</td>
+      <td>string | false</td>
       <td>false</td>
       <td>If a selector is provided, popover objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://jsbin.com/zopod/1/edit">an informative example</a>.</td>
     </tr>

--- a/docs/4.0/components/tooltips.md
+++ b/docs/4.0/components/tooltips.md
@@ -201,7 +201,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>selector</td>
-      <td>string</td>
+      <td>string | boolean</td>
       <td>false</td>
       <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://jsbin.com/zopod/1/edit">an informative example</a>.</td>
     </tr>

--- a/docs/4.0/components/tooltips.md
+++ b/docs/4.0/components/tooltips.md
@@ -201,7 +201,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
     <tr>
       <td>selector</td>
-      <td>string | boolean</td>
+      <td>string | false</td>
       <td>false</td>
       <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have popovers added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="https://jsbin.com/zopod/1/edit">an informative example</a>.</td>
     </tr>


### PR DESCRIPTION
Spotted when looking up [documentation for Popups](http://getbootstrap.com/javascript/#popovers-options), and wondering why a raw element couldn't be passed in as a `container` according to the documentation - I looked in the source and [saw that it *could*](https://github.com/twbs/bootstrap/blob/c78cbb275b0c559f5c9436ee3df816e1f6195201/js/src/tooltip.js#L284) – whatever's in `container` (if truthy) gets passed into [jQuery's appendTo](http://api.jquery.com/appendto/)!

I also spotted that the Tooltip type checking [explicitly allows for an element to be passed](https://github.com/twbs/bootstrap/blob/v4-dev/js/src/tooltip.js#L65), it's literally just that the documentation is out of sync.

With this change, the documentation for Tooltip and Popover now matches the types defined in the DefaultType constant in js/src/tooltip.js