### PR TITLE
Show .invalid-feedback after invalid file input

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -51,6 +51,7 @@
   }
 
   .form-control,
+  .form-control-file,
   .custom-select {
     .was-validated &:#{$state},
     &.is-#{$state} {


### PR DESCRIPTION
Set `display: block` for `.invalid-feedback` for invalid file inputs. Fixes #24831 