### PR TITLE
Port button group accessibility callout from v3 to v4

### DIFF
--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -12,6 +12,14 @@ Group a series of buttons together on a single line with the button group. Add o
 * Will be replaced with the ToC, excluding the "Contents" header
 {:toc}
 
+{% callout warning %}
+## Ensure correct `role` and provide a label
+
+In order for assistive technologies (such as screen readers) to convey that a series of buttons is grouped, an appropriate `role` attribute needs to be provided. For button groups, this would be `role="group"`, while toolbars should have a `role="toolbar"`.
+
+In addition, groups and toolbars should be given an explicit label, as most assistive technologies will otherwise not announce them, despite the presence of the correct role attribute. In the examples provided here, we use `aria-label`, but alternatives such as `aria-labelledby` can also be used.
+{% endcallout %}
+
 ## Basic example
 
 Wrap a series of buttons with `.btn` in `.btn-group`.


### PR DESCRIPTION
Added straight after the TOC because it applies to groups/toolbars overall, and it would arguably feel strange having it as a child section in one or the other.

Closes https://github.com/twbs/bootstrap/issues/21867