### PR TITLE
Fix removed ".modal-open" in "body"

### DIFF
--- a/dist/js/bootstrap.js
+++ b/dist/js/bootstrap.js
@@ -2138,7 +2138,8 @@ var Modal = function ($) {
       this._element.setAttribute('aria-hidden', true);
       this._isTransitioning = false;
       this._showBackdrop(function () {
-        $(document.body).removeClass(ClassName.OPEN);
+        if ($('.modal:visible').length == 0)
+          $(document.body).removeClass(ClassName.OPEN);
         _this17._resetAdjustments();
         _this17._resetScrollbar();
         $(_this17._element).trigger(Event.HIDDEN);


### PR DESCRIPTION
When I close modal and another is open. Class ".modal-open" in "body" tag is removed

![ybkzjvjgqxs8kbvbxc8-sw](https://user-images.githubusercontent.com/1054403/27294236-288c62d2-5519-11e7-96cd-0258b349d3dd.png)

