### PR TITLE
Pagination that is wider than it's container overflows horizontally

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,5 +1,6 @@
 .pagination {
   display: flex;
+  flex-wrap: wrap;
   // 1-2: Disable browser default list styles
   padding-left: 0; // 1
   list-style: none; // 2


### PR DESCRIPTION
Pagination component with a lot of items causes horizontal overflow. Not sure if this is intended (like use a flex utility), I would expect it to break to a new line by default.