### PR TITLE
Tweak ESLint rules

### DIFF
--- a/assets/js/ie-emulation-modes-warning.js
+++ b/assets/js/ie-emulation-modes-warning.js
@@ -27,7 +27,7 @@
     // IE JavaScript conditional compilation docs: https://msdn.microsoft.com/library/121hztk3%28v=vs.94%29.aspx
     // @cc_on docs: https://msdn.microsoft.com/library/8ka90k2e%28v=vs.94%29.aspx
     var jscriptVersion = new Function('/*@cc_on return @_jscript_version; @*/')() // eslint-disable-line no-new-func
-    if (jscriptVersion === undefined) {
+    if (typeof jscriptVersion === 'undefined') {
       return 11 // IE11+ not in emulation mode
     }
     if (jscriptVersion < 9) {

--- a/js/.eslintrc.json
+++ b/js/.eslintrc.json
@@ -14,9 +14,8 @@
   "rules": {
     // Possible Errors
     "no-await-in-loop": "error",
-    "no-compare-neg-zero": "error",
     "no-extra-parens": "error",
-    "no-prototype-builtins": "off",
+    "no-prototype-builtins": "error",
     "no-template-curly-in-string": "error",
     "valid-jsdoc": "error",
 
@@ -85,7 +84,6 @@
     "no-unused-expressions": "error",
     "no-useless-call": "error",
     "no-useless-concat": "error",
-    "no-useless-escape": "error",
     "no-useless-return": "off",
     "no-void": "error",
     "no-warning-comments": "off",
@@ -108,7 +106,7 @@
     "no-shadow": "off",
     "no-shadow-restricted-names": "error",
     "no-undef-init": "error",
-    "no-undefined": "off",
+    "no-undefined": "error",
     "no-use-before-define": "off",
 
     // Node.js and CommonJS
@@ -213,7 +211,7 @@
     "wrap-regex": "off",
 
     // ECMAScript 6
-    "arrow-body-style": "off",
+    "arrow-body-style": ["error", "as-needed"],
     "arrow-parens": "error",
     "arrow-spacing": "error",
     "generator-star-spacing": "error",

--- a/js/.eslintrc.json
+++ b/js/.eslintrc.json
@@ -74,7 +74,7 @@
     "no-param-reassign": "off",
     "no-proto": "error",
     "no-restricted-properties": "error",
-    "no-return-assign": "off",
+    "no-return-assign": "error",
     "no-return-await": "error",
     "no-script-url": "error",
     "no-self-compare": "error",

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -443,7 +443,7 @@ const Carousel = (($) => {
         if (typeof config === 'number') {
           data.to(config)
         } else if (typeof action === 'string') {
-          if (data[action] === undefined) {
+          if (typeof data[action] === 'undefined') {
             throw new Error(`No method named "${action}"`)
           }
           data[action]()

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -343,7 +343,7 @@ const Collapse = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -204,7 +204,7 @@ const Dropdown = (($) => {
 
     _getConfig(config) {
       const elementData = $(this._element).data()
-      if (elementData.placement !== undefined) {
+      if (typeof elementData.placement !== 'undefined') {
         elementData.placement = AttachmentMap[elementData.placement.toUpperCase()]
       }
 
@@ -287,7 +287,7 @@ const Dropdown = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -507,7 +507,7 @@ const Modal = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config](relatedTarget)

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -114,7 +114,8 @@ const Popover = (($) => {
     }
 
     getTipElement() {
-      return this.tip = this.tip || $(this.config.template)[0]
+      this.tip = this.tip || $(this.config.template)[0]
+      return this.tip
     }
 
     setContent() {

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -162,7 +162,7 @@ const Popover = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -231,7 +231,7 @@ const ScrollSpy = (($) => {
       for (let i = this._offsets.length; i--;) {
         const isActiveTarget = this._activeTarget !== this._targets[i]
             && scrollTop >= this._offsets[i]
-            && (this._offsets[i + 1] === undefined ||
+            && (typeof this._offsets[i + 1] === 'undefined' ||
                 scrollTop < this._offsets[i + 1])
 
         if (isActiveTarget) {
@@ -246,6 +246,7 @@ const ScrollSpy = (($) => {
       this._clear()
 
       let queries = this._selector.split(',')
+      // eslint-disable-next-line arrow-body-style
       queries     = queries.map((selector) => {
         return `${selector}[data-target="${target}"],` +
                `${selector}[href="${target}"]`
@@ -287,7 +288,7 @@ const ScrollSpy = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -238,7 +238,7 @@ const Tab = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -698,7 +698,7 @@ const Tooltip = (($) => {
         }
 
         if (typeof config === 'string') {
-          if (data[config] === undefined) {
+          if (typeof data[config] === 'undefined') {
             throw new Error(`No method named "${config}"`)
           }
           data[config]()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -415,7 +415,8 @@ const Tooltip = (($) => {
     }
 
     getTipElement() {
-      return this.tip = this.tip || $(this.config.template)[0]
+      this.tip = this.tip || $(this.config.template)[0]
+      return this.tip
     }
 
     setContent() {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -42,7 +42,7 @@ const Util = (($) => {
         if ($(event.target).is(this)) {
           return event.handleObj.handler.apply(this, arguments) // eslint-disable-line prefer-rest-params
         }
-        return undefined
+        return undefined // eslint-disable-line no-undefined
       }
     }
   }
@@ -55,7 +55,7 @@ const Util = (($) => {
     const el = document.createElement('bootstrap')
 
     for (const name in TransitionEndEvent) {
-      if (el.style[name] !== undefined) {
+      if (typeof el.style[name] !== 'undefined') {
         return {
           end: TransitionEndEvent[name]
         }
@@ -138,7 +138,7 @@ const Util = (($) => {
 
     typeCheckConfig(componentName, config, configTypes) {
       for (const property in configTypes) {
-        if (configTypes.hasOwnProperty(property)) {
+        if (Object.prototype.hasOwnProperty.call(configTypes, property)) {
           const expectedTypes = configTypes[property]
           const value         = config[property]
           const valueType     = value && isElement(value) ?

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.alert, undefined, 'alert was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.alert, 'undefined', 'alert was set back to undefined (org value)')
   })
 
   QUnit.test('should return jquery collection containing the element', function (assert) {

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.button, undefined, 'button was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.button, 'undefined', 'button was set back to undefined (org value)')
   })
 
   QUnit.test('should return jquery collection containing the element', function (assert) {

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.carousel, undefined, 'carousel was set back to undefined (orig value)')
+    assert.strictEqual(typeof $.fn.carousel, 'undefined', 'carousel was set back to undefined (orig value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -371,14 +371,14 @@ $(function () {
     var done = assert.async()
     $(template)
       .on('slid.bs.carousel', function (e) {
-        assert.ok(e.from !== undefined, 'from present')
-        assert.ok(e.to !== undefined, 'to present')
+        assert.ok(typeof e.from !== 'undefined', 'from present')
+        assert.ok(typeof e.to !== 'undefined', 'to present')
         $(this).off()
         done()
       })
       .on('slide.bs.carousel', function (e) {
-        assert.ok(e.from !== undefined, 'from present')
-        assert.ok(e.to !== undefined, 'to present')
+        assert.ok(typeof e.from !== 'undefined', 'from present')
+        assert.ok(typeof e.to !== 'undefined', 'to present')
         $(this).off('slide.bs.carousel')
       })
       .bootstrapCarousel('next')

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.collapse, undefined, 'collapse was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.collapse, 'undefined', 'collapse was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.dropdown, undefined, 'dropdown was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.dropdown, 'undefined', 'dropdown was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -644,7 +644,7 @@ $(function () {
     $triggerDropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdownMenu.attr('style') === undefined, 'No inline style applied by Popper.js')
+        assert.ok(typeof $dropdownMenu.attr('style') === 'undefined', 'No inline style applied by Popper.js')
         done()
       })
     $triggerDropdown.trigger($.Event('click'))

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -34,7 +34,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.modal, undefined, 'modal was set back to undefined (orig value)')
+    assert.strictEqual(typeof $.fn.modal, 'undefined', 'modal was set back to undefined (orig value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -380,7 +380,7 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('hidden.bs.modal', function () {
-        assert.strictEqual($body.data('padding-right'), undefined, 'data-padding-right should be cleared after closing')
+        assert.strictEqual(typeof $body.data('padding-right'), 'undefined', 'data-padding-right should be cleared after closing')
         $body.removeAttr('style')
         done()
       })
@@ -422,7 +422,7 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('hidden.bs.modal', function () {
-        assert.strictEqual($element.data('padding-right'), undefined, 'data-padding-right should be cleared after closing')
+        assert.strictEqual(typeof $element.data('padding-right'), 'undefined', 'data-padding-right should be cleared after closing')
         $element.remove()
         done()
       })
@@ -464,7 +464,7 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('hidden.bs.modal', function () {
-        assert.strictEqual($element.data('margin-right'), undefined, 'data-margin-right should be cleared after closing')
+        assert.strictEqual(typeof $element.data('margin-right'), 'undefined', 'data-margin-right should be cleared after closing')
         $element.remove()
         done()
       })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -22,7 +22,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.popover, undefined, 'popover was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.popover, 'undefined', 'popover was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -304,7 +304,7 @@ $(function () {
         assert.ok(false, 'should not fire any popover events')
       })
       .bootstrapPopover('hide')
-    assert.strictEqual($popover.data('bs.popover'), undefined, 'should not initialize the popover')
+    assert.strictEqual(typeof $popover.data('bs.popover'), 'undefined', 'should not initialize the popover')
   })
 
   QUnit.test('should fire inserted event', function (assert) {

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.scrollspy, undefined, 'scrollspy was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.scrollspy, 'undefined', 'scrollspy was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -21,7 +21,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.tab, undefined, 'tab was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.tab, 'undefined', 'tab was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -22,7 +22,7 @@ $(function () {
 
   QUnit.test('should provide no conflict', function (assert) {
     assert.expect(1)
-    assert.strictEqual($.fn.tooltip, undefined, 'tooltip was set back to undefined (org value)')
+    assert.strictEqual(typeof $.fn.tooltip, 'undefined', 'tooltip was set back to undefined (org value)')
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -382,7 +382,7 @@ $(function () {
       .on('inserted.bs.tooltip', function () {
         var $tooltip = $($(this).data('bs.tooltip').tip)
         assert.ok($tooltip.hasClass('bs-tooltip-right'))
-        assert.ok($tooltip.attr('style') === undefined)
+        assert.ok(typeof $tooltip.attr('style') === 'undefined')
         $styles.remove()
         done()
       })
@@ -701,7 +701,7 @@ $(function () {
         assert.ok(false, 'should not fire any tooltip events')
       })
       .bootstrapTooltip('hide')
-    assert.strictEqual($tooltip.data('bs.tooltip'), undefined, 'should not initialize the tooltip')
+    assert.strictEqual(typeof $tooltip.data('bs.tooltip'), 'undefined', 'should not initialize the tooltip')
   })
 
   QUnit.test('should not remove tooltip if multiple triggers are set and one is still active', function (assert) {


### PR DESCRIPTION
* removed a few enabled rules which we are already using the default values
* enabled a few for strictness

@Johann-S: I know we disagreed last time on `undefined` but I still believe we should enable this. That being said, the other changes are good too, so I can revert that part if you insist.

We should also discuss which other rules we might enable. I know for sure I'd like semicolons, but it's a personal matter of taste plus this would conflict with your other PRs so it's something we should do in the future, if ever.