### PR TITLE
Input Group Addon add option to configure `$input-group-addon-color`

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -71,7 +71,7 @@
   font-size: $font-size-base; // Match inputs
   font-weight: $font-weight-normal;
   line-height: $input-btn-line-height;
-  color: $input-color;
+  color: $input-group-addon-color;
   text-align: center;
   background-color: $input-group-addon-bg;
   border: $input-btn-border-width solid $input-group-addon-border-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -397,6 +397,7 @@ $form-check-inline-margin-x: .75rem !default;
 
 $form-group-margin-bottom:       1rem !default;
 
+$input-group-addon-color:        $input-color !default;
 $input-group-addon-bg:           $gray-200 !default;
 $input-group-addon-border-color: $input-border-color !default;
 


### PR DESCRIPTION
We can set `$input-group-addon-bg` but can't set `$input-group-addon-color`. This is useful if you have a combination of dark background addon's and light background inputs or vice versa.