### PR TITLE
Fix nested cards on card group

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -172,14 +172,17 @@
   display: flex;
   flex-direction: column;
 
-  .card {
+  // The child selector allows nested `.card` within `.card-group`
+  // to display properly.
+  > .card {
     margin-bottom: $card-group-margin;
   }
 
   @include media-breakpoint-up(sm) {
     flex-flow: row wrap;
-
-    .card {
+    // The child selector allows nested `.card` within `.card-group`
+    // to display properly.
+    > .card {
       // Flexbugs #4: https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
       flex: 1 0 0%;
       margin-bottom: 0;


### PR DESCRIPTION
This PR fixes #24752 and it adds a child selector to `.card` inside .`card-group` so it the styles are scoped to that child and don't get inherited.

I've tested with nested cards and nested card-groups with headers and footers.

Thanks a lot @jhhazelaar and @gijsbotje 