### PR TITLE
Only add CSS transitions on Buttons for background-color, border-colo…

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -349,7 +349,7 @@ $btn-border-radius:              $border-radius !default;
 $btn-border-radius-lg:           $border-radius-lg !default;
 $btn-border-radius-sm:           $border-radius-sm !default;
 
-$btn-transition:                 all .15s ease-in-out !default;
+$btn-transition:                 background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
 
 // Forms


### PR DESCRIPTION
…r, and box-shadow

Changing CSS properties on Buttons cause unwanted transitions e.g. padding, border-width.