### PR TITLE
Fix running test on iOS with Saucelabs

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -48,10 +48,10 @@
   # Win Opera 15+ not currently supported by Sauce Labs
 
   {
-    browserName: "Safari",
+    browserName: "iphone",
     deviceName: "iPhone Simulator",
-    platformVersion: "9.3",
-    platformName: "iOS"
+    platformName: "OS X 10.11",
+    version: "9.3"
   },
 
   # iOS Chrome not currently supported by Sauce Labs


### PR DESCRIPTION
Currently we thought our test were runs on iOS 9.3 but due to this bad configuration or maybe a change in Saucelabs it wasn't the case. Our tests were run on Windows 7 Safari 5 😨 

It was because of that my branch `v4-experimental-tooltip` cannot build correctly (#22444)

Thank you @FezVrasta for the idea to check on Angular project 👍 

/CC @mdo 