### PR TITLE
Documentation - Add inserted event for Tooltip and Popover

### DIFF
--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -353,6 +353,10 @@ Toggles the ability for an element's popover to be shown or hidden.
       <td>hidden.bs.popover</td>
       <td>This event is fired when the popover has finished being hidden from the user (will wait for CSS transitions to complete).</td>
     </tr>
+    <tr>
+      <td>inserted.bs.popover</td>
+      <td>This event is fired after the <code>show.bs.popover</code> event when the tooltip template has been added to the DOM.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -329,6 +329,10 @@ Toggles the ability for an element's tooltip to be shown or hidden.
       <td>hidden.bs.tooltip</td>
       <td>This event is fired when the tooltip has finished being hidden from the user (will wait for CSS transitions to complete).</td>
     </tr>
+    <tr>
+      <td>inserted.bs.tooltip</td>
+      <td>This event is fired after the <code>show.bs.tooltip</code> event when the tooltip template has been added to the DOM.</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
``inserted.bs.`` event is triggered in our code and present in the old documentation (http://getbootstrap.com/javascript/#popovers-events)