### PR TITLE
Add responsive variations for sizing

### DIFF
--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -4,7 +4,12 @@
 
 @each $prop, $abbrev in (width: w, height: h) {
   @each $size, $length in $sizes {
-    .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+    @each $breakpoint in map-keys($grid-breakpoints) {
+      @include media-breakpoint-up($breakpoint) {
+        $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+        .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

With this kind of code:
```html
<div class="card-body">
    <h2 class="card-title font-weight-light">Dashboard Features</h2>
    <div class="row mx-auto py-3">
        <div class="col-sm">
            <h3>Email alerts</h3>
            <p>Get an email everytime a new comment appears on one of your journal's publications.</p>
        </div>
        <div class="col-sm">
            <h3>Journal dedicated recent comments</h3>
            <p>The dashboard holds a list of the most recent comments on your journal's publications.</p>
        </div>
        <div class="col-sm">
            <h3>Invite colleagues to your journal's dashboard</h3>
            <p>You may invite collaborators to your dashboard  who can also choose to be alerted to new comments on your journal.</p>
        </div>
        <div class="col-sm">
            <h3>Journal dedicated search</h3>
            <p>Search through all your journal's publications comments for authors, commenters, comments' content, …</p>
        </div>
        <div class="col-sm">
            <h3>Number of commented publications</h3>
            <p>Get the number of your journal's commented publications.</p>
        </div>
    </div>
    <div class="row mx-auto w-lg-75 py-3">
        <div class="col-sm">
            <h3>Certified Journal response</h3>
            <p>Leave official Journal responses on PubPeer.</p>
        </div>
        <div class="col-sm">
            <h3>Acknowledge comments</h3>
            <p>Let PubPeer users know that your journal has seen a comments.</p>
        </div>
        <div class="col-sm">
            <h3>Free trial period</h3>
            <p>Try out Journal Dashboard for free.</p>
        </div>
        <div class="col-sm">
            <h3>PubPeer statistics</h3>
            <p>Access stats such as the number of page views for each PubPeer thread.</p>
        </div>
    </div>
</div>
```

My page looks like this on large:

![capture d ecran 2017-10-31 a 15 28 20](https://user-images.githubusercontent.com/1185840/32229119-6595cea2-be50-11e7-8895-fcf976c4b525.png)

And will look like this on smaller screen:

![capture d ecran 2017-10-31 a 15 28 32](https://user-images.githubusercontent.com/1185840/32229174-84725b24-be50-11e7-902c-10c9703aa15a.png)

Would that be a good idea for Bootstrap?

Thanks for your attention.

Xavier
