### PR TITLE
changes 1px to $border-width variable on cards border

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -626,7 +626,7 @@ $jumbotron-bg:                   $gray-200 !default;
 
 $card-spacer-y:            .75rem !default;
 $card-spacer-x:            1.25rem !default;
-$card-border-width:        1px !default;
+$card-border-width:        $border-width !default;
 $card-border-radius:       $border-radius !default;
 $card-border-color:        rgba($black,.125) !default;
 $card-inner-border-radius: calc(#{$card-border-radius} - #{$card-border-width}) !default;


### PR DESCRIPTION
Cards variables reads:
```scss
$card-border-width:        1px !default;
```
This PR changes it to:
```scss
$card-border-width:        $border-width !default;
```
To keep consistency.

What do you think?
