### PR TITLE
Vertical aligns horizontal forms using flex instead of math

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -87,23 +87,20 @@ select.form-control {
 
 // For use with horizontal and inline forms, when you need the label text to
 // align with the form controls.
-.col-form-label {
-  padding-top: calc(#{$input-btn-padding-y} + #{$input-btn-border-width});
-  padding-bottom: calc(#{$input-btn-padding-y} + #{$input-btn-border-width});
-  margin-bottom: 0; // Override the `<label>` default
+:not(.form-row).col-form-label {
+  @include media-breakpoint-up(sm) {
+    align-self: center;
+    margin-bottom: 0; // Override the `<label>` default
+  }
   line-height: $input-btn-line-height;
 }
 
 .col-form-label-lg {
-  padding-top: calc(#{$input-btn-padding-y-lg} + #{$input-btn-border-width});
-  padding-bottom: calc(#{$input-btn-padding-y-lg} + #{$input-btn-border-width});
   font-size: $font-size-lg;
   line-height: $input-btn-line-height-lg;
 }
 
 .col-form-label-sm {
-  padding-top: calc(#{$input-btn-padding-y-sm} + #{$input-btn-border-width});
-  padding-bottom: calc(#{$input-btn-padding-y-sm} + #{$input-btn-border-width});
   font-size: $font-size-sm;
   line-height: $input-btn-line-height-sm;
 }


### PR DESCRIPTION
This PR changes vertical alignment of labels on horizontal forms from paddings and clac to a more robust solution with flex. Let's let the computer do the math 😄 

The visual result is the same.

This PR is related to #24328

@XhmikosR @mdo what do you guys think?
