### PR TITLE
Style redirect page

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <title>Bootstrap - Content moved</title>
+    <link rel="canonical" href="{{ page.redirect.to }}">
+    <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+    <style>
+      .title { font-size: 2.8rem; margin-top: 1rem; margin-bottom: .5rem; font-weight: 300; }
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
+    </style>
+  </head>
+  <body>
+    <div style="width: 500px; margin: 40px auto; text-align: center">
+      <h1 class="title">Redirecting…</h1>
+      <a href="{{ page.redirect.to }}" style="font-size: 0.9rem; color: #7952b3">Click here if you are not redirected.</a>
+    </div>
+    <script>location="{{ page.redirect.to }}"</script>
+  </body>
+</html>


### PR DESCRIPTION
Style the redirect page thats visible for a brief second (or more on slower connections). [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) can use a `redirect.html` layout 🙌 I've used inline styles to save on load time. Here's a screenshot:

![image](https://user-images.githubusercontent.com/10660468/29246941-20a38082-7fbc-11e7-8fac-86a0bf561dab.png)

It ain't a work of art but its more Bootstrappy then the default. Let me know what you think 👍 
