### PR TITLE
Fix for copy/paste error in iOS hack to tooltips

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -308,8 +308,7 @@ const Tooltip = (($) => {
         // empty mouseover listeners to the body's immediate children;
         // only needed because of broken event delegation on iOS
         // https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
-        if ('ontouchstart' in document.documentElement &&
-           !$(parent).closest(Selector.NAVBAR_NAV).length) {
+        if ('ontouchstart' in document.documentElement) {
           $('body').children().on('mouseover', null, $.noop)
         }
 


### PR DESCRIPTION
(with apologies, this slipped through due to build system problems on my
end)

patches a mistake in https://github.com/twbs/bootstrap/pull/22481