### PR TITLE
Modal - prevent bubbling of [esc] when closing

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -151,7 +151,11 @@
   Modal.prototype.escape = function () {
     if (this.isShown && this.options.keyboard) {
       this.$element.on('keydown.dismiss.bs.modal', $.proxy(function (e) {
-        e.which == 27 && this.hide()
+        if (e.which == 27) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.hide();
+        }
       }, this))
     } else if (!this.isShown) {
       this.$element.off('keydown.dismiss.bs.modal')


### PR DESCRIPTION
This is also fixed in version 4. 