### PR TITLE
Text Truncate should truncate text on non block level elements

### DIFF
--- a/scss/mixins/_text-truncate.scss
+++ b/scss/mixins/_text-truncate.scss
@@ -2,6 +2,7 @@
 // Requires inline-block or block for proper styling
 
 @mixin text-truncate() {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/scss/mixins/_text-truncate.scss
+++ b/scss/mixins/_text-truncate.scss
@@ -1,8 +1,8 @@
 // Text truncate
 // Requires inline-block or block for proper styling
 
-@mixin text-truncate() {
-  display: block;
+@mixin text-truncate($display: inline-block) {
+  display: $display;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Demo: https://jsfiddle.net/ybzL5vu9/1/

`.text-truncate` doesn't work on non block level elements, used inline-block and width: 100% just incase someone wanted to truncate two sections of text on the same line.

Edit: I just saw the comment at the top of the mixin file. I think this change would be easier for end users to use. Changed to `display: block` because of vertical spacing issues with `inline-block`. I think block would be the more common use case.