### PR TITLE
`$input-height` and `$input-height-*` should include borders, no need to calculate select.form-control heights, and calculate form validation icon sizes

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -62,8 +62,7 @@
 
 select.form-control {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height} + #{$select-border-width});
+    height: $input-height;
   }
 
   &:focus::-ms-value {
@@ -161,8 +160,7 @@ select.form-control {
 
 select.form-control-sm {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height-sm} + #{$select-border-width});
+    height: $input-height-sm;
   }
 }
 
@@ -175,8 +173,7 @@ select.form-control-sm {
 
 select.form-control-lg {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
-    height: calc(#{$input-height-lg} + #{$select-border-width});
+    height: $input-height-lg;
   }
 }
 
@@ -252,10 +249,11 @@ select.form-control-lg {
 .form-control-success,
 .form-control-warning,
 .form-control-danger {
+  $input-height-no-borders: ($input-height - ($input-btn-border-width * 2));
   padding-right: ($input-btn-padding-x * 3);
   background-repeat: no-repeat;
-  background-position: center right ($input-height / 4);
-  background-size: ($input-height / 2) ($input-height / 2);
+  background-position: center right ($input-height-no-borders / 4);
+  background-size: ($input-height-no-borders / 2);
 }
 
 // Form validation states

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -224,7 +224,7 @@ $grid-gutter-widths: (
 $line-height-lg:         1.5 !default;
 $line-height-sm:         1.5 !default;
 
-$border-width: 1px !default;
+$border-width: .0625rem !default;
 
 $border-radius:          .25rem !default;
 $border-radius-lg:       .3rem !default;
@@ -412,9 +412,9 @@ $input-color-focus:              $input-color !default;
 
 $input-color-placeholder:        $gray-light !default;
 
-$input-height:                   (($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2)) !default;
-$input-height-lg:                (($font-size-lg * $input-btn-line-height-lg) + ($input-btn-padding-y-lg * 2)) !default;
-$input-height-sm:                (($font-size-sm * $input-btn-line-height-sm) + ($input-btn-padding-y-sm * 2)) !default;
+$input-height:                   (($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2) + ($input-btn-border-width * 2)) !default;
+$input-height-lg:                (($font-size-lg * $input-btn-line-height-lg) + ($input-btn-padding-y-lg * 2) + ($input-btn-border-width * 2)) !default;
+$input-height-sm:                (($font-size-sm * $input-btn-line-height-sm) + ($input-btn-padding-y-sm * 2) + ($input-btn-border-width * 2)) !default;
 
 $input-transition:               border-color ease-in-out .15s, box-shadow ease-in-out .15s !default;
 


### PR DESCRIPTION
Updated so $input-height, $input-height-lg, and $input-height-sm reflect the height of inputs with borders. Select elements should be the same size as other inputs when the value of $input-btn-border-width is greater than 1px.