### PR TITLE
Adapt UglifyJS config for IE10

### DIFF
--- a/build/uglifyjs.config.json
+++ b/build/uglifyjs.config.json
@@ -1,5 +1,8 @@
 {
-	"output" : {
+	"output": {
 		"comments": "/^!/"
-	}
+	},
+  "compress": {
+    "typeofs": false
+  }
 }


### PR DESCRIPTION
I came across jquery/jquery@0bf499c which links to mishoo/UglifyJS2#2198. Apparently the default compression config of UglifyJS possibly produces code incompatible with IE10. I thought that this might possibly be relevant for this project here since IE10 is also supported (as discussed in #21416).

No idea whether this would really change anything in the output, maybe the constructs which would trigger this (something with `typeof`) aren't even used but better safe than sorry. (Also, it might prevent problems in the future, especially if jQuery should get ditched).