### PR TITLE
Some .navbar .dropdown-menu optimisation

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -251,21 +251,6 @@ const Dropdown = (($) => {
       return $(this._element).closest('.navbar').length > 0
     }
 
-    _navbarPositioning() {
-      const $parentNavbar = $(this._element).closest('.navbar')
-      if ($(this._menu).hasClass(ClassName.MENURIGHT)) {
-        if (!$parentNavbar.hasClass('navbar-expand')) {
-          return {
-            position: 'static',
-            transform: '',
-            float: 'none'
-          }
-        }
-      }
-
-      return {}
-    }
-
     _getPopperConfig() {
       const popperConfig = {
         placement : this._getPlacement(),

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -165,11 +165,6 @@
             left: auto; // Reset the default from `.dropdown-menu`
           }
 
-          .dropdown-menu-left {
-            right: auto;
-            left: 0;
-          }
-
           .nav-link {
             padding-right: .5rem;
             padding-left: .5rem;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -141,13 +141,6 @@
 
     &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
-        .navbar-nav {
-          .dropdown-menu {
-            position: static;
-            float: none;
-          }
-        }
-
         > .container,
         > .container-fluid {
           padding-right: 0;


### PR DESCRIPTION
We do not need [those css rules](https://github.com/twbs/bootstrap/blob/ca60fe4f23581d62b69b2d040bbd6aa5afd7ade6/scss/_navbar.scss#L144) because are inherited from [here](https://github.com/twbs/bootstrap/blob/ca60fe4f23581d62b69b2d040bbd6aa5afd7ade6/scss/_navbar.scss#L79).

Also, I think we do not need `.dropdown-menu-left`, because this is inherited from [`.dropdown-menu`](https://github.com/twbs/bootstrap/blob/ca60fe4f23581d62b69b2d040bbd6aa5afd7ade6/scss/_dropdown.scss#L38).

I'm not sure about the existence of member `_navbarPositioning()`, those rules are already aplyed from css.

### Test plan
- `npm run js-compile` & `js-minify`
- `npm run css-compile` & `css-prefix` & `css-minify`
- https://codepen.io/zalog/pen/RgWKKo

cc: #22707