### PR TITLE
Adds missing !important on rounded border utility classes

### DIFF
--- a/scss/utilities/_borders.scss
+++ b/scss/utilities/_borders.scss
@@ -44,9 +44,9 @@
 }
 
 .rounded-circle {
-  border-radius: 50%;
+  border-radius: 50% !important;
 }
 
 .rounded-0 {
-  border-radius: 0;
+  border-radius: 0 !important;
 }


### PR DESCRIPTION
This PR sdds missing `!important` on rounded border utility classes