### PR TITLE
Update card outline mixin

### DIFF
--- a/scss/mixins/_cards.scss
+++ b/scss/mixins/_cards.scss
@@ -13,6 +13,12 @@
 @mixin card-outline-variant($color) {
   background-color: transparent;
   border-color: $color;
+
+  .card-header,
+  .card-footer {
+    background-color: transparent;
+    border-color: $color;
+  }
 }
 
 //


### PR DESCRIPTION
Fixes #22056 by ensuring outline cards make their header/footer transparent and use the right border color.