### PR TITLE
Drop width from sizing utils

### DIFF
--- a/docs/utilities/sizing.md
+++ b/docs/utilities/sizing.md
@@ -4,16 +4,9 @@ title: Sizing
 group: utilities
 ---
 
-Easily make an element as wide or as tall (relative to its parent) with our width and height utilities. Includes support for `25%`, `50%`, `75%`, and `100%` by default.
+Easily make an element as tall (relative to its parent) with our height utilities. Includes support for `25%`, `50%`, `75%`, and `100%` by default. Mix and match with our existing grid classes for controlling `width`.
 
-Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Modify those values as you need to generate different utilities here.
-
-{% example html %}
-<div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>
-<div class="w-50 p-3" style="background-color: #eee;">Width 50%</div>
-<div class="w-75 p-3" style="background-color: #eee;">Width 75%</div>
-<div class="w-100 p-3" style="background-color: #eee;">Width 100%</div>
-{% endexample %}
+Height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Modify those values as you need to generate different utilities here.
 
 {% example html %}
 <div style="height: 100px; background-color: rgba(255,0,0,0.1);">
@@ -24,7 +17,7 @@ Width and height utilities are generated from the `$sizes` Sass map in `_variabl
 </div>
 {% endexample %}
 
-You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
+Use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
 
 {% example html %}
 <img class="mw-100" data-src="holder.js/1000px100?text=Max-width%20%3D%20100%25" alt="Max-width 100%">

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -148,7 +148,7 @@ $spacers: (
   5: ($spacer * 3)
 ) !default;
 
-// This variable affects the `.h-*` and `.w-*` classes.
+// This variable affects the `.h-*` classes.
 $sizes: (
   25: 25%,
   50: 50%,

--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -1,6 +1,6 @@
 // Width and height
 
-@each $prop, $abbrev in (width: w, height: h) {
+@each $prop, $abbrev in (height: h) {
   @each $size, $length in $sizes {
     .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
   }


### PR DESCRIPTION
Follow up to #22376. `.col-` classes now only set `width`, so we can use those for width sizing. I've left height for now though.