### PR TITLE
Prevent default for ESC in modal.js

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -289,6 +289,7 @@ const Modal = (($) => {
       if (this._isShown && this._config.keyboard) {
         $(this._element).on(Event.KEYDOWN_DISMISS, (event) => {
           if (event.which === ESCAPE_KEYCODE) {
+            event.preventDefault()
             this.hide()
           }
         })


### PR DESCRIPTION
ESC can be used to close modals, but on OS X/macOS this also jumps out
of full-screen mode. `preventDefault` suppresses this.

Closes https://github.com/twbs/bootstrap/issues/22362