### PR TITLE
Rename some .open to .show

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -113,8 +113,8 @@
 
 
 // The clickable button for toggling the menu
-// Remove the gradient and set the same inset shadow as the :active state
-.btn-group.open .dropdown-toggle {
+// Set the same inset shadow as the :active state
+.btn-group.show .dropdown-toggle {
   @include box-shadow($btn-active-box-shadow);
 
   // Show no shadow for `.btn-link` since it has no other button styles.

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -79,12 +79,6 @@
   @include border-left-radius(0);
 }
 
-// On active and open, don't show outline
-.btn-group .dropdown-toggle:active,
-.btn-group.open .dropdown-toggle {
-  outline: 0;
-}
-
 
 // Sizing
 //

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -216,9 +216,9 @@
       }
     }
 
-    .open > .nav-link,
+    .show > .nav-link,
     .active > .nav-link,
-    .nav-link.open,
+    .nav-link.show,
     .nav-link.active {
       color: $navbar-light-active-color;
     }
@@ -261,9 +261,9 @@
       }
     }
 
-    .open > .nav-link,
+    .show > .nav-link,
     .active > .nav-link,
-    .nav-link.open,
+    .nav-link.show,
     .nav-link.active {
       color: $navbar-inverse-active-color;
     }


### PR DESCRIPTION
Fixes #22307. Also drops one instance of an `outline` override as we don't want to be doing that.