### PR TITLE
Fix input-group-btn height when next to textarea

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -136,6 +136,7 @@
   // `font-size` in combination with `inline-block` on buttons.
   font-size: 0;
   white-space: nowrap;
+  align-items: stretch;
 
   // Negative margin for spacing, position for bringing hovered/focused/actived
   // element above the siblings.

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -132,11 +132,11 @@
 
 .input-group-btn {
   position: relative;
+  align-items: stretch;
   // Jankily prevent input button groups from wrapping with `white-space` and
   // `font-size` in combination with `inline-block` on buttons.
   font-size: 0;
   white-space: nowrap;
-  align-items: stretch;
 
   // Negative margin for spacing, position for bringing hovered/focused/actived
   // element above the siblings.


### PR DESCRIPTION
As a fix for "Input Group w/ Textarea #23745", I added a `align-items:stretch;` to the .input-group-btn class. 
This stretches the height to be 100% of the textarea (or input) next to it. 

Fixes #23745


