### PR TITLE
New watch task

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "css-compile": "node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap.scss dist/css/bootstrap.css && node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap-grid.scss dist/css/bootstrap-grid.css && node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap-reboot.scss dist/css/bootstrap-reboot.css",
     "css-compile-docs": "node-sass --output-style expanded --source-map true --precision 6 docs/assets/scss/docs.scss docs/assets/css/docs.min.css",
     "css-prefix": "postcss --config build/ --replace dist/css/*.css",
-    "css-prefix-docs": "postcss --config build/ --no-map --replace docs/assets/css/docs.min.css docs/examples/**/*.css",
+    "css-prefix-docs": "postcss --config build/ --no-map --replace docs/assets/css/docs.min.css",
     "css-minify": "cleancss --level 1 --source-map --output dist/css/bootstrap.min.css dist/css/bootstrap.css && cleancss --level 1 --source-map --output dist/css/bootstrap-grid.min.css dist/css/bootstrap-grid.css && cleancss --level 1 --source-map --output dist/css/bootstrap-reboot.min.css dist/css/bootstrap-reboot.css",
     "css-minify-docs": "cleancss --level 1 --source-map --output docs/assets/css/docs.min.css docs/assets/css/docs.min.css",
     "js": "npm-run-all js-compile js-minify",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "release-zip": "cd dist/ && zip -r9 bootstrap-$npm_package_version-dist.zip * && shx mv bootstrap-$npm_package_version-dist.zip ..",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all dist js-test docs",
-    "watch": "nodemon -e scss -x \"npm run css && npm run css-docs\""
+    "watch-css": "nodemon --ignore js/ --ignore dist/ -e scss -x \"npm run css && npm run css-docs\"",
+    "watch-js": "nodemon --ignore scss/ --ignore js/dist/ --ignore dist/ -e js -x \"npm run js-compile\"",
+    "watch": "npm-run-all --parallel watch-css watch-js"
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "release-version": "node build/change-version.js",
     "release-zip": "cd dist/ && zip -r9 bootstrap-$npm_package_version-dist.zip * && shx mv bootstrap-$npm_package_version-dist.zip ..",
     "dist": "npm-run-all --parallel css js",
-    "test": "npm-run-all dist js-test docs"
+    "test": "npm-run-all dist js-test docs",
+    "watch": "nodemon -e scss -x \"npm run css && npm run css-docs\""
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",
@@ -81,6 +82,7 @@
     "htmlhint": "^0.9.13",
     "htmllint-cli": "^0.0.6",
     "node-sass": "^4.5.2",
+    "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "postcss-cli": "^3.1.1",


### PR DESCRIPTION
Adds an `watch` task to compile CSS while the local server is running. Likely need to expand to JS, or at least rename to `watch-css` if it only affects the CSS. To get the right output, I removed the `docs/examples/` directory for the prefix task; it was rewriting all the example CSS and adding source maps for them (not needed).

