### PR TITLE
(#22414) Renamed for consistency `$modal-dialog-sm-up-margin-y`, `$mo…

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -54,7 +54,7 @@
   background-clip: padding-box;
   border: $modal-content-border-width solid $modal-content-border-color;
   @include border-radius($border-radius-lg);
-  @include box-shadow($modal-content-xs-box-shadow);
+  @include box-shadow($modal-content-box-shadow-xs);
   // Remove focus outline from opened modal
   outline: 0;
 }
@@ -127,11 +127,11 @@
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     max-width: $modal-md;
-    margin: $modal-dialog-sm-up-margin-y auto;
+    margin: $modal-dialog-margin-y-sm-up auto;
   }
 
   .modal-content {
-    @include box-shadow($modal-content-sm-up-box-shadow);
+    @include box-shadow($modal-content-box-shadow-sm-up);
   }
 
   .modal-sm { max-width: $modal-sm; }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -758,15 +758,15 @@ $badge-pill-border-radius:    10rem !default;
 $modal-inner-padding:         15px !default;
 
 $modal-dialog-margin:         10px !default;
-$modal-dialog-sm-up-margin-y: 30px !default;
+$modal-dialog-margin-y-sm-up: 30px !default;
 
 $modal-title-line-height:     $line-height-base !default;
 
 $modal-content-bg:               $white !default;
 $modal-content-border-color:     rgba($black,.2) !default;
 $modal-content-border-width:     $border-width !default;
-$modal-content-xs-box-shadow:    0 3px 9px rgba($black,.5) !default;
-$modal-content-sm-up-box-shadow: 0 5px 15px rgba($black,.5) !default;
+$modal-content-box-shadow-xs:    0 3px 9px rgba($black,.5) !default;
+$modal-content-box-shadow-sm-up: 0 5px 15px rgba($black,.5) !default;
 
 $modal-backdrop-bg:           $black !default;
 $modal-backdrop-opacity:      .5 !default;


### PR DESCRIPTION
…dal-content-xs-box-shadow`, `$modal-content-sm-up-box-shadow`, to `$modal-dialog-margin-y-sm-up`, `$modal-content-box-shadow-xs`, `$modal-content-box-shadow-sm-up`, respectively

https://github.com/twbs/bootstrap/issues/22414