### PR TITLE
Use variable for heading margin bottom in reboot

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -93,7 +93,7 @@ hr {
 // margin for easier control within type scales as it avoids margin collapsing.
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
-  margin-bottom: .5rem;
+  margin-bottom: $headings-margin-bottom;
 }
 
 // Reset margins on paragraphs

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -4,7 +4,6 @@
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
-  margin-bottom: $headings-margin-bottom;
   font-family: $headings-font-family;
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;


### PR DESCRIPTION
This margin is overridden in [_type](https://github.com/twbs/bootstrap/blob/45722e94acdffc314d7f835ed8a73cd0d56d879a/scss/_type.scss#L7) anyway, but I figure the variable should be used in reset
