### PR TITLE
Change `$grid-gutter-width` to rem from px

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -176,7 +176,7 @@ $container-max-widths: (
 // Set the number of columns and specify the width of the gutters.
 
 $grid-columns:                12 !default;
-$grid-gutter-width:           30px !default;
+$grid-gutter-width:           1.875rem !default;
 
 // Components
 //


### PR DESCRIPTION
This changes `$grid-gutter-width` from 30px to 1.875rem. The px value makes it hard to calculate things based on `$grid-gutter-width` when everything else is based on rems.