### PR TITLE
Improves badges docs

### DIFF
--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -10,23 +10,14 @@ toc: true
 
 Badges scale to match the size of the immediate parent element by using relative font sizing and `em` units.
 
-<div class="bd-example">
-<div class="h1">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h2">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h3">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h4">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h5">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h6">Example heading <span class="badge badge-secondary">New</span></div>
-</div>
-
-{% highlight html %}
+{% example html %}
 <h1>Example heading <span class="badge badge-secondary">New</span></h1>
 <h2>Example heading <span class="badge badge-secondary">New</span></h2>
 <h3>Example heading <span class="badge badge-secondary">New</span></h3>
 <h4>Example heading <span class="badge badge-secondary">New</span></h4>
 <h5>Example heading <span class="badge badge-secondary">New</span></h5>
 <h6>Example heading <span class="badge badge-secondary">New</span></h6>
-{% endhighlight %}
+{% endexample %}
 
 Badges can be used as part of links or buttons to provide a counter.
 


### PR DESCRIPTION
Badges docs is using `highlight html` and HTML to demo badges on headers.

To keep docs DRY this PR is changing it to `example html`
