### PR TITLE
Remove remaining references to v4 Alpha

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-v4-alpha.getbootstrap.com
+getbootstrap.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://v4-alpha.getbootstrap.com">
-    <img src="http://v4-alpha.getbootstrap.com/assets/brand/bootstrap-solid.svg" width=72 height=72>
+  <a href="https://getbootstrap.com">
+    <img src="http://getbootstrap.com/assets/brand/bootstrap-solid.svg" width=72 height=72>
   </a>
 
   <h3 align="center">Bootstrap</h3>
@@ -8,7 +8,7 @@
   <p align="center">
     Sleek, intuitive, and powerful front-end framework for faster and easier web development.
     <br>
-    <a href="https://v4-alpha.getbootstrap.com"><strong>Explore Bootstrap docs &raquo;</strong></a>
+    <a href="https://getbootstrap.com/docs/4.0"><strong>Explore Bootstrap docs &raquo;</strong></a>
     <br>
     <br>
     <a href="https://themes.getbootstrap.com">Bootstrap Themes</a>

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -272,7 +272,7 @@ svg:not(:root) {
 // DON'T remove the click delay when `<meta name="viewport" content="width=device-width">` is present.
 // However, they DO support removing the click delay via `touch-action: manipulation`.
 // See:
-// * https://v4-alpha.getbootstrap.com/content/reboot/#click-delay-optimization-for-touch
+// * https://getbootstrap.com/docs/4.0/content/reboot/#click-delay-optimization-for-touch
 // * http://caniuse.com/#feat=css-touch-action
 // * https://patrickhlauke.github.io/touch/tests/results/#suppressing-300ms-delay
 


### PR DESCRIPTION
This commit removes the remaining refrences to the v4 Alpha website and replaces them with the
corresponding v4 Beta ones.

**Note:** We have to hard code the current docs version at some places. Wouldn't it be good to have a `/docs/latest/` redirect to solve this "issue" in the future?