### PR TITLE
`@mixin pagination-size()` doesn't apply line-height

### DIFF
--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -4,6 +4,7 @@
   .page-link {
     padding: $padding-y $padding-x;
     font-size: $font-size;
+    line-height: $line-height;
   }
 
   .page-item {


### PR DESCRIPTION
https://github.com/twbs/bootstrap/blob/v4-dev/scss/mixins/_pagination.scss#L3

`@mixin pagination-size` has a `$line-height` argument, but it's never used.