### PR TITLE
Rename for consistency `$table-sm-cell-padding`, `$table-bg-accent`, `$table-bg-hover`, `$table-bg-active`, `$table-inverse-bg-accent`, `$table-inverse-bg-hover` to `$table-cell-padding-sm`, `$table-accent-bg`, `$table-hover-bg`, `$table-active-bg`, `$table-inverse-accent-bg`, `$table-inverse-hover-bg`, respectively (#22414)

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -37,7 +37,7 @@
 .table-sm {
   th,
   td {
-    padding: $table-sm-cell-padding;
+    padding: $table-cell-padding-sm;
   }
 }
 
@@ -69,7 +69,7 @@
 
 .table-striped {
   tbody tr:nth-of-type(odd) {
-    background-color: $table-bg-accent;
+    background-color: $table-accent-bg;
   }
 }
 
@@ -81,7 +81,7 @@
 .table-hover {
   tbody tr {
     @include hover {
-      background-color: $table-bg-hover;
+      background-color: $table-hover-bg;
     }
   }
 }
@@ -93,7 +93,7 @@
 // inheritance to nested tables.
 
 // Generate the contextual variants
-@include table-row-variant(active, $table-bg-active);
+@include table-row-variant(active, $table-active-bg);
 @include table-row-variant(success, $state-success-bg);
 @include table-row-variant(info, $state-info-bg);
 @include table-row-variant(warning, $state-warning-bg);
@@ -134,14 +134,14 @@
 
   &.table-striped {
     tbody tr:nth-of-type(odd) {
-      background-color: $table-inverse-bg-accent;
+      background-color: $table-inverse-accent-bg;
     }
   }
 
   &.table-hover {
     tbody tr {
       @include hover {
-        background-color: $table-inverse-bg-hover;
+        background-color: $table-inverse-hover-bg;
       }
     }
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -313,12 +313,12 @@ $list-inline-padding: 5px !default;
 // Customizes the `.table` component with basic values, each used across all table variations.
 
 $table-cell-padding:            .75rem !default;
-$table-sm-cell-padding:         .3rem !default;
+$table-cell-padding-sm:         .3rem !default;
 
 $table-bg:                      transparent !default;
-$table-bg-accent:               rgba($black,.05) !default;
-$table-bg-hover:                rgba($black,.075) !default;
-$table-bg-active:               $table-bg-hover !default;
+$table-accent-bg:               rgba($black,.05) !default;
+$table-hover-bg:                rgba($black,.075) !default;
+$table-active-bg:               $table-hover-bg !default;
 
 $table-border-width:            $border-width !default;
 $table-border-color:            $gray-lighter !default;
@@ -327,8 +327,8 @@ $table-head-bg:                 $gray-lighter !default;
 $table-head-color:              $gray !default;
 
 $table-inverse-bg:              $gray-dark !default;
-$table-inverse-bg-accent:       rgba($white, .05) !default;
-$table-inverse-bg-hover:        rgba($white, .075) !default;
+$table-inverse-accent-bg:       rgba($white, .05) !default;
+$table-inverse-hover-bg:        rgba($white, .075) !default;
 $table-inverse-border-color:    lighten($gray-dark, 7.5%) !default;
 $table-inverse-color:           $body-bg !default;
 


### PR DESCRIPTION
https://github.com/twbs/bootstrap/issues/22414