### PR TITLE
Opaque input borders

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -329,7 +329,7 @@ $input-bg:                       $white !default;
 $input-disabled-bg:              $gray-200 !default;
 
 $input-color:                    $gray-700 !default;
-$input-border-color:             rgba($black,.15) !default;
+$input-border-color:             $gray-400 !default;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
 $input-box-shadow:               inset 0 1px 1px rgba($black,.075) !default;
 


### PR DESCRIPTION
Building on #24197.

Move back to opaque borders on the `<input>`s to resolve some visual oddities. It works great with translucent borders on just the inputs, but when mixing with buttons and input group addons and the like, it starts to fall apart quickly. We'll get a modifier in there in the future for inputs against darker backgrounds perhaps.

Closes #23379, too.