### PR TITLE
prevent empty carousel from throwing, and staying in a 'sliding' state

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -144,7 +144,7 @@
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
     if ($.support.transition && this.$element.hasClass('slide')) {
       $next.addClass(type)
-      if (typeof $next == 'object' && $next.length) 
+      if (typeof $next == 'object' && $next.length)
       {
         $next[0].offsetWidth // force reflow
       }

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -144,7 +144,10 @@
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
     if ($.support.transition && this.$element.hasClass('slide')) {
       $next.addClass(type)
-      if (typeof $next == 'object' && $next.length) $next[0].offsetWidth // force reflow
+      if (typeof $next == 'object' && $next.length) 
+      {
+        $next[0].offsetWidth // force reflow
+      }
       $active.addClass(direction)
       $next.addClass(direction)
       $active

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -144,7 +144,7 @@
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
     if ($.support.transition && this.$element.hasClass('slide')) {
       $next.addClass(type)
-      if (typeof $next == 'object' && $next.length)
+      if (typeof $next === 'object' && $next.length)
       {
         $next[0].offsetWidth // force reflow
       }

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -144,7 +144,7 @@
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
     if ($.support.transition && this.$element.hasClass('slide')) {
       $next.addClass(type)
-      $next[0].offsetWidth // force reflow
+      if (typeof $next == 'object' && $next.length) $next[0].offsetWidth // force reflow
       $active.addClass(direction)
       $next.addClass(direction)
       $active


### PR DESCRIPTION
There are numerous questions on stack overflow relating to how the carousel becomes broken when it is emptied for any reason. This makes binding slides using angular or similar technologies very difficult, as they will routinely replace the set of slides with a new set.

whist I believe that calling `$.carousel()` should reset all the settings (particularly the `sliding` state), this simpler tweak at least ensures that if you use an angular / react binding to the carousel and it becomes empty, it does not get stuck in a sliding state.

please consider this pull - or something similar.

- https://stackoverflow.com/questions/29027830/getting-cannot-read-property-offsetwidth-of-undefined-with-bootstrap-carousel
- https://stackoverflow.com/questions/35918723/bootstrap-carousel-controls-causing-error
- https://stackoverflow.com/questions/29027830/getting-cannot-read-property-offsetwidth-of-undefined-with-bootstrap-carousel