### PR TITLE
Changes reference to gray-dark from 900 to 800 on theming doc

### DIFF
--- a/docs/4.0/getting-started/theming.md
+++ b/docs/4.0/getting-started/theming.md
@@ -238,7 +238,7 @@ $colors: (
   "purple": $purple,
   "white": $white,
   "gray": $gray-600,
-  "gray-dark": $gray-900
+  "gray-dark": $gray-800
 ) !default;
 {% endhighlight %}
 


### PR DESCRIPTION
This PR fixes #24353

Theming docs has a wrong reference to `gray-dark` to `gray-900` instead of `gray-800`