### PR TITLE
Changes alerts to improve accessibility

### DIFF
--- a/docs/4.0/components/alerts.md
+++ b/docs/4.0/components/alerts.md
@@ -59,10 +59,10 @@ You can see this in action with a live demo:
 
 {% example html %}
 <div class="alert alert-warning alert-dismissible fade show" role="alert">
+  <strong>Holy guacamole!</strong> You should check in on some of those fields below.
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>
   </button>
-  <strong>Holy guacamole!</strong> You should check in on some of those fields below.
 </div>
 {% endexample %}
 


### PR DESCRIPTION
This PR is a simple order change of the close btn on alerts that improves the way a screen reader reads them. 

Instead of going:

>"Close, Holy guacamole! You should check in on some of those fields below, alert, Close, button"

now it goes:

>"Holy guacamole! You should check in on some of those fields below, Close, alert, Close, button"

Which IMO it makes more sense.