### PR TITLE
Changes badge-pill-border-radius variable from 10px to 50 percent to ensure ro…

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -694,9 +694,8 @@ $badge-padding-y:             .25em !default;
 $badge-padding-x:             .4em !default;
 
 $badge-pill-padding-x:        .6em !default;
-// Use a higher than normal value to ensure completely rounded edges when
-// customizing padding or font-size on labels.
-$badge-pill-border-radius:    10rem !default;
+
+$badge-pill-border-radius:    50% !default;
 
 
 // Modals


### PR DESCRIPTION
Hi! Variables.scss reads:

```scss
// Use a higher than normal value to ensure completely rounded edges when
// customizing padding or font-size on labels.
$badge-pill-border-radius:    10rem !default;
```
If we want to ensure completely rounded edges, that value should be 50%. This PR changes it to:

```scss
$badge-pill-border-radius:    50% !default;
```

What do you think?