### PR TITLE
update the button color for active status

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -35,6 +35,7 @@
   &:not([disabled]):not(.disabled):active,
   &:not([disabled]):not(.disabled).active,
   .show > &.dropdown-toggle {
+    color: color-yiq($active-background);
     background-color: $active-background;
     background-image: none; // Remove the gradient for the pressed/active state
     border-color: $active-border;


### PR DESCRIPTION
update the button color for active status check with yiq as it's done for basic state and hover state

For templating purpose if the input parameter of the mixin for the active state backgound color is not in the same range as hover color, then the font-color is incorrect.