### PR TITLE
Add shim for "new" HTML5 structural elements

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -39,6 +39,10 @@ html {
   @-ms-viewport { width: device-width; }
 }
 
+// Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
+article, aside, dialog, figcaption, figure, footer, header, hgroup, main, nav, section {
+  display: block;
+}
 
 // Body
 //


### PR DESCRIPTION
For IE10 (and any older browsers) support , so at least the layout doesn't fall apart if author is using them.