### PR TITLE
Changed Typography title to Text

### DIFF
--- a/docs/4.0/utilities/text.md
+++ b/docs/4.0/utilities/text.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Typography
+title: Text
 description: Documentation and examples for common text utilities to control alignment, wrapping, weight, and more.
 group: utilities
 toc: true


### PR DESCRIPTION
There's a file `utilities/_text.scss` but in docs the related section was named Typography. 

I instinctivelly tried to import `utilities/_typography.scss` first, as all other files are named according to their docs section.