### PR TITLE
Fix modal overflow with our navbar documentation and fix typo

### DIFF
--- a/assets/scss/_component-examples.scss
+++ b/assets/scss/_component-examples.scss
@@ -285,6 +285,10 @@
   }
 }
 
+.modal.show {
+  z-index: 1072;
+}
+
 // Example tabbable tabs
 .bd-example-tabs .nav-tabs {
   margin-bottom: 1rem;

--- a/assets/scss/_component-examples.scss
+++ b/assets/scss/_component-examples.scss
@@ -287,7 +287,16 @@
 
 .modal.show {
   z-index: 1072;
+
+  .tooltip, .popover {
+    z-index: 1073;
+  }
 }
+
+.modal-backdrop {
+  z-index: 1071;
+}
+
 
 // Example tabbable tabs
 .bd-example-tabs .nav-tabs {

--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -226,10 +226,10 @@ When modals become too long for the user's viewport or device, they scroll indep
       </div>
       <div class="modal-body">
         <h5>Popover in a modal</h5>
-        <p>This <a href="#" role="button" class="btn btn-secondary popover-test" title="Popover title" data-content="Popover body content is set in this attribute.">button</a> triggers a popover on click.</p>
+        <p>This <a href="#" role="button" class="btn btn-secondary popover-test" title="Popover title" data-content="Popover body content is set in this attribute." data-container="#exampleModalPopovers">button</a> triggers a popover on click.</p>
         <hr>
         <h5>Tooltips in a modal</h5>
-        <p><a href="#" class="tooltip-test" title="Tooltip">This link</a> and <a href="#" class="tooltip-test" title="Tooltip">that link</a> have tooltips on hover.</p>
+        <p><a href="#" class="tooltip-test" title="Tooltip" data-container="#exampleModalPopovers">This link</a> and <a href="#" class="tooltip-test" title="Tooltip" data-container="#exampleModalPopovers">that link</a> have tooltips on hover.</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/docs/4.0/getting-started/webpack.md
+++ b/docs/4.0/getting-started/webpack.md
@@ -12,7 +12,7 @@ toc: true
 
 ## Importing JavaScript
 
-Import [Bootstrap's JavaScript](/getting-started/javascript/) by adding this line to your app's entry point (usally `index.js` or `app.js`):
+Import [Bootstrap's JavaScript](/getting-started/javascript/) by adding this line to your app's entry point (usually `index.js` or `app.js`):
 
 {% highlight js %}
 import 'bootstrap';


### PR DESCRIPTION
Some quick fix : 
- Typo: usally -> usually 
- Modal overflow with our documentation navbar see : 

![modal bootstrap - google chrome](https://user-images.githubusercontent.com/1689750/27263472-e2461700-5469-11e7-9ef0-24a1c71efe2f.jpg)

/CC @mdo
