### PR TITLE
Fix alert dismissible close button overflow

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -26,11 +26,13 @@
 // Expand the right padding and account for the close button's positioning.
 
 .alert-dismissible {
+  position: relative;
+
   // Adjust close link position
   .close {
-    position: relative;
-    top: -$alert-padding-y;
-    right: -$alert-padding-x;
+    position: absolute;
+    top: 0;
+    right: 0;
     padding: $alert-padding-y $alert-padding-x;
     color: inherit;
   }


### PR DESCRIPTION
Fixes #21889: 

This fix keeps the large tap size for the close button but takes the close button out of the height equation by absolutely positioning the button relative to the alert-dismissible container.