### PR TITLE
Use the box-shadow mixin for .btn on focus

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -22,7 +22,7 @@
   &:focus,
   &.focus {
     outline: 0;
-    box-shadow: $btn-focus-box-shadow;
+    @include box-shadow($btn-focus-box-shadow);
   }
 
   // Disabled comes first so active can properly restyle


### PR DESCRIPTION
Apply the box-shadow mixin to .btn:focus as well so it can be customizable by $enable-shadows.