### PR TITLE
fix tooltip documentation page missing classname prefix "bs-" to tooltip top

### DIFF
--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -139,7 +139,7 @@ You should only add tooltips to HTML elements that are traditionally keyboard-fo
 <a href="#" data-toggle="tooltip" title="Some tooltip text!">Hover over me</a>
 
 <!-- Generated markup by the plugin -->
-<div class="tooltip tooltip-top" role="tooltip">
+<div class="tooltip bs-tooltip-top" role="tooltip">
   <div class="arrow"></div>
   <div class="tooltip-inner">
     Some tooltip text!


### PR DESCRIPTION
fix doc error