### PR TITLE
V4 variable reuse

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  color: $card-color;
   word-wrap: break-word;
   background-color: $card-bg;
   background-clip: border-box;

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -62,6 +62,7 @@
     @return $light;
   }
 }
+
 @function yiq($color) {
   $r: red($color);
   $g: green($color);
@@ -71,9 +72,11 @@
 
   @return $yiq;
 }
+
 @function color-brightness($color) {
   @return yiq($color);
 }
+
 @function color-difference($color1, $color2) {
   $r1: red($color1);
   $g1: green($color1);
@@ -87,6 +90,7 @@
 
   @return $diff;
 }
+
 @function test-contrast($color1, $color2) {
   $delta-brightness: abs(color-brightness($color1) - color-brightness($color2));
   $color-difference: color-difference($color1, $color2);
@@ -97,13 +101,15 @@
 
   @return false;
 }
+
 @function use-if-contrast($color1, $color2, $dark: #111, $light: #fff) {
   @if test-contrast($color1, $color2) {
     @return $color1;
   }
   @return contrast-yiq($color2, $dark, $light);
 }
-@function contrast-yiq($color, $dark: #111, $light: #fff) {
+
+@function contrast-yiq($color, $dark: $yiq-text-dark, $light: $yiq-text-light) {
   $yiq: yiq($color);
 
   @if ($yiq >= $yiq-contrasted-threshold) {
@@ -111,6 +117,10 @@
   } @else {
     @return $light;
   }
+}
+
+@function opacity-to-mix($forecolor, $backcolor) {
+  @return mix(opacify($forecolor, 1), $backcolor, alpha($forecolor) * 100);
 }
 
 // Retrieve color Sass maps

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -62,14 +62,51 @@
     @return $light;
   }
 }
-@function contrast-yiq($color, $dark: #111, $light: #fff) {
+@function yiq($color) {
   $r: red($color);
   $g: green($color);
   $b: blue($color);
 
   $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
 
-  @if ($yiq >= 150) {
+  @return $yiq;
+}
+@function color-brightness($color) {
+  @return yiq($color);
+}
+@function color-difference($color1, $color2) {
+  $r1: red($color1);
+  $g1: green($color1);
+  $b1: blue($color1);
+
+  $r2: red($color2);
+  $g2: green($color2);
+  $b2: blue($color2);
+
+  $diff: (max($r1, $r2) - min($r1, $r2)) + (max($g1, $g2) - min($g1, $g2)) + (max($b1, $b2) - min($b1, $b2));
+
+  @return $diff;
+}
+@function test-contrast($color1, $color2) {
+  $delta-brightness: abs(color-brightness($color1) - color-brightness($color2));
+  $color-difference: color-difference($color1, $color2);
+
+  @if ($delta-brightness > 125) and ($color-difference > 500) {
+    @return true;
+  }
+
+  @return false;
+}
+@function use-if-contrast($color1, $color2, $dark: #111, $light: #fff) {
+  @if test-contrast($color1, $color2) {
+    @return $color1;
+  }
+  @return contrast-yiq($color2, $dark, $light);
+}
+@function contrast-yiq($color, $dark: #111, $light: #fff) {
+  $yiq: yiq($color);
+
+  @if ($yiq >= $yiq-contrasted-threshold) {
     @return $dark;
   } @else {
     @return $light;

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -62,6 +62,19 @@
     @return $light;
   }
 }
+@function contrast-yiq($color, $dark: #111, $light: #fff) {
+  $r: red($color);
+  $g: green($color);
+  $b: blue($color);
+
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+
+  @if ($yiq >= 150) {
+    @return $dark;
+  } @else {
+    @return $light;
+  }
+}
 
 // Retrieve color Sass maps
 @function color($key: "blue") {

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -46,6 +46,7 @@
   padding: $list-group-item-padding-y $list-group-item-padding-x;
   // Place the border on the list items and negative margin up for better styling
   margin-bottom: -$list-group-border-width;
+  color: $list-group-color;
   background-color: $list-group-bg;
   border: $list-group-border-width solid $list-group-border-color;
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -69,6 +69,7 @@
   display: flex;
   flex-direction: column;
   width: 100%; // Ensure `.modal-content` extends the full width of the parent `.modal-dialog`
+  color: $modal-content-color;
   // counteract the pointer-events: none; in the .modal-dialog
   pointer-events: auto;
   background-color: $modal-content-bg;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -250,6 +250,9 @@ $box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
 $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
 $box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
 
+$component-bg:                $body-bg;
+$component-color:             contrast-yiq($component-bg);
+
 $component-active-bg:         theme-color("primary") !default;
 $component-active-color:      contrast-yiq($component-active-bg) !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -750,7 +750,7 @@ $pagination-padding-x-lg:           1.5rem !default;
 $pagination-line-height:            1.25 !default;
 
 $pagination-color:                  $link-color !default;
-$pagination-bg:                     $white !default;
+$pagination-bg:                     $body-bg !default;
 $pagination-border-width:           $border-width !default;
 $pagination-border-color:           $gray-300 !default;
 
@@ -766,7 +766,7 @@ $pagination-active-bg:              $component-active-bg !default;
 $pagination-active-border-color:    $pagination-active-bg !default;
 
 $pagination-disabled-color:         $gray-600 !default;
-$pagination-disabled-bg:            $white !default;
+$pagination-disabled-bg:            $body-bg !default;
 $pagination-disabled-border-color:  $gray-300 !default;
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -805,8 +805,8 @@ $card-columns-margin:               $card-spacer-y !default;
 
 $tooltip-font-size:                 $font-size-sm !default;
 $tooltip-max-width:                 200px !default;
-$tooltip-color:                     $white !default;
 $tooltip-bg:                        $black !default;
+$tooltip-color:                     contrast-yiq($tooltip-bg) !default;
 $tooltip-border-radius:             $border-radius !default;
 $tooltip-opacity:                   .9 !default;
 $tooltip-padding-y:                 .25rem !default;
@@ -926,8 +926,8 @@ $progress-font-size:                ($font-size-base * .75) !default;
 $progress-bg:                       $gray-200 !default;
 $progress-border-radius:            $border-radius !default;
 $progress-box-shadow:               inset 0 .1rem .1rem rgba($black, .1) !default;
-$progress-bar-color:                $white !default;
-$progress-bar-bg:                   $primary !default;
+$progress-bar-bg:                   theme-color("primary") !default;
+$progress-bar-color:                contrast-yiq($progress-bar-bg) !default;
 $progress-bar-animation-timing:     1s linear infinite !default;
 $progress-bar-transition:           width .6s ease !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -250,8 +250,8 @@ $box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
 $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
 $box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
 
-$component-bg:                $body-bg;
-$component-color:             contrast-yiq($component-bg);
+$component-bg:                $body-bg !default;
+$component-color:             use-if-contrast($body-color, $component-bg) !default;
 
 $component-active-bg:         theme-color("primary") !default;
 $component-active-color:      contrast-yiq($component-active-bg) !default;
@@ -654,11 +654,11 @@ $dropdown-divider-bg:               $gray-200 !default;
 $dropdown-box-shadow:               0 .5rem 1rem rgba($black, .175) !default;
 
 $dropdown-link-color:               contrast-yiq($dropdown-bg, $gray-900) !default;
-$dropdown-link-hover-color:         darken($dropdown-link-color, 5%) !default;
 $dropdown-link-hover-bg:            $gray-100 !default;
+$dropdown-link-hover-color:         use-if-contrast(darken($dropdown-link-color, 5%), $dropdown-link-hover-bg) !default;
 
-$dropdown-link-active-color:        $component-active-color !default;
 $dropdown-link-active-bg:           $component-active-bg !default;
+$dropdown-link-active-color:        use-if-contrast($component-active-color, $dropdown-link-active-bg) !default;
 
 $dropdown-link-disabled-color:      $gray-600 !default;
 
@@ -692,8 +692,8 @@ $nav-tabs-border-color:             $gray-300 !default;
 $nav-tabs-border-width:             $border-width !default;
 $nav-tabs-border-radius:            $border-radius !default;
 $nav-tabs-link-hover-border-color:  $gray-200 $gray-200 $nav-tabs-border-color !default;
-$nav-tabs-link-active-color:        $gray-700 !default;
 $nav-tabs-link-active-bg:           $body-bg !default;
+$nav-tabs-link-active-color:        use-if-contrast($gray-700, $nav-tabs-link-active-bg) !default;
 $nav-tabs-link-active-border-color: $gray-300 $gray-300 $nav-tabs-link-active-bg !default;
 
 $nav-pills-border-radius:           $border-radius !default;
@@ -752,8 +752,8 @@ $pagination-padding-y-lg:           .75rem !default;
 $pagination-padding-x-lg:           1.5rem !default;
 $pagination-line-height:            1.25 !default;
 
-$pagination-color:                  $link-color !default;
 $pagination-bg:                     $body-bg !default;
+$pagination-color:                  use-if-contrast($link-color, $pagination-bg) !default;
 $pagination-border-width:           $border-width !default;
 $pagination-border-color:           $gray-300 !default;
 
@@ -762,10 +762,11 @@ $pagination-focus-outline:          0 !default;
 
 $pagination-hover-color:            $link-hover-color !default;
 $pagination-hover-bg:               $gray-200 !default;
+$pagination-hover-color:            use-if-contrast($link-hover-color, $pagination-hover-bg) !default;
 $pagination-hover-border-color:     $gray-300 !default;
 
-$pagination-active-color:           $component-active-color !default;
 $pagination-active-bg:              $component-active-bg !default;
+$pagination-active-color:           use-if-contrast($component-active-color, $pagination-active-bg) !default;
 $pagination-active-border-color:    $pagination-active-bg !default;
 
 $pagination-disabled-color:         $gray-600 !default;
@@ -786,10 +787,11 @@ $card-spacer-x:                     1.25rem !default;
 $card-border-width:                 $border-width !default;
 $card-border-radius:                $border-radius !default;
 $card-bg:                           $component-bg !default;
+$card-color:                        use-if-contrast($component-color, $card-bg) !default;
 $card-border-color:                 rgba(contrast-yiq($card-bg, $black), .125) !default;
 $card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 $card-cap-bg:                       rgba(contrast-yiq($card-bg, $black), .03) !default;
-$card-cap-color:                    $body-color !default;
+$card-cap-color:                    use-if-contrast($card-color, opacity-to-mix($card-cap-bg, $card-bg)) !default;
 
 $card-img-overlay-padding:          1.25rem !default;
 
@@ -841,7 +843,7 @@ $popover-header-color:              $headings-color !default;
 $popover-header-padding-y:          .5rem !default;
 $popover-header-padding-x:          .75rem !default;
 
-$popover-body-color:                $component-color !default;
+$popover-body-color:                use-if-contrast($component-color, $popover-bg) !default;
 $popover-body-padding-y:            $popover-header-padding-y !default;
 $popover-body-padding-x:            $popover-header-padding-x !default;
 
@@ -877,6 +879,7 @@ $modal-dialog-margin-y-sm-up:       1.75rem !default;
 $modal-title-line-height:           $line-height-base !default;
 
 $modal-content-bg:                  $component-bg !default;
+$modal-content-color:               use-if-contrast($component-color, $modal-content-bg) !default;
 $modal-content-border-color:        rgba(contrast-yiq($modal-content-bg, $black), .2) !default;
 $modal-content-border-width:        $border-width !default;
 $modal-content-border-radius:       $border-radius-lg !default;
@@ -935,6 +938,7 @@ $progress-bar-transition:           width .6s ease !default;
 // List group
 
 $list-group-bg:                     $component-bg !default;
+$list-group-color:                  use-if-contrast($component-color, $list-group-bg) !default;
 $list-group-border-color:           rgba(contrast-yiq($list-group-bg, $black), .125) !default;
 $list-group-border-width:           $border-width !default;
 $list-group-border-radius:          $border-radius !default;
@@ -943,8 +947,8 @@ $list-group-item-padding-y:         .75rem !default;
 $list-group-item-padding-x:         1.25rem !default;
 
 $list-group-hover-bg:               $gray-100 !default;
-$list-group-active-color:           $component-active-color !default;
 $list-group-active-bg:              $component-active-bg !default;
+$list-group-active-color:           use-if-contrast($component-active-color, $list-group-active-bg) !default;
 $list-group-active-border-color:    $list-group-active-bg !default;
 
 $list-group-disabled-color:         $gray-600 !default;
@@ -953,8 +957,8 @@ $list-group-disabled-bg:            $list-group-bg !default;
 $list-group-action-color:           $gray-700 !default;
 $list-group-action-hover-color:     $list-group-action-color !default;
 
-$list-group-action-active-color:    $body-color !default;
 $list-group-action-active-bg:       $gray-200 !default;
+$list-group-action-active-color:    use-if-contrast($component-color, $list-group-action-active-bg) !default;
 
 
 // Image thumbnails

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -651,7 +651,7 @@ $dropdown-border-color:             rgba(contrast-yiq($dropdown-bg, $black), .15
 $dropdown-border-radius:            $border-radius !default;
 $dropdown-border-width:             $border-width !default;
 $dropdown-divider-bg:               $gray-200 !default;
-$dropdown-box-shadow:               0 .5rem 1rem rgba($black,.175) !default;
+$dropdown-box-shadow:               0 .5rem 1rem rgba($black, .175) !default;
 
 $dropdown-link-color:               contrast-yiq($dropdown-bg, $gray-900) !default;
 $dropdown-link-hover-color:         darken($dropdown-link-color, 5%) !default;
@@ -832,7 +832,7 @@ $popover-font-size:                 $font-size-sm !default;
 $popover-bg:                        $component-bg !default;
 $popover-max-width:                 276px !default;
 $popover-border-width:              $border-width !default;
-$popover-border-color:              rgba(contrast-yiq( $popover-bg, $black), .2) !default;
+$popover-border-color:              rgba(contrast-yiq($popover-bg, $black), .2) !default;
 $popover-border-radius:             $border-radius-lg !default;
 $popover-box-shadow:                0 .25rem .5rem rgba($black, .2) !default;
 
@@ -935,7 +935,7 @@ $progress-bar-transition:           width .6s ease !default;
 // List group
 
 $list-group-bg:                     $component-bg !default;
-$list-group-border-color:           rgba(contrast-yiq($list-group-bg, $black ), .125) !default;
+$list-group-border-color:           rgba(contrast-yiq($list-group-bg, $black), .125) !default;
 $list-group-border-width:           $border-width !default;
 $list-group-border-radius:          $border-radius !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -346,8 +346,8 @@ $table-cell-padding:          .75rem !default;
 $table-cell-padding-sm:       .3rem !default;
 
 $table-bg:                    transparent !default;
-$table-accent-bg:             rgba($black, .05) !default;
-$table-hover-bg:              rgba($black, .075) !default;
+$table-accent-bg:             rgba(contrast-yiq($body-bg, $black), .05) !default;
+$table-hover-bg:              rgba(contrast-yiq($body-bg, $black), .075) !default;
 $table-active-bg:             $table-hover-bg !default;
 
 $table-border-width:          $border-width !default;
@@ -459,8 +459,8 @@ $input-line-height-lg:                  $input-btn-line-height-lg !default;
 $input-bg:                              $white !default;
 $input-disabled-bg:                     $gray-200 !default;
 
-$input-color:                           $gray-700 !default;
-$input-border-color:                    $gray-400 !default;
+$input-color:                           contrast-yiq($input-bg, $gray-700) !default;
+$input-border-color:                    contrast-yiq($input-bg, $gray-400) !default;
 $input-border-width:                    $input-btn-border-width !default;
 $input-box-shadow:                      inset 0 1px 1px rgba($black, .075) !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -250,8 +250,8 @@ $box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
 $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
 $box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
 
-$component-active-color:      $white !default;
-$component-active-bg:         $primary !default;
+$component-active-bg:         theme-color("primary") !default;
+$component-active-color:      contrast-yiq($component-active-bg) !default;
 
 $caret-width:                 .3em !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -646,15 +646,15 @@ $form-feedback-icon-invalid:        str-replace(url("data:image/svg+xml,%3csvg x
 $dropdown-min-width:                10rem !default;
 $dropdown-padding-y:                .5rem !default;
 $dropdown-spacer:                   .125rem !default;
-$dropdown-bg:                       $white !default;
-$dropdown-border-color:             rgba($black, .15) !default;
+$dropdown-bg:                       $component-bg !default;
+$dropdown-border-color:             rgba(contrast-yiq($dropdown-bg, $black), .15) !default;
 $dropdown-border-radius:            $border-radius !default;
 $dropdown-border-width:             $border-width !default;
 $dropdown-divider-bg:               $gray-200 !default;
-$dropdown-box-shadow:               0 .5rem 1rem rgba($black, .175) !default;
+$dropdown-box-shadow:               0 .5rem 1rem rgba($black,.175) !default;
 
-$dropdown-link-color:               $gray-900 !default;
-$dropdown-link-hover-color:         darken($gray-900, 5%) !default;
+$dropdown-link-color:               contrast-yiq($dropdown-bg, $gray-900) !default;
+$dropdown-link-hover-color:         darken($dropdown-link-color, 5%) !default;
 $dropdown-link-hover-bg:            $gray-100 !default;
 
 $dropdown-link-active-color:        $component-active-color !default;
@@ -785,11 +785,11 @@ $card-spacer-y:                     .75rem !default;
 $card-spacer-x:                     1.25rem !default;
 $card-border-width:                 $border-width !default;
 $card-border-radius:                $border-radius !default;
-$card-border-color:                 rgba($black, .125) !default;
+$card-bg:                           $component-bg !default;
+$card-border-color:                 rgba(contrast-yiq($card-bg, $black), .125) !default;
 $card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
-$card-cap-bg:                       rgba($black, .03) !default;
+$card-cap-bg:                       rgba(contrast-yiq($card-bg, $black), .03) !default;
 $card-cap-color:                    $body-color !default;
-$card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;
 
@@ -829,10 +829,10 @@ $form-feedback-tooltip-border-radius: $tooltip-border-radius !default;
 // Popovers
 
 $popover-font-size:                 $font-size-sm !default;
-$popover-bg:                        $white !default;
+$popover-bg:                        $component-bg !default;
 $popover-max-width:                 276px !default;
 $popover-border-width:              $border-width !default;
-$popover-border-color:              rgba($black, .2) !default;
+$popover-border-color:              rgba(contrast-yiq( $popover-bg, $black), .2) !default;
 $popover-border-radius:             $border-radius-lg !default;
 $popover-box-shadow:                0 .25rem .5rem rgba($black, .2) !default;
 
@@ -841,7 +841,7 @@ $popover-header-color:              $headings-color !default;
 $popover-header-padding-y:          .5rem !default;
 $popover-header-padding-x:          .75rem !default;
 
-$popover-body-color:                $body-color !default;
+$popover-body-color:                $component-color !default;
 $popover-body-padding-y:            $popover-header-padding-y !default;
 $popover-body-padding-x:            $popover-header-padding-x !default;
 
@@ -876,8 +876,8 @@ $modal-dialog-margin-y-sm-up:       1.75rem !default;
 
 $modal-title-line-height:           $line-height-base !default;
 
-$modal-content-bg:                  $white !default;
-$modal-content-border-color:        rgba($black, .2) !default;
+$modal-content-bg:                  $component-bg !default;
+$modal-content-border-color:        rgba(contrast-yiq($modal-content-bg, $black), .2) !default;
 $modal-content-border-width:        $border-width !default;
 $modal-content-border-radius:       $border-radius-lg !default;
 $modal-content-box-shadow-xs:       0 .25rem .5rem rgba($black, .5) !default;
@@ -934,8 +934,8 @@ $progress-bar-transition:           width .6s ease !default;
 
 // List group
 
-$list-group-bg:                     $white !default;
-$list-group-border-color:           rgba($black, .125) !default;
+$list-group-bg:                     $component-bg !default;
+$list-group-border-color:           rgba(contrast-yiq($list-group-bg, $black ), .125) !default;
 $list-group-border-width:           $border-width !default;
 $list-group-border-radius:          $border-radius !default;
 


### PR DESCRIPTION
In a nutshell:

* extract `color-yiq` mixin to a generic `contrast-yiq` function to be used for ensuring contrast;
* introduce `$component-*` variables linked to `$body-` variables;
* link the following to `$body-` vars:
  * input; rationale: usually have the same background as body;
  * table; rationale: transparent background; usually sit against body;
* link the following to `$component-` vars:
 * card, dropdowns, list groups, modals and popovers; rationale: one might want to change all components at once
* ensured contrast:
  * in input, tooltip and progressbar, between text and background
  * in table, for adequate hover / active background (with opacity)
  * in the rest of the components, for adequate border color (with opacity)

Few notes:
* with the current variable set, the output will not be changed. It's only when one starts to play around;
* while modal and cards have a dedicated color for background, they lack one for color. In terms, it's inherited from the nearest ancestor;

Related to https://github.com/twbs/bootstrap/issues/23595