### PR TITLE
Fix .btn-outline-light hover color

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -58,7 +58,11 @@ fieldset[disabled] a.btn {
 
 @each $color, $value in $theme-colors {
   .btn-outline-#{$color} {
-    @include button-outline-variant($value, #fff);
+    @if $color == "light" {
+      @include button-outline-variant($value, $gray-900);
+    } @else {
+      @include button-outline-variant($value, $white);
+    }
   }
 }
 


### PR DESCRIPTION
Uses some if/else action to ensure there's readable text on hover. Swapped out a hex value to a variable while I was in there.

Fixes #23398, fixes #23351.