### PR TITLE
Use css to display Dropdown in Navbar

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -186,6 +186,7 @@ const Dropdown = (($) => {
     }
 
     update() {
+      this._inNavbar = this._detectNavbar()
       if (this._popper !== null) {
         this._popper.scheduleUpdate()
       }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -251,21 +251,6 @@ const Dropdown = (($) => {
       return $(this._element).closest('.navbar').length > 0
     }
 
-    _navbarPositioning() {
-      const $parentNavbar = $(this._element).closest('.navbar')
-      if ($(this._menu).hasClass(ClassName.MENURIGHT)) {
-        if (!$parentNavbar.hasClass('navbar-expand')) {
-          return {
-            position: 'static',
-            transform: '',
-            float: 'none'
-          }
-        }
-      }
-
-      return {}
-    }
-
     _getPopperConfig() {
       const popperConfig = {
         placement : this._getPlacement(),

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -96,10 +96,11 @@ const Dropdown = (($) => {
   class Dropdown {
 
     constructor(element, config) {
-      this._element = element
-      this._popper  = null
-      this._config = this._getConfig(config)
-      this._menu = this._getMenuElement()
+      this._element  = element
+      this._popper   = null
+      this._config   = this._getConfig(config)
+      this._menu     = this._getMenuElement()
+      this._inNavbar = this._detectNavbar()
 
       this._addEventListeners()
     }
@@ -153,17 +154,7 @@ const Dropdown = (($) => {
           element = parent
         }
       }
-      this._popper = new Popper(element, this._menu, {
-        placement : this._getPlacement(),
-        modifiers : {
-          offset : {
-            offset : this._config.offset
-          },
-          flip : {
-            enabled : this._config.flip
-          }
-        }
-      })
+      this._popper = new Popper(element, this._menu, this._getPopperConfig())
 
       // if this is a touch-enabled device we add extra
       // empty mouseover listeners to the body's immediate children;
@@ -253,8 +244,52 @@ const Dropdown = (($) => {
       } else if ($(this._menu).hasClass(ClassName.MENURIGHT)) {
         placement = AttachmentMap.BOTTOMEND
       }
-
       return placement
+    }
+
+    _detectNavbar() {
+      return $(this._element).closest('.navbar').length > 0
+    }
+
+    _navbarPositioning() {
+      const $parentNavbar = $(this._element).closest('.navbar')
+      if ($(this._menu).hasClass(ClassName.MENURIGHT)) {
+        if (!$parentNavbar.hasClass('navbar-expand')) {
+          return {
+            position: 'static',
+            transform: '',
+            float: 'none'
+          }
+        }
+      }
+
+      return {}
+    }
+
+    _getPopperConfig() {
+      const popperConfig = {
+        placement : this._getPlacement(),
+        modifiers : {
+          offset : {
+            offset : this._config.offset
+          },
+          flip : {
+            enabled : this._config.flip
+          }
+        }
+      }
+
+      if (this._inNavbar) {
+        popperConfig.modifiers.AfterApplyStyle = {
+          enabled: true,
+          order: 901, // ApplyStyle order + 1
+          fn: () => {
+            // reset Popper styles
+            $(this._menu).attr('style', '')
+          }
+        }
+      }
+      return popperConfig
     }
 
     // static

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -141,13 +141,6 @@
 
     &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
-        .navbar-nav {
-          .dropdown-menu {
-            position: static;
-            float: none;
-          }
-        }
-
         > .container,
         > .container-fluid {
           padding-right: 0;
@@ -170,11 +163,6 @@
           .dropdown-menu-right {
             right: 0;
             left: auto; // Reset the default from `.dropdown-menu`
-          }
-
-          .dropdown-menu-left {
-            right: auto;
-            left: 0;
           }
 
           .nav-link {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -77,9 +77,8 @@
   }
 
   .dropdown-menu {
-    position: static !important;
+    position: static;
     float: none;
-    transform: unset !important;
   }
 }
 
@@ -142,6 +141,13 @@
 
     &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
+        .navbar-nav {
+          .dropdown-menu {
+            position: static;
+            float: none;
+          }
+        }
+
         > .container,
         > .container-fluid {
           padding-right: 0;
@@ -158,8 +164,17 @@
           flex-direction: row;
 
           .dropdown-menu {
-            position: absolute !important;
-            top: 100% !important;
+            position: absolute;
+          }
+
+          .dropdown-menu-right {
+            right: 0;
+            left: auto; // Reset the default from `.dropdown-menu`
+          }
+
+          .dropdown-menu-left {
+            right: auto;
+            left: 0;
           }
 
           .nav-link {


### PR DESCRIPTION
In this PR, we remove CSS aplied by Popper.js (only for Dropdown in navbar) to let our CSS do the job.

We detect a weird behavior, If we have a navbar in 100% width container an horizontal scroll appear.
See this CodePen : https://codepen.io/zalog/pen/Rgrbod (first Navbar)

I'm not sure if it's really a bad behavior, maybe @mdo can help us in this use case ? 

Thank you to @zalog to review/improve my first commit 👍 

Close : #22699
