### PR TITLE
Support $grid-gutter-widths for responsive gutter widths

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -191,6 +191,15 @@ $container-max-widths: (
 $grid-columns:                12 !default;
 $grid-gutter-width:           30px !default;
 
+$grid-gutter-widths: (
+  xs: $grid-gutter-width,     // 30px
+  sm: $grid-gutter-width,     // 30px
+  md: $grid-gutter-width,     // 30px
+  lg: $grid-gutter-width,     // 30px
+  xl: $grid-gutter-width      // 30px
+) !default;
+
+
 // Components
 //
 // Define common padding and border radius sizes and more.

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -25,10 +25,20 @@
       @extend %grid-column;
     }
 
+    // Allow gutter width to be different depending on breakpoints
     @include media-breakpoint-only($breakpoint, $breakpoints) {
       $gutter: map-get($gutters, $breakpoint);
 
-      .col {
+      @for $i from 1 through $columns {
+        .col#{$infix}-#{$i} {
+          padding-left: ($gutter / 2);
+          padding-right: ($gutter / 2);
+        }
+      }
+
+      .col,
+      .col#{$infix},
+      .col#{$infix}-auto {
         padding-left: ($gutter / 2);
         padding-right: ($gutter / 2);
       }

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -39,13 +39,13 @@
       .col,
       .col#{$infix},
       .col#{$infix}-auto {
-        padding-left: ($gutter / 2);
         padding-right: ($gutter / 2);
+        padding-left: ($gutter / 2);
       }
 
       .row {
-        margin-left: ($gutter / -2);
         margin-right: ($gutter / -2);
+        margin-left: ($gutter / -2);
       }
     }
 

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -3,14 +3,12 @@
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `$grid-columns`.
 
-@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
+@mixin make-grid-columns($columns: $grid-columns, $gutters: $grid-gutter-widths, $breakpoints: $grid-breakpoints) {
   // Common properties for all breakpoints
   %grid-column {
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
   }
 
   @each $breakpoint in map-keys($breakpoints) {
@@ -25,6 +23,20 @@
     .col#{$infix},
     .col#{$infix}-auto {
       @extend %grid-column;
+    }
+
+    @include media-breakpoint-only($breakpoint, $breakpoints) {
+      $gutter: map-get($gutters, $breakpoint);
+
+      .col {
+        padding-left: ($gutter / 2);
+        padding-right: ($gutter / 2);
+      }
+
+      .row {
+        margin-left: ($gutter / -2);
+        margin-right: ($gutter / -2);
+      }
     }
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -31,8 +31,8 @@
 
       @for $i from 1 through $columns {
         .col#{$infix}-#{$i} {
-          padding-left: ($gutter / 2);
           padding-right: ($gutter / 2);
+          padding-left: ($gutter / 2);
         }
       }
 


### PR DESCRIPTION
This is actually a missing feature that appears on the doc: 

Variable : `$grid-gutter-widths`
https://v4-alpha.getbootstrap.com/layout/grid/#variables

This approach aims to define different gutter widths depending on the defined breakpoints.