### PR TITLE
Update carousel display settings

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -22,7 +22,7 @@
 .carousel-item.active,
 .carousel-item-next,
 .carousel-item-prev {
-  display: flex;
+  display: block;
 }
 
 .carousel-item-next,
@@ -133,7 +133,7 @@
 
   li {
     position: relative;
-    flex: 1 0 auto;
+    flex: 0 1 auto;
     width: $carousel-indicator-width;
     height: $carousel-indicator-height;
     margin-right: $carousel-indicator-spacer;


### PR DESCRIPTION
Use `display: block` since we're not really using any flex styles on the `.carousel-items` (only their controls and indicators). For the indicators, since moving to `width`, our indicators grow to fill available space, so we need to change `flex: 1 0 auto` to `flex: 0 1 auto` to prevent that.