### PR TITLE
Escape SassScript in custom variable values

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,16 +1,16 @@
 :root {
   @each $color, $value in $colors {
-    --#{$color}: $value;
+    --#{$color}: #{$value};
   }
 
   @each $color, $value in $theme-colors {
-    --#{$color}: $value;
+    --#{$color}: #{$value};
   }
 
   @each $bp, $value in $grid-breakpoints {
-    --breakpoint-#{$bp}: $value;
+    --breakpoint-#{$bp}: #{$value};
   }
 
-  --font-family-sans-serif: $font-family-sans-serif;
-  --font-family-monospace: $font-family-monospace;
+  --font-family-sans-serif: #{$font-family-sans-serif};
+  --font-family-monospace: #{$font-family-monospace};
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,4 +1,5 @@
 :root {
+  // Custom variable values only support SassScript inside `#{}`.
   @each $color, $value in $colors {
     --#{$color}: #{$value};
   }
@@ -11,6 +12,8 @@
     --breakpoint-#{$bp}: #{$value};
   }
 
+  // Use `inspect` for lists so that quoted items keep the quotes.
+  // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
   --font-family-sans-serif: #{inspect($font-family-sans-serif)};
   --font-family-monospace: #{inspect($font-family-monospace)};
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -11,6 +11,6 @@
     --breakpoint-#{$bp}: #{$value};
   }
 
-  --font-family-sans-serif: #{$font-family-sans-serif};
-  --font-family-monospace: #{$font-family-monospace};
+  #{--font-family-sans-serif}: $font-family-sans-serif;
+  #{--font-family-monospace}: $font-family-monospace;
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -11,6 +11,6 @@
     --breakpoint-#{$bp}: #{$value};
   }
 
-  #{--font-family-sans-serif}: $font-family-sans-serif;
-  #{--font-family-monospace}: $font-family-monospace;
+  --font-family-sans-serif: #{inspect($font-family-sans-serif)};
+  --font-family-monospace: #{inspect($font-family-monospace)};
 }


### PR DESCRIPTION
This is required for Sass v3.5+ compatibility.
See https://github.com/sass/sass/blob/stable/doc-src/SASS_CHANGELOG.md#backwards-incompatibilities----must-read and https://github.com/sass/sass/issues/2383