### PR TITLE
Increase $headings-line-height from 1.1 to 1.2

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -233,7 +233,7 @@ $h6-font-size:                1rem !default;
 $headings-margin-bottom:      ($spacer / 2) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        500 !default;
-$headings-line-height:        1.1 !default;
+$headings-line-height:        1.2 !default;
 $headings-color:              inherit !default;
 
 $display1-size:               6rem !default;


### PR DESCRIPTION
This way, descenders are not cropped when truncating. Fixes #23956.