### PR TITLE
Removes background from form-control-plaintext

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -130,6 +130,7 @@ select.form-control {
   padding-bottom: $input-btn-padding-y;
   margin-bottom: 0; // match inputs if this class comes on inputs with default margins
   line-height: $input-btn-line-height;
+  background-color: transparent;
   border: solid transparent;
   border-width: $input-btn-border-width 0;
 


### PR DESCRIPTION
Fixes #23845

This PR removes background from `.form-control-plaintext`

![screen shot 2017-09-06 at 4 40 38 pm](https://user-images.githubusercontent.com/1832037/30131158-22f6841e-9322-11e7-9b50-c306ad5c54b6.png)

@patrickhlauke Do you think this fixes it?