### PR TITLE
Update Bootstrap masthead - Vertically center "B"

### DIFF
--- a/docs/assets/scss/_masthead.scss
+++ b/docs/assets/scss/_masthead.scss
@@ -9,6 +9,7 @@
 
   .bd-booticon {
     margin: 0 auto 2rem;
+    line-height: 8rem;
     color: $bd-purple-light;
     border-color: $bd-purple-light;
   }


### PR DESCRIPTION
This change would vertically center the B and make it look a bit better IMO.
I have included screenshots, judge for yourself.

Before:
![bootstrap_before](https://cloud.githubusercontent.com/assets/12650063/26460946/a681058c-417b-11e7-9fbd-f1dfa7009949.png)

After:
![bootstrap_after](https://cloud.githubusercontent.com/assets/12650063/26460949/a82f8a48-417b-11e7-85db-bf995d7bc404.png)