### PR TITLE
fix(css): force .navbar .dropdown-menu positioning

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -75,6 +75,12 @@
     padding-right: 0;
     padding-left: 0;
   }
+
+  .dropdown-menu {
+    position: static !important;
+    float: none;
+    transform: unset !important;
+  }
 }
 
 
@@ -136,14 +142,6 @@
 
     &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
-        .navbar-nav {
-          .dropdown-menu {
-            position: static !important;
-            float: none;
-            transform: unset !important;
-          }
-        }
-
         > .container,
         > .container-fluid {
           padding-right: 0;
@@ -160,7 +158,8 @@
           flex-direction: row;
 
           .dropdown-menu {
-            position: absolute;
+            position: absolute !important;
+            top: 100% !important;
           }
 
           .nav-link {


### PR DESCRIPTION
**Demo**
- Before: http://codepen.io/zalog/pen/eWLvRP
- After: http://codepen.io/zalog/pen/WjgGzM

**Problems:**
Please follow my example in _before_, the problems are in the same order.
- for navbars that never collapse `.navbar.navbar-expand`, `.dropdown-menu` has `position: static` and push parent `.navbar` container down
- if `.dropdown-menu` it's on the edge of browser, popper will move it and seems unnatural for `.navbar`
- if we use only `.navbar` (for navbar that always collapse), `.dropdown-menu` act in _popper style_

--

I tried to solve that by forcing `.dropdown-menu` to act like before popper, and in a mobile first abordation.

cc @Johann-S, #22628, #22630