### PR TITLE
[Grid docs] Adds a comment about the fact that grids values should be set in px

### DIFF
--- a/docs/4.0/layout/grid.md
+++ b/docs/4.0/layout/grid.md
@@ -727,4 +727,4 @@ $container-max-widths: (
 );
 {% endhighlight %}
 
-When making any changes to the Sass variables or maps, you'll need to save your changes and recompile. Doing so will output a brand new set of predefined grid classes for column widths, offsets, and ordering. Responsive visibility utilities will also be updated to use the custom breakpoints.
+When making any changes to the Sass variables or maps, you'll need to save your changes and recompile. Doing so will output a brand new set of predefined grid classes for column widths, offsets, and ordering. Responsive visibility utilities will also be updated to use the custom breakpoints. Make sure to set grid values in `px` (not `rem`, `em` or `%`).


### PR DESCRIPTION
This PR adds a clarification that grid values should be set in `px` in order to compile bootstrap correctly.

This is a common issue users fall into and it can avoid issues reporting the fact that bootstrap doesn't compile when breakpoints are set in `em`s or `rem`s

What do you think?