### PR TITLE
Docs fixes for badges in buttons

### DIFF
--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -41,7 +41,7 @@ Note that depending on how they are used, badges may be confusing for users of s
 Unless the context is clear (as with the "Notifications" example, where it is understood that the "4" is the number of notifications), consider including additional context with a visually hidden piece of additional text.
 
 {% example html %}
-<button class="btn">
+<button class="btn btn-primary">
   Profile <span class="badge badge-light">9</span>
   <span class="sr-only">unread messages</span>
 </button>

--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -30,33 +30,21 @@ Badges scale to match the size of the immediate parent element by using relative
 
 Badges can be used as part of links or buttons to provide a counter.
 
-<div class="bd-example">
-<button class="btn">
-  Notifications <span class="badge badge-secondary">4</span>
+{% example html %}
+<button class="btn btn-primary">
+  Notifications <span class="badge badge-light">4</span>
 </button>
-</div>
+{% endexample %}
 
-{% highlight html %}
-<button class="btn">
-  Notifications <span class="badge badge-secondary">4</span>
-</button>
-{% endhighlight %}
 
 Note that depending on how they are used, badges may be confusing for users of screen readers and similar assistive technologies. While the styling of badges provides a visual cue as to their purpose, these users will simply be presented with the content of the badge. Depending on the specific situation, these badges may seem like random additional words or numbers at the end of a sentence, link or button. Unless the context is clear (as with the "Notifications" example, where it is arguably understandable that the "4" gives a count of the number of notifications), consider including additional context – for instance using a visually hidden piece of additional text.
 
-<div class="bd-example">
+{% example html %}
 <button class="btn">
-  Profile <span class="badge badge-secondary">9</span>
+  Profile <span class="badge badge-light">9</span>
   <span class="sr-only">unread messages</span>
 </button>
-</div>
-
-{% highlight html %}
-<button class="btn">
-  Profile <span class="badge badge-secondary">9</span>
-  <span class="sr-only">unread messages</span>
-</button>
-{% endhighlight %}
+{% endexample %}
 
 ## Contextual variations
 

--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -36,8 +36,9 @@ Badges can be used as part of links or buttons to provide a counter.
 </button>
 {% endexample %}
 
+Note that depending on how they are used, badges may be confusing for users of screen readers and similar assistive technologies. While the styling of badges provides a visual cue as to their purpose, these users will simply be presented with the content of the badge. Depending on the specific situation, these badges may seem like random additional words or numbers at the end of a sentence, link, or button.
 
-Note that depending on how they are used, badges may be confusing for users of screen readers and similar assistive technologies. While the styling of badges provides a visual cue as to their purpose, these users will simply be presented with the content of the badge. Depending on the specific situation, these badges may seem like random additional words or numbers at the end of a sentence, link or button. Unless the context is clear (as with the "Notifications" example, where it is arguably understandable that the "4" gives a count of the number of notifications), consider including additional context – for instance using a visually hidden piece of additional text.
+Unless the context is clear (as with the "Notifications" example, where it is understood that the "4" is the number of notifications), consider including additional context with a visually hidden piece of additional text.
 
 {% example html %}
 <button class="btn">


### PR DESCRIPTION
This corrects some changes from #23060:

- Buttons must have a base and modifier class. I've added `.btn-primary` to fix that.
- Given the primary buttons, I've changed the badges to `.badge-light` for contrast.
- `.bd-example` and `{% highlight %}` don't need to be separate, so I've combined them with our `{% example %}` blocks designed for these situations.
- I've tweaked some docs content: added a serial comma, broke apart a rather large paragraph, and consolidated some text.

/cc @patrickhlauke 