### PR TITLE
Fix toggle for Tooltips/Popover

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -184,6 +184,10 @@ const Tooltip = (($) => {
     }
 
     toggle(event) {
+      if (!this._isEnabled) {
+        return
+      }
+
       if (event) {
         const dataKey = this.constructor.DATA_KEY
         let context = $(event.currentTarget).data(dataKey)
@@ -234,8 +238,8 @@ const Tooltip = (($) => {
       if (this._popper !== null) {
         this._popper.destroy()
       }
-      this._popper        = null
 
+      this._popper = null
       this.element = null
       this.config  = null
       this.tip     = null
@@ -706,7 +710,6 @@ const Tooltip = (($) => {
         }
       })
     }
-
   }
 
 

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -387,4 +387,27 @@ $(function () {
 
     $popover.bootstrapPopover('show')
   })
+
+  QUnit.test('popover should be shown right away after the call of disable/enable', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+    var $popover = $('<a href="#">@mdo</a>')
+      .appendTo('#qunit-fixture')
+      .bootstrapPopover({
+        title: 'Test popover',
+        content: 'with disable/enable'
+      })
+      .on('shown.bs.popover', function () {
+        assert.strictEqual($('.popover').hasClass('show'), true)
+        done()
+      })
+
+    $popover.bootstrapPopover('disable')
+    $popover.trigger($.Event('click'))
+    setTimeout(function () {
+      assert.strictEqual($('.popover').length === 0, true)
+      $popover.bootstrapPopover('enable')
+      $popover.trigger($.Event('click'))
+    }, 200)
+  })
 })

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -826,4 +826,26 @@ $(function () {
 
     $el.bootstrapTooltip('show')
   })
+
+  QUnit.test('tooltip should be shown right away after the call of disable/enable', function (assert) {
+    assert.expect(2)
+    var done = assert.async()
+
+    var $trigger = $('<a href="#" rel="tooltip" data-trigger="click" title="Another tooltip"/>')
+      .appendTo('#qunit-fixture')
+      .bootstrapTooltip()
+      .on('shown.bs.tooltip', function () {
+        assert.strictEqual($('.tooltip').hasClass('show'), true)
+        done()
+      })
+
+
+    $trigger.bootstrapTooltip('disable')
+    $trigger.trigger($.Event('click'))
+    setTimeout(function () {
+      assert.strictEqual($('.tooltip').length === 0, true)
+      $trigger.bootstrapTooltip('enable')
+      $trigger.trigger($.Event('click'))
+    }, 200)
+  })
 })


### PR DESCRIPTION
`toggle` method were called by Tootlip and Popover even if they were disabled

Close: #23525