### PR TITLE
Dropup dropdown-menu should have margin on the bottom instead of top

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -44,7 +44,7 @@
   float: left;
   min-width: $dropdown-min-width;
   padding: $dropdown-padding-y 0;
-  margin: $dropdown-margin-top 0 0; // override default ul
+  margin: $dropdown-spacer 0 0; // override default ul
   font-size: $font-size-base; // Redeclare because nesting can cause inheritance issues
   color: $body-color;
   text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -26,6 +26,11 @@
 // Allow for dropdowns to go bottom up (aka, dropup-menu)
 // Just add .dropup after the standard .dropdown class and you're set.
 .dropup {
+  .dropdown-menu {
+    margin-top: 0;
+    margin-bottom: $dropdown-spacer;
+  }
+
   .dropdown-toggle {
     &::after {
       border-top: 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -491,7 +491,7 @@ $form-feedback-invalid-color: theme-color("danger") !default;
 
 $dropdown-min-width:             10rem !default;
 $dropdown-padding-y:             .5rem !default;
-$dropdown-margin-top:            .125rem !default;
+$dropdown-spacer:                .125rem !default;
 $dropdown-bg:                    $white !default;
 $dropdown-border-color:          rgba($black,.15) !default;
 $dropdown-border-width:          $border-width !default;


### PR DESCRIPTION
(#22414) Rename for consistency `$dropdown-margin-top` to `$dropdown-spacer`