### PR TITLE
Fix #23209. remove line height from input type number

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -19,7 +19,7 @@
   border: $input-btn-border-width solid $input-border-color;
   // line height issue in input type number. Solve by not assiging line height in inuput number type.
   &:not([type="number"]) {
-   line-height: $input-btn-line-height;
+    line-height: $input-btn-line-height;
   }
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @if $enable-rounded {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -19,7 +19,7 @@
   border: $input-btn-border-width solid $input-border-color;
   // line height issue in input type number. Solve by not assiging line height in inuput number type.
   &:not([type="number"]) {
-  	line-height: $input-btn-line-height;
+   line-height: $input-btn-line-height;
   }
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @if $enable-rounded {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -11,14 +11,16 @@
   // height: $input-height;
   padding: $input-btn-padding-y $input-btn-padding-x;
   font-size: $font-size-base;
-  line-height: $input-btn-line-height;
   color: $input-color;
   background-color: $input-bg;
   // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214.
   background-image: none;
   background-clip: padding-box;
   border: $input-btn-border-width solid $input-border-color;
-
+  // line height issue in input type number. Solve by not assiging line height in inuput number type.
+  &:not([type="number"]){
+  	line-height: $input-btn-line-height;
+  }
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @if $enable-rounded {
     // Manually use the if/else instead of the mixin to account for iOS override

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -18,7 +18,7 @@
   background-clip: padding-box;
   border: $input-btn-border-width solid $input-border-color;
   // line height issue in input type number. Solve by not assiging line height in inuput number type.
-  &:not([type="number"]){
+  &:not([type="number"]) {
   	line-height: $input-btn-line-height;
   }
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.


### PR DESCRIPTION
Solved issue mention in #23209. There is line height issue only in input type number. I have remove line height from number type by adding this css code
`&:not([type="number"]){
  	line-height: $input-btn-line-height;
  }`