### PR TITLE
Fix sticky headings

### DIFF
--- a/assets/js/src/application.js
+++ b/assets/js/src/application.js
@@ -96,15 +96,10 @@
         .tooltip('_fixTitle')
     })
 
+    anchors.options = {
+      icon: '#'
+    }
+    anchors.add('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5')
+    $('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5').wrapInner('<span></span>')
   })
-
 }(jQuery))
-
-;(function () {
-  'use strict'
-
-  anchors.options = {
-    icon: '#'
-  }
-  anchors.add('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5')
-}())

--- a/assets/js/src/application.js
+++ b/assets/js/src/application.js
@@ -100,6 +100,6 @@
       icon: '#'
     }
     anchors.add('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5')
-    $('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5').wrapInner('<span></span>')
+    $('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5').wrapInner('<div></div>')
   })
 }(jQuery))

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -11,9 +11,14 @@
   > h2[id],
   > h3[id],
   > h4[id] {
+    pointer-events: none;
+
+    > span,
+    > a {
+      pointer-events: auto;
+    }
+
     &::before {
-      position: relative;
-      z-index: -1;
       display: block;
       height: 6rem;
       margin-top: -6rem;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -13,7 +13,7 @@
   > h4[id] {
     pointer-events: none;
 
-    > span,
+    > div,
     > a {
       pointer-events: auto;
     }


### PR DESCRIPTION
Isolates work from @MartijnCuppens in #23257 to fix #23252. Main difference is placement of the JS and more specific CSS so that we're not using unnecessary universal selectors. I wasn't stoked on injecting markup, but any other CSS-only solution seems to have significant drawbacks.