### PR TITLE
Share button hover and focus styles

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -13,7 +13,7 @@
   @include box-shadow($btn-box-shadow);
 
   // Hover and focus styles are shared
-  @include hover {
+  @include hover-focus {
     color: $color;
     background-color: $active-background;
     border-color: $active-border;


### PR DESCRIPTION
this fixes a bug where button variants did not share the styles between focus and hover. 

fixes #22657 
