### PR TITLE
Popup and tooltip: dimensions  in rem and bug fix of arrow placement

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -29,7 +29,7 @@
     height: calc(2*#{$popover-border-width} + #{$popover-arrow-height}); 
   }
 
-  $popover-arrow-margin: 0.5*$popover-arrow-width; 
+  $popover-arrow-margin: -$popover-arrow-width/2; 
   $popover-arrow-before-coor: calc(-#{$popover-arrow-width} - #{$popover-border-width});
   $popover-arrow-after-coor : -$popover-arrow-width;
 
@@ -62,7 +62,7 @@
     .arrow::before,
     .arrow::after {
       border-bottom-width: 0;
-      margin-left: -$popover-arrow-margin;
+      margin-left: $popover-arrow-margin;
     }
 
     .arrow::before {
@@ -85,7 +85,7 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -$popover-arrow-margin;
+      margin-top: $popover-arrow-margin;
       border-left-width: 0;
     }
 
@@ -109,7 +109,7 @@
 
     .arrow::before,
     .arrow::after {
-      margin-left: -$popover-arrow-margin; 
+      margin-left: $popover-arrow-margin; 
       border-top-width: 0;
     }
 
@@ -145,7 +145,7 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -$popover-arrow-margin;
+      margin-top: $popover-arrow-margin;
       border-right-width: 0;
     }
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -26,8 +26,13 @@
     position: absolute;
     display: block;
     width: $popover-arrow-width;
-    height: $popover-arrow-height;
+    height: $popover-arrow-height; background-color: red;
   }
+
+$popover-arrow-margin: /*$popover-arrow-width +*/ 0.5*$popover-arrow-width; 
+
+$popover-arrow-inner-width: calc(#{$popover-arrow-width} - #{$popover-border-width});
+$minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-border-width});
 
   .arrow::before,
   .arrow::after {
@@ -39,17 +44,17 @@
 
   .arrow::before {
     content: "";
-    border-width: $popover-arrow-outer-width;
+    border-width: $popover-arrow-width; //$popover-arrow-outer-width;
   }
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-outer-width;
+    border-width: $popover-arrow-width; //$popover-arrow-outer-width; TODO skal være smallere
   }
 
   // Popover directions
 
   &.bs-popover-top {
-    margin-bottom: $popover-arrow-width;
+    margin-bottom: $popover-arrow-width; //$popover-arrow-outer-width - $popover-border-width; //$popover-arrow-width;
 
     .arrow {
       bottom: 0;
@@ -61,17 +66,27 @@
     }
 
     .arrow::before {
-      bottom: -$popover-arrow-outer-width;
-      margin-left: -($popover-arrow-outer-width - 5);
+      bottom: -$popover-arrow-width; //-$popover-arrow-outer-width;
+      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-$popover-arrow-outer-width; //-($popover-arrow-outer-width - 5);
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: -($popover-arrow-outer-width - 1);
-      margin-left: -($popover-arrow-outer-width - 5);
+      bottom: $minus-popover-arrow-inner-width; //$popover-arrow-width; //-($popover-arrow-outer-width - 1);
+      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-($popover-arrow-outer-width - 5);
       border-top-color: $popover-arrow-color;
     }
   }
+
+
+
+
+
+
+
+
+
+
 
   &.bs-popover-right {
     margin-left: $popover-arrow-width;
@@ -82,17 +97,17 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -($popover-arrow-outer-width - 3);
+      margin-top: 0;//-($popover-arrow-outer-width - 3);
       border-left-width: 0;
     }
 
     .arrow::before {
-      left: -$popover-arrow-outer-width;
+      left: 0;//-$popover-arrow-outer-width;
       border-right-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      left: -($popover-arrow-outer-width - 1);
+      left: 0;//-($popover-arrow-outer-width - 1);
       border-right-color: $popover-arrow-color;
     }
   }
@@ -106,20 +121,32 @@
 
     .arrow::before,
     .arrow::after {
-      margin-left: -($popover-arrow-width - 3);
+//      margin-left: -($popover-arrow-width - 3);
       border-top-width: 0;
     }
 
     .arrow::before {
-      top: -$popover-arrow-outer-width;
+      top: -$popover-arrow-width; //-$popover-arrow-outer-width;
+      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-$popover-arrow-outer-width; //-($popover-arrow-outer-width - 5);
       border-bottom-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      top: -($popover-arrow-outer-width - 1);
+      top: $minus-popover-arrow-inner-width; //$popover-arrow-width; //-($popover-arrow-outer-width - 1);
+      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-($popover-arrow-outer-width - 5);
       border-bottom-color: $popover-arrow-color;
     }
+/*
+    .arrow::before {
+      top: 0;//-$popover-arrow-outer-width;
+      border-bottom-color: $popover-arrow-outer-color;
+    }
 
+    .arrow::after {
+      top: 0;//-($popover-arrow-outer-width - 1);
+      border-bottom-color: $popover-arrow-color;
+    }
+*/
     // This will remove the popover-header's border just below the arrow
     .popover-header::before {
       position: absolute;
@@ -142,17 +169,17 @@
 
     .arrow::before,
     .arrow::after {
-      margin-top: -($popover-arrow-outer-width - 3);
+      margin-top: 0;//-($popover-arrow-outer-width - 3);
       border-right-width: 0;
     }
 
     .arrow::before {
-      right: -$popover-arrow-outer-width;
+      right: 0; //-$popover-arrow-outer-width;
       border-left-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      right: -($popover-arrow-outer-width - 1);
+      right: 0;//-($popover-arrow-outer-width - 1);
       border-left-color: $popover-arrow-color;
     }
   }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -25,13 +25,13 @@
   .arrow {
     position: absolute;
     display: block;
-    width: calc(2*#{$popover-border-width} + #{$popover-arrow-width}); 
-    height: calc(2*#{$popover-border-width} + #{$popover-arrow-height}); 
+    width: calc(2*#{$popover-border-width} + #{$popover-arrow-width});
+    height: calc(2*#{$popover-border-width} + #{$popover-arrow-height});
   }
 
-  $popover-arrow-margin: -$popover-arrow-width/2; 
+  $popover-arrow-margin: -$popover-arrow-width / 2;
   $popover-arrow-before-coor: calc(-#{$popover-arrow-width} - #{$popover-border-width});
-  $popover-arrow-after-coor : -$popover-arrow-width;
+  $popover-arrow-after-coor: -$popover-arrow-width;
 
   .arrow::before,
   .arrow::after {
@@ -43,17 +43,17 @@
 
   .arrow::before {
     content: "";
-    border-width: $popover-arrow-width; 
+    border-width: $popover-arrow-width;
   }
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-width; 
+    border-width: $popover-arrow-width;
   }
 
   // Popover directions
 
   &.bs-popover-top {
-    margin-bottom: $popover-arrow-width; 
+    margin-bottom: $popover-arrow-width;
 
     .arrow {
       bottom: 0;
@@ -66,12 +66,12 @@
     }
 
     .arrow::before {
-      bottom: $popover-arrow-before-coor; 
+      bottom: $popover-arrow-before-coor;
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: $popover-arrow-after-coor; 
+      bottom: $popover-arrow-after-coor;
       border-top-color: $popover-arrow-color;
     }
   }
@@ -109,7 +109,7 @@
 
     .arrow::before,
     .arrow::after {
-      margin-left: $popover-arrow-margin; 
+      margin-left: $popover-arrow-margin;
       border-top-width: 0;
     }
 
@@ -119,7 +119,7 @@
     }
 
     .arrow::after {
-      top: $popover-arrow-after-coor; 
+      top: $popover-arrow-after-coor;
       border-bottom-color: $popover-arrow-color;
     }
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -25,14 +25,13 @@
   .arrow {
     position: absolute;
     display: block;
-    width: $popover-arrow-width;
-    height: $popover-arrow-height; background-color: red;
+    width: calc(2*#{$popover-border-width} + #{$popover-arrow-width}); 
+    height: calc(2*#{$popover-border-width} + #{$popover-arrow-height}); 
   }
 
-$popover-arrow-margin: /*$popover-arrow-width +*/ 0.5*$popover-arrow-width; 
-
-$popover-arrow-inner-width: calc(#{$popover-arrow-width} - #{$popover-border-width});
-$minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-border-width});
+  $popover-arrow-margin: 0.5*$popover-arrow-width; 
+  $popover-arrow-before-coor: calc(-#{$popover-arrow-width} - #{$popover-border-width});
+  $popover-arrow-after-coor : -$popover-arrow-width;
 
   .arrow::before,
   .arrow::after {
@@ -44,17 +43,17 @@ $minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-bor
 
   .arrow::before {
     content: "";
-    border-width: $popover-arrow-width; //$popover-arrow-outer-width;
+    border-width: $popover-arrow-width; 
   }
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-width; //$popover-arrow-outer-width; TODO skal være smallere
+    border-width: $popover-arrow-width; 
   }
 
   // Popover directions
 
   &.bs-popover-top {
-    margin-bottom: $popover-arrow-width; //$popover-arrow-outer-width - $popover-border-width; //$popover-arrow-width;
+    margin-bottom: $popover-arrow-width; 
 
     .arrow {
       bottom: 0;
@@ -63,30 +62,19 @@ $minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-bor
     .arrow::before,
     .arrow::after {
       border-bottom-width: 0;
+      margin-left: -$popover-arrow-margin;
     }
 
     .arrow::before {
-      bottom: -$popover-arrow-width; //-$popover-arrow-outer-width;
-      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-$popover-arrow-outer-width; //-($popover-arrow-outer-width - 5);
+      bottom: $popover-arrow-before-coor; 
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: $minus-popover-arrow-inner-width; //$popover-arrow-width; //-($popover-arrow-outer-width - 1);
-      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-($popover-arrow-outer-width - 5);
+      bottom: $popover-arrow-after-coor; 
       border-top-color: $popover-arrow-color;
     }
   }
-
-
-
-
-
-
-
-
-
-
 
   &.bs-popover-right {
     margin-left: $popover-arrow-width;
@@ -97,17 +85,17 @@ $minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-bor
 
     .arrow::before,
     .arrow::after {
-      margin-top: 0;//-($popover-arrow-outer-width - 3);
+      margin-top: -$popover-arrow-margin;
       border-left-width: 0;
     }
 
     .arrow::before {
-      left: 0;//-$popover-arrow-outer-width;
+      left: $popover-arrow-before-coor;
       border-right-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      left: 0;//-($popover-arrow-outer-width - 1);
+      left: $popover-arrow-after-coor;
       border-right-color: $popover-arrow-color;
     }
   }
@@ -121,32 +109,20 @@ $minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-bor
 
     .arrow::before,
     .arrow::after {
-//      margin-left: -($popover-arrow-width - 3);
+      margin-left: -$popover-arrow-margin; 
       border-top-width: 0;
     }
 
     .arrow::before {
-      top: -$popover-arrow-width; //-$popover-arrow-outer-width;
-      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-$popover-arrow-outer-width; //-($popover-arrow-outer-width - 5);
+      top: $popover-arrow-before-coor;
       border-bottom-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      top: $minus-popover-arrow-inner-width; //$popover-arrow-width; //-($popover-arrow-outer-width - 1);
-      margin-left: -$popover-arrow-margin; //-$popover-arrow-width; //-($popover-arrow-outer-width - 5);
+      top: $popover-arrow-after-coor; 
       border-bottom-color: $popover-arrow-color;
-    }
-/*
-    .arrow::before {
-      top: 0;//-$popover-arrow-outer-width;
-      border-bottom-color: $popover-arrow-outer-color;
     }
 
-    .arrow::after {
-      top: 0;//-($popover-arrow-outer-width - 1);
-      border-bottom-color: $popover-arrow-color;
-    }
-*/
     // This will remove the popover-header's border just below the arrow
     .popover-header::before {
       position: absolute;
@@ -169,17 +145,17 @@ $minus-popover-arrow-inner-width: calc(-#{$popover-arrow-width} + #{$popover-bor
 
     .arrow::before,
     .arrow::after {
-      margin-top: 0;//-($popover-arrow-outer-width - 3);
+      margin-top: -$popover-arrow-margin;
       border-right-width: 0;
     }
 
     .arrow::before {
-      right: 0; //-$popover-arrow-outer-width;
+      right: $popover-arrow-before-coor;
       border-left-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      right: 0;//-($popover-arrow-outer-width - 1);
+      right: $popover-arrow-after-coor;
       border-left-color: $popover-arrow-color;
     }
   }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -25,13 +25,13 @@
   .arrow {
     position: absolute;
     display: block;
-    width: calc(2*#{$popover-border-width} + #{$popover-arrow-width}); 
-    height: calc(2*#{$popover-border-width} + #{$popover-arrow-height}); 
+    width: calc(2*#{$popover-border-width} + #{$popover-arrow-width});
+    height: calc(2*#{$popover-border-width} + #{$popover-arrow-height});
   }
 
-  $popover-arrow-margin: -$popover-arrow-width/2; 
+  $popover-arrow-margin: -$popover-arrow-width / 2;
   $popover-arrow-before-coor: calc(-#{$popover-arrow-width} - #{$popover-border-width});
-  $popover-arrow-after-coor : -$popover-arrow-width;
+  $popover-arrow-after-coor: -$popover-arrow-width;
 
   .arrow::before,
   .arrow::after {
@@ -43,17 +43,17 @@
 
   .arrow::before {
     content: "";
-    border-width: $popover-arrow-width; 
+    border-width: $popover-arrow-width;
   }
   .arrow::after {
     content: "";
-    border-width: $popover-arrow-width; 
+    border-width: $popover-arrow-width;
   }
 
   // Popover directions
 
   &.bs-popover-top {
-    margin-bottom: $popover-arrow-width; 
+    margin-bottom: $popover-arrow-width;
 
     .arrow {
       bottom: 0;
@@ -61,17 +61,17 @@
 
     .arrow::before,
     .arrow::after {
-      border-bottom-width: 0;
       margin-left: $popover-arrow-margin;
+      border-bottom-width: 0;
     }
 
     .arrow::before {
-      bottom: $popover-arrow-before-coor; 
+      bottom: $popover-arrow-before-coor;
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: $popover-arrow-after-coor; 
+      bottom: $popover-arrow-after-coor;
       border-top-color: $popover-arrow-color;
     }
   }
@@ -109,7 +109,7 @@
 
     .arrow::before,
     .arrow::after {
-      margin-left: $popover-arrow-margin; 
+      margin-left: $popover-arrow-margin;
       border-top-width: 0;
     }
 
@@ -119,7 +119,7 @@
     }
 
     .arrow::after {
-      top: $popover-arrow-after-coor; 
+      top: $popover-arrow-after-coor;
       border-bottom-color: $popover-arrow-color;
     }
 

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,4 +1,5 @@
 // Base class
+
 .tooltip {
   position: absolute;
   z-index: $zindex-tooltip;
@@ -20,6 +21,8 @@
     width: $tooltip-arrow-width;
     height: $tooltip-arrow-height;
   }
+  
+  $tooltip-arrow-margin: -$tooltip-arrow-width/2; 
 
   &.bs-tooltip-top {
     padding: $tooltip-arrow-width 0;
@@ -28,7 +31,7 @@
     }
 
     .arrow::before {
-      margin-left: -($tooltip-arrow-width - 2);
+      margin-left: $tooltip-arrow-margin; 
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
       border-top-color: $tooltip-arrow-color;
@@ -41,7 +44,7 @@
     }
 
     .arrow::before {
-      margin-top: -($tooltip-arrow-width - 2);
+      margin-top: $tooltip-arrow-margin; 
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
       border-right-color: $tooltip-arrow-color;
@@ -54,7 +57,7 @@
     }
 
     .arrow::before {
-      margin-left: -($tooltip-arrow-width - 2);
+      margin-left: $tooltip-arrow-margin; 
       content: "";
       border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-bottom-color: $tooltip-arrow-color;
@@ -68,7 +71,7 @@
 
     .arrow::before {
       right: 0;
-      margin-top: -($tooltip-arrow-width - 2);
+      margin-top: $tooltip-arrow-margin; 
       content: "";
       border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-left-color: $tooltip-arrow-color;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -21,8 +21,8 @@
     width: $tooltip-arrow-width;
     height: $tooltip-arrow-height;
   }
-  
-  $tooltip-arrow-margin: -$tooltip-arrow-width/2; 
+
+  $tooltip-arrow-margin: -$tooltip-arrow-width/2;
 
   &.bs-tooltip-top {
     padding: $tooltip-arrow-width 0;
@@ -31,7 +31,7 @@
     }
 
     .arrow::before {
-      margin-left: $tooltip-arrow-margin; 
+      margin-left: $tooltip-arrow-margin;
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
       border-top-color: $tooltip-arrow-color;
@@ -44,7 +44,7 @@
     }
 
     .arrow::before {
-      margin-top: $tooltip-arrow-margin; 
+      margin-top: $tooltip-arrow-margin;
       content: "";
       border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
       border-right-color: $tooltip-arrow-color;
@@ -57,7 +57,7 @@
     }
 
     .arrow::before {
-      margin-left: $tooltip-arrow-margin; 
+      margin-left: $tooltip-arrow-margin;
       content: "";
       border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-bottom-color: $tooltip-arrow-color;
@@ -71,7 +71,7 @@
 
     .arrow::before {
       right: 0;
-      margin-top: $tooltip-arrow-margin; 
+      margin-top: $tooltip-arrow-margin;
       content: "";
       border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;
       border-left-color: $tooltip-arrow-color;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -22,7 +22,7 @@
     height: $tooltip-arrow-height;
   }
 
-  $tooltip-arrow-margin: -$tooltip-arrow-width/2;
+  $tooltip-arrow-margin: -$tooltip-arrow-width / 2;
 
   &.bs-tooltip-top {
     padding: $tooltip-arrow-width 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -620,28 +620,33 @@ $tooltip-arrow-color:         $tooltip-bg !default;
 
 // Popovers
 
-$popover-inner-padding:               1px !default;
+$popover-inner-padding:               0.0625rem !default;
 $popover-bg:                          $white !default;
 $popover-max-width:                   276px !default;
-$popover-border-width:                $border-width !default;
+$popover-border-width:                12px; //$border-width !default;
 $popover-border-color:                rgba($black,.2) !default;
-$popover-box-shadow:                  0 5px 10px rgba($black,.2) !default;
+$popover-box-shadow:                  0 0.3125rem 0.625rem rgba($black,.2) !default;
 
 $popover-header-bg:                    darken($popover-bg, 3%) !default;
 $popover-header-color:                 $headings-color !default;
-$popover-header-padding-y:             8px !default;
-$popover-header-padding-x:             14px !default;
+$popover-header-padding-y:             0.5rem !default;
+$popover-header-padding-x:             0.875rem !default;
 
 $popover-body-color:               $body-color !default;
-$popover-body-padding-y:           9px !default;
-$popover-body-padding-x:           14px !default;
+$popover-body-padding-y:           0.5625rem !default;
+$popover-body-padding-x:           0.875rem !default;
 
-$popover-arrow-width:                 10px !default;
-$popover-arrow-height:                5px !default;
-$popover-arrow-color:                 $popover-bg !default;
+$popover-arrow-width:                 .8rem !default; // 10px !default;
+$popover-arrow-height:                .4rem !default; //5px !default;
+$popover-arrow-color: blue;//                $popover-bg !default;
 
-$popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
-$popover-arrow-outer-color:           fade-in($popover-border-color, .05) !default;
+//ORIGINAL $popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
+//NEW 
+//$popover-arrow-outer-width: calc(#{$popover-arrow-width} + 1.41*#{$popover-border-width}) !default; //NEW
+//$popover-arrow-outer-width: calc(#{$popover-arrow-width} + #{$popover-border-width}) !default; //NEW
+
+
+$popover-arrow-outer-color: green;//           fade-in($popover-border-color, .05) !default;
 
 
 // Badges

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -623,7 +623,7 @@ $tooltip-arrow-color:         $tooltip-bg !default;
 $popover-inner-padding:               0.0625rem !default;
 $popover-bg:                          $white !default;
 $popover-max-width:                   276px !default;
-$popover-border-width:                12px; //$border-width !default;
+$popover-border-width:                $border-width !default;
 $popover-border-color:                rgba($black,.2) !default;
 $popover-box-shadow:                  0 0.3125rem 0.625rem rgba($black,.2) !default;
 
@@ -636,17 +636,11 @@ $popover-body-color:               $body-color !default;
 $popover-body-padding-y:           0.5625rem !default;
 $popover-body-padding-x:           0.875rem !default;
 
-$popover-arrow-width:                 .8rem !default; // 10px !default;
-$popover-arrow-height:                .4rem !default; //5px !default;
-$popover-arrow-color: blue;//                $popover-bg !default;
+$popover-arrow-width:                 .8rem !default; 
+$popover-arrow-height:                .4rem !default; 
+$popover-arrow-color:                 $popover-bg !default;
 
-//ORIGINAL $popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
-//NEW 
-//$popover-arrow-outer-width: calc(#{$popover-arrow-width} + 1.41*#{$popover-border-width}) !default; //NEW
-//$popover-arrow-outer-width: calc(#{$popover-arrow-width} + #{$popover-border-width}) !default; //NEW
-
-
-$popover-arrow-outer-color: green;//           fade-in($popover-border-color, .05) !default;
+$popover-arrow-outer-color:            fade-in($popover-border-color, .05) !default;
 
 
 // Badges

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -608,13 +608,13 @@ $tooltip-max-width:           200px !default;
 $tooltip-color:               $white !default;
 $tooltip-bg:                  $black !default;
 $tooltip-opacity:             .9 !default;
-$tooltip-padding-y:           3px !default;
-$tooltip-padding-x:           8px !default;
+$tooltip-padding-y:           0.1875rem !default;
+$tooltip-padding-x:           0.5rem !default;
 $tooltip-margin:              0 !default;
 
 
-$tooltip-arrow-width:         5px !default;
-$tooltip-arrow-height:        5px !default;
+$tooltip-arrow-width:         0.3125rem !default;
+$tooltip-arrow-height:        0.3125rem !default;
 $tooltip-arrow-color:         $tooltip-bg !default;
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -623,7 +623,7 @@ $tooltip-arrow-color:         $tooltip-bg !default;
 $popover-inner-padding:               0.0625rem !default;
 $popover-bg:                          $white !default;
 $popover-max-width:                   276px !default;
-$popover-border-width:                12px; //$border-width !default;
+$popover-border-width:                $border-width !default;
 $popover-border-color:                rgba($black,.2) !default;
 $popover-box-shadow:                  0 0.3125rem 0.625rem rgba($black,.2) !default;
 
@@ -638,7 +638,7 @@ $popover-body-padding-x:           0.875rem !default;
 
 $popover-arrow-width:                 .8rem !default; // 10px !default;
 $popover-arrow-height:                .4rem !default; //5px !default;
-$popover-arrow-color: blue;//                $popover-bg !default;
+$popover-arrow-color:                 $popover-bg !default;
 
 //ORIGINAL $popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
 //NEW 
@@ -646,7 +646,7 @@ $popover-arrow-color: blue;//                $popover-bg !default;
 //$popover-arrow-outer-width: calc(#{$popover-arrow-width} + #{$popover-border-width}) !default; //NEW
 
 
-$popover-arrow-outer-color: green;//           fade-in($popover-border-color, .05) !default;
+$popover-arrow-outer-color:            fade-in($popover-border-color, .05) !default;
 
 
 // Badges

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -608,36 +608,36 @@ $tooltip-max-width:           200px !default;
 $tooltip-color:               $white !default;
 $tooltip-bg:                  $black !default;
 $tooltip-opacity:             .9 !default;
-$tooltip-padding-y:           0.1875rem !default;
-$tooltip-padding-x:           0.5rem !default;
+$tooltip-padding-y:           .1875rem !default;
+$tooltip-padding-x:           .5rem !default;
 $tooltip-margin:              0 !default;
 
 
-$tooltip-arrow-width:         0.3125rem !default;
-$tooltip-arrow-height:        0.3125rem !default;
+$tooltip-arrow-width:         .3125rem !default;
+$tooltip-arrow-height:        .3125rem !default;
 $tooltip-arrow-color:         $tooltip-bg !default;
 
 
 // Popovers
 
-$popover-inner-padding:               0.0625rem !default;
+$popover-inner-padding:               .0625rem !default;
 $popover-bg:                          $white !default;
 $popover-max-width:                   276px !default;
 $popover-border-width:                $border-width !default;
 $popover-border-color:                rgba($black,.2) !default;
-$popover-box-shadow:                  0 0.3125rem 0.625rem rgba($black,.2) !default;
+$popover-box-shadow:                  0 .3125rem .625rem rgba($black,.2) !default;
 
 $popover-header-bg:                    darken($popover-bg, 3%) !default;
 $popover-header-color:                 $headings-color !default;
-$popover-header-padding-y:             0.5rem !default;
-$popover-header-padding-x:             0.875rem !default;
+$popover-header-padding-y:             .5rem !default;
+$popover-header-padding-x:             .875rem !default;
 
 $popover-body-color:               $body-color !default;
-$popover-body-padding-y:           0.5625rem !default;
-$popover-body-padding-x:           0.875rem !default;
+$popover-body-padding-y:           .5625rem !default;
+$popover-body-padding-x:           .875rem !default;
 
-$popover-arrow-width:                 .8rem !default; 
-$popover-arrow-height:                .4rem !default; 
+$popover-arrow-width:                 .8rem !default;
+$popover-arrow-height:                .4rem !default;
 $popover-arrow-color:                 $popover-bg !default;
 
 $popover-arrow-outer-color:            fade-in($popover-border-color, .05) !default;


### PR DESCRIPTION
Hi
This PR will change the dimensions of popover and tooltip from px to rem AND fix a bug in the way the arrow of popover and tooltips are placed. The current placement of the arrow is only centered on the element when border-width and arrow-width are default values. This PR will allow both border-width and arrow-width to be changed
It need to be merged/integrated with #23763
Could solve #23793 and issues in #23468 
Setting `$border-width: 20px; $popover-border-width:10px;` in Bootstrap 4-beta would give
![bootstrap-popover-4-beta](https://user-images.githubusercontent.com/11357972/30019686-b5e58a44-9161-11e7-9fc7-173f6d23188a.png)
In this PR (with `$popover-arrow-width: 1rem;`) it would be
![bootstrap-popover-nielsholt](https://user-images.githubusercontent.com/11357972/30020049-d08ce206-9162-11e7-987a-bec76b2d7391.png)


