### PR TITLE
Rename `$card-border-radius-inner` to `$card-inner-border-radius`

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -68,7 +68,7 @@
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
-    @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
+    @include border-radius($card-inner-border-radius $card-inner-border-radius 0 0);
   }
 }
 
@@ -78,7 +78,7 @@
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {
-    @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
+    @include border-radius(0 0 $card-inner-border-radius $card-inner-border-radius);
   }
 }
 
@@ -170,18 +170,18 @@
 
 .card-img {
   width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
-  @include border-radius($card-border-radius-inner);
+  @include border-radius($card-inner-border-radius);
 }
 
 // Card image caps
 .card-img-top {
   width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
-  @include border-top-radius($card-border-radius-inner);
+  @include border-top-radius($card-inner-border-radius);
 }
 
 .card-img-bottom {
   width: 100%; // Required because we use flexbox and this inherently applies align-self: stretch
-  @include border-bottom-radius($card-border-radius-inner);
+  @include border-bottom-radius($card-inner-border-radius);
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -673,7 +673,7 @@ $card-spacer-x:            1.25rem !default;
 $card-border-width:        1px !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba($black,.125) !default;
-$card-border-radius-inner: calc(#{$card-border-radius} - #{$card-border-width}) !default;
+$card-inner-border-radius: calc(#{$card-border-radius} - #{$card-border-width}) !default;
 $card-cap-bg:              $gray-lightest !default;
 $card-bg:                  $white !default;
 


### PR DESCRIPTION
Renamed `$card-border-radius-inner` to `$card-inner-border-radius` to match the variable naming pattern in other components e.g. `$popover-inner-padding` and `$modal-inner-padding`