### PR TITLE
Fixes color of popover arrow on bottom popovers

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -117,7 +117,7 @@
 
     .arrow::after {
       top: -($popover-arrow-outer-width - 1);
-      border-bottom-color: $popover-arrow-color;
+      border-bottom-color: $popover-header-bg;
     }
 
     // This will remove the popover-header's border just below the arrow


### PR DESCRIPTION
There is a bug on popovers, the arrow on the bottom pop overs is white:

<img width="60" alt="screen shot 2017-08-30 at 9 37 42 pm" src="https://user-images.githubusercontent.com/1832037/29903844-adb37794-8dcb-11e7-87bd-f6d9ec73b1b6.png">

I've changed it to header grey:
<img width="61" alt="screen shot 2017-08-30 at 9 37 36 pm" src="https://user-images.githubusercontent.com/1832037/29903861-bd0f4b8c-8dcb-11e7-8b02-7dc7219e90ba.png">

What do you think?
