### PR TITLE
fix docs modal example fade out

### DIFF
--- a/assets/scss/_component-examples.scss
+++ b/assets/scss/_component-examples.scss
@@ -285,7 +285,7 @@
   }
 }
 
-.modal.show {
+.modal {
   z-index: 1072;
 
   .tooltip, .popover {


### PR DESCRIPTION
the z-index was only corrected for `.modal.show` which made the modal drop behind the header and backdrop when fading out
simply dropping the `.show` from this selector will correct this issue

@XhmikosR 