### PR TITLE
V4 without jquery: fix tests

### DIFF
--- a/js/tests/unit/dom/eventHandler.js
+++ b/js/tests/unit/dom/eventHandler.js
@@ -85,11 +85,13 @@ $(function () {
     assert.expect(1)
 
     var element = document.createElement('div')
+    document.body.appendChild(element)
     EventHandler.on(element, 'click.namespace', function () {
       assert.ok(true, 'listener called')
     })
 
     EventHandler.trigger(element, 'click')
+    document.body.removeChild(element)
   })
 
   QUnit.test('on should add delegated event listener', function (assert) {
@@ -201,6 +203,7 @@ $(function () {
     assert.expect(2)
 
     var element = document.createElement('div')
+    document.body.appendChild(element)
 
     EventHandler.on(element, 'click.namespace', function () {
       assert.ok(true, 'first listener called')
@@ -212,12 +215,14 @@ $(function () {
 
     EventHandler.off(element, 'click')
     EventHandler.trigger(element, 'click')
+    document.body.removeChild(element)
   })
 
   QUnit.test('off should remove the specified namespaced listeners for native events', function (assert) {
     assert.expect(3)
 
     var element = document.createElement('div')
+    document.body.appendChild(element)
 
     EventHandler.on(element, 'click.namespace', function () {
       assert.ok(true, 'first listener called')
@@ -229,5 +234,6 @@ $(function () {
 
     EventHandler.off(element, 'click.namespace')
     EventHandler.trigger(element, 'click')
+    document.body.removeChild(element)
   })
 })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -627,7 +627,6 @@ $(function () {
 
   QUnit.test('should not follow link in area tag', function (assert) {
     assert.expect(2)
-    var done = assert.async()
 
     $('<map><area id="test" shape="default" data-toggle="modal" data-target="#modal-test" href="demo.html"/></map>')
       .appendTo('#qunit-fixture')
@@ -635,19 +634,19 @@ $(function () {
     $('<div id="modal-test"><div class="contents"><div id="close" data-dismiss="modal"/></div></div>')
       .appendTo('#qunit-fixture')
 
-    var evt = document.createEvent('HTMLEvents')
-    evt.initEvent('click', true, true)
+    // We need to use CustomEvent here to have a working preventDefault in IE tests.
+    var evt = new CustomEvent('click', {
+      bubbles: true,
+      cancelable: true
+    })
 
     $('#test')
       .on('click.bs.modal.data-api', function (event) {
         assert.notOk(event.defaultPrevented, 'navigating to href will happen')
-
-        setTimeout(function () {
-          assert.ok(evt.defaultPrevented, 'model shown instead of navigating to href')
-          done()
-        }, 1)
       })
+
     $('#test')[0].dispatchEvent(evt)
+    assert.ok(evt.defaultPrevented, 'model shown instead of navigating to href')
   })
 
   QUnit.test('should not parse target as html', function (assert) {


### PR DESCRIPTION
Related to https://github.com/twbs/bootstrap/pull/23586#issuecomment-330031101
There were a couple of buggy tests for IE 11:
 - trying to fire a `click` on an element not added to the DOM does not produce any effect
 - `defaultPrevented` does not work for code-generated events