### PR TITLE
Hiding Elements: new doc section in display.md

### DIFF
--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -49,9 +49,26 @@ Responsive variations also exist for every single utility mentioned above.
 
 ## Hiding Elements
 
+For faster mobile-friendly development, use responsive display classes for showing and hiding elements by device. Avoid creating entirely different versions of the same site, instead hide element responsively for each screen size.
+
 To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-none` classes for any responsive screen variation.
 
-To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none.d-md-block.d-xl-none` will hide the element for all screen sizes but it will shows it only on medium and large devices.
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none.d-md-block.d-xl-none` will hide the element for all screen sizes except on medium and large devices.
+
+| Screen Size        | Class |
+| ---                | --- |
+| Hidden on all      | `d-none` |
+| Hidden only on xs  | `d-none d-sm-block` |
+| Hidden only on sm  | `d-sm-none d-md-block` |
+| Hidden only on md  | `d-md-none d-lg-block` |
+| Hidden only on lg  | `d-lg-none d-xl-block` |
+| Hidden only on xl  | `d-xl-none` |
+| Visible on all     | `d-block` |
+| Visible only on xs | `d-block d-sm-none` |
+| Visible only on sm | `d-none d-sm-block d-md-none` |
+| Visible only on md | `d-none d-md-block d-lg-none` |
+| Visible only on lg | `d-none d-lg-block d-xl-none` |
+| Visible only on xl | `d-none d-xl-block` |
 
 ## Display in print
 

--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -47,6 +47,12 @@ Responsive variations also exist for every single utility mentioned above.
 - `.d{{ bp.abbr }}-flex`
 - `.d{{ bp.abbr }}-inline-flex`{% endfor %}
 
+## Hiding Elements
+
+To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-none` classes for any responsive screen variation.
+
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-block` class, for example `.d-none.d-md-block.d-xl-none` will hide the element for all screen sizes but it will shows it only on medium and large devices.
+
 ## Display in print
 
 Change the `display` value of elements when printing with our print display utilities.

--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -51,7 +51,7 @@ Responsive variations also exist for every single utility mentioned above.
 
 To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-none` classes for any responsive screen variation.
 
-To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-block` class, for example `.d-none.d-md-block.d-xl-none` will hide the element for all screen sizes but it will shows it only on medium and large devices.
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none.d-md-block.d-xl-none` will hide the element for all screen sizes but it will shows it only on medium and large devices.
 
 ## Display in print
 


### PR DESCRIPTION
The **Beta version** removed all the `.hidden-` classes. They where replaced with `d-*-none` classes. But no docs can be found in https://getbootstrap.com/docs/4.0/utilities/display/

This PR adds a new section how to hide elements. This is section should replace the **Alpha version** docs for `hidden-*` class found in https://v4-alpha.getbootstrap.com/layout/responsive-utilities/

More info about the change can be found in the migration docs  https://getbootstrap.com/docs/4.0/migration/#responsive-utilities