### PR TITLE
Fix test failure with jQuery 1.9.1

### DIFF
--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -158,7 +158,7 @@ $(function () {
 
   QUnit.test('should handle disabled attribute on non-button elements', function (assert) {
     assert.expect(2)
-    var groupHTML = '  <div class="btn-group disabled" data-toggle="buttons" aria-disabled="true" disabled>'
+    var groupHTML = '<div class="btn-group disabled" data-toggle="buttons" aria-disabled="true" disabled>'
       + '<label class="btn btn-danger disabled" aria-disabled="true" disabled>'
       + '<input type="checkbox" aria-disabled="true" autocomplete="off" disabled class="disabled"/>'
       + '</label>'


### PR DESCRIPTION
1.10.x and newer work fine, this was an issue in 1.9.x.