### PR TITLE
Use correct version of babel-preset-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-plugin-transform-es2015-modules-strip": "^0.1.1",
-    "babel-preset-es2015": "^7.0.0-alpha.7",
+    "babel-preset-es2015": "^6.24.1",
     "clean-css-cli": "^4.1.3",
     "eslint": "^3.19.0",
     "htmlhint": "^0.9.13",


### PR DESCRIPTION
The 7.x-alpha preset won't work with 6.x core.

An alternative would be to bump babel-cli to 7.x-alpha (if you'd like to help us test :D) though it's probably best to wait until rc/release.