### PR TITLE
Fix Card Deck and Card Group when .card-title contains a long word

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -20,6 +20,7 @@
 
 .card-title {
   margin-bottom: $card-spacer-y;
+  hyphens: auto;
 }
 
 .card-subtitle {


### PR DESCRIPTION
Here's a caption and demo of behaviour before :

![capture d ecran 2017-04-16 a 14 29 10](https://cloud.githubusercontent.com/assets/283481/25071314/17db63bc-22b4-11e7-94e6-c7a63e1fe9ca.png)

> You need to adjust width of the HTML preview frame to the size of a *small* device and see the bug

https://jsfiddle.net/pitpit/ed3fcfx3/

Here's a caption and a demo after the fix:

![capture d ecran 2017-04-16 a 14 53 07](https://cloud.githubusercontent.com/assets/283481/25071330/6d8b03f8-22b4-11e7-9eb0-2c4aee011ce8.png)

https://jsfiddle.net/pitpit/tcsy9fte/
