### PR TITLE
Adds a flex wrap to pagination

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,5 +1,6 @@
 .pagination {
   display: flex;
+  flex-wrap: wrap;
   // 1-2: Disable browser default list styles
   padding-left: 0; // 1
   list-style: none; // 2


### PR DESCRIPTION
Even though this PR doesn't solve #24159 it's related to it.

Pagination doesn't wrap, so when the user has lots of pages it generates a horizontal scroll bar:

![screen shot 2017-09-28 at 2 30 13 pm](https://user-images.githubusercontent.com/1832037/30981200-f800f58e-a459-11e7-99ac-11bf7021f0e0.png)

This PR introduces a wrap, it's not a perfect solution for responsive paginations but at least it doesn't break the layout:

![screen shot 2017-09-28 at 2 30 57 pm](https://user-images.githubusercontent.com/1832037/30981217-0dc56940-a45a-11e7-8ae2-19c4d057b419.png)

What do you think? 

