### PR TITLE
Add text-align to `<body>` so we can inherit it in `<th>`s

### DIFF
--- a/docs/4.0/content/reboot.md
+++ b/docs/4.0/content/reboot.md
@@ -24,7 +24,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 
 - The `box-sizing` is globally set on every element—including `*:before` and `*:after`, to `border-box`. This ensures that the declared width of element is never exceeded due to padding or border.
   - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach.
-- The `<body>` also sets a global `font-family` and `line-height`. This is inherited later by some form elements to prevent font inconsistencies.
+- The `<body>` also sets a global `font-family`, `line-height`, and `text-align`. This is inherited later by some form elements to prevent font inconsistencies.
 - For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
 
 ## Native font stack

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -48,6 +48,8 @@ article, aside, dialog, figcaption, figure, footer, header, hgroup, main, nav, s
 //
 // 1. Remove the margin in all browsers.
 // 2. As a best practice, apply a default `background-color`.
+// 3. Set an explicit initial text-align value so that we can later use the
+//    the `inherit` value on things like `<th>` elements.
 
 body {
   margin: 0; // 1
@@ -56,6 +58,7 @@ body {
   font-weight: $font-weight-base;
   line-height: $line-height-base;
   color: $body-color;
+  text-align: left; // 3
   background-color: $body-bg; // 2
 }
 
@@ -304,8 +307,9 @@ caption {
 }
 
 th {
-  // Matches default `<td>` alignment
-  text-align: left;
+  // Matches default `<td>` alignment by inheriting from the `<body>`, or the
+  // closest parent with a set `text-align`.
+  text-align: inherit;
 }
 
 


### PR DESCRIPTION
This sets an explicit `text-align` on the `<body>` element so we can use `inherit` to override the default `<th>` `text-align` value. Most browsers center this text, so we previously applied a specific `text-align: left` to the `<th>`s. That had a side effect of not responding in the same way as `<td>`s do when setting an alignment value on the `<table>`.

Fixes #22519.