### PR TITLE
Remove system-ui from font stack due to i18n issues

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -244,7 +244,7 @@ $transition-collapse:    height .35s ease !default;
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
 $font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:       $font-family-sans-serif !default;
 


### PR DESCRIPTION
On Windows, `system-ui` causes all sorts of issues. This PR removes it for now, reverting #21356 and closing #22328.