### PR TITLE
FIX: Broken 'Examples' Link in the Footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
     <ul class="bd-footer-links">
       <li><a href="https://github.com/twbs/bootstrap">GitHub</a></li>
       <li><a href="https://twitter.com/getbootstrap">Twitter</a></li>
-      <li><a href="/examples/">Examples</a></li>
+      <li><a href="/docs/4.0/examples/">Examples</a></li>
       <li><a href="/about/history/">About</a></li>
     </ul>
     <p>Designed and built with all the love in the world by <a href="https://twitter.com/mdo" target="_blank" rel="noopener">@mdo</a> and <a href="https://twitter.com/fat" target="_blank" rel="noopener">@fat</a>. Maintained by the <a href="https://github.com/orgs/twbs/people">core team</a> with the help of <a href="https://github.com/twbs/bootstrap/graphs/contributors">our contributors</a>.</p>


### PR DESCRIPTION
The examples link in the footer is broken! This PR fixes that. 

![img](https://i.imgur.com/20R4Npb.png)

The fix has the same link as there is in the header!

Looking forward, to have my first contribution in _the_ Bootstrap! 🍕