### PR TITLE
Remove `cursor: not-allowed` styles

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -28,7 +28,6 @@
   // Disabled comes first so active can properly restyle
   &.disabled,
   &:disabled {
-    cursor: $cursor-disabled;
     opacity: .65;
     @include box-shadow(none);
   }

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -41,13 +41,11 @@
 
   &:disabled {
     ~ .custom-control-indicator {
-      cursor: $custom-control-disabled-cursor;
       background-color: $custom-control-disabled-indicator-bg;
     }
 
     ~ .custom-control-description {
       color: $custom-control-disabled-description-color;
-      cursor: $custom-control-disabled-cursor;
     }
   }
 }
@@ -165,7 +163,6 @@
 
   &:disabled {
     color: $custom-select-disabled-color;
-    cursor: $cursor-disabled;
     background-color: $custom-select-disabled-bg;
   }
 

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -90,7 +90,6 @@
   &.disabled,
   &:disabled {
     color: $dropdown-link-disabled-color;
-    cursor: $cursor-disabled;
     background-color: transparent;
     // Remove CSS gradients if they're enabled
     @if $enable-gradients {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -58,10 +58,6 @@
     // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
     opacity: 1;
   }
-
-  &:disabled {
-    cursor: $cursor-disabled;
-  }
 }
 
 select.form-control {
@@ -212,7 +208,6 @@ select.form-control-lg {
   &.disabled {
     .form-check-label {
       color: $text-muted;
-      cursor: $cursor-disabled;
     }
   }
 }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -65,7 +65,6 @@
   &.disabled,
   &:disabled {
     color: $list-group-disabled-color;
-    cursor: $cursor-disabled;
     background-color: $list-group-disabled-bg;
   }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -19,10 +19,9 @@
     text-decoration: none;
   }
 
-  // Disabled state lightens text and removes hover/tab effects
+  // Disabled state lightens text
   &.disabled {
     color: $nav-disabled-link-color;
-    cursor: $cursor-disabled;
   }
 }
 

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -29,7 +29,6 @@
   &.disabled .page-link {
     color: $pagination-disabled-color;
     pointer-events: none;
-    cursor: $cursor-disabled; // While `pointer-events: none` removes the cursor in modern browsers, we provide a disabled cursor as a fallback.
     background-color: $pagination-disabled-bg;
     border-color: $pagination-disabled-border;
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -368,13 +368,6 @@ input[type="radio"],
 input[type="checkbox"] {
   box-sizing: border-box; // 1. Add the correct box sizing in IE 10-
   padding: 0; // 2. Remove the padding in IE 10-
-
-  // Apply a disabled cursor for radios and checkboxes.
-  //
-  // Note: Neither radios nor checkboxes can be readonly.
-  &:disabled {
-    cursor: $cursor-disabled;
-  }
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -433,8 +433,6 @@ $form-group-margin-bottom:       1rem !default;
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
 
-$cursor-disabled:                not-allowed !default;
-
 $custom-control-gutter:   1.5rem !default;
 $custom-control-spacer-y: .25rem !default;
 $custom-control-spacer-x: 1rem !default;
@@ -444,7 +442,6 @@ $custom-control-indicator-bg:         #ddd !default;
 $custom-control-indicator-bg-size:    50% 50% !default;
 $custom-control-indicator-box-shadow: inset 0 .25rem .25rem rgba($black,.1) !default;
 
-$custom-control-disabled-cursor:             $cursor-disabled !default;
 $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 


### PR DESCRIPTION
Per discussion on https://github.com/twbs/bootstrap/issues/22222#issuecomment-292819959

> browsers don't normally use the "not-allowed" cursor in these circumstances, so it makes BS a bit opinionated here. (and, at least on Windows, the "not-allowed" cursor looks rather fugly with its red colour compared to other regular mouse pointers)
>
> ![capture](https://cloud.githubusercontent.com/assets/895831/24841663/1f9bbd46-1d81-11e7-9e96-54502b731edf.PNG)

Closes https://github.com/twbs/bootstrap/issues/22222