### PR TITLE
Fix error in Alerts component doc

### DIFF
--- a/docs/4.0/components/alerts.md
+++ b/docs/4.0/components/alerts.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Examples
 
-Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the height **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts jQuery plugin](#dismissing).
+Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the eight **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts jQuery plugin](#dismissing).
 
 {% example html %}
 {% for color in site.data.theme-colors %}

--- a/docs/4.0/components/alerts.md
+++ b/docs/4.0/components/alerts.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Examples
 
-Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the four **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts jQuery plugin](#dismissing).
+Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the height **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts jQuery plugin](#dismissing).
 
 {% example html %}
 {% for color in site.data.theme-colors %}


### PR DESCRIPTION
In the examples introductory text, the sentence _use one of the four required contextual classes_ is wrong now that there are more contextual classes for alerts.

Could we use twig to do the count dynamically ? something like `{{ site.data.theme-colors | length }}`. Maybe I'm getting ahead of myself :)