### PR TITLE
Add border for group input in the navbar-inverse

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -279,4 +279,9 @@
   .navbar-text {
     color: $navbar-inverse-color;
   }
+  
+  .input-group .form-control {
+    border-color: $btn-secondary-border;
+  }
+  
 }


### PR DESCRIPTION
Add `$btn-secondary-border` border color for form control in input group in the navbar when there is a dark background.

Because the normal border color is `rgba(0,0,0,.15)` and depend of the background color the input in input group seems to have no border.

Fix #21098
Close #21318