### PR TITLE
Use Popper.js to manage arrow position

### DIFF
--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -298,6 +298,18 @@
   margin-top: .25rem;
   margin-bottom: .25rem;
 }
+.bs-tooltip-top-docs,
+.bs-tooltip-bottom-docs {
+  .arrow {
+    left: 50%;
+  }
+}
+.bs-tooltip-right-docs,
+.bs-tooltip-left-docs {
+  .arrow {
+    top: 50%;
+  }
+}
 
 // Popovers
 .bd-example-popover-static {
@@ -310,6 +322,18 @@
   float: left;
   width: 260px;
   margin: 1.25rem;
+}
+.bs-popover-top-docs,
+.bs-popover-bottom-docs {
+  .arrow {
+    left: 50%;
+  }
+}
+.bs-popover-right-docs,
+.bs-popover-left-docs {
+  .arrow {
+    top: 50%;
+  }
 }
 
 // Tooltips

--- a/docs/components/popovers.md
+++ b/docs/components/popovers.md
@@ -56,32 +56,32 @@ $(function () {
 Four options are available: top, right, bottom, and left aligned.
 
 <div class="bd-example bd-example-popover-static">
-  <div class="popover bs-popover-top">
-    <div class="arrow"></div>
+  <div class="popover bs-popover-top bs-popover-top-docs">
+    <div class="arrow" x-arrow></div>
     <h3 class="popover-title">Popover top</h3>
     <div class="popover-content">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
-  <div class="popover bs-popover-right">
-    <div class="arrow"></div>
+  <div class="popover bs-popover-right bs-popover-right-docs">
+    <div class="arrow" x-arrow></div>
     <h3 class="popover-title">Popover right</h3>
     <div class="popover-content">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
-  <div class="popover bs-popover-bottom">
-    <div class="arrow"></div>
+  <div class="popover bs-popover-bottom bs-popover-bottom-docs">
+    <div class="arrow" x-arrow></div>
     <h3 class="popover-title">Popover bottom</h3>
     <div class="popover-content">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
-  <div class="popover bs-popover-left">
-    <div class="arrow"></div>
+  <div class="popover bs-popover-left bs-popover-left-docs">
+    <div class="arrow" x-arrow></div>
     <h3 class="popover-title">Popover left</h3>
     <div class="popover-content">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
@@ -234,7 +234,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     <tr>
       <td>template</td>
       <td>string</td>
-      <td><code>'&lt;div class="popover" role="tooltip"&gt;&lt;div class="arrow"&gt;&lt;/div&gt;&lt;h3 class="popover-title"&gt;&lt;/h3&gt;&lt;div class="popover-content"&gt;&lt;/div&gt;&lt;/div&gt;'</code></td>
+      <td><code>'&lt;div class="popover" role="tooltip"&gt;&lt;div class="arrow" x-arrow&gt;&lt;/div&gt;&lt;h3 class="popover-title"&gt;&lt;/h3&gt;&lt;div class="popover-content"&gt;&lt;/div&gt;&lt;/div&gt;'</code></td>
       <td>
         <p>Base HTML to use when creating the popover.</p>
         <p>The popover's <code>title</code> will be injected into the <code>.popover-title</code>.</p>

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -51,26 +51,26 @@ Hover over the links below to see tooltips:
 Four options are available: top, right, bottom, and left aligned.
 
 <div class="bd-example bd-example-tooltip-static">
-  <div class="tooltip bs-tooltip-top" role="tooltip">
-    <div class="arrow"></div>
+  <div class="tooltip bs-tooltip-top bs-tooltip-top-docs" role="tooltip">
+    <div class="arrow" x-arrow></div>
     <div class="tooltip-inner">
       Tooltip on the top
     </div>
   </div>
-  <div class="tooltip bs-tooltip-right" role="tooltip">
-    <div class="arrow"></div>
+  <div class="tooltip bs-tooltip-right bs-tooltip-right-docs" role="tooltip">
+    <div class="arrow" x-arrow></div>
     <div class="tooltip-inner">
       Tooltip on the right
     </div>
   </div>
-  <div class="tooltip bs-tooltip-bottom" role="tooltip">
-    <div class="arrow"></div>
+  <div class="tooltip bs-tooltip-bottom bs-tooltip-bottom-docs" role="tooltip">
+    <div class="arrow" x-arrow></div>
     <div class="tooltip-inner">
       Tooltip on the bottom
     </div>
   </div>
-  <div class="tooltip bs-tooltip-left" role="tooltip">
-    <div class="arrow"></div>
+  <div class="tooltip bs-tooltip-left bs-tooltip-left-docs" role="tooltip">
+    <div class="arrow" x-arrow></div>
     <div class="tooltip-inner">
       Tooltip on the left
     </div>
@@ -140,7 +140,7 @@ You should only add tooltips to HTML elements that are traditionally keyboard-fo
 
 <!-- Generated markup by the plugin -->
 <div class="tooltip bs-tooltip-top" role="tooltip">
-  <div class="arrow"></div>
+  <div class="arrow" x-arrow></div>
   <div class="tooltip-inner">
     Some tooltip text!
   </div>
@@ -213,7 +213,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     <tr>
       <td>template</td>
       <td>string</td>
-      <td><code>'&lt;div class="tooltip" role="tooltip"&gt;&lt;div class="arrow"&gt;&lt;/div&gt;&lt;div class="tooltip-inner"&gt;&lt;/div&gt;&lt;/div&gt;'</code></td>
+      <td><code>'&lt;div class="tooltip" role="tooltip"&gt;&lt;div class="arrow" x-arrow&gt;&lt;/div&gt;&lt;div class="tooltip-inner"&gt;&lt;/div&gt;&lt;/div&gt;'</code></td>
       <td>
         <p>Base HTML to use when creating the tooltip.</p>
         <p>The tooltip's <code>title</code> will be injected into the <code>.tooltip-inner</code>.</p>

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -30,7 +30,7 @@ const Popover = (($) => {
     trigger   : 'click',
     content   : '',
     template  : '<div class="popover" role="tooltip">'
-              + '<div class="arrow"></div>'
+              + '<div class="arrow" x-arrow></div>'
               + '<h3 class="popover-title"></h3>'
               + '<div class="popover-content"></div></div>'
   })

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -60,7 +60,7 @@ const Tooltip = (($) => {
   const Default = {
     animation           : true,
     template            : '<div class="tooltip" role="tooltip">'
-                        + '<div class="arrow"></div>'
+                        + '<div class="arrow" x-arrow></div>'
                         + '<div class="tooltip-inner"></div></div>',
     trigger             : 'hover focus',
     title               : '',

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -20,14 +20,19 @@
 
   // Arrows
   //
-  // .popover-arrow is outer, .popover-arrow::after is inner
+  // .arrow is outer, .arrow::after is inner
+
+  .arrow {
+    position: absolute;
+    display: block;
+    width: $popover-arrow-width;
+    height: $popover-arrow-height;
+  }
 
   .arrow::before,
   .arrow::after {
     position: absolute;
     display: block;
-    width: 0;
-    height: 0;
     border-color: transparent;
     border-style: solid;
   }
@@ -38,7 +43,7 @@
   }
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-width;
+    border-width: $popover-arrow-outer-width;
   }
 
   // Popover directions
@@ -46,21 +51,24 @@
   &.bs-popover-top {
     margin-bottom: $popover-arrow-width;
 
+    .arrow {
+      bottom: 0;
+    }
+
     .arrow::before,
     .arrow::after {
-      left: 50%;
       border-bottom-width: 0;
     }
 
     .arrow::before {
       bottom: -$popover-arrow-outer-width;
-      margin-left: -$popover-arrow-outer-width;
+      margin-left: -($popover-arrow-outer-width - 5);
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
       bottom: -($popover-arrow-outer-width - 1);
-      margin-left: -$popover-arrow-width;
+      margin-left: -($popover-arrow-outer-width - 5);
       border-top-color: $popover-arrow-color;
     }
   }
@@ -68,21 +76,23 @@
   &.bs-popover-right {
     margin-left: $popover-arrow-width;
 
+    .arrow {
+      left: 0;
+    }
+
     .arrow::before,
     .arrow::after {
-      top: 50%;
+      margin-top: -($popover-arrow-outer-width - 3);
       border-left-width: 0;
     }
 
     .arrow::before {
       left: -$popover-arrow-outer-width;
-      margin-top: -$popover-arrow-outer-width;
       border-right-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
       left: -($popover-arrow-outer-width - 1);
-      margin-top: -($popover-arrow-outer-width - 1);
       border-right-color: $popover-arrow-color;
     }
   }
@@ -90,21 +100,23 @@
   &.bs-popover-bottom {
     margin-top: $popover-arrow-width;
 
+    .arrow {
+      top: 0;
+    }
+
     .arrow::before,
     .arrow::after {
-      left: 50%;
+      margin-left: -($popover-arrow-width - 3);
       border-top-width: 0;
     }
 
     .arrow::before {
       top: -$popover-arrow-outer-width;
-      margin-left: -$popover-arrow-outer-width;
       border-bottom-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
       top: -($popover-arrow-outer-width - 1);
-      margin-left: -$popover-arrow-width;
       border-bottom-color: $popover-arrow-color;
     }
 
@@ -124,21 +136,23 @@
   &.bs-popover-left {
     margin-right: $popover-arrow-width;
 
+    .arrow {
+      right: 0;
+    }
+
     .arrow::before,
     .arrow::after {
-      top: 50%;
+      margin-top: -($popover-arrow-outer-width - 3);
       border-right-width: 0;
     }
 
     .arrow::before {
       right: -$popover-arrow-outer-width;
-      margin-top: -$popover-arrow-outer-width;
       border-left-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
       right: -($popover-arrow-outer-width - 1);
-      margin-top: -($popover-arrow-outer-width - 1);
       border-left-color: $popover-arrow-color;
     }
   }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -14,13 +14,21 @@
 
   &.show { opacity: $tooltip-opacity; }
 
+  .arrow {
+    position: absolute;
+    display: block;
+    width: $tooltip-arrow-width;
+    height: $tooltip-arrow-height;
+  }
+
   &.bs-tooltip-top {
     padding: $tooltip-arrow-width 0;
+    .arrow {
+      bottom: 0;
+    }
 
     .arrow::before {
-      bottom: 0;
-      left: 50%;
-      margin-left: -$tooltip-arrow-width;
+      margin-left: -($tooltip-arrow-width - 2);
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
       border-top-color: $tooltip-arrow-color;
@@ -28,11 +36,12 @@
   }
   &.bs-tooltip-right {
     padding: 0 $tooltip-arrow-width;
+    .arrow {
+      left: 0;
+    }
 
     .arrow::before {
-      top: 50%;
-      left: 0;
-      margin-top: -$tooltip-arrow-width;
+      margin-top: -($tooltip-arrow-width - 2);
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
       border-right-color: $tooltip-arrow-color;
@@ -40,11 +49,12 @@
   }
   &.bs-tooltip-bottom {
     padding: $tooltip-arrow-width 0;
+    .arrow {
+      top: 0;
+    }
 
     .arrow::before {
-      top: 0;
-      left: 50%;
-      margin-left: -$tooltip-arrow-width;
+      margin-left: -($tooltip-arrow-width - 2);
       content: "";
       border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-bottom-color: $tooltip-arrow-color;
@@ -52,11 +62,13 @@
   }
   &.bs-tooltip-left {
     padding: 0 $tooltip-arrow-width;
+    .arrow {
+      right: 0;
+    }
 
     .arrow::before {
-      top: 50%;
       right: 0;
-      margin-top: -$tooltip-arrow-width;
+      margin-top: -($tooltip-arrow-width - 2);
       content: "";
       border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-left-color: $tooltip-arrow-color;
@@ -65,8 +77,6 @@
 
   .arrow::before {
     position: absolute;
-    width: 0;
-    height: 0;
     border-color: transparent;
     border-style: solid;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -698,7 +698,9 @@ $tooltip-padding-y:           3px !default;
 $tooltip-padding-x:           8px !default;
 $tooltip-margin:              0 !default;
 
+
 $tooltip-arrow-width:         5px !default;
+$tooltip-arrow-height:        5px !default;
 $tooltip-arrow-color:         $tooltip-bg !default;
 
 
@@ -721,6 +723,7 @@ $popover-content-padding-y:           9px !default;
 $popover-content-padding-x:           14px !default;
 
 $popover-arrow-width:                 10px !default;
+$popover-arrow-height:                5px !default;
 $popover-arrow-color:                 $popover-bg !default;
 
 $popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;


### PR DESCRIPTION
Use Popper.js to manage arrow position instead of using CSS

Close : #22669, #22572