### PR TITLE
Allow easy customization of docs variables

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -1,11 +1,11 @@
 // Local docs variables
-$bd-purple:          #563d7c;
-$bd-purple-bright:   lighten(saturate($bd-purple, 5%), 15%);
-$bd-purple-light:    #cdbfe3;
-$bd-purple-lightest: #f5f2f9;
-$bd-graphite:        #2a2730;
-$bd-graphite-light:  lighten($bd-graphite, 40%);
-$bd-yellow:          #ffe484;
-$bd-danger:          #d9534f;
-$bd-warning:         #f0ad4e;
-$bd-info:            #5bc0de;
+$bd-purple:          #563d7c !default;
+$bd-purple-bright:   lighten(saturate($bd-purple, 5%), 15%) !default;
+$bd-purple-light:    #cdbfe3 !default;
+$bd-purple-lightest: #f5f2f9 !default;
+$bd-graphite:        #2a2730 !default;
+$bd-graphite-light:  lighten($bd-graphite, 40%) !default;
+$bd-yellow:          #ffe484 !default;
+$bd-danger:          #d9534f !default;
+$bd-warning:         #f0ad4e !default;
+$bd-info:            #5bc0de !default;


### PR DESCRIPTION
* append `!default` to local docs variables

---
Hey bootstrappers 👋 

I'm generating some corp. docs and want to override the 
default docs variables, without touching the default vars.
Seems some `!default` are missing here.