### PR TITLE
Buttons cursor is not pointer / no-allowed

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -12,6 +12,7 @@
   vertical-align: middle;
   user-select: none;
   border: $input-btn-border-width solid transparent;
+  cursor: pointer;
   @include button-size($input-btn-padding-y, $input-btn-padding-x, $font-size-base, $input-btn-line-height, $btn-border-radius);
   @include transition($btn-transition);
 
@@ -28,6 +29,7 @@
   // Disabled comes first so active can properly restyle
   &.disabled,
   &:disabled {
+    cursor: not-allowed;
     opacity: .65;
     @include box-shadow(none);
   }

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -10,9 +10,9 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
+  cursor: pointer;
   user-select: none;
   border: $input-btn-border-width solid transparent;
-  cursor: pointer;
   @include button-size($input-btn-padding-y, $input-btn-padding-x, $font-size-base, $input-btn-line-height, $btn-border-radius);
   @include transition($btn-transition);
 


### PR DESCRIPTION
Buttons hover state for `btn` class does not have `cursor: pointer` or `cursor: not-allowed` as it used to be in v3.

Even for CSS spec `cursor: pointer` is primarily designed for links (`<a/>` tag) it is still very useful for modern web to have indication that this button is clickable via cursor change.

Optional: `cursor: not-allowed` is much less viable but to be consistent and keep backward compatibility it was added either.

It is possible to check difference here:
v3 http://getbootstrap.com/components/#btn-dropdowns
v4 https://v4-alpha.getbootstrap.com/components/buttons/ 