### PR TITLE
fix popover arrow computations

### DIFF
--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -51,32 +51,32 @@ Four options are available: top, right, bottom, and left aligned.
 
 <div class="bd-example bd-example-popover-static">
   <div class="popover bs-popover-top bs-popover-top-docs">
-    <div class="arrow"></div>
     <h3 class="popover-header">Popover top</h3>
+	<div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
   <div class="popover bs-popover-right bs-popover-right-docs">
-    <div class="arrow"></div>
     <h3 class="popover-header">Popover right</h3>
+	<div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
   <div class="popover bs-popover-bottom bs-popover-bottom-docs">
-    <div class="arrow"></div>
     <h3 class="popover-header">Popover bottom</h3>
+	<div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
   </div>
 
   <div class="popover bs-popover-left bs-popover-left-docs">
-    <div class="arrow"></div>
     <h3 class="popover-header">Popover left</h3>
+	<div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>

--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -52,7 +52,7 @@ Four options are available: top, right, bottom, and left aligned.
 <div class="bd-example bd-example-popover-static">
   <div class="popover bs-popover-top bs-popover-top-docs">
     <h3 class="popover-header">Popover top</h3>
-	<div class="arrow"></div>
+    <div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
@@ -60,7 +60,7 @@ Four options are available: top, right, bottom, and left aligned.
 
   <div class="popover bs-popover-right bs-popover-right-docs">
     <h3 class="popover-header">Popover right</h3>
-	<div class="arrow"></div>
+    <div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
@@ -68,7 +68,7 @@ Four options are available: top, right, bottom, and left aligned.
 
   <div class="popover bs-popover-bottom bs-popover-bottom-docs">
     <h3 class="popover-header">Popover bottom</h3>
-	<div class="arrow"></div>
+    <div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
@@ -76,7 +76,7 @@ Four options are available: top, right, bottom, and left aligned.
 
   <div class="popover bs-popover-left bs-popover-left-docs">
     <h3 class="popover-header">Popover left</h3>
-	<div class="arrow"></div>
+    <div class="arrow"></div>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -30,8 +30,8 @@ const Popover = (($) => {
     trigger   : 'click',
     content   : '',
     template  : '<div class="popover" role="tooltip">'
-              + '<div class="arrow"></div>'
               + '<h3 class="popover-header"></h3>'
+              + '<div class="arrow"></div>'
               + '<div class="popover-body"></div></div>'
   })
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -122,14 +122,11 @@
 
     // This will remove the popover-header's border just below the arrow
 
-    .popover-header::before {
-      position: absolute;
+    .popover-header:not(:empty) + .arrow:after {
       top: -($popover-arrow-width);
-      left: 50%;
-      display: block;
       margin-left: -($popover-arrow-width + $popover-border-width);
       content: "";
-      border: ($popover-arrow-width + $popover-border-width) solid transparent;
+      border-width: ($popover-arrow-width + $popover-border-width);
       border-top-width: 0;
       border-bottom-color: $popover-header-bg;
     }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -122,7 +122,7 @@
 
     // This will remove the popover-header's border just below the arrow
 
-    .popover-header:not(:empty) + .arrow:after {
+    .popover-header:not(:empty) + .arrow::after {
       top: -($popover-arrow-width);
       margin-left: -($popover-arrow-width + $popover-border-width);
       content: "";

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -20,7 +20,7 @@
 
   // Arrows
   //
-  // .arrow is outer, .arrow::after is inner
+  // .arrow:before is outer, .arrow::after is inner
 
   .arrow {
     position: absolute;
@@ -41,9 +41,10 @@
     content: "";
     border-width: $popover-arrow-outer-width;
   }
+
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-outer-width;
+    border-width: $popover-arrow-width;
   }
 
   // Popover directions
@@ -57,18 +58,17 @@
 
     .arrow::before,
     .arrow::after {
+      top: 100%;
       border-bottom-width: 0;
     }
 
     .arrow::before {
-      bottom: -$popover-arrow-outer-width;
-      margin-left: -($popover-arrow-outer-width - 5);
+      margin-left: -($popover-arrow-outer-width);
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: -($popover-arrow-outer-width - 1);
-      margin-left: -($popover-arrow-outer-width - 5);
+      margin-left: -$popover-arrow-width;
       border-top-color: $popover-arrow-color;
     }
   }
@@ -82,17 +82,17 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -($popover-arrow-outer-width - 3);
+      right: 100%;
       border-left-width: 0;
     }
 
     .arrow::before {
-      left: -$popover-arrow-outer-width;
+      margin-top: -($popover-arrow-outer-width);
       border-right-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      left: -($popover-arrow-outer-width - 1);
+      margin-top: -$popover-arrow-width;
       border-right-color: $popover-arrow-color;
     }
   }
@@ -106,30 +106,32 @@
 
     .arrow::before,
     .arrow::after {
-      margin-left: -($popover-arrow-width - 3);
+      bottom: 100%;
       border-top-width: 0;
     }
 
     .arrow::before {
-      top: -$popover-arrow-outer-width;
+      margin-left: -($popover-arrow-outer-width);
       border-bottom-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      top: -($popover-arrow-outer-width - 1);
+      margin-left: -($popover-arrow-width);
       border-bottom-color: $popover-arrow-color;
     }
 
     // This will remove the popover-header's border just below the arrow
+
     .popover-header::before {
       position: absolute;
-      top: 0;
+      top: -($popover-arrow-width);
       left: 50%;
       display: block;
-      width: 20px;
-      margin-left: -10px;
+      margin-left: -($popover-arrow-width + $popover-border-width);
       content: "";
-      border-bottom: 1px solid $popover-header-bg;
+      border: ($popover-arrow-width + $popover-border-width) solid transparent;
+      border-top-width: 0;
+      border-bottom-color: $popover-header-bg;
     }
   }
 
@@ -142,17 +144,17 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -($popover-arrow-outer-width - 3);
+      left: 100%;
       border-right-width: 0;
     }
 
     .arrow::before {
-      right: -$popover-arrow-outer-width;
+      margin-top: -($popover-arrow-outer-width);
       border-left-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      right: -($popover-arrow-outer-width - 1);
+      margin-top: -$popover-arrow-width;
       border-left-color: $popover-arrow-color;
     }
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -666,7 +666,7 @@ $popover-arrow-width:                 10px !default;
 $popover-arrow-height:                5px !default;
 $popover-arrow-color:                 $popover-bg !default;
 
-$popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
+$popover-arrow-outer-width:           ($popover-arrow-width + round($popover-border-width * 1.4142)) !default; //1.4142 -> value of sqrt(2)
 $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !default;
 
 


### PR DESCRIPTION
Current `border` of popover arrow can be only 1px.

This PR takes into account popover border too.

You can play with arrow border here: http://www.cssarrowplease.com/

Also this PR fixes white arrow background with popover-header

before:
![image](https://user-images.githubusercontent.com/6099236/28269212-8147b798-6b01-11e7-8cc2-d58d24ec1662.png)


after:
![image](https://user-images.githubusercontent.com/6099236/28268616-39d177c0-6aff-11e7-8899-8ff78c03e9b1.png)
