### PR TITLE
Adds a border radius to the image when it's the only child of a card group

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -215,6 +215,13 @@
 
         &:only-child {
           @include border-radius($card-border-radius);
+
+          .card-img-top {
+            @include border-top-radius($card-border-radius);
+          }
+          .card-img-bottom {
+            @include border-bottom-radius($card-border-radius);
+          }
         }
 
         &:not(:first-child):not(:last-child):not(:only-child) {


### PR DESCRIPTION
When a card is the only child of a card group, img-top and img-bottom don't have a border radius:
![screen shot 2017-10-10 at 10 45 02 am](https://user-images.githubusercontent.com/1832037/31389683-3cef2038-ada8-11e7-83b8-f43c17a7c97f.png)


This PR is adding those border radius back:
![screen shot 2017-10-10 at 10 45 44 am](https://user-images.githubusercontent.com/1832037/31389696-45e82fb8-ada8-11e7-9d2f-668f15780a2e.png)
