### PR TITLE
Add .font-weight-light class, add !important to the classes

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -240,6 +240,7 @@ $font-size-lg:   1.25rem !default;
 $font-size-sm:   .875rem !default;
 $font-size-xs:   .75rem !default;
 
+$font-weight-light: light !default;
 $font-weight-normal: normal !default;
 $font-weight-bold: bold !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -240,7 +240,7 @@ $font-size-lg:   1.25rem !default;
 $font-size-sm:   .875rem !default;
 $font-size-xs:   .75rem !default;
 
-$font-weight-light: light !default;
+$font-weight-light: 300 !default;
 $font-weight-normal: normal !default;
 $font-weight-bold: bold !default;
 

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -28,9 +28,10 @@
 
 // Weight and italics
 
-.font-weight-normal { font-weight: $font-weight-normal; }
-.font-weight-bold   { font-weight: $font-weight-bold; }
-.font-italic        { font-style: italic; }
+.font-weight-light  { font-weight: $font-weight-light !important; }
+.font-weight-normal { font-weight: $font-weight-normal !important; }
+.font-weight-bold   { font-weight: $font-weight-bold !important; }
+.font-italic        { font-style: italic !important; }
 
 // Contextual colors
 


### PR DESCRIPTION
Adds the class and `!important` to match other utils.

Fixes #20528.