### PR TITLE
Add back cursor: pointer for .btn-link

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -76,6 +76,7 @@ fieldset[disabled] a.btn {
   font-weight: $font-weight-normal;
   color: $link-color;
   background-color: transparent;
+  cursor: pointer;
   border-radius: 0;
 
   @include hover {


### PR DESCRIPTION
https://github.com/twbs/bootstrap/commit/232e86d0b4e1a4ff0dc3aa4e6d75c14a54fa8ac8 makes total sense but buttons with class `.btn-link` should still display a cursor.