### PR TITLE
Fix broken carousel in IE11

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -134,7 +134,7 @@
   li {
     position: relative;
     flex: 1 0 auto;
-    max-width: $carousel-indicator-width;
+    width: $carousel-indicator-width;
     height: $carousel-indicator-height;
     margin-right: $carousel-indicator-spacer;
     margin-left: $carousel-indicator-spacer;

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -34,17 +34,29 @@
 // CSS3 transforms when supported by the browser
 .carousel-item-next.carousel-item-left,
 .carousel-item-prev.carousel-item-right {
-  transform: translate3d(0, 0, 0);
+  transform: translateX(0);
+
+  @supports (transform-style: preserve-3d) {
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 .carousel-item-next,
 .active.carousel-item-right {
-  transform: translate3d(100%, 0, 0);
+  transform: translateX(100%);
+
+  @supports (transform-style: preserve-3d) {
+    transform: translate3d(100%, 0, 0);
+  }
 }
 
 .carousel-item-prev,
 .active.carousel-item-left {
-  transform: translate3d(-100%, 0, 0);
+  transform: translateX(-100%);
+
+  @supports (transform-style: preserve-3d) {
+    transform: translate3d(-100%, 0, 0);
+  }
 }
 
 


### PR DESCRIPTION
Two fixes here:

- First, IE11 doesn't do 3d transforms, so we need the fallback. Luckily, `@supports` is dope as hell.

- Second, IE11 has a weird bug with `flex: 1 0 auto` and `min-width` on flex items in a variable width parent container. The fix? Use `width` instead. See https://github.com/philipwalton/flexbugs/issues/128 for details.

Fixes #22882