### PR TITLE
Forces the search box to stay inside the navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -32,6 +32,11 @@
     align-items: center;
     justify-content: space-between;
   }
+
+  // Forces the search box to stay inside the navbar container
+  .form-control {
+    width: 100%;
+  }
 }
 
 


### PR DESCRIPTION
This doesn't resolve #23932 since the caret still breaks, but it does solve the navbar overflow

It forces the search box to stay inside the navbar container.

@mdo I don't know if this is the most elegant of solutions since we should avoid contextual selectors, but I couldn't think of a better one unless we are willing to remove this line (I still couldn't figure out what it does):
https://github.com/twbs/bootstrap/blob/v4-dev/scss/_forms.scss#L325

This is a codepen to show the fix:
https://codepen.io/andresgalante/pen/MvNNWe
