### PR TITLE
Make placeholder links optional

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -204,18 +204,19 @@ a {
 // It would be more straightforward to just use a[href] in previous block, but that
 // causes specificity issues in many other styles that are too complex to fix.
 // See https://github.com/twbs/bootstrap/issues/19402
-
-a:not([href]):not([tabindex]) {
-  color: inherit;
-  text-decoration: none;
-
-  @include hover-focus {
+@if $enable-placeholder-links {
+  a:not([href]):not([tabindex]) {
     color: inherit;
     text-decoration: none;
-  }
 
-  &:focus {
-    outline: 0;
+    @include hover-focus {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    &:focus {
+      outline: 0;
+    }
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -126,6 +126,7 @@ $enable-transitions:        true !default;
 $enable-hover-media-query:  false !default;
 $enable-grid-classes:       true !default;
 $enable-print-styles:       true !default;
+$enable-placeholder-links:  true !default;
 
 
 // Spacing


### PR DESCRIPTION
Long story short - after update to Bootstrap beta 4 I've noticed that all `a.btn` has black color text. As I investigated there were discussion in #19402 which come up to neutralize links without href to the plain text style. Also some people mentioned that it breaks the style of their react app so their removed "reboot.scss" from their build. I think removing "reboot" is not a good option as there are many useful things, but make the reset of placeholder links optional(enabled by default) is a perfect compromise for rich web app users