### PR TITLE
Fix to Chrome inheritance bug (#22872)

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -18,20 +18,19 @@
 //    we force a non-overlapping, non-auto-hiding scrollbar to counteract.
 // 6. Change the default tap highlight to be completely transparent in iOS.
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box; // 1
+}
+
 html {
-  box-sizing: inherit; // 1
   font-family: sans-serif; // 2
   line-height: 1.15; // 3
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4
   -ms-overflow-style: scrollbar; // 5
   -webkit-tap-highlight-color: rgba(0,0,0,0); // 6
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box; // 1
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -19,7 +19,7 @@
 // 6. Change the default tap highlight to be completely transparent in iOS.
 
 html {
-  box-sizing: border-box; // 1
+  box-sizing: inherit; // 1
   font-family: sans-serif; // 2
   line-height: 1.15; // 3
   -webkit-text-size-adjust: 100%; // 4
@@ -31,7 +31,7 @@ html {
 *,
 *::before,
 *::after {
-  box-sizing: inherit; // 1
+  box-sizing: border-box; // 1
 }
 
 // IE10+ doesn't honor `<meta name="viewport">` in some cases.


### PR DESCRIPTION
 I have changed:

```css
*,
*::before,
*::after {
  box-sizing: inherit; }
```
to

```css
*,
*::before,
*::after {
  box-sizing: border-box; }
```

Also, to address duplication of `box-sizing` from the `html` selector above, changed `box-sizing:border-box;` to `box-sizing:inherit;` from `html`.

Fixes #22872.
Resolves the issue with PR https://github.com/twbs/bootstrap/pull/23025.
