### PR TITLE
docs: fix Popper.js name and removed comma

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ bower install bootstrap#v{{ site.current_version }}
 <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 {% endhighlight %}
 
-<h5>JS, Popper, and jQuery</h5>
+<h5>JS, Popper.js and jQuery</h5>
 {% highlight html %}
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.popper }}" integrity="{{ site.cdn.popper_hash }}" crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ bower install bootstrap#v{{ site.current_version }}
 <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 {% endhighlight %}
 
-<h5>JS, Popper.js and jQuery</h5>
+<h5>JS, Popper.js, and jQuery</h5>
 {% highlight html %}
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
 <script src="{{ site.cdn.popper }}" integrity="{{ site.cdn.popper_hash }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
I'm sorry for being nitpicking 😅

commans before "and" aren't usually needed, and the Popper.js name was misspelled.