### PR TITLE
Fix removed ".modal-open" in "body"

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -170,8 +170,9 @@
     var that = this
     this.$element.hide()
     this.backdrop(function () {
-      if ($('.modal:visible').length == 0)
+      if ($('.modal:visible').length === 0) {
         that.$body.removeClass('modal-open')
+      }
       that.resetAdjustments()
       that.resetScrollbar()
       that.$element.trigger('hidden.bs.modal')

--- a/js/modal.js
+++ b/js/modal.js
@@ -170,7 +170,8 @@
     var that = this
     this.$element.hide()
     this.backdrop(function () {
-      that.$body.removeClass('modal-open')
+      if ($('.modal:visible').length == 0)
+        that.$body.removeClass('modal-open')
       that.resetAdjustments()
       that.resetScrollbar()
       that.$element.trigger('hidden.bs.modal')


### PR DESCRIPTION
When I close modal and another is open. Class ".modal-open" in "body" tag is removed

![ybkzjvjgqxs8kbvbxc8-sw](https://user-images.githubusercontent.com/1054403/27294757-fd9d4b48-551a-11e7-92ea-55854a92acb9.png)