### PR TITLE
Remove background-image: none; on .form-control

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -12,8 +12,6 @@
   line-height: $input-btn-line-height;
   color: $input-color;
   background-color: $input-bg;
-  // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214.
-  background-image: none;
   background-clip: padding-box;
   border: $input-btn-border-width solid $input-border-color;
 


### PR DESCRIPTION
As the diff shows, this was for a Firefox Android issue that's since been fixed. Closes #23817.