### PR TITLE
Fix for right padding in dismissible alerts

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -27,7 +27,8 @@
 // Expand the right padding and account for the close button's positioning.
 
 .alert-dismissible {
-  padding-right: ($close-font-size + $alert-padding-x);
+  padding-right: ($close-font-size + $alert-padding-x * 2);
+  
   // Adjust close link position
   .close {
     position: absolute;

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -27,6 +27,8 @@
 // Expand the right padding and account for the close button's positioning.
 
 .alert-dismissible {
+  padding-right: ($close-font-size + $alert-padding-x);
+  
   // Adjust close link position
   .close {
     position: absolute;

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -28,7 +28,6 @@
 
 .alert-dismissible {
   padding-right: ($close-font-size + $alert-padding-x);
-  
   // Adjust close link position
   .close {
     position: absolute;

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -28,7 +28,7 @@
 
 .alert-dismissible {
   padding-right: ($close-font-size + $alert-padding-x * 2);
-  
+
   // Adjust close link position
   .close {
     position: absolute;


### PR DESCRIPTION
Added right padding to dismissible alerts to avoid button/text overlap.

Fixes #24469 