### PR TITLE
Remove the tap-highlight-color override

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -16,7 +16,6 @@
 // 4. Prevent adjustments of font size after orientation changes in IE on Windows Phone and in iOS.
 // 5. Setting @viewport causes scrollbars to overlap content in IE11 and Edge, so
 //    we force a non-overlapping, non-auto-hiding scrollbar to counteract.
-// 6. Change the default tap highlight to be completely transparent in iOS.
 
 *,
 *::before,
@@ -30,7 +29,6 @@ html {
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
   -ms-overflow-style: scrollbar; // 5
-  -webkit-tap-highlight-color: rgba($black, 0); // 6
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.


### PR DESCRIPTION
Fixes #19709.

We've long removed the tap highlight, but that takes away from some decent accessibility friendliness. This removes that code so that the highlight is restored to tap targets. It only appears on the tap, disappearing after you release.

/x-ref: https://github.com/necolas/normalize.css/issues/23 where they discuss it's removal in https://github.com/necolas/normalize.css/commit/09be23f8320602edd343e55bbaf4ebc02550b1cc. I'm guessing we just left our implementation intact.