### PR TITLE
Add css-docs task to the dist build

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "maintenance-shrinkwrap": "npm shrinkwrap --dev && shx mv npm-shrinkwrap.json build/npm-shrinkwrap.json",
     "release-version": "node build/change-version.js",
     "release-zip": "cd dist/ && zip -r9 bootstrap-$npm_package_version-dist.zip * && shx mv bootstrap-$npm_package_version-dist.zip ..",
-    "dist": "npm-run-all --parallel css js",
+    "dist": "npm-run-all --parallel css js css-docs",
     "test": "npm-run-all dist js-test docs",
     "watch-css": "nodemon --ignore js/ --ignore dist/ -e scss -x \"npm run css && npm run css-docs\"",
     "watch-js": "nodemon --ignore scss/ --ignore js/dist/ --ignore dist/ -e js -x \"npm run js-compile-plugins\"",


### PR DESCRIPTION
I've been burned by some out of date docs CSS when working on Bootstrap. Adding this to the mix to ensure whenever we explicitly compile things, we include the docs, too.