### PR TITLE
Fix bad title for our dispose method in our documentation

### DIFF
--- a/docs/4.0/components/carousel.md
+++ b/docs/4.0/components/carousel.md
@@ -263,7 +263,7 @@ Cycles to the previous item. **Returns to the caller before the previous item ha
 
 Cycles to the next item. **Returns to the caller before the next item has been shown** (i.e. before the `slid.bs.carousel` event occurs).
 
-### `.carousel('dispose')`
+#### `.carousel('dispose')`
 
 Destroys an element's carousel.
 

--- a/docs/4.0/components/collapse.md
+++ b/docs/4.0/components/collapse.md
@@ -226,7 +226,7 @@ Shows a collapsible element. **Returns to the caller before the collapsible elem
 
 Hides a collapsible element. **Returns to the caller before the collapsible element has actually been hidden** (i.e. before the `hidden.bs.collapse` event occurs).
 
-### `.collapse('dispose')`
+#### `.collapse('dispose')`
 
 Destroys an element's collapse.
 

--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -633,7 +633,7 @@ Manually readjust the modal's position if the height of a modal changes while it
 
 {% highlight js %}$('#myModal').modal('handleUpdate'){% endhighlight %}
 
-### `.modal('dispose')`
+#### `.modal('dispose')`
 
 Destroys an element's modal.
 

--- a/docs/4.0/components/navs.md
+++ b/docs/4.0/components/navs.md
@@ -583,7 +583,7 @@ Selects the given tab and shows its associated pane. Any other tab that was prev
 $('#someTab').tab('show')
 {% endhighlight %}
 
-### .tab('dispose')
+#### .tab('dispose')
 
 Destroys an element's tab.
 

--- a/docs/4.0/components/scrollspy.md
+++ b/docs/4.0/components/scrollspy.md
@@ -280,7 +280,7 @@ $('[data-spy="scroll"]').each(function () {
 })
 {% endhighlight %}
 
-### `.scrollspy('dispose')`
+#### `.scrollspy('dispose')`
 
 Destroys an element's scrollspy.
 


### PR DESCRIPTION
I made a small mistake when I added `dispose` method... 

![image](https://user-images.githubusercontent.com/1689750/32174565-854bed90-bd82-11e7-8296-356f246d2626.png)

![image](https://user-images.githubusercontent.com/1689750/32174619-a183bb50-bd82-11e7-8125-f348d8969a16.png)
