### PR TITLE
Start testing on Node v8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ git:
   depth: 3
 node_js:
   - "4"
-  - "7"
+  - "8"
 before_install:
-  - if [[ `npm -v` != 4* ]]; then npm install -g npm@4; fi
+  - if [[ `npm -v` != 5* ]]; then npm install -g npm@5; fi
   - "export TRAVIS_COMMIT_MSG=\"`git log --format=%B --no-merges -n 1`\""
   - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip browser\]'; export TWBS_DO_BROWSER=$?; true
 install:


### PR DESCRIPTION
Bootstrap informally supports **the last two LTS releases and the current release** of Node. v7 is in maintenance-only mode and v8 (the current release) will begin LTS in October 2017, so this PR moves testing from v7 to v8. v4 is in maintenance-only mode, but is currently being retained for legacy support (as one of the last two LTS releases). Bootstrap's v4 support will likely be deprecated in October 2017. See https://github.com/nodejs/LTS for more information.  