### PR TITLE
Custom select focus border

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -57,6 +57,7 @@
       border-color: $color;
 
       &:focus {
+        border-color: $color;
         box-shadow: 0 0 0 $input-focus-width rgba($color, .25);
       }
 


### PR DESCRIPTION
Overrides the `border-color` on focus of custom selects with form validation states applied.

Fixes #24553.