### PR TITLE
Navbar dropup

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -152,17 +152,6 @@
           padding-left: 0;
         }
 
-        .dropup {
-          .dropdown-menu {
-            position: absolute;
-            top: auto;
-            bottom: 100%;
-          }
-
-          .dropdown-toggle {
-            @include caret(up);
-          }
-        }
       }
 
       @include media-breakpoint-up($next) {
@@ -171,6 +160,14 @@
 
         .navbar-nav {
           flex-direction: row;
+
+          .dropup {
+            .dropdown-menu {
+              position: absolute;
+              top: auto;
+              bottom: 100%;
+            }
+          }
 
           .dropdown-menu {
             position: absolute;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -74,13 +74,6 @@
     position: static;
     float: none;
   }
-
-  .dropdown-toggle {
-    &::after {
-      border-top: $caret-width solid;
-      border-bottom: 0;
-    }
-  }
 }
 
 


### PR DESCRIPTION
This is fix for https://github.com/twbs/bootstrap/pull/23520
1) There is no need redefine `.dropdown-toggler` in navbar. 
Everything should work from `_dropdown.scss`
2) Move `.dropdown-menu` positions to `media-breakpoint-up` in `.navbar-expand`


codepen with css changes
https://codepen.io/anon/pen/PJOEoo