### PR TITLE
Remove placement attribute from our Dropdown plugin

### DIFF
--- a/docs/4.0/components/dropdowns.md
+++ b/docs/4.0/components/dropdowns.md
@@ -574,7 +574,7 @@ Regardless of whether you call your dropdown via JavaScript or instead use the d
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-placement=""`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-offset=""`.
 
 <table class="table table-bordered table-striped table-responsive">
   <thead>
@@ -586,14 +586,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>placement</td>
-      <td>string</td>
-      <td>'bottom'</td>
-      <td>
-        <p>How to position the popover - top | bottom.</p>
-      </td>
-    </tr>
     <tr>
       <td>offset</td>
       <td>number | string</td>

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -75,13 +75,11 @@ const Dropdown = (() => {
   }
 
   const Default = {
-    placement   : AttachmentMap.BOTTOM,
     offset      : 0,
     flip        : true
   }
 
   const DefaultType = {
-    placement   : 'string',
     offset      : '(number|string)',
     flip        : 'boolean'
   }
@@ -203,11 +201,6 @@ const Dropdown = (() => {
     }
 
     _getConfig(config) {
-      const elementData = $(this._element).data()
-      if (typeof elementData.placement !== 'undefined') {
-        elementData.placement = AttachmentMap[elementData.placement.toUpperCase()]
-      }
-
       config = $.extend(
         {},
         this.constructor.Default,
@@ -234,10 +227,10 @@ const Dropdown = (() => {
 
     _getPlacement() {
       const $parentDropdown = $(this._element).parent()
-      let placement = this._config.placement
+      let placement = AttachmentMap.BOTTOM
 
       // Handle dropup
-      if ($parentDropdown.hasClass(ClassName.DROPUP) || this._config.placement === AttachmentMap.TOP) {
+      if ($parentDropdown.hasClass(ClassName.DROPUP)) {
         placement = AttachmentMap.TOP
         if ($(this._menu).hasClass(ClassName.MENURIGHT)) {
           placement = AttachmentMap.TOPEND


### PR DESCRIPTION
This attribute was useless and confusing for folks, because we determine the placement of our Dropdowns thanks to the parent class.

That was me who introduced that attribute and it was a mistake sorry 😟