### PR TITLE
cover popover arrow when title is present

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -89,16 +89,19 @@
       border-bottom-color: $popover-arrow-color;
     }
 
-    // This will remove the popover-title's border just below the arrow
+    // This will cover the popover's arrow with the title's background color
     .popover-title::before {
       position: absolute;
-      top: 0;
+      top: -($popover-arrow-width - 1);
       left: 50%;
+      z-index: $zindex-popover + 1;
       display: block;
-      width: 20px;
-      margin-left: -10px;
+      width: 0;
+      margin-left: -$popover-arrow-width;
       content: "";
-      border-bottom: 1px solid $popover-title-bg;
+      border: $popover-arrow-width solid transparent;
+      border-top-width: 0;
+      border-bottom-color: $popover-title-bg;
     }
   }
 


### PR DESCRIPTION
## Summary
Following issue #22432 and PR #22433 , change the arrow color of popover when title is present -
![image](https://cloud.githubusercontent.com/assets/10364499/25009865/e478bdfc-2070-11e7-9113-af739551c1d9.png)

See it in action here - http://jsbin.com/tubuwu/edit?html,output

## Before
Arrow color was the same, regardless of the presence or absence of a title in the popover

## After
Arrow color is now dependent on the presence or absence of a title in the popover

## Technical
I've used an existing pseudo element of the title, originally intended to fix a gap between the popover and the arrow, and redesigned it to cover the arrow entirely with the title's background color.