### PR TITLE
fix(css): .dropdown-menu-right positioning

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -162,6 +162,11 @@
             top: 100% !important;
           }
 
+          .dropdown-menu-right {
+            right: 0;
+            left: auto !important;
+          }
+
           .nav-link {
             padding-right: .5rem;
             padding-left: .5rem;


### PR DESCRIPTION
This is a fix for placing `.dropdown-menu-right` on the right position for `.navbar` and override Popper.js.

Problem: http://output.jsbin.com/sozuva/1
This PR: https://codepen.io/zalog/pen/BREOMv

cc #22636, #22640, #22699