### PR TITLE
Fix #23013: Add boder-top:0 in .list-group-flush .list-group-item

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -89,6 +89,7 @@
     border-bottom: 0;
     border-left: 0;
     border-radius: 0;
+
     &:first-child {
       border-top: 0;
     }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -85,9 +85,9 @@
 
 .list-group-flush {
   .list-group-item {
+    border-top: 0;
     border-right: 0;
     border-left: 0;
-    border-top: 0;
     border-radius: 0;
   }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -89,6 +89,9 @@
     border-bottom: 0;
     border-left: 0;
     border-radius: 0;
+    &:first-child {
+      border-top: 0;
+    }
   }
 
   &:first-child {

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -87,6 +87,7 @@
   .list-group-item {
     border-right: 0;
     border-left: 0;
+    border-top: 0;
     border-radius: 0;
   }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -85,8 +85,8 @@
 
 .list-group-flush {
   .list-group-item {
-    border-top: 0;
     border-right: 0;
+    border-bottom: 0;
     border-left: 0;
     border-radius: 0;
   }


### PR DESCRIPTION
Fixes #23013. I have added `boder-top:0` in **file _list-group.scss** in class `.list-group-flush .list-group-item` this isssue only shows in chrome browser. 