### PR TITLE
Adds breakpoints to sizing utility classes

### DIFF
--- a/docs/4.0/utilities/sizing.md
+++ b/docs/4.0/utilities/sizing.md
@@ -6,7 +6,29 @@ group: utilities
 toc: true
 ---
 
-Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Includes support for `25%`, `50%`, `75%`, and `100%` by default. Modify those values as you need to generate different utilities here.
+## Overview
+
+Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Includes support for `25%`, `50%`, `75%`, and `100%` by default. Modify those values as you need to generate different sizing utilities.
+
+## Notation
+
+Sizing utilities are named using the format `{property}-{size}` for `xs` and `{property}-{breakpoint}-{size}` for `sm`, `md`, `lg`, and `xl`.
+
+Where *property* is one of:
+
+* `w` - for classes that set `width`
+* `h` - for classes that set `height`
+
+Where *size* is one of:
+
+* `25` - (by default) for classes that set the `width` or `height` to `25%`
+* `50` - (by default) for classes that set the `width` or `height` to `50%`
+* `75` - (by default) for classes that set the `width` or `height` to `75%`
+* `100` - (by default) for classes that set the `width` or `height` to `100%`
+
+(You can add more sizes by adding entries to the `$sizes` Sass map in `_variables.scss`)
+
+## Examples
 
 {% example html %}
 <div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>

--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -1,8 +1,15 @@
 // Width and height
 
-@each $prop, $abbrev in (width: w, height: h) {
-  @each $size, $length in $sizes {
-    .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @each $prop, $abbrev in (width: w, height: h) {
+      @each $size, $length in $sizes {
+        .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+        .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR closes #24003 and it adds breakpoints to sizing utility classes.

It also updates the docs to surface this change.

@Johann-S you know my feelings about utility classes 💩  but I think that since we are doing this for spacers, adding it for sizing is valid.

Closes #24062 too