### PR TITLE
Add dropdown-item-padding-y var

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -61,7 +61,7 @@
 .dropdown-item {
   display: block;
   width: 100%; // For `<button>`s
-  padding: 3px $dropdown-item-padding-x;
+  padding: $dropdown-item-padding-y $dropdown-item-padding-x;
   clear: both;
   font-weight: $font-weight-normal;
   color: $dropdown-link-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -547,6 +547,7 @@ $dropdown-link-active-bg:        $component-active-bg !default;
 
 $dropdown-link-disabled-color:   $gray-light !default;
 
+$dropdown-item-padding-y:        .25rem !default;
 $dropdown-item-padding-x:        1.5rem !default;
 
 $dropdown-header-color:          $gray-light !default;


### PR DESCRIPTION
- Closes #21622 which kept the 3px
- Puts variable in proper order for shorthand (y x)