### PR TITLE
remove max- from height of documentation sidebars

### DIFF
--- a/assets/scss/_sidebar.scss
+++ b/assets/scss/_sidebar.scss
@@ -8,7 +8,7 @@
   @supports (position: sticky) {
     position: sticky;
     top: 4rem;
-    max-height: calc(100vh - 4rem);
+    height: calc(100vh - 4rem);
     overflow-y: auto;
   }
   order: 2;
@@ -59,7 +59,7 @@
       position: sticky;
       top: 4rem;
       z-index: 1000;
-      max-height: calc(100vh - 4rem);
+      height: calc(100vh - 4rem);
     }
     border-right: 1px solid rgba(0,0,0,.1);
   }


### PR DESCRIPTION
If the content of the page does not extend the full viewport height, the sidebars are shortened
Which results in the following screenshot
<img width="788" alt="schermafbeelding 2017-10-19 om 21 49 31" src="https://user-images.githubusercontent.com/7714133/31790967-7698f68a-b517-11e7-85b8-908bf893325b.png">
