### PR TITLE
Alerts example code: Close button before message?

### DIFF
--- a/docs/4.0/components/alerts.md
+++ b/docs/4.0/components/alerts.md
@@ -59,10 +59,10 @@ You can see this in action with a live demo:
 
 {% example html %}
 <div class="alert alert-warning alert-dismissible fade show" role="alert">
-  <strong>Holy guacamole!</strong> You should check in on some of those fields below.
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>
   </button>
+  <strong>Holy guacamole!</strong> You should check in on some of those fields below.
 </div>
 {% endexample %}
 


### PR DESCRIPTION
The close button's float-right styling requires that its markup appear before the message;
otherwise the styling breaks once the content begins wrapping.