### PR TITLE
fix(build): Use UMD and fix build to properly load deps

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -37,7 +37,7 @@ module.exports = {
   input: path.resolve(__dirname, '../js/src/index.js'),
   output: {
     file: path.resolve(__dirname, `../dist/js/${fileDest}`),
-    format: 'iife'
+    format: 'umd'
   },
   name: 'bootstrap',
   external,

--- a/docs/4.0/getting-started/webpack.md
+++ b/docs/4.0/getting-started/webpack.md
@@ -26,25 +26,9 @@ import 'bootstrap/js/dist/dropdown';
 ...
 {% endhighlight %}
 
-Bootstrap is dependent on [jQuery](https://jquery.com/) and [Popper](https://popper.js.org/), so npm will install them for you if needed. But they must be explicitly provided by webpack. Add the following code to the `plugins` section in your webpack config file:
-
-{% highlight js %}
-  // don't forget to import webpack (using import or require) to use webpack.ProvidePlugin
-  plugins: [
-    ...
-      new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-        'window.jQuery': 'jquery',
-        Popper: ['popper.js', 'default'],
-        // In case you imported plugins individually, you must also require them here:
-        Util: "exports-loader?Util!bootstrap/js/dist/util",
-        Dropdown: "exports-loader?Dropdown!bootstrap/js/dist/dropdown",
-        ...
-      })
-    ...
-  ]
-{% endhighlight %}
+Bootstrap is dependent on [jQuery](https://jquery.com/) and [Popper](https://popper.js.org/),
+these are defined as `peerDependencies`, this means that you will have to make sure to add both of them
+to your `package.json` using `npm --save jquery popper.js`.
 
 {% callout warning %}
 Notice that if you chose to **import plugins individually**, you must also install [exports-loader](https://github.com/webpack-contrib/exports-loader)


### PR DESCRIPTION
This PR aims to fix the dependencies problem of Bootstrap and its dependencies.

With the changes proposed in this PR, both the "vanilla" and the webpack/rollup approaches will work out of the box without any additional configuration.

Example of vanilla usage:

```html
<!DOCTYPE html>

<head>
    <title>Bootstrap test</title>
    <link href="node_modules/bootstrap/dist/css/bootstrap.css" rel="stylesheet" />
</head>

<body>
    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
        Tooltip on top
    </button>
    <script src="node_modules/jquery/dist/jquery.js"></script>
    <script src="node_modules/popper.js/dist/umd/popper.js"></script>
    <script src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
    <script>
        $(function () {
            $('[data-toggle="tooltip"]').tooltip();
        });
    </script>
</body>
```

Example of webpack usage:
```html
<!-- index.html -->
<!DOCTYPE html>

<head>
    <title>Bootstrap test</title>
    <link href="node_modules/bootstrap/dist/css/bootstrap.css" rel="stylesheet" />
</head>

<body>
    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
        Tooltip on top
    </button>
    <script src="./bundle.js"></script>
</body>
```

```js
// index.js
import $ from 'jquery';
import 'bootstrap';

$(function() {
  $('[data-toggle="tooltip"]').tooltip();
});
```

```js
// webpack.config.js
module.exports = {
  entry: './index.js',
  output: {
    filename: './bundle.js',
  },
  resolve: {
    modules: [`${__dirname}/node_modules`],
  },
};
```