### PR TITLE
Fixes input group btn height bug

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -5,7 +5,7 @@
 .input-group {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
 
   .form-control {
@@ -29,6 +29,8 @@
 .input-group-addon,
 .input-group-btn,
 .input-group .form-control {
+  display: flex;
+  align-items: center;
   &:not(:first-child):not(:last-child) {
     @include border-radius(0);
   }
@@ -132,6 +134,7 @@
 
 .input-group-btn {
   position: relative;
+  align-items: stretch;
   // Jankily prevent input button groups from wrapping with `white-space` and
   // `font-size` in combination with `inline-block` on buttons.
   font-size: 0;


### PR DESCRIPTION
This is a follow up from this PR #23806.

The elements within input-group now stretches to avoid bugs like the one described on #23745, it now looks like this:
![screen shot 2017-09-03 at 1 52 30 pm](https://user-images.githubusercontent.com/1832037/30004992-4b4816b4-90af-11e7-9046-c3c28542da1d.png)


@mattcheah Please feel free to take this PR as an example to fix yours if you want. If you do please close this PR

This is fixing the problems introduced on this commit: https://github.com/twbs/bootstrap/commit/02ae73fc0fc21049ea4199dfda18c87c9b709e52

Fixes #23745 