### PR TITLE
Fix .btn-group wrapping (#24111)

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -5,6 +5,7 @@
 .btn-group-vertical {
   position: relative;
   display: inline-flex;
+  flex-flow: wrap;
   vertical-align: middle; // match .btn alignment given font-size hack above
 
   > .btn {


### PR DESCRIPTION
Fixes #24111

Previous:
![image](https://user-images.githubusercontent.com/7963804/30857245-4bb7934a-a2bb-11e7-9942-08f5a883a7e6.png)

Wrap by default (this pull):
![image](https://user-images.githubusercontent.com/7963804/30857277-68aa30ca-a2bb-11e7-88f6-9bf205ff722a.png)
