### PR TITLE
Fix link to Extend section in Migration docs

### DIFF
--- a/docs/4.0/migration.md
+++ b/docs/4.0/migration.md
@@ -68,7 +68,7 @@ Here are the big ticket items you'll want to be aware of when moving from v3 to 
   - the upstream version of [Glyphicons](https://glyphicons.com/)
   - [Octicons](https://octicons.github.com/)
   - [Font Awesome](http://fontawesome.io/)
-  - See the [Extend page]({{ site.baseurl }}/docs/{{ site.docs_version }}/extend) for a list of alternatives. Have additional suggestions? Please open an issue or PR.
+  - See the [Extend page]({{ site.baseurl }}/docs/{{ site.docs_version }}/extend/icons/) for a list of alternatives. Have additional suggestions? Please open an issue or PR.
 - Dropped the Affix jQuery plugin.
   - We recommend using `position: sticky` instead. [See the HTML5 Please entry](http://html5please.com/#sticky) for details and specific polyfill recommendations. One suggestion is to use an `@supports` rule for implementing it (e.g., `@supports (position: sticky) { ... }`)/
   - If you were using Affix to apply additional, non-`position` styles, the polyfills might not support your use case. One option for such uses is the third-party [ScrollPos-Styler](https://github.com/acch/scrollpos-styler) library.


### PR DESCRIPTION
Point Extend link to `/extend/icons/`, the same link that is in the sidebar.