### PR TITLE
No check on element is null causes error in tooltip.show.complete

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -230,7 +230,10 @@
 
       this.applyPlacement(calculatedOffset, placement)
 
-      var complete = function () {
+      var complete = function () {       
+        if (that.$element === null) { 
+	        return
+        }
         var prevHoverState = that.hoverState
         that.$element.trigger('shown.bs.' + that.type)
         that.hoverState = null

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -230,9 +230,9 @@
 
       this.applyPlacement(calculatedOffset, placement)
 
-      var complete = function () {       
-        if (that.$element === null) { 
-	        return
+      var complete = function () {
+        if (that.$element === null) {
+          return
         }
         var prevHoverState = that.hoverState
         that.$element.trigger('shown.bs.' + that.type)


### PR DESCRIPTION
When, while destroying a tooltip, a mouseover (on the element with that tooltip) can raise an error.

This change checks for the existence of that.$element before doing anything,