### PR TITLE
Fix jQuery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "license": "MIT",
   "dependencies": {},
   "peerDependencies": {
-    "jquery": "3.0.0 - 4.0.0",
+    "jquery": "^3.0.0",
     "popper.js": "^1.12.3"
   },
   "devDependencies": {
@@ -118,6 +118,7 @@
     "LICENSE"
   ],
   "jspm": {
+    "registry": "npm",
     "main": "js/bootstrap",
     "directories": {
       "lib": "dist"
@@ -133,8 +134,8 @@
     },
     "dependencies": {},
     "peerDependencies": {
-      "jquery": "3",
-      "popper.js": "npm:popper.js@^1.12.3"
+      "jquery": "^3.0.0",
+      "popper.js": "^1.12.3"
     }
   }
 }


### PR DESCRIPTION
https://github.com/npm/node-semver#hyphen-ranges-xyz---abc: `3.0.0 - 4.0.0` := `>=3.0.0 <=4.0.0`
https://github.com/npm/node-semver#caret-ranges-123-025-004: `^3.0.0` := `>=3.0.0 <4.0.0`

For test - https://semver.npmjs.com/:
- pick a package - `jquery`
- enter a range - `2.0.0 - 3.0.0`
- enter a range - `^2.0.0`