### PR TITLE
(#22414) Rename for consistency `$input-bg-disabled`, `$input-bg-focus`, `$input-border-color-focus`, `$input-box-shadow-focus`, `$input-color-focus`, `$input-color-placeholder` to `$input-disabled-bg`, `$input-focus-bg`, `$input-focus-border-color`, `$input-focus-box-shadow`, `$input-focus-color`, `$input-placeholder-color`, respectively

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -42,7 +42,7 @@
 
   // Placeholder
   &::placeholder {
-    color: $input-color-placeholder;
+    color: $input-placeholder-color;
     // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
     opacity: 1;
   }
@@ -54,7 +54,7 @@
   // don't honor that edge case; we style them as disabled anyway.
   &:disabled,
   &[readonly] {
-    background-color: $input-bg-disabled;
+    background-color: $input-disabled-bg;
     // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.
     opacity: 1;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -393,7 +393,7 @@ $btn-transition:                 all .2s ease-in-out !default;
 // Forms
 
 $input-bg:                       $white !default;
-$input-bg-disabled:              $gray-lighter !default;
+$input-disabled-bg:              $gray-lighter !default;
 
 $input-color:                    $gray !default;
 $input-border-color:             rgba($black,.15) !default;
@@ -404,12 +404,12 @@ $input-border-radius:            $border-radius !default;
 $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
-$input-bg-focus:                 $input-bg !default;
-$input-border-color-focus:       lighten($brand-primary, 25%) !default;
-$input-box-shadow-focus:         $input-box-shadow, rgba($input-border-color-focus, .6) !default;
-$input-color-focus:              $input-color !default;
+$input-focus-bg:                 $input-bg !default;
+$input-focus-border-color:       lighten($brand-primary, 25%) !default;
+$input-focus-box-shadow:         $input-box-shadow, rgba($input-focus-border-color, .6) !default;
+$input-focus-color:              $input-color !default;
 
-$input-color-placeholder:        $gray-light !default;
+$input-placeholder-color:        $gray-light !default;
 
 $input-height:                   (($font-size-base * $input-btn-line-height) + ($input-btn-padding-y * 2)) !default;
 $input-height-lg:                (($font-size-lg * $input-btn-line-height-lg) + ($input-btn-padding-y-lg * 2)) !default;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -46,10 +46,10 @@
 // contrast against a dark gray background.
 @mixin form-control-focus() {
   &:focus {
-    color: $input-color-focus;
-    background-color: $input-bg-focus;
-    border-color: $input-border-color-focus;
+    color: $input-focus-color;
+    background-color: $input-focus-bg;
+    border-color: $input-focus-border-color;
     outline: none;
-    @include box-shadow($input-box-shadow-focus);
+    @include box-shadow($input-focus-box-shadow);
   }
 }


### PR DESCRIPTION
https://github.com/twbs/bootstrap/issues/22414