### PR TITLE
Remove ::first-letter and ::first-line selectors from print styles

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -12,15 +12,20 @@
   @media print {
     *,
     *::before,
-    *::after,
-    p::first-letter,
-    div::first-letter,
-    blockquote::first-letter,
-    li::first-letter,
-    p::first-line,
-    div::first-line,
-    blockquote::first-line,
-    li::first-line {
+    *::after {
+      // Bootstrap specific; comment the following selectors out
+      // as we don't set any shadow on first line/letter in Bootstrap
+      // and these selectors trigger a nasty rendering bug in current Chrome
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=739800
+      // p::first-letter,
+      // div::first-letter,
+      // blockquote::first-letter,
+      // li::first-letter,
+      // p::first-line,
+      // div::first-line,
+      // blockquote::first-line,
+      // li::first-line
+
       // Bootstrap specific; comment out `color` and `background`
       //color: #000 !important; // Black prints faster:
                                 //   http://www.sanbeiji.com/archives/953

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -13,19 +13,6 @@
     *,
     *::before,
     *::after {
-      // Bootstrap specific; comment the following selectors out
-      // as we don't set any shadow on first line/letter in Bootstrap
-      // and these selectors trigger a nasty rendering bug in current Chrome
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=739800
-      // p::first-letter,
-      // div::first-letter,
-      // blockquote::first-letter,
-      // li::first-letter,
-      // p::first-line,
-      // div::first-line,
-      // blockquote::first-line,
-      // li::first-line
-
       // Bootstrap specific; comment out `color` and `background`
       //color: #000 !important; // Black prints faster:
                                 //   http://www.sanbeiji.com/archives/953


### PR DESCRIPTION
Bootstrap itself doesn't use any `::first-letter` or `::first-line`
styles. These selectors also cause(d) problems in IE11 (see
https://github.com/h5bp/html5-boilerplate/pull/1799) and currently cause
a nasty rendering bug in Chrome where the first letter is vertically
shifted (see https://github.com/twbs/bootstrap/issues/21771)

Closes https://github.com/twbs/bootstrap/issues/21771