### PR TITLE
Add display utilities link in 'Utilities for layout' docs page

### DIFF
--- a/docs/4.0/layout/utilities-for-layout.md
+++ b/docs/4.0/layout/utilities-for-layout.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Changing `display`
 
-Use our `display` utilities for responsively toggling common values of the `display` property. Mix it with our grid system, content, or components to show or hide them across specific viewports.
+Use our [display utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/) for responsively toggling common values of the `display` property. Mix it with our grid system, content, or components to show or hide them across specific viewports.
 
 ## Flexbox options
 


### PR DESCRIPTION
[Utilities for layout docs page](http://getbootstrap.com/docs/4.0/layout/utilities-for-layout/) already links to `flexbox`, `spacing`, and `visibility` utilities docs, but not to `display` utilities docs. This PR adds the missing link.