### PR TITLE
Use postcss-calc to simplify css calc(), closes #23581

### DIFF
--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -5,6 +5,7 @@ module.exports = (ctx) => ({
     sourcesContent: true
   },
   plugins: {
+    'postcss-calc': {},
     autoprefixer: {
       browsers: [
         //

--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,6 +1309,12 @@
         "boom": "2.10.1"
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2034,6 +2040,12 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2789,6 +2801,12 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "infinity-agent": {
       "version": "2.0.3",
@@ -4440,6 +4458,18 @@
         "supports-color": "4.2.1"
       }
     },
+    "postcss-calc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.0.tgz",
+      "integrity": "sha1-toGyecbST74OM+2QRYA3BURdYTs=",
+      "dev": true,
+      "requires": {
+        "css-unit-converter": "1.1.1",
+        "postcss": "6.0.9",
+        "postcss-selector-parser": "2.2.3",
+        "reduce-css-calc": "2.0.5"
+      }
+    },
     "postcss-cli": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-4.1.0.tgz",
@@ -4704,6 +4734,17 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-value-parser": {
@@ -5013,6 +5054,16 @@
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.0.5.tgz",
+      "integrity": "sha1-M8l4OMXUxxGlwU74XOT95BSD970=",
+      "dev": true,
+      "requires": {
+        "css-unit-converter": "1.1.1",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "regenerate": {
@@ -5937,6 +5988,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
       "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
+      "dev": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.14",
+    "postcss-calc": "^6.0.0",
     "postcss-cli": "^4.1.0",
     "qunit-phantomjs-runner": "^2.3.0",
     "qunitjs": "^2.4.0",


### PR DESCRIPTION
It will simplify css calc() expression on `.col-form-label`, `.col-form-label-lg` and `.col-form-label-sm`.