### PR TITLE
Adds 'system-ui' to the font stack following W3C new font spec

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -231,7 +231,7 @@ $transition-collapse:    height .35s ease !default;
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
+$font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
 $font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:       $font-family-sans-serif !default;
 


### PR DESCRIPTION
There is a new `system-ui` value defined for `font-family` at [W3C CSS Fonts Level 4](https://www.w3.org/TR/css-fonts-4/#system-ui-def) working draft.

> `system-ui` is intended to let text render with the default user interface font on the platform on which the UA is running.

Since Bootstrap emulates a system-ui font stack, I though that by adding this value we are future proofing the stack.

What do you think?
