### PR TITLE
Removed reference to .text-white

### DIFF
--- a/docs/4.0/utilities/colors.md
+++ b/docs/4.0/utilities/colors.md
@@ -11,7 +11,7 @@ toc: true
 <p class="text-{{ color.name }}">.text-{{ color.name }}</p>{% endfor %}
 {% endexample %}
 
-Contextual text classes also work well on anchors with the provided hover and focus states. **Note that the `.text-white` class has no link styling.**
+Contextual text classes also work well on anchors with the provided hover and focus states.
 
 {% example html %}
 {% for color in site.data.theme-colors %}


### PR DESCRIPTION
The .text-white class doesn't exist, and is not listed as a color in this list, so this reference is wrong.