### PR TITLE
Zero Columns

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -42,9 +42,9 @@
 
       .col#{$infix}-0 {
         @include make-col(0, $grid-columns);
-        overflow: hidden;
-        padding-left: 0;
         padding-right: 0;
+        padding-left: 0;
+        overflow: hidden;
       }
 
       @for $i from 1 through $columns {

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -40,6 +40,13 @@
         max-width: none; // Reset earlier grid tiers
       }
 
+      .col#{$infix}-0 {
+        @include make-col(0, $grid-columns);
+        overflow: hidden;
+        padding-left: 0;
+        padding-right: 0;
+      }
+
       @for $i from 1 through $columns {
         .col#{$infix}-#{$i} {
           @include make-col($i, $columns);


### PR DESCRIPTION
Add .col-<size>-0 classes with `overflow: hidden` and `padding-left/right: 0`

This was addressed a while back (https://github.com/twbs/bootstrap/issues/11391) but not included. As @tkaprol [commented](https://github.com/twbs/bootstrap/issues/11391#issuecomment-31082835), they would be useful in animation. I am working on a responsive collapsible sidebar and this is the missing piece. The sidebar uses col classes to responsively change it's expanded width and the new col-0 classes to collapse it.
