### PR TITLE
Use touch-action: none instead of manipulation

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -285,7 +285,7 @@ label,
 select,
 summary,
 textarea {
-  touch-action: manipulation;
+  touch-action: none;
 }
 
 


### PR DESCRIPTION
For whatever reason, in Chrome, setting touch-action: manipulation on a large interface causes significant performance issues (i.e. scrolling, resizing). If this is only here to support getting rid of the delay on IE/Edge, touch-action: none [achieves the same goal](https://patrickhlauke.github.io/touch/tests/results/#suppressing-300ms-delay) without wrecking the performance of other browsers.