### PR TITLE
Remove `color` property from `badge` class

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -9,7 +9,6 @@
   font-size: $badge-font-size;
   font-weight: $badge-font-weight;
   line-height: 1;
-  color: $badge-color;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;


### PR DESCRIPTION
I suggest removing `color: #FFF` from the `badge` class, because it is
provided by the `badge-<modifier>` classes along with a
background-color, whereas there is no corresponding background-color
provided on the `badge` class itself.

Background
----------

According to the documentation:

> [badge] Requires one of the contextual, color modifier classes for `color` and
> `background-color`.

That is, color and background color should be provided by a modifier
class, rather than the badge class itself.

For example:

```html
<span class='badge badge-primary'>4</span>
```

rather than 
```html
<span class='badge'>4</span>
```



In general, providing a `color` property without also providing a
`background-color` should be avoided. [W3 QA tips]

In this context, this is a problem only if someone creates a `badge`
without providing a modifier. Such an omition may be difficult to trouble-shoot,
because this will most likely yield white text on a white background.

[W3 QA tips](https://www.w3.org/QA/Tips/color)