### PR TITLE
Docs - avoid Tooltips/Popovers overflow on documentations's navbar

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -33,7 +33,7 @@
     position: -webkit-sticky;
     position: sticky;
     top: 0;
-    z-index: 1030; // over everything in bootstrap
+    z-index: 1071; // over everything in bootstrap
   }
 
   .navbar-nav {


### PR DESCRIPTION
This PR avoid this effect on our new awesome documentation 

![popovers bootstrap - mozilla firefox](https://cloud.githubusercontent.com/assets/1689750/26671237/077a91da-46b5-11e7-8268-f1189d6d6717.jpg)

By the way, thank you @mdo for your awesome work on our new documentation ❤️ 

/CC @mdo 