### PR TITLE
Correct $zindex-sticky value

### DIFF
--- a/docs/4.0/layout/overview.md
+++ b/docs/4.0/layout/overview.md
@@ -163,8 +163,8 @@ We don't encourage customization of these values; should you change one, you lik
 
 ```scss
 $zindex-dropdown:          1000 !default;
+$zindex-sticky:            1020 !default;
 $zindex-fixed:             1030 !default;
-$zindex-sticky:            1030 !default;
 $zindex-modal-backdrop:    1040 !default;
 $zindex-modal:             1050 !default;
 $zindex-popover:           1060 !default;


### PR DESCRIPTION
The value for `$zindex-sticky` in `docs/4.0/layout/overview.md` does not match the value defined in `scss/_variables.scss`

https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss#L501