### PR TITLE
Fixes rounded corners on first and lat child on vertical btn group

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -152,14 +152,14 @@
     &:not(:first-child):not(:last-child) {
       border-radius: 0;
     }
-  }
 
-  &:first-child:not(:last-child) {
-    @include border-bottom-radius(0);
-  }
+    &:first-child:not(:last-child) {
+      @include border-bottom-radius(0);
+    }
 
-  &:last-child:not(:first-child) {
-    @include border-top-radius(0);
+    &:last-child:not(:first-child) {
+      @include border-top-radius(0);
+    }
   }
 
   > .btn-group:not(:first-child):not(:last-child) > .btn {


### PR DESCRIPTION
This PR fixes #24118 a bug introduced here https://github.com/twbs/bootstrap/commit/cd22eb1da03d5dbc9062ad5c9e75c05429e4bcd0

v4-dev looks like this:
<img width="105" alt="screen shot 2017-09-26 at 9 41 42 am" src="https://user-images.githubusercontent.com/1832037/30861374-dfd12822-a2a0-11e7-940e-0332f3ef4d32.png">

Because it's not selecting the first and last btn. Now it does and it looks like this:
<img width="103" alt="screen shot 2017-09-26 at 9 54 24 am" src="https://user-images.githubusercontent.com/1832037/30861399-f753b578-a2a0-11e7-954b-812d75432d14.png">

What do you think?