### PR TITLE
Removes border-radius from btn-link

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -76,7 +76,6 @@ fieldset[disabled] a.btn {
   font-weight: $font-weight-normal;
   color: $link-color;
   background-color: transparent;
-  border-radius: 0;
 
   @include hover {
     color: $link-hover-color;


### PR DESCRIPTION
Since `.btn-link` has a transparent background, what's the point of setting the border radius to 0?