### PR TITLE
Collapse with flex elements

### DIFF
--- a/docs/4.0/components/collapse.md
+++ b/docs/4.0/components/collapse.md
@@ -226,6 +226,10 @@ Shows a collapsible element. **Returns to the caller before the collapsible elem
 
 Hides a collapsible element. **Returns to the caller before the collapsible element has actually been hidden** (i.e. before the `hidden.bs.collapse` event occurs).
 
+#### `.collapse('update')`
+
+Update a collapsible element if it changed during its lifetime.
+
 ### `.collapse('dispose')`
 
 Destroys an element's collapse.

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -46,6 +46,7 @@ const Collapse = (() => {
 
   const ClassName = {
     SHOW       : 'show',
+    FLEXSHOW   : 'flexshow',
     COLLAPSE   : 'collapse',
     COLLAPSING : 'collapsing',
     COLLAPSED  : 'collapsed'
@@ -113,7 +114,7 @@ const Collapse = (() => {
     // public
 
     toggle() {
-      if ($(this._element).hasClass(ClassName.SHOW)) {
+      if ($(this._element).hasClass(ClassName.SHOW) || $(this._element).hasClass(ClassName.FLEXSHOW)) {
         this.hide()
       } else {
         this.show()
@@ -121,8 +122,9 @@ const Collapse = (() => {
     }
 
     show() {
+      const showClass = this._getShowClass()
       if (this._isTransitioning ||
-        $(this._element).hasClass(ClassName.SHOW)) {
+        $(this._element).hasClass(showClass)) {
         return
       }
 
@@ -176,7 +178,7 @@ const Collapse = (() => {
         $(this._element)
           .removeClass(ClassName.COLLAPSING)
           .addClass(ClassName.COLLAPSE)
-          .addClass(ClassName.SHOW)
+          .addClass(showClass)
 
         this._element.style[dimension] = ''
 
@@ -201,8 +203,9 @@ const Collapse = (() => {
     }
 
     hide() {
+      const showClass = this._getShowClass()
       if (this._isTransitioning ||
-        !$(this._element).hasClass(ClassName.SHOW)) {
+        !$(this._element).hasClass(showClass)) {
         return
       }
 
@@ -221,7 +224,7 @@ const Collapse = (() => {
       $(this._element)
         .addClass(ClassName.COLLAPSING)
         .removeClass(ClassName.COLLAPSE)
-        .removeClass(ClassName.SHOW)
+        .removeClass(showClass)
 
       if (this._triggerArray.length) {
         for (let i = 0; i < this._triggerArray.length; i++) {
@@ -316,7 +319,7 @@ const Collapse = (() => {
 
     _addAriaAndCollapsedClass(element, triggerArray) {
       if (element) {
-        const isOpen = $(element).hasClass(ClassName.SHOW)
+        const isOpen = $(element).hasClass(ClassName.SHOW) || $(element).hasClass(ClassName.FLEXSHOW)
 
         if (triggerArray.length) {
           $(triggerArray)
@@ -326,6 +329,19 @@ const Collapse = (() => {
       }
     }
 
+    _getShowClass() {
+      const tabClass = this._element.classList
+      let useFlex = $(this._element).css('display') === 'flex'
+      // Detect flex in used classes
+      for (let i = 0; i < tabClass.length; i++) {
+        const tmpDisplay = $('<div></div>').addClass(tabClass[i]).css('display')
+        if (tmpDisplay === 'flex') {
+          useFlex = true
+          break
+        }
+      }
+      return !useFlex ? ClassName.SHOW : ClassName.FLEXSHOW
+    }
 
     // static
 

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -88,7 +88,8 @@ const Collapse = (() => {
         }
       }
 
-      this._parent = this._config.parent ? this._getParent() : null
+      this._parent    = this._config.parent ? this._getParent() : null
+      this._showClass = this._getShowClass()
 
       if (!this._config.parent) {
         this._addAriaAndCollapsedClass(this._element, this._triggerArray)
@@ -114,7 +115,7 @@ const Collapse = (() => {
     // public
 
     toggle() {
-      if ($(this._element).hasClass(ClassName.SHOW) || $(this._element).hasClass(ClassName.FLEXSHOW)) {
+      if ($(this._element).hasClass(this._showClass)) {
         this.hide()
       } else {
         this.show()
@@ -122,9 +123,8 @@ const Collapse = (() => {
     }
 
     show() {
-      const showClass = this._getShowClass()
       if (this._isTransitioning ||
-        $(this._element).hasClass(showClass)) {
+        $(this._element).hasClass(this._showClass)) {
         return
       }
 
@@ -178,7 +178,7 @@ const Collapse = (() => {
         $(this._element)
           .removeClass(ClassName.COLLAPSING)
           .addClass(ClassName.COLLAPSE)
-          .addClass(showClass)
+          .addClass(this._showClass)
 
         this._element.style[dimension] = ''
 
@@ -203,9 +203,8 @@ const Collapse = (() => {
     }
 
     hide() {
-      const showClass = this._getShowClass()
       if (this._isTransitioning ||
-        !$(this._element).hasClass(showClass)) {
+        !$(this._element).hasClass(this._showClass)) {
         return
       }
 
@@ -215,8 +214,7 @@ const Collapse = (() => {
         return
       }
 
-      const dimension       = this._getDimension()
-
+      const dimension                = this._getDimension()
       this._element.style[dimension] = `${this._element.getBoundingClientRect()[dimension]}px`
 
       Util.reflow(this._element)
@@ -224,7 +222,7 @@ const Collapse = (() => {
       $(this._element)
         .addClass(ClassName.COLLAPSING)
         .removeClass(ClassName.COLLAPSE)
-        .removeClass(showClass)
+        .removeClass(this._showClass)
 
       if (this._triggerArray.length) {
         for (let i = 0; i < this._triggerArray.length; i++) {
@@ -264,6 +262,16 @@ const Collapse = (() => {
 
     setTransitioning(isTransitioning) {
       this._isTransitioning = isTransitioning
+    }
+
+    update() {
+      if ($(this._element).hasClass(this._showClass)) {
+        $(this._element).removeClass(this._showClass)
+        this._showClass = this._getShowClass()
+        $(this._element).addClass(this._showClass)
+      } else {
+        this._showClass = this._getShowClass()
+      }
     }
 
     dispose() {
@@ -331,15 +339,28 @@ const Collapse = (() => {
 
     _getShowClass() {
       const tabClass = this._element.classList
-      let useFlex = $(this._element).css('display') === 'flex'
+
+      // Detect flex for inline style
+      let useFlex = $(this._element).css('display').indexOf('flex') !== -1
+
+      // Create a wrapper to hide our flex detection
+      const $tmpWrapper = $('<div class="d-none"></div>')
+      $tmpWrapper.insertAfter($(this._element))
+
+      const $tmpElem = $('<div></div>')
+      $tmpWrapper.append($tmpElem)
+
       // Detect flex in used classes
       for (let i = 0; i < tabClass.length; i++) {
-        const tmpDisplay = $('<div></div>').addClass(tabClass[i]).css('display')
-        if (tmpDisplay === 'flex') {
+        $tmpElem.addClass(tabClass[i])
+        const tmpDisplay = $tmpElem.css('display')
+        $tmpElem.removeClass(tabClass[i])
+        if (tmpDisplay.indexOf('flex') !== -1) {
           useFlex = true
           break
         }
       }
+      $tmpWrapper.remove()
       return !useFlex ? ClassName.SHOW : ClassName.FLEXSHOW
     }
 

--- a/js/tests/visual/collapse.html
+++ b/js/tests/visual/collapse.html
@@ -55,6 +55,22 @@
           </div>
         </div>
       </div>
+      <div class="row mt-2">
+        <div class="col-sm-12">
+          <p>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+              Show collapse element with flex
+            </button>
+          </p>
+          <div class="collapse row" id="collapseExample">
+            <div class="col-sm-5">
+              <div class="card card-block">
+                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -20,13 +20,15 @@
 }
 
 tr {
-  &.collapse.show {
+  &.collapse.show,
+  &.collapse.flexshow {
     display: table-row;
   }
 }
 
 tbody {
-  &.collapse.show {
+  &.collapse.show,
+  &.collapse.flexshow {
     display: table-row-group;
   }
 }

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -14,6 +14,9 @@
   &.show {
     display: block;
   }
+  &.flexshow {
+    display: flex;
+  }
 }
 
 tr {


### PR DESCRIPTION
Detect if the element use flexbox, if it's the case add `.flexshow`

- [x] Add Visual test
- [x] Detect all posible flex values (inline-flex, flex, etc...)

We detect flex by creating hidden div(s) and we add each class to this hidden div to detect if this div is displayed in flex mode or not. 

We do that only when we call the constructor of Collapse plugins that's why I added an `update` method if the collapsible element change, to detect once again the appropriate show class

Close : #22600

/CC : @mdo