### PR TITLE
Separate font-family setting for SVG (#24673)

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -276,6 +276,9 @@ img {
 
 svg:not(:root) {
   overflow: hidden; // Hide the overflow in IE
+  // Workaround Chrome performance issue,
+  // see: https://github.com/twbs/bootstrap/issues/24673
+  font-family: $font-family-svg;
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -222,6 +222,7 @@ $transition-collapse:         height .35s ease !default;
 // stylelint-disable value-keyword-case
 $font-family-sans-serif:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 $font-family-monospace:       "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
+$font-family-svg:             sans-serif !default;
 $font-family-base:            $font-family-sans-serif !default;
 // stylelint-enable value-keyword-case
 


### PR DESCRIPTION
Workaround for #24673. See <https://crbug.com/781344> for details.