### PR TITLE
Support multiple Carousel indicators lists

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -137,8 +137,11 @@
 
     if (this.$indicators.length) {
       this.$indicators.find('.active').removeClass('active')
-      var $nextIndicator = $(this.$indicators.children()[this.getItemIndex($next)])
-      $nextIndicator && $nextIndicator.addClass('active')
+      var nextItemIndex = this.getItemIndex($next)
+      for(var i=0; i<this.$indicators.length; i++){
+        var $nextIndicator = $( $(this.$indicators[i]).children()[nextItemIndex] )
+        $nextIndicator && $nextIndicator.addClass('active')
+      }
     }
 
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -138,10 +138,10 @@
     if (this.$indicators.length) {
       this.$indicators.find('.active').removeClass('active')
       var nextItemIndex = this.getItemIndex($next)
-      for(var i=0; i<this.$indicators.length; i++){
-        var $nextIndicator = $( $(this.$indicators[i]).children()[nextItemIndex] )
+      $(this.$indicators).each(function(index,indicator){
+        var $nextIndicator = $( $(indicator).children()[nextItemIndex])
         $nextIndicator && $nextIndicator.addClass('active')
-      }
+      })
     }
 
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -138,7 +138,7 @@
     if (this.$indicators.length) {
       this.$indicators.find('.active').removeClass('active')
       var nextItemIndex = this.getItemIndex($next)
-      $(this.$indicators).each(function(index,indicator){
+      $(this.$indicators).each(function(index, indicator){
         var $nextIndicator = $($(indicator).children()[nextItemIndex])
         $nextIndicator && $nextIndicator.addClass('active')
       })

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -139,7 +139,7 @@
       this.$indicators.find('.active').removeClass('active')
       var nextItemIndex = this.getItemIndex($next)
       $(this.$indicators).each(function(index,indicator){
-        var $nextIndicator = $( $(indicator).children()[nextItemIndex])
+        var $nextIndicator = $($(indicator).children()[nextItemIndex])
         $nextIndicator && $nextIndicator.addClass('active')
       })
     }


### PR DESCRIPTION
Carousel now supports multiple carousel-indicators lists to switch .active class on all of them simultaneously.