### PR TITLE
Changes $list-inline-padding from px to rem

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -280,7 +280,7 @@ $dt-font-weight:              $font-weight-bold !default;
 $kbd-box-shadow:              inset 0 -.1rem 0 rgba($black, .25) !default;
 $nested-kbd-font-weight:      $font-weight-bold !default;
 
-$list-inline-padding:         5px !default;
+$list-inline-padding:         .5rem !default;
 
 $mark-bg:                     #fcf8e3 !default;
 


### PR DESCRIPTION
Changes `$list-inline-padding` from `5px` to `.5rem`

It not only changes `px` to `rem` but also increases the space a bit so items doen't look so close together.