### PR TITLE
bug fix: Fixes #23926 responsive state on navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -97,6 +97,7 @@
 // the default flexbox row orienation. Requires the use of `flex-wrap: wrap`
 // on the `.navbar` parent.
 .navbar-collapse {
+  flex-basis: 100%;
   flex-grow: 1;
   // For always expanded or extra full navbars, ensure content aligns itself
   // properly vertically. Can be easily overridden with flex utilities.
@@ -177,6 +178,9 @@
         // scss-lint:disable ImportantRule
         .navbar-collapse {
           display: flex !important;
+
+          // Changes flex-bases to auto because of an IE10 bug
+          flex-basis: auto;
         }
         // scss-lint:enable ImportantRule
 


### PR DESCRIPTION
#23652 fixes IE10 but introduces a bug on small devices on navbar on any browser, you can test it on `v4-dev` branch.

This PR closes #23926.

I've tested on IE10 up and other modern browsers.

@XhmikosR @mdo can you please review it?