### PR TITLE
Added type="button" to <button>s without any type

### DIFF
--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -31,7 +31,7 @@ Badges scale to match the size of the immediate parent element by using relative
 Badges can be used as part of links or buttons to provide a counter.
 
 {% example html %}
-<button class="btn btn-primary">
+<button type="button" class="btn btn-primary">
   Notifications <span class="badge badge-light">4</span>
 </button>
 {% endexample %}
@@ -41,7 +41,7 @@ Note that depending on how they are used, badges may be confusing for users of s
 Unless the context is clear (as with the "Notifications" example, where it is understood that the "4" is the number of notifications), consider including additional context with a visually hidden piece of additional text.
 
 {% example html %}
-<button class="btn btn-primary">
+<button type="button" class="btn btn-primary">
   Profile <span class="badge badge-light">9</span>
   <span class="sr-only">unread messages</span>
 </button>

--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -422,7 +422,7 @@ Modals have two optional sizes, available via modifier classes to be placed on a
 
 {% highlight html %}
 <!-- Large modal -->
-<button class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-lg">Large modal</button>
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-lg">Large modal</button>
 
 <div class="modal fade bd-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg">

--- a/docs/4.0/examples/tooltip-viewport/index.html
+++ b/docs/4.0/examples/tooltip-viewport/index.html
@@ -18,19 +18,19 @@
 
   <body>
 
-    <button class="btn btn-secondary float-right tooltip-bottom" title="This should be shifted to the left">Shift Left</button>
-    <button class="btn btn-secondary tooltip-bottom" title="This should be shifted to the right">Shift Right</button>
-    <button class="btn btn-secondary tooltip-right" title="This should be shifted down">Shift Down</button>
+    <button type="button" class="btn btn-secondary float-right tooltip-bottom" title="This should be shifted to the left">Shift Left</button>
+    <button type="button" class="btn btn-secondary tooltip-bottom" title="This should be shifted to the right">Shift Right</button>
+    <button type="button" class="btn btn-secondary tooltip-right" title="This should be shifted down">Shift Down</button>
 
-    <button class="btn btn-secondary tooltip-right btn-bottom" title="This should be shifted up">Shift Up</button>
+    <button type="button" class="btn btn-secondary tooltip-right btn-bottom" title="This should be shifted up">Shift Up</button>
 
     <div class="container-viewport">
-      <button class="btn btn-secondary tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
-      <button class="btn btn-secondary tooltip-viewport-right" title="This should be shifted down">Shift Down</button>
+      <button type="button" class="btn btn-secondary tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
+      <button type="button" class="btn btn-secondary tooltip-viewport-right" title="This should be shifted down">Shift Down</button>
 
-      <button class="btn btn-secondary float-right tooltip-viewport-bottom" title="This should be shifted to the right">Shift Right</button>
+      <button type="button" class="btn btn-secondary float-right tooltip-viewport-bottom" title="This should be shifted to the right">Shift Right</button>
 
-      <button class="btn btn-secondary tooltip-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
+      <button type="button" class="btn btn-secondary tooltip-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
     </div>
 
 

--- a/docs/4.0/utilities/clearfix.md
+++ b/docs/4.0/utilities/clearfix.md
@@ -32,7 +32,7 @@ The following example shows how the clearfix can be used. Without the clearfix t
 
 {% example html %}
 <div class="bg-info clearfix">
-  <button class="btn btn-secondary float-left">Example Button floated left</button>
-  <button class="btn btn-secondary float-right">Example Button floated right</button>
+  <button type="button" class="btn btn-secondary float-left">Example Button floated left</button>
+  <button type="button" class="btn btn-secondary float-right">Example Button floated right</button>
 </div>
 {% endexample %}


### PR DESCRIPTION
https://github.com/twbs/bootlint/wiki/W007

Found as part of my work on bootlint for BS4: twbs/bootlint#410.

I created the following one-liner to do it:
```sh
find docs/ -type f -exec perl -pi -e \
  's/(?<=<button )(.*?)(?=>)/@{[(index($1,"type=")!=-1?"$1":"type=\"button\" $1")]}/g' {} +
```

BTW, I am occasionally rebasing my patch branches so you shouldn't need to merge the current HEAD of `v4-dev` into my patch.