### PR TITLE
bug fix: fix navbar toggler in responsive mode #23926

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -105,6 +105,9 @@
 
 // Button for toggling the navbar when in its collapsed state
 .navbar-toggler {
+  position: absolute;
+  top: 0;
+  right: 0;
   padding: $navbar-toggler-padding-y $navbar-toggler-padding-x;
   font-size: $navbar-toggler-font-size;
   line-height: 1;


### PR DESCRIPTION
This PR fixes #23926; it seems to do the trick.

Tested in recent versions of Chrome, Firefox,...and IE10.