### PR TITLE
Modify caret mark behaviour wrt screen size

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -27,9 +27,17 @@
 // Just add .dropup after the standard .dropdown class and you're set.
 .dropup {
   .dropdown-toggle {
-    &::after {
-      border-top: 0;
-      border-bottom: $caret-width solid;
+    @media (max-width: 768px){
+      &::after {
+        border-top: 0;
+        border-bottom: $caret-width solid;
+      }
+    }
+    @media (min-width: 768px){
+      &::after {
+        border-top: 0;
+        border-bottom: $caret-width solid;
+      }
     }
   }
 }


### PR DESCRIPTION
Intended as a fix for #22786. I'm new here, so feel free to comment your issues. One issue from my side is that I hardcoded the value `768px` into the file. Is this fine or do I use the functions from `_breakpoints.scss`?