### PR TITLE
Adds text-muted and text-white to the examples on color utilities

### DIFF
--- a/docs/4.0/utilities/colors.md
+++ b/docs/4.0/utilities/colors.md
@@ -10,7 +10,7 @@ toc: true
 {% for color in site.data.theme-colors %}
 <p class="text-{{ color.name }}">.text-{{ color.name }}</p>{% endfor %}
 <p class="text-muted">.text-muted</p>
-<p class="text-white bg-dark p-3">.text-white</p>
+<p class="text-white bg-dark p-2">.text-white</p>
 {% endexample %}
 
 Contextual text classes also work well on anchors with the provided hover and focus states. **Note that the `.text-white` class has no link styling.**
@@ -19,7 +19,7 @@ Contextual text classes also work well on anchors with the provided hover and fo
 {% for color in site.data.theme-colors %}
 <p><a href="#" class="text-{{ color.name }}{% if color.name == "light" %} bg-gray{% endif %}">{{ color.name | capitalize }} link</a></p>{% endfor %}
 <p><a href="#" class="text-muted">Muted link</a></p>
-<p class="bg-dark p-3"><a href="#" class="text-white">White link</a></p>
+<p class="bg-dark p-2"><a href="#" class="text-white">White link</a></p>
 {% endexample %}
 
 Similar to the contextual text color classes, easily set the background of an element to any contextual class. Anchor components will darken on hover, just like the text classes. Background utilities **do not set `color`**, so in some cases you'll want to use `.text-*` utilities.

--- a/docs/4.0/utilities/colors.md
+++ b/docs/4.0/utilities/colors.md
@@ -9,6 +9,8 @@ toc: true
 {% example html %}
 {% for color in site.data.theme-colors %}
 <p class="text-{{ color.name }}">.text-{{ color.name }}</p>{% endfor %}
+<p class="text-muted">.text-muted</p>
+<p class="text-white bg-dark p-3">.text-white</p>
 {% endexample %}
 
 Contextual text classes also work well on anchors with the provided hover and focus states. **Note that the `.text-white` class has no link styling.**
@@ -16,6 +18,8 @@ Contextual text classes also work well on anchors with the provided hover and fo
 {% example html %}
 {% for color in site.data.theme-colors %}
 <p><a href="#" class="text-{{ color.name }}{% if color.name == "light" %} bg-gray{% endif %}">{{ color.name | capitalize }} link</a></p>{% endfor %}
+<p><a href="#" class="text-muted">Muted link</a></p>
+<p class="bg-dark p-3"><a href="#" class="text-white">White link</a></p>
 {% endexample %}
 
 Similar to the contextual text color classes, easily set the background of an element to any contextual class. Anchor components will darken on hover, just like the text classes. Background utilities **do not set `color`**, so in some cases you'll want to use `.text-*` utilities.


### PR DESCRIPTION
Hi @XhmikosR @Johann-S I think we should reopen and merge #23757

This PR I am sending proved that `.text-white` styles links since it's just `color: #fff !important;`

![screen shot 2017-09-07 at 8 13 29 pm](https://user-images.githubusercontent.com/1832037/30189294-5aa3cac4-9409-11e7-8568-d4d622a6d44c.png) ![screen shot 2017-09-07 at 8 13 36 pm](https://user-images.githubusercontent.com/1832037/30189295-5aae6100-9409-11e7-81a7-a83d9989518b.png)

On this PR I am adding the examples.