### PR TITLE
Rename grayscale function to gray

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -72,7 +72,7 @@
   @return map-get($theme-colors, $key);
 }
 
-@function grayscale($key: "100") {
+@function gray($key: "100") {
   @return map-get($grays, $key);
 }
 


### PR DESCRIPTION
Fixes #23428.

The original function apparently interferes with the `grayscale` filter from native CSS. This will be a breaking change and needs to be noted in #23577.