### PR TITLE
Fixes link color on navbar-text

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -235,6 +235,13 @@
 
   .navbar-text {
     color: $navbar-light-color;
+    a {
+      color: $navbar-light-active-color;
+
+      @include hover-focus {
+        color: $navbar-light-active-color;
+      }
+    }
   }
 }
 
@@ -280,5 +287,12 @@
 
   .navbar-text {
     color: $navbar-dark-color;
+    a {
+      color: $navbar-dark-active-color;
+
+      @include hover-focus {
+        color: $navbar-dark-active-color;
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes #23693 

It fixes colors for anchors inside `navbar-text`.

This is how they look like now:

<img width="791" alt="screen shot 2017-08-27 at 7 11 32 am" src="https://user-images.githubusercontent.com/1832037/29749887-8b40a812-8afb-11e7-8583-52a9449eb433.png">
<img width="789" alt="screen shot 2017-08-27 at 7 11 40 am" src="https://user-images.githubusercontent.com/1832037/29749888-8b4d6b74-8afb-11e7-833c-c825ab5445f1.png">

