### PR TITLE
Minor: Documentation Copy and Paste error

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -146,7 +146,7 @@ For example, here are two grid layouts that apply to every device and viewport, 
       1 of 2
     </div>
     <div class="col">
-      1 of 2
+      2 of 2
     </div>
   </div>
   <div class="row">
@@ -154,10 +154,10 @@ For example, here are two grid layouts that apply to every device and viewport, 
       1 of 3
     </div>
     <div class="col">
-      1 of 3
+      2 of 3
     </div>
     <div class="col">
-      1 of 3
+      3 of 3
     </div>
   </div>
 </div>


### PR DESCRIPTION
I know this isn't against master, but the error doesn't exist in master.