### PR TITLE
v4 docs remove left over Tooltips and Popover documentation from Butt…

### DIFF
--- a/docs/4.0/components/button-group.md
+++ b/docs/4.0/components/button-group.md
@@ -195,7 +195,3 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
   ...
 </div>
 {% endhighlight %}
-
-## Tooltips and popovers
-
-Due to the specific implementation (and some other components), a bit of special casing is required for tooltips and popovers within button groups. **You'll have to specify the option `container: 'body'`** to avoid unwanted side effects (such as the element growing wider and/or losing its rounded corners when the tooltip or popover is triggered).


### PR DESCRIPTION
…on Group page