### PR TITLE
Move `.form-control-lg` and `.form-control-sm` css to Sass placeholder

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -152,11 +152,15 @@ select.form-control {
 // The `.form-group-* form-control` variations are sadly duplicated to avoid the
 // issue documented in https://github.com/twbs/bootstrap/issues/15074.
 
-.form-control-sm {
+%form-control-sm {
   padding: $input-btn-padding-y-sm $input-btn-padding-x-sm;
   font-size: $font-size-sm;
   line-height: $input-btn-line-height-sm;
   @include border-radius($input-border-radius-sm);
+}
+
+.form-control-sm {
+  @extend %form-control-sm;
 }
 
 select.form-control-sm {
@@ -166,11 +170,15 @@ select.form-control-sm {
   }
 }
 
-.form-control-lg {
+%form-control-lg {
   padding: $input-btn-padding-y-lg $input-btn-padding-x-lg;
   font-size: $font-size-lg;
   line-height: $input-btn-line-height-lg;
   @include border-radius($input-border-radius-lg);
+}
+
+.form-control-lg {
+  @extend %form-control-lg;
 }
 
 select.form-control-lg {

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -52,12 +52,12 @@
 .input-group-lg > .form-control,
 .input-group-lg > .input-group-addon,
 .input-group-lg > .input-group-btn > .btn {
-  @extend .form-control-lg;
+  @extend %form-control-lg;
 }
 .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
 .input-group-sm > .input-group-btn > .btn {
-  @extend .form-control-sm;
+  @extend %form-control-sm;
 }
 
 


### PR DESCRIPTION
`@extend .form-control-lg;` and `@extend .form-control-sm;` in _input-groups.scss adds some potentially unwanted css selectors.
```
.input-group-lg > .form-control-static.form-control
.input-group-lg > .form-control-static.input-group-addon
.input-group-lg > .input-group-btn > .form-control-static.btn
.input-group-lg > select.form-control
.input-group-lg > select.input-group-addon
.input-group-lg > .input-group-btn > select.btn
.input-group-lg > select.form-control:not([size]):not([multiple])
.input-group-lg > select.input-group-addon:not([size]):not([multiple])
.input-group-lg > .input-group-btn > select.btn:not([size]):not([multiple])
```
adds similar selectors for `.input-group-sm` as well.

This puts `.form-control-lg` and `.form-control-sm` css properties in Sass placeholder to help reduce the number of selectors generated.