### PR TITLE
include img-fluid width 100% for svg files #23476

### DIFF
--- a/scss/mixins/_image.scss
+++ b/scss/mixins/_image.scss
@@ -13,6 +13,9 @@
   // Part 2: Override the height to auto, otherwise images will be stretched
   // when setting a width and height attribute on the img element.
   height: auto;
+  &[src$=".svg"] {
+    width: 100%;
+  }
 }
 
 


### PR DESCRIPTION
have added `width:100%` for SVG image src as per reference in #23476