### PR TITLE
Remove `thumbnail-transition` from `.img-thumbnail`.

### DIFF
--- a/docs/4.0/migration.md
+++ b/docs/4.0/migration.md
@@ -6,6 +6,12 @@ group: migration
 toc: true
 ---
 
+## Beta 3 changes
+
+While Beta 2 saw the bulk of our breaking changes during the beta phase, but we still have a few that needed to be addressed in the Beta 3 release. These changes apply if you're updating to Beta 3 from Beta 2 or any older version of Bootstrap.
+
+- Removed the unused `$thumbnail-transition` variable. We weren't transitioning anything, so it was just extra code.
+
 ## Beta 2 changes
 
 While in beta, we aim to have no breaking changes. However, things don't always go as planned. Below are the breaking changes to bear in mind when moving from Beta 1 to Beta 2.

--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -16,7 +16,6 @@
   background-color: $thumbnail-bg;
   border: $thumbnail-border-width solid $thumbnail-border-color;
   @include border-radius($thumbnail-border-radius);
-  @include transition($thumbnail-transition);
   @include box-shadow($thumbnail-box-shadow);
 
   // Keep them at most 100% wide

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -761,7 +761,6 @@ $thumbnail-border-width:            $border-width !default;
 $thumbnail-border-color:            #ddd !default;
 $thumbnail-border-radius:           $border-radius !default;
 $thumbnail-box-shadow:              0 1px 2px rgba($black,.075) !default;
-$thumbnail-transition:              all .2s ease-in-out !default;
 
 
 // Figures


### PR DESCRIPTION
We don't change anything so the transition is basically unused.