### PR TITLE
Prevent long words in `.card-title`s from breaking auto layout

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -20,6 +20,7 @@
 
 .card-title {
   margin-bottom: $card-spacer-y;
+  word-break: break-all;
 }
 
 .card-subtitle {


### PR DESCRIPTION
Alternate fix to card titles breaking the automatic card sizing in decks and groups without use of `hyphen`s property. Closes #22453.