### PR TITLE
Adds support for <picture>

### DIFF
--- a/docs/4.0/content/images.md
+++ b/docs/4.0/content/images.md
@@ -69,3 +69,15 @@ Align images with the [helper float classes]({{ site.baseurl }}/docs/{{ site.doc
   <img src="..." class="rounded" alt="...">
 </div>
 {% endhighlight %}
+
+
+## Picture
+
+If you are using the `<picture>` [element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) to specify multiple `<source>` elements for a specific `<img>` make sure to add a `.picture` class to display `.img-*` styles correctly.
+
+{% highlight html %}
+​<picture class="picture img-thumbnail">
+ <source srcset="..." type="image/svg+xml">
+ <img src="..." alt="...">
+</picture>
+{% endhighlight %}

--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -41,3 +41,12 @@
   font-size: $figure-caption-font-size;
   color: $figure-caption-color;
 }
+
+
+//
+// Picture
+//
+
+.picture {
+  display: inline-block;
+}


### PR DESCRIPTION
This PR closes #24176 and creates a class `.picture` to make `picture` element correctly display `img-*` styles.

It also adds documentation on how to use it under Images.