### PR TITLE
docs/4.0/examples/blog: Use ml-sm-auto instead of offset-sm-1

### DIFF
--- a/docs/4.0/examples/blog/index.html
+++ b/docs/4.0/examples/blog/index.html
@@ -109,7 +109,7 @@
 
         </div><!-- /.blog-main -->
 
-        <div class="col-sm-3 offset-sm-1 blog-sidebar">
+        <div class="col-sm-3 ml-auto blog-sidebar">
           <div class="sidebar-module sidebar-module-inset">
             <h4>About</h4>
             <p>Etiam porta <em>sem malesuada magna</em> mollis euismod. Cras mattis consectetur purus sit amet fermentum. Aenean lacinia bibendum nulla sed consectetur.</p>

--- a/docs/4.0/examples/blog/index.html
+++ b/docs/4.0/examples/blog/index.html
@@ -109,7 +109,7 @@
 
         </div><!-- /.blog-main -->
 
-        <div class="col-sm-3 ml-auto blog-sidebar">
+        <div class="col-sm-3 ml-sm-auto blog-sidebar">
           <div class="sidebar-module sidebar-module-inset">
             <h4>About</h4>
             <p>Etiam porta <em>sem malesuada magna</em> mollis euismod. Cras mattis consectetur purus sit amet fermentum. Aenean lacinia bibendum nulla sed consectetur.</p>


### PR DESCRIPTION
Bootstrap 4.0 Beta 1 [dropped the offset classes in favor of using margin utilities](https://github.com/twbs/bootstrap/pull/22942). Update the blog example in the docs to use the appropriate `ml-auto` instead of `offset-sm-1` class to retain a pixel perfect layout with previous versions.

[_Bootstrap 4.0 Alpha 6_](https://v4-alpha.getbootstrap.com/examples/blog/):

![screen shot 2017-08-13 at 11 22 54-fs8](https://user-images.githubusercontent.com/191754/29248229-9c265b62-801b-11e7-91b8-6a7929424494.png)

[_Bootstrap 4.0 Beta 1_](https://getbootstrap.com/docs/4.0/examples/blog/):

![screen shot 2017-08-13 at 11 21 55-fs8](https://user-images.githubusercontent.com/191754/29248222-6709cf04-801b-11e7-8169-8566bf0532a7.png)