### PR TITLE
Remove invalid bower.json (#24584)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,1 +1,0 @@
-@$% Not a Bower package. Use a better package management tool instead. ^&*


### PR DESCRIPTION
Fixes #24584 ("Could you please remove bower.json making it possible for those of us who haven't had time to switch away from Bower to still include Bootstrap (manually) in our projects").

The earlier PR to remove bower support is #23568.

I'm motivated to contribute as part of [Hacktoberfest](https://hacktoberfest.digitalocean.com/).