### PR TITLE
Add fallback border-radius to .btn

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -90,5 +90,10 @@
   padding: $padding-y $padding-x;
   font-size: $font-size;
   line-height: $line-height;
-  @include border-radius($border-radius);
+  // Manually declare to provide an override to the browser default
+  @if $enable-rounded {
+    border-radius: $border-radius;
+  } @else {
+    border-radius: 0;
+  }
 }


### PR DESCRIPTION
Fixes #24503 by manually calling the border-radius instead of using the mixin.