### PR TITLE
Busy sliding event

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -124,9 +124,11 @@ const Carousel = (($) => {
     // public
 
     next() {
-      if (!this._isSliding) {
-        this._slide(Direction.NEXT)
+      if (this._isSliding) {
+        return
       }
+
+      this._slide(Direction.NEXT)
     }
 
     nextWhenVisible() {
@@ -137,9 +139,11 @@ const Carousel = (($) => {
     }
 
     prev() {
-      if (!this._isSliding) {
-        this._slide(Direction.PREV)
+      if (this._isSliding) {
+        return
       }
+
+      this._slide(Direction.PREV)
     }
 
     pause(event) {

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -20,13 +20,13 @@
         </ol>
         <div class="carousel-inner">
           <div class="carousel-item active">
-            <img src="http://i.imgur.com/iEZgY7Y.jpg" alt="First slide">
+            <img src="http://placehold.it/1110x400" alt="First slide">
           </div>
           <div class="carousel-item">
-            <img src="http://i.imgur.com/eNWn1Xs.jpg" alt="Second slide">
+            <img src="http://placehold.it/1110x400" alt="Second slide">
           </div>
           <div class="carousel-item">
-            <img src="http://i.imgur.com/Nm7xoti.jpg" alt="Third slide">
+            <img src="http://placehold.it/1110x400" alt="Third slide">
           </div>
         </div>
         <a class="carousel-control-prev" href="#carousel-example-generic" role="button" data-slide="prev">

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -50,6 +50,10 @@
         $('#carousel-example-generic').on('slid.bs.carousel', function(event) {
           console.log('slid at ', event.timeStamp)
         })
+        $('#carousel-example-generic').on('busysliding.bs.carousel', function(event) {
+          //console.log('slid at ', event.timeStamp)
+          console.log('busy sliding at', event.timeStamp);
+        })
       })
     </script>
   </body>

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -23,10 +23,10 @@
             <img src="http://placehold.it/1110x400" alt="First slide">
           </div>
           <div class="carousel-item">
-            <img src="http://placehold.it/1110x400" alt="Second slide">
+            <img src="http://placehold.it/1111x400" alt="Second slide">
           </div>
           <div class="carousel-item">
-            <img src="http://placehold.it/1110x400" alt="Third slide">
+            <img src="http://placehold.it/1112x400" alt="Third slide">
           </div>
         </div>
         <a class="carousel-control-prev" href="#carousel-example-generic" role="button" data-slide="prev">


### PR DESCRIPTION
The branch adds a 'busy sliding' event that goes off every time a slide request is submitted while the carousel is already sliding.

The justification for something like this is to allow developers to display an indicator such as a 'spinner' to indicate that the carousel has indeed recieved the request from the UI controls/That the UI controls are being 'spammed'. An indicator such as this can be embedded as a part of the UI as well, but an event like this merely allows the developer to implement their own indicators, by utlizing both the current 'slid' event and the newly added event.

The image URLs in the visual test seemed to be broken, so I replaced them with placeholdits

Note: I wasn't sure about the mapping of next/prev to left/right respectively in the current state of the carousel module. I assumed a mapping of next/prev to right/left, which goes against what the code is already doing but which also made more sense for the time being. 