### PR TITLE
Run stylelint and autoprefixer for examples too

### DIFF
--- a/build/.stylelintrc
+++ b/build/.stylelintrc
@@ -19,7 +19,7 @@
     "declaration-block-semicolon-space-after": "always-single-line",
     "declaration-empty-line-before": null,
     "declaration-no-important": true,
-    "font-family-name-quotes": "always-where-required",
+    "font-family-name-quotes": "always-where-recommended",
     "font-weight-notation": "numeric",
     "function-comma-space-after": null,
     "function-url-no-scheme-relative": true,

--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = (ctx) => ({
-  map: ctx.file.dirname.startsWith('docs') || ctx.file.dirname.includes('examples') ? false : {
+  map: ctx.file.dirname.includes('examples') ? false : {
     inline: false,
     annotation: true,
     sourcesContent: true

--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = (ctx) => ({
-  map: ctx.file.dirname.startsWith('docs') ? false : {
+  map: ctx.file.dirname.startsWith('docs') || ctx.file.dirname.includes('examples') ? false : {
     inline: false,
     annotation: true,
     sourcesContent: true

--- a/docs/4.0/examples/.stylelintrc
+++ b/docs/4.0/examples/.stylelintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../build/.stylelintrc",
+  "rules": {
+    "at-rule-no-vendor-prefix": null,
+    "comment-empty-line-before": null,
+    "media-feature-name-no-vendor-prefix": null,
+    "property-no-vendor-prefix": null,
+    "selector-no-qualifying-type": null,
+    "selector-no-vendor-prefix": null,
+    "value-no-vendor-prefix": null
+  }
+}

--- a/docs/4.0/examples/blog/blog.css
+++ b/docs/4.0/examples/blog/blog.css
@@ -13,12 +13,18 @@ body {
   color: #555;
 }
 
-h1, .h1,
-h2, .h2,
-h3, .h3,
-h4, .h4,
-h5, .h5,
-h6, .h6 {
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3,
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 400;
   color: #333;

--- a/docs/4.0/examples/dashboard/dashboard.css
+++ b/docs/4.0/examples/dashboard/dashboard.css
@@ -27,16 +27,10 @@ h1 {
   bottom: 0;
   left: 0;
   z-index: 1000;
-  padding: 20px;
+  padding: 20px 0;
   overflow-x: hidden;
   overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
   border-right: 1px solid #eee;
-}
-
-/* Sidebar navigation */
-.sidebar {
-  padding-right: 0;
-  padding-left: 0;
 }
 
 .sidebar .nav {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "css-compile": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/bootstrap.scss dist/css/bootstrap.css && node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/bootstrap-grid.scss dist/css/bootstrap-grid.css && node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/bootstrap-reboot.scss dist/css/bootstrap-reboot.css",
     "css-compile-docs": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 assets/scss/docs.scss assets/css/docs.min.css",
     "css-lint": "stylelint --config build/.stylelintrc --syntax scss \"scss/**/*.scss\"",
-    "css-lint-docs": "stylelint --config build/.stylelintrc --syntax scss \"assets/scss/*.scss\"",
+    "css-lint-docs": "stylelint --config build/.stylelintrc --syntax scss \"assets/scss/*.scss\" && stylelint --config docs/4.0/examples/.stylelintrc \"docs/**/*.css\"",
     "css-prefix": "postcss --config build/postcss.config.js --replace \"dist/css/*.css\"",
     "css-prefix-docs": "postcss --config build/postcss.config.js --replace \"assets/css/docs.min.css\" \"docs/**/*.css\"",
     "css-minify": "cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap.min.css dist/css/bootstrap.css && cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap-grid.min.css dist/css/bootstrap-grid.css && cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap-reboot.min.css dist/css/bootstrap-reboot.css",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "css-lint": "stylelint --config build/.stylelintrc --syntax scss \"scss/**/*.scss\"",
     "css-lint-docs": "stylelint --config build/.stylelintrc --syntax scss \"assets/scss/*.scss\"",
     "css-prefix": "postcss --config build/postcss.config.js --replace \"dist/css/*.css\"",
-    "css-prefix-docs": "postcss --config build/postcss.config.js --no-map --replace assets/css/docs.min.css",
+    "css-prefix-docs": "postcss --config build/postcss.config.js --replace \"assets/css/docs.min.css\" \"docs/**/*.css\"",
     "css-minify": "cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap.min.css dist/css/bootstrap.css && cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap-grid.min.css dist/css/bootstrap-grid.css && cleancss --level 1 --source-map --source-map-inline-sources --output dist/css/bootstrap-reboot.min.css dist/css/bootstrap-reboot.css",
     "css-minify-docs": "cleancss --level 1 --source-map --source-map-inline-sources --output assets/css/docs.min.css assets/css/docs.min.css",
     "js": "npm-run-all js-lint* js-compile* js-minify*",


### PR DESCRIPTION
~~I assume this is a leftover from v3 thus we don't want a `docs.min.css.map` being generated.~~

I also added the examples to the `css-prefix-docs` script.

Fixes #24211 