### PR TITLE
Fixing docs example in input-group section

### DIFF
--- a/docs/4.0/components/input-group.md
+++ b/docs/4.0/components/input-group.md
@@ -123,7 +123,7 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
   </div>
   <div class="col-lg-6">
     <div class="input-group">
-      <input type="text" class="form-control" placeholder="Search for..." aria-label="Search for...>
+      <input type="text" class="form-control" placeholder="Search for..." aria-label="Search for...">
       <span class="input-group-btn">
         <button class="btn btn-secondary" type="button">Go!</button>
       </span>


### PR DESCRIPTION
One of the examples in the Input Group -> Button Addons section was broken because of a missing quote.
Before:
![image](https://user-images.githubusercontent.com/10811255/27933538-e46cefd6-626f-11e7-876b-61a1b1ccf48a.png)

After:
![image](https://user-images.githubusercontent.com/10811255/27933548-efad9026-626f-11e7-85bf-bd41a56cdcbf.png)
