### PR TITLE
Change base 64 encoded GIFs to SVGs

### DIFF
--- a/site/docs/4.1/examples/carousel/index.html
+++ b/site/docs/4.1/examples/carousel/index.html
@@ -103,19 +103,19 @@
         <!-- Three columns of text below the carousel -->
         <div class="row">
           <div class="col-lg-4">
-            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
+            <span class="d-block mx-auto rounded-circle" style="background-color: #777; width: 140px; height: 140px;"></span>
             <h2>Heading</h2>
             <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
+            <span class="d-block mx-auto rounded-circle" style="background-color: #777; width: 140px; height: 140px;"></span>
             <h2>Heading</h2>
             <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
+            <span class="d-block mx-auto rounded-circle" style="background-color: #777; width: 140px; height: 140px;"></span>
             <h2>Heading</h2>
             <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>

--- a/site/docs/4.1/examples/carousel/index.html
+++ b/site/docs/4.1/examples/carousel/index.html
@@ -53,7 +53,7 @@
         </ol>
         <div class="carousel-inner">
           <div class="carousel-item active">
-            <img class="first-slide" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="First slide">
+            <svg width="100%" height="100%" class="first-slide" alt="First slide" xmlns="http://www.w3.org/2000/svg"><path fill="#777" d="M0 0h1v1H0z"/></svg>
             <div class="container">
               <div class="carousel-caption text-left">
                 <h1>Example headline.</h1>
@@ -63,7 +63,7 @@
             </div>
           </div>
           <div class="carousel-item">
-            <img class="second-slide" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Second slide">
+            <svg width="100%" height="100%" class="second-second" alt="First slide" xmlns="http://www.w3.org/2000/svg"><path fill="#777" d="M0 0h1v1H0z"/></svg>
             <div class="container">
               <div class="carousel-caption">
                 <h1>Another example headline.</h1>
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div class="carousel-item">
-            <img class="third-slide" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Third slide">
+            <svg width="100%" height="100%" class="third-slide" alt="Third slide" xmlns="http://www.w3.org/2000/svg"><path fill="#777" d="M0 0h1v1H0z"/></svg>
             <div class="container">
               <div class="carousel-caption text-right">
                 <h1>One more for good measure.</h1>
@@ -103,19 +103,19 @@
         <!-- Three columns of text below the carousel -->
         <div class="row">
           <div class="col-lg-4">
-            <img class="rounded-circle" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Generic placeholder image" width="140" height="140">
+            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
             <h2>Heading</h2>
             <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <img class="rounded-circle" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Generic placeholder image" width="140" height="140">
+            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
             <h2>Heading</h2>
             <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
           </div><!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <img class="rounded-circle" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Generic placeholder image" width="140" height="140">
+            <svg width="140" height="140"><circle cx="70" cy="70" r="70" fill="#777"/></svg>
             <h2>Heading</h2>
             <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
             <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>


### PR DESCRIPTION
Fixes #23185 

For reference, an example of the decoded SVG is as follows:

```svg
<svg width="1" height="1" xmlns="http://www.w3.org/2000/svg"><path fill="#00dc83" d="M0 0h1v1H0z"/></svg>
```

Minified using SVGOMG: https://github.com/jakearchibald/svgomg
