### PR TITLE
Adds underline back to `btn-link` on focus

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -86,6 +86,7 @@ fieldset[disabled] a.btn {
 
   &:focus,
   &.focus {
+    text-decoration: $link-hover-decoration;
     border-color: transparent;
     box-shadow: none;
   }


### PR DESCRIPTION
During this clean up: https://github.com/twbs/bootstrap/commit/cd22eb1da03d5dbc9062ad5c9e75c05429e4bcd0 we removed the focus state indication for `btn-link`. Even though links don't have an underline and btn-link should mimic links they are missing some indication of the item been focus.

This PR closes #24720 and brings back the underline. Thanks @timfish 