### PR TITLE
V4 without jquery: workaround for ms edge defaultPrevented reset

### DIFF
--- a/js/tests/unit/dom/eventHandler.js
+++ b/js/tests/unit/dom/eventHandler.js
@@ -59,6 +59,24 @@ $(function () {
     EventHandler.trigger(element, 'foobar.namespace')
   })
 
+  QUnit.test('should mirror preventDefault for native events', function (assert) {
+    assert.expect(2)
+
+    var element = document.createElement('div')
+    document.body.appendChild(element)
+
+    $(element).on('click', function (event) {
+      event.preventDefault()
+      assert.ok(true, 'first listener called')
+    })
+    element.addEventListener('click', function (event) {
+      assert.ok(event.defaultPrevented, 'defaultPrevented is true in second listener')
+    })
+
+    EventHandler.trigger(element, 'click')
+    document.body.removeChild(element)
+  })
+
   QUnit.test('on should add event listener', function (assert) {
     assert.expect(1)
 


### PR DESCRIPTION
Related to https://github.com/twbs/bootstrap/pull/23586#issuecomment-330319137 and https://saucelabs.com/jobs/03afada422c7448d84ea067dee18906d failed job

Workaround for M$ Edge resetting defaultPrevented flag on dispatchEvent

@Johann-S I will really appreciate your opinion about this