### PR TITLE
Add new mixin, and remove duplicate styles

### DIFF
--- a/less/mixins/grid.less
+++ b/less/mixins/grid.less
@@ -18,14 +18,18 @@
   &:extend(.clearfix all);
 }
 
-// Generate the extra small columns
-.make-xs-column(@columns; @gutter: @grid-gutter-width) {
+// Generate the column
+.make-column(@gutter: @grid-gutter-width) {
   position: relative;
   float: left;
-  width: percentage((@columns / @grid-columns));
   min-height: 1px;
   padding-left:  (@gutter / 2);
   padding-right: (@gutter / 2);
+}
+
+// Generate the extra small columns
+.make-xs-column(@columns) {
+  width: percentage((@columns / @grid-columns));
 }
 .make-xs-column-offset(@columns) {
   margin-left: percentage((@columns / @grid-columns));
@@ -38,14 +42,8 @@
 }
 
 // Generate the small columns
-.make-sm-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
+.make-sm-column(@columns) {
   @media (min-width: @screen-sm-min) {
-    float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
@@ -66,14 +64,8 @@
 }
 
 // Generate the medium columns
-.make-md-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
+.make-md-column(@columns) {
   @media (min-width: @screen-md-min) {
-    float: left;
     width: percentage((@columns / @grid-columns));
   }
 }
@@ -94,14 +86,8 @@
 }
 
 // Generate the large columns
-.make-lg-column(@columns; @gutter: @grid-gutter-width) {
-  position: relative;
-  min-height: 1px;
-  padding-left:  (@gutter / 2);
-  padding-right: (@gutter / 2);
-
+.make-lg-column(@columns) {
   @media (min-width: @screen-lg-min) {
-    float: left;
     width: percentage((@columns / @grid-columns));
   }
 }


### PR DESCRIPTION
### Problem
```
.main {
  .make-xs-column(12);
  .make-md-column(8);
  .make-lg-column(9);
}
.sidebar {
  .make-xs-column(12);
  .make-md-column(4);
  .make-lg-column(3);
}
```
### Outputs
```
.main {
    position: relative;
    float: left;
    width: 100%;
    min-height: 1px;
    padding-left: 15px;
    padding-right: 15px;
    position: relative;
    min-height: 1px;
    padding-left: 15px;
    padding-right: 15px;
    position: relative;
    min-height: 1px;
    padding-left: 15px;
    padding-right: 15px;
}
```
And all media queries with respective width.
With new added mixin we use it this way
```
.main {
  .make-column();
  .make-xs-column(12);
  .make-md-column(8);
  .make-lg-column(9);
}
```
and we get this CSS
```
.main {
    position: relative;
    float: left;
    min-height: 1px;
    padding-left: 15px;
    padding-right: 15px;
    width: 100%;
}
```
I know that this change has a low chance to be merged, but I tried. :)