### PR TITLE
Adds a note on typography docs about using `rem`s for font-size-base

### DIFF
--- a/docs/4.0/content/typography.md
+++ b/docs/4.0/content/typography.md
@@ -16,7 +16,7 @@ Bootstrap sets basic global display, typography, and link styles. When more cont
 - Set the global link color via `$link-color` and apply link underlines only on `:hover`.
 - Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
 
-These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`.
+These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`. Make sure to set `$font-size-base` in `rem`.
 
 ## Headings
 
@@ -297,24 +297,24 @@ Here's an example of it in practice. Choose whatever `font-size`s and media quer
 
 {% highlight scss %}
 html {
-  font-size: 14px;
+  font-size: 1rem;
 }
 
 @include media-breakpoint-up(sm) {
   html {
-    font-size: 16px;
+    font-size: 1.2rem;
   }
 }
 
 @include media-breakpoint-up(md) {
   html {
-    font-size: 20px;
+    font-size: 1.4rem;
   }
 }
 
 @include media-breakpoint-up(lg) {
   html {
-    font-size: 28px;
+    font-size: 1.6rem;
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
After reading this issue #23982 I've added a note on the docs related to how to set `font-size-base` units.

My guess is that other users will try to set font size base in px and they'll get a sass error too.

I've also changed the responsive typography example from `px`s to `rem`s to help copy-and-paste users get an accessible website.

What do you think?