### PR TITLE
Throw error about Popper.js only when it's needed

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -13,14 +13,6 @@ import Util from './util'
 const Dropdown = (($) => {
 
   /**
-   * Check for Popper dependency
-   * Popper - https://popper.js.org
-   */
-  if (typeof Popper === 'undefined') {
-    throw new Error('Bootstrap dropdown require Popper.js (https://popper.js.org)')
-  }
-
-  /**
    * ------------------------------------------------------------------------
    * Constants
    * ------------------------------------------------------------------------
@@ -143,6 +135,14 @@ const Dropdown = (($) => {
 
       if (showEvent.isDefaultPrevented()) {
         return
+      }
+
+      /**
+       * Check for Popper dependency
+       * Popper - https://popper.js.org
+       */
+      if (typeof Popper === 'undefined') {
+        throw new Error('Bootstrap dropdown require Popper.js (https://popper.js.org)')
       }
 
       let element = this._element

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -13,15 +13,6 @@ import Util from './util'
 const Tooltip = (($) => {
 
   /**
-   * Check for Popper dependency
-   * Popper - https://popper.js.org
-   */
-  if (typeof Popper === 'undefined') {
-    throw new Error('Bootstrap tooltips require Popper.js (https://popper.js.org)')
-  }
-
-
-  /**
    * ------------------------------------------------------------------------
    * Constants
    * ------------------------------------------------------------------------
@@ -120,6 +111,13 @@ const Tooltip = (($) => {
   class Tooltip {
 
     constructor(element, config) {
+      /**
+       * Check for Popper dependency
+       * Popper - https://popper.js.org
+       */
+      if (typeof Popper === 'undefined') {
+        throw new Error('Bootstrap tooltips require Popper.js (https://popper.js.org)')
+      }
 
       // private
       this._isEnabled     = true


### PR DESCRIPTION
Throw error about Popper.js only when it's needed because some of our plugins don't use it

As I said here #24572 we throw error on global scope and it break our entire JavaScript, some of our users don't use our Dropdown or Tooltips/Popovers so they don't need to see this error because they don't need Popper.js

Will be very usefull if #24572 is merged :smile: 

Fixes : #24304