### PR TITLE
Clean up the reset code for button's rounded corners in button group and input button

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -54,8 +54,7 @@
     float: left;
   }
 
-  // Reset rounded corners individual because sometimes a single button can be
-  // in a .btn-group and we need :first-child and :last-child to both match.
+  // Reset rounded corners
   > .btn:not(:last-child):not(.dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
     @include border-right-radius(0);

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -44,46 +44,27 @@
 }
 
 .btn-group {
-  > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
-    border-radius: 0;
-  }
-
-  // Set corners individual because sometimes a single button can be in a .btn-group
-  // and we need :first-child and :last-child to both match
   > .btn:first-child {
     margin-left: 0;
-
-    &:not(:last-child):not(.dropdown-toggle) {
-      @include border-right-radius(0);
-    }
   }
 
-
-  // Need .dropdown-toggle since :last-child doesn't apply given a .dropdown-menu
-  // immediately after it
-  > .btn:last-child:not(:first-child),
-  > .dropdown-toggle:not(:first-child) {
-    @include border-left-radius(0);
-  }
-
-  // Custom edits for including btn-groups within btn-groups (useful for including
+  // Alignment for including btn-groups within btn-groups (useful for including
   // dropdown buttons within a btn-group)
   > .btn-group {
     float: left;
   }
 
-  > .btn-group:not(:first-child):not(:last-child) > .btn {
-    border-radius: 0;
+  // Reset rounded corners individual because sometimes a single button can be
+  // in a .btn-group and we need :first-child and :last-child to both match.
+  // Use :last-of-type since :last-child doesn't apply given a .dropdown-menu
+  // immediately after .btn.
+  > .btn:not(:last-of-type),
+  > .btn-group:not(:last-child) > .btn {
+    @include border-right-radius(0);
   }
 
-  > .btn-group:first-child:not(:last-child) {
-    > .btn:last-child,
-    > .dropdown-toggle {
-      @include border-right-radius(0);
-    }
-  }
-
-  > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  > .btn:not(:first-child),
+  > .btn-group:not(:first-child) > .btn {
     @include border-left-radius(0);
   }
 }

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -132,32 +132,14 @@
     margin-left: 0;
   }
 
-  > .btn {
-    &:not(:first-child):not(:last-child) {
-      border-radius: 0;
-    }
-
-    &:first-child:not(:last-child) {
-      @include border-bottom-radius(0);
-    }
-
-    &:last-child:not(:first-child) {
-      @include border-top-radius(0);
-    }
+  // Reset rounded corners
+  > .btn:not(:last-child):not(.dropdown-toggle),
+  > .btn-group:not(:last-child) > .btn {
+    @include border-bottom-radius(0);
   }
 
-  > .btn-group:not(:first-child):not(:last-child) > .btn {
-    border-radius: 0;
-  }
-
-  > .btn-group:first-child:not(:last-child) {
-    > .btn:last-child,
-    > .dropdown-toggle {
-      @include border-bottom-radius(0);
-    }
-  }
-
-  > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  > .btn:not(:first-child),
+  > .btn-group:not(:first-child) > .btn {
     @include border-top-radius(0);
   }
 }

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -56,9 +56,7 @@
 
   // Reset rounded corners individual because sometimes a single button can be
   // in a .btn-group and we need :first-child and :last-child to both match.
-  // Use :last-of-type since :last-child doesn't apply given a .dropdown-menu
-  // immediately after .btn.
-  > .btn:not(:last-of-type),
+  > .btn:not(:last-child):not(.dropdown-toggle),
   > .btn-group:not(:last-child) > .btn {
     @include border-right-radius(0);
   }

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -120,8 +120,7 @@
 .input-group-addon:not(:last-child),
 .input-group-btn:not(:last-child) > .btn,
 .input-group-btn:not(:last-child) > .btn-group > .btn,
-.input-group-btn:not(:last-child) > .dropdown-toggle,
-.input-group-btn:not(:first-child) > .btn:not(:last-child):not(.dropdown-toggle),
+.input-group-btn:last-child > .btn:not(:last-of-type),
 .input-group-btn:not(:first-child) > .btn-group:not(:last-child) > .btn {
   @include border-right-radius(0);
 }
@@ -136,7 +135,6 @@
 .input-group-addon:not(:first-child),
 .input-group-btn:not(:first-child) > .btn,
 .input-group-btn:not(:first-child) > .btn-group > .btn,
-.input-group-btn:not(:first-child) > .dropdown-toggle,
 .input-group-btn:not(:last-child) > .btn:not(:first-child),
 .input-group-btn:not(:last-child) > .btn-group:not(:first-child) > .btn {
   @include border-left-radius(0);

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -35,10 +35,6 @@
 .input-group .custom-file {
   display: flex;
   align-items: center;
-
-  &:not(:first-child):not(:last-child) {
-    @include border-radius(0);
-  }
 }
 
 .input-group .custom-file {

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -120,7 +120,7 @@
 .input-group-addon:not(:last-child),
 .input-group-btn:not(:last-child) > .btn,
 .input-group-btn:not(:last-child) > .btn-group > .btn,
-.input-group-btn:last-child > .btn:not(:last-of-type),
+.input-group-btn:not(:first-child) > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group-btn:not(:first-child) > .btn-group:not(:last-child) > .btn {
   @include border-right-radius(0);
 }


### PR DESCRIPTION
A `.dropdown-toggle` selector is used to reset a button's rounded corner in button group and input button. But should not use a `dropdown-toggle` selector to reset it, because `dropdown-toggle` does not have rounded corners by default.

This PR including the follwings:
- Use `last-of-type` selector instead of `.dropdown-toggle`
- Remove `border-raduis :0` because it is enough by each reset of the left and right side

I hope that this PR will help improve code. Thanks.