### PR TITLE
Hound CI: Specify `ignore_file` for stylelint.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,6 +3,7 @@ fail_on_violations: true
 stylelint:
   config_file: build/.stylelintrc
   enabled: true
+  ignore_file: .houndignore
 
 eslint:
   config_file: js/.eslintrc.json


### PR DESCRIPTION
Specify `ignore_file` for stylelint.

I noticed that Hound complained on #24323, which it shouldn't have so this hopefully should fix it.