### PR TITLE
Display Headings - add variable and breakpoints

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -25,28 +25,22 @@ h6, .h6 { font-size: $h6-font-size; }
   font-weight: $lead-font-weight;
 }
 
+//
 // Type display classes
-.display-1 {
-  font-size: $display1-size;
-  font-weight: $display1-weight;
-  line-height: $display-line-height;
-}
-.display-2 {
-  font-size: $display2-size;
-  font-weight: $display2-weight;
-  line-height: $display-line-height;
-}
-.display-3 {
-  font-size: $display3-size;
-  font-weight: $display3-weight;
-  line-height: $display-line-height;
-}
-.display-4 {
-  font-size: $display4-size;
-  font-weight: $display4-weight;
-  line-height: $display-line-height;
-}
+//
 
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    @each $number, $map in $display-headings {
+      .display#{$infix}-#{$number}   {
+        font-size:   map-get($map, 'font-size');
+        font-weight: map-get($map, 'font-weight');
+        line-height: map-get($map, 'line-height');
+      }
+    }
+  }
+}
 
 //
 // Horizontal rules

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -260,6 +260,30 @@ $display3-weight:             300 !default;
 $display4-weight:             300 !default;
 $display-line-height:         $headings-line-height !default;
 
+$display-headings: () !default;
+$display-headings:  map-merge((
+  1: (
+    "font-size":   $display1-size,
+    "font-weight": $display1-weight,
+    "line-height": $display-line-height,
+  ),
+  2: (
+    "font-size":   $display2-size,
+    "font-weight": $display2-weight,
+    "line-height": $display-line-height,
+  ),
+  3: (
+    "font-size":   $display3-size,
+    "font-weight": $display3-weight,
+    "line-height": $display-line-height,
+  ),
+  4: (
+    "font-size":   $display4-size,
+    "font-weight": $display4-weight,
+    "line-height": $display-line-height,
+  )
+), $display-headings);
+
 $lead-font-size:              ($font-size-base * 1.25) !default;
 $lead-font-weight:            300 !default;
 


### PR DESCRIPTION
- Add breakpoint mappings for display-x
- Use $display-headings map to allow for extending like $theme-colors