### PR TITLE
Dismissable badges

### DIFF
--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -76,3 +76,21 @@ Using the `.badge` classes with the `<a>` element quickly provide _actionable_ b
 {% for color in site.data.theme-colors %}
 <a href="#" class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %}
 {% endexample %}
+
+
+## Dismisable badges
+
+{% example html %}
+<span class="badge badge-primary">
+  Dismissable badge
+  <button type="button" class="close" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</span>
+<a href="#" class="badge badge-secondary">
+  Dismissable link badge
+  <button type="button" class="close" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</a>
+{% endexample %}

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -18,6 +18,15 @@
   &:empty {
     display: none;
   }
+  // changes the .close btn to create dismissable badges
+  .close {
+    padding-right: $badge-padding-x;
+    padding-left: $badge-padding-x;
+    margin-right: -$badge-padding-x;
+    font-size: inherit;
+    color: inherit;
+    text-shadow: none;
+  }
 }
 
 // Quick fix for badges in buttons


### PR DESCRIPTION
I have a use case for a dismissible badge. It’s a filter that generates badges.

![toolbar-example](https://user-images.githubusercontent.com/1832037/29944452-94d30b9a-8e6b-11e7-8b5a-0003218866b5.png)

I don’t know if it’s common enough, but in case it is this PR introduces dismissible badges by accommodating the size of the `.close` btn when they are inside a `.badge`

What do you think? worth having it in case a user has a use case as twisted as mine? or should this just live in my codebase?