### PR TITLE
Remove hardcoded padding on .navbar-expand

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -163,8 +163,8 @@
           }
 
           .nav-link {
-            padding-right: .5rem;
-            padding-left: .5rem;
+            padding-right: $nav-link-padding-x;
+            padding-left: $nav-link-padding-x;
           }
         }
 


### PR DESCRIPTION
Removes the hardcoded .5rem padding from .nav-link within .navbar-expand, respecting user value in custom.scss. Fixes #23789.