### PR TITLE
Generate CSS variables for -colors

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -3,6 +3,9 @@ scss_files:
   - "scss/**/*.scss"
   - "docs/assets/scss/**/*.scss"
 
+exclude:
+  - "scss/_root.scss"
+
 plugin_directories: ['.scss-linters']
 
 # List of gem names to load custom linters from (make sure they are already

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,0 +1,5 @@
+:root {
+  @each $color, $value in $theme-colors {
+    --#{$color}: $value;
+  }
+}

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -8,6 +8,7 @@
 @import "functions";
 @import "variables";
 @import "mixins";
+@import "root";
 @import "print";
 @import "reboot";
 @import "type";


### PR DESCRIPTION
Interesting idea proposed by #23349. We could build with Sass, but compile some utilities to help those not using our Sass-based compilation flow. I'd say we could even wrap these in conditionals to not include them unless asked for, but that'd defeat the purpose a bit.

I dunno how far we'd take this though...