### PR TITLE
Fix overflowing text in Cards with `word-wrap: break-word`

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -6,6 +6,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  word-wrap: break-word;
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
@@ -20,7 +22,6 @@
 
 .card-title {
   margin-bottom: $card-spacer-y;
-  word-break: break-all;
 }
 
 .card-subtitle {


### PR DESCRIPTION
Demo: https://jsfiddle.net/4h6okLkn/2/

Long text with no whitespace overflow in cards, this fix should cover most long text in cards. I used `word-wrap: break-word` instead of `word-break: break-all` because it breaks up the words a little bit better.