### PR TITLE
fix: block display of tables

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -164,7 +164,6 @@
 
     &#{$infix} {
       @include media-breakpoint-down($breakpoint) {
-        display: block;
         width: 100%;
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
I am really not sure of this. But is it necessary for a table to have block property for tables?

As mentioned here in [docs](https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables)

```
<table class="table table-responsive">
  ...
</table>
```

`display: block` seems to override the table property


