### PR TITLE
Add vars for yiq color contrast function

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -57,9 +57,9 @@
   $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
 
   @if ($yiq >= 150) {
-    @return #111;
+    @return $yiq-text-dark;
   } @else {
-    @return #fff;
+    @return $yiq-text-light;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -78,6 +78,10 @@ $theme-colors: map-merge((
 // Set a specific jump point for requesting color jumps
 $theme-color-interval:      8% !default;
 
+// Customize the light and dark text colors for use in our YIQ color contrast function.
+$yiq-text-dark: #111 !default;
+$yiq-text-light: #fff !default;
+
 
 // Options
 //


### PR DESCRIPTION
Adds two vars instead of the hardcoded colors we had previously. This supersedes #23440, getting us close to what that implementation provides without all the additional Sass map merges.