### PR TITLE
New feature: outline badges

### DIFF
--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -59,6 +59,15 @@ Add any of the below mentioned modifier classes to change the appearance of a ba
 {% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
 {{ callout-include | markdownify }}
 
+## Outline badges
+
+Use the modifier classes `.badge-outline-*` to replace background with a border colors on any badge.
+
+{% example html %}
+{% for color in site.data.theme-colors %}
+<span class="badge badge-outline-{{ color.name }}">{{ color.name | capitalize }}</span>{% endfor %}
+{% endexample %}
+
 ## Pill badges
 
 Use the `.badge-pill` modifier class to make badges more rounded (with a larger `border-radius` and additional horizontal `padding`). Useful if you miss the badges from v3.
@@ -73,6 +82,11 @@ Use the `.badge-pill` modifier class to make badges more rounded (with a larger 
 Using the `.badge` classes with the `<a>` element quickly provide _actionable_ badges with hover and focus states.
 
 {% example html %}
-{% for color in site.data.theme-colors %}
-<a href="#" class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %}
+<div class="mb-2">{% for color in site.data.theme-colors %}
+  <a href="#" class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %}
+</div>
+
+<div>{% for color in site.data.theme-colors %}
+  <a href="#" class="badge badge-outline-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %}
+</div>
 {% endexample %}

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -45,3 +45,9 @@
     @include badge-variant($value);
   }
 }
+
+@each $color, $value in $theme-colors {
+  .badge-outline-#{$color} {
+    @include badge-outline-variant($value);
+  }
+}

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -10,3 +10,16 @@
     }
   }
 }
+
+@mixin badge-outline-variant($color) {
+  color: $color;
+  border: $border-width solid $color;
+
+  &[href] {
+    @include hover-focus {
+      @include color-yiq($color);
+      text-decoration: none;
+      background-color: $color;
+    }
+  }
+}


### PR DESCRIPTION
This PR closes #23882

It adds outlined badges and they look like this:

![screen shot 2017-09-08 at 9 56 24 am](https://user-images.githubusercontent.com/1832037/30212609-0b43f0c6-947c-11e7-98b0-ac11f0130496.png)

![screen shot 2017-09-08 at 9 57 18 am](https://user-images.githubusercontent.com/1832037/30212631-28d3966e-947c-11e7-945b-199da848f9f1.png)

Do you think it's worth adding the same hover animation to badges as in btns for consistency?