### PR TITLE
Add semicolon for our dist files in stamp.js

### DIFF
--- a/build/stamp.js
+++ b/build/stamp.js
@@ -29,7 +29,7 @@ if (typeof jQuery === 'undefined') {
 (function () {
 `
   const stampEnd = `
-})()`
+})();`
 
   process.stdout.write(stampTop)
 


### PR DESCRIPTION
Important change and should be merge before the first beta (it was the case in Alpha 6 see : https://github.com/twbs/bootstrap/blob/v4.0.0-alpha.6/dist/js/bootstrap.js#L3535)

/CC @XhmikosR 

Close : #23175

