### PR TITLE
Remove jQuery from Util.js

### DIFF
--- a/js/src/alert.js
+++ b/js/src/alert.js
@@ -118,7 +118,7 @@ const Alert = (($) => {
 
       $(element)
         .one(Util.TRANSITION_END, (event) => this._destroyElement(element, event))
-        .emulateTransitionEnd(TRANSITION_DURATION)
+      Util.emulateTransitionEnd(element, TRANSITION_DURATION)
     }
 
     _destroyElement(element) {

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -406,8 +406,8 @@ const Carousel = (($) => {
             setTimeout(() => $(this._element).trigger(slidEvent), 0)
 
           })
-          .emulateTransitionEnd(TRANSITION_DURATION)
 
+        Util.emulateTransitionEnd(activeElement, TRANSITION_DURATION)
       } else {
         $(activeElement).removeClass(ClassName.ACTIVE)
         $(nextElement).addClass(ClassName.ACTIVE)

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -194,7 +194,8 @@ const Collapse = (($) => {
 
       $(this._element)
         .one(Util.TRANSITION_END, complete)
-        .emulateTransitionEnd(TRANSITION_DURATION)
+
+      Util.emulateTransitionEnd(this._element, TRANSITION_DURATION)
 
       this._element.style[dimension] = `${this._element[scrollSize]}px`
     }
@@ -255,7 +256,7 @@ const Collapse = (($) => {
 
       $(this._element)
         .one(Util.TRANSITION_END, complete)
-        .emulateTransitionEnd(TRANSITION_DURATION)
+      Util.emulateTransitionEnd(this._element, TRANSITION_DURATION)
     }
 
     setTransitioning(isTransitioning) {

--- a/js/src/dom/event.js
+++ b/js/src/dom/event.js
@@ -1,0 +1,38 @@
+/**
+ * --------------------------------------------------------------------------
+ * Bootstrap (v4.0.0-beta): dom/event.js
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+const Event = {
+  on(element, event, handler) {
+    if (typeof event !== 'string') {
+      return
+    }
+    element.addEventListener(event, handler, false)
+  },
+
+  one(element, event, handler) {
+    const complete = () => {
+      /* eslint func-style: off */
+      handler()
+      element.removeEventListener(event, complete, false)
+    }
+    Event.on(element, event, complete)
+  },
+
+  trigger(element, event) {
+    if (typeof event !== 'string') {
+      return
+    }
+
+    const eventToDispatch = new CustomEvent(event, {
+      bubbles: true,
+      cancelable: true
+    })
+    element.dispatchEvent(eventToDispatch)
+  }
+}
+
+export default Event

--- a/js/src/dom/event.js
+++ b/js/src/dom/event.js
@@ -5,6 +5,13 @@
  * --------------------------------------------------------------------------
  */
 
+const TransitionEndEvent = {
+  WebkitTransition : 'webkitTransitionEnd',
+  MozTransition    : 'transitionend',
+  OTransition      : 'oTransitionEnd otransitionend',
+  transition       : 'transitionend'
+}
+
 const Event = {
   on(element, event, handler) {
     if (typeof event !== 'string') {
@@ -32,6 +39,22 @@ const Event = {
       cancelable: true
     })
     element.dispatchEvent(eventToDispatch)
+  },
+
+  getBrowserTransitionEnd() {
+    if (window.QUnit) {
+      return false
+    }
+
+    const el = document.createElement('bootstrap')
+    for (const name in TransitionEndEvent) {
+      if (el.style[name] !== undefined) {
+        return {
+          end: TransitionEndEvent[name]
+        }
+      }
+    }
+    return false
   }
 }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -192,10 +192,10 @@ const Modal = (($) => {
       $(this._dialog).off(Event.MOUSEDOWN_DISMISS)
 
       if (transition) {
-
         $(this._element)
           .one(Util.TRANSITION_END, (event) => this._hideModal(event))
-          .emulateTransitionEnd(TRANSITION_DURATION)
+
+        Util.emulateTransitionEnd(this._element, TRANSITION_DURATION)
       } else {
         this._hideModal()
       }
@@ -267,7 +267,8 @@ const Modal = (($) => {
       if (transition) {
         $(this._dialog)
           .one(Util.TRANSITION_END, transitionComplete)
-          .emulateTransitionEnd(TRANSITION_DURATION)
+
+        Util.emulateTransitionEnd(this._dialog, TRANSITION_DURATION)
       } else {
         transitionComplete()
       }
@@ -374,8 +375,8 @@ const Modal = (($) => {
 
         $(this._backdrop)
           .one(Util.TRANSITION_END, callback)
-          .emulateTransitionEnd(BACKDROP_TRANSITION_DURATION)
 
+        Util.emulateTransitionEnd(this._backdrop, BACKDROP_TRANSITION_DURATION)
       } else if (!this._isShown && this._backdrop) {
         $(this._backdrop).removeClass(ClassName.SHOW)
 
@@ -390,7 +391,8 @@ const Modal = (($) => {
            $(this._element).hasClass(ClassName.FADE)) {
           $(this._backdrop)
             .one(Util.TRANSITION_END, callbackRemove)
-            .emulateTransitionEnd(BACKDROP_TRANSITION_DURATION)
+
+          Util.emulateTransitionEnd(this._backdrop, BACKDROP_TRANSITION_DURATION)
         } else {
           callbackRemove()
         }

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -172,8 +172,8 @@ const Tab = (($) => {
       if (active && isTransitioning) {
         $(active)
           .one(Util.TRANSITION_END, complete)
-          .emulateTransitionEnd(TRANSITION_DURATION)
 
+        Util.emulateTransitionEnd(active, TRANSITION_DURATION)
       } else {
         complete()
       }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -338,7 +338,8 @@ const Tooltip = (($) => {
         if (Util.supportsTransitionEnd() && $(this.tip).hasClass(ClassName.FADE)) {
           $(this.tip)
             .one(Util.TRANSITION_END, complete)
-            .emulateTransitionEnd(Tooltip._TRANSITION_DURATION)
+
+          Util.emulateTransitionEnd(this.tip, Tooltip._TRANSITION_DURATION)
         } else {
           complete()
         }
@@ -385,17 +386,15 @@ const Tooltip = (($) => {
 
       if (Util.supportsTransitionEnd() &&
           $(this.tip).hasClass(ClassName.FADE)) {
-
         $(tip)
           .one(Util.TRANSITION_END, complete)
-          .emulateTransitionEnd(TRANSITION_DURATION)
 
+        Util.emulateTransitionEnd(tip, TRANSITION_DURATION)
       } else {
         complete()
       }
 
       this._hoverState = ''
-
     }
 
     update() {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -9,23 +9,9 @@ import Event from './dom/event'
 
 const Util = (() => {
 
-
-  /**
-   * ------------------------------------------------------------------------
-   * Private TransitionEnd Helpers
-   * ------------------------------------------------------------------------
-   */
-
-  let transition = false
+  const transition = Event.getBrowserTransitionEnd()
 
   const MAX_UID = 1000000
-
-  const TransitionEndEvent = {
-    WebkitTransition : 'webkitTransitionEnd',
-    MozTransition    : 'transitionend',
-    OTransition      : 'oTransitionEnd otransitionend',
-    transition       : 'transitionend'
-  }
 
   // shoutout AngusCroll (https://goo.gl/pxwQGp)
   function toType(obj) {
@@ -35,28 +21,6 @@ const Util = (() => {
   function isElement(obj) {
     return (obj[0] || obj).nodeType
   }
-
-  function transitionEndTest() {
-    if (window.QUnit) {
-      return false
-    }
-
-    const el = document.createElement('bootstrap')
-
-    for (const name in TransitionEndEvent) {
-      if (el.style[name] !== undefined) {
-        return {
-          end: TransitionEndEvent[name]
-        }
-      }
-    }
-
-    return false
-  }
-
-  (() => {
-    transition = transitionEndTest()
-  })()
 
 
   /**

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -1,3 +1,5 @@
+import Event from './dom/event'
+
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v4.0.0-beta): util.js
@@ -5,7 +7,7 @@
  * --------------------------------------------------------------------------
  */
 
-const Util = (($) => {
+const Util = (() => {
 
 
   /**
@@ -34,19 +36,6 @@ const Util = (($) => {
     return (obj[0] || obj).nodeType
   }
 
-  function getSpecialTransitionEndEvent() {
-    return {
-      bindType: transition.end,
-      delegateType: transition.end,
-      handle(event) {
-        if ($(event.target).is(this)) {
-          return event.handleObj.handler.apply(this, arguments) // eslint-disable-line prefer-rest-params
-        }
-        return undefined
-      }
-    }
-  }
-
   function transitionEndTest() {
     if (window.QUnit) {
       return false
@@ -65,31 +54,9 @@ const Util = (($) => {
     return false
   }
 
-  function transitionEndEmulator(duration) {
-    let called = false
-
-    $(this).one(Util.TRANSITION_END, () => {
-      called = true
-    })
-
-    setTimeout(() => {
-      if (!called) {
-        Util.triggerTransitionEnd(this)
-      }
-    }, duration)
-
-    return this
-  }
-
-  function setTransitionEndSupport() {
+  (() => {
     transition = transitionEndTest()
-
-    $.fn.emulateTransitionEnd = transitionEndEmulator
-
-    if (Util.supportsTransitionEnd()) {
-      $.event.special[Util.TRANSITION_END] = getSpecialTransitionEndEvent()
-    }
-  }
+  })()
 
 
   /**
@@ -117,8 +84,8 @@ const Util = (($) => {
       }
 
       try {
-        const $selector = $(selector)
-        return $selector.length > 0 ? selector : null
+        const elements = document.querySelectorAll(selector)
+        return elements.length > 0 ? selector : null
       } catch (error) {
         return null
       }
@@ -129,11 +96,17 @@ const Util = (($) => {
     },
 
     triggerTransitionEnd(element) {
-      $(element).trigger(transition.end)
+      Event.trigger(element, Util.TRANSITION_END)
     },
 
     supportsTransitionEnd() {
       return Boolean(transition)
+    },
+
+    emulateTransitionEnd(element, duration) {
+      setTimeout(() => {
+        Util.triggerTransitionEnd(element)
+      }, duration)
     },
 
     typeCheckConfig(componentName, config, configTypes) {
@@ -155,10 +128,8 @@ const Util = (($) => {
     }
   }
 
-  setTransitionEndSupport()
-
   return Util
 
-})(jQuery)
+})()
 
 export default Util

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -96,6 +96,7 @@
     </script>
 
     <!-- Transpiled Plugins -->
+    <script src="../dist/dom/event.js"></script>
     <script src="../dist/util.js"></script>
     <script src="../dist/alert.js"></script>
     <script src="../dist/button.js"></script>

--- a/js/tests/visual/alert.html
+++ b/js/tests/visual/alert.html
@@ -45,6 +45,7 @@
     </div>
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/alert.js"></script>
   </body>

--- a/js/tests/visual/button.html
+++ b/js/tests/visual/button.html
@@ -45,6 +45,7 @@
     </div>
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/button.js"></script>
   </body>

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -41,6 +41,7 @@
     </div>
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/carousel.js"></script>
 

--- a/js/tests/visual/collapse.html
+++ b/js/tests/visual/collapse.html
@@ -58,6 +58,7 @@
     </div>
 
     <script src="../../../docs/assets/js/vendor/jquery-slim.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/collapse.js"></script>
   </body>

--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -119,6 +119,7 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/dropdown.js"></script>
     <script src="../../dist/collapse.js"></script>

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -171,6 +171,7 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/modal.js"></script>
     <script src="../../dist/collapse.js"></script>

--- a/js/tests/visual/popover.html
+++ b/js/tests/visual/popover.html
@@ -34,6 +34,7 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/tooltip.js"></script>
     <script src="../../dist/popover.js"></script>

--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -88,6 +88,7 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/scrollspy.js"></script>
     <script src="../../dist/dropdown.js"></script>

--- a/js/tests/visual/tab.html
+++ b/js/tests/visual/tab.html
@@ -226,6 +226,7 @@
     </div>
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/event.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/tab.js"></script>
     <script src="../../dist/dropdown.js"></script>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "js-lint": "eslint js/ && eslint --config js/tests/.eslintrc.json --env node build/ Gruntfile.js",
     "js-lint-docs": "eslint --config js/tests/.eslintrc.json assets/js/",
     "js-compile": "npm-run-all --parallel js-compile-*",
-    "js-compile-bundle": "shx cat js/src/util.js js/src/alert.js js/src/button.js js/src/carousel.js js/src/collapse.js js/src/dropdown.js js/src/modal.js js/src/scrollspy.js js/src/tab.js js/src/tooltip.js js/src/popover.js | shx sed \"s/^(import|export).*//\" | babel --filename js/src/bootstrap.js | node build/stamp.js > dist/js/bootstrap.js",
+    "js-compile-bundle": "shx cat js/src/dom/event.js js/src/util.js js/src/alert.js js/src/button.js js/src/carousel.js js/src/collapse.js js/src/dropdown.js js/src/modal.js js/src/scrollspy.js js/src/tab.js js/src/tooltip.js js/src/popover.js | shx sed \"s/^(import|export).*//\" | babel --filename js/src/bootstrap.js | node build/stamp.js > dist/js/bootstrap.js",
     "js-compile-plugins": "babel js/src/ --out-dir js/dist/ --source-maps",
     "js-minify": "uglifyjs --config-file build/uglifyjs.config.json --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
     "js-minify-docs": "uglifyjs --config-file build/uglifyjs.config.json --output assets/js/docs.min.js assets/js/vendor/anchor.min.js assets/js/vendor/clipboard.min.js assets/js/vendor/holder.min.js assets/js/src/application.js assets/js/src/pwa.js",


### PR DESCRIPTION
That's the first try to remove jQuery from our source, with this PR no more jQuery in Util.js and other plugins will follow the move 😄 

I added a new folder `dom` which will allow us to make some usefull functions to replace jQuery


