### PR TITLE
Adds a default flag to $paragraph-margin-bottom

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -175,7 +175,7 @@ $link-hover-decoration: underline !default;
 //
 // Style p element.
 
-$paragraph-margin-bottom: 1rem;
+$paragraph-margin-bottom: 1rem !default;
 
 
 // Grid breakpoints


### PR DESCRIPTION
On #23140 we’ve introduce the `$paragraph-margin-bottom` variable to add a bottom margin on paragraphs. There is a missing `!default` flag making it hard to overwrite.

This PR is adding the `!default` flag

What do you think?