### PR TITLE
Use variable for heading margin bottom in reboot

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -93,7 +93,7 @@ hr {
 // margin for easier control within type scales as it avoids margin collapsing.
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
-  margin-bottom: .5rem;
+  margin-bottom: $headings-margin-bottom;
 }
 
 // Reset margins on paragraphs


### PR DESCRIPTION
don't hardcode bottom margin for headings reset

from https://github.com/twbs/bootstrap/pull/24082#issuecomment-333758361