### PR TITLE
Ensure that button.btn and a.btn have the same cursor

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -10,6 +10,7 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
+  cursor: default;
   user-select: none;
   border: $input-btn-border-width solid transparent;
   @include button-size($input-btn-padding-y, $input-btn-padding-x, $font-size-base, $input-btn-line-height, $btn-border-radius);
@@ -75,6 +76,7 @@ fieldset[disabled] a.btn {
 .btn-link {
   font-weight: $font-weight-normal;
   color: $link-color;
+  cursor: pointer;
   background-color: transparent;
   border-radius: 0;
 


### PR DESCRIPTION
This PR adds the `cursor: default` property to the `.btn` class to ensure that `button.btn` and `a.btn` have matching cursor behavior. It also adds `cursor: pointer` to `.btn-link`. I believe this aligns with the intent of 232e86d0b4e1a4ff0dc3aa4e6d75c14a54fa8ac8 (added as part of https://github.com/twbs/bootstrap/pull/21439).