### PR TITLE
js-minify task should just minify our dist files not our docs.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "js-compile-standalone": "rollup --environment BUNDLE:false --config build/rollup.config.js",
     "js-compile-bundle": "rollup --environment BUNDLE:true --config build/rollup.config.js",
     "js-compile-plugins": "babel --no-babelrc js/src/ --out-dir js/dist/ --source-maps --presets=es2015 --plugins=transform-es2015-modules-strip",
-    "js-minify": "npm-run-all --parallel js-minify-*",
+    "js-minify": "npm-run-all --parallel js-minify-standalone js-minify-bundle",
     "js-minify-standalone": "uglifyjs --config-file build/uglifyjs.config.json --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
     "js-minify-bundle": "uglifyjs --config-file build/uglifyjs.config.json --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js",
     "js-minify-docs": "uglifyjs --config-file build/uglifyjs.config.json --output assets/js/docs.min.js assets/js/vendor/anchor.min.js assets/js/vendor/clipboard.min.js assets/js/vendor/holder.min.js assets/js/src/application.js assets/js/src/pwa.js",


### PR DESCRIPTION
`js-minify` task should just minify our dist files not our docs.min.js

Note : It didn't change the fact that currently copyrights are removed from our `docs.min.js`