### PR TITLE
Form Validation `.valid-feedback` and `.valid-tooltip` are unstyled

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -256,28 +256,6 @@ select.form-control-lg {
 // pseudo-classes but also includes `.is-invalid` and `.is-valid` classes for
 // server side validation.
 
-.invalid-feedback {
-  display: none;
-  margin-top: .25rem;
-  font-size: .875rem;
-  color: $form-feedback-invalid-color;
-}
-
-.invalid-tooltip {
-  position: absolute;
-  top: 100%;
-  z-index: 5;
-  display: none;
-  width: 250px;
-  padding: .5rem;
-  margin-top: .1rem;
-  font-size: .875rem;
-  line-height: 1;
-  color: #fff;
-  background-color: rgba($form-feedback-invalid-color,.8);
-  border-radius: .2rem;
-}
-
 @include form-validation-state("valid", $form-feedback-valid-color);
 @include form-validation-state("invalid", $form-feedback-invalid-color);
 

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -23,6 +23,28 @@
 
 @mixin form-validation-state($state, $color) {
 
+  .#{$state}-feedback {
+    display: none;
+    margin-top: .25rem;
+    font-size: .875rem;
+    color: $color;
+  }
+
+  .#{$state}-tooltip {
+    position: absolute;
+    top: 100%;
+    z-index: 5;
+    display: none;
+    width: 250px;
+    padding: .5rem;
+    margin-top: .1rem;
+    font-size: .875rem;
+    line-height: 1;
+    color: #fff;
+    background-color: rgba($color,.8);
+    border-radius: .2rem;
+  }
+
   .form-control,
   .custom-select {
     .was-validated &:#{$state},


### PR DESCRIPTION
This adds styles for `.valid-feedback` and `.valid-tooltip`. If those items aren't supposed to have styles:

```
 @mixin form-validation-state($state, $color) {
  ...
       ~ .#{$state}-feedback,
       ~ .#{$state}-tooltip {
         display: block;
       }
  ...
}
```

needs to be changed.