### PR TITLE
Nav Pills with open dropdown don't reflect the nav-pills active state…

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -74,12 +74,12 @@
 .nav-pills {
   .nav-link {
     @include border-radius($nav-pills-border-radius);
+  }
 
-    &.active,
-    .show > & {
-      color: $nav-pills-link-active-color;
-      background-color: $nav-pills-link-active-bg;
-    }
+  .nav-link.active,
+  .show > .nav-link {
+    color: $nav-pills-link-active-color;
+    background-color: $nav-pills-link-active-bg;
   }
 }
 


### PR DESCRIPTION
The active state should also be reflected when using collapse plugin inside nav-pills.

Latest v4-dev branch doesn't work like the current docs site http://v4-alpha.getbootstrap.com/components/navs/#pills-with-dropdowns. I think it was introduced at https://github.com/twbs/bootstrap/commit/91b62941afb7115807fc2925398ebccfc68f5377.

Fixes #23482.