### PR TITLE
Update colors in `_root.scss`

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,11 +1,11 @@
 :root {
   // Custom variable values only support SassScript inside `#{}`.
   @each $color, $value in $colors {
-    --#{$color}: #{$value};
+    --color-#{$color}: #{$value};
   }
 
   @each $color, $value in $theme-colors {
-    --#{$color}: #{$value};
+    --color-#{$color}: #{$value};
   }
 
   @each $bp, $value in $grid-breakpoints {


### PR DESCRIPTION
Jekyll compilator breaks on this file:

```
Error in node_modules/bootstrap/scss/_root.scss:4 Invalid CSS after "...lor}: #{$value}": expected "{", was ";" 
  Liquid Exception: Invalid CSS after "...lor}: #{$value}": expected "{", was ";" in /_layouts/base.html
jekyll 3.5.2 | Error:  Invalid CSS after "...lor}: #{$value}": expected "{", was ";"
```

This fix repair this error