### PR TITLE
Make 1.9.1 the minimum jQuery version again.

### DIFF
--- a/docs/4.0/migration.md
+++ b/docs/4.0/migration.md
@@ -17,7 +17,7 @@ While in beta, we aim to have no breaking changes. However, things don't always 
 - Renamed `.table-inverse`, `.thead-inverse`, and `.thead-default` to `.*-dark` and `.*-light`, matching our color schemes used elsewhere.
 - Responsive tables now generate classes for each grid breakpoint. This breaks from Beta 1 in that the `.table-responsive` you've been using is more like `.table-responsive-md`. You may now use `.table-responsive` or `.table-responsive-{sm,md,lg,xl}` as needed.
 - Dropped Bower support as the package manager has been deprecated for alternatives (e.g., Yarn or npm). [See bower/bower#2298](https://github.com/bower/bower/issues/2298) for details.
-- Bootstrap now requires jQuery 3.0.0 or higher.
+- Bootstrap still requires jQuery 1.9.1 or higher, but you're advised to use version 3.x since v3.x's supported browsers are the ones Bootstrap supports plus v3.x has some security fixes.
 - Removed the unused `.form-control-label` class. If you did make use of this class, it was duplicate of the `.col-form-label` class that vertically centered a `<label>` with it's associated input in horizontal form layouts.
 - Changed the `color-yiq` from a mixin that included the `color` property to a function that returns a value, allowing you to use it for any CSS property. For example, instead of `color-yiq(#000)`, you'd write `color: color-yiq(#000);`.
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -24,10 +24,14 @@ import Util from './util'
   }
 
   const version = $.fn.jquery.split(' ')[0].split('.')
-  const min = 3
-  const max = 4
-  if (version[0] < min || version[0] >= max) {
-    throw new Error('Bootstrap\'s JavaScript requires at least jQuery v3.0.0 but less than v4.0.0')
+  const minMajor = 1
+  const ltMajor  = 2
+  const minMinor = 9
+  const minPatch = 1
+  const maxMajor = 4
+
+  if (version[0] < ltMajor && version[1] < minMinor || version[0] === minMajor && version[1] === minMinor && version[2] < minPatch || version[0] >= maxMajor) {
+    throw new Error('Bootstrap\'s JavaScript requires at least jQuery v1.9.1 but less than v4.0.0')
   }
 })($)
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "license": "MIT",
   "dependencies": {},
   "peerDependencies": {
-    "jquery": "^3.0.0",
+    "jquery": "1.9.1 - 3",
     "popper.js": "^1.12.3"
   },
   "devDependencies": {


### PR DESCRIPTION
~~We'll just show a warning message instead.~~

~~While we don't use 2.x nor test it, a lot of people might still use it.~~

~~**Do not merge yet.** I'm still not personally sold we should do this. I do see the point of people using various CMS and not being able to update jQuery, but on the other hand this feels very inconsistent to me...~~