### PR TITLE
Update input/button padding to fix cutoff text in Windows Chrome

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -296,15 +296,15 @@ $table-dark-color:           $body-bg !default;
 
 $input-btn-padding-y:       .375rem !default;
 $input-btn-padding-x:       .75rem !default;
-$input-btn-line-height:     1.5 !default;
+$input-btn-line-height:     $line-height-base !default;
 
 $input-btn-padding-y-sm:    .25rem !default;
 $input-btn-padding-x-sm:    .5rem !default;
-$input-btn-line-height-sm:  1.5 !default;
+$input-btn-line-height-sm:  $line-height-sm !default;
 
 $input-btn-padding-y-lg:    .5rem !default;
 $input-btn-padding-x-lg:    1rem !default;
-$input-btn-line-height-lg:  1.5 !default;
+$input-btn-line-height-lg:  $line-height-lg !default;
 
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -294,9 +294,9 @@ $table-dark-color:           $body-bg !default;
 //
 // For each of Bootstrap's buttons, define text, background and border color.
 
-$input-btn-padding-y:       .5rem !default;
+$input-btn-padding-y:       .375rem !default;
 $input-btn-padding-x:       .75rem !default;
-$input-btn-line-height:     1.25 !default;
+$input-btn-line-height:     1.5 !default;
 
 $input-btn-padding-y-sm:    .25rem !default;
 $input-btn-padding-x-sm:    .5rem !default;


### PR DESCRIPTION
This adjusts the vertical `padding` and `line-height` for inputs, selects, textareas, and buttons to ensure they have the same height as before, but without the cutoff text in Windows Chrome. Still probably need to test the larger inputs and selects mentioned in the bug reports.

Closes #24070 and fixes #23347.

Update CSS in action: https://codepen.io/emdeoh/pen/borved.