### PR TITLE
Rewritten modal without jquery

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -205,7 +205,7 @@ const Carousel = (() => {
     }
 
     dispose() {
-      EventHandler.off(this._element, DATA_KEY)
+      EventHandler.off(this._element, EVENT_KEY)
       Data.removeData(this._element, DATA_KEY)
 
       this._items             = null

--- a/js/src/dom/data.js
+++ b/js/src/dom/data.js
@@ -21,7 +21,7 @@ const mapData = (() => {
       id++
     },
     get(element, key) {
-      if (typeof element.key === 'undefined') {
+      if (typeof element === 'undefined' || typeof element.key === 'undefined') {
         return null
       }
 

--- a/js/src/dom/manipulator.js
+++ b/js/src/dom/manipulator.js
@@ -1,3 +1,5 @@
+import Util from '../util'
+
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v4.0.0-beta): dom/manipulator.js
@@ -18,6 +20,24 @@ const Manipulator = {
       return input.bsChecked || input.checked
     }
     throw new Error('INPUT parameter is not an HTMLInputElement')
+  },
+
+  setDataAttribute(element, key, value) {
+    const $ = Util.jQuery
+    if (typeof $ !== 'undefined') {
+      $(element).data(key, value)
+    }
+
+    element.setAttribute(`data-${key.replace(/[A-Z]/g, (chr) => `-${chr.toLowerCase()}`)}`, value)
+  },
+
+  removeDataAttribute(element, key) {
+    const $ = Util.jQuery
+    if (typeof $ !== 'undefined') {
+      $(element).removeData(key)
+    }
+
+    element.removeAttribute(`data-${key.replace(/[A-Z]/g, (chr) => `-${chr.toLowerCase()}`)}`)
   }
 }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -1,4 +1,7 @@
-import $ from 'jquery'
+import Data from './dom/data'
+import EventHandler from './dom/eventHandler'
+import Manipulator from './dom/manipulator'
+import SelectorEngine from './dom/selectorEngine'
 import Util from './util'
 
 
@@ -23,7 +26,6 @@ const Modal = (() => {
   const DATA_KEY                     = 'bs.modal'
   const EVENT_KEY                    = `.${DATA_KEY}`
   const DATA_API_KEY                 = '.data-api'
-  const JQUERY_NO_CONFLICT           = $.fn[NAME]
   const TRANSITION_DURATION          = 300
   const BACKDROP_TRANSITION_DURATION = 150
   const ESCAPE_KEYCODE               = 27 // KeyboardEvent.which value for Escape (Esc) key
@@ -85,7 +87,7 @@ const Modal = (() => {
     constructor(element, config) {
       this._config              = this._getConfig(config)
       this._element             = element
-      this._dialog              = $(element).find(Selector.DIALOG)[0]
+      this._dialog              = SelectorEngine.findOne(Selector.DIALOG, element)
       this._backdrop            = null
       this._isShown             = false
       this._isBodyOverflowing   = false
@@ -117,17 +119,15 @@ const Modal = (() => {
         return
       }
 
-      if (Util.supportsTransitionEnd() && $(this._element).hasClass(ClassName.FADE)) {
+      if (Util.supportsTransitionEnd() && this._element.classList.contains(ClassName.FADE)) {
         this._isTransitioning = true
       }
 
-      const showEvent = $.Event(Event.SHOW, {
+      const showEvent = EventHandler.trigger(this._element, Event.SHOW, {
         relatedTarget
       })
 
-      $(this._element).trigger(showEvent)
-
-      if (this._isShown || showEvent.isDefaultPrevented()) {
+      if (this._isShown || showEvent === null || showEvent.defaultPrevented) {
         return
       }
 
@@ -138,20 +138,20 @@ const Modal = (() => {
 
       this._adjustDialog()
 
-      $(document.body).addClass(ClassName.OPEN)
+      document.body.classList.add(ClassName.OPEN)
 
       this._setEscapeEvent()
       this._setResizeEvent()
 
-      $(this._element).on(
+      EventHandler.on(this._element,
         Event.CLICK_DISMISS,
         Selector.DATA_DISMISS,
         (event) => this.hide(event)
       )
 
-      $(this._dialog).on(Event.MOUSEDOWN_DISMISS, () => {
-        $(this._element).one(Event.MOUSEUP_DISMISS, (event) => {
-          if ($(event.target).is(this._element)) {
+      EventHandler.on(this._dialog, Event.MOUSEDOWN_DISMISS, () => {
+        EventHandler.one(this._element, Event.MOUSEUP_DISMISS, (event) => {
+          if (event.target === this._element) {
             this._ignoreBackdropClick = true
           }
         })
@@ -169,17 +169,15 @@ const Modal = (() => {
         return
       }
 
-      const transition = Util.supportsTransitionEnd() && $(this._element).hasClass(ClassName.FADE)
+      const transition = Util.supportsTransitionEnd() && this._element.classList.contains(ClassName.FADE)
 
       if (transition) {
         this._isTransitioning = true
       }
 
-      const hideEvent = $.Event(Event.HIDE)
+      const hideEvent = EventHandler.trigger(this._element, Event.HIDE)
 
-      $(this._element).trigger(hideEvent)
-
-      if (!this._isShown || hideEvent.isDefaultPrevented()) {
+      if (!this._isShown || hideEvent === null || hideEvent.defaultPrevented) {
         return
       }
 
@@ -188,17 +186,15 @@ const Modal = (() => {
       this._setEscapeEvent()
       this._setResizeEvent()
 
-      $(document).off(Event.FOCUSIN)
+      EventHandler.off(document, Event.FOCUSIN)
 
-      $(this._element).removeClass(ClassName.SHOW)
+      this._element.classList.remove(ClassName.SHOW)
 
-      $(this._element).off(Event.CLICK_DISMISS)
-      $(this._dialog).off(Event.MOUSEDOWN_DISMISS)
+      EventHandler.off(this._element, Event.CLICK_DISMISS)
+      EventHandler.off(this._dialog, Event.MOUSEDOWN_DISMISS)
 
       if (transition) {
-        $(this._element)
-          .one(Util.TRANSITION_END, (event) => this._hideModal(event))
-
+        EventHandler.one(this._element, Util.TRANSITION_END, (event) => this._hideModal(event))
         Util.emulateTransitionEnd(this._element, TRANSITION_DURATION)
       } else {
         this._hideModal()
@@ -206,9 +202,12 @@ const Modal = (() => {
     }
 
     dispose() {
-      $.removeData(this._element, DATA_KEY)
+      Data.removeData(this._element, DATA_KEY)
 
-      $(window, document, this._element, this._backdrop).off(EVENT_KEY)
+      EventHandler.off(window, EVENT_KEY)
+      EventHandler.off(document, EVENT_KEY)
+      EventHandler.off(this._element, EVENT_KEY)
+      EventHandler.off(this._backdrop, EVENT_KEY)
 
       this._config              = null
       this._element             = null
@@ -227,14 +226,14 @@ const Modal = (() => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = Util.extend({}, Default, config)
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
     }
 
     _showElement(relatedTarget) {
       const transition = Util.supportsTransitionEnd() &&
-        $(this._element).hasClass(ClassName.FADE)
+        this._element.classList.contains(ClassName.FADE)
 
       if (!this._element.parentNode ||
          this._element.parentNode.nodeType !== Node.ELEMENT_NODE) {
@@ -250,28 +249,24 @@ const Modal = (() => {
         Util.reflow(this._element)
       }
 
-      $(this._element).addClass(ClassName.SHOW)
+      this._element.classList.add(ClassName.SHOW)
 
       if (this._config.focus) {
         this._enforceFocus()
       }
-
-      const shownEvent = $.Event(Event.SHOWN, {
-        relatedTarget
-      })
 
       const transitionComplete = () => {
         if (this._config.focus) {
           this._element.focus()
         }
         this._isTransitioning = false
-        $(this._element).trigger(shownEvent)
+        EventHandler.trigger(this._element, Event.SHOWN, {
+          relatedTarget
+        })
       }
 
       if (transition) {
-        $(this._dialog)
-          .one(Util.TRANSITION_END, transitionComplete)
-
+        EventHandler.one(this._dialog, Util.TRANSITION_END, transitionComplete)
         Util.emulateTransitionEnd(this._dialog, TRANSITION_DURATION)
       } else {
         transitionComplete()
@@ -279,20 +274,19 @@ const Modal = (() => {
     }
 
     _enforceFocus() {
-      $(document)
-        .off(Event.FOCUSIN) // guard against infinite focus loop
-        .on(Event.FOCUSIN, (event) => {
-          if (document !== event.target &&
-              this._element !== event.target &&
-              !$(this._element).has(event.target).length) {
-            this._element.focus()
-          }
-        })
+      EventHandler.off(document, Event.FOCUSIN) // guard against infinite focus loop
+      EventHandler.on(document, Event.FOCUSIN, (event) => {
+        if (document !== event.target &&
+            this._element !== event.target &&
+            !this._element.contains(event.target)) {
+          this._element.focus()
+        }
+      })
     }
 
     _setEscapeEvent() {
       if (this._isShown && this._config.keyboard) {
-        $(this._element).on(Event.KEYDOWN_DISMISS, (event) => {
+        EventHandler.on(this._element, Event.KEYDOWN_DISMISS, (event) => {
           if (event.which === ESCAPE_KEYCODE) {
             event.preventDefault()
             this.hide()
@@ -300,15 +294,15 @@ const Modal = (() => {
         })
 
       } else if (!this._isShown) {
-        $(this._element).off(Event.KEYDOWN_DISMISS)
+        EventHandler.off(this._element, Event.KEYDOWN_DISMISS)
       }
     }
 
     _setResizeEvent() {
       if (this._isShown) {
-        $(window).on(Event.RESIZE, (event) => this.handleUpdate(event))
+        EventHandler.on(window, Event.RESIZE, (event) => this.handleUpdate(event))
       } else {
-        $(window).off(Event.RESIZE)
+        EventHandler.off(window, Event.RESIZE)
       }
     }
 
@@ -317,22 +311,22 @@ const Modal = (() => {
       this._element.setAttribute('aria-hidden', true)
       this._isTransitioning = false
       this._showBackdrop(() => {
-        $(document.body).removeClass(ClassName.OPEN)
+        document.body.classList.remove(ClassName.OPEN)
         this._resetAdjustments()
         this._resetScrollbar()
-        $(this._element).trigger(Event.HIDDEN)
+        EventHandler.trigger(this._element, Event.HIDDEN)
       })
     }
 
     _removeBackdrop() {
       if (this._backdrop) {
-        $(this._backdrop).remove()
+        this._backdrop.parentNode.removeChild(this._backdrop)
         this._backdrop = null
       }
     }
 
     _showBackdrop(callback) {
-      const animate = $(this._element).hasClass(ClassName.FADE) ?
+      const animate = this._element.classList.contains(ClassName.FADE) ?
         ClassName.FADE : ''
 
       if (this._isShown && this._config.backdrop) {
@@ -342,12 +336,12 @@ const Modal = (() => {
         this._backdrop.className = ClassName.BACKDROP
 
         if (animate) {
-          $(this._backdrop).addClass(animate)
+          this._backdrop.classList.add(animate)
         }
 
-        $(this._backdrop).appendTo(document.body)
+        document.body.appendChild(this._backdrop)
 
-        $(this._element).on(Event.CLICK_DISMISS, (event) => {
+        EventHandler.on(this._element, Event.CLICK_DISMISS, (event) => {
           if (this._ignoreBackdropClick) {
             this._ignoreBackdropClick = false
             return
@@ -366,7 +360,7 @@ const Modal = (() => {
           Util.reflow(this._backdrop)
         }
 
-        $(this._backdrop).addClass(ClassName.SHOW)
+        this._backdrop.classList.add(ClassName.SHOW)
 
         if (!callback) {
           return
@@ -377,12 +371,10 @@ const Modal = (() => {
           return
         }
 
-        $(this._backdrop)
-          .one(Util.TRANSITION_END, callback)
-
+        EventHandler.one(this._backdrop, Util.TRANSITION_END, callback)
         Util.emulateTransitionEnd(this._backdrop, BACKDROP_TRANSITION_DURATION)
       } else if (!this._isShown && this._backdrop) {
-        $(this._backdrop).removeClass(ClassName.SHOW)
+        this._backdrop.classList.remove(ClassName.SHOW)
 
         const callbackRemove = () => {
           this._removeBackdrop()
@@ -392,10 +384,8 @@ const Modal = (() => {
         }
 
         if (Util.supportsTransitionEnd() &&
-           $(this._element).hasClass(ClassName.FADE)) {
-          $(this._backdrop)
-            .one(Util.TRANSITION_END, callbackRemove)
-
+           this._element.classList.contains(ClassName.FADE)) {
+          EventHandler.one(this._backdrop, Util.TRANSITION_END, callbackRemove)
           Util.emulateTransitionEnd(this._backdrop, BACKDROP_TRANSITION_DURATION)
         } else {
           callbackRemove()
@@ -442,54 +432,66 @@ const Modal = (() => {
         //   while $(DOMNode).css('padding-right') returns the calculated value or 0 if not set
 
         // Adjust fixed content padding
-        $(Selector.FIXED_CONTENT).each((index, element) => {
-          const actualPadding = $(element)[0].style.paddingRight
-          const calculatedPadding = $(element).css('padding-right')
-          $(element).data('padding-right', actualPadding).css('padding-right', `${parseFloat(calculatedPadding) + this._scrollbarWidth}px`)
-        })
+        Util.makeArray(SelectorEngine.find(Selector.FIXED_CONTENT))
+          .forEach((element) => {
+            const actualPadding = element.style.paddingRight
+            const calculatedPadding = window.getComputedStyle(element)['padding-right']
+            Manipulator.setDataAttribute(element, 'padding-right', actualPadding)
+            element.style.paddingRight = `${parseFloat(calculatedPadding) + this._scrollbarWidth}px`
+          })
 
         // Adjust sticky content margin
-        $(Selector.STICKY_CONTENT).each((index, element) => {
-          const actualMargin = $(element)[0].style.marginRight
-          const calculatedMargin = $(element).css('margin-right')
-          $(element).data('margin-right', actualMargin).css('margin-right', `${parseFloat(calculatedMargin) - this._scrollbarWidth}px`)
-        })
+        Util.makeArray(SelectorEngine.find(Selector.STICKY_CONTENT))
+          .forEach((element) => {
+            const actualMargin = element.style.marginRight
+            const calculatedMargin = window.getComputedStyle(element)['margin-right']
+            Manipulator.setDataAttribute(element, 'margin-right', actualMargin)
+            element.style.marginRight = `${parseFloat(calculatedMargin) - this._scrollbarWidth}px`
+          })
 
         // Adjust navbar-toggler margin
-        $(Selector.NAVBAR_TOGGLER).each((index, element) => {
-          const actualMargin = $(element)[0].style.marginRight
-          const calculatedMargin = $(element).css('margin-right')
-          $(element).data('margin-right', actualMargin).css('margin-right', `${parseFloat(calculatedMargin) + this._scrollbarWidth}px`)
-        })
+        Util.makeArray(SelectorEngine.find(Selector.NAVBAR_TOGGLER))
+          .forEach((element) => {
+            const actualMargin = element.style.marginRight
+            const calculatedMargin = window.getComputedStyle(element)['margin-right']
+            Manipulator.setDataAttribute(element, 'margin-right', actualMargin)
+            element.style.marginRight = `${parseFloat(calculatedMargin) + this._scrollbarWidth}px`
+          })
 
         // Adjust body padding
         const actualPadding = document.body.style.paddingRight
-        const calculatedPadding = $('body').css('padding-right')
-        $('body').data('padding-right', actualPadding).css('padding-right', `${parseFloat(calculatedPadding) + this._scrollbarWidth}px`)
+        const calculatedPadding = window.getComputedStyle(document.body)['padding-right']
+        Manipulator.setDataAttribute(document.body, 'padding-right', actualPadding)
+        document.body.style.paddingRight = `${parseFloat(calculatedPadding) + this._scrollbarWidth}px`
       }
     }
 
     _resetScrollbar() {
       // Restore fixed content padding
-      $(Selector.FIXED_CONTENT).each((index, element) => {
-        const padding = $(element).data('padding-right')
-        if (typeof padding !== 'undefined') {
-          $(element).css('padding-right', padding).removeData('padding-right')
-        }
-      })
+      Util.makeArray(SelectorEngine.find(Selector.FIXED_CONTENT))
+        .forEach((element) => {
+          const padding = Util.getDataAttribute(element, 'padding-right')
+          if (typeof padding !== 'undefined') {
+            Manipulator.removeDataAttribute(element, 'padding-right')
+            element.style.paddingRight = padding
+          }
+        })
 
       // Restore sticky content and navbar-toggler margin
-      $(`${Selector.STICKY_CONTENT}, ${Selector.NAVBAR_TOGGLER}`).each((index, element) => {
-        const margin = $(element).data('margin-right')
-        if (typeof margin !== 'undefined') {
-          $(element).css('margin-right', margin).removeData('margin-right')
-        }
-      })
+      Util.makeArray(SelectorEngine.find(`${Selector.STICKY_CONTENT}, ${Selector.NAVBAR_TOGGLER}`))
+        .forEach((element) => {
+          const margin = Util.getDataAttribute(element, 'margin-right')
+          if (typeof margin !== 'undefined') {
+            Manipulator.removeDataAttribute(element, 'margin-right')
+            element.style.marginRight = margin
+          }
+        })
 
       // Restore body padding
-      const padding = $('body').data('padding-right')
+      const padding = Util.getDataAttribute(document.body, 'padding-right')
       if (typeof padding !== 'undefined') {
-        $('body').css('padding-right', padding).removeData('padding-right')
+        Manipulator.removeDataAttribute(document.body, 'padding-right')
+        document.body.style.paddingRight = padding
       }
     }
 
@@ -507,17 +509,17 @@ const Modal = (() => {
 
     static _jQueryInterface(config, relatedTarget) {
       return this.each(function () {
-        let data      = $(this).data(DATA_KEY)
-        const _config = $.extend(
+        let data      = Data.getData(this, DATA_KEY)
+        const _config = Util.extend(
           {},
           Modal.Default,
-          $(this).data(),
+          Util.getDataAttributes(this),
           typeof config === 'object' && config
         )
 
         if (!data) {
           data = new Modal(this, _config)
-          $(this).data(DATA_KEY, data)
+          Data.setData(this, DATA_KEY, data)
         }
 
         if (typeof config === 'string') {
@@ -540,53 +542,66 @@ const Modal = (() => {
    * ------------------------------------------------------------------------
    */
 
-  $(document).on(Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
+  EventHandler.on(document, Event.CLICK_DATA_API, Selector.DATA_TOGGLE, function (event) {
     let target
     const selector = Util.getSelectorFromElement(this)
 
     if (selector) {
-      target = $(selector)[0]
+      target = SelectorEngine.findOne(selector)
     }
 
-    const config = $(target).data(DATA_KEY) ?
-      'toggle' : $.extend({}, $(target).data(), $(this).data())
+    const config = Data.getData(target, DATA_KEY) ?
+      'toggle' : Util.extend({}, Util.getDataAttributes(target), Util.getDataAttributes(this))
 
     if (this.tagName === 'A' || this.tagName === 'AREA') {
       event.preventDefault()
     }
 
-    const $target = $(target).one(Event.SHOW, (showEvent) => {
-      if (showEvent.isDefaultPrevented()) {
+    if (typeof target === 'undefined' || target === null) {
+      return
+    }
+
+    EventHandler.one(target, Event.SHOW, (showEvent) => {
+      if (showEvent.defaultPrevented) {
         // only register focus restorer if modal will actually get shown
         return
       }
 
-      $target.one(Event.HIDDEN, () => {
-        if ($(this).is(':visible')) {
+      EventHandler.one(target, Event.HIDDEN, () => {
+        if (Util.isVisible(this)) {
           this.focus()
         }
       })
     })
 
-    Modal._jQueryInterface.call($(target), config, this)
+    let data = Data.getData(target, DATA_KEY)
+    if (!data) {
+      data = new Modal(target, config)
+      Data.setData(target, DATA_KEY, data)
+    }
+
+    data.show(this)
   })
 
 
-  /**
+  /*
    * ------------------------------------------------------------------------
    * jQuery
    * ------------------------------------------------------------------------
    */
-
-  $.fn[NAME]             = Modal._jQueryInterface
-  $.fn[NAME].Constructor = Modal
-  $.fn[NAME].noConflict  = function () {
-    $.fn[NAME] = JQUERY_NO_CONFLICT
-    return Modal._jQueryInterface
+  const $ = Util.jQuery
+  if (typeof $ !== 'undefined') {
+    const JQUERY_NO_CONFLICT = $.fn[NAME]
+    $.fn[NAME]             = Modal._jQueryInterface
+    $.fn[NAME].Constructor = Modal
+    $.fn[NAME].noConflict  = function () {
+      $.fn[NAME] = JQUERY_NO_CONFLICT
+      return Modal._jQueryInterface
+    }
   }
 
   return Modal
 
-})(jQuery)
+})()
 
 export default Modal

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -1,6 +1,5 @@
 import EventHandler from './dom/eventHandler'
 
-
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v4.0.0-beta): util.js
@@ -9,8 +8,6 @@ import EventHandler from './dom/eventHandler'
  */
 
 const Util = (() => {
-
-  const transition = EventHandler.getBrowserTransitionEnd()
 
   const MAX_UID = 1000000
 
@@ -64,7 +61,7 @@ const Util = (() => {
     },
 
     supportsTransitionEnd() {
-      return Boolean(transition)
+      return Boolean(EventHandler.getBrowserTransitionEnd())
     },
 
     emulateTransitionEnd(element, duration) {
@@ -142,6 +139,10 @@ const Util = (() => {
           && element.style.visibility !== 'hidden'
       }
       return false
+    },
+
+    get jQuery() {
+      return window.$ || window.jQuery
     }
   }
 

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -9,6 +9,8 @@ import EventHandler from './dom/eventHandler'
 
 const Util = (() => {
 
+  const transition = Boolean(EventHandler.getBrowserTransitionEnd())
+
   const MAX_UID = 1000000
 
   // shoutout AngusCroll (https://goo.gl/pxwQGp)
@@ -18,6 +20,20 @@ const Util = (() => {
 
   function isElement(obj) {
     return (obj[0] || obj).nodeType
+  }
+
+  function normalizeData(val) {
+    if (val === 'true') {
+      return true
+    } else if (val === 'false') {
+      return false
+    } else if (val === 'null') {
+      return null
+    } else if (val === Number(val).toString()) {
+      return Number(val)
+    }
+
+    return val
   }
 
   /**
@@ -61,7 +77,7 @@ const Util = (() => {
     },
 
     supportsTransitionEnd() {
-      return Boolean(EventHandler.getBrowserTransitionEnd())
+      return transition
     },
 
     emulateTransitionEnd(element, duration) {
@@ -88,7 +104,8 @@ const Util = (() => {
       }
     },
 
-    extend(obj1, obj2) {
+    extend(obj1, ...others) {
+      const obj2 = others.shift()
       for (const secondProp in obj2) {
         if (Object.prototype.hasOwnProperty.call(obj2, secondProp)) {
           const secondVal = obj2[secondProp]
@@ -101,6 +118,11 @@ const Util = (() => {
           }
         }
       }
+
+      if (others.length) {
+        this.extend(obj1, ...others)
+      }
+
       return obj1
     },
 
@@ -116,16 +138,34 @@ const Util = (() => {
         return {}
       }
 
-      const attributes = {}
-      for (let i = 0; i < element.attributes.length; i++) {
-        const attribute = element.attributes[i]
-        if (attribute.nodeName.indexOf('data-') !== -1) {
-          // remove 'data-' part of the attribute name
-          const attributeName = attribute.nodeName.substring('data-'.length)
-          attributes[attributeName] = attribute.nodeValue
+      let attributes
+      if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'dataset')) {
+        attributes = this.extend({}, element.dataset)
+      } else {
+        attributes = {}
+        for (let i = 0; i < element.attributes.length; i++) {
+          const attribute = element.attributes[i]
+          if (attribute.nodeName.indexOf('data-') !== -1) {
+            // remove 'data-' part of the attribute name
+            const attributeName = attribute.nodeName.substring('data-'.length).replace(/-./g, (str) => str.charAt(1).toUpperCase())
+            attributes[attributeName] = attribute.nodeValue
+          }
         }
       }
+
+      for (const key in attributes) {
+        if (!Object.prototype.hasOwnProperty.call(attributes, key)) {
+          continue
+        }
+
+        attributes[key] = normalizeData(attributes[key])
+      }
+
       return attributes
+    },
+
+    getDataAttribute(element, key) {
+      return normalizeData(element.getAttribute(`data-${key.replace(/[A-Z]/g, (chr) => `-${chr.toLowerCase()}`)}`))
     },
 
     isVisible(element) {

--- a/js/tests/index.html
+++ b/js/tests/index.html
@@ -113,6 +113,7 @@
     <script src="../dist/popover.js"></script>
 
     <!-- Unit Tests -->
+    <script src="unit/dom/eventHandler.js"></script>
     <script src="unit/alert.js"></script>
     <script src="unit/button.js"></script>
     <script src="unit/carousel.js"></script>

--- a/js/tests/unit/dom/eventHandler.js
+++ b/js/tests/unit/dom/eventHandler.js
@@ -1,0 +1,233 @@
+$(function () {
+  'use strict'
+
+  QUnit.module('event handler')
+
+  QUnit.test('should be defined', function (assert) {
+    assert.expect(1)
+    assert.ok(EventHandler, 'EventHandler is defined')
+  })
+
+  QUnit.test('should trigger event correctly', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    element.addEventListener('foobar', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('should trigger event through jQuery event system', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    $(element).on('foobar', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('should trigger namespaced event through jQuery event system', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+    $(element).on('foobar.namespace', function () {
+      assert.ok(true, 'first listener called')
+    })
+    element.addEventListener('foobar.namespace', function () {
+      assert.ok(true, 'second listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar.namespace')
+  })
+
+  QUnit.test('should mirror preventDefault', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+    $(element).on('foobar.namespace', function (event) {
+      event.preventDefault()
+      assert.ok(true, 'first listener called')
+    })
+    element.addEventListener('foobar.namespace', function (event) {
+      assert.ok(event.defaultPrevented, 'defaultPrevented is true in second listener')
+    })
+
+    EventHandler.trigger(element, 'foobar.namespace')
+  })
+
+  QUnit.test('on should add event listener', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    EventHandler.on(element, 'foobar', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('on should add namespaced event listener', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    EventHandler.on(element, 'foobar.namespace', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar.namespace')
+  })
+
+  QUnit.test('on should add native namespaced event listener', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    EventHandler.on(element, 'click.namespace', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'click')
+  })
+
+  QUnit.test('on should add delegated event listener', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    var subelement = document.createElement('span')
+    element.appendChild(subelement)
+
+    var anchor = document.createElement('a')
+    element.appendChild(anchor)
+
+    EventHandler.on(element, 'click.namespace', 'a', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.on(element, 'click', 'span', function () {
+      assert.notOk(true, 'listener should not be called')
+    })
+
+    document.body.appendChild(element)
+    EventHandler.trigger(anchor, 'click')
+    document.body.removeChild(element)
+  })
+
+  QUnit.test('one should remove the listener after the event', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    EventHandler.one(element, 'foobar', function () {
+      assert.ok(true, 'listener called')
+    })
+
+    EventHandler.trigger(element, 'foobar')
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('off should remove a listener', function (assert) {
+    assert.expect(1)
+
+    var element = document.createElement('div')
+    var handler = function () {
+      assert.ok(true, 'listener called')
+    }
+
+    EventHandler.on(element, 'foobar', handler)
+    EventHandler.trigger(element, 'foobar')
+
+    EventHandler.off(element, 'foobar', handler)
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('off should remove all the listeners', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+
+    EventHandler.on(element, 'foobar', function () {
+      assert.ok(true, 'first listener called')
+    })
+    EventHandler.on(element, 'foobar', function () {
+      assert.ok(true, 'second listener called')
+    })
+    EventHandler.trigger(element, 'foobar')
+
+    EventHandler.off(element, 'foobar')
+    EventHandler.trigger(element, 'foobar')
+  })
+
+  QUnit.test('off should remove all the namespaced listeners if namespace is passed', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+
+    EventHandler.on(element, 'foobar.namespace', function () {
+      assert.ok(true, 'first listener called')
+    })
+    EventHandler.on(element, 'foofoo.namespace', function () {
+      assert.ok(true, 'second listener called')
+    })
+    EventHandler.trigger(element, 'foobar.namespace')
+    EventHandler.trigger(element, 'foofoo.namespace')
+
+    EventHandler.off(element, '.namespace')
+    EventHandler.trigger(element, 'foobar.namespace')
+    EventHandler.trigger(element, 'foofoo.namespace')
+  })
+
+  QUnit.test('off should remove the namespaced listeners', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+
+    EventHandler.on(element, 'foobar.namespace', function () {
+      assert.ok(true, 'first listener called')
+    })
+    EventHandler.on(element, 'foofoo.namespace', function () {
+      assert.ok(true, 'second listener called')
+    })
+    EventHandler.trigger(element, 'foobar.namespace')
+
+    EventHandler.off(element, 'foobar.namespace')
+    EventHandler.trigger(element, 'foobar.namespace')
+
+    EventHandler.trigger(element, 'foofoo.namespace')
+  })
+
+  QUnit.test('off should remove the all the namespaced listeners for native events', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+
+    EventHandler.on(element, 'click.namespace', function () {
+      assert.ok(true, 'first listener called')
+    })
+    EventHandler.on(element, 'click.namespace2', function () {
+      assert.ok(true, 'second listener called')
+    })
+    EventHandler.trigger(element, 'click')
+
+    EventHandler.off(element, 'click')
+    EventHandler.trigger(element, 'click')
+  })
+
+  QUnit.test('off should remove the specified namespaced listeners for native events', function (assert) {
+    assert.expect(3)
+
+    var element = document.createElement('div')
+
+    EventHandler.on(element, 'click.namespace', function () {
+      assert.ok(true, 'first listener called')
+    })
+    EventHandler.on(element, 'click.namespace2', function () {
+      assert.ok(true, 'second listener called')
+    })
+    EventHandler.trigger(element, 'click')
+
+    EventHandler.off(element, 'click.namespace')
+    EventHandler.trigger(element, 'click')
+  })
+})

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -211,7 +211,12 @@ $(function () {
       .on('shown.bs.modal', function () {
         assert.ok($('#modal-test').length, 'modal inserted into dom')
         assert.ok($('#modal-test').is(':visible'), 'modal visible')
-        $div.trigger($.Event('keydown', { which: 27 }))
+
+        var evt = document.createEvent('HTMLEvents')
+        evt.initEvent('keydown', true, true)
+        evt.which = 27
+
+        $div[0].dispatchEvent(evt)
 
         setTimeout(function () {
           assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
@@ -289,15 +294,19 @@ $(function () {
       .one('hidden.bs.modal', function () {
         // after one open-close cycle
         assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
-        $(this)
-          .one('shown.bs.modal', function () {
-            $('#close').trigger('click')
-          })
-          .one('hidden.bs.modal', function () {
-            assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
-            done()
-          })
-          .bootstrapModal('show')
+
+        var $this = $(this)
+        setTimeout(function () {
+          $this
+            .one('shown.bs.modal', function () {
+              $('#close').trigger('click')
+            })
+            .one('hidden.bs.modal', function () {
+              assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+              done()
+            })
+            .bootstrapModal('show')
+        }, 0)
       })
       .bootstrapModal('show')
   })
@@ -626,16 +635,19 @@ $(function () {
     $('<div id="modal-test"><div class="contents"><div id="close" data-dismiss="modal"/></div></div>')
       .appendTo('#qunit-fixture')
 
+    var evt = document.createEvent('HTMLEvents')
+    evt.initEvent('click', true, true)
+
     $('#test')
       .on('click.bs.modal.data-api', function (event) {
-        assert.notOk(event.isDefaultPrevented(), 'navigating to href will happen')
+        assert.notOk(event.defaultPrevented, 'navigating to href will happen')
 
         setTimeout(function () {
-          assert.ok(event.isDefaultPrevented(), 'model shown instead of navigating to href')
+          assert.ok(evt.defaultPrevented, 'model shown instead of navigating to href')
           done()
         }, 1)
       })
-      .trigger('click')
+    $('#test')[0].dispatchEvent(evt)
   })
 
   QUnit.test('should not parse target as html', function (assert) {

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -175,7 +175,10 @@
 
     <script src="../../../assets/js/vendor/jquery-slim.min.js"></script>
     <script src="../../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/dom/data.js"></script>
     <script src="../../dist/dom/eventHandler.js"></script>
+    <script src="../../dist/dom/manipulator.js"></script>
+    <script src="../../dist/dom/selectorEngine.js"></script>
     <script src="../../dist/util.js"></script>
     <script src="../../dist/modal.js"></script>
     <script src="../../dist/collapse.js"></script>


### PR DESCRIPTION
To make it work correctly the following changes were required:

- Trigger events in jQuery if available
- Add util functions for manipulating data attributes and jQuery data object
- `Util.extend` now supports multiple objects