### PR TITLE
update README, use next tag for npm, yarn installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://getbootstrap.com/">
-    <img src="https://getbootstrap.com/assets/brand/bootstrap-solid.svg" alt="" width=72 height=72>
+    <img src="https://getbootstrap.com/assets/brand/bootstrap-solid.svg" alt="Bootstrap" width=150 height=150>
   </a>
-
   <h3 align="center">Bootstrap</h3>
+  <h5 align="center">(v4.0.0-beta.2)</h5>
 
   <p align="center">
     Sleek, intuitive, and powerful front-end framework for faster and easier web development.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Several quick start options are available:
 
 - [Download the latest release.](https://github.com/twbs/bootstrap/archive/v4.0.0-beta.2.zip)
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
-- Install with [npm](https://www.npmjs.com/): `npm install bootstrap@4.0.0-beta.2`
-- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@4.0.0-beta.2`
+- Install with [npm](https://www.npmjs.com/): `npm install bootstrap@next`
+- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@next`
 - Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:4.0.0-beta.2`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).
 


### PR DESCRIPTION
use next tag to always install the latest version of bootstrap published to the registry