### PR TITLE
Dropdown must be displayed in position static for navbar, to override Popper css

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -138,8 +138,9 @@
       @include media-breakpoint-down($breakpoint) {
         .navbar-nav {
           .dropdown-menu {
-            position: static;
+            position: static !important;
             float: none;
+            transform: unset !important;
           }
         }
 


### PR DESCRIPTION
A lack of my previous PR to remove Tether for Popper.
Popper apply inline style which override our CSS.

Close : #22628 