### PR TITLE
Fix broken Examples link in the docs footer include – `footer.html`.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <ul class="bd-footer-links">
       <li><a href="{{ site.repo }}">GitHub</a></li>
       <li><a href="https://twitter.com/getbootstrap">Twitter</a></li>
-      <li><a href="{{ site.baseurl }}/examples/">Examples</a></li>
+      <li><a href="{{ site.baseurl }}/docs/{{ site.docs_version }}/examples/">Examples</a></li>
       <li><a href="{{ site.baseurl }}/about/">About</a></li>
     </ul>
     <p>Designed and built with all the love in the world by <a href="https://twitter.com/mdo" target="_blank" rel="noopener">@mdo</a> and <a href="https://twitter.com/fat" target="_blank" rel="noopener">@fat</a>. Maintained by the <a href="https://github.com/orgs/twbs/people">core team</a> with the help of <a href="https://github.com/twbs/bootstrap/graphs/contributors">our contributors</a>.</p>


### PR DESCRIPTION
Re:  #23343 – **Broken Links on getbootstrap.com**

Clicking the `Examples` link in the home page footer yields 404.

![2017-08-11_23-43-22](https://user-images.githubusercontent.com/80144/29237625-1abcd56e-7ef0-11e7-8098-f029c1bde509.jpg)

If merged, this makes the footer `Examples` link like the one in docs-navbar.html which is the same source code folder.

Therefore `_includes/footer.html` and `_includes/docs-navbar.html` now use the same link to `Examples`.