### PR TITLE
Remove not necessary condition in tooltip.js

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -622,18 +622,18 @@ const Tooltip = (() => {
         config
       )
 
-      if (config.delay && typeof config.delay === 'number') {
+      if (typeof config.delay === 'number') {
         config.delay = {
           show : config.delay,
           hide : config.delay
         }
       }
 
-      if (config.title && typeof config.title === 'number') {
+      if (typeof config.title === 'number') {
         config.title = config.title.toString()
       }
 
-      if (config.content && typeof config.content === 'number') {
+      if (typeof config.content === 'number') {
         config.content = config.content.toString()
       }
 


### PR DESCRIPTION
`$.extend` always returns an object.