### PR TITLE
Removing jQuery from Carousel

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -1,4 +1,6 @@
-import $ from 'jquery'
+import Data from './dom/data'
+import EventHandler from './dom/eventHandler'
+import SelectorEngine from './dom/selectorEngine'
 import Util from './util'
 
 
@@ -104,8 +106,8 @@ const Carousel = (() => {
       this.touchTimeout       = null
 
       this._config            = this._getConfig(config)
-      this._element           = $(element)[0]
-      this._indicatorsElement = $(this._element).find(Selector.INDICATORS)[0]
+      this._element           = element
+      this._indicatorsElement = SelectorEngine.findOne(Selector.INDICATORS, this._element)
 
       this._addEventListeners()
     }
@@ -133,8 +135,7 @@ const Carousel = (() => {
     nextWhenVisible() {
       // Don't call next when the page isn't visible
       // or the carousel or its parent isn't visible
-      if (!document.hidden &&
-        ($(this._element).is(':visible') && $(this._element).css('visibility') !== 'hidden')) {
+      if (!document.hidden && Util.isVisible(this._element)) {
         this.next()
       }
     }
@@ -150,7 +151,7 @@ const Carousel = (() => {
         this._isPaused = true
       }
 
-      if ($(this._element).find(Selector.NEXT_PREV)[0] &&
+      if (SelectorEngine.findOne(Selector.NEXT_PREV, this._element) &&
         Util.supportsTransitionEnd()) {
         Util.triggerTransitionEnd(this._element)
         this.cycle(true)
@@ -179,8 +180,7 @@ const Carousel = (() => {
     }
 
     to(index) {
-      this._activeElement = $(this._element).find(Selector.ACTIVE_ITEM)[0]
-
+      this._activeElement = SelectorEngine.findOne(Selector.ACTIVE_ITEM, this._element)
       const activeIndex = this._getItemIndex(this._activeElement)
 
       if (index > this._items.length - 1 || index < 0) {
@@ -188,7 +188,7 @@ const Carousel = (() => {
       }
 
       if (this._isSliding) {
-        $(this._element).one(Event.SLID, () => this.to(index))
+        EventHandler.one(this._element, Event.SLID, () => this.to(index))
         return
       }
 
@@ -206,8 +206,8 @@ const Carousel = (() => {
     }
 
     dispose() {
-      $(this._element).off(EVENT_KEY)
-      $.removeData(this._element, DATA_KEY)
+      EventHandler.off(this._element, DATA_KEY)
+      Data.removeData(this._element, DATA_KEY)
 
       this._items             = null
       this._config            = null
@@ -223,21 +223,22 @@ const Carousel = (() => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = Util.extend(Util.extend({}, Default), config)
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
     }
 
     _addEventListeners() {
       if (this._config.keyboard) {
-        $(this._element)
-          .on(Event.KEYDOWN, (event) => this._keydown(event))
+        EventHandler
+          .on(this._element, Event.KEYDOWN, (event) => this._keydown(event))
       }
 
       if (this._config.pause === 'hover') {
-        $(this._element)
-          .on(Event.MOUSEENTER, (event) => this.pause(event))
-          .on(Event.MOUSELEAVE, (event) => this.cycle(event))
+        EventHandler
+          .on(this._element, Event.MOUSEENTER, (event) => this.pause(event))
+        EventHandler
+          .on(this._element, Event.MOUSELEAVE, (event) => this.cycle(event))
         if ('ontouchstart' in document.documentElement) {
           // if it's a touch-enabled device, mouseenter/leave are fired as
           // part of the mouse compatibility events on first tap - the carousel
@@ -246,13 +247,14 @@ const Carousel = (() => {
           // (as if it's the second time we tap on it, mouseenter compat event
           // is NOT fired) and after a timeout (to allow for mouse compatibility
           // events to fire) we explicitly restart cycling
-          $(this._element).on(Event.TOUCHEND, () => {
-            this.pause()
-            if (this.touchTimeout) {
-              clearTimeout(this.touchTimeout)
-            }
-            this.touchTimeout = setTimeout((event) => this.cycle(event), TOUCHEVENT_COMPAT_WAIT + this._config.interval)
-          })
+          EventHandler
+            .on(this._element, Event.TOUCHEND, () => {
+              this.pause()
+              if (this.touchTimeout) {
+                clearTimeout(this.touchTimeout)
+              }
+              this.touchTimeout = setTimeout((event) => this.cycle(event), TOUCHEVENT_COMPAT_WAIT + this._config.interval)
+            })
         }
       }
     }
@@ -277,7 +279,7 @@ const Carousel = (() => {
     }
 
     _getItemIndex(element) {
-      this._items = $.makeArray($(element).parent().find(Selector.ITEM))
+      this._items = Util.makeArray(SelectorEngine.find(Selector.ITEM, element.parentNode))
       return this._items.indexOf(element)
     }
 
@@ -303,40 +305,39 @@ const Carousel = (() => {
 
     _triggerSlideEvent(relatedTarget, eventDirectionName) {
       const targetIndex = this._getItemIndex(relatedTarget)
-      const fromIndex = this._getItemIndex($(this._element).find(Selector.ACTIVE_ITEM)[0])
-      const slideEvent = $.Event(Event.SLIDE, {
+      const fromIndex   = this._getItemIndex(SelectorEngine.findOne(Selector.ACTIVE_ITEM, this._element))
+
+      return EventHandler.trigger(this._element, Event.SLIDE, {
         relatedTarget,
         direction: eventDirectionName,
         from: fromIndex,
         to: targetIndex
       })
-
-      $(this._element).trigger(slideEvent)
-
-      return slideEvent
     }
 
     _setActiveIndicatorElement(element) {
       if (this._indicatorsElement) {
-        $(this._indicatorsElement)
-          .find(Selector.ACTIVE)
-          .removeClass(ClassName.ACTIVE)
+        const indicators = SelectorEngine.find(Selector.ACTIVE, this._indicatorsElement)
+        for (let i = 0; i < indicators.length; i++) {
+          indicators[i].classList.remove(ClassName.ACTIVE)
+        }
 
         const nextIndicator = this._indicatorsElement.children[
           this._getItemIndex(element)
         ]
 
         if (nextIndicator) {
-          $(nextIndicator).addClass(ClassName.ACTIVE)
+          nextIndicator.classList.add(ClassName.ACTIVE)
         }
       }
     }
 
     _slide(direction, element) {
-      const activeElement = $(this._element).find(Selector.ACTIVE_ITEM)[0]
+      const activeElement = SelectorEngine.findOne(Selector.ACTIVE_ITEM, this._element)
       const activeElementIndex = this._getItemIndex(activeElement)
-      const nextElement   = element || activeElement &&
+      const nextElement = element || activeElement &&
         this._getItemByDirection(direction, activeElement)
+
       const nextElementIndex = this._getItemIndex(nextElement)
       const isCycling = Boolean(this._interval)
 
@@ -354,13 +355,13 @@ const Carousel = (() => {
         eventDirectionName = Direction.RIGHT
       }
 
-      if (nextElement && $(nextElement).hasClass(ClassName.ACTIVE)) {
+      if (nextElement && nextElement.classList.contains(ClassName.ACTIVE)) {
         this._isSliding = false
         return
       }
 
       const slideEvent = this._triggerSlideEvent(nextElement, eventDirectionName)
-      if (slideEvent.isDefaultPrevented()) {
+      if (slideEvent.defaultPrevented) {
         return
       }
 
@@ -377,44 +378,50 @@ const Carousel = (() => {
 
       this._setActiveIndicatorElement(nextElement)
 
-      const slidEvent = $.Event(Event.SLID, {
-        relatedTarget: nextElement,
-        direction: eventDirectionName,
-        from: activeElementIndex,
-        to: nextElementIndex
-      })
-
       if (Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.SLIDE)) {
+        this._element.classList.contains(ClassName.SLIDE)) {
 
-        $(nextElement).addClass(orderClassName)
+        nextElement.classList.add(orderClassName)
 
         Util.reflow(nextElement)
 
-        $(activeElement).addClass(directionalClassName)
-        $(nextElement).addClass(directionalClassName)
+        activeElement.classList.add(directionalClassName)
+        nextElement.classList.add(directionalClassName)
 
-        $(activeElement)
-          .one(Util.TRANSITION_END, () => {
-            $(nextElement)
-              .removeClass(`${directionalClassName} ${orderClassName}`)
-              .addClass(ClassName.ACTIVE)
+        EventHandler
+          .one(activeElement, Util.TRANSITION_END, () => {
+            nextElement.classList.remove(directionalClassName)
+            nextElement.classList.remove(orderClassName)
+            nextElement.classList.add(ClassName.ACTIVE)
 
-            $(activeElement).removeClass(`${ClassName.ACTIVE} ${orderClassName} ${directionalClassName}`)
+            activeElement.classList.remove(ClassName.ACTIVE)
+            activeElement.classList.remove(orderClassName)
+            activeElement.classList.remove(directionalClassName)
 
             this._isSliding = false
 
-            setTimeout(() => $(this._element).trigger(slidEvent), 0)
-
+            setTimeout(() => {
+              EventHandler.trigger(this._element, Event.SLID, {
+                relatedTarget: nextElement,
+                direction: eventDirectionName,
+                from: activeElementIndex,
+                to: nextElementIndex
+              })
+            }, 0)
           })
 
         Util.emulateTransitionEnd(activeElement, TRANSITION_DURATION)
       } else {
-        $(activeElement).removeClass(ClassName.ACTIVE)
-        $(nextElement).addClass(ClassName.ACTIVE)
+        activeElement.classList.remove(ClassName.ACTIVE)
+        nextElement.classList.add(ClassName.ACTIVE)
 
         this._isSliding = false
-        $(this._element).trigger(slidEvent)
+        EventHandler.trigger(this._element, Event.SLID, {
+          relatedTarget: nextElement,
+          direction: eventDirectionName,
+          from: activeElementIndex,
+          to: nextElementIndex
+        })
       }
 
       if (isCycling) {
@@ -427,18 +434,19 @@ const Carousel = (() => {
 
     static _jQueryInterface(config) {
       return this.each(function () {
-        let data      = $(this).data(DATA_KEY)
-        const _config = $.extend({}, Default, $(this).data())
+        let data      = Data.getData(this, DATA_KEY)
+        const _config = Util.extend(
+          Util.extend({}, Default), Data.getData(this, DATA_KEY))
 
         if (typeof config === 'object') {
-          $.extend(_config, config)
+          Util.extend(_config, config)
         }
 
         const action = typeof config === 'string' ? config : _config.slide
 
         if (!data) {
           data = new Carousel(this, _config)
-          $(this).data(DATA_KEY, data)
+          Data.setData(this, DATA_KEY, data)
         }
 
         if (typeof config === 'number') {
@@ -462,13 +470,13 @@ const Carousel = (() => {
         return
       }
 
-      const target = $(selector)[0]
+      const target = SelectorEngine.findOne(selector)
 
-      if (!target || !$(target).hasClass(ClassName.CAROUSEL)) {
+      if (!target || !target.classList.contains(ClassName.CAROUSEL)) {
         return
       }
 
-      const config     = $.extend({}, $(target).data(), $(this).data())
+      const config     = Util.extend(Util.extend({}, Util.getDataAttributes(target)), Util.getDataAttributes(this))
       const slideIndex = this.getAttribute('data-slide-to')
 
       if (slideIndex) {
@@ -478,12 +486,11 @@ const Carousel = (() => {
       Carousel._jQueryInterface.call($(target), config)
 
       if (slideIndex) {
-        $(target).data(DATA_KEY).to(slideIndex)
+        Data.getData(target, DATA_KEY).to(slideIndex)
       }
 
       event.preventDefault()
     }
-
   }
 
 
@@ -493,14 +500,14 @@ const Carousel = (() => {
    * ------------------------------------------------------------------------
    */
 
-  $(document)
-    .on(Event.CLICK_DATA_API, Selector.DATA_SLIDE, Carousel._dataApiClickHandler)
+  EventHandler
+    .on(document, Event.CLICK_DATA_API, Selector.DATA_SLIDE, Carousel._dataApiClickHandler)
 
-  $(window).on(Event.LOAD_DATA_API, () => {
-    $(Selector.DATA_RIDE).each(function () {
-      const $carousel = $(this)
-      Carousel._jQueryInterface.call($carousel, $carousel.data())
-    })
+  EventHandler.on(window, Event.LOAD_DATA_API, () => {
+    const carousels = Util.makeArray(SelectorEngine.find(Selector.DATA_RIDE))
+    for (let i = 0; i < carousels.length; i++) {
+      Carousel._jQueryInterface.call($(carousels[i]), Data.getData(carousels[i], DATA_KEY))
+    }
   })
 
 

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -25,7 +25,6 @@ const Carousel = (() => {
   const DATA_KEY               = 'bs.carousel'
   const EVENT_KEY              = `.${DATA_KEY}`
   const DATA_API_KEY           = '.data-api'
-  const JQUERY_NO_CONFLICT     = $.fn[NAME]
   const TRANSITION_DURATION    = 600
   const ARROW_LEFT_KEYCODE     = 37 // KeyboardEvent.which value for left arrow key
   const ARROW_RIGHT_KEYCODE    = 39 // KeyboardEvent.which value for right arrow key
@@ -224,6 +223,25 @@ const Carousel = (() => {
 
     _getConfig(config) {
       config = Util.extend(Util.extend({}, Default), config)
+      // try to cast interval parameter when it's possible
+      if (typeof config.interval === 'string') {
+        const tmpIntervalNumber = Number(config.interval)
+        if (!isNaN(tmpIntervalNumber)) {
+          config.interval = tmpIntervalNumber
+        }
+        if (config.interval === 'true' || config.interval === 'false') {
+          config.interval = config.interval.toLowerCase() === 'true'
+        }
+      }
+
+      if (typeof config.keyboard === 'string') {
+        config.keyboard = config.keyboard.toLowerCase() === 'true'
+      }
+
+      if (typeof config.wrap === 'string') {
+        config.wrap = config.wrap.toLowerCase() === 'true'
+      }
+
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
     }
@@ -279,7 +297,8 @@ const Carousel = (() => {
     }
 
     _getItemIndex(element) {
-      this._items = Util.makeArray(SelectorEngine.find(Selector.ITEM, element.parentNode))
+      this._items = typeof element !== 'undefined' && element !== null ?
+        Util.makeArray(SelectorEngine.find(Selector.ITEM, element.parentNode)) : []
       return this._items.indexOf(element)
     }
 
@@ -432,34 +451,38 @@ const Carousel = (() => {
 
     // static
 
+    static _carouselInterface(element, config) {
+      let data    = Data.getData(element, DATA_KEY)
+      let _config = Util.extend(
+        Util.extend({}, Default), Util.getDataAttributes(element))
+
+      if (typeof config === 'object') {
+        _config = Util.extend(_config, config)
+      }
+
+      const action = typeof config === 'string' ? config : _config.slide
+
+      if (!data) {
+        data = new Carousel(element, _config)
+        Data.setData(element, DATA_KEY, data)
+      }
+
+      if (typeof config === 'number') {
+        data.to(config)
+      } else if (typeof action === 'string') {
+        if (typeof data[action] === 'undefined') {
+          throw new Error(`No method named "${action}"`)
+        }
+        data[action]()
+      } else if (_config.interval) {
+        data.pause()
+        data.cycle()
+      }
+    }
+
     static _jQueryInterface(config) {
       return this.each(function () {
-        let data      = Data.getData(this, DATA_KEY)
-        const _config = Util.extend(
-          Util.extend({}, Default), Data.getData(this, DATA_KEY))
-
-        if (typeof config === 'object') {
-          Util.extend(_config, config)
-        }
-
-        const action = typeof config === 'string' ? config : _config.slide
-
-        if (!data) {
-          data = new Carousel(this, _config)
-          Data.setData(this, DATA_KEY, data)
-        }
-
-        if (typeof config === 'number') {
-          data.to(config)
-        } else if (typeof action === 'string') {
-          if (typeof data[action] === 'undefined') {
-            throw new Error(`No method named "${action}"`)
-          }
-          data[action]()
-        } else if (_config.interval) {
-          data.pause()
-          data.cycle()
-        }
+        Carousel._carouselInterface(this, config)
       })
     }
 
@@ -483,7 +506,7 @@ const Carousel = (() => {
         config.interval = false
       }
 
-      Carousel._jQueryInterface.call($(target), config)
+      Carousel._carouselInterface(target, config)
 
       if (slideIndex) {
         Data.getData(target, DATA_KEY).to(slideIndex)
@@ -515,17 +538,21 @@ const Carousel = (() => {
    * ------------------------------------------------------------------------
    * jQuery
    * ------------------------------------------------------------------------
+   * add .carousel to jQuery only if jQuery is present
    */
 
-  $.fn[NAME]             = Carousel._jQueryInterface
-  $.fn[NAME].Constructor = Carousel
-  $.fn[NAME].noConflict  = function () {
-    $.fn[NAME] = JQUERY_NO_CONFLICT
-    return Carousel._jQueryInterface
+  if (typeof window.$ !== 'undefined' || typeof window.jQuery !== 'undefined') {
+    const $                  = window.$ || window.jQuery
+    const JQUERY_NO_CONFLICT = $.fn[NAME]
+    $.fn[NAME]               = Carousel._jQueryInterface
+    $.fn[NAME].Constructor   = Carousel
+    $.fn[NAME].noConflict    = function () {
+      $.fn[NAME] = JQUERY_NO_CONFLICT
+      return Carousel._jQueryInterface
+    }
   }
 
   return Carousel
-
-})(jQuery)
+})()
 
 export default Carousel

--- a/js/src/dom/data.js
+++ b/js/src/dom/data.js
@@ -39,6 +39,7 @@ const mapData = (() => {
       const keyProperties = element.key
       if (keyProperties.key === key) {
         delete storeData[keyProperties.id]
+        delete element.key
       }
     }
   }

--- a/js/src/dom/eventHandler.js
+++ b/js/src/dom/eventHandler.js
@@ -67,6 +67,7 @@ if (!window.Event || typeof window.Event !== 'function') {
 
 const namespaceRegex = /[^.]*(?=\..*)\.|.*/
 const stripNameRegex = /\..*/
+const keyEventRegex  = /^key/
 
 // Events storage
 const eventRegistry = {}
@@ -94,14 +95,29 @@ const nativeEvents = [
   'error', 'abort', 'scroll'
 ]
 
+const customEvents = {
+  mouseenter: 'mouseover',
+  mouseleave: 'mouseout'
+}
+
+function fixEvent(event) {
+  // Add which for key events
+  if (event.which === null && keyEventRegex.test(event.type)) {
+    event.which = event.charCode !== null ? event.charCode : event.keyCode
+  }
+  return event
+}
+
 function bootstrapHandler(element, fn) {
   return function (event) {
+    event = fixEvent(event)
     return fn.apply(element, [event])
   }
 }
 
 function bootstrapDelegationHandler(selector, fn) {
   return function (event) {
+    event = fixEvent(event)
     const domElements = document.querySelectorAll(selector)
     for (let target = event.target; target && target !== this; target = target.parentNode) {
       for (let i = domElements.length; i--;) {
@@ -124,8 +140,15 @@ const EventHandler = {
 
     const delegation      = typeof handler === 'string'
     const originalHandler = delegation ? delegationFn : handler
+
     // allow to get the native events from namespaced events ('click.bs.button' --> 'click')
     let typeEvent = originalTypeEvent.replace(stripNameRegex, '')
+
+    const custom = customEvents[typeEvent]
+    if (custom) {
+      typeEvent = custom
+    }
+
     const isNative = nativeEvents.indexOf(typeEvent) > -1
     if (!isNative) {
       typeEvent = originalTypeEvent
@@ -140,6 +163,7 @@ const EventHandler = {
     const fn = !delegation ? bootstrapHandler(element, handler) : bootstrapDelegationHandler(handler, delegationFn)
     handlers[uid] = fn
     originalHandler.uidEvent = uid
+    fn.originalHandler = originalHandler
     element.addEventListener(typeEvent, fn, delegation)
   },
 
@@ -162,16 +186,46 @@ const EventHandler = {
       return
     }
 
-    const typeEvent = originalTypeEvent.replace(stripNameRegex, '')
-    const events = getEvent(element)
-    if (!events || !events[typeEvent]) {
-      return
+    const events      = getEvent(element)
+    let typeEvent     = originalTypeEvent.replace(stripNameRegex, '')
+    const inNamespace = typeEvent !== originalTypeEvent
+    const custom      = customEvents[typeEvent]
+    if (custom) {
+      typeEvent = custom
+    }
+    const isNative = nativeEvents.indexOf(typeEvent) > -1
+    if (!isNative) {
+      typeEvent = originalTypeEvent
     }
 
-    const uidEvent = handler.uidEvent
-    const fn = events[typeEvent][uidEvent]
-    element.removeEventListener(typeEvent, fn, false)
-    delete events[typeEvent][uidEvent]
+    if (typeof handler === 'undefined') {
+      for (const elementEvent in events) {
+        if (!Object.prototype.hasOwnProperty.call(events, elementEvent)) {
+          continue
+        }
+
+        const storeElementEvent = events[elementEvent]
+        for (const keyHandlers in storeElementEvent) {
+          if (!Object.prototype.hasOwnProperty.call(storeElementEvent, keyHandlers)) {
+            continue
+          }
+          // delete all the namespaced listeners
+          if (inNamespace && keyHandlers.indexOf(originalTypeEvent) > -1) {
+            const handlerFn = events[elementEvent][keyHandlers]
+            EventHandler.off(element, elementEvent, handlerFn.originalHandler)
+          }
+        }
+      }
+    } else {
+      if (!events || !events[typeEvent]) {
+        return
+      }
+
+      const uidEvent = handler.uidEvent
+      const fn = events[typeEvent][uidEvent]
+      element.removeEventListener(typeEvent, fn, false)
+      delete events[typeEvent][uidEvent]
+    }
   },
 
   trigger(element, event, args) {

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -89,6 +89,56 @@ const Util = (() => {
           }
         }
       }
+    },
+
+    extend(obj1, obj2) {
+      for (const secondProp in obj2) {
+        if (Object.prototype.hasOwnProperty.call(obj2, secondProp)) {
+          const secondVal = obj2[secondProp]
+          // Is this value an object?  If so, iterate over its properties, copying them over
+          if (secondVal && Object.prototype.toString.call(secondVal) === '[object Object]') {
+            obj1[secondProp] = obj1[secondProp] || {}
+            Util.extend(obj1[secondProp], secondVal)
+          } else {
+            obj1[secondProp] = secondVal
+          }
+        }
+      }
+      return obj1
+    },
+
+    makeArray(nodeList) {
+      if (typeof nodeList === 'undefined' || nodeList === null) {
+        return []
+      }
+      return Array.prototype.slice.call(nodeList)
+    },
+
+    getDataAttributes(element) {
+      if (typeof element === 'undefined' || element === null) {
+        return {}
+      }
+
+      const attributes = {}
+      for (let i = 0; i < element.attributes.length; i++) {
+        const attribute = element.attributes[i]
+        if (attribute.nodeName.indexOf('data-') !== -1) {
+          // remove 'data-' part of the attribute name
+          const attributeName = attribute.nodeName.substring('data-'.length)
+          attributes[attributeName] = attribute.nodeValue
+        }
+      }
+      return attributes
+    },
+
+    isVisible(element) {
+      if (typeof element === 'undefined' || element === null) {
+        return false
+      }
+
+      return element.style.display !== 'none'
+        && element.parentNode.style.display !== 'none'
+        && element.style.visibility !== 'hidden'
     }
   }
 

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -136,9 +136,12 @@ const Util = (() => {
         return false
       }
 
-      return element.style.display !== 'none'
-        && element.parentNode.style.display !== 'none'
-        && element.style.visibility !== 'hidden'
+      if (element.style !== null && element.parentNode !== null && typeof element.parentNode.style !== 'undefined') {
+        return element.style.display !== 'none'
+          && element.parentNode.style.display !== 'none'
+          && element.style.visibility !== 'hidden'
+      }
+      return false
     }
   }
 

--- a/js/tests/.eslintrc.json
+++ b/js/tests/.eslintrc.json
@@ -5,6 +5,7 @@
   },
   "globals": {
     "EventHandler": false,
+    "Data": false,
     "Util": false
   },
   "parserOptions": {

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -14,6 +14,7 @@ $(function () {
       $.fn.bootstrapCarousel = $.fn.carousel.noConflict()
     },
     afterEach: function () {
+      $('.carousel').bootstrapCarousel('dispose')
       $.fn.carousel = $.fn.bootstrapCarousel
       delete $.fn.bootstrapCarousel
     }
@@ -79,16 +80,18 @@ $(function () {
   QUnit.test('should not fire slid when slide is prevented', function (assert) {
     assert.expect(1)
     var done = assert.async()
-    $('<div class="carousel"/>')
-      .on('slide.bs.carousel', function (e) {
-        e.preventDefault()
-        assert.ok(true, 'slide event fired')
-        done()
-      })
-      .on('slid.bs.carousel', function () {
-        assert.ok(false, 'slid event fired')
-      })
-      .bootstrapCarousel('next')
+    var $carousel = $('<div class="carousel"/>')
+    $carousel.appendTo('#qunit-fixture')
+
+    EventHandler.on($carousel[0], 'slide.bs.carousel', function (e) {
+      e.preventDefault()
+      assert.ok(true, 'slide event fired')
+      done()
+    })
+    EventHandler.on($carousel[0], 'slid.bs.carousel', function () {
+      assert.ok(false, 'slid event fired')
+    })
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should reset when slide is prevented', function (assert) {
@@ -114,10 +117,11 @@ $(function () {
         + '<a class="right carousel-control" href="#carousel-example-generic" data-slide="next"/>'
         + '</div>'
     var $carousel = $(carouselHTML)
+    $carousel.appendTo('#qunit-fixture')
 
     var done = assert.async()
-    $carousel
-      .one('slide.bs.carousel', function (e) {
+    EventHandler
+      .one($carousel[0], 'slide.bs.carousel', function (e) {
         e.preventDefault()
         setTimeout(function () {
           assert.ok($carousel.find('.carousel-item:eq(0)').is('.active'), 'first item still active')
@@ -125,7 +129,9 @@ $(function () {
           $carousel.bootstrapCarousel('next')
         }, 0)
       })
-      .one('slid.bs.carousel', function () {
+
+    EventHandler
+      .one($carousel[0], 'slid.bs.carousel', function () {
         setTimeout(function () {
           assert.ok(!$carousel.find('.carousel-item:eq(0)').is('.active'), 'first item still active')
           assert.ok(!$carousel.find('.carousel-indicators li:eq(0)').is('.active'), 'first indicator still active')
@@ -134,7 +140,8 @@ $(function () {
           done()
         }, 0)
       })
-      .bootstrapCarousel('next')
+
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should fire slide event with direction', function (assert) {
@@ -173,23 +180,24 @@ $(function () {
         + '<a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a>'
         + '</div>'
     var $carousel = $(carouselHTML)
+    $carousel.appendTo('#qunit-fixture')
 
     var done = assert.async()
 
-    $carousel
-      .one('slide.bs.carousel', function (e) {
+    EventHandler
+      .one($carousel[0], 'slide.bs.carousel', function (e) {
         assert.ok(e.direction, 'direction present on next')
         assert.strictEqual(e.direction, 'left', 'direction is left on next')
 
-        $carousel
-          .one('slide.bs.carousel', function (e) {
+        EventHandler
+          .one($carousel[0], 'slide.bs.carousel', function (e) {
             assert.ok(e.direction, 'direction present on prev')
             assert.strictEqual(e.direction, 'right', 'direction is right on prev')
             done()
           })
-          .bootstrapCarousel('prev')
+        $carousel.bootstrapCarousel('prev')
       })
-      .bootstrapCarousel('next')
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should fire slid event with direction', function (assert) {
@@ -228,23 +236,24 @@ $(function () {
         + '<a class="right carousel-control" href="#myCarousel" data-slide="next">&rsaquo;</a>'
         + '</div>'
     var $carousel = $(carouselHTML)
+    $carousel.appendTo('#qunit-fixture')
 
     var done = assert.async()
 
-    $carousel
-      .one('slid.bs.carousel', function (e) {
+    EventHandler
+      .one($carousel[0], 'slid.bs.carousel', function (e) {
         assert.ok(e.direction, 'direction present on next')
         assert.strictEqual(e.direction, 'left', 'direction is left on next')
 
-        $carousel
-          .one('slid.bs.carousel', function (e) {
+        EventHandler
+          .one($carousel[0], 'slid.bs.carousel', function (e) {
             assert.ok(e.direction, 'direction present on prev')
             assert.strictEqual(e.direction, 'right', 'direction is right on prev')
             done()
           })
-          .bootstrapCarousel('prev')
+        $carousel.bootstrapCarousel('prev')
       })
-      .bootstrapCarousel('next')
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should fire slide event with relatedTarget', function (assert) {
@@ -284,14 +293,17 @@ $(function () {
         + '</div>'
 
     var done = assert.async()
+    var $carousel = $(template)
+    $carousel.appendTo('#qunit-fixture')
 
-    $(template)
-      .on('slide.bs.carousel', function (e) {
+    EventHandler
+      .one($carousel[0], 'slide.bs.carousel', function (e) {
         assert.ok(e.relatedTarget, 'relatedTarget present')
         assert.ok($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
         done()
       })
-      .bootstrapCarousel('next')
+
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should fire slid event with relatedTarget', function (assert) {
@@ -331,14 +343,17 @@ $(function () {
         + '</div>'
 
     var done = assert.async()
+    var $carousel = $(template)
+    $carousel.appendTo('#qunit-fixture')
 
-    $(template)
-      .on('slid.bs.carousel', function (e) {
+    EventHandler
+      .one($carousel[0], 'slid.bs.carousel', function (e) {
         assert.ok(e.relatedTarget, 'relatedTarget present')
         assert.ok($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
         done()
       })
-      .bootstrapCarousel('next')
+
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should fire slid and slide events with from and to', function (assert) {
@@ -369,19 +384,22 @@ $(function () {
         + '</div>'
 
     var done = assert.async()
-    $(template)
-      .on('slid.bs.carousel', function (e) {
+    var $carousel = $(template)
+
+    EventHandler
+      .one($carousel[0], 'slid.bs.carousel', function (e) {
         assert.ok(typeof e.from !== 'undefined', 'from present')
         assert.ok(typeof e.to !== 'undefined', 'to present')
-        $(this).off()
         done()
       })
-      .on('slide.bs.carousel', function (e) {
+
+    EventHandler
+      .one($carousel[0], 'slide.bs.carousel', function (e) {
         assert.ok(typeof e.from !== 'undefined', 'from present')
         assert.ok(typeof e.to !== 'undefined', 'to present')
-        $(this).off('slide.bs.carousel')
       })
-      .bootstrapCarousel('next')
+
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should set interval from data attribute', function (assert) {
@@ -423,26 +441,27 @@ $(function () {
     $carousel.attr('data-interval', 1814)
 
     $carousel.appendTo('body')
-    $('[data-slide]').first().trigger('click')
-    assert.strictEqual($carousel.data('bs.carousel')._config.interval, 1814)
+    EventHandler.trigger($('[data-slide]').first()[0], 'click')
+    assert.strictEqual(Data.getData($carousel[0], 'bs.carousel')._config.interval, 1814)
     $carousel.remove()
 
     $carousel.appendTo('body').attr('data-modal', 'foobar')
-    $('[data-slide]').first().trigger('click')
-    assert.strictEqual($carousel.data('bs.carousel')._config.interval, 1814, 'even if there is an data-modal attribute set')
+    EventHandler.trigger($('[data-slide]').first()[0], 'click')
+    assert.strictEqual(Data.getData($carousel[0], 'bs.carousel')._config.interval, 1814, 'even if there is an data-modal attribute set')
     $carousel.remove()
 
     $carousel.appendTo('body')
-    $('[data-slide]').first().trigger('click')
+    EventHandler.trigger($('[data-slide]').first()[0], 'click')
     $carousel.attr('data-interval', 1860)
-    $('[data-slide]').first().trigger('click')
-    assert.strictEqual($carousel.data('bs.carousel')._config.interval, 1814, 'attributes should be read only on initialization')
+    EventHandler.trigger($('[data-slide]').first()[0], 'click')
+    assert.strictEqual(Data.getData($carousel[0], 'bs.carousel')._config.interval, 1814, 'attributes should be read only on initialization')
+    $carousel.bootstrapCarousel('dispose')
     $carousel.remove()
 
     $carousel.attr('data-interval', false)
     $carousel.appendTo('body')
     $carousel.bootstrapCarousel(1)
-    assert.strictEqual($carousel.data('bs.carousel')._config.interval, false, 'data attribute has higher priority than default options')
+    assert.strictEqual(Data.getData($carousel[0], 'bs.carousel')._config.interval, false, 'data attribute has higher priority than default options')
     $carousel.remove()
   })
 
@@ -519,7 +538,7 @@ $(function () {
 
     assert.strictEqual($template.find('.carousel-item')[1], $template.find('.active')[0], 'second item active')
 
-    $template.trigger($.Event('keydown', { which: 37 }))
+    EventHandler.trigger($template[0], 'keydown', { which: 37 })
 
     assert.strictEqual($template.find('.carousel-item')[0], $template.find('.active')[0], 'first item active')
   })
@@ -545,7 +564,7 @@ $(function () {
 
     assert.strictEqual($template.find('.carousel-item')[0], $template.find('.active')[0], 'first item active')
 
-    $template.trigger($.Event('keydown', { which: 39 }))
+    EventHandler.trigger($template[0], 'keydown', { which: 39 })
 
     assert.strictEqual($template.find('.carousel-item')[1], $template.find('.active')[0], 'second item active')
   })
@@ -564,21 +583,20 @@ $(function () {
     $template.bootstrapCarousel()
     var done = assert.async()
 
-    var eventArrowDown = $.Event('keydown', { which: 40 })
-    var eventArrowUp   = $.Event('keydown', { which: 38 })
-
-    $template.one('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+    EventHandler.one($template[0], 'keydown', function (event) {
+      assert.strictEqual(event.defaultPrevented, false)
     })
 
-    $template.trigger(eventArrowDown)
+    // arrow down
+    EventHandler.trigger($template[0], 'keydown', { which: 40 })
 
-    $template.one('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+    EventHandler.one($template[0], 'keydown', function (event) {
+      assert.strictEqual(event.defaultPrevented, false)
       done()
     })
 
-    $template.trigger(eventArrowUp)
+    // arrow up
+    EventHandler.trigger($template[0], 'keydown', { which: 38 })
   })
 
   QUnit.test('should support disabling the keyboard navigation', function (assert) {
@@ -681,22 +699,21 @@ $(function () {
 
     var done = assert.async()
 
-    $carousel
-      .one('slid.bs.carousel', function () {
-        assert.strictEqual(getActiveId(), 'two', 'carousel slid from 1st to 2nd slide')
-        $carousel
-          .one('slid.bs.carousel', function () {
-            assert.strictEqual(getActiveId(), 'three', 'carousel slid from 2nd to 3rd slide')
-            $carousel
-              .one('slid.bs.carousel', function () {
-                assert.strictEqual(getActiveId(), 'one', 'carousel wrapped around and slid from 3rd to 1st slide')
-                done()
-              })
-              .bootstrapCarousel('next')
-          })
-          .bootstrapCarousel('next')
+    EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+      assert.strictEqual(getActiveId(), 'two', 'carousel slid from 1st to 2nd slide')
+
+      EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+        assert.strictEqual(getActiveId(), 'three', 'carousel slid from 2nd to 3rd slide')
+
+        EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+          assert.strictEqual(getActiveId(), 'one', 'carousel wrapped around and slid from 3rd to 1st slide')
+          done()
+        })
+        $carousel.bootstrapCarousel('next')
       })
-      .bootstrapCarousel('next')
+      $carousel.bootstrapCarousel('next')
+    })
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should wrap around from start to end when wrap option is true', function (assert) {
@@ -725,12 +742,11 @@ $(function () {
 
     var done = assert.async()
 
-    $carousel
-      .on('slid.bs.carousel', function () {
-        assert.strictEqual($carousel.find('.carousel-item.active').attr('id'), 'three', 'carousel wrapped around and slid from 1st to 3rd slide')
-        done()
-      })
-      .bootstrapCarousel('prev')
+    EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+      assert.strictEqual($carousel.find('.carousel-item.active').attr('id'), 'three', 'carousel wrapped around and slid from 1st to 3rd slide')
+      done()
+    })
+    $carousel.bootstrapCarousel('prev')
   })
 
   QUnit.test('should stay at the end when the next method is called and wrap is false', function (assert) {
@@ -760,23 +776,22 @@ $(function () {
 
     var done = assert.async()
 
-    $carousel
-      .one('slid.bs.carousel', function () {
-        assert.strictEqual(getActiveId(), 'two', 'carousel slid from 1st to 2nd slide')
-        $carousel
-          .one('slid.bs.carousel', function () {
-            assert.strictEqual(getActiveId(), 'three', 'carousel slid from 2nd to 3rd slide')
-            $carousel
-              .one('slid.bs.carousel', function () {
-                assert.ok(false, 'carousel slid when it should not have slid')
-              })
-              .bootstrapCarousel('next')
-            assert.strictEqual(getActiveId(), 'three', 'carousel did not wrap around and stayed on 3rd slide')
-            done()
-          })
-          .bootstrapCarousel('next')
+    EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+      assert.strictEqual(getActiveId(), 'two', 'carousel slid from 1st to 2nd slide')
+
+      EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+        assert.strictEqual(getActiveId(), 'three', 'carousel slid from 2nd to 3rd slide')
+
+        EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+          assert.ok(false, 'carousel slid when it should not have slid')
+        })
+        $carousel.bootstrapCarousel('next')
+        assert.strictEqual(getActiveId(), 'three', 'carousel did not wrap around and stayed on 3rd slide')
+        done()
       })
-      .bootstrapCarousel('next')
+      $carousel.bootstrapCarousel('next')
+    })
+    $carousel.bootstrapCarousel('next')
   })
 
   QUnit.test('should stay at the start when the prev method is called and wrap is false', function (assert) {
@@ -803,11 +818,10 @@ $(function () {
         + '</div>'
     var $carousel = $(carouselHTML)
 
-    $carousel
-      .on('slid.bs.carousel', function () {
-        assert.ok(false, 'carousel slid when it should not have slid')
-      })
-      .bootstrapCarousel('prev')
+    EventHandler.one($carousel[0], 'slid.bs.carousel', function () {
+      assert.ok(false, 'carousel slid when it should not have slid')
+    })
+    $carousel.bootstrapCarousel('prev')
     assert.strictEqual($carousel.find('.carousel-item.active').attr('id'), 'one', 'carousel did not wrap around and stayed on 1st slide')
   })
 

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -42,13 +42,15 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../dist/dom/eventHandler.js"></script>
+    <script src="../../dist/dom/selectorEngine.js"></script>
+    <script src="../../dist/dom/data.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/carousel.js"></script>
 
     <script>
       $(function() {
         // Test to show that the carousel doesn't slide when the current tab isn't visible
-        $('#carousel-example-generic').on('slid.bs.carousel', function(event) {
+        EventHandler.on(SelectorEngine.find('#carousel-example-generic'), 'slid.bs.carousel', function (event) {
           console.log('slid at ', event.timeStamp)
         })
       })


### PR DESCRIPTION
Rewrite our Carousel plugin without jQuery

- ~Improve `off` method of our EventHandler to remove listeners in an entire namespace~


Work in progress...