### PR TITLE
Reset button element border-radius in Reboot

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -322,6 +322,13 @@ label {
   margin-bottom: .5rem;
 }
 
+// Remove the default `border-radius` that macOS Chrome adds.
+//
+// Details at https://github.com/twbs/bootstrap/issues/24093
+button {
+  border-radius: 0;
+}
+
 // Work around a Firefox/IE bug where the transparent `button` background
 // results in a loss of the default `button` focus styles.
 //


### PR DESCRIPTION
Fixes #24093.

This goes in Reboot vs the `.btn` class given it affects `<button>` elements everywhere (e.g., dropdown items). This shouldn't affect the display much given we neutralize a bunch of other styles on the `<button>` element already.

/cc @razh