### PR TITLE
Update _modal.scss

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -68,11 +68,11 @@
   left: 0;
   z-index: $zindex-modal-backdrop;
   background-color: $modal-backdrop-bg;
-  display:none;  
+  display: none; 
 
   // Fade for backdrop
   &.fade { opacity: 0; }
-  &.show { display:block; opacity: $modal-backdrop-opacity; }
+  &.show { display: block; opacity: $modal-backdrop-opacity; }
 }
 
 // Modal header

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -68,14 +68,11 @@
   left: 0;
   z-index: $zindex-modal-backdrop;
   background-color: $modal-backdrop-bg;
-  display:none;
+  display:none;  
 
   // Fade for backdrop
   &.fade { opacity: 0; }
-  &.show { 
-    opacity: $modal-backdrop-opacity; 
-    display:block; 
-  }
+  &.show { display:block; opacity: $modal-backdrop-opacity; }
 }
 
 // Modal header

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -68,10 +68,14 @@
   left: 0;
   z-index: $zindex-modal-backdrop;
   background-color: $modal-backdrop-bg;
+  display:none;
 
   // Fade for backdrop
   &.fade { opacity: 0; }
-  &.show { opacity: $modal-backdrop-opacity; }
+  &.show { 
+    opacity: $modal-backdrop-opacity; 
+    display:block; 
+  }
 }
 
 // Modal header


### PR DESCRIPTION
Adding display:none; to .modal-backdrop and display:block; to .modal-backdrop.show because otherwise the modal backdrop is still there after closing the modal and overlays the site and disables so other navigation elements.