### PR TITLE
Adds component disabled color variable to improve consistency

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -225,8 +225,9 @@ $border-radius:          .25rem !default;
 $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
-$component-active-color: $white !default;
-$component-active-bg:    theme-color("primary") !default;
+$component-active-color:    $white !default;
+$component-active-bg:       theme-color("primary") !default;
+$component-disabled-color:  $gray-600 !default;
 
 $caret-width:            .3em !default;
 
@@ -349,7 +350,7 @@ $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba(
 $btn-focus-box-shadow:           0 0 0 3px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
-$btn-link-disabled-color:        $gray-600 !default;
+$btn-link-disabled-color:        $component-disabled-color !default;
 
 $btn-block-spacing-y:            .5rem !default;
 
@@ -421,7 +422,7 @@ $custom-control-indicator-bg-size:    50% 50% !default;
 $custom-control-indicator-box-shadow: inset 0 .25rem .25rem rgba($black,.1) !default;
 
 $custom-control-indicator-disabled-bg:       $gray-200 !default;
-$custom-control-description-disabled-color:  $gray-600 !default;
+$custom-control-description-disabled-color:  $component-disabled-color !default;
 
 $custom-control-indicator-checked-color:      $white !default;
 $custom-control-indicator-checked-bg:         theme-color("primary") !default;
@@ -450,7 +451,7 @@ $custom-select-height:              $input-height  !default;
 $custom-select-indicator-padding:   1rem !default; // Extra padding to account for the presence of the background-image based indicator
 $custom-select-line-height:         $input-btn-line-height !default;
 $custom-select-color:               $input-color !default;
-$custom-select-disabled-color:      $gray-600 !default;
+$custom-select-disabled-color:      $component-disabled-color !default;
 $custom-select-bg:            $white !default;
 $custom-select-disabled-bg:   $gray-200 !default;
 $custom-select-bg-size:       8px 10px !default; // In pixels because image dimensions
@@ -516,7 +517,7 @@ $dropdown-link-hover-bg:         $gray-100 !default;
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
 
-$dropdown-link-disabled-color:   $gray-600 !default;
+$dropdown-link-disabled-color:   $component-disabled-color !default;
 
 $dropdown-item-padding-y:        .25rem !default;
 $dropdown-item-padding-x:        1.5rem !default;
@@ -541,7 +542,7 @@ $zindex-tooltip:            1070 !default;
 
 $nav-link-padding-y:            .5rem !default;
 $nav-link-padding-x:            1rem !default;
-$nav-link-disabled-color:       $gray-600 !default;
+$nav-link-disabled-color:       $component-disabled-color !default;
 
 $nav-tabs-border-color:                       #ddd !default;
 $nav-tabs-border-width:                       $border-width !default;
@@ -608,7 +609,7 @@ $pagination-active-color:              $white !default;
 $pagination-active-bg:                 theme-color("primary") !default;
 $pagination-active-border-color:       theme-color("primary") !default;
 
-$pagination-disabled-color:            $gray-600 !default;
+$pagination-disabled-color:            $component-disabled-color !default;
 $pagination-disabled-bg:               $white !default;
 $pagination-disabled-border-color:     #ddd !default;
 
@@ -766,7 +767,7 @@ $list-group-active-color:             $component-active-color !default;
 $list-group-active-bg:                $component-active-bg !default;
 $list-group-active-border-color:      $list-group-active-bg !default;
 
-$list-group-disabled-color:      $gray-600 !default;
+$list-group-disabled-color:      $component-disabled-color !default;
 $list-group-disabled-bg:         $list-group-bg !default;
 
 $list-group-action-color:             $gray-700 !default;


### PR DESCRIPTION
This is a suggestion to improve consistency

There are several components that have definitions for disabled state color:
```scss
$btn-link-disabled-color:                    $gray-600 !default;
$custom-control-description-disabled-color:  $gray-600 !default;
$custom-select-disabled-color:               $gray-600 !default;
$dropdown-link-disabled-color:               $gray-600 !default;
$nav-link-disabled-color:                    $gray-600 !default;
$pagination-disabled-color:                  $gray-600 !default;
$list-group-disabled-color:                  $gray-600 !default;

// these are different
$navbar-dark-disabled-color:        rgba($white,.25) !default;
$navbar-light-disabled-color:       rgba($black,.3) !default;
```
What about adding a `$component-disabled-color` to define the disabled state colors?

```scss
$component-disabled-color:  $gray-600 !default;
```
What do you think?