### PR TITLE
Make sticky header offset CSS not selectable

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -15,10 +15,11 @@
       position: relative;
       z-index: -1;
       display: block;
-      height: 6rem;
+      padding-top: 6rem;
       margin-top: -6rem;
       visibility: hidden;
       content: "";
+      user-select: none;
     }
   }
 


### PR DESCRIPTION
Should fix #23252. Really the `user-select` is probably all we need, but figured I'd also tweak the hack to use `padding-top` instead of a fixed `height`.