### PR TITLE
Fixed #21237 - Toggle buttons don't honor [disabled] or .disabled

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -90,7 +90,8 @@ const Button = (($) => {
           }
 
           if (triggerChangeEvent) {
-            if (input.disabled || rootElement.disabled ||
+            if (input.hasAttribute('disabled') ||
+              rootElement.hasAttribute('disabled') ||
               input.classList.contains('disabled') ||
               rootElement.classList.contains('disabled')) {
               return

--- a/js/src/button.js
+++ b/js/src/button.js
@@ -90,6 +90,11 @@ const Button = (($) => {
           }
 
           if (triggerChangeEvent) {
+            if (input.disabled || rootElement.disabled ||
+              input.classList.contains('disabled') ||
+              rootElement.classList.contains('disabled')) {
+              return
+            }
             input.checked = !$(this._element).hasClass(ClassName.ACTIVE)
             $(input).trigger('change')
           }

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -156,4 +156,21 @@ $(function () {
     assert.ok($btn2.is(':not([aria-pressed])'), 'label for nested radio input has not been given an aria-pressed attribute')
   })
 
+  QUnit.test('should handle disabled attribute on non-button elements', function (assert) {
+    assert.expect(2)
+    var groupHTML = '  <div class="btn-group disabled" data-toggle="buttons" aria-disabled="true" disabled>'
+      + '<label class="btn btn-danger disabled" aria-disabled="true" disabled>'
+      + '<input type="checkbox" aria-disabled="true" autocomplete="off" disabled class="disabled"/>'
+      + '</label>'
+      + '</div>'
+    var $group = $(groupHTML).appendTo('#qunit-fixture')
+
+    var $btn = $group.children().eq(0)
+    var $input = $btn.children().eq(0)
+
+    $btn.trigger('click')
+    assert.ok($btn.is(':not(.active)'), 'button did not become active')
+    assert.ok(!$input.is(':checked'), 'checkbox did not get checked')
+  })
+
 })


### PR DESCRIPTION
This commit adds a check for disabled attributes and classes on the button element.

Close : #21237