### PR TITLE
Adds a top margin to the jumbotron

### DIFF
--- a/scss/_jumbotron.scss
+++ b/scss/_jumbotron.scss
@@ -1,5 +1,6 @@
 .jumbotron {
   padding: $jumbotron-padding ($jumbotron-padding / 2);
+  margin-top: $jumbotron-padding;
   margin-bottom: $jumbotron-padding;
   background-color: $jumbotron-bg;
   @include border-radius($border-radius-lg);


### PR DESCRIPTION
This PR adds a top margin to the jumbotron component. This makes the top and bottom margins equal.