### PR TITLE
Fixes broken link to the "about" page on the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <li><a href="{{ site.repo }}">GitHub</a></li>
       <li><a href="https://twitter.com/getbootstrap">Twitter</a></li>
       <li><a href="{{ site.baseurl }}/docs/{{ site.docs_version }}/examples/">Examples</a></li>
-      <li><a href="{{ site.baseurl }}/docs/{{ site.docs_version }}/about/">About</a></li>
+      <li><a href="{{ site.baseurl }}/docs/{{ site.docs_version }}/about/history/">About</a></li>
     </ul>
     <p>Designed and built with all the love in the world by <a href="https://twitter.com/mdo" target="_blank" rel="noopener">@mdo</a> and <a href="https://twitter.com/fat" target="_blank" rel="noopener">@fat</a>. Maintained by the <a href="https://github.com/orgs/twbs/people">core team</a> with the help of <a href="https://github.com/twbs/bootstrap/graphs/contributors">our contributors</a>.</p>
     <p>Currently v{{ site.current_version }}. Code licensed <a rel="license noopener" href="https://github.com/twbs/bootstrap/blob/master/LICENSE" target="_blank">MIT</a>, docs <a rel="license noopener" href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.</p>


### PR DESCRIPTION
This PR fixes a broken "about" link on the docs footer