### PR TITLE
Fix input-only checks/radios with yet to be added position utilities

### DIFF
--- a/docs/4.0/components/forms.md
+++ b/docs/4.0/components/forms.md
@@ -238,17 +238,17 @@ Group checkboxes or radios on the same horizontal row by adding `.form-check-inl
 
 ### Without labels
 
-Should you have no text within the `<label>`, the input is positioned as you'd expect. **Currently only works on non-inline checkboxes and radios.** Remember to still provide some form of label for assistive technologies (for instance, using `aria-label`).
+Add `.position-static` to inputs within `.form-check` that don't have any label text. Remember to still provide some form of label for assistive technologies (for instance, using `aria-label`).
 
 {% example html %}
 <div class="form-check">
   <label class="form-check-label">
-    <input class="form-check-input" type="checkbox" id="blankCheckbox" value="option1" aria-label="...">
+    <input class="form-check-input position-static" type="checkbox" id="blankCheckbox" value="option1" aria-label="...">
   </label>
 </div>
 <div class="form-check">
   <label class="form-check-label">
-    <input class="form-check-input" type="radio" name="blankRadio" id="blankRadio1" value="option1" aria-label="...">
+    <input class="form-check-input position-static" type="radio" name="blankRadio" id="blankRadio1" value="option1" aria-label="...">
   </label>
 </div>
 {% endexample %}

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -236,10 +236,6 @@ select.form-control-lg {
   position: absolute;
   margin-top: $form-check-input-margin-y;
   margin-left: -$form-check-input-gutter;
-
-  &:only-child {
-    position: static;
-  }
 }
 
 // Radios and checkboxes on same line


### PR DESCRIPTION
Fixes #22813.

Basically, our `.form-check` was using `:only-child` to try to say "limit this style to the input if there's no label text," but plain text within an HTML element doesn't count as an element (child or not). As such, we need to explicitly say when something is static.

**This depends on #18476 or something like it.**