### PR TITLE
Revert #23108 to restore list group borders

### DIFF
--- a/docs/4.0/components/card.md
+++ b/docs/4.0/components/card.md
@@ -96,6 +96,19 @@ Mix and match multiple content types to create the card you need, or throw every
 
 {% example html %}
 <div class="card" style="width: 20rem;">
+  <div class="card-header">
+    Featured
+  </div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Cras justo odio</li>
+    <li class="list-group-item">Dapibus ac facilisis in</li>
+    <li class="list-group-item">Vestibulum at eros</li>
+  </ul>
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="card" style="width: 20rem;">
   <img class="card-img-top" data-src="holder.js/100px180/?text=Image cap" alt="Card image cap">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>

--- a/docs/4.0/components/card.md
+++ b/docs/4.0/components/card.md
@@ -90,10 +90,6 @@ Create lists of content in a card with a flush list group.
 </div>
 {% endexample %}
 
-### Kitchen sink
-
-Mix and match multiple content types to create the card you need, or throw everything in there. Shown below are image styles, blocks, text styles, and a list group—all wrapped in a fixed-width card.
-
 {% example html %}
 <div class="card" style="width: 20rem;">
   <div class="card-header">
@@ -106,6 +102,10 @@ Mix and match multiple content types to create the card you need, or throw every
   </ul>
 </div>
 {% endexample %}
+
+### Kitchen sink
+
+Mix and match multiple content types to create the card you need, or throw everything in there. Shown below are image styles, blocks, text styles, and a list group—all wrapped in a fixed-width card.
 
 {% example html %}
 <div class="card" style="width: 20rem;">

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -86,13 +86,8 @@
 .list-group-flush {
   .list-group-item {
     border-right: 0;
-    border-bottom: 0;
     border-left: 0;
     border-radius: 0;
-
-    &:first-child {
-      border-top: 0;
-    }
   }
 
   &:first-child {


### PR DESCRIPTION
Turns out we never needed #23108 and I need to pay more attention to testing even straightforward CSS changes. #23013 isn't a bug—it's bad markup that's missing the `.list-group` class.

While I was in here, I added another example for future use.

Fixes #24300.