### PR TITLE
Add `docs-clean` task to watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "release-zip": "cd dist/ && zip -r9 bootstrap-$npm_package_version-dist.zip * && shx mv bootstrap-$npm_package_version-dist.zip ..",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all dist js-test docs",
-    "watch-css": "nodemon --ignore js/ --ignore dist/ -e scss -x \"npm run css && npm run css-docs\"",
-    "watch-js": "nodemon --ignore scss/ --ignore js/dist/ --ignore dist/ -e js -x \"npm run js-compile\"",
+    "watch-css": "nodemon --ignore js/ --ignore dist/ -e scss -x \"npm run css && npm run css-docs && npm run docs-clean\"",
+    "watch-js": "nodemon --ignore scss/ --ignore js/dist/ --ignore dist/ -e js -x \"npm run js-compile && npm run docs-clean\"",
     "watch": "npm-run-all --parallel watch-css watch-js"
   },
   "style": "dist/css/bootstrap.css",


### PR DESCRIPTION
Without this, the CSS and JS files don't get copied over to the `docs/dist/` folder during development. I imagine we can simplify this and not run it twice, and instead run it once? Unsure.

/cc @johann-s