### PR TITLE
Fix responsive .col-{infix}-auto

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -36,7 +36,8 @@
       }
       .col#{$infix}-auto {
         flex: 0 0 auto;
-        max-width: none;
+        width: auto;
+        max-width: none; // Reset earlier grid tiers
       }
 
       @for $i from 1 through $columns {

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -36,7 +36,7 @@
       }
       .col#{$infix}-auto {
         flex: 0 0 auto;
-        width: auto;
+        max-width: none;
       }
 
       @for $i from 1 through $columns {


### PR DESCRIPTION
Responsive automatic column resets weren't working because they inherited their `max-width` from lower grid tiers. This was because we were setting a `width`, but not resetting the `max-width` alongside it.