### PR TITLE
Remove box-shadow from .btn-link:focus

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -84,6 +84,7 @@ fieldset[disabled] a.btn {
   &:focus,
   &:active {
     border-color: transparent;
+    box-shadow: none;
   }
   @include hover {
     border-color: transparent;


### PR DESCRIPTION
When focused, these buttons styled as links still give good visible focus indication through the underline, so this should not be a concern.

Closes #22655