### PR TITLE
Sticky footer example with flexbox (v4)

### DIFF
--- a/docs/4.0/examples/sticky-footer-navbar/index.html
+++ b/docs/4.0/examples/sticky-footer-navbar/index.html
@@ -54,7 +54,9 @@
 
     <footer class="footer">
       <div class="container">
-        <span class="text-muted">Place sticky footer content here.</span>
+        <p class="text-muted">Place sticky footer content here.</p>
+        <img class="img-fluid" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==">
+        <p class="text-muted">With Flexbox the footer height doesn't need to be fixed.</p>
       </div>
     </footer>
 

--- a/docs/4.0/examples/sticky-footer-navbar/sticky-footer-navbar.css
+++ b/docs/4.0/examples/sticky-footer-navbar/sticky-footer-navbar.css
@@ -2,19 +2,16 @@
 -------------------------------------------------- */
 html {
   position: relative;
-  min-height: 100%;
+  height: 100%;
 }
 body {
-  /* Margin bottom by footer height */
-  margin-bottom: 60px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .footer {
-  position: absolute;
-  bottom: 0;
   width: 100%;
-  /* Set the fixed height of the footer here */
-  height: 60px;
-  line-height: 60px; /* Vertically center the text there */
   background-color: #f5f5f5;
 }
 
@@ -30,6 +27,10 @@ body > .container {
 .footer > .container {
   padding-right: 15px;
   padding-left: 15px;
+}
+
+.footer img {
+  width: 200px;
 }
 
 code {

--- a/docs/4.0/examples/sticky-footer/index.html
+++ b/docs/4.0/examples/sticky-footer/index.html
@@ -29,7 +29,9 @@
 
     <footer class="footer">
       <div class="container">
-        <span class="text-muted">Place sticky footer content here.</span>
+        <p class="text-muted">Place sticky footer content here.</p>
+        <img class="img-fluid" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==">
+        <p class="text-muted">With Flexbox the footer height doesn't need to be fixed.</p>
       </div>
     </footer>
 

--- a/docs/4.0/examples/sticky-footer/sticky-footer.css
+++ b/docs/4.0/examples/sticky-footer/sticky-footer.css
@@ -2,19 +2,16 @@
 -------------------------------------------------- */
 html {
   position: relative;
-  min-height: 100%;
+  height: 100%;
 }
 body {
-  /* Margin bottom by footer height */
-  margin-bottom: 60px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .footer {
-  position: absolute;
-  bottom: 0;
   width: 100%;
-  /* Set the fixed height of the footer here */
-  height: 60px;
-  line-height: 60px; /* Vertically center the text there */
   background-color: #f5f5f5;
 }
 
@@ -27,4 +24,8 @@ body {
   width: auto;
   max-width: 680px;
   padding: 0 15px;
+}
+
+.footer img {
+  width: 200px;
 }


### PR DESCRIPTION
In July 2017 flexbox support is at [97.48%](http://caniuse.com/#search=flexbox) (prefixed). In the past, the sticky footer element has relied on absolute positioning and a fixed height. The utility of a fixed height footer is fairly limited, not to mention the unsightly mess created when the footer expands beyond the predetermined fixed height. 

With the use of flexbox, the sticky footer example CSS becomes lighter and the sticky footer element's height can be `auto`.