### PR TITLE
Generate CSS variables for colors, breakpoints, fonts

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -3,6 +3,9 @@ scss_files:
   - "scss/**/*.scss"
   - "docs/assets/scss/**/*.scss"
 
+exclude:
+  - "scss/_root.scss"
+
 plugin_directories: ['.scss-linters']
 
 # List of gem names to load custom linters from (make sure they are already

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,0 +1,16 @@
+:root {
+  @each $color, $value in $colors {
+    --#{$color}: $value;
+  }
+
+  @each $color, $value in $theme-colors {
+    --#{$color}: $value;
+  }
+
+  @each $bp, $value in $grid-breakpoints {
+    --breakpoint-#{$bp}: $value;
+  }
+
+  --font-family-sans-serif: $font-family-sans-serif;
+  --font-family-monospace: $font-family-monospace;
+}

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -8,6 +8,7 @@
 @import "functions";
 @import "variables";
 @import "mixins";
+@import "root";
 @import "print";
 @import "reboot";
 @import "type";


### PR DESCRIPTION
Exposes:

- The `$theme-colors` and `$colors` to have the full bootstrap-picked palette
- The `$grid-breakpoints` to use in media queries
- The two `$font-family-*` stacks

See #23349
Supersedes #23446