### PR TITLE
Fix for Issue #22225: Replaced hardcoded box-shadow values with $btn-focus-box-shadow scss …

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -22,9 +22,9 @@
   &.focus {
     // Avoid using mixin so we can pass custom focus shadow properly
     @if $enable-shadows {
-      box-shadow: $btn-box-shadow, 0 0 0 2px rgba($border, .5);
+      box-shadow: $btn-box-shadow, $btn-focus-box-shadow;
     } @else {
-      box-shadow: 0 0 0 2px rgba($border, .5);
+      box-shadow: $btn-focus-box-shadow;
     }
   }
 
@@ -60,7 +60,7 @@
 
   &:focus,
   &.focus {
-    box-shadow: 0 0 0 2px rgba($color, .5);
+    box-shadow: $btn-focus-box-shadow;
   }
 
   &.disabled,


### PR DESCRIPTION
…variable. Will work with $enable-shadows set or not, as per behaviour of .btn base style in scss/_buttons.scss file.