### PR TITLE
Rename `.table-inverse`, `.thead-inverse`, `.thead-default` to `.*-dark`, `.*-light`

### DIFF
--- a/docs/4.0/content/tables.md
+++ b/docs/4.0/content/tables.md
@@ -45,10 +45,10 @@ Using the most basic table markup, here's how `.table`-based tables look in Boot
 </table>
 {% endexample %}
 
-You can also invert the colors—with light text on dark backgrounds—with `.table-inverse`.
+You can also invert the colors—with light text on dark backgrounds—with `.table-dark`.
 
 {% example html %}
-<table class="table table-inverse">
+<table class="table table-dark">
   <thead>
     <tr>
       <th>#</th>
@@ -82,11 +82,11 @@ You can also invert the colors—with light text on dark backgrounds—with `.ta
 
 ## Table head options
 
-Similar to default and inverse tables, use one of two modifier classes to make `<thead>`s appear light or dark gray.
+Similar to tables and dark tables, use the modifier classes `.thead-light` or `.thead-dark` to make `<thead>`s appear light or dark gray.
 
 {% example html %}
 <table class="table">
-  <thead class="thead-inverse">
+  <thead class="thead-dark">
     <tr>
       <th>#</th>
       <th>First Name</th>
@@ -117,7 +117,7 @@ Similar to default and inverse tables, use one of two modifier classes to make `
 </table>
 
 <table class="table">
-  <thead class="thead-default">
+  <thead class="thead-light">
     <tr>
       <th>#</th>
       <th>First Name</th>
@@ -186,7 +186,7 @@ Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`
 {% endexample %}
 
 {% example html %}
-<table class="table table-striped table-inverse">
+<table class="table table-striped table-dark">
   <thead>
     <tr>
       <th>#</th>
@@ -261,7 +261,7 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 {% endexample %}
 
 {% example html %}
-<table class="table table-bordered table-inverse">
+<table class="table table-bordered table-dark">
   <thead>
     <tr>
       <th>#</th>
@@ -335,7 +335,7 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 {% endexample %}
 
 {% example html %}
-<table class="table table-hover table-inverse">
+<table class="table table-hover table-dark">
   <thead>
     <tr>
       <th>#</th>
@@ -403,7 +403,7 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 {% endexample %}
 
 {% example html %}
-<table class="table table-sm table-inverse">
+<table class="table table-sm table-dark">
   <thead>
     <tr>
       <th>#</th>
@@ -487,10 +487,10 @@ Use contextual classes to color table rows or individual cells.
 </tr>
 {% endhighlight %}
 
-Regular table background variants are not available with the inverse table, however, you may use [text or background utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/colors/) to achieve similar styles.
+Regular table background variants are not available with the dark table, however, you may use [text or background utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/colors/) to achieve similar styles.
 
 <div class="bd-example">
-  <table class="table table-inverse">
+  <table class="table table-dark">
     <thead>
       <tr>
         <th>#</th>

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -99,25 +99,25 @@
 @include table-row-variant(active, $table-active-bg);
 
 
-// Inverse styles
+// Dark styles
 //
 // Same table markup, but inverted color scheme: dark background and light text.
 
-.thead-inverse {
+.thead-dark {
   th {
     color: $table-dark-color;
     background-color: $table-dark-bg;
   }
 }
 
-.thead-default {
+.thead-light {
   th {
     color: $table-head-color;
     background-color: $table-head-bg;
   }
 }
 
-.table-inverse {
+.table-dark {
   color: $table-dark-color;
   background-color: $table-dark-bg;
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -105,8 +105,8 @@
 
 .thead-inverse {
   th {
-    color: $table-inverse-color;
-    background-color: $table-inverse-bg;
+    color: $table-dark-color;
+    background-color: $table-dark-bg;
   }
 }
 
@@ -118,13 +118,13 @@
 }
 
 .table-inverse {
-  color: $table-inverse-color;
-  background-color: $table-inverse-bg;
+  color: $table-dark-color;
+  background-color: $table-dark-bg;
 
   th,
   td,
   thead th {
-    border-color: $table-inverse-border-color;
+    border-color: $table-dark-border-color;
   }
 
   &.table-bordered {
@@ -133,14 +133,14 @@
 
   &.table-striped {
     tbody tr:nth-of-type(odd) {
-      background-color: $table-inverse-accent-bg;
+      background-color: $table-dark-accent-bg;
     }
   }
 
   &.table-hover {
     tbody tr {
       @include hover {
-        background-color: $table-inverse-hover-bg;
+        background-color: $table-dark-hover-bg;
       }
     }
   }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -103,17 +103,21 @@
 //
 // Same table markup, but inverted color scheme: dark background and light text.
 
-.thead-dark {
-  th {
-    color: $table-dark-color;
-    background-color: $table-dark-bg;
+.table {
+  .thead-dark {
+    th {
+      color: $table-dark-color;
+      background-color: $table-dark-bg;
+      border-color: $table-dark-border-color;
+    }
   }
-}
 
-.thead-light {
-  th {
-    color: $table-head-color;
-    background-color: $table-head-bg;
+  .thead-light {
+    th {
+      color: $table-head-color;
+      background-color: $table-head-bg;
+      border-color: $table-border-color;
+    }
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -321,11 +321,11 @@ $table-border-color:            $gray-200 !default;
 $table-head-bg:                 $gray-200 !default;
 $table-head-color:              $gray-700 !default;
 
-$table-inverse-bg:              $gray-900 !default;
-$table-inverse-accent-bg:       rgba($white, .05) !default;
-$table-inverse-hover-bg:        rgba($white, .075) !default;
-$table-inverse-border-color:    lighten($gray-900, 7.5%) !default;
-$table-inverse-color:           $body-bg !default;
+$table-dark-bg:              $gray-900 !default;
+$table-dark-accent-bg:       rgba($white, .05) !default;
+$table-dark-hover-bg:        rgba($white, .075) !default;
+$table-dark-border-color:    lighten($gray-900, 7.5%) !default;
+$table-dark-color:           $body-bg !default;
 
 
 // Buttons


### PR DESCRIPTION
Sending another breaking change, this seemed like an oversight. I renamed `.table-inverse`, `.thead-inverse`, `.thead-default` to `.table-dark`, `.thead-dark`, `.thead-light`. I also changed the variables `$table-inverse-*` to `$table-dark-*`.

The last commit fixes a bug where `.thead-inverse` and `.thead-default` doesn't apply the proper variant border color, also made the selector more specific so that it will win over the parent `.table` class e.g. using `.table-inverse` with `.thead-default`.