### PR TITLE
Remove postcss-flexbugs-fixes

### DIFF
--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -35,7 +35,6 @@ module.exports = (ctx) => ({
         'Android >= 4',
         'Opera >= 12'
       ]
-    },
-    'postcss-flexbugs-fixes': {}
+    }
   }
 })

--- a/docs/4.0/getting-started/download.md
+++ b/docs/4.0/getting-started/download.md
@@ -15,7 +15,7 @@ toc: true
 <a href="{{ site.download.dist }}" class="btn btn-bd-purple" onclick="ga('send', 'event', 'Getting started', 'Download', 'Download Bootstrap');">Download Bootstrap</a>
 
 ## Source files
-**Want to compile Bootstrap with your project's asset pipeline?** Choose this option to download our source Sass, JavaScript, and documentation files. Requires a Sass compiler, [Autoprefixer](https://github.com/postcss/autoprefixer), [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes), and [some setup]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/build-tools/#tooling-setup).
+**Want to compile Bootstrap with your project's asset pipeline?** Choose this option to download our source Sass, JavaScript, and documentation files. Requires a Sass compiler, [Autoprefixer](https://github.com/postcss/autoprefixer), and [some setup]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/build-tools/#tooling-setup).
 
 <a href="{{ site.download.source }}" class="btn btn-bd-purple" onclick="ga('send', 'event', 'Getting started', 'Download', 'Download source');">Download source</a>
 
@@ -30,7 +30,7 @@ Skip the download and use the Bootstrap CDN to deliver Bootstrap's compiled CSS 
 
 ## Package managers
 
-Pull in Bootstrap's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Bootstrap will **require a Sass compiler, [Autoprefixer](https://github.com/postcss/autoprefixer), and [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes)** for a setup that matches our official compiled versions.
+Pull in Bootstrap's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Bootstrap will **require a Sass compiler and [Autoprefixer](https://github.com/postcss/autoprefixer)** for a setup that matches our official compiled versions.
 
 ### npm
 

--- a/docs/4.0/getting-started/webpack.md
+++ b/docs/4.0/getting-started/webpack.md
@@ -61,7 +61,7 @@ First, create your own `_custom.scss` and use it to override the [built-in custo
 @import "~bootstrap/scss/bootstrap";
 {% endhighlight %}
 
-For Bootstrap to compile, make sure you install and use the required loaders: [sass-loader](https://github.com/webpack-contrib/sass-loader), [postcss-loader](https://github.com/postcss/postcss-loader) with [Autoprefixer](https://github.com/postcss/autoprefixer#webpack) and [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes). With minimal setup, your webpack config should include this rule or similar:
+For Bootstrap to compile, make sure you install and use the required loaders: [sass-loader](https://github.com/webpack-contrib/sass-loader), [postcss-loader](https://github.com/postcss/postcss-loader) with [Autoprefixer](https://github.com/postcss/autoprefixer#webpack). With minimal setup, your webpack config should include this rule or similar:
 
 {% highlight js %}
   ...

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.14",
     "postcss-cli": "^4.0.0",
-    "postcss-flexbugs-fixes": "^3.0.0",
     "qunit-phantomjs-runner": "^2.3.0",
     "qunitjs": "^2.3.2",
     "shelljs": "^0.7.7",

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -197,7 +197,7 @@
 
     .card {
       display: flex;
-      flex: 1 0 0;
+      flex: 1 0 0%;
       flex-direction: column;
       margin-right: $card-deck-margin;
       margin-left: $card-deck-margin;
@@ -216,7 +216,7 @@
     flex-flow: row wrap;
 
     .card {
-      flex: 1 0 0;
+      flex: 1 0 0%;
 
       + .card {
         margin-left: 0;


### PR DESCRIPTION
This drops the dependency of postcss-flexbugs-fixes, removing it from our build process and docs. This undoes #19109, which originally fixed #18569. This PR also includes the changes to `_cards.scss` by @obinnangini in #22773.