### PR TITLE
Allow users to customize focus and active button states.

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -357,7 +357,11 @@ $btn-font-weight:             $font-weight-normal !default;
 $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
 $btn-focus-width:             $input-btn-focus-width !default;
 $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
+$btn-focus-bg-lightness:      -7.5% !default;
+$btn-focus-border-lightness:  -10% !default;
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
+$btn-active-bg-lightness:     -10% !default;
+$btn-active-border-lightness: -12.5% !default;
 
 $btn-link-disabled-color:     $gray-600 !default;
 

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -3,7 +3,13 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
-@mixin button-variant($background, $border, $hover-background: darken($background, 7.5%), $hover-border: darken($border, 10%), $active-background: darken($background, 10%), $active-border: darken($border, 12.5%)) {
+@mixin button-variant(
+  $background,
+  $border,
+  $hover-background: adjust-color($background, $lightness: $btn-focus-bg-lightness),
+  $hover-border: adjust-color($border, $lightness: $btn-focus-border-lightness),
+  $active-background: adjust-color($background, $lightness: $btn-active-bg-lightness),
+  $active-border: adjust-color($border, $lightness: $btn-active-border-lightness)) {
   color: color-yiq($background);
   @include gradient-bg($background);
   border-color: $border;


### PR DESCRIPTION
This enhancement of the buttons mixin allows the user the following adjustments in `_variables.scss`:

- Adjust the percentages of the `:focus` and `:active` state color function
- Either 'lighten' or 'darken' the states by using a positive or negative value
- Mix 'lighten' and 'darken' states