### PR TITLE
Improves colors on drop menus on navbar

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -130,6 +130,130 @@
   background-size: 100% 100%;
 }
 
+// Navbar themes
+//
+// Styles for switching between navbars with light or dark background.
+
+// Dark links against a light background
+.navbar-light {
+  .navbar-brand {
+    color: $navbar-light-active-color;
+
+    @include hover-focus {
+      color: $navbar-light-active-color;
+    }
+  }
+
+  .navbar-nav {
+    .nav-link {
+      color: $navbar-light-color;
+
+      @include hover-focus {
+        color: $navbar-light-hover-color;
+      }
+
+      &.disabled {
+        color: $navbar-light-disabled-color;
+      }
+    }
+
+    .dropdown-menu {
+      background-color: $navbar-dark-dropdown-bg;
+      border-color: $navbar-light-dropdown-border-color;
+    }
+
+    .dropdown-item {
+      color: $navbar-light-dropdown-link-color;
+
+      @include hover-focus {
+        color: $navbar-light-dropdown-link-hover-color;
+        background-color: $navbar-light-dropdown-link-hover-bg;
+      }
+    }
+
+    .show > .nav-link,
+    .active > .nav-link,
+    .nav-link.show,
+    .nav-link.active {
+      color: $navbar-light-active-color;
+    }
+  }
+
+  .navbar-toggler {
+    color: $navbar-light-color;
+    border-color: $navbar-light-toggler-border-color;
+  }
+
+  .navbar-toggler-icon {
+    background-image: $navbar-light-toggler-icon-bg;
+  }
+
+  .navbar-text {
+    color: $navbar-light-color;
+  }
+}
+
+
+// White links against a dark background
+.navbar-dark {
+  .navbar-brand {
+    color: $navbar-dark-active-color;
+
+    @include hover-focus {
+      color: $navbar-dark-active-color;
+    }
+  }
+
+  .navbar-nav {
+    .nav-link {
+      color: $navbar-dark-color;
+
+      @include hover-focus {
+        color: $navbar-dark-hover-color;
+      }
+
+      &.disabled {
+        color: $navbar-dark-disabled-color;
+      }
+    }
+
+    .dropdown-menu {
+      background-color: $navbar-dark-dropdown-bg;
+      border-color: $navbar-dark-dropdown-border-color;
+    }
+
+    .dropdown-item {
+      color: $navbar-dark-dropdown-link-color;
+
+      @include hover-focus {
+        color: $navbar-dark-dropdown-link-hover-color;
+        background-color: $navbar-dark-dropdown-link-hover-bg;
+      }
+    }
+
+    .show > .nav-link,
+    .active > .nav-link,
+    .nav-link.show,
+    .nav-link.active {
+      color: $navbar-dark-active-color;
+    }
+  }
+
+  .navbar-toggler {
+    color: $navbar-dark-color;
+    border-color: $navbar-dark-toggler-border-color;
+  }
+
+  .navbar-toggler-icon {
+    background-image: $navbar-dark-toggler-icon-bg;
+  }
+
+  .navbar-text {
+    color: $navbar-dark-color;
+  }
+}
+
+
 // Generate series of `.navbar-expand-*` responsive classes for configuring
 // where your navbar collapses.
 .navbar-expand {
@@ -155,7 +279,19 @@
 
           .dropdown-menu {
             position: absolute;
+            background-color: $dropdown-bg;
+            border-color: $dropdown-border-color;
           }
+
+          .dropdown-item {
+            color: $dropdown-link-color;
+
+            @include hover-focus {
+              color: $dropdown-link-hover-color;
+              background-color: $dropdown-link-hover-bg;
+            }
+          }
+
 
           .dropdown-menu-right {
             right: 0;
@@ -188,100 +324,5 @@
         }
       }
     }
-  }
-}
-
-
-// Navbar themes
-//
-// Styles for switching between navbars with light or dark background.
-
-// Dark links against a light background
-.navbar-light {
-  .navbar-brand {
-    color: $navbar-light-active-color;
-
-    @include hover-focus {
-      color: $navbar-light-active-color;
-    }
-  }
-
-  .navbar-nav {
-    .nav-link {
-      color: $navbar-light-color;
-
-      @include hover-focus {
-        color: $navbar-light-hover-color;
-      }
-
-      &.disabled {
-        color: $navbar-light-disabled-color;
-      }
-    }
-
-    .show > .nav-link,
-    .active > .nav-link,
-    .nav-link.show,
-    .nav-link.active {
-      color: $navbar-light-active-color;
-    }
-  }
-
-  .navbar-toggler {
-    color: $navbar-light-color;
-    border-color: $navbar-light-toggler-border-color;
-  }
-
-  .navbar-toggler-icon {
-    background-image: $navbar-light-toggler-icon-bg;
-  }
-
-  .navbar-text {
-    color: $navbar-light-color;
-  }
-}
-
-// White links against a dark background
-.navbar-dark {
-  .navbar-brand {
-    color: $navbar-dark-active-color;
-
-    @include hover-focus {
-      color: $navbar-dark-active-color;
-    }
-  }
-
-  .navbar-nav {
-    .nav-link {
-      color: $navbar-dark-color;
-
-      @include hover-focus {
-        color: $navbar-dark-hover-color;
-      }
-
-      &.disabled {
-        color: $navbar-dark-disabled-color;
-      }
-    }
-
-    .show > .nav-link,
-    .active > .nav-link,
-    .nav-link.show,
-    .nav-link.active {
-      color: $navbar-dark-active-color;
-    }
-  }
-
-  .navbar-toggler {
-    color: $navbar-dark-color;
-    border-color: $navbar-dark-toggler-border-color;
-  }
-
-  .navbar-toggler-icon {
-    background-image: $navbar-dark-toggler-icon-bg;
-  }
-
-  .navbar-text {
-    color: $navbar-dark-color;
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -533,19 +533,30 @@ $navbar-toggler-padding-x:           .75rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-dark-color:                 rgba($white,.5) !default;
-$navbar-dark-hover-color:           rgba($white,.75) !default;
-$navbar-dark-active-color:          rgba($white,1) !default;
-$navbar-dark-disabled-color:        rgba($white,.25) !default;
+$navbar-dark-color:                     rgba($white,.5) !default;
+$navbar-dark-hover-color:               rgba($white,.75) !default;
+$navbar-dark-active-color:              rgba($white,1) !default;
+$navbar-dark-disabled-color:            rgba($white,.25) !default;
 $navbar-dark-toggler-icon-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-dark-toggler-border-color:  rgba($white,.1) !default;
+$navbar-dark-toggler-border-color:      rgba($white,.1) !default;
+$navbar-dark-dropdown-border-color:     rgba($white,.1) !default;
+$navbar-dark-dropdown-bg:               transparent !default;
+$navbar-dark-dropdown-link-color:       $navbar-dark-color !default;
+$navbar-dark-dropdown-link-hover-color: $navbar-dark-hover-color !default;
+$navbar-dark-dropdown-link-hover-bg:    transparent !default;
 
-$navbar-light-color:                rgba($black,.5) !default;
-$navbar-light-hover-color:          rgba($black,.7) !default;
-$navbar-light-active-color:         rgba($black,.9) !default;
-$navbar-light-disabled-color:       rgba($black,.3) !default;
+$navbar-light-color:                     rgba($black,.5) !default;
+$navbar-light-hover-color:               rgba($black,.7) !default;
+$navbar-light-active-color:              rgba($black,.9) !default;
+$navbar-light-disabled-color:            rgba($black,.3) !default;
 $navbar-light-toggler-icon-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-light-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-light-toggler-border-color: rgba($black,.1) !default;
+$navbar-light-toggler-border-color:      rgba($black,.1) !default;
+$navbar-light-dropdown-border-color:     rgba($black,.1) !default;
+$navbar-light-dropdown-bg:               transparent !default;
+$navbar-light-dropdown-link-color:       $navbar-light-color !default;
+$navbar-light-dropdown-link-hover-color: $navbar-light-hover-color !default;
+$navbar-light-dropdown-link-hover-bg:    transparent !default;
+
 
 // Pagination
 


### PR DESCRIPTION
This PR fixes #23915 and it looks like this:

![Image of the navbar menu](http://g.recordit.co/RGtAwKjuEp.gif)

Notice that I had to reverse the order of the declarations on the `_navbar.scss` putting first themes and then breakpoints to avoid increasing specificity on themes.

also, I've created variables for dropmenu styles on navbar so users have full control of them.

@mdo @xhmikosr @Johann-S  Since this is not a tiny change I did as much test I could and I think it's solid, but a fresh pair of eyes is really welcome 😄 
