### PR TITLE
Object spread : less jQuery more ES6

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -10,6 +10,7 @@ module.exports = {
     ]
   ],
   plugins: [
-    process.env.PLUGINS && 'transform-es2015-modules-strip'
+    process.env.PLUGINS && 'transform-es2015-modules-strip',
+    '@babel/proposal-object-rest-spread'
   ].filter(Boolean)
 };

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -15,7 +15,8 @@ const plugins = [
     externalHelpersWhitelist: [ // include only required helpers
       'defineProperties',
       'createClass',
-      'inheritsLoose'
+      'inheritsLoose',
+      'extends'
     ]
   })
 ]

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -223,7 +223,10 @@ const Carousel = (($) => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = {
+        ...Default,
+        ...config
+      }
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
     }
@@ -428,10 +431,16 @@ const Carousel = (($) => {
     static _jQueryInterface(config) {
       return this.each(function () {
         let data      = $(this).data(DATA_KEY)
-        const _config = $.extend({}, Default, $(this).data())
+        let _config = {
+          ...Default,
+          ...$(this).data()
+        }
 
         if (typeof config === 'object') {
-          $.extend(_config, config)
+          _config = {
+            ..._config,
+            ...config
+          }
         }
 
         const action = typeof config === 'string' ? config : _config.slide
@@ -468,7 +477,10 @@ const Carousel = (($) => {
         return
       }
 
-      const config     = $.extend({}, $(target).data(), $(this).data())
+      const config = {
+        ...$(target).data(),
+        ...$(this).data()
+      }
       const slideIndex = this.getAttribute('data-slide-to')
 
       if (slideIndex) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -277,7 +277,10 @@ const Collapse = (($) => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = {
+        ...Default,
+        ...config
+      }
       config.toggle = Boolean(config.toggle) // coerce string values
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
@@ -338,12 +341,11 @@ const Collapse = (($) => {
       return this.each(function () {
         const $this   = $(this)
         let data      = $this.data(DATA_KEY)
-        const _config = $.extend(
-          {},
-          Default,
-          $this.data(),
-          typeof config === 'object' && config
-        )
+        const _config = {
+          ...Default,
+          ...$this.data(),
+          ...typeof config === 'object' && config
+        }
 
         if (!data && _config.toggle && /show|hide/.test(config)) {
           _config.toggle = false

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -210,12 +210,11 @@ const Dropdown = (($) => {
     }
 
     _getConfig(config) {
-      config = $.extend(
-        {},
-        this.constructor.Default,
-        $(this._element).data(),
-        config
-      )
+      config = {
+        ...this.constructor.Default,
+        ...$(this._element).data(),
+        ...config
+      }
 
       Util.typeCheckConfig(
         NAME,
@@ -262,7 +261,10 @@ const Dropdown = (($) => {
       const offsetConf = {}
       if (typeof this._config.offset === 'function') {
         offsetConf.fn = (data) => {
-          data.offsets = $.extend({}, data.offsets, this._config.offset(data.offsets) || {})
+          data.offsets = {
+            ...data.offsets,
+            ...this._config.offset(data.offsets) || {}
+          }
           return data
         }
       } else {

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -227,7 +227,10 @@ const Modal = (($) => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = {
+        ...Default,
+        ...config
+      }
       Util.typeCheckConfig(NAME, config, DefaultType)
       return config
     }
@@ -506,12 +509,11 @@ const Modal = (($) => {
     static _jQueryInterface(config, relatedTarget) {
       return this.each(function () {
         let data      = $(this).data(DATA_KEY)
-        const _config = $.extend(
-          {},
-          Modal.Default,
-          $(this).data(),
-          typeof config === 'object' && config
-        )
+        const _config = {
+          ...Modal.Default,
+          ...$(this).data(),
+          ...typeof config === 'object' && config
+        }
 
         if (!data) {
           data = new Modal(this, _config)
@@ -547,7 +549,10 @@ const Modal = (($) => {
     }
 
     const config = $(target).data(DATA_KEY) ?
-      'toggle' : $.extend({}, $(target).data(), $(this).data())
+      'toggle' : {
+        ...$(target).data(),
+        ...$(this).data()
+      }
 
     if (this.tagName === 'A' || this.tagName === 'AREA') {
       event.preventDefault()

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -26,19 +26,25 @@ const Popover = (($) => {
   const CLASS_PREFIX        = 'bs-popover'
   const BSCLS_PREFIX_REGEX  = new RegExp(`(^|\\s)${CLASS_PREFIX}\\S+`, 'g')
 
-  const Default = $.extend({}, Tooltip.Default, {
-    placement : 'right',
-    trigger   : 'click',
-    content   : '',
-    template  : '<div class="popover" role="tooltip">'
-              + '<div class="arrow"></div>'
-              + '<h3 class="popover-header"></h3>'
-              + '<div class="popover-body"></div></div>'
-  })
+  const Default = {
+    ...Tooltip.Default,
+    ...{
+      placement : 'right',
+      trigger   : 'click',
+      content   : '',
+      template  : '<div class="popover" role="tooltip">'
+                + '<div class="arrow"></div>'
+                + '<h3 class="popover-header"></h3>'
+                + '<div class="popover-body"></div></div>'
+    }
+  }
 
-  const DefaultType = $.extend({}, Tooltip.DefaultType, {
-    content : '(string|element|function)'
-  })
+  const DefaultType = {
+    ...Tooltip.DefaultType,
+    ...{
+      content : '(string|element|function)'
+    }
+  }
 
   const ClassName = {
     FADE : 'fade',

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -171,7 +171,10 @@ const ScrollSpy = (($) => {
     // private
 
     _getConfig(config) {
-      config = $.extend({}, Default, config)
+      config = {
+        ...Default,
+        ...config
+      }
 
       if (typeof config.target !== 'string') {
         let id = $(config.target).attr('id')

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -501,10 +501,13 @@ const Tooltip = (($) => {
       })
 
       if (this.config.selector) {
-        this.config = $.extend({}, this.config, {
-          trigger  : 'manual',
-          selector : ''
-        })
+        this.config = {
+          ...this.config,
+          ...{
+            trigger  : 'manual',
+            selector : ''
+          }
+        }
       } else {
         this._fixTitle()
       }
@@ -613,12 +616,11 @@ const Tooltip = (($) => {
     }
 
     _getConfig(config) {
-      config = $.extend(
-        {},
-        this.constructor.Default,
-        $(this.element).data(),
-        config
-      )
+      config = {
+        ...this.constructor.Default,
+        ...$(this.element).data(),
+        ...config
+      }
 
       if (typeof config.delay === 'number') {
         config.delay = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "chokidar": "1.7.0",
         "commander": "2.11.0",
         "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
+        "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "output-file-sync": "2.0.0",
@@ -580,7 +580,7 @@
         "@babel/plugin-transform-template-literals": "7.0.0-beta.31",
         "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.31",
         "@babel/plugin-transform-unicode-regex": "7.0.0-beta.31",
-        "browserslist": "2.8.0",
+        "browserslist": "2.9.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -704,7 +704,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "anymatch": {
@@ -862,7 +862,7 @@
       "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
       "dev": true,
       "requires": {
-        "browserslist": "2.8.0",
+        "browserslist": "2.9.0",
         "caniuse-lite": "1.0.30000760",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
@@ -1111,9 +1111,9 @@
       }
     },
     "browserslist": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.8.0.tgz",
-      "integrity": "sha512-iiWHM1Et6Q4TQpB7Ar6pxuM3TNMXasVJY4Y/oh3q38EwR3Z+IdZ9MyVf7PI4MJFB4xpwMcZgs9bEUnPG2E3TCA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
+      "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000760",
@@ -1143,7 +1143,7 @@
       "requires": {
         "axios": "0.16.2",
         "bytes": "3.0.0",
-        "ci-env": "1.4.0",
+        "ci-env": "1.5.2",
         "commander": "2.11.0",
         "github-build": "1.2.0",
         "glob": "7.1.2",
@@ -1250,9 +1250,9 @@
       }
     },
     "ci-env": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.4.0.tgz",
-      "integrity": "sha512-IRvBrZSkdlsHgGZtaM41WBHJKEHpheqMO6B8lHN452zHiKN0imDcDjI9rIqIA4Y5/2uOAxnA8yYqWBzoYqxMMQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.5.2.tgz",
+      "integrity": "sha512-6NSB3PSw6L7w9vqmlTveD1JpaOhngFYRqhFKNPtSLpx8kpu/3BZwf84Sz8+hsmDzaD+ITuuiNdN6ya5c2DhHWg==",
       "dev": true
     },
     "circular-json": {
@@ -1373,9 +1373,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1810,9 +1810,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
-      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
+      "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
       "dev": true,
       "requires": {
         "ajv": "5.3.0",
@@ -1823,7 +1823,7 @@
         "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -1836,7 +1836,7 @@
         "inquirer": "3.0.6",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -1884,7 +1884,7 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "browserslist": "2.8.0",
+        "browserslist": "2.9.0",
         "caniuse-db": "1.0.30000760",
         "requireindex": "1.1.0"
       }
@@ -1900,9 +1900,9 @@
       }
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -2315,9 +2315,9 @@
       }
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -3362,14 +3362,11 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4052,9 +4049,9 @@
       }
     },
     "node-sass": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.0.tgz",
-      "integrity": "sha512-rh0CvkxpYdQdbWx4EQfunmG0+99BVyVwQHlFE+yUzc6lteF5K3WUcJ0bdmv9E9CqQA1RfuMyvmpDP99cmBObow==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.1.tgz",
+      "integrity": "sha512-0zQQ7tjEK5W8RfW9LiQrkzfo7uLZ0QtZGV69rdKn5cFzdweHLJ14lR6xLPvI6UimkXMO8m0qDsXwUCNdnqV3sA==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -4736,9 +4733,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.6.tgz",
-      "integrity": "sha512-wZlMkIJM1hFcM9F7nSrRCbKKfkH0kk/GrCoj3EUoKU8kx9xPtvnOZNHKsQOM12+xqbYv2HeBWI8Y8pxb6vmnRQ==",
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.7.tgz",
+      "integrity": "sha1-uNIlYY5dleJ6wrWR3r9YGFepwW0=",
       "dev": true
     },
     "postcss": {
@@ -4882,9 +4879,9 @@
       }
     },
     "postcss-less": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.2.tgz",
-      "integrity": "sha512-zRMQLHjD5BsnKOPAr+jCw3M5NoHoEANJ1xg8ftu0lpfRailrchh3spt9n6jFdBF/WGpI8Q+Ch21QnLlLaKGxnA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
+      "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
       "dev": true,
       "requires": {
         "postcss": "5.2.18"
@@ -5610,9 +5607,9 @@
       }
     },
     "rollup": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.1.tgz",
-      "integrity": "sha512-XW+ITD31w/Y8AlC2F5A+6wIBc+aIDUfY2z4eAkJRIq78l+dchU9zlfJ51WWuVxTNR08q4g8AUAw7M3s2vWxEmg==",
+      "version": "0.51.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.5.tgz",
+      "integrity": "sha512-nvwUduO53TvWigOaOv7t+rNoEUW53sTUeqMAjlxp7ekeHirPECnWXSwiPwiqvGNdbJTQbOdHFPAZZfjo61BtVQ==",
       "dev": true
     },
     "rollup-plugin-babel": {
@@ -6188,7 +6185,7 @@
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
         "postcss": "6.0.14",
-        "postcss-less": "1.1.2",
+        "postcss-less": "1.1.3",
         "postcss-media-query-parser": "0.2.3",
         "postcss-reporter": "5.0.0",
         "postcss-resolve-nested-selector": "0.1.1",
@@ -6500,9 +6497,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.8.tgz",
-      "integrity": "sha512-1lnTkrJWw6LJ7n43ZyYVXx0eN2PQh0c3Inb0nY/vj5fNfwykXQFif2kvNgm/Bf0ClLA8R6SKaMHFzo9io4Q+vg==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.9.tgz",
+      "integrity": "sha512-ari2E89bD7f+fMU173NgF12JBcOhgoxeyuCs97h5K58IBENrnG9eVj2lFadrOPdqf0KifsxVmUQfzA2cHNxCZQ==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",


### PR DESCRIPTION
This PR will remove the use of `$.extend` in favor of this awesome ES6 feature : https://babeljs.io/docs/plugins/transform-object-rest-spread/ which will do the same as `$.extend` but without jQuery :smile: 

Currently I only made the change for our Tooltips but if everybody is ok I'll do the same for our other plugins :+1: 