### PR TITLE
Adds a note on the image docs about how to use img-* classes with picture

### DIFF
--- a/docs/4.0/content/images.md
+++ b/docs/4.0/content/images.md
@@ -69,3 +69,15 @@ Align images with the [helper float classes]({{ site.baseurl }}/docs/{{ site.doc
   <img src="..." class="rounded" alt="...">
 </div>
 {% endhighlight %}
+
+
+## Picture
+
+If you are using the `<picture>` element to specify multiple `<source>` elements for a specific `<img>`, make sure to add the `.img-*` classes to the `<img>` and not to the `<picture>` tag.
+
+{% highlight html %}
+​<picture>
+ <source srcset="..." type="image/svg+xml">
+ <img src="..."  class="img-fluid img-thumbnail" alt="...">
+</picture>
+{% endhighlight %}


### PR DESCRIPTION
This PR closes #24176 

It adds a note about how to use bootstrap's `img-*` classes with `<picture>`.

What do you think?