### PR TITLE
Simplify social.html.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="description" content="{{ page.description | default: site.description }}">
+<meta name="author" content="{{ site.authors }}">
 <meta name="generator" content="Jekyll v{{ jekyll.version }}">
 
 <title>

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,36 +1,18 @@
-<!-- Meta -->
-<meta name="description" content="{{ site.description }}">
-<meta name="author" content="{{ site.authors }}">
-
 <!-- Twitter -->
+<meta name="twitter:card" content="{% if page.title %}summary{% else %}summary_large_image{% endif %}">
 <meta name="twitter:site" content="@{{ site.twitter }}">
 <meta name="twitter:creator" content="@{{ site.twitter }}">
-
-{% if page.title %}
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="{{ page.title }}">
-  <meta name="twitter:description" content="{{ page.description }}">
-  <meta name="twitter:image" content="{{ site.url }}{{ site.social_logo_path }}">
-{% else %}
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ site.title }}">
-  <meta name="twitter:description" content="{{ site.description }}">
-  <meta name="twitter:image" content="{{ site.url }}{{ site.social_image_path }}">
-{% endif %}
+<meta name="twitter:title" content="{{ page.title | default: site.title }}">
+<meta name="twitter:description" content="{{ page.description | default: site.description }}">
+<meta name="twitter:image" content="{% if page.title %}{{ site.url | append: site.social_logo_path }}{% else %}{{ site.url | append: site.social_image_path }}{% endif %}">
 
 <!-- Facebook -->
-{% if page.title %}
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-  <meta property="og:title" content="{{ page.title }}">
-  <meta property="og:description" content="{{ page.description }}">
-  <meta property="og:type" content="website">
-{% else %}
-  <meta property="og:url" content="{{ site.url }}">
-  <meta property="og:title" content="{{ site.title }}">
-  <meta property="og:description" content="{{ site.description }}">
-{% endif %}
-<meta property="og:image" content="{{ site.url | replace: 'https://', 'http://' }}{{ site.social_image_path }}">
-<meta property="og:image:secure_url" content="{{ site.url }}{{ site.social_image_path }}">
+<meta property="og:url" content="{{ site.url | append: page.url }}">
+<meta property="og:title" content="{{ page.title | default: site.title }}">
+<meta property="og:description" content="{{ page.description | default: site.description }}">
+<meta property="og:type" content="website">
+<meta property="og:image" content="{{ site.url | replace: 'https://', 'http://' | append: site.social_image_path }}">
+<meta property="og:image:secure_url" content="{{ site.url | append: site.social_image_path }}">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">


### PR DESCRIPTION
This also fixes the wrong usage of `site.description` instead of `page.description` in meta description.

From <https://shopify.github.io/liquid/filters/default/>:

> default - returns the given variable unless it is null or the empty string, when it will return the given value, e.g. {{ undefined_variable | default: "Default value" }} #=> "Default value" 