### PR TITLE
Use flex instead of block for Collapse .show

### DIFF
--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -10,7 +10,7 @@
 .collapse {
   display: none;
   &.show {
-    display: block;
+    display: flex;
   }
 }
 


### PR DESCRIPTION
Use `flex` for Collapse `.show` class

Not sure about if it's the good solution or not so I hope feedbacks from @mdo 😄 

Close : #22600 