### PR TITLE
Use `$white` variable for `.navbar-dark`'s color.

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -541,7 +541,7 @@ $navbar-toggler-border-radius:      $btn-border-radius !default;
 
 $navbar-dark-color:                 rgba($white,.5) !default;
 $navbar-dark-hover-color:           rgba($white,.75) !default;
-$navbar-dark-active-color:          rgba($white,1) !default;
+$navbar-dark-active-color:          $white !default;
 $navbar-dark-disabled-color:        rgba($white,.25) !default;
 $navbar-dark-toggler-icon-bg:       str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E"), "#", "%23") !default;
 $navbar-dark-toggler-border-color:  rgba($white,.1) !default;


### PR DESCRIPTION
Using `rgba($white,1)` results in `white` instead of the hex.