### PR TITLE
allow default font family control

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -25,7 +25,7 @@
 }
 
 html {
-  font-family: sans-serif; // 2
+  font-family: $font-family-base; // 2
   line-height: 1.15; // 3
   -webkit-text-size-adjust: 100%; // 4
   -ms-text-size-adjust: 100%; // 4


### PR DESCRIPTION
Allow users to override and change default `font family`. 

Without this, to use a custom font, users must manually override default `font-family: san-serif` in each and every place were `font-family` is not specified within a selector declaration.

TDLR; This changes nothing except allows users to control default font families without tons of work. 