### PR TITLE
Badges add Sass variable to configure `$badge-border-radius`

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -12,7 +12,7 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  @include border-radius();
+  @include border-radius($badge-border-radius);
 
   // Empty badges collapse automatically
   &:empty {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -649,6 +649,7 @@ $badge-font-size:             75% !default;
 $badge-font-weight:           $font-weight-bold !default;
 $badge-padding-y:             .25em !default;
 $badge-padding-x:             .4em !default;
+$badge-border-radius:         $border-radius !default;
 
 $badge-pill-padding-x:        .6em !default;
 // Use a higher than normal value to ensure completely rounded edges when


### PR DESCRIPTION
Would be nice to be able to customize badge `border-radius` without having to change the border radius globally.