### PR TITLE
Improves rounded border utilities

### DIFF
--- a/scss/utilities/_borders.scss
+++ b/scss/utilities/_borders.scss
@@ -27,20 +27,16 @@
   border-radius: $border-radius !important;
 }
 .rounded-top {
-  border-top-left-radius: $border-radius !important;
-  border-top-right-radius: $border-radius !important;
+  border-radius: $border-radius $border-radius 0 0 !important;
 }
 .rounded-right {
-  border-top-right-radius: $border-radius !important;
-  border-bottom-right-radius: $border-radius !important;
+  border-radius: 0 $border-radius $border-radius 0 !important;
 }
 .rounded-bottom {
-  border-bottom-right-radius: $border-radius !important;
-  border-bottom-left-radius: $border-radius !important;
+  border-radius: 0 0 $border-radius $border-radius !important;
 }
 .rounded-left {
-  border-top-left-radius: $border-radius !important;
-  border-bottom-left-radius: $border-radius !important;
+  border-radius: $border-radius 0 0 $border-radius !important;
 }
 
 .rounded-circle {


### PR DESCRIPTION
This PR closes #23865

It was reported that rounded borders utilities were not overwriting default styles, for example on `<button class="btn btn-primary rounded-left">Test</button>` you'd still get the right side borders rounded. Thanks @jesobreira for spotting this.