### PR TITLE
Wall of Browser Bugs: Update CSS multi-column entries

### DIFF
--- a/_data/browser-bugs.yml
+++ b/_data/browser-bugs.yml
@@ -142,16 +142,6 @@
   browser: >
     Firefox
   summary: >
-    `position: absolute` element that's wider than its column renders differently than other browsers
-  upstream_bug: >
-    Mozilla#1282363
-  origin: >
-    Bootstrap#20161
-
--
-  browser: >
-    Firefox
-  summary: >
     Layout with floated columns breaks when printing
   upstream_bug: >
     Mozilla#1315994
@@ -237,6 +227,16 @@
     Chromium#370155
   origin: >
     Bootstrap#12832
+
+-
+  browser: >
+    Chrome
+  summary: >
+    `position: absolute` element that's wider than its column is incorrectly clipped to column boundary
+  upstream_bug: >
+    Chromium#269061
+  origin: >
+    Bootstrap#20161
 
 -
   browser: >


### PR DESCRIPTION
Remove https://bugzilla.mozilla.org/show_bug.cgi?id=1282363
because CSSWG deemed Firefox's behavior to be the correct behavior per
https://github.com/w3c/csswg-drafts/issues/314

Replace it with a Chrome bug about changing Chrome to follow the spec & Firefox:
https://bugs.chromium.org/p/chromium/issues/detail?id=269061

Will search for / file corresponding Edge & WebKit bugs later.