### PR TITLE
form-control states apply to all sizes

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -38,26 +38,8 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  @include form-control-focus();
-
-  // Placeholder
-  &::placeholder {
-    color: $input-color-placeholder;
-    // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-    opacity: 1;
-  }
-
-  // Disabled and read-only inputs
-  //
-  // HTML5 says that controls under a fieldset > legend:first-child won't be
-  // disabled if the fieldset is disabled. Due to implementation difficulty, we
-  // don't honor that edge case; we style them as disabled anyway.
-  &:disabled,
-  &[readonly] {
-    background-color: $input-bg-disabled;
-    // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
-    opacity: 1;
-  }
+  // Also customise `:disabled` state and placeholder style
+  @include form-control-states();
 }
 
 select.form-control {
@@ -157,6 +139,7 @@ select.form-control {
   font-size: $font-size-sm;
   line-height: $input-btn-line-height-sm;
   @include border-radius($input-border-radius-sm);
+  @include form-control-states();
 }
 
 select.form-control-sm {
@@ -171,6 +154,7 @@ select.form-control-sm {
   font-size: $font-size-lg;
   line-height: $input-btn-line-height-lg;
   @include border-radius($input-border-radius-lg);
+  @include form-control-states();
 }
 
 select.form-control-lg {

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -44,7 +44,7 @@
 //
 // Example usage: change the default blue border and shadow to white for better
 // contrast against a dark gray background.
-@mixin form-control-focus() {
+@mixin form-control-states() {
   &:focus {
     color: $input-color-focus;
     background-color: $input-bg-focus;
@@ -52,9 +52,7 @@
     outline: none;
     @include box-shadow($input-box-shadow-focus);
   }
-}
 
-@mixin form-control-states() {
   // Placeholder
   &::placeholder {
     color: $input-color-placeholder;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -53,3 +53,24 @@
     @include box-shadow($input-box-shadow-focus);
   }
 }
+
+@mixin form-control-states() {
+  // Placeholder
+  &::placeholder {
+    color: $input-color-placeholder;
+    // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+    opacity: 1;
+  }
+
+  // Disabled and read-only inputs
+  //
+  // HTML5 says that controls under a fieldset > legend:first-child won't be
+  // disabled if the fieldset is disabled. Due to implementation difficulty, we
+  // don't honor that edge case; we style them as disabled anyway.
+  &:disabled,
+  &[readonly] {
+    background-color: $input-bg-disabled;
+    // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Modify a mixin for form-control states and apply to all form-control sizes. Noticed the issue when I changed from form-control to form-control-lg and the placeholder colour didn't update. Then I noticed that the disabled state wasn't applied ... the focus style may not be applied...?

Comments still need tidying up if this looks like to correct fix.