### PR TITLE
Custom file focus styling for firefox keyboard users

### DIFF
--- a/js/src/helper.js
+++ b/js/src/helper.js
@@ -70,7 +70,7 @@ const Helper = (() => {
   $(document).on(Event.INPUTFOCUSIN, Selector.CUSTOMFILE, handleFocusin)
   $(document).on(Event.INPUTFOCUSOUT, Selector.CUSTOMFILE, handleFocusout)
   $(document).on(Event.FORMRESET, Selector.FORM, handleFormReset)
-  
+
 })($)
 
 export default Helper

--- a/js/src/helper.js
+++ b/js/src/helper.js
@@ -44,10 +44,12 @@ const Helper = (() => {
   }
 
   function handleFocusin() {
+    // Needed for keyboard users in firefox
     $(this).addClass('focus')
   }
 
   function handleFocusout() {
+    // Needed for keyboard users in firefox
     $(this).removeClass('focus')
   }
 

--- a/js/src/helper.js
+++ b/js/src/helper.js
@@ -25,8 +25,10 @@ const Helper = (() => {
   }
 
   const Event = {
-    INPUTCHANGE : `change${EVENT_KEY}`,
-    FORMRESET   : `reset${EVENT_KEY}`
+    INPUTCHANGE   : `change${EVENT_KEY}`,
+    FORMRESET     : `reset${EVENT_KEY}`,
+    INPUTFOCUSIN  : `focusin${EVENT_KEY}`,
+    INPUTFOCUSOUT : `focusout${EVENT_KEY}`
   }
 
   const ClassName = {
@@ -39,6 +41,14 @@ const Helper = (() => {
     if ($fileControl.length === 1) {
       $fileControl.text(this.value)
     }
+  }
+
+  function handleFocusin() {
+    $(this).addClass('focus')
+  }
+
+  function handleFocusout() {
+    $(this).removeClass('focus')
   }
 
   function handleFormReset() {
@@ -55,7 +65,10 @@ const Helper = (() => {
    */
 
   $(document).on(Event.INPUTCHANGE, Selector.CUSTOMFILE, handleInputChange)
+  $(document).on(Event.INPUTFOCUSIN, Selector.CUSTOMFILE, handleFocusin)
+  $(document).on(Event.INPUTFOCUSOUT, Selector.CUSTOMFILE, handleFocusout)
   $(document).on(Event.FORMRESET, Selector.FORM, handleFormReset)
+  
 })($)
 
 export default Helper

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -205,7 +205,8 @@
   margin: 0;
   opacity: 0;
 
-  &:focus ~ .custom-file-control {
+  &:focus ~ .custom-file-control,
+  &.focus ~ .custom-file-control {
     box-shadow: $custom-file-focus-box-shadow;
   }
 }


### PR DESCRIPTION
Firefox does not correctly work with the `input[type="file"]:focus ~ .custom-file-control` sibling selector, as it considers the browse button inside the file input to have focus and not the actual `input[type="file"`), when either clicking the browse button or tabbing into the input.

See the answer for question https://stackoverflow.com/questions/20095105/input-type-file-focus-adjacent-selector-in-css (its an old question from 2015, but it is still applicable).

**Proposed solution:**
The `<label>` wrapper does make focus styling work for mouse users, but does not work for keyboard users (the inner browse button of the file input gets focus, not the actual file input when tabbing into the file input).

Adding a `focusin`/`focusout` handler (in `helpers.js`) that adds/removes the class `.focus`, and adding the class selector in `_custom-forms.scss` addresses this issue.
