### PR TITLE
Reformat all markdown files using Prettier

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,89 +2,60 @@
 
 Looking to contribute something to Bootstrap? **Here's how you can help.**
 
-Please take a moment to review this document in order to make the contribution
-process easy and effective for everyone involved.
+Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved.
 
-Following these guidelines helps to communicate that you respect the time of
-the developers managing and developing this open source project. In return,
-they should reciprocate that respect in addressing your issue or assessing
-patches and features.
-
+Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, they should reciprocate that respect in addressing your issue or assessing patches and features.
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/twbs/bootstrap/issues) is
-the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests)
-and [submitting pull requests](#pull-requests), but please respect the following
-restrictions:
+The [issue tracker](https://github.com/twbs/bootstrap/issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
-* Please **do not** use the issue tracker for personal support requests.  Stack
-  Overflow ([`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4) tag), [Slack](https://bootstrap-slack.herokuapp.com/) or [IRC](README.md#community) are better places to get help.
+* Please **do not** use the issue tracker for personal support requests. Stack Overflow ([`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4) tag), [Slack](https://bootstrap-slack.herokuapp.com/) or [IRC](README.md#community) are better places to get help.
 
-* Please **do not** derail or troll issues. Keep the discussion on topic and
-  respect the opinions of others.
+* Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
-* Please **do not** post comments consisting solely of "+1" or ":thumbsup:".
-  Use [GitHub's "reactions" feature](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments)
-  instead. We reserve the right to delete comments which violate this rule.
+* Please **do not** post comments consisting solely of "+1" or ":thumbsup:". Use [GitHub's "reactions" feature](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments) instead. We reserve the right to delete comments which violate this rule.
 
-* Please **do not** open issues regarding the official themes offered on <https://themes.getbootstrap.com/>.
-  Instead, please email any questions or feedback regarding those themes to `themes AT getbootstrap DOT com`.
-
+* Please **do not** open issues regarding the official themes offered on <https://themes.getbootstrap.com/>. Instead, please email any questions or feedback regarding those themes to `themes AT getbootstrap DOT com`.
 
 ## Issues and labels
 
 Our bug tracker utilizes several labels to help organize and identify issues. Here's what they represent and how we use them:
 
-- `browser bug` - Issues that are reported to us, but actually are the result of a browser-specific bug. These are diagnosed with reduced test cases and result in an issue opened on that browser's own bug tracker.
-- `confirmed` - Issues that have been confirmed with a reduced test case and identify a bug in Bootstrap.
-- `css` - Issues stemming from our compiled CSS or source Sass files.
-- `docs` - Issues for improving or updating our documentation.
-- `examples` - Issues involving the example templates included in our docs.
-- `feature` - Issues asking for a new feature to be added, or an existing one to be extended or modified. New features require a minor version bump (e.g., `v3.0.0` to `v3.1.0`).
-- `build` - Issues with our build system, which is used to run all our tests, concatenate and compile source files, and more.
-- `help wanted` - Issues we need or would love help from the community to resolve.
-- `js` - Issues stemming from our compiled or source JavaScript files.
-- `meta` - Issues with the project itself or our GitHub repository.
+* `browser bug` - Issues that are reported to us, but actually are the result of a browser-specific bug. These are diagnosed with reduced test cases and result in an issue opened on that browser's own bug tracker.
+* `confirmed` - Issues that have been confirmed with a reduced test case and identify a bug in Bootstrap.
+* `css` - Issues stemming from our compiled CSS or source Sass files.
+* `docs` - Issues for improving or updating our documentation.
+* `examples` - Issues involving the example templates included in our docs.
+* `feature` - Issues asking for a new feature to be added, or an existing one to be extended or modified. New features require a minor version bump (e.g., `v3.0.0` to `v3.1.0`).
+* `build` - Issues with our build system, which is used to run all our tests, concatenate and compile source files, and more.
+* `help wanted` - Issues we need or would love help from the community to resolve.
+* `js` - Issues stemming from our compiled or source JavaScript files.
+* `meta` - Issues with the project itself or our GitHub repository.
 
 For a complete look at our labels, see the [project labels page](https://github.com/twbs/bootstrap/labels).
 
-
 ## Bug reports
 
-A bug is a _demonstrable problem_ that is caused by the code in the repository.
-Good bug reports are extremely helpful, so thanks!
+A bug is a _demonstrable problem_ that is caused by the code in the repository. Good bug reports are extremely helpful, so thanks!
 
 Guidelines for bug reports:
 
-0. **Validate and lint your code** &mdash; [validate your HTML](https://html5.validator.nu/)
-   and [lint your HTML](https://github.com/twbs/bootlint) to ensure your
-   problem isn't caused by a simple error in your own code.
+0. **Validate and lint your code** &mdash; [validate your HTML](https://html5.validator.nu/) and [lint your HTML](https://github.com/twbs/bootlint) to ensure your problem isn't caused by a simple error in your own code.
 
-1. **Use the GitHub issue search** &mdash; check if the issue has already been
-   reported.
+1. **Use the GitHub issue search** &mdash; check if the issue has already been reported.
 
-2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` or development branch in the repository.
+1. **Check if the issue has been fixed** &mdash; try to reproduce it using the latest `master` or development branch in the repository.
 
-3. **Isolate the problem** &mdash; ideally create a [reduced test
-   case](https://css-tricks.com/reduced-test-cases/) and a live example.
-   [This JS Bin](https://jsbin.com/lolome/edit?html,output) is a helpful template.
+1. **Isolate the problem** &mdash; ideally create a [reduced test case](https://css-tricks.com/reduced-test-cases/) and a live example. [This JS Bin](https://jsbin.com/lolome/edit?html,output) is a helpful template.
 
-
-A good bug report shouldn't leave others needing to chase you up for more
-information. Please try to be as detailed as possible in your report. What is
-your environment? What steps will reproduce the issue? What browser(s) and OS
-experience the problem? Do other browsers show the bug differently? What
-would you expect to be the outcome? All these details will help people to fix
-any potential bugs.
+A good bug report shouldn't leave others needing to chase you up for more information. Please try to be as detailed as possible in your report. What is your environment? What steps will reproduce the issue? What browser(s) and OS experience the problem? Do other browsers show the bug differently? What would you expect to be the outcome? All these details will help people to fix any potential bugs.
 
 Example:
 
 > Short and descriptive example bug report title
 >
-> A summary of the issue and the browser/OS environment in which it occurs. If
-> suitable, include the steps required to reproduce the bug.
+> A summary of the issue and the browser/OS environment in which it occurs. If suitable, include the steps required to reproduce the bug.
 >
 > 1. This is the first step
 > 2. This is the second step
@@ -92,15 +63,11 @@ Example:
 >
 > `<url>` - a link to the reduced test case
 >
-> Any other information you want to share that is relevant to the issue being
-> reported. This might include the lines of code that you have identified as
-> causing the bug, and potential solutions (and your opinions on their
-> merits).
+> Any other information you want to share that is relevant to the issue being reported. This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
 
 ### Reporting upstream browser bugs
 
-Sometimes bugs reported to us are actually caused by bugs in the browser(s) themselves, not bugs in Bootstrap per se.
-When feasible, we aim to report such upstream bugs to the relevant browser vendor(s), and then list them on our [Wall of Browser Bugs](https://getbootstrap.com/browser-bugs/) and [document them in MDN](https://developer.mozilla.org/en-US/docs/Web).
+Sometimes bugs reported to us are actually caused by bugs in the browser(s) themselves, not bugs in Bootstrap per se. When feasible, we aim to report such upstream bugs to the relevant browser vendor(s), and then list them on our [Wall of Browser Bugs](https://getbootstrap.com/browser-bugs/) and [document them in MDN](https://developer.mozilla.org/en-US/docs/Web).
 
 | Vendor(s)     | Browser(s)                   | Rendering engine | Bug reporting website(s)                                                              | Notes                                                    |
 | ------------- | ---------------------------- | ---------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------- |
@@ -113,46 +80,25 @@ When feasible, we aim to report such upstream bugs to the relevant browser vendo
 
 [@twbs-lmvtfy](https://github.com/twbs-lmvtfy) is a Bootstrap bot that hangs out in our GitHub issue tracker and automatically checks for HTML validation errors in live examples (e.g. jsFiddles, JS Bins, Bootplys, Plunks, CodePens, etc.) posted in issue comments. If it finds any errors, it will post a follow-up comment on the issue and point out the errors. If this happens with an example you've posted, please fix the errors and post an updated live example. If you opened a bug report, please check whether the bug still occurs with your revised, valid live example. If the bug no longer occurs, it was probably due to your invalid HTML rather than something in Bootstrap and we'd appreciate it if you could close out the GitHub issue.
 
-
 ## Feature requests
 
-Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
-case to convince the project's developers of the merits of this feature. Please
-provide as much detail and context as possible.
-
+Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the project. It's up to _you_ to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
 
 ## Pull requests
 
-Good pull requests—patches, improvements, new features—are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
-commits.
+Good pull requests—patches, improvements, new features—are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
 
-**Please ask first** before embarking on any significant pull request (e.g.
-implementing features, refactoring code, porting to a different language),
-otherwise you risk spending a lot of time working on something that the
-project's developers might not want to merge into the project.
+**Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
 
-Please adhere to the [coding guidelines](#code-guidelines) used throughout the
-project (indentation, accurate comments, etc.) and any other requirements
-(such as test coverage).
+Please adhere to the [coding guidelines](#code-guidelines) used throughout the project (indentation, accurate comments, etc.) and any other requirements (such as test coverage).
 
-**Do not edit `bootstrap.css`, or `bootstrap.js`
-directly!** Those files are automatically generated. You should edit the
-source files in [`/bootstrap/scss/`](https://github.com/twbs/bootstrap/tree/master/scss)
-and/or [`/bootstrap/js/`](https://github.com/twbs/bootstrap/tree/master/js) instead.
+**Do not edit `bootstrap.css`, or `bootstrap.js` directly!** Those files are automatically generated. You should edit the source files in [`/bootstrap/scss/`](https://github.com/twbs/bootstrap/tree/master/scss) and/or [`/bootstrap/js/`](https://github.com/twbs/bootstrap/tree/master/js) instead.
 
-Similarly, when contributing to Bootstrap's documentation, you should edit the
-documentation source files in
-[the `/bootstrap/docs/` directory of the `master` branch](https://github.com/twbs/bootstrap/tree/master/docs).
-**Do not edit the `gh-pages` branch.** That branch is generated from the
-documentation source files and is managed separately by the Bootstrap Core Team.
+Similarly, when contributing to Bootstrap's documentation, you should edit the documentation source files in [the `/bootstrap/docs/` directory of the `master` branch](https://github.com/twbs/bootstrap/tree/master/docs). **Do not edit the `gh-pages` branch.** That branch is generated from the documentation source files and is managed separately by the Bootstrap Core Team.
 
-Adhering to the following process is the best way to get your work
-included in the project:
+Adhering to the following process is the best way to get your work included in the project:
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) the project, clone your fork,
-   and configure the remotes:
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the project, clone your fork, and configure the remotes:
 
    ```bash
    # Clone your fork of the repo into the current directory
@@ -170,18 +116,13 @@ included in the project:
    git pull upstream master
    ```
 
-3. Create a new topic branch (off the main project development branch) to
-   contain your feature, change, or fix:
+3. Create a new topic branch (off the main project development branch) to contain your feature, change, or fix:
 
    ```bash
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit
-   message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-   or your code is unlikely be merged into the main project. Use Git's
-   [interactive rebase](https://help.github.com/articles/about-git-rebase/)
-   feature to tidy up your commits before making them public.
+4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) or your code is unlikely be merged into the main project. Use Git's [interactive rebase](https://help.github.com/articles/about-git-rebase/) feature to tidy up your commits before making them public.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
@@ -195,14 +136,9 @@ included in the project:
    git push origin <topic-branch-name>
    ```
 
-7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/)
-    with a clear title and description against the `master` branch.
+7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/) with a clear title and description against the `master` branch.
 
-**IMPORTANT**: By submitting a patch, you agree to allow the project owners to
-license your work under the terms of the [MIT License](LICENSE) (if it
-includes code changes) and under the terms of the
-[Creative Commons Attribution 3.0 Unported License](docs/LICENSE)
-(if it includes documentation changes).
+**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the [MIT License](LICENSE) (if it includes code changes) and under the terms of the [Creative Commons Attribution 3.0 Unported License](docs/LICENSE) (if it includes documentation changes).
 
 ### Pull request bots
 
@@ -213,40 +149,37 @@ includes code changes) and under the terms of the
 
 [@twbs-savage](https://github.com/twbs-savage) is a Bootstrap bot that automatically runs cross-browser tests (via [Sauce](https://saucelabs.com/) and Travis CI) on JavaScript pull requests. Savage will leave a comment on pull requests stating whether cross-browser JS tests passed or failed, with a link to the full Travis build details. If your pull request fails, check the Travis log to see which browser + OS combinations failed. Each browser test in the Travis log includes a link to a Sauce page with details about the test. On those details pages, you can watch a screencast of the test run to see exactly which unit tests failed.
 
-
 ## Code guidelines
 
 ### HTML
 
 [Adhere to the Code Guide.](http://codeguide.co/#html)
 
-- Use tags and elements appropriate for an HTML5 doctype (e.g., self-closing tags).
-- Use CDNs and HTTPS for third-party JS when possible. We don't use protocol-relative URLs in this case because they break when viewing the page locally via `file://`.
-- Use [WAI-ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) attributes in documentation examples to promote accessibility.
+* Use tags and elements appropriate for an HTML5 doctype (e.g., self-closing tags).
+* Use CDNs and HTTPS for third-party JS when possible. We don't use protocol-relative URLs in this case because they break when viewing the page locally via `file://`.
+* Use [WAI-ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) attributes in documentation examples to promote accessibility.
 
 ### CSS
 
 [Adhere to the Code Guide.](http://codeguide.co/#css)
 
-- When feasible, default color palettes should comply with [WCAG color contrast guidelines](https://www.w3.org/TR/WCAG20/#visual-audio-contrast).
-- Except in rare cases, don't remove default `:focus` styles (via e.g. `outline: none;`) without providing alternative styles. See [this A11Y Project post](http://a11yproject.com/posts/never-remove-css-outlines/) for more details.
+* When feasible, default color palettes should comply with [WCAG color contrast guidelines](https://www.w3.org/TR/WCAG20/#visual-audio-contrast).
+* Except in rare cases, don't remove default `:focus` styles (via e.g. `outline: none;`) without providing alternative styles. See [this A11Y Project post](http://a11yproject.com/posts/never-remove-css-outlines/) for more details.
 
 ### JS
 
-- No semicolons (in client-side JS)
-- 2 spaces (no tabs)
-- strict mode
-- "Attractive"
-- Don't use [jQuery event alias convenience methods](https://github.com/jquery/jquery/blob/master/src/event/alias.js) (such as `$().focus()`). Instead, use [`$().trigger(eventType, ...)`](https://api.jquery.com/trigger/) or [`$().on(eventType, ...)`](https://api.jquery.com/on/), depending on whether you're firing an event or listening for an event. (For example, `$().trigger('focus')` or `$().on('focus', function (event) { /* handle focus event */ })`) We do this to be compatible with custom builds of jQuery where the event aliases module has been excluded.
+* No semicolons (in client-side JS)
+* 2 spaces (no tabs)
+* strict mode
+* "Attractive"
+* Don't use [jQuery event alias convenience methods](https://github.com/jquery/jquery/blob/master/src/event/alias.js) (such as `$().focus()`). Instead, use [`$().trigger(eventType, ...)`](https://api.jquery.com/trigger/) or [`$().on(eventType, ...)`](https://api.jquery.com/on/), depending on whether you're firing an event or listening for an event. (For example, `$().trigger('focus')` or `$().on('focus', function (event) { /* handle focus event */ })`) We do this to be compatible with custom builds of jQuery where the event aliases module has been excluded.
 
 ### Checking coding style
 
 Run `npm run test` before committing to ensure your changes follow our coding standards.
 
-
 ## License
 
-By contributing your code, you agree to license your contribution under the [MIT License](LICENSE).
-By contributing to the documentation, you agree to license your contribution under the [Creative Commons Attribution 3.0 Unported License](docs/LICENSE).
+By contributing your code, you agree to license your contribution under the [MIT License](LICENSE). By contributing to the documentation, you agree to license your contribution under the [Creative Commons Attribution 3.0 Unported License](docs/LICENSE).
 
 Prior to v3.1.0, Bootstrap's code was released under the Apache License v2.0.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,22 @@
 Before opening an issue:
 
-- [Search for duplicate or closed issues](https://github.com/twbs/bootstrap/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Validate](https://html5.validator.nu/) and [lint](https://github.com/twbs/bootlint#in-the-browser) any HTML to avoid common problems
-- Prepare a [reduced test case](https://css-tricks.com/reduced-test-cases/) for any bugs
-- Read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md)
+* [Search for duplicate or closed issues](https://github.com/twbs/bootstrap/issues?utf8=%E2%9C%93&q=is%3Aissue)
+* [Validate](https://html5.validator.nu/) and [lint](https://github.com/twbs/bootlint#in-the-browser) any HTML to avoid common problems
+* Prepare a [reduced test case](https://css-tricks.com/reduced-test-cases/) for any bugs
+* Read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md)
 
 When asking general "how to" questions:
 
-- Please do not open an issue here
-- Instead, ask for help on [StackOverflow, IRC, or Slack](https://github.com/twbs/bootstrap/blob/master/README.md#community)
+* Please do not open an issue here
+* Instead, ask for help on [StackOverflow, IRC, or Slack](https://github.com/twbs/bootstrap/blob/master/README.md#community)
 
 When reporting a bug, include:
 
-- Operating system and version (Windows, Mac OS X, Android, iOS, Win10 Mobile)
-- Browser and version (Chrome, Firefox, Safari, IE, MS Edge, Opera 15+, Android Browser)
-- Reduced test cases and potential fixes using [CodePen](https://codepen.io/) or [JS Bin](https://jsbin.com/)
+* Operating system and version (Windows, Mac OS X, Android, iOS, Win10 Mobile)
+* Browser and version (Chrome, Firefox, Safari, IE, MS Edge, Opera 15+, Android Browser)
+* Reduced test cases and potential fixes using [CodePen](https://codepen.io/) or [JS Bin](https://jsbin.com/)
 
 When suggesting a feature, include:
 
-- As much detail as possible for what we should add and why it's important to Bootstrap
-- Relevant links to prior art, screenshots, or live demos whenever possible
+* As much detail as possible for what we should add and why it's important to Bootstrap
+* Relevant links to prior art, screenshots, or live demos whenever possible

--- a/README.md
+++ b/README.md
@@ -23,43 +23,33 @@
 
 ## Table of contents
 
-- [Quick start](#quick-start)
-- [Status](#status)
-- [What's included](#whats-included)
-- [Bugs and feature requests](#bugs-and-feature-requests)
-- [Documentation](#documentation)
-- [Contributing](#contributing)
-- [Community](#community)
-- [Versioning](#versioning)
-- [Creators](#creators)
-- [Copyright and license](#copyright-and-license)
+* [Quick start](#quick-start)
+* [Status](#status)
+* [What's included](#whats-included)
+* [Bugs and feature requests](#bugs-and-feature-requests)
+* [Documentation](#documentation)
+* [Contributing](#contributing)
+* [Community](#community)
+* [Versioning](#versioning)
+* [Creators](#creators)
+* [Copyright and license](#copyright-and-license)
 
 ## Quick start
 
 Several quick start options are available:
 
-- [Download the latest release.](https://github.com/twbs/bootstrap/archive/v4.0.0-beta.2.zip)
-- Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
-- Install with [npm](https://www.npmjs.com/): `npm install bootstrap@4.0.0-beta.2`
-- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@4.0.0-beta.2`
-- Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:4.0.0-beta.2`
-- Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).
+* [Download the latest release.](https://github.com/twbs/bootstrap/archive/v4.0.0-beta.2.zip)
+* Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
+* Install with [npm](https://www.npmjs.com/): `npm install bootstrap@4.0.0-beta.2`
+* Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@4.0.0-beta.2`
+* Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:4.0.0-beta.2`
+* Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap -Pre` Sass: `Install-Package bootstrap.sass -Pre` (`-Pre` is only required until Bootstrap v4 has a stable release).
 
 Read the [Getting started page](https://getbootstrap.com/getting-started/) for information on the framework contents, templates and examples, and more.
 
 ## Status
 
-[![Slack](https://bootstrap-slack.herokuapp.com/badge.svg)](https://bootstrap-slack.herokuapp.com/)
-[![Build Status](https://img.shields.io/travis/twbs/bootstrap/v4-dev.svg)](https://travis-ci.org/twbs/bootstrap)
-[![npm version](https://img.shields.io/npm/v/bootstrap.svg)](https://www.npmjs.com/package/bootstrap)
-[![Gem version](https://img.shields.io/gem/v/bootstrap.svg)](https://rubygems.org/gems/bootstrap)
-[![Meteor Atmosphere](https://img.shields.io/badge/meteor-twbs%3Abootstrap-blue.svg)](https://atmospherejs.com/twbs/bootstrap)
-[![Packagist Prerelease](https://img.shields.io/packagist/vpre/twbs/bootstrap.svg)](https://packagist.org/packages/twbs/bootstrap)
-[![NuGet](https://img.shields.io/nuget/vpre/bootstrap.svg)](https://www.nuget.org/packages/bootstrap/absoluteLatest)
-[![peerDependencies Status](https://img.shields.io/david/peer/twbs/bootstrap.svg)](https://david-dm.org/twbs/bootstrap?type=peer)
-[![devDependency Status](https://img.shields.io/david/dev/twbs/bootstrap.svg)](https://david-dm.org/twbs/bootstrap?type=dev)
-[![CSS gzip size](http://img.badgesize.io/twbs/bootstrap/v4-dev/dist/css/bootstrap.min.css?compression=gzip&label=CSS+gzip+size)](https://github.com/twbs/bootstrap/tree/v4-dev/dist/css/bootstrap.min.css)
-[![JS gzip size](http://img.badgesize.io/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js?compression=gzip&label=JS+gzip+size)](https://github.com/twbs/bootstrap/tree/v4-dev/dist/js/bootstrap.min.js)
+[![Slack](https://bootstrap-slack.herokuapp.com/badge.svg)](https://bootstrap-slack.herokuapp.com/) [![Build Status](https://img.shields.io/travis/twbs/bootstrap/v4-dev.svg)](https://travis-ci.org/twbs/bootstrap) [![npm version](https://img.shields.io/npm/v/bootstrap.svg)](https://www.npmjs.com/package/bootstrap) [![Gem version](https://img.shields.io/gem/v/bootstrap.svg)](https://rubygems.org/gems/bootstrap) [![Meteor Atmosphere](https://img.shields.io/badge/meteor-twbs%3Abootstrap-blue.svg)](https://atmospherejs.com/twbs/bootstrap) [![Packagist Prerelease](https://img.shields.io/packagist/vpre/twbs/bootstrap.svg)](https://packagist.org/packages/twbs/bootstrap) [![NuGet](https://img.shields.io/nuget/vpre/bootstrap.svg)](https://www.nuget.org/packages/bootstrap/absoluteLatest) [![peerDependencies Status](https://img.shields.io/david/peer/twbs/bootstrap.svg)](https://david-dm.org/twbs/bootstrap?type=peer) [![devDependency Status](https://img.shields.io/david/dev/twbs/bootstrap.svg)](https://david-dm.org/twbs/bootstrap?type=dev) [![CSS gzip size](http://img.badgesize.io/twbs/bootstrap/v4-dev/dist/css/bootstrap.min.css?compression=gzip&label=CSS+gzip+size)](https://github.com/twbs/bootstrap/tree/v4-dev/dist/css/bootstrap.min.css) [![JS gzip size](http://img.badgesize.io/twbs/bootstrap/v4-dev/dist/js/bootstrap.min.js?compression=gzip&label=JS+gzip+size)](https://github.com/twbs/bootstrap/tree/v4-dev/dist/js/bootstrap.min.js)
 
 [![Sauce Labs Test Status](https://saucelabs.com/browser-matrix/bootstrap.svg)](https://saucelabs.com/u/bootstrap)
 
@@ -91,11 +81,9 @@ bootstrap/
 
 We provide compiled CSS and JS (`bootstrap.*`), as well as compiled and minified CSS and JS (`bootstrap.min.*`). CSS [source maps](https://developers.google.com/web/tools/chrome-devtools/debug/readability/source-maps) (`bootstrap.*.map`) are available for use with certain browsers' developer tools. Bundled JS files (`bootstrap.bundle.js` and minified `bootstrap.bundle.min.js`) include [Popper](https://popper.js.org/), but not [jQuery](https://jquery.com/).
 
-
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first read the [issue guidelines](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md#using-the-issue-tracker) and search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/twbs/bootstrap/issues/new).
-
 
 ## Documentation
 
@@ -115,11 +103,10 @@ Learn more about using Jekyll by reading its [documentation](https://jekyllrb.co
 
 ### Documentation for previous releases
 
-- For v2.3.2: <https://getbootstrap.com/2.3.2/>
-- For v3.3.x: <https://getbootstrap.com/docs/3.3/>
+* For v2.3.2: <https://getbootstrap.com/2.3.2/>
+* For v3.3.x: <https://getbootstrap.com/docs/3.3/>
 
 [Previous releases](https://github.com/twbs/bootstrap/releases) and their documentation are also available for download.
-
 
 ## Contributing
 
@@ -129,18 +116,16 @@ Moreover, if your pull request contains JavaScript patches or features, you must
 
 Editor preferences are available in the [editor config](https://github.com/twbs/bootstrap/blob/master/.editorconfig) for easy use in common text editors. Read more and download plugins at <http://editorconfig.org/>.
 
-
 ## Community
 
 Get updates on Bootstrap's development and chat with the project maintainers and community members.
 
-- Follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap).
-- Read and subscribe to [The Official Bootstrap Blog](https://blog.getbootstrap.com/).
-- Join [the official Slack room](https://bootstrap-slack.herokuapp.com/).
-- Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.
-- Implementation help may be found at Stack Overflow (tagged [`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4)).
-- Developers should use the keyword `bootstrap` on packages which modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/browse/keyword/bootstrap) or similar delivery mechanisms for maximum discoverability.
-
+* Follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap).
+* Read and subscribe to [The Official Bootstrap Blog](https://blog.getbootstrap.com/).
+* Join [the official Slack room](https://bootstrap-slack.herokuapp.com/).
+* Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.
+* Implementation help may be found at Stack Overflow (tagged [`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4)).
+* Developers should use the keyword `bootstrap` on packages which modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/browse/keyword/bootstrap) or similar delivery mechanisms for maximum discoverability.
 
 ## Versioning
 
@@ -148,19 +133,17 @@ For transparency into our release cycle and in striving to maintain backward com
 
 See [the Releases section of our GitHub project](https://github.com/twbs/bootstrap/releases) for changelogs for each release version of Bootstrap. Release announcement posts on [the official Bootstrap blog](https://blog.getbootstrap.com/) contain summaries of the most noteworthy changes made in each release.
 
-
 ## Creators
 
 **Mark Otto**
 
-- <https://twitter.com/mdo>
-- <https://github.com/mdo>
+* <https://twitter.com/mdo>
+* <https://github.com/mdo>
 
 **Jacob Thornton**
 
-- <https://twitter.com/fat>
-- <https://github.com/fat>
-
+* <https://twitter.com/fat>
+* <https://github.com/fat>
 
 ## Copyright and license
 

--- a/_includes/callout-danger-async-methods.md
+++ b/_includes/callout-danger-async-methods.md
@@ -1,7 +1,7 @@
 {% callout danger %}
+
 #### Asynchronous methods and transitions
 
 All API methods are **asynchronous** and start a **transition**. They return to the caller as soon as the transition is started but **before it ends**. In addition, a method call on a **transitioning component will be ignored**.
 
-[See our JavaScript documentation for more information.]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/)
-{% endcallout %}
+[See our JavaScript documentation for more information.]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/) {% endcallout %}

--- a/_includes/callout-info-mediaqueries-breakpoints.md
+++ b/_includes/callout-info-mediaqueries-breakpoints.md
@@ -1,3 +1,1 @@
-{% callout info %}
-Note that since browsers do not currently support [range context queries](https://www.w3.org/TR/mediaqueries-4/#range-context), we work around the limitations of [`min-` and `max-` prefixes](https://www.w3.org/TR/mediaqueries-4/#mq-min-max) and viewports with fractional widths (which can occur under certain conditions on high-dpi devices, for instance) by using values with higher precision for these comparisons.
-{% endcallout %}
+{% callout info %} Note that since browsers do not currently support [range context queries](https://www.w3.org/TR/mediaqueries-4/#range-context), we work around the limitations of [`min-` and `max-` prefixes](https://www.w3.org/TR/mediaqueries-4/#mq-min-max) and viewports with fractional widths (which can occur under certain conditions on high-dpi devices, for instance) by using values with higher precision for these comparisons. {% endcallout %}

--- a/_includes/callout-warning-color-assistive-technologies.md
+++ b/_includes/callout-warning-color-assistive-technologies.md
@@ -1,5 +1,5 @@
 {% callout warning %}
+
 #### Conveying meaning to assistive technologies
 
-Using color to add meaning only provides a visual indication, which will not be conveyed to users of assistive technologies – such as screen readers. Ensure that information denoted by the color is either obvious from the content itself (e.g. the visible text), or is included through alternative means, such as additional text hidden with the `.sr-only` class.
-{% endcallout %}
+Using color to add meaning only provides a visual indication, which will not be conveyed to users of assistive technologies – such as screen readers. Ensure that information denoted by the color is either obvious from the content itself (e.g. the visible text), or is included through alternative means, such as additional text hidden with the `.sr-only` class. {% endcallout %}

--- a/docs/4.0/about/brand.md
+++ b/docs/4.0/about/brand.md
@@ -66,7 +66,7 @@ The project and framework should always be referred to as **Bootstrap**. No Twit
 
 ## Colors
 
-Our docs and branding use a handful of primary colors to differentiate what *is* Bootstrap from what *is in* Bootstrap. In other words, if it's purple, it's representative of Bootstrap.
+Our docs and branding use a handful of primary colors to differentiate what _is_ Bootstrap from what _is in_ Bootstrap. In other words, if it's purple, it's representative of Bootstrap.
 
 <div class="bd-brand">
   <div class="color-swatches">

--- a/docs/4.0/about/license.md
+++ b/docs/4.0/about/license.md
@@ -13,22 +13,22 @@ Bootstrap is released under the MIT license and is copyright {{ site.time | date
 
 #### It permits you to:
 
-- Freely download and use Bootstrap, in whole or in part, for personal, private, company internal, or commercial purposes
-- Use Bootstrap in packages or distributions that you create
-- Modify the source code
-- Grant a sublicense to modify and distribute Bootstrap to third parties not included in the license
+* Freely download and use Bootstrap, in whole or in part, for personal, private, company internal, or commercial purposes
+* Use Bootstrap in packages or distributions that you create
+* Modify the source code
+* Grant a sublicense to modify and distribute Bootstrap to third parties not included in the license
 
 #### It forbids you to:
 
-- Hold the authors and license owners liable for damages as Bootstrap is provided without warranty
-- Hold the creators or copyright holders of Bootstrap liable
-- Redistribute any piece of Bootstrap without proper attribution
-- Use any marks owned by Twitter in any way that might state or imply that Twitter endorses your distribution
-- Use any marks owned by Twitter in any way that might state or imply that you created the Twitter software in question
+* Hold the authors and license owners liable for damages as Bootstrap is provided without warranty
+* Hold the creators or copyright holders of Bootstrap liable
+* Redistribute any piece of Bootstrap without proper attribution
+* Use any marks owned by Twitter in any way that might state or imply that Twitter endorses your distribution
+* Use any marks owned by Twitter in any way that might state or imply that you created the Twitter software in question
 
 #### It does not require you to:
 
-- Include the source of Bootstrap itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it
-- Submit changes that you make to Bootstrap back to the Bootstrap project (though such feedback is encouraged)
+* Include the source of Bootstrap itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it
+* Submit changes that you make to Bootstrap back to the Bootstrap project (though such feedback is encouraged)
 
 The full Bootstrap license is located [in the project repository]({{ site.repo }}/blob/v{{ site.current_version }}/LICENSE) for more information.

--- a/docs/4.0/components/alerts.md
+++ b/docs/4.0/components/alerts.md
@@ -10,22 +10,21 @@ toc: true
 
 Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the eight **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts jQuery plugin](#dismissing).
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="alert alert-{{ color.name }}" role="alert">
   This is a {{ color.name }} alert—check it out!
 </div>{% endfor %}
 {% endexample %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ### Link color
 
 Use the `.alert-link` utility class to quickly provide matching colored links within any alert.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="alert alert-{{ color.name }}" role="alert">
   This is a {{ color.name }} alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.
 </div>{% endfor %}
@@ -36,6 +35,7 @@ Use the `.alert-link` utility class to quickly provide matching colored links wi
 Alerts can also contain additional HTML elements like headings, paragraphs and dividers.
 
 {% example html %}
+
 <div class="alert alert-success" role="alert">
   <h4 class="alert-heading">Well done!</h4>
   <p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
@@ -44,20 +44,20 @@ Alerts can also contain additional HTML elements like headings, paragraphs and d
 </div>
 {% endexample %}
 
-
 ### Dismissing
 
 Using the alert JavaScript plugin, it's possible to dismiss any alert inline. Here's how:
 
-- Be sure you've loaded the alert plugin, or the compiled Bootstrap JavaScript.
-- If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util). The compiled version includes this.
-- Add a dismiss button and the `.alert-dismissible` class, which adds extra padding to the right of the alert and positions the `.close` button.
-- On the dismiss button, add the `data-dismiss="alert"` attribute, which triggers the JavaScript functionality. Be sure to use the `<button>` element with it for proper behavior across all devices.
-- To animate alerts when dismissing them, be sure to add the `.fade` and `.show` classes.
+* Be sure you've loaded the alert plugin, or the compiled Bootstrap JavaScript.
+* If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util). The compiled version includes this.
+* Add a dismiss button and the `.alert-dismissible` class, which adds extra padding to the right of the alert and positions the `.close` button.
+* On the dismiss button, add the `data-dismiss="alert"` attribute, which triggers the JavaScript functionality. Be sure to use the `<button>` element with it for proper behavior across all devices.
+* To animate alerts when dismissing them, be sure to add the `.fade` and `.show` classes.
 
 You can see this in action with a live demo:
 
 {% example html %}
+
 <div class="alert alert-warning alert-dismissible fade show" role="alert">
   <strong>Holy guacamole!</strong> You should check in on some of those fields below.
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
@@ -72,27 +72,21 @@ You can see this in action with a live demo:
 
 Enable dismissal of an alert via JavaScript:
 
-{% highlight js %}
-$('.alert').alert()
-{% endhighlight %}
+{% highlight js %} $('.alert').alert() {% endhighlight %}
 
 Or with `data` attributes on a button **within the alert**, as demonstrated above:
 
-{% highlight html %}
-<button type="button" class="close" data-dismiss="alert" aria-label="Close">
-  <span aria-hidden="true">&times;</span>
-</button>
-{% endhighlight %}
+{% highlight html %} <button type="button" class="close" data-dismiss="alert" aria-label="Close"> <span aria-hidden="true">&times;</span> </button> {% endhighlight %}
 
 Note that closing an alert will remove it from the DOM.
 
 ### Methods
 
-| Method | Description |
-| --- | --- |
-| `$().alert()` | Makes an alert listen for click events on descendant elements which have the `data-dismiss="alert"` attribute. (Not necessary when using the data-api's auto-initialization.) |
-| `$().alert('close')` | Closes an alert by removing it from the DOM. If the `.fade` and `.show` classes are present on the element, the alert will fade out before it is removed. |
-| `$().alert('dispose')` | Destroys an element's alert. |
+| Method                 | Description                                                                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$().alert()`          | Makes an alert listen for click events on descendant elements which have the `data-dismiss="alert"` attribute. (Not necessary when using the data-api's auto-initialization.) |
+| `$().alert('close')`   | Closes an alert by removing it from the DOM. If the `.fade` and `.show` classes are present on the element, the alert will fade out before it is removed.                     |
+| `$().alert('dispose')` | Destroys an element's alert.                                                                                                                                                  |
 
 {% highlight js %}$(".alert").alert('close'){% endhighlight %}
 
@@ -100,13 +94,9 @@ Note that closing an alert will remove it from the DOM.
 
 Bootstrap's alert plugin exposes a few events for hooking into alert functionality.
 
-| Event | Description |
-| --- | --- |
-| `close.bs.alert` | This event fires immediately when the <code>close</code> instance method is called. |
+| Event             | Description                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `close.bs.alert`  | This event fires immediately when the <code>close</code> instance method is called.             |
 | `closed.bs.alert` | This event is fired when the alert has been closed (will wait for CSS transitions to complete). |
 
-{% highlight js %}
-$('#myAlert').on('closed.bs.alert', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myAlert').on('closed.bs.alert', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/badge.md
+++ b/docs/4.0/components/badge.md
@@ -20,6 +20,7 @@ Badges scale to match the size of the immediate parent element by using relative
 </div>
 
 {% highlight html %}
+
 <h1>Example heading <span class="badge badge-secondary">New</span></h1>
 <h2>Example heading <span class="badge badge-secondary">New</span></h2>
 <h3>Example heading <span class="badge badge-secondary">New</span></h3>
@@ -30,49 +31,30 @@ Badges scale to match the size of the immediate parent element by using relative
 
 Badges can be used as part of links or buttons to provide a counter.
 
-{% example html %}
-<button type="button" class="btn btn-primary">
-  Notifications <span class="badge badge-light">4</span>
-</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary"> Notifications <span class="badge badge-light">4</span> </button> {% endexample %}
 
 Note that depending on how they are used, badges may be confusing for users of screen readers and similar assistive technologies. While the styling of badges provides a visual cue as to their purpose, these users will simply be presented with the content of the badge. Depending on the specific situation, these badges may seem like random additional words or numbers at the end of a sentence, link, or button.
 
 Unless the context is clear (as with the "Notifications" example, where it is understood that the "4" is the number of notifications), consider including additional context with a visually hidden piece of additional text.
 
-{% example html %}
-<button type="button" class="btn btn-primary">
-  Profile <span class="badge badge-light">9</span>
-  <span class="sr-only">unread messages</span>
-</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary"> Profile <span class="badge badge-light">9</span> <span class="sr-only">unread messages</span> </button> {% endexample %}
 
 ## Contextual variations
 
 Add any of the below mentioned modifier classes to change the appearance of a badge.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
-<span class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</span>{% endfor %}
-{% endexample %}
+{% example html %} {% for color in site.data.theme-colors %} <span class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</span>{% endfor %} {% endexample %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ## Pill badges
 
 Use the `.badge-pill` modifier class to make badges more rounded (with a larger `border-radius` and additional horizontal `padding`). Useful if you miss the badges from v3.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
-<span class="badge badge-pill badge-{{ color.name }}">{{ color.name | capitalize }}</span>{% endfor %}
-{% endexample %}
+{% example html %} {% for color in site.data.theme-colors %} <span class="badge badge-pill badge-{{ color.name }}">{{ color.name | capitalize }}</span>{% endfor %} {% endexample %}
 
 ## Links
 
 Using the contextual `.badge-*` classes on an `<a>` element quickly provide _actionable_ badges with hover and focus states.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
-<a href="#" class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %}
-{% endexample %}
+{% example html %} {% for color in site.data.theme-colors %} <a href="#" class="badge badge-{{ color.name }}">{{ color.name | capitalize }}</a>{% endfor %} {% endexample %}

--- a/docs/4.0/components/breadcrumb.md
+++ b/docs/4.0/components/breadcrumb.md
@@ -10,6 +10,7 @@ group: components
 Separators are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content).
 
 {% example html %}
+
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item active" aria-current="page">Home</li>

--- a/docs/4.0/components/button-group.md
+++ b/docs/4.0/components/button-group.md
@@ -11,6 +11,7 @@ toc: true
 Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript radio and checkbox style behavior with [our buttons plugin]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/buttons/#button-plugin).
 
 {% example html %}
+
 <div class="btn-group" role="group" aria-label="Basic example">
   <button type="button" class="btn btn-secondary">Left</button>
   <button type="button" class="btn btn-secondary">Middle</button>
@@ -19,18 +20,19 @@ Wrap a series of buttons with `.btn` in `.btn-group`. Add on optional JavaScript
 {% endexample %}
 
 {% callout warning %}
+
 #### Ensure correct `role` and provide a label
 
 In order for assistive technologies (such as screen readers) to convey that a series of buttons is grouped, an appropriate `role` attribute needs to be provided. For button groups, this would be `role="group"`, while toolbars should have a `role="toolbar"`.
 
-In addition, groups and toolbars should be given an explicit label, as most assistive technologies will otherwise not announce them, despite the presence of the correct role attribute. In the examples provided here, we use `aria-label`, but alternatives such as `aria-labelledby` can also be used.
-{% endcallout %}
+In addition, groups and toolbars should be given an explicit label, as most assistive technologies will otherwise not announce them, despite the presence of the correct role attribute. In the examples provided here, we use `aria-label`, but alternatives such as `aria-labelledby` can also be used. {% endcallout %}
 
 ## Button toolbar
 
 Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space out groups, buttons, and more.
 
 {% example html %}
+
 <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group mr-2" role="group" aria-label="First group">
     <button type="button" class="btn btn-secondary">1</button>
@@ -52,6 +54,7 @@ Combine sets of button groups into button toolbars for more complex components. 
 Feel free to mix input groups with button groups in your toolbars. Similar to the example above, you'll likely need some utilities though to space things properly.
 
 {% example html %}
+
 <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
   <div class="btn-group mr-2" role="group" aria-label="First group">
     <button type="button" class="btn btn-secondary">1</button>
@@ -104,6 +107,7 @@ Instead of applying button sizing classes to every button in a group, just add `
 </div>
 
 {% highlight html %}
+
 <div class="btn-group btn-group-lg" role="group" aria-label="...">...</div>
 <div class="btn-group" role="group" aria-label="...">...</div>
 <div class="btn-group btn-group-sm" role="group" aria-label="...">...</div>
@@ -114,6 +118,7 @@ Instead of applying button sizing classes to every button in a group, just add `
 Place a `.btn-group` within another `.btn-group` when you want dropdown menus mixed with a series of buttons.
 
 {% example html %}
+
 <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
   <button type="button" class="btn btn-secondary">1</button>
   <button type="button" class="btn btn-secondary">2</button>
@@ -144,7 +149,6 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
     <button type="button" class="btn btn-secondary">Button</button>
   </div>
 </div>
-
 
 <div class="bd-example">
   <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
@@ -192,6 +196,7 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
 </div>
 
 {% highlight html %}
+
 <div class="btn-group-vertical">
   ...
 </div>

--- a/docs/4.0/components/buttons.md
+++ b/docs/4.0/components/buttons.md
@@ -11,15 +11,11 @@ toc: true
 
 Bootstrap includes several predefined button styles, each serving its own semantic purpose, with a few extras thrown in for more control.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
-<button type="button" class="btn btn-{{ color.name }}">{{ color.name | capitalize }}</button>{% endfor %}
+{% example html %} {% for color in site.data.theme-colors %} <button type="button" class="btn btn-{{ color.name }}">{{ color.name | capitalize }}</button>{% endfor %}
 
-<button type="button" class="btn btn-link">Link</button>
-{% endexample %}
+<button type="button" class="btn btn-link">Link</button> {% endexample %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ## Button tags
 
@@ -27,78 +23,51 @@ The `.btn` classes are designed to be used with the `<button>` element. However,
 
 When using button classes on `<a>` elements that are used to trigger in-page functionality (like collapsing content), rather than linking to new pages or sections within the current page, these links should be given a `role="button"` to appropriately convey their purpose to assistive technologies such as screen readers.
 
-{% example html %}
-<a class="btn btn-primary" href="#" role="button">Link</a>
-<button class="btn btn-primary" type="submit">Button</button>
-<input class="btn btn-primary" type="button" value="Input">
-<input class="btn btn-primary" type="submit" value="Submit">
-<input class="btn btn-primary" type="reset" value="Reset">
-{% endexample %}
+{% example html %} <a class="btn btn-primary" href="#" role="button">Link</a> <button class="btn btn-primary" type="submit">Button</button> <input class="btn btn-primary" type="button" value="Input"> <input class="btn btn-primary" type="submit" value="Submit"> <input class="btn btn-primary" type="reset" value="Reset"> {% endexample %}
 
 ## Outline buttons
 
 In need of a button, but not the hefty background colors they bring? Replace the default modifier classes with the `.btn-outline-*` ones to remove all background images and colors on any button.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
-<button type="button" class="btn btn-outline-{{ color.name }}">{{ color.name | capitalize }}</button>{% endfor %}
-{% endexample %}
+{% example html %} {% for color in site.data.theme-colors %} <button type="button" class="btn btn-outline-{{ color.name }}">{{ color.name | capitalize }}</button>{% endfor %} {% endexample %}
 
 ## Sizes
 
 Fancy larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes.
 
-{% example html %}
-<button type="button" class="btn btn-primary btn-lg">Large button</button>
-<button type="button" class="btn btn-secondary btn-lg">Large button</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary btn-lg">Large button</button> <button type="button" class="btn btn-secondary btn-lg">Large button</button> {% endexample %}
 
-{% example html %}
-<button type="button" class="btn btn-primary btn-sm">Small button</button>
-<button type="button" class="btn btn-secondary btn-sm">Small button</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary btn-sm">Small button</button> <button type="button" class="btn btn-secondary btn-sm">Small button</button> {% endexample %}
 
 Create block level buttons—those that span the full width of a parent—by adding `.btn-block`.
 
-{% example html %}
-<button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
-<button type="button" class="btn btn-secondary btn-lg btn-block">Block level button</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button> <button type="button" class="btn btn-secondary btn-lg btn-block">Block level button</button> {% endexample %}
 
 ## Active state
 
 Buttons will appear pressed (with a darker background, darker border, and inset shadow) when active. **There's no need to add a class to `<button>`s as they use a pseudo-class**. However, you can still force the same active appearance with `.active` (and include the <code>aria-pressed="true"</code> attribute) should you need to replicate the state programmatically.
 
-{% example html %}
-<a href="#" class="btn btn-primary btn-lg active" role="button" aria-pressed="true">Primary link</a>
-<a href="#" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">Link</a>
-{% endexample %}
+{% example html %} <a href="#" class="btn btn-primary btn-lg active" role="button" aria-pressed="true">Primary link</a> <a href="#" class="btn btn-secondary btn-lg active" role="button" aria-pressed="true">Link</a> {% endexample %}
 
 ## Disabled state
 
 Make buttons look inactive by adding the `disabled` boolean attribute to any `<button>` element.
 
-{% example html %}
-<button type="button" class="btn btn-lg btn-primary" disabled>Primary button</button>
-<button type="button" class="btn btn-secondary btn-lg" disabled>Button</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-lg btn-primary" disabled>Primary button</button> <button type="button" class="btn btn-secondary btn-lg" disabled>Button</button> {% endexample %}
 
 Disabled buttons using the `<a>` element behave a bit different:
 
-- `<a>`s don't support the `disabled` attribute, so you must add the `.disabled` class to make it visually appear disabled.
-- Some future-friendly styles are included to disable all `pointer-events` on anchor buttons. In browsers which support that property, you won't see the disabled cursor at all.
-- Disabled buttons should include the `aria-disabled="true"` attribute to indicate the state of the element to assistive technologies.
+* `<a>`s don't support the `disabled` attribute, so you must add the `.disabled` class to make it visually appear disabled.
+* Some future-friendly styles are included to disable all `pointer-events` on anchor buttons. In browsers which support that property, you won't see the disabled cursor at all.
+* Disabled buttons should include the `aria-disabled="true"` attribute to indicate the state of the element to assistive technologies.
 
-{% example html %}
-<a href="#" class="btn btn-primary btn-lg disabled" role="button" aria-disabled="true">Primary link</a>
-<a href="#" class="btn btn-secondary btn-lg disabled" role="button" aria-disabled="true">Link</a>
-{% endexample %}
+{% example html %} <a href="#" class="btn btn-primary btn-lg disabled" role="button" aria-disabled="true">Primary link</a> <a href="#" class="btn btn-secondary btn-lg disabled" role="button" aria-disabled="true">Link</a> {% endexample %}
 
 {% callout warning %}
+
 #### Link functionality caveat
 
-The `.disabled` class uses `pointer-events: none` to try to disable the link functionality of `<a>`s, but that CSS property is not yet standardized. In addition, even in browsers that do support `pointer-events: none`, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links. So to be safe, add a `tabindex="-1"` attribute on these links (to prevent them from receiving keyboard focus) and use custom JavaScript to disable their functionality.
-{% endcallout %}
+The `.disabled` class uses `pointer-events: none` to try to disable the link functionality of `<a>`s, but that CSS property is not yet standardized. In addition, even in browsers that do support `pointer-events: none`, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links. So to be safe, add a `tabindex="-1"` attribute on these links (to prevent them from receiving keyboard focus) and use custom JavaScript to disable their functionality. {% endcallout %}
 
 ## Button plugin
 
@@ -108,11 +77,7 @@ Do more with buttons. Control button states or create groups of buttons for more
 
 Add `data-toggle="button"` to toggle a button's `active` state. If you're pre-toggling a button, you must manually add the `.active` class **and** `aria-pressed="true"` to the `<button>`.
 
-{% example html %}
-<button type="button" class="btn btn-primary" data-toggle="button" aria-pressed="false" autocomplete="off">
-  Single toggle
-</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-primary" data-toggle="button" aria-pressed="false" autocomplete="off"> Single toggle </button> {% endexample %}
 
 ### Checkbox and radio buttons
 
@@ -123,6 +88,7 @@ The checked state for these buttons is **only updated via `click` event** on the
 Note that pre-checked buttons require you to manually add the `.active` class to the input's `<label>`.
 
 {% example html %}
+
 <div class="btn-group" data-toggle="buttons">
   <label class="btn btn-secondary active">
     <input type="checkbox" checked autocomplete="off"> Checkbox 1 (pre-checked)
@@ -137,6 +103,7 @@ Note that pre-checked buttons require you to manually add the `.active` class to
 {% endexample %}
 
 {% example html %}
+
 <div class="btn-group" data-toggle="buttons">
   <label class="btn btn-secondary active">
     <input type="radio" name="options" id="option1" autocomplete="off" checked> Radio 1 (preselected)
@@ -152,7 +119,7 @@ Note that pre-checked buttons require you to manually add the `.active` class to
 
 ### Methods
 
-| Method | Description |
-| --- | --- |
-| `$().button('toggle')` | Toggles push state. Gives the button the appearance that it has been activated. |
-| `$().button('dispose')` | Destroys an element's button. |
+| Method                  | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `$().button('toggle')`  | Toggles push state. Gives the button the appearance that it has been activated. |
+| `$().button('dispose')` | Destroys an element's button.                                                   |

--- a/docs/4.0/components/card.md
+++ b/docs/4.0/components/card.md
@@ -668,4 +668,14 @@ Cards can be organized into [Masonry](https://masonry.desandro.com/)-like column
 
 Card columns can also be extended and customized with some additional code. Shown below is an extension of the `.card-columns` class using the same CSS we use—CSS columns— to generate a set of responsive tiers for changing the number of columns.
 
-{% highlight scss %} .card-columns { @include media-breakpoint-only(lg) { column-count: 4; } @include media-breakpoint-only(xl) { column-count: 5; } } {% endhighlight %}
+<!-- prettier-ignore -->
+{% highlight scss %}
+.card-columns {
+  @include media-breakpoint-only(lg) {
+    column-count: 4;
+  }
+  @include media-breakpoint-only(xl) {
+    column-count: 5;
+  }
+}
+{% endhighlight %}

--- a/docs/4.0/components/card.md
+++ b/docs/4.0/components/card.md
@@ -17,6 +17,7 @@ Cards are built with as little markup and styles as possible, but still manage t
 Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start, so they'll naturally fill the full width of its parent element. This is easily customized with our various [sizing options](#sizing).
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <img class="card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
   <div class="card-body">
@@ -36,6 +37,7 @@ Cards support a wide variety of content, including images, text, list groups, li
 The building block of a card is the `.card-body`. Use it whenever you need a padded section within a card.
 
 {% example html %}
+
 <div class="card">
   <div class="card-body">
     This is some text within a card body.
@@ -50,6 +52,7 @@ Card titles are used by adding `.card-title` to a `<h*>` tag. In the same way, l
 Subtitles are used by adding a `.card-subtitle` to a `<h*>` tag. If the `.card-title` and the `.card-subtitle` items are placed in a `.card-body` item, the card title and subtitle are aligned nicely.
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
@@ -66,6 +69,7 @@ Subtitles are used by adding a `.card-subtitle` to a `<h*>` tag. If the `.card-t
 `.card-img-top` places an image to the top of the card. With `.card-text`, text can be added to the card. Text within `.card-text` can also be styled with the standard HTML tags.
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <img class="card-img-top" data-src="holder.js/100px180/?text=Image cap" alt="Card image cap">
   <div class="card-body">
@@ -79,6 +83,7 @@ Subtitles are used by adding a `.card-subtitle` to a `<h*>` tag. If the `.card-t
 Create lists of content in a card with a flush list group.
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <ul class="list-group list-group-flush">
     <li class="list-group-item">Cras justo odio</li>
@@ -89,6 +94,7 @@ Create lists of content in a card with a flush list group.
 {% endexample %}
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <div class="card-header">
     Featured
@@ -106,6 +112,7 @@ Create lists of content in a card with a flush list group.
 Mix and match multiple content types to create the card you need, or throw everything in there. Shown below are image styles, blocks, text styles, and a list group—all wrapped in a fixed-width card.
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <img class="card-img-top" data-src="holder.js/100px180/?text=Image cap" alt="Card image cap">
   <div class="card-body">
@@ -129,6 +136,7 @@ Mix and match multiple content types to create the card you need, or throw every
 Add an optional header and/or footer within a card.
 
 {% example html %}
+
 <div class="card">
   <div class="card-header">
     Featured
@@ -144,6 +152,7 @@ Add an optional header and/or footer within a card.
 Card headers can be styled by adding `.card-header` to `<h*>` elements.
 
 {% example html %}
+
 <div class="card">
   <h4 class="card-header">Featured</h4>
   <div class="card-body">
@@ -155,6 +164,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 {% endexample %}
 
 {% example html %}
+
 <div class="card">
   <div class="card-header">
     Quote
@@ -169,6 +179,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 {% endexample %}
 
 {% example html %}
+
 <div class="card text-center">
   <div class="card-header">
     Featured
@@ -193,6 +204,7 @@ Cards assume no specific `width` to start, so they'll be 100% wide unless otherw
 Using the grid, wrap cards in columns and rows as needed.
 
 {% example html %}
+
 <div class="row">
   <div class="col-sm-6">
     <div class="card">
@@ -220,6 +232,7 @@ Using the grid, wrap cards in columns and rows as needed.
 Use our handful of [available sizing utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/sizing/) to quickly set a card's width.
 
 {% example html %}
+
 <div class="card w-75">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
@@ -242,6 +255,7 @@ Use our handful of [available sizing utilities]({{ site.baseurl }}/docs/{{ site.
 Use custom CSS in your stylesheets or as inline styles to set a width.
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
@@ -256,6 +270,7 @@ Use custom CSS in your stylesheets or as inline styles to set a width.
 You can quickly change the text alignment of any card—in its entirety or specific parts—with our [text align classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/text/#text-alignment).
 
 {% example html %}
+
 <div class="card" style="width: 20rem;">
   <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
@@ -286,6 +301,7 @@ You can quickly change the text alignment of any card—in its entirety or speci
 Add some navigation to a card's header (or block) with Bootstrap's [nav components]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/navs/).
 
 {% example html %}
+
 <div class="card text-center">
   <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs">
@@ -309,6 +325,7 @@ Add some navigation to a card's header (or block) with Bootstrap's [nav componen
 {% endexample %}
 
 {% example html %}
+
 <div class="card text-center">
   <div class="card-header">
     <ul class="nav nav-pills card-header-pills">
@@ -340,6 +357,7 @@ Cards include a few options for working with images. Choose from appending "imag
 Similar to headers and footers, cards can include top and bottom "image caps"—images at the top or bottom of a card.
 
 {% example html %}
+
 <div class="card mb-3">
   <img class="card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
   <div class="card-body">
@@ -363,6 +381,7 @@ Similar to headers and footers, cards can include top and bottom "image caps"—
 Turn an image into a card background and overlay your card's text. Depending on the image, you may or may not need additional styles or utilities.
 
 {% example html %}
+
 <div class="card bg-dark text-white">
   <img class="card-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
   <div class="card-img-overlay">
@@ -381,8 +400,8 @@ Cards include various options for customizing their backgrounds, borders, and co
 
 Use [text and background utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/colors/) to change the appearance of a card.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="card{% unless color.name == "light" %} text-white{% endunless %} bg-{{ color.name }} mb-3" style="max-width: 20rem;">
   <div class="card-header">Header</div>
   <div class="card-body">
@@ -392,15 +411,14 @@ Use [text and background utilities]({{ site.baseurl }}/docs/{{ site.docs_version
 </div>{% endfor %}
 {% endexample %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ### Border
 
 Use [border utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/borders/) to change just the `border-color` of a card. Note that you can put `.text-{color}` classes on the parent `.card` or a subset of the card's contents as shown below.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="card border-{{ color.name }} mb-3" style="max-width: 20rem;">
   <div class="card-header">Header</div>
   <div class="card-body{% unless color.name == "light" %} text-{{ color.name }}{% endunless %}">
@@ -415,6 +433,7 @@ Use [border utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities
 You can also change the borders on the card header and footer as needed, and even remove their `background-color` with `.bg-transparent`.
 
 {% example html %}
+
 <div class="card border-success mb-3" style="max-width: 20rem;">
   <div class="card-header bg-transparent border-success">Header</div>
   <div class="card-body text-success">
@@ -434,6 +453,7 @@ In addition to styling the content within cards, Bootstrap includes a few option
 Use card groups to render cards as a single, attached element with equal width and height columns. Card groups use `display: flex;` to achieve their uniform sizing.
 
 {% example html %}
+
 <div class="card-group">
   <div class="card">
     <img class="card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
@@ -465,6 +485,7 @@ Use card groups to render cards as a single, attached element with equal width a
 When using card groups with footers, their content will automatically line up.
 
 {% example html %}
+
 <div class="card-group">
   <div class="card">
     <img class="card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
@@ -504,6 +525,7 @@ When using card groups with footers, their content will automatically line up.
 Need a set of equal width and height cards that aren't attached to one another? Use card decks.
 
 {% example html %}
+
 <div class="card-deck">
   <div class="card">
     <img class="card-img-top" data-src="holder.js/100px200/" alt="Card image cap">
@@ -535,6 +557,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
 Just like with card groups, card footers in decks will automatically line up.
 
 {% example html %}
+
 <div class="card-deck">
   <div class="card">
     <img class="card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
@@ -576,6 +599,7 @@ Cards can be organized into [Masonry](https://masonry.desandro.com/)-like column
 **Heads up!** Your mileage with card columns may vary. To prevent cards breaking across columns, we must set them to `display: inline-block` as `column-break-inside: avoid` isn't a bulletproof solution yet.
 
 {% example html %}
+
 <div class="card-columns">
   <div class="card">
     <img class="card-img-top" data-src="holder.js/100px160/" alt="Card image cap">
@@ -644,13 +668,4 @@ Cards can be organized into [Masonry](https://masonry.desandro.com/)-like column
 
 Card columns can also be extended and customized with some additional code. Shown below is an extension of the `.card-columns` class using the same CSS we use—CSS columns— to generate a set of responsive tiers for changing the number of columns.
 
-{% highlight scss %}
-.card-columns {
-  @include media-breakpoint-only(lg) {
-    column-count: 4;
-  }
-  @include media-breakpoint-only(xl) {
-    column-count: 5;
-  }
-}
-{% endhighlight %}
+{% highlight scss %} .card-columns { @include media-breakpoint-only(lg) { column-count: 4; } @include media-breakpoint-only(xl) { column-count: 5; } } {% endhighlight %}

--- a/docs/4.0/components/carousel.md
+++ b/docs/4.0/components/carousel.md
@@ -27,6 +27,7 @@ Be sure to set a unique id on the `.carousel` for optional controls, especially 
 Here's a carousel with slides only. Note the presence of the `.d-block` and `.img-fluid` on carousel images to prevent browser default image alignment.
 
 {% example html %}
+
 <div id="carouselExampleSlidesOnly" class="carousel slide" data-ride="carousel">
   <div class="carousel-inner">
     <div class="carousel-item active">
@@ -47,6 +48,7 @@ Here's a carousel with slides only. Note the presence of the `.d-block` and `.im
 Adding in the previous and next controls:
 
 {% example html %}
+
 <div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
   <div class="carousel-inner">
     <div class="carousel-item active">
@@ -75,6 +77,7 @@ Adding in the previous and next controls:
 You can also add the indicators to the carousel, alongside the controls, too.
 
 {% example html %}
+
 <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
   <ol class="carousel-indicators">
     <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
@@ -104,10 +107,10 @@ You can also add the indicators to the carousel, alongside the controls, too.
 {% endexample %}
 
 {% callout warning %}
+
 #### Initial active element required
 
-The `.active` class needs to be added to one of the slides. Otherwise, the carousel will not be visible.
-{% endcallout %}
+The `.active` class needs to be added to one of the slides. Otherwise, the carousel will not be visible. {% endcallout %}
 
 ### With captions
 
@@ -155,6 +158,7 @@ Add captions to your slides easily with the `.carousel-caption` element within a
 </div>
 
 {% highlight html %}
+
 <div class="carousel-item">
   <img src="..." alt="...">
   <div class="carousel-caption d-none d-md-block">
@@ -176,9 +180,7 @@ The `data-ride="carousel"` attribute is used to mark a carousel as animating sta
 
 Call carousel manually with:
 
-{% highlight js %}
-$('.carousel').carousel()
-{% endhighlight %}
+{% highlight js %} $('.carousel').carousel() {% endhighlight %}
 
 ### Options
 
@@ -230,18 +232,13 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### `.carousel(options)`
 
 Initializes the carousel with an optional options `object` and starts cycling through items.
 
-{% highlight js %}
-$('.carousel').carousel({
-  interval: 2000
-})
-{% endhighlight %}
+{% highlight js %} $('.carousel').carousel({ interval: 2000 }) {% endhighlight %}
 
 #### `.carousel('cycle')`
 
@@ -271,10 +268,10 @@ Destroys an element's carousel.
 
 Bootstrap's carousel class exposes two events for hooking into carousel functionality. Both events have the following additional properties:
 
-- `direction`: The direction in which the carousel is sliding (either `"left"` or `"right"`).
-- `relatedTarget`: The DOM element that is being slid into place as the active item.
-- `from`: The index of the current item
-- `to`: The index of the next item
+* `direction`: The direction in which the carousel is sliding (either `"left"` or `"right"`).
+* `relatedTarget`: The DOM element that is being slid into place as the active item.
+* `from`: The index of the current item
+* `to`: The index of the next item
 
 All carousel events are fired at the carousel itself (i.e. at the `<div class="carousel">`).
 
@@ -297,8 +294,4 @@ All carousel events are fired at the carousel itself (i.e. at the `<div class="c
   </tbody>
 </table>
 
-{% highlight js %}
-$('#myCarousel').on('slide.bs.carousel', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myCarousel').on('slide.bs.carousel', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/carousel.md
+++ b/docs/4.0/components/carousel.md
@@ -238,7 +238,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 Initializes the carousel with an optional options `object` and starts cycling through items.
 
-{% highlight js %} $('.carousel').carousel({ interval: 2000 }) {% endhighlight %}
+<!-- prettier-ignore -->
+{% highlight js %}
+  $('.carousel').carousel({
+    interval: 2000
+  })
+{% endhighlight %}
 
 #### `.carousel('cycle')`
 

--- a/docs/4.0/components/collapse.md
+++ b/docs/4.0/components/collapse.md
@@ -10,13 +10,14 @@ toc: true
 
 Click the buttons below to show and hide another element via class changes:
 
-- `.collapse` hides content
-- `.collapsing` is applied during transitions
-- `.collapse.show` shows content
+* `.collapse` hides content
+* `.collapsing` is applied during transitions
+* `.collapse.show` shows content
 
 You can use a link with the `href` attribute, or a button with the `data-target` attribute. In both cases, the `data-toggle="collapse"` is required.
 
 {% example html %}
+
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
     Link with href
@@ -34,10 +35,10 @@ You can use a link with the `href` attribute, or a button with the `data-target`
 
 ## Multiple targets
 
-A `<button>` or `<a>` can show and hide multiple elements by referencing them with a JQuery selector in its `href` or `data-target` attribute.
-Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-target` attribute
+A `<button>` or `<a>` can show and hide multiple elements by referencing them with a JQuery selector in its `href` or `data-target` attribute. Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-target` attribute
 
 {% example html %}
+
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>
   <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#multiCollapseExample2" aria-expanded="false" aria-controls="multiCollapseExample2">Toggle second element</button>
@@ -66,6 +67,7 @@ Multiple `<button>` or `<a>` can show and hide an element if they each reference
 Using the [card]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/card/) component, you can extend the default collapse behavior to create an accordion.
 
 {% example html %}
+
 <div id="accordion" role="tablist">
   <div class="card">
     <div class="card-header" role="tab" id="headingOne">
@@ -81,6 +83,7 @@ Using the [card]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/card
         Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
       </div>
     </div>
+
   </div>
   <div class="card">
     <div class="card-header" role="tab" id="headingTwo">
@@ -116,6 +119,7 @@ Using the [card]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/card
 You can also create accordions with custom markup. Add the `data-children` attribute and specify a set of sibling elements to toggle (e.g., `.item`). Then, use the same attributes and classes as shown above for connecting toggles to their associated content.
 
 {% example html %}
+
 <div id="exampleAccordion" data-children=".item">
   <div class="item">
     <a data-toggle="collapse" data-parent="#exampleAccordion" href="#exampleAccordion1" role="button" aria-expanded="true" aria-controls="exampleAccordion1">
@@ -150,9 +154,9 @@ Additionally, if your control element is targeting a single collapsible element 
 
 The collapse plugin utilizes a few classes to handle the heavy lifting:
 
-- `.collapse` hides the content
-- `.collapse.show` shows the content
-- `.collapsing` is added when the transition starts, and removed when it finishes
+* `.collapse` hides the content
+* `.collapse.show` shows the content
+* `.collapsing` is added when the transition starts, and removed when it finishes
 
 These classes can be found in `_transitions.scss`.
 
@@ -166,9 +170,7 @@ To add accordion-like group management to a collapsible area, add the data attri
 
 Enable manually with:
 
-{% highlight js %}
-$('.collapse').collapse()
-{% endhighlight %}
+{% highlight js %} $('.collapse').collapse() {% endhighlight %}
 
 ### Options
 
@@ -201,18 +203,13 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### `.collapse(options)`
 
 Activates your content as a collapsible element. Accepts an optional options `object`.
 
-{% highlight js %}
-$('#myCollapsible').collapse({
-  toggle: false
-})
-{% endhighlight %}
+{% highlight js %} $('#myCollapsible').collapse({ toggle: false }) {% endhighlight %}
 
 #### `.collapse('toggle')`
 
@@ -261,8 +258,4 @@ Bootstrap's collapse class exposes a few events for hooking into collapse functi
   </tbody>
 </table>
 
-{% highlight js %}
-$('#myCollapsible').on('hidden.bs.collapse', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myCollapsible').on('hidden.bs.collapse', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/dropdowns.md
+++ b/docs/4.0/components/dropdowns.md
@@ -31,6 +31,7 @@ Wrap the dropdown's toggle (your button or link) and the dropdown menu within `.
 Any single `.btn` can be turned into a dropdown toggle with some markup changes. Here's how you can put them to work with either `<button>` elements:
 
 {% example html %}
+
 <div class="dropdown">
   <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropdown button
@@ -46,6 +47,7 @@ Any single `.btn` can be turned into a dropdown toggle with some markup changes.
 And with `<a>` elements:
 
 {% example html %}
+
 <div class="dropdown show">
   <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropdown link
@@ -125,7 +127,9 @@ The best part is you can do this with any button variant, too:
 </div>
 
 {% highlight html %}
+
 <!-- Example single danger button -->
+
 <div class="btn-group">
   <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Action
@@ -228,7 +232,9 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 </div>
 
 {% highlight html %}
+
 <!-- Example split danger button -->
+
 <div class="btn-group">
   <button type="button" class="btn btn-danger">Action</button>
   <button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -306,7 +312,9 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 </div><!-- /example -->
 
 {% highlight html %}
+
 <!-- Large button groups (default and split) -->
+
 <div class="btn-group">
   <button class="btn btn-secondary btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Large button
@@ -328,6 +336,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
 </div>
 
 <!-- Small button groups (default and split) -->
+
 <div class="btn-group">
   <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Small button
@@ -385,7 +394,9 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 </div>
 
 {% highlight html %}
+
 <!-- Default dropup button -->
+
 <div class="btn-group dropup">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropup
@@ -396,6 +407,7 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 </div>
 
 <!-- Split dropup button -->
+
 <div class="btn-group dropup">
   <button type="button" class="btn btn-secondary">
     Split dropup
@@ -445,7 +457,9 @@ Trigger dropdown menus at the right of the elements by adding `.dropright` to th
 </div>
 
 {% highlight html %}
+
 <!-- Default dropright button -->
+
 <div class="btn-group dropright">
   <button type="button" class="btn btn-secondary">Dropright</button>
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -457,6 +471,7 @@ Trigger dropdown menus at the right of the elements by adding `.dropright` to th
 </div>
 
 <!-- Split dropright button -->
+
 <div class="btn-group dropright">
   <button type="button" class="btn btn-secondary">
     Split dropright
@@ -508,7 +523,9 @@ Trigger dropdown menus at the left of the elements by adding `.dropleft` to the 
 </div>
 
 {% highlight html %}
+
 <!-- Default dropleft button -->
+
 <div class="btn-group dropleft">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropleft
@@ -519,6 +536,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropleft` to the 
 </div>
 
 <!-- Split dropleft button -->
+
 <div class="btn-group">
   <div class="btn-group dropleft" role="group">
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -534,12 +552,12 @@ Trigger dropdown menus at the left of the elements by adding `.dropleft` to the 
 </div>
 {% endhighlight %}
 
-
 ## Menu items
 
-Historically dropdown menu contents *had* to be links, but that's no longer the case with v4. Now you can optionally use `<button>` elements in your dropdowns instead of just `<a>`s.
+Historically dropdown menu contents _had_ to be links, but that's no longer the case with v4. Now you can optionally use `<button>` elements in your dropdowns instead of just `<a>`s.
 
 {% example html %}
+
 <div class="dropdown">
   <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropdown
@@ -556,11 +574,10 @@ Historically dropdown menu contents *had* to be links, but that's no longer the 
 
 By default, a dropdown menu is automatically positioned 100% from the top and along the left side of its parent. Add `.dropdown-menu-right` to a `.dropdown-menu` to right align the dropdown menu.
 
-{% callout info %}
-**Heads up!** Dropdowns are positioned thanks to Popper.js (except when they are contained in a navbar).
-{% endcallout %}
+{% callout info %} **Heads up!** Dropdowns are positioned thanks to Popper.js (except when they are contained in a navbar). {% endcallout %}
 
 {% example html %}
+
 <div class="btn-group">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     This dropdown's menu is right-aligned
@@ -578,6 +595,7 @@ By default, a dropdown menu is automatically positioned 100% from the top and al
 Add a header to label sections of actions in any dropdown menu.
 
 {% example html %}
+
 <div class="dropdown-menu">
   <h6 class="dropdown-header">Dropdown header</h6>
   <a class="dropdown-item" href="#">Action</a>
@@ -590,6 +608,7 @@ Add a header to label sections of actions in any dropdown menu.
 Separate groups of related menu items with a divider.
 
 {% example html %}
+
 <div class="dropdown-menu">
   <a class="dropdown-item" href="#">Action</a>
   <a class="dropdown-item" href="#">Another action</a>
@@ -604,6 +623,7 @@ Separate groups of related menu items with a divider.
 Put a form within a dropdown menu, or make it into a dropdown menu, and use [margin or padding utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) to give it the negative space you require.
 
 {% example html %}
+
 <div class="dropdown-menu">
   <form class="px-4 py-3">
     <div class="form-group">
@@ -629,6 +649,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
 {% endexample %}
 
 {% example html %}
+
 <form class="dropdown-menu p-4">
   <div class="form-group">
     <label for="exampleDropdownFormEmail2">Email address</label>
@@ -653,6 +674,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
 Add `.disabled` to items in the dropdown to **style them as disabled**.
 
 {% example html %}
+
 <div class="dropdown-menu">
   <a class="dropdown-item" href="#">Regular link</a>
   <a class="dropdown-item disabled" href="#">Disabled link</a>
@@ -664,15 +686,14 @@ Add `.disabled` to items in the dropdown to **style them as disabled**.
 
 Via data attributes or JavaScript, the dropdown plugin toggles hidden content (dropdown menus) by toggling the `.show` class on the parent list item. The `data-toggle="dropdown"` attribute is relied on for closing dropdown menus at an application level, so it's a good idea to always use it.
 
-{% callout info %}
-On touch-enabled devices, opening a dropdown adds empty (`$.noop`) `mouseover` handlers to the immediate children of the `<body>` element. This admittedly ugly hack is necessary to work around a [quirk in iOS' event delegation](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html), which would otherwise prevent a tap anywhere outside of the dropdown from triggering the code that closes the dropdown. Once the dropdown is closed, these additional empty `mouseover` handlers are removed.
-{% endcallout %}
+{% callout info %} On touch-enabled devices, opening a dropdown adds empty (`$.noop`) `mouseover` handlers to the immediate children of the `<body>` element. This admittedly ugly hack is necessary to work around a [quirk in iOS' event delegation](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html), which would otherwise prevent a tap anywhere outside of the dropdown from triggering the code that closes the dropdown. Once the dropdown is closed, these additional empty `mouseover` handlers are removed. {% endcallout %}
 
 ### Via data attributes
 
 Add `data-toggle="dropdown"` to a link or button to toggle a dropdown.
 
 {% highlight html %}
+
 <div class="dropdown">
   <button id="dLabel" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Dropdown trigger
@@ -687,15 +708,13 @@ Add `data-toggle="dropdown"` to a link or button to toggle a dropdown.
 
 Call the dropdowns via JavaScript:
 
-{% highlight js %}
-$('.dropdown-toggle').dropdown()
-{% endhighlight %}
+{% highlight js %} $('.dropdown-toggle').dropdown() {% endhighlight %}
 
 {% callout info %}
+
 ##### `data-toggle="dropdown"` still required
 
-Regardless of whether you call your dropdown via JavaScript or instead use the data-api, `data-toggle="dropdown"` is always required to be present on the dropdown's trigger element.
-{% endcallout %}
+Regardless of whether you call your dropdown via JavaScript or instead use the data-api, `data-toggle="dropdown"` is always required to be present on the dropdown's trigger element. {% endcallout %}
 
 ### Options
 
@@ -728,25 +747,21 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-| Method | Description |
-| --- | --- |
-| `$().dropdown('toggle')` | Toggles the dropdown menu of a given navbar or tabbed navigation. |
-| `$().dropdown('update')` | Updates the position of an element's dropdown. |
-| `$().dropdown('dispose')` | Destroys an element's dropdown. |
+| Method                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `$().dropdown('toggle')`  | Toggles the dropdown menu of a given navbar or tabbed navigation. |
+| `$().dropdown('update')`  | Updates the position of an element's dropdown.                    |
+| `$().dropdown('dispose')` | Destroys an element's dropdown.                                   |
 
 ### Events
 
 All dropdown events are fired at the `.dropdown-menu`'s parent element and have a `relatedTarget` property, whose value is the toggling anchor element.
 
-| Event | Description |
-| --- | --- |
-| `show.bs.dropdown` | This event fires immediately when the show instance method is called. |
-| `shown.bs.dropdown` | This event is fired when the dropdown has been made visible to the user (will wait for CSS transitions, to complete). |
-| `hide.bs.dropdown` | This event is fired immediately when the hide instance method has been called. |
-| `hidden.bs.dropdown`| This event is fired when the dropdown has finished being hidden from the user (will wait for CSS transitions, to complete). |
+| Event                | Description                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `show.bs.dropdown`   | This event fires immediately when the show instance method is called.                                                       |
+| `shown.bs.dropdown`  | This event is fired when the dropdown has been made visible to the user (will wait for CSS transitions, to complete).       |
+| `hide.bs.dropdown`   | This event is fired immediately when the hide instance method has been called.                                              |
+| `hidden.bs.dropdown` | This event is fired when the dropdown has finished being hidden from the user (will wait for CSS transitions, to complete). |
 
-{% highlight js %}
-$('#myDropdown').on('show.bs.dropdown', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myDropdown').on('show.bs.dropdown', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/forms.md
+++ b/docs/4.0/components/forms.md
@@ -15,6 +15,7 @@ Be sure to use an appropriate `type` attribute on all inputs (e.g., `email` for 
 Here's a quick example to demonstrate Bootstrap's form styles. Keep reading for documentation on required classes, form layout, and more.
 
 {% example html %}
+
 <form>
   <div class="form-group">
     <label for="exampleInputEmail1">Email address</label>
@@ -42,6 +43,7 @@ Textual form controls—like `<input>`s, `<select>`s, and `<textarea>`s—are st
 Be sure to explore our [custom forms](#custom-forms) to further style `<select>`s.
 
 {% example html %}
+
 <form>
   <div class="form-group">
     <label for="exampleFormControlInput1">Email address</label>
@@ -77,6 +79,7 @@ Be sure to explore our [custom forms](#custom-forms) to further style `<select>`
 For file inputs, swap the `.form-control` for `.form-control-file`.
 
 {% example html %}
+
 <form>
   <div class="form-group">
     <label for="exampleFormControlFile1">Example file input</label>
@@ -89,14 +92,10 @@ For file inputs, swap the `.form-control` for `.form-control-file`.
 
 Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 
-{% example html %}
-<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg">
-<input class="form-control" type="text" placeholder="Default input">
-<input class="form-control form-control-sm" type="text" placeholder=".form-control-sm">
-{% endexample %}
+{% example html %} <input class="form-control form-control-lg" type="text" placeholder=".form-control-lg"> <input class="form-control" type="text" placeholder="Default input"> <input class="form-control form-control-sm" type="text" placeholder=".form-control-sm"> {% endexample %}
 
-{% example html %}
-<select class="form-control form-control-lg">
+{% example html %} <select class="form-control form-control-lg">
+
   <option>Large select</option>
 </select>
 <select class="form-control">
@@ -111,15 +110,14 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 
 Add the `readonly` boolean attribute on an input to prevent modification of the input's value. Read-only inputs appear lighter (just like disabled inputs), but retain the standard cursor.
 
-{% example html %}
-<input class="form-control" type="text" placeholder="Readonly input here…" readonly>
-{% endexample %}
+{% example html %} <input class="form-control" type="text" placeholder="Readonly input here…" readonly> {% endexample %}
 
 ### Readonly plain text
 
 If you want to have `<input readonly>` elements in your form styled as plain text, use the `.form-control-plaintext` class to remove the default form field styling and preserve the correct margin and padding.
 
 {% example html %}
+
 <form>
   <div class="form-group row">
     <label for="staticEmail" class="col-sm-2 col-form-label">Email</label>
@@ -137,6 +135,7 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 {% endexample %}
 
 {% example html %}
+
 <form class="form-inline">
   <div class="form-group mb-2">
     <label for="staticEmail2" class="sr-only">Email</label>
@@ -161,6 +160,7 @@ Disabled checkboxes and radios are supported, but to provide a `not-allowed` cur
 By default, any number of checkboxes and radios that are immediate sibling will be vertically stacked and appropriately spaced with `.form-check`.
 
 {% example html %}
+
 <div class="form-check">
   <label class="form-check-label">
     <input class="form-check-input" type="checkbox" value="">
@@ -176,6 +176,7 @@ By default, any number of checkboxes and radios that are immediate sibling will 
 {% endexample %}
 
 {% example html %}
+
 <div class="form-check">
   <label class="form-check-label">
     <input class="form-check-input" type="radio" name="exampleRadios" id="exampleRadios1" value="option1" checked>
@@ -201,6 +202,7 @@ By default, any number of checkboxes and radios that are immediate sibling will 
 Group checkboxes or radios on the same horizontal row by adding `.form-check-inline` to any `.form-check`.
 
 {% example html %}
+
 <div class="form-check form-check-inline">
   <label class="form-check-label">
     <input class="form-check-input" type="checkbox" id="inlineCheckbox1" value="option1"> 1
@@ -219,6 +221,7 @@ Group checkboxes or radios on the same horizontal row by adding `.form-check-inl
 {% endexample %}
 
 {% example html %}
+
 <div class="form-check form-check-inline">
   <label class="form-check-label">
     <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1"> 1
@@ -241,6 +244,7 @@ Group checkboxes or radios on the same horizontal row by adding `.form-check-inl
 Add `.position-static` to inputs within `.form-check` that don't have any label text. Remember to still provide some form of label for assistive technologies (for instance, using `aria-label`).
 
 {% example html %}
+
 <div class="form-check">
   <label class="form-check-label">
     <input class="form-check-input position-static" type="checkbox" id="blankCheckbox" value="option1" aria-label="...">
@@ -262,6 +266,7 @@ Since Bootstrap applies `display: block` and `width: 100%` to almost all our for
 The `.form-group` class is the easiest way to add some structure to forms. Its only purpose is to provide `margin-bottom` around a label and control pairing. As a bonus, since it's a class you can use it with `<fieldset>`s, `<div>`s, or nearly any other element.
 
 {% example html %}
+
 <form>
   <div class="form-group">
     <label for="formGroupExampleInput">Example label</label>
@@ -279,6 +284,7 @@ The `.form-group` class is the easiest way to add some structure to forms. Its o
 More complex forms can be built using our grid classes. Use these for form layouts that require multiple columns, varied widths, and additional alignment options.
 
 {% example html %}
+
 <form>
   <div class="row">
     <div class="col">
@@ -296,6 +302,7 @@ More complex forms can be built using our grid classes. Use these for form layou
 You may also swap `.row` for `.form-row`, a variation of our standard grid row that overrides the default column gutters for tighter and more compact layouts.
 
 {% example html %}
+
 <form>
   <div class="form-row">
     <div class="col">
@@ -311,6 +318,7 @@ You may also swap `.row` for `.form-row`, a variation of our standard grid row t
 More complex layouts can also be created with the grid system.
 
 {% example html %}
+
 <form>
   <div class="form-row">
     <div class="form-group col-md-6">
@@ -365,6 +373,7 @@ Create horizontal forms with the grid by adding the `.row` class to form groups 
 Be sure to add `.col-form-label` to your `<label>`s as well so they're vertically centered with their associated form controls. For `<legend>` elements, you can use `.col-form-legend` to make them appear similar to regular `<label>` elements.
 
 {% example html %}
+
 <form>
   <div class="form-group row">
     <label for="inputEmail3" class="col-sm-2 col-form-label">Email</label>
@@ -426,6 +435,7 @@ Be sure to add `.col-form-label` to your `<label>`s as well so they're verticall
 Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s to correctly follow the size of `.form-control-lg` and `.form-control-sm`.
 
 {% example html %}
+
 <form>
   <div class="form-group row">
     <label for="colFormLabelSm" class="col-sm-2 col-form-label col-form-label-sm">Email</label>
@@ -453,6 +463,7 @@ Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s t
 As shown in the previous examples, our grid system allows you to place any number of `.col`s within a `.row` or `.form-row`. They'll split the available width equally between them. You may also pick a subset of your columns to take up more or less space, while the remaining `.col`s equally split the rest, with specific column classes like `.col-7`.
 
 {% example html %}
+
 <form>
   <div class="form-row">
     <div class="col-7">
@@ -473,6 +484,7 @@ As shown in the previous examples, our grid system allows you to place any numbe
 The example below uses a flexbox utility to vertically center the contents and changes `.col` to `.col-auto` so that your columns only take up as much space as needed. Put another way, the column sizes itself based on the contents.
 
 {% example html %}
+
 <form>
   <div class="form-row align-items-center">
     <div class="col-auto">
@@ -503,6 +515,7 @@ The example below uses a flexbox utility to vertically center the contents and c
 You can then remix that once again with size-specific column classes.
 
 {% example html %}
+
 <form>
   <div class="form-row align-items-center">
     <div class="col-sm-3">
@@ -533,6 +546,7 @@ You can then remix that once again with size-specific column classes.
 And of course [custom form controls](#custom-forms) are supported.
 
 {% example html %}
+
 <form>
   <div class="form-row align-items-center">
     <div class="col-auto">
@@ -562,18 +576,20 @@ And of course [custom form controls](#custom-forms) are supported.
 
 Use the `.form-inline` class to display a series of labels, form controls, and buttons on a single horizontal row. Form controls within inline forms vary slightly from their default states.
 
-- Controls are `display: flex`, collapsing any HTML white space and allowing you to provide alignment control with [spacing]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) and [flexbox]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/) utilities.
-- Controls and input groups receive `width: auto` to override the Bootstrap default `width: 100%`.
-- Controls **only appear inline in viewports that are at least 576px wide** to account for narrow viewports on mobile devices.
+* Controls are `display: flex`, collapsing any HTML white space and allowing you to provide alignment control with [spacing]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) and [flexbox]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/) utilities.
+* Controls and input groups receive `width: auto` to override the Bootstrap default `width: 100%`.
+* Controls **only appear inline in viewports that are at least 576px wide** to account for narrow viewports on mobile devices.
 
 You may need to manually address the width and alignment of individual form controls with [spacing utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) (as shown below). Lastly, be sure to always include a `<label>` with each form control, even if you need to hide it from non-screenreader visitors with `.sr-only`.
 
 {% example html %}
+
 <form class="form-inline">
   <label class="sr-only" for="inlineFormInputName2">Name</label>
   <input type="text" class="form-control mb-2 mr-sm-2" id="inlineFormInputName2" placeholder="Jane Doe">
 
-  <label class="sr-only" for="inlineFormInputGroupUsername2">Username</label>
+<label class="sr-only" for="inlineFormInputGroupUsername2">Username</label>
+
   <div class="input-group mb-2 mr-sm-2">
     <div class="input-group-addon">@</div>
     <input type="text" class="form-control" id="inlineFormInputGroupUsername2" placeholder="Username">
@@ -585,13 +601,15 @@ You may need to manually address the width and alignment of individual form cont
     </label>
   </div>
 
-  <button type="submit" class="btn btn-primary mb-2">Submit</button>
+<button type="submit" class="btn btn-primary mb-2">Submit</button>
+
 </form>
 {% endexample %}
 
 Custom form controls and selects are also supported.
 
 {% example html %}
+
 <form class="form-inline">
   <label class="mr-2" for="inlineFormCustomSelectPref">Preference</label>
   <select class="custom-select mb-2 mr-sm-2" id="inlineFormCustomSelectPref">
@@ -607,38 +625,35 @@ Custom form controls and selects are also supported.
     <span class="custom-control-description">Remember my preference</span>
   </label>
 
-  <button type="submit" class="btn btn-primary mb-2">Submit</button>
+<button type="submit" class="btn btn-primary mb-2">Submit</button>
+
 </form>
 {% endexample %}
 
 {% callout warning %}
+
 #### Alternatives to hidden labels
-Assistive technologies such as screen readers will have trouble with your forms if you don't include a label for every input. For these inline forms, you can hide the labels using the `.sr-only` class. There are further alternative methods of providing a label for assistive technologies, such as the `aria-label`, `aria-labelledby` or `title` attribute. If none of these are present, assistive technologies may resort to using the `placeholder` attribute, if present, but note that use of `placeholder` as a replacement for other labelling methods is not advised.
-{% endcallout %}
+
+Assistive technologies such as screen readers will have trouble with your forms if you don't include a label for every input. For these inline forms, you can hide the labels using the `.sr-only` class. There are further alternative methods of providing a label for assistive technologies, such as the `aria-label`, `aria-labelledby` or `title` attribute. If none of these are present, assistive technologies may resort to using the `placeholder` attribute, if present, but note that use of `placeholder` as a replacement for other labelling methods is not advised. {% endcallout %}
 
 ## Help text
 
 Block-level help text in forms can be created using `.form-text` (previously known as `.help-block` in v3). Inline help text can be flexibly implemented using any inline HTML element and utility classes like `.text-muted`.
 
 {% callout warning %}
+
 ##### Associating help text with form controls
 
-Help text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this help text when the user focuses or enters the control.
-{% endcallout %}
+Help text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this help text when the user focuses or enters the control. {% endcallout %}
 
 Help text below inputs can be styled with `.form-text`. This class includes `display: block` and adds some top margin for easy spacing from the inputs above.
 
-{% example html %}
-<label for="inputPassword5">Password</label>
-<input type="password" id="inputPassword5" class="form-control" aria-describedby="passwordHelpBlock">
-<small id="passwordHelpBlock" class="form-text text-muted">
-  Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.
-</small>
-{% endexample %}
+{% example html %} <label for="inputPassword5">Password</label> <input type="password" id="inputPassword5" class="form-control" aria-describedby="passwordHelpBlock"> <small id="passwordHelpBlock" class="form-text text-muted"> Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji. </small> {% endexample %}
 
 Inline text can use any typical inline HTML element (be it a `<small>`, `<span>`, or something else) with nothing more than a utility class.
 
 {% example html %}
+
 <form class="form-inline">
   <div class="form-group">
     <label for="inputPassword6">Password</label>
@@ -654,13 +669,12 @@ Inline text can use any typical inline HTML element (be it a `<small>`, `<span>`
 
 Add the `disabled` boolean attribute on an input to prevent user interactions and make it appear lighter.
 
-{% highlight html %}
-<input class="form-control" id="disabledInput" type="text" placeholder="Disabled input here..." disabled>
-{% endhighlight %}
+{% highlight html %} <input class="form-control" id="disabledInput" type="text" placeholder="Disabled input here..." disabled> {% endhighlight %}
 
 Add the `disabled` attribute to a `<fieldset>` to disable all the controls within.
 
 {% example html %}
+
 <form>
   <fieldset disabled>
     <div class="form-group">
@@ -684,36 +698,34 @@ Add the `disabled` attribute to a `<fieldset>` to disable all the controls withi
 {% endexample %}
 
 {% callout warning %}
+
 #### Caveat with anchors
 
-By default, browsers will treat all native form controls (`<input>`, `<select>` and `<button>` elements) inside a `<fieldset disabled>` as disabled, preventing both keyboard and mouse interactions on them. However, if your form also includes `<a ... class="btn btn-*">` elements, these will only be given a style of `pointer-events: none`. As noted in the section about [disabled state for buttons]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/buttons/#disabled-state) (and specifically in the sub-section for anchor elements), this CSS property is not yet standardized and isn't fully supported in Opera 18 and below, or in Internet Explorer 10, and won't prevent keyboard users from being able to focus or activate these links. So to be safe, use custom JavaScript to disable such links.
-{% endcallout %}
+By default, browsers will treat all native form controls (`<input>`, `<select>` and `<button>` elements) inside a `<fieldset disabled>` as disabled, preventing both keyboard and mouse interactions on them. However, if your form also includes `<a ... class="btn btn-*">` elements, these will only be given a style of `pointer-events: none`. As noted in the section about [disabled state for buttons]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/buttons/#disabled-state) (and specifically in the sub-section for anchor elements), this CSS property is not yet standardized and isn't fully supported in Opera 18 and below, or in Internet Explorer 10, and won't prevent keyboard users from being able to focus or activate these links. So to be safe, use custom JavaScript to disable such links. {% endcallout %}
 
 {% callout danger %}
+
 #### Cross-browser compatibility
 
-While Bootstrap will apply these styles in all browsers, Internet Explorer 11 and below don't fully support the `disabled` attribute on a `<fieldset>`. Use custom JavaScript to disable the fieldset in these browsers.
-{% endcallout %}
+While Bootstrap will apply these styles in all browsers, Internet Explorer 11 and below don't fully support the `disabled` attribute on a `<fieldset>`. Use custom JavaScript to disable the fieldset in these browsers. {% endcallout %}
 
 ## Validation
 
 Provide valuable, actionable feedback to your users with HTML5 form validation–[available in all our supported browsers](https://caniuse.com/#feat=form-validation). Choose from the browser default validation feedback, or implement custom messages with our built-in classes and starter JavaScript.
 
-{% callout warning %}
-We **highly recommend** custom validation styles as native browser defaults are not announced to screen readers.
-{% endcallout %}
+{% callout warning %} We **highly recommend** custom validation styles as native browser defaults are not announced to screen readers. {% endcallout %}
 
 ### How it works
 
 Here's how form validation works with Bootstrap:
 
-- HTML form validation is applied via CSS's two pseudo-classes, `:invalid` and `:valid`. It applies to `<input>`, `<select>`, and `<textarea>` elements.
-- Bootstrap scopes the `:invalid` and `:valid` styles to parent `.was-validated` class, usually applied to the `<form>`. Otherwise, any required field without a value shows up as invalid on page load. This way, you may choose when to activate them (typically after form submission is attempted).
-- As a fallback, `.is-invalid` and `.is-valid` classes may be used instead of the pseudo-classes for [server side validation](#server-side). They do not require a `.was-validated` parent class.
-- Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.
-- All modern browsers support the [constraint validation API](https://www.w3.org/TR/html5/forms.html#the-constraint-validation-api), a series of JavaScript methods for validating form controls.
-- Feedback messages may utilize the [browser defaults](#browser-defaults) (different for each browser, and unstylable via CSS) or our custom feedback styles with additional HTML and CSS.
-- You may provide custom validity messages with `setCustomValidity` in JavaScript.
+* HTML form validation is applied via CSS's two pseudo-classes, `:invalid` and `:valid`. It applies to `<input>`, `<select>`, and `<textarea>` elements.
+* Bootstrap scopes the `:invalid` and `:valid` styles to parent `.was-validated` class, usually applied to the `<form>`. Otherwise, any required field without a value shows up as invalid on page load. This way, you may choose when to activate them (typically after form submission is attempted).
+* As a fallback, `.is-invalid` and `.is-valid` classes may be used instead of the pseudo-classes for [server side validation](#server-side). They do not require a `.was-validated` parent class.
+* Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.
+* All modern browsers support the [constraint validation API](https://www.w3.org/TR/html5/forms.html#the-constraint-validation-api), a series of JavaScript methods for validating form controls.
+* Feedback messages may utilize the [browser defaults](#browser-defaults) (different for each browser, and unstylable via CSS) or our custom feedback styles with additional HTML and CSS.
+* You may provide custom validity messages with `setCustomValidity` in JavaScript.
 
 With that in mind, consider the following demos for our custom form validation styles, optional server side classes, and browser defaults.
 
@@ -724,6 +736,7 @@ For custom Bootstrap form validation messages, you'll need to add the `novalidat
 When attempting to submit, you'll see the `:invalid` and `:valid` styles applied to your form controls.
 
 {% example html %}
+
 <form id="needs-validation" novalidate>
   <div class="row">
     <div class="col-md-6 mb-3">
@@ -778,6 +791,7 @@ When attempting to submit, you'll see the `:invalid` and `:valid` styles applied
   }, false);
 })();
 </script>
+
 {% endexample %}
 
 ### Browser defaults
@@ -787,6 +801,7 @@ Not interested in custom validation feedback messages or writing JavaScript to c
 While these feedback styles cannot be styled with CSS, you can still customize the feedback text through JavaScript.
 
 {% example html %}
+
 <form>
   <div class="row">
     <div class="col-md-6 mb-3">
@@ -822,7 +837,8 @@ While these feedback styles cannot be styled with CSS, you can still customize t
     </div>
   </div>
 
-  <button class="btn btn-primary" type="submit">Submit form</button>
+<button class="btn btn-primary" type="submit">Submit form</button>
+
 </form>
 {% endexample %}
 
@@ -831,6 +847,7 @@ While these feedback styles cannot be styled with CSS, you can still customize t
 We recommend using client side validation, but in case you require server side, you can indicate invalid and valid form fields with `.is-invalid` and `.is-valid`. Note that `.invalid-feedback` is also supported with these classes.
 
 {% example html %}
+
 <form>
   <div class="row">
     <div class="col-md-6 mb-3">
@@ -866,7 +883,8 @@ We recommend using client side validation, but in case you require server side, 
     </div>
   </div>
 
-  <button class="btn btn-primary" type="submit">Submit form</button>
+<button class="btn btn-primary" type="submit">Submit form</button>
+
 </form>
 {% endexample %}
 
@@ -875,6 +893,7 @@ We recommend using client side validation, but in case you require server side, 
 Our example forms show native textual `<input>`s above, but form validation styles are available for our custom form controls, too.
 
 {% example html %}
+
 <form class="was-validated">
   <label class="custom-control custom-checkbox">
     <input type="checkbox" class="custom-control-input" required>
@@ -917,9 +936,9 @@ For even more customization and cross browser consistency, use our completely cu
 
 Each checkbox and radio is wrapped in a `<label>` for three reasons:
 
-- It provides a larger hit areas for checking the control.
-- It provides a helpful and semantic wrapper to help us replace the default `<input>`s.
-- It triggers the state of the `<input>` automatically, meaning no JavaScript is required.
+* It provides a larger hit areas for checking the control.
+* It provides a helpful and semantic wrapper to help us replace the default `<input>`s.
+* It triggers the state of the `<input>` automatically, meaning no JavaScript is required.
 
 We hide the default `<input>` with `opacity` and use the `.custom-control-indicator` to build a new custom form indicator in its place. Unfortunately we can't build a custom one from just the `<input>` because CSS's `content` doesn't work on that element.
 
@@ -929,13 +948,7 @@ In the checked states, we use **base64 embedded SVG icons** from [Open Iconic](h
 
 #### Checkboxes
 
-{% example html %}
-<label class="custom-control custom-checkbox">
-  <input type="checkbox" class="custom-control-input">
-  <span class="custom-control-indicator"></span>
-  <span class="custom-control-description">Check this custom checkbox</span>
-</label>
-{% endexample %}
+{% example html %} <label class="custom-control custom-checkbox"> <input type="checkbox" class="custom-control-input"> <span class="custom-control-indicator"></span> <span class="custom-control-description">Check this custom checkbox</span> </label> {% endexample %}
 
 Custom checkboxes can also utilize the `:indeterminate` pseudo class when manually set via JavaScript (there is no available HTML attribute for specifying it).
 
@@ -949,35 +962,17 @@ Custom checkboxes can also utilize the `:indeterminate` pseudo class when manual
 
 If you're using jQuery, something like this should suffice:
 
-{% highlight js %}
-$('.your-checkbox').prop('indeterminate', true)
-{% endhighlight %}
+{% highlight js %} $('.your-checkbox').prop('indeterminate', true) {% endhighlight %}
 
 #### Radios
 
-{% example html %}
-<label class="custom-control custom-radio">
-  <input id="radio1" name="radio" type="radio" class="custom-control-input">
-  <span class="custom-control-indicator"></span>
-  <span class="custom-control-description">Toggle this custom radio</span>
-</label>
-<label class="custom-control custom-radio">
-  <input id="radio2" name="radio" type="radio" class="custom-control-input">
-  <span class="custom-control-indicator"></span>
-  <span class="custom-control-description">Or toggle this other custom radio</span>
-</label>
-{% endexample %}
+{% example html %} <label class="custom-control custom-radio"> <input id="radio1" name="radio" type="radio" class="custom-control-input"> <span class="custom-control-indicator"></span> <span class="custom-control-description">Toggle this custom radio</span> </label> <label class="custom-control custom-radio"> <input id="radio2" name="radio" type="radio" class="custom-control-input"> <span class="custom-control-indicator"></span> <span class="custom-control-description">Or toggle this other custom radio</span> </label> {% endexample %}
 
 #### Disabled
 
 Custom checkboxes and radios can also be disabled. Add the `disabled` boolean attribute to the `<input>` and the custom indicator and label description will be automatically styled.
 
-{% example html %}
-<label class="custom-control custom-checkbox">
-  <input type="checkbox" class="custom-control-input" disabled>
-  <span class="custom-control-indicator"></span>
-  <span class="custom-control-description">Check this custom checkbox</span>
-</label>
+{% example html %} <label class="custom-control custom-checkbox"> <input type="checkbox" class="custom-control-input" disabled> <span class="custom-control-indicator"></span> <span class="custom-control-description">Check this custom checkbox</span> </label>
 
 <label class="custom-control custom-radio">
   <input id="radio3" name="radioDisabled" type="radio" class="custom-control-input" disabled>
@@ -991,6 +986,7 @@ Custom checkboxes and radios can also be disabled. Add the `disabled` boolean at
 Custom checkboxes and radios are inline to start. Add a parent with class `.custom-controls-stacked` to ensure each form control is on separate lines.
 
 {% example html %}
+
 <div class="custom-controls-stacked">
   <label class="custom-control custom-radio">
     <input id="radioStacked3" name="radio-stacked" type="radio" class="custom-control-input">
@@ -1009,8 +1005,8 @@ Custom checkboxes and radios are inline to start. Add a parent with class `.cust
 
 Custom `<select>` menus need only a custom class, `.custom-select` to trigger the custom styles.
 
-{% example html %}
-<select class="custom-select">
+{% example html %} <select class="custom-select">
+
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
@@ -1020,22 +1016,17 @@ Custom `<select>` menus need only a custom class, `.custom-select` to trigger th
 
 ### File browser
 
-The file input is the most gnarly of the bunch and require additional JavaScript if you'd like to hook them up with functional *Choose file...* and selected file name text.
+The file input is the most gnarly of the bunch and require additional JavaScript if you'd like to hook them up with functional _Choose file..._ and selected file name text.
 
-{% example html %}
-<label class="custom-file">
-  <input type="file" id="file2" class="custom-file-input">
-  <span class="custom-file-control"></span>
-</label>
-{% endexample %}
+{% example html %} <label class="custom-file"> <input type="file" id="file2" class="custom-file-input"> <span class="custom-file-control"></span> </label> {% endexample %}
 
 Here's how it works:
 
-- We wrap the `<input>` in a `<label>` so the custom control properly triggers the file browser.
-- We hide the default file `<input>` via `opacity`.
-- We use `::after` to generate a custom background and directive (*Choose file...*).
-- We use `::before` to generate and position the *Browse* button.
-- We declare a `height` on the `<input>` for proper spacing for surrounding content.
+* We wrap the `<input>` in a `<label>` so the custom control properly triggers the file browser.
+* We hide the default file `<input>` via `opacity`.
+* We use `::after` to generate a custom background and directive (_Choose file..._).
+* We use `::before` to generate and position the _Browse_ button.
+* We declare a `height` on the `<input>` for proper spacing for surrounding content.
 
 In other words, it's an entirely custom element, all generated via CSS.
 
@@ -1043,17 +1034,6 @@ In other words, it's an entirely custom element, all generated via CSS.
 
 The [`:lang()` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:lang) is used to allow for easy translation of the "Browse" and "Choose file..." text into other languages. Simply override or add entries to the `$custom-file-text` SCSS variable with the relevant [language tag](https://en.wikipedia.org/wiki/IETF_language_tag) and localized strings. The English strings can be customized the same way. For example, here's how one might add a Spanish translation (Spanish's language code is `es`):
 
-{% highlight scss %}
-$custom-file-text: (
-  placeholder: (
-    en: "Choose file...",
-    es: "Seleccionar archivo..."
-  ),
-  button-label: (
-    en: "Browse",
-    es: "Navegar"
-  )
-);
-{% endhighlight %}
+{% highlight scss %} $custom-file-text: ( placeholder: ( en: "Choose file...", es: "Seleccionar archivo..." ), button-label: ( en: "Browse", es: "Navegar" ) ); {% endhighlight %}
 
 You'll need to set the language of your document (or subtree thereof) correctly in order for the correct text to be shown. This can be done using [the `lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) or the [`Content-Language` HTTP header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.12), among other methods.

--- a/docs/4.0/components/input-group.md
+++ b/docs/4.0/components/input-group.md
@@ -11,6 +11,7 @@ toc: true
 Place one add-on or button on either side of an input. You may also place one on both sides of an input. **We do not support multiple form-controls in a single input group** and `<label>`s must come outside the input group.
 
 {% example html %}
+
 <div class="input-group">
   <span class="input-group-addon" id="basic-addon1">@</span>
   <input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="basic-addon1">
@@ -45,6 +46,7 @@ Place one add-on or button on either side of an input. You may also place one on
 Add the relative form sizing classes to the `.input-group` itself and contents within will automatically resize—no need for repeating the form control size classes on each element.
 
 {% example html %}
+
 <div class="input-group input-group-lg">
   <span class="input-group-addon" id="sizing-addon1">@</span>
   <input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="sizing-addon1">
@@ -61,6 +63,7 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 Place any checkbox or radio option within an input group's addon instead of text.
 
 {% example html %}
+
 <div class="row">
   <div class="col-lg-6">
     <div class="input-group">
@@ -86,6 +89,7 @@ Place any checkbox or radio option within an input group's addon instead of text
 Multiple add-ons are supported and can be mixed with checkbox and radio input versions.
 
 {% example html %}
+
 <div class="row">
   <div class="col-lg-6">
     <div class="input-group">
@@ -111,6 +115,7 @@ Multiple add-ons are supported and can be mixed with checkbox and radio input ve
 Buttons in input groups must wrapped in a `.input-group-btn` for proper alignment and sizing. This is required due to default browser styles that cannot be overridden.
 
 {% example html %}
+
 <div class="row">
   <div class="col-lg-6">
     <div class="input-group">
@@ -148,6 +153,7 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
 ## Buttons with dropdowns
 
 {% example html %}
+
 <div class="row">
   <div class="col-lg-6">
     <div class="input-group">
@@ -189,6 +195,7 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
 ## Segmented buttons
 
 {% example html %}
+
 <div class="row">
   <div class="col-lg-6">
     <div class="input-group">
@@ -236,6 +243,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
 ### Custom select
 
 {% example html %}
+
 <div class="input-group mb-3">
   <label class="input-group-addon" for="inputGroupSelect01">Options</label>
   <select class="custom-select" id="inputGroupSelect01">
@@ -284,6 +292,7 @@ Input groups include support for custom selects and custom file inputs. Browser 
 ### Custom file input
 
 {% example html %}
+
 <div class="input-group mb-3">
   <span class="input-group-addon">Upload</span>
   <label class="custom-file">

--- a/docs/4.0/components/jumbotron.md
+++ b/docs/4.0/components/jumbotron.md
@@ -8,6 +8,7 @@ group: components
 A lightweight, flexible component that can optionally extend the entire viewport to showcase key marketing messages on your site.
 
 {% example html %}
+
 <div class="jumbotron">
   <h1 class="display-3">Hello, world!</h1>
   <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
@@ -22,6 +23,7 @@ A lightweight, flexible component that can optionally extend the entire viewport
 To make the jumbotron full width, and without rounded corners, add the `.jumbotron-fluid` modifier class and add a `.container` or `.container-fluid` within.
 
 {% example html %}
+
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
     <h1 class="display-3">Fluid jumbotron</h1>

--- a/docs/4.0/components/list-group.md
+++ b/docs/4.0/components/list-group.md
@@ -11,6 +11,7 @@ toc: true
 The most basic list group is an unordered list with list items and the proper classes. Build upon it with the options that follow, or with your own CSS as needed.
 
 {% example html %}
+
 <ul class="list-group">
   <li class="list-group-item">Cras justo odio</li>
   <li class="list-group-item">Dapibus ac facilisis in</li>
@@ -25,6 +26,7 @@ The most basic list group is an unordered list with list items and the proper cl
 Add `.active` to a `.list-group-item` to indicate the current active selection.
 
 {% example html %}
+
 <ul class="list-group">
   <li class="list-group-item active">Cras justo odio</li>
   <li class="list-group-item">Dapibus ac facilisis in</li>
@@ -39,6 +41,7 @@ Add `.active` to a `.list-group-item` to indicate the current active selection.
 Add `.disabled` to a `.list-group-item` to make it _appear_ disabled. Note that some elements with `.disabled` will also require custom JavaScript to fully disable their click events (e.g., links).
 
 {% example html %}
+
 <ul class="list-group">
   <li class="list-group-item disabled">Cras justo odio</li>
   <li class="list-group-item">Dapibus ac facilisis in</li>
@@ -55,6 +58,7 @@ Use `<a>`s or `<button>`s to create _actionable_ list group items with hover, di
 Be sure to **not use the standard `.btn` classes here**.
 
 {% example html %}
+
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-action active">
     Cras justo odio
@@ -69,6 +73,7 @@ Be sure to **not use the standard `.btn` classes here**.
 With `<button>`s, you can also make use of the `disabled` attribute instead of the `.disabled` class. Sadly, `<a>`s don't support the disabled attribute.
 
 {% example html %}
+
 <div class="list-group">
   <button type="button" class="list-group-item list-group-item-action active">
     Cras justo odio
@@ -85,10 +90,12 @@ With `<button>`s, you can also make use of the `disabled` attribute instead of t
 Use contextual classes to style list items with a stateful background and color.
 
 {% example html %}
+
 <ul class="list-group">
   <li class="list-group-item">Dapibus ac facilisis in</li>
 
-  {% for color in site.data.theme-colors %}
+{% for color in site.data.theme-colors %}
+
   <li class="list-group-item list-group-item-{{ color.name }}">This is a {{ color.name }} list group item</li>{% endfor %}
 </ul>
 {% endexample %}
@@ -96,22 +103,23 @@ Use contextual classes to style list items with a stateful background and color.
 Contextual classes also work with `.list-group-item-action`. Note the addition of the hover styles here not present in the previous example. Also supported is the `.active` state; apply it to indicate an active selection on a contextual list group item.
 
 {% example html %}
+
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-action">Dapibus ac facilisis in</a>
 
-  {% for color in site.data.theme-colors %}
-  <a href="#" class="list-group-item list-group-item-action list-group-item-{{ color.name }}">This is a {{ color.name }} list group item</a>{% endfor %}
+{% for color in site.data.theme-colors %} <a href="#" class="list-group-item list-group-item-action list-group-item-{{ color.name }}">This is a {{ color.name }} list group item</a>{% endfor %}
+
 </div>
 {% endexample %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ## With badges
 
 Add badges to any list group item to show unread counts, activity, and more with the help of some [utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/).
 
 {% example html %}
+
 <ul class="list-group">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Cras justo odio
@@ -133,6 +141,7 @@ Add badges to any list group item to show unread counts, activity, and more with
 Add nearly any HTML within, even for linked list groups like the one below, with the help of [flexbox utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/).
 
 {% example html %}
+
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-action flex-column align-items-start active">
     <div class="d-flex w-100 justify-content-between">
@@ -195,6 +204,7 @@ Use the tab JavaScript plugin—include it individually or through the compiled 
 </div>
 
 {% highlight html %}
+
 <div class="row">
   <div class="col-4">
     <div class="list-group" id="list-tab" role="tablist">
@@ -230,6 +240,7 @@ You can activate a list group navigation without writing any JavaScript by simpl
 </div>
 
 <!-- Tab panes -->
+
 <div class="tab-content">
   <div class="tab-pane active" id="home" role="tabpanel">...</div>
   <div class="tab-pane" id="profile" role="tabpanel">...</div>
@@ -243,27 +254,18 @@ You can activate a list group navigation without writing any JavaScript by simpl
 
 Enable tabbable list item via JavaScript (each list item needs to be activated individually):
 
-{% highlight js %}
-$('#myList a').on('click', function (e) {
-  e.preventDefault()
-  $(this).tab('show')
-})
-{% endhighlight %}
+{% highlight js %} $('#myList a').on('click', function (e) { e.preventDefault() $(this).tab('show') }) {% endhighlight %}
 
 You can activate individual list item in several ways:
 
-{% highlight js %}
-$('#myList a[href="#profile"]').tab('show') // Select tab by name
-$('#myList a:first-child').tab('show') // Select first tab
-$('#myList a:last-child').tab('show') // Select last tab
-$('#myList a:nth-child(3)').tab('show') // Select third tab
-{% endhighlight %}
+{% highlight js %} $('#myList a[href="#profile"]').tab('show') // Select tab by name $('#myList a:first-child').tab('show') // Select first tab $('#myList a:last-child').tab('show') // Select last tab $('#myList a:nth-child(3)').tab('show') // Select third tab {% endhighlight %}
 
 ### Fade effect
 
 To make tabs panel fade in, add `.fade` to each `.tab-pane`. The first tab pane must also have `.show` to make the initial content visible.
 
 {% highlight html %}
+
 <div class="tab-content">
   <div class="tab-pane fade show active" id="home" role="tabpanel">...</div>
   <div class="tab-pane fade" id="profile" role="tabpanel">...</div>
@@ -279,6 +281,7 @@ To make tabs panel fade in, add `.fade` to each `.tab-pane`. The first tab pane 
 Activates a list item element and content container. Tab should have either a `data-target` or an `href` targeting a container node in the DOM.
 
 {% highlight html %}
+
 <div class="list-group" id="myList" role="tablist">
   <a class="list-group-item list-group-item-action active" data-toggle="list" href="#home" role="tab">Home</a>
   <a class="list-group-item list-group-item-action" data-toggle="list" href="#profile" role="tab">Profile</a>
@@ -298,15 +301,14 @@ Activates a list item element and content container. Tab should have either a `d
     $('#myList a:last-child').tab('show')
   })
 </script>
+
 {% endhighlight %}
 
 #### .tab('show')
 
 Selects the given list item and shows its associated pane. Any other list item that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (for example, before the `shown.bs.tab` event occurs).
 
-{% highlight js %}
-$('#someListItem').tab('show')
-{% endhighlight %}
+{% highlight js %} $('#someListItem').tab('show') {% endhighlight %}
 
 ### Events
 
@@ -346,9 +348,4 @@ If no tab was already active, the `hide.bs.tab` and `hidden.bs.tab` events will 
   </tbody>
 </table>
 
-{% highlight js %}
-$('a[data-toggle="list"]').on('shown.bs.tab', function (e) {
-  e.target // newly activated tab
-  e.relatedTarget // previous active tab
-})
-{% endhighlight %}
+{% highlight js %} $('a[data-toggle="list"]').on('shown.bs.tab', function (e) { e.target // newly activated tab e.relatedTarget // previous active tab }) {% endhighlight %}

--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -10,18 +10,14 @@ toc: true
 
 Before getting started with Bootstrap's modal component, be sure to read the following as our menu options have recently changed.
 
-- Modals are built with HTML, CSS, and JavaScript. They're positioned over everything else in the document and remove scroll from the `<body>` so that modal content scrolls instead.
-- Clicking on the modal "backdrop" will automatically close the modal.
-- Bootstrap only supports one modal window at a time. Nested modals aren't supported as we believe them to be poor user experiences.
-- Modals use `position: fixed`, which can sometimes be a bit particular about its rendering. Whenever possible, place your modal HTML in a top-level position to avoid potential interference from other elements. You'll likely run into issues when nesting a `.modal` within another fixed element.
-- Once again, due to `position: fixed`, there are some caveats with using modals on mobile devices. [See our browser support docs]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/browsers-devices/#modals-and-dropdowns-on-mobile) for details.
-- Due to how HTML5 defines its semantics, [the `autofocus` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) has no effect in Bootstrap modals. To achieve the same effect, use some custom JavaScript:
+* Modals are built with HTML, CSS, and JavaScript. They're positioned over everything else in the document and remove scroll from the `<body>` so that modal content scrolls instead.
+* Clicking on the modal "backdrop" will automatically close the modal.
+* Bootstrap only supports one modal window at a time. Nested modals aren't supported as we believe them to be poor user experiences.
+* Modals use `position: fixed`, which can sometimes be a bit particular about its rendering. Whenever possible, place your modal HTML in a top-level position to avoid potential interference from other elements. You'll likely run into issues when nesting a `.modal` within another fixed element.
+* Once again, due to `position: fixed`, there are some caveats with using modals on mobile devices. [See our browser support docs]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/browsers-devices/#modals-and-dropdowns-on-mobile) for details.
+* Due to how HTML5 defines its semantics, [the `autofocus` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) has no effect in Bootstrap modals. To achieve the same effect, use some custom JavaScript:
 
-{% highlight js %}
-$('#myModal').on('shown.bs.modal', function () {
-  $('#myInput').trigger('focus')
-})
-{% endhighlight %}
+{% highlight js %} $('#myModal').on('shown.bs.modal', function () { $('#myInput').trigger('focus') }) {% endhighlight %}
 
 Keep reading for demos and usage guidelines.
 
@@ -54,6 +50,7 @@ Below is a _static_ modal example (meaning its `position` and `display` have bee
 </div>
 
 {% highlight html %}
+
 <div class="modal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -106,12 +103,15 @@ Toggle a working modal demo by clicking the button below. It will slide down and
 </div>
 
 {% highlight html %}
+
 <!-- Button trigger modal -->
+
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
   Launch demo modal
 </button>
 
 <!-- Modal -->
+
 <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -181,12 +181,15 @@ When modals become too long for the user's viewport or device, they scroll indep
 </div>
 
 {% highlight html %}
+
 <!-- Button trigger modal -->
+
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModalLong">
   Launch demo modal
 </button>
 
 <!-- Modal -->
+
 <div class="modal fade" id="exampleModalLong" tabindex="-1" role="dialog" aria-labelledby="exampleModalLongTitle" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -239,12 +242,15 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal. 
 </div>
 
 {% highlight html %}
+
 <!-- Button trigger modal -->
+
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModalCenter">
   Launch demo modal
 </button>
 
 <!-- Modal -->
+
 <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -301,6 +307,7 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal. 
 </div>
 
 {% highlight html %}
+
 <div class="modal-body">
   <h5>Popover in a modal</h5>
   <p>This <a href="#" role="button" class="btn btn-secondary popover-test" title="Popover title" data-content="Popover body content is set in this attribute.">button</a> triggers a popover on click.</p>
@@ -364,6 +371,7 @@ Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` w
 </div>
 
 {% highlight html %}
+
 <div class="modal-body">
   <div class="container-fluid">
     <div class="row">
@@ -400,10 +408,7 @@ Have a bunch of buttons that all trigger the same modal with slightly different 
 
 Below is a live demo followed by example HTML and JavaScript. For more information, [read the modal events docs](#events) for details on `relatedTarget`.
 
-{% example html %}
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@mdo">Open modal for @mdo</button>
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@fat">Open modal for @fat</button>
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@getbootstrap">Open modal for @getbootstrap</button>
+{% example html %} <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@mdo">Open modal for @mdo</button> <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@fat">Open modal for @fat</button> <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal" data-whatever="@getbootstrap">Open modal for @getbootstrap</button>
 
 <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
@@ -435,23 +440,14 @@ Below is a live demo followed by example HTML and JavaScript. For more informati
 </div>
 {% endexample %}
 
-{% highlight js %}
-$('#exampleModal').on('show.bs.modal', function (event) {
-  var button = $(event.relatedTarget) // Button that triggered the modal
-  var recipient = button.data('whatever') // Extract info from data-* attributes
-  // If necessary, you could initiate an AJAX request here (and then do the updating in a callback).
-  // Update the modal's content. We'll use jQuery here, but you could use a data binding library or other methods instead.
-  var modal = $(this)
-  modal.find('.modal-title').text('New message to ' + recipient)
-  modal.find('.modal-body input').val(recipient)
-})
-{% endhighlight %}
+{% highlight js %} $('#exampleModal').on('show.bs.modal', function (event) { var button = $(event.relatedTarget) // Button that triggered the modal var recipient = button.data('whatever') // Extract info from data-\* attributes // If necessary, you could initiate an AJAX request here (and then do the updating in a callback). // Update the modal's content. We'll use jQuery here, but you could use a data binding library or other methods instead. var modal = $(this) modal.find('.modal-title').text('New message to ' + recipient) modal.find('.modal-body input').val(recipient) }) {% endhighlight %}
 
 ### Remove animation
 
 For modals that simply appear rather than fade in to view, remove the `.fade` class from your modal markup.
 
 {% highlight html %}
+
 <div class="modal" tabindex="-1" role="dialog" aria-labelledby="..." aria-hidden="true">
   ...
 </div>
@@ -479,7 +475,9 @@ Modals have two optional sizes, available via modifier classes to be placed on a
 </div>
 
 {% highlight html %}
+
 <!-- Large modal -->
+
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-lg">Large modal</button>
 
 <div class="modal fade bd-example-modal-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
@@ -491,6 +489,7 @@ Modals have two optional sizes, available via modifier classes to be placed on a
 </div>
 
 <!-- Small modal -->
+
 <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-sm">Small modal</button>
 
 <div class="modal fade bd-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
@@ -516,6 +515,7 @@ Modals have two optional sizes, available via modifier classes to be placed on a
         ...
       </div>
     </div>
+
   </div>
 </div>
 
@@ -543,9 +543,7 @@ The modal plugin toggles your hidden content on demand, via data attributes or J
 
 Activate a modal without writing JavaScript. Set `data-toggle="modal"` on a controller element, like a button, along with a `data-target="#foo"` or `href="#foo"` to target a specific modal to toggle.
 
-{% highlight html %}
-<button type="button" data-toggle="modal" data-target="#myModal">Launch modal</button>
-{% endhighlight %}
+{% highlight html %} <button type="button" data-toggle="modal" data-target="#myModal">Launch modal</button> {% endhighlight %}
 
 ### Via JavaScript
 
@@ -596,18 +594,13 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### `.modal(options)`
 
 Activates your content as a modal. Accepts an optional options `object`.
 
-{% highlight js %}
-$('#myModal').modal({
-  keyboard: false
-})
-{% endhighlight %}
+{% highlight js %} $('#myModal').modal({ keyboard: false }) {% endhighlight %}
 
 #### `.modal('toggle')`
 
@@ -668,8 +661,4 @@ Bootstrap's modal class exposes a few events for hooking into modal functionalit
   </tbody>
 </table>
 
-{% highlight js %}
-$('#myModal').on('hidden.bs.modal', function (e) {
-  // do something...
-})
-{% endhighlight %}
+{% highlight js %} $('#myModal').on('hidden.bs.modal', function (e) { // do something... }) {% endhighlight %}

--- a/docs/4.0/components/navbar.md
+++ b/docs/4.0/components/navbar.md
@@ -10,12 +10,12 @@ toc: true
 
 Here's what you need to know before getting started with the navbar:
 
-- Navbars require a wrapping `.navbar` with `.navbar-expand{-sm|-md|-lg|-xl}` for responsive collapsing and [color scheme](#color-schemes) classes.
-- Navbars and their contents are fluid by default. Use [optional containers](#containers) to limit their horizontal width.
-- Use our [spacing]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) and [flex]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/) utility classes for controlling spacing and alignment within navbars.
-- Navbars are responsive by default, but you can easily modify them to change that. Responsive behavior depends on our Collapse JavaScript plugin.
-- Navbars are hidden by default when printing. Force them to be printed by adding `.d-print` to the `.navbar`. See the [display]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/) utility class.
-- Ensure accessibility by using a `<nav>` element or, if using a more generic element such as a `<div>`, add a `role="navigation"` to every navbar to explicitly identify it as a landmark region for users of assistive technologies.
+* Navbars require a wrapping `.navbar` with `.navbar-expand{-sm|-md|-lg|-xl}` for responsive collapsing and [color scheme](#color-schemes) classes.
+* Navbars and their contents are fluid by default. Use [optional containers](#containers) to limit their horizontal width.
+* Use our [spacing]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) and [flex]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/) utility classes for controlling spacing and alignment within navbars.
+* Navbars are responsive by default, but you can easily modify them to change that. Responsive behavior depends on our Collapse JavaScript plugin.
+* Navbars are hidden by default when printing. Force them to be printed by adding `.d-print` to the `.navbar`. See the [display]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/) utility class.
+* Ensure accessibility by using a `<nav>` element or, if using a more generic element such as a `<div>`, add a `role="navigation"` to every navbar to explicitly identify it as a landmark region for users of assistive technologies.
 
 Read on for an example and list of supported sub-components.
 
@@ -23,16 +23,17 @@ Read on for an example and list of supported sub-components.
 
 Navbars come with built-in support for a handful of sub-components. Choose from the following as needed:
 
-- `.navbar-brand` for your company, product, or project name.
-- `.navbar-nav` for a full-height and lightweight navigation (including support for dropdowns).
-- `.navbar-toggler` for use with our collapse plugin and other [navigation toggling](#responsive-behaviors) behaviors.
-- `.form-inline` for any form controls and actions.
-- `.navbar-text` for adding vertically centered strings of text.
-- `.collapse.navbar-collapse` for grouping and hiding navbar contents by a parent breakpoint.
+* `.navbar-brand` for your company, product, or project name.
+* `.navbar-nav` for a full-height and lightweight navigation (including support for dropdowns).
+* `.navbar-toggler` for use with our collapse plugin and other [navigation toggling](#responsive-behaviors) behaviors.
+* `.form-inline` for any form controls and actions.
+* `.navbar-text` for adding vertically centered strings of text.
+* `.collapse.navbar-collapse` for grouping and hiding navbar contents by a parent breakpoint.
 
 Here's an example of all the sub-components included in a responsive light-themed navbar that automatically collapses at the `lg` (large) breakpoint.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -77,12 +78,15 @@ This example uses [color]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilit
 The `.navbar-brand` can be applied to most elements, but an anchor works best as some elements might require utility classes or custom styles.
 
 {% example html %}
+
 <!-- As a link -->
+
 <nav class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
 </nav>
 
 <!-- As a heading -->
+
 <nav class="navbar navbar-light bg-light">
   <span class="navbar-brand mb-0 h1">Navbar</span>
 </nav>
@@ -91,7 +95,9 @@ The `.navbar-brand` can be applied to most elements, but an anchor works best as
 Adding images to the `.navbar-brand` will likely always require custom styles or utilities to properly size. Here are some examples to demonstrate.
 
 {% example html %}
+
 <!-- Just an image -->
+
 <nav class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">
     <img src="{{ site.baseurl }}/assets/brand/bootstrap-solid.svg" width="30" height="30" alt="">
@@ -100,7 +106,9 @@ Adding images to the `.navbar-brand` will likely always require custom styles or
 {% endexample %}
 
 {% example html %}
+
 <!-- Image and text -->
+
 <nav class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">
     <img src="{{ site.baseurl }}/assets/brand/bootstrap-solid.svg" width="30" height="30" class="d-inline-block align-top" alt="">
@@ -116,6 +124,7 @@ Navbar navigation links build on our `.nav` options with their own modifier clas
 Active states—with `.active`—to indicate the current page can be applied directly to `.nav-link`s or their immediate parent `.nav-item`s.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -143,6 +152,7 @@ Active states—with `.active`—to indicate the current page can be applied dir
 And because we use classes for our navs, you can avoid the list-based approach entirely if you like.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
@@ -162,6 +172,7 @@ And because we use classes for our navs, you can avoid the list-based approach e
 You may also utilize dropdowns in your navbar nav. Dropdown menus require a wrapping element for positioning, so be sure to use separate and nested elements for `.nav-item` and `.nav-link` as shown below.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
@@ -198,6 +209,7 @@ You may also utilize dropdowns in your navbar nav. Dropdown menus require a wrap
 Place various form controls and components within a navbar with `.form-inline`.
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light">
   <form class="form-inline">
     <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
@@ -209,6 +221,7 @@ Place various form controls and components within a navbar with `.form-inline`.
 Align the contents of your inline forms with utilities as needed.
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light justify-content-between">
   <a class="navbar-brand">Navbar</a>
   <form class="form-inline">
@@ -221,6 +234,7 @@ Align the contents of your inline forms with utilities as needed.
 Input groups work, too:
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light">
   <form class="form-inline">
     <div class="input-group">
@@ -234,6 +248,7 @@ Input groups work, too:
 Various buttons are supported as part of these navbar forms, too. This is also a great reminder that vertical alignment utilities can be used to align different sized elements.
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light">
   <form class="form-inline">
     <button class="btn btn-outline-success" type="button">Main button</button>
@@ -247,6 +262,7 @@ Various buttons are supported as part of these navbar forms, too. This is also a
 Navbars may contain bits of text with the help of `.navbar-text`. This class adjusts vertical alignment and horizontal spacing for strings of text.
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light">
   <span class="navbar-text">
     Navbar text with an inline element
@@ -257,6 +273,7 @@ Navbars may contain bits of text with the help of `.navbar-text`. This class adj
 Mix and match with other components and utilities as needed.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar w/ text</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
@@ -312,6 +329,7 @@ Theming the navbar has never been easier thanks to the combination of theming cl
         <button class="btn btn-outline-info my-2 my-sm-0" type="submit">Search</button>
       </form>
     </div>
+
   </nav>
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
@@ -340,6 +358,7 @@ Theming the navbar has never been easier thanks to the combination of theming cl
         <button class="btn btn-outline-light my-2 my-sm-0" type="submit">Search</button>
       </form>
     </div>
+
   </nav>
 
   <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd;">
@@ -368,10 +387,12 @@ Theming the navbar has never been easier thanks to the combination of theming cl
         <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">Search</button>
       </form>
     </div>
+
   </nav>
 </div>
 
 {% highlight html %}
+
 <nav class="navbar navbar-dark bg-dark">
   <!-- Navbar content -->
 </nav>
@@ -390,6 +411,7 @@ Theming the navbar has never been easier thanks to the combination of theming cl
 Although it's not required, you can wrap a navbar in a `.container` to center it on a page or add one within to only center the contents of a [fixed or static top navbar](#placement).
 
 {% example html %}
+
 <div class="container">
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <a class="navbar-brand" href="#">Navbar</a>
@@ -400,6 +422,7 @@ Although it's not required, you can wrap a navbar in a `.container` to center it
 When the container is within your navbar, its horizontal padding is removed at breakpoints lower than your specified `.navbar-expand{-sm|-md|-lg|-xl}` class. This ensures we're not doubling up on padding unnecessarily on lower viewports when your navbar is collapsed.
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container">
     <a class="navbar-brand" href="#">Navbar</a>
@@ -414,24 +437,28 @@ Use our [position utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/uti
 Also note that **`.sticky-top` uses `position: sticky`, which [isn't fully supported in every browser](https://caniuse.com/#feat=css-sticky)**.
 
 {% example html %}
+
 <nav class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">Default</a>
 </nav>
 {% endexample %}
 
 {% example html %}
+
 <nav class="navbar fixed-top navbar-light bg-light">
   <a class="navbar-brand" href="#">Fixed top</a>
 </nav>
 {% endexample %}
 
 {% example html %}
+
 <nav class="navbar fixed-bottom navbar-light bg-light">
   <a class="navbar-brand" href="#">Fixed bottom</a>
 </nav>
 {% endexample %}
 
 {% example html %}
+
 <nav class="navbar sticky-top navbar-light bg-light">
   <a class="navbar-brand" href="#">Sticky top</a>
 </nav>
@@ -450,6 +477,7 @@ Navbar togglers are left-aligned by default, but should they follow a sibling el
 With no `.navbar-brand` shown in lowest breakpoint:
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -478,6 +506,7 @@ With no `.navbar-brand` shown in lowest breakpoint:
 With a brand name shown on the left and toggler on the right:
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
@@ -507,6 +536,7 @@ With a brand name shown on the left and toggler on the right:
 With a toggler on the left and brand name on the right:
 
 {% example html %}
+
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo03" aria-controls="navbarTogglerDemo03" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -538,6 +568,7 @@ With a toggler on the left and brand name on the right:
 Sometimes you want to use the collapse plugin to trigger hidden content elsewhere on the page. Because our plugin works on the `id` and `data-target` matching, that's easily done!
 
 {% example html %}
+
 <div class="pos-f-t">
   <div class="collapse" id="navbarToggleExternalContent">
     <div class="bg-dark p-4">

--- a/docs/4.0/components/navs.md
+++ b/docs/4.0/components/navs.md
@@ -12,11 +12,10 @@ Navigation available in Bootstrap share general markup and styles, from the base
 
 The base `.nav` component is built with flexbox and provide a strong foundation for building all types of navigation components. It includes some style overrides (for working with lists), some link padding for larger hit areas, and basic disabled styling.
 
-{% callout info %}
-The base `.nav` component does not include any `.active` state. The following examples include the class, mainly to demonstrate that this particular class does not trigger any special styling.
-{% endcallout %}
+{% callout info %} The base `.nav` component does not include any `.active` state. The following examples include the class, mainly to demonstrate that this particular class does not trigger any special styling. {% endcallout %}
 
 {% example html %}
+
 <ul class="nav">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -36,6 +35,7 @@ The base `.nav` component does not include any `.active` state. The following ex
 Classes are used throughout, so your markup can be super flexible. Use `<ul>`s like above, or roll your own with say a `<nav>` element. Because the `.nav` uses `display: flex`, the nav links behave the same as nav items would, but without the extra markup.
 
 {% example html %}
+
 <nav class="nav">
   <a class="nav-link active" href="#">Active</a>
   <a class="nav-link" href="#">Link</a>
@@ -55,6 +55,7 @@ Change the horizontal alignment of your nav with [flexbox utilities]({{ site.bas
 Centered with `.justify-content-center`:
 
 {% example html %}
+
 <ul class="nav justify-content-center">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -74,6 +75,7 @@ Centered with `.justify-content-center`:
 Right-aligned with `.justify-content-end`:
 
 {% example html %}
+
 <ul class="nav justify-content-end">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -95,6 +97,7 @@ Right-aligned with `.justify-content-end`:
 Stack your navigation by changing the flex item direction with the `.flex-column` utility. Need to stack them on some viewports but not others? Use the responsive versions (e.g., `.flex-sm-column`).
 
 {% example html %}
+
 <ul class="nav flex-column">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -114,6 +117,7 @@ Stack your navigation by changing the flex item direction with the `.flex-column
 As always, vertical navigation is possible without `<ul>`s, too.
 
 {% example html %}
+
 <nav class="nav flex-column">
   <a class="nav-link active" href="#">Active</a>
   <a class="nav-link" href="#">Link</a>
@@ -127,6 +131,7 @@ As always, vertical navigation is possible without `<ul>`s, too.
 Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabbed interface. Use them to create tabbable regions with our [tab JavaScript plugin](#javascript-behavior).
 
 {% example html %}
+
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -148,6 +153,7 @@ Takes the basic nav from above and adds the `.nav-tabs` class to generate a tabb
 Take that same HTML, but use `.nav-pills` instead:
 
 {% example html %}
+
 <ul class="nav nav-pills">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -169,6 +175,7 @@ Take that same HTML, but use `.nav-pills` instead:
 Force your `.nav`'s contents to extend the full available width one of two modifier classes. To proportionately fill all available space with your `.nav-item`s, use `.nav-fill`. Notice that all horizontal space is occupied, but not every nav item has the same width.
 
 {% example html %}
+
 <ul class="nav nav-pills nav-fill">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -188,6 +195,7 @@ Force your `.nav`'s contents to extend the full available width one of two modif
 When using a `<nav>`-based navigation, be sure to include `.nav-item` on the anchors.
 
 {% example html %}
+
 <nav class="nav nav-pills nav-fill">
   <a class="nav-item nav-link active" href="#">Active</a>
   <a class="nav-item nav-link" href="#">Link</a>
@@ -199,6 +207,7 @@ When using a `<nav>`-based navigation, be sure to include `.nav-item` on the anc
 For equal-width elements, use `.nav-justified`. All horizontal space will be occupied by nav links, but unlike the `.nav-fill` above, every nav item will be the same width.
 
 {% example html %}
+
 <nav class="nav nav-pills nav-justified">
   <a class="nav-link active" href="#">Active</a>
   <a class="nav-link" href="#">Longer nav link</a>
@@ -210,6 +219,7 @@ For equal-width elements, use `.nav-justified`. All horizontal space will be occ
 Similar to the `.nav-fill` example using a `<nav>`-based navigation, be sure to include `.nav-item` on the anchors.
 
 {% example html %}
+
 <nav class="nav nav-pills nav-justified">
   <a class="nav-item nav-link active" href="#">Active</a>
   <a class="nav-item nav-link" href="#">Link</a>
@@ -218,11 +228,13 @@ Similar to the `.nav-fill` example using a `<nav>`-based navigation, be sure to 
 </nav>
 
 {% endexample %}
+
 ## Working with flex utilities
 
 If you need responsive nav variations, consider using a series of [flexbox utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/). While more verbose, these utilities offer greater customization across responsive breakpoints. In the example below, our nav will be stacked on the lowest breakpoint, then adapt to a horizontal layout that fills the available width starting from the small breakpoint.
 
 {% example html %}
+
 <nav class="nav nav-pills flex-column flex-sm-row">
   <a class="flex-sm-fill text-sm-center nav-link active" href="#">Active</a>
   <a class="flex-sm-fill text-sm-center nav-link" href="#">Link</a>
@@ -244,6 +256,7 @@ Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin
 ### Tabs with dropdowns
 
 {% example html %}
+
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -270,6 +283,7 @@ Add dropdown menus with a little extra HTML and the [dropdowns JavaScript plugin
 ### Pills with dropdowns
 
 {% example html %}
+
 <ul class="nav nav-pills">
   <li class="nav-item">
     <a class="nav-link active" href="#">Active</a>
@@ -329,6 +343,7 @@ Note that dynamic tabbed interfaces should <em>not</em> contain dropdown menus, 
 </div>
 
 {% highlight html %}
+
 <ul class="nav nav-tabs" id="myTab" role="tablist">
   <li class="nav-item">
     <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
@@ -371,6 +386,7 @@ To help fit your needs, this works with `<ul>`-based markup, as shown above, or 
 </div>
 
 {% highlight html %}
+
 <nav>
   <div class="nav nav-tabs" id="nav-tab" role="tablist">
     <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab" aria-controls="nav-home" aria-selected="true">Home</a>
@@ -413,6 +429,7 @@ The tabs plugin also works with pills.
 </div>
 
 {% highlight html %}
+
 <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
   <li class="nav-item">
     <a class="nav-link active" id="pills-home-tab" data-toggle="pill" href="#pills-home" role="tab" aria-controls="pills-home" aria-selected="true">Home</a>
@@ -463,6 +480,7 @@ And with vertical pills.
 </div>
 
 {% highlight html %}
+
 <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
   <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill" href="#v-pills-home" role="tab" aria-controls="v-pills-home" aria-selected="true">Home</a>
   <a class="nav-link" id="v-pills-profile-tab" data-toggle="pill" href="#v-pills-profile" role="tab" aria-controls="v-pills-profile" aria-selected="false">Profile</a>
@@ -482,7 +500,9 @@ And with vertical pills.
 You can activate a tab or pill navigation without writing any JavaScript by simply specifying `data-toggle="tab"` or `data-toggle="pill"` on an element. Use these data attributes on `.nav-tabs` or `.nav-pills`.
 
 {% highlight html %}
+
 <!-- Nav tabs -->
+
 <ul class="nav nav-tabs" id="myTab" role="tablist">
   <li class="nav-item">
     <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
@@ -499,6 +519,7 @@ You can activate a tab or pill navigation without writing any JavaScript by simp
 </ul>
 
 <!-- Tab panes -->
+
 <div class="tab-content">
   <div class="tab-pane active" id="home" role="tabpanel" aria-labelledby="home-tab">...</div>
   <div class="tab-pane" id="profile" role="tabpanel" aria-labelledby="profile-tab">...</div>
@@ -511,27 +532,18 @@ You can activate a tab or pill navigation without writing any JavaScript by simp
 
 Enable tabbable tabs via JavaScript (each tab needs to be activated individually):
 
-{% highlight js %}
-$('#myTab a').on('click', function (e) {
-  e.preventDefault()
-  $(this).tab('show')
-})
-{% endhighlight %}
+{% highlight js %} $('#myTab a').on('click', function (e) { e.preventDefault() $(this).tab('show') }) {% endhighlight %}
 
 You can activate individual tabs in several ways:
 
-{% highlight js %}
-$('#myTab a[href="#profile"]').tab('show') // Select tab by name
-$('#myTab li:first-child a').tab('show') // Select first tab
-$('#myTab li:last-child a').tab('show') // Select last tab
-$('#myTab li:nth-child(3) a').tab('show') // Select third tab
-{% endhighlight %}
+{% highlight js %} $('#myTab a[href="#profile"]').tab('show') // Select tab by name $('#myTab li:first-child a').tab('show') // Select first tab $('#myTab li:last-child a').tab('show') // Select last tab $('#myTab li:nth-child(3) a').tab('show') // Select third tab {% endhighlight %}
 
 ### Fade effect
 
 To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must also have `.show` to make the initial content visible.
 
 {% highlight html %}
+
 <div class="tab-content">
   <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">...</div>
   <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">...</div>
@@ -542,14 +554,14 @@ To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must a
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### $().tab
 
 Activates a tab element and content container. Tab should have either a `data-target` or an `href` targeting a container node in the DOM.
 
 {% highlight html %}
+
 <ul class="nav nav-tabs" id="myTab" role="tablist">
   <li class="nav-item">
     <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">Home</a>
@@ -577,15 +589,14 @@ Activates a tab element and content container. Tab should have either a `data-ta
     $('#myTab li:last-child a').tab('show')
   })
 </script>
+
 {% endhighlight %}
 
 #### .tab('show')
 
 Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.bs.tab` event occurs).
 
-{% highlight js %}
-$('#someTab').tab('show')
-{% endhighlight %}
+{% highlight js %} $('#someTab').tab('show') {% endhighlight %}
 
 #### .tab('dispose')
 
@@ -629,9 +640,4 @@ If no tab was already active, then the `hide.bs.tab` and `hidden.bs.tab` events 
   </tbody>
 </table>
 
-{% highlight js %}
-$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-  e.target // newly activated tab
-  e.relatedTarget // previous active tab
-})
-{% endhighlight %}
+{% highlight js %} $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) { e.target // newly activated tab e.relatedTarget // previous active tab }) {% endhighlight %}

--- a/docs/4.0/components/pagination.md
+++ b/docs/4.0/components/pagination.md
@@ -13,6 +13,7 @@ We use a large block of connected links for our pagination, making links hard to
 In addition, as pages likely have more than one such navigation section, it's advisable to provide a descriptive `aria-label` for the `<nav>` to reflect its purpose. For example, if the pagination component is used to navigate between a set of search results, an appropriate label could be `aria-label="Search results pages"`.
 
 {% example html %}
+
 <nav aria-label="Page navigation example">
   <ul class="pagination">
     <li class="page-item"><a class="page-link" href="#">Previous</a></li>
@@ -29,6 +30,7 @@ In addition, as pages likely have more than one such navigation section, it's ad
 Looking to use an icon or symbol in place of text for some pagination links? Be sure to provide proper screen reader support with `aria` attributes and the `.sr-only` utility.
 
 {% example html %}
+
 <nav aria-label="Page navigation example">
   <ul class="pagination">
     <li class="page-item">
@@ -57,6 +59,7 @@ Pagination links are customizable for different circumstances. Use `.disabled` f
 While the `.disabled` class uses `pointer-events: none` to _try_ to disable the link functionality of `<a>`s, that CSS property is not yet standardized and doesn't account for keyboard navigation. As such, you should always add `tabindex="-1"` on disabled links and use custom JavaScript to fully disable their functionality.
 
 {% example html %}
+
 <nav aria-label="...">
   <ul class="pagination">
     <li class="page-item disabled">
@@ -77,6 +80,7 @@ While the `.disabled` class uses `pointer-events: none` to _try_ to disable the 
 You can optionally swap out active or disabled anchors for `<span>`, or omit the anchor in the case of the prev/next arrows, to remove click functionality and prevent keyboard focus while retaining intended styles.
 
 {% example html %}
+
 <nav aria-label="...">
   <ul class="pagination">
     <li class="page-item disabled">
@@ -102,6 +106,7 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
 Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for additional sizes.
 
 {% example html %}
+
 <nav aria-label="...">
   <ul class="pagination pagination-lg">
     <li class="page-item disabled">
@@ -118,6 +123,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 {% endexample %}
 
 {% example html %}
+
 <nav aria-label="...">
   <ul class="pagination pagination-sm">
     <li class="page-item disabled">
@@ -138,6 +144,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 Change the alignment of pagination components with [flexbox utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/).
 
 {% example html %}
+
 <nav aria-label="Page navigation example">
   <ul class="pagination justify-content-center">
     <li class="page-item disabled">
@@ -154,6 +161,7 @@ Change the alignment of pagination components with [flexbox utilities]({{ site.b
 {% endexample %}
 
 {% example html %}
+
 <nav aria-label="Page navigation example">
   <ul class="pagination justify-content-end">
     <li class="page-item disabled">

--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -10,16 +10,16 @@ toc: true
 
 Things to know when using the popover plugin:
 
-- Popovers rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning. You must include [popper.min.js]({{ site.cdn.popper }}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper.js in order for popovers to work!
-- Popovers require the [tooltip plugin]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/tooltips/) as a dependency.
-- If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
-- Popovers are opt-in for performance reasons, so **you must initialize them yourself**.
-- Zero-length `title` and `content` values will never show a popover.
-- Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
-- Triggering popovers on hidden elements will not work.
-- Popovers for `.disabled` or `disabled` elements must be triggered on a wrapper element.
-- When triggered from anchors that wrap across multiple lines, popovers will be centered between the anchors' overall width. Use `white-space: nowrap;` on your `<a>`s to avoid this behavior.
-- Popovers must be hidden before their corresponding elements have been removed from the DOM.
+* Popovers rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning. You must include [popper.min.js]({{ site.cdn.popper }}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper.js in order for popovers to work!
+* Popovers require the [tooltip plugin]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/tooltips/) as a dependency.
+* If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
+* Popovers are opt-in for performance reasons, so **you must initialize them yourself**.
+* Zero-length `title` and `content` values will never show a popover.
+* Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
+* Triggering popovers on hidden elements will not work.
+* Popovers for `.disabled` or `disabled` elements must be triggered on a wrapper element.
+* When triggered from anchors that wrap across multiple lines, popovers will be centered between the anchors' overall width. Use `white-space: nowrap;` on your `<a>`s to avoid this behavior.
+* Popovers must be hidden before their corresponding elements have been removed from the DOM.
 
 Keep reading to see how popovers work with some examples.
 
@@ -27,23 +27,13 @@ Keep reading to see how popovers work with some examples.
 
 One way to initialize all popovers on a page would be to select them by their `data-toggle` attribute:
 
-{% highlight js %}
-$(function () {
-  $('[data-toggle="popover"]').popover()
-})
-{% endhighlight %}
+{% highlight js %} $(function () { $('[data-toggle="popover"]').popover() }) {% endhighlight %}
 
 ## Example: Using the `container` option
 
 When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead.
 
-{% highlight js %}
-$(function () {
-  $('.example-popover').popover({
-    container: 'body'
-  })
-})
-{% endhighlight %}
+{% highlight js %} $(function () { $('.example-popover').popover({ container: 'body' }) }) {% endhighlight %}
 
 ## Static popover
 
@@ -87,9 +77,7 @@ Four options are available: top, right, bottom, and left aligned.
 
 ## Live demo
 
-{% example html %}
-<button type="button" class="btn btn-lg btn-danger" data-toggle="popover" title="Popover title" data-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
-{% endexample %}
+{% example html %} <button type="button" class="btn btn-lg btn-danger" data-toggle="popover" title="Popover title" data-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button> {% endexample %}
 
 ### Four directions
 
@@ -110,19 +98,14 @@ Four options are available: top, right, bottom, and left aligned.
   </div>
 </div>
 
-{% highlight html %}
-<button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="top" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-  Popover on top
-</button>
+{% highlight html %} <button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="top" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."> Popover on top </button>
 
 <button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="right" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
   Popover on right
 </button>
 
 <button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="bottom" data-content="Vivamus
-sagittis lacus vel augue laoreet rutrum faucibus.">
-  Popover on bottom
-</button>
+sagittis lacus vel augue laoreet rutrum faucibus."> Popover on bottom </button>
 
 <button type="button" class="btn btn-secondary" data-container="body" data-toggle="popover" data-placement="left" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
   Popover on left
@@ -134,21 +117,14 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
 Use the `focus` trigger to dismiss popovers on the user's next click of a different element than the toggle element.
 
 {% callout danger %}
+
 #### Specific markup required for dismiss-on-next-click
 
-For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
-{% endcallout %}
+For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute. {% endcallout %}
 
-{% example html %}
-<a tabindex="0" class="btn btn-lg btn-danger" role="button" data-toggle="popover" data-trigger="focus" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>
-{% endexample %}
+{% example html %} <a tabindex="0" class="btn btn-lg btn-danger" role="button" data-toggle="popover" data-trigger="focus" title="Dismissible popover" data-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a> {% endexample %}
 
-{% highlight js %}
-$('.popover-dismiss').popover({
-  trigger: 'focus'
-})
-{% endhighlight %}
-
+{% highlight js %} $('.popover-dismiss').popover({ trigger: 'focus' }) {% endhighlight %}
 
 ## Usage
 
@@ -268,15 +244,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </table>
 
 {% callout info %}
+
 #### Data attributes for individual popovers
 
-Options for individual popovers can alternatively be specified through the use of data attributes, as explained above.
-{% endcallout %}
+Options for individual popovers can alternatively be specified through the use of data attributes, as explained above. {% endcallout %}
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### `$().popover(options)`
 
@@ -363,8 +338,4 @@ Updates the position of an element's popover.
   </tbody>
 </table>
 
-{% highlight js %}
-$('#myPopover').on('hidden.bs.popover', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myPopover').on('hidden.bs.popover', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/progress.md
+++ b/docs/4.0/components/progress.md
@@ -10,14 +10,15 @@ toc: true
 
 Progress components are built with two HTML elements, some CSS to set the width, and a few attributes. We don't use [the HTML5 `<progress>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress), ensuring you can stack progress bars, animate them, and place text labels over them.
 
-- We use the `.progress` as a wrapper to indicate the max value of the progress bar.
-- We use the inner `.progress-bar` to indicate the progress so far.
-- The `.progress-bar` requires an inline style, utility class, or custom CSS to set their width.
-- The `.progress-bar` also requires some `role` and `aria` attributes to make it accessible.
+* We use the `.progress` as a wrapper to indicate the max value of the progress bar.
+* We use the inner `.progress-bar` to indicate the progress so far.
+* The `.progress-bar` requires an inline style, utility class, or custom CSS to set their width.
+* The `.progress-bar` also requires some `role` and `aria` attributes to make it accessible.
 
 Put that all together, and you have the following examples.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
@@ -38,6 +39,7 @@ Put that all together, and you have the following examples.
 Bootstrap provides a handful of [utilities for setting width]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/sizing/). Depending on your needs, these may help with quickly configuring progress.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar w-75" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
@@ -48,6 +50,7 @@ Bootstrap provides a handful of [utilities for setting width]({{ site.baseurl }}
 Add labels to your progress bars by placing text within the `.progress-bar`.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">25%</div>
 </div>
@@ -58,6 +61,7 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
 We only set a `height` value on the `.progress`, so if you change that value the inner `.progress-bar` will automatically resize accordingly.
 
 {% example html %}
+
 <div class="progress" style="height: 1px;">
   <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
@@ -71,6 +75,7 @@ We only set a `height` value on the `.progress`, so if you change that value the
 Use background utility classes to change the appearance of individual progress bars.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar bg-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
@@ -90,6 +95,7 @@ Use background utility classes to change the appearance of individual progress b
 Include multiple progress bars in a progress component if you need.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar" role="progressbar" style="width: 15%" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100"></div>
   <div class="progress-bar bg-success" role="progressbar" style="width: 30%" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100"></div>
@@ -102,6 +108,7 @@ Include multiple progress bars in a progress component if you need.
 Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gradient over the progress bar's background color.
 
 {% example html %}
+
 <div class="progress">
   <div class="progress-bar progress-bar-striped" role="progressbar" style="width: 10%" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
@@ -135,6 +142,7 @@ The striped gradient can also be animated. Add `.progress-bar-animated` to `.pro
 </div>
 
 {% highlight html %}
+
 <div class="progress">
   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div>
 </div>

--- a/docs/4.0/components/scrollspy.md
+++ b/docs/4.0/components/scrollspy.md
@@ -10,11 +10,11 @@ toc: true
 
 Scrollspy has a few requirements to function properly:
 
-- If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
-- It must be used on a Bootstrap [nav component]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/navs/) or [list group]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/list-group/).
-- Scrollspy requires `position: relative;` on the element you're spying on, usually the `<body>`.
-- When spying on elements other than the `<body>`, be sure to have a `height` set and `overflow-y: scroll;` applied.
-- Anchors (`<a>`) are required and must point to an element with that `id`.
+* If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
+* It must be used on a Bootstrap [nav component]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/navs/) or [list group]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/list-group/).
+* Scrollspy requires `position: relative;` on the element you're spying on, usually the `<body>`.
+* When spying on elements other than the `<body>`, be sure to have a `height` set and `overflow-y: scroll;` applied.
+* Anchors (`<a>`) are required and must point to an element with that `id`.
 
 When successfully implemented, your nav or list group will update accordingly, moving the `.active` class from one item to the next based on their associated targets.
 
@@ -60,6 +60,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
 </div>
 
 {% highlight html %}
+
 <nav id="navbar-example2" class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <ul class="nav nav-pills">
@@ -140,6 +141,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 </div>
 
 {% highlight html %}
+
 <nav id="navbar-example3" class="navbar navbar-light bg-light">
   <a class="navbar-brand" href="#">Navbar</a>
   <nav class="nav nav-pills flex-column">
@@ -205,6 +207,7 @@ Scrollspy also works with `.list-group`s. Scroll the area next to the list group
 </div>
 
 {% highlight html %}
+
 <div id="list-example" class="list-group">
   <a class="list-group-item list-group-item-action" href="#list-item-1">Item 1</a>
   <a class="list-group-item list-group-item-action" href="#list-item-2">Item2</a>
@@ -223,20 +226,16 @@ Scrollspy also works with `.list-group`s. Scroll the area next to the list group
 </div>
 {% endhighlight %}
 
-
 ## Usage
 
 ### Via data attributes
 
 To easily add scrollspy behavior to your topbar navigation, add `data-spy="scroll"` to the element you want to spy on (most typically this would be the `<body>`). Then add the `data-target` attribute with the ID or class of the parent element of any Bootstrap `.nav` component.
 
-{% highlight css %}
-body {
-  position: relative;
-}
-{% endhighlight %}
+{% highlight css %} body { position: relative; } {% endhighlight %}
 
 {% highlight html %}
+
 <body data-spy="scroll" data-target="#navbar-example">
   ...
   <div id="navbar-example">
@@ -252,21 +251,19 @@ body {
 
 After adding `position: relative;` in your CSS, call the scrollspy via JavaScript:
 
-{% highlight js %}
-$('body').scrollspy({ target: '#navbar-example' })
-{% endhighlight %}
+{% highlight js %} $('body').scrollspy({ target: '#navbar-example' }) {% endhighlight %}
 
 {% callout danger %}
+
 #### Resolvable ID targets required
 
-Navbar links must have resolvable id targets. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`.
-{% endcallout %}
+Navbar links must have resolvable id targets. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`. {% endcallout %}
 
 {% callout info %}
+
 #### Non-`:visible` target elements ignored
 
-Target elements that are not [`:visible` according to jQuery](https://api.jquery.com/visible-selector/) will be ignored and their corresponding nav items will never be highlighted.
-{% endcallout %}
+Target elements that are not [`:visible` according to jQuery](https://api.jquery.com/visible-selector/) will be ignored and their corresponding nav items will never be highlighted. {% endcallout %}
 
 ### Methods
 
@@ -274,11 +271,7 @@ Target elements that are not [`:visible` according to jQuery](https://api.jquery
 
 When using scrollspy in conjunction with adding or removing of elements from the DOM, you'll need to call the refresh method like so:
 
-{% highlight js %}
-$('[data-spy="scroll"]').each(function () {
-  var $spy = $(this).scrollspy('refresh')
-})
-{% endhighlight %}
+{% highlight js %} $('[data-spy="scroll"]').each(function () { var $spy = $(this).scrollspy('refresh') }) {% endhighlight %}
 
 #### `.scrollspy('dispose')`
 
@@ -324,8 +317,4 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
   </tbody>
 </table>
 
-{% highlight js %}
-$('[data-spy="scroll"]').on('activate.bs.scrollspy', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('[data-spy="scroll"]').on('activate.bs.scrollspy', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/components/tooltips.md
+++ b/docs/4.0/components/tooltips.md
@@ -10,15 +10,15 @@ toc: true
 
 Things to know when using the tooltip plugin:
 
-- Tooltips rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning. You must include [popper.min.js]({{ site.cdn.popper }}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper.js in order for tooltips to work!
-- If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
-- Tooltips are opt-in for performance reasons, so **you must initialize them yourself**.
-- Tooltips with zero-length titles are never displayed.
-- Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
-- Triggering tooltips on hidden elements will not work.
-- Tooltips for `.disabled` or `disabled` elements must be triggered on a wrapper element.
-- When triggered from hyperlinks that span multiple lines, tooltips will be centered. Use `white-space: nowrap;` on your `<a>`s to avoid this behavior.
-- Tooltips must be hidden before their corresponding elements have been removed from the DOM.
+* Tooltips rely on the 3rd party library [Popper.js](https://popper.js.org/) for positioning. You must include [popper.min.js]({{ site.cdn.popper }}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper.js in order for tooltips to work!
+* If you're building our JavaScript from source, it [requires `util.js`]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/#util).
+* Tooltips are opt-in for performance reasons, so **you must initialize them yourself**.
+* Tooltips with zero-length titles are never displayed.
+* Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
+* Triggering tooltips on hidden elements will not work.
+* Tooltips for `.disabled` or `disabled` elements must be triggered on a wrapper element.
+* When triggered from hyperlinks that span multiple lines, tooltips will be centered. Use `white-space: nowrap;` on your `<a>`s to avoid this behavior.
+* Tooltips must be hidden before their corresponding elements have been removed from the DOM.
 
 Got all that? Great, let's see how they work with some examples.
 
@@ -26,11 +26,7 @@ Got all that? Great, let's see how they work with some examples.
 
 One way to initialize all tooltips on a page would be to select them by their `data-toggle` attribute:
 
-{% highlight js %}
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
-{% endhighlight %}
+{% highlight js %} $(function () { $('[data-toggle="tooltip"]').tooltip() }) {% endhighlight %}
 
 ## Examples
 
@@ -86,28 +82,11 @@ Hover over the buttons below to see their tooltips.
   </div>
 </div>
 
-{% highlight html %}
-<button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
-  Tooltip on top
-</button>
-<button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Tooltip on right">
-  Tooltip on right
-</button>
-<button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">
-  Tooltip on bottom
-</button>
-<button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="Tooltip on left">
-  Tooltip on left
-</button>
-{% endhighlight %}
+{% highlight html %} <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Tooltip on top"> Tooltip on top </button> <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Tooltip on right"> Tooltip on right </button> <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom"> Tooltip on bottom </button> <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="Tooltip on left"> Tooltip on left </button> {% endhighlight %}
 
 And with custom HTML added:
 
-{% highlight html %}
-<button type="button" class="btn btn-secondary" data-toggle="tooltip" data-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
-  Tooltip with HTML
-</button>
-{% endhighlight %}
+{% highlight html %} <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>"> Tooltip with HTML </button> {% endhighlight %}
 
 ## Usage
 
@@ -115,25 +94,26 @@ The tooltip plugin generates content and markup on demand, and by default places
 
 Trigger the tooltip via JavaScript:
 
-{% highlight js %}
-$('#example').tooltip(options)
-{% endhighlight %}
+{% highlight js %} $('#example').tooltip(options) {% endhighlight %}
 
 ### Markup
 
 The required markup for a tooltip is only a `data` attribute and `title` on the HTML element you wish to have a tooltip. The generated markup of a tooltip is rather simple, though it does require a position (by default, set to `top` by the plugin).
 
 {% callout warning %}
+
 #### Making tooltips work for keyboard and assistive technology users
 
-You should only add tooltips to HTML elements that are traditionally keyboard-focusable and interactive (such as links or form controls). Although arbitrary HTML elements (such as `<span>`s) can be made focusable by adding the `tabindex="0"` attribute, this will add potentially annoying and confusing tab stops on non-interactive elements for keyboard users. In addition, most assistive technologies currently do not announce the tooltip in this situation.
-{% endcallout %}
+You should only add tooltips to HTML elements that are traditionally keyboard-focusable and interactive (such as links or form controls). Although arbitrary HTML elements (such as `<span>`s) can be made focusable by adding the `tabindex="0"` attribute, this will add potentially annoying and confusing tab stops on non-interactive elements for keyboard users. In addition, most assistive technologies currently do not announce the tooltip in this situation. {% endcallout %}
 
 {% highlight html %}
+
 <!-- HTML to write -->
+
 <a href="#" data-toggle="tooltip" title="Some tooltip text!">Hover over me</a>
 
 <!-- Generated markup by the plugin -->
+
 <div class="tooltip bs-tooltip-top" role="tooltip">
   <div class="arrow"></div>
   <div class="tooltip-inner">
@@ -248,15 +228,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </table>
 
 {% callout info %}
+
 #### Data attributes for individual tooltips
 
-Options for individual tooltips can alternatively be specified through the use of data attributes, as explained above.
-{% endcallout %}
+Options for individual tooltips can alternatively be specified through the use of data attributes, as explained above. {% endcallout %}
 
 ### Methods
 
-{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-danger-async-methods.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 #### `$().tooltip(options)`
 
@@ -343,8 +322,4 @@ Updates the position of an element's tooltip.
   </tbody>
 </table>
 
-{% highlight js %}
-$('#myTooltip').on('hidden.bs.tooltip', function () {
-  // do something…
-})
-{% endhighlight %}
+{% highlight js %} $('#myTooltip').on('hidden.bs.tooltip', function () { // do something… }) {% endhighlight %}

--- a/docs/4.0/content/code.md
+++ b/docs/4.0/content/code.md
@@ -10,41 +10,34 @@ toc: true
 
 Wrap inline snippets of code with `<code>`. Be sure to escape HTML angle brackets.
 
-{% example html %}
-For example, <code>&lt;section&gt;</code> should be wrapped as inline.
-{% endexample %}
+{% example html %} For example, <code>&lt;section&gt;</code> should be wrapped as inline. {% endexample %}
 
 ## Code blocks
 
 Use `<pre>`s for multiple lines of code. Once again, be sure to escape any angle brackets in the code for proper rendering. You may optionally add the `.pre-scrollable` class, which will set a max-height of 350px and provide a y-axis scrollbar.
 
 {% example html %}
+
 <pre><code>&lt;p&gt;Sample text here...&lt;/p&gt;
 &lt;p&gt;And another line of sample text here...&lt;/p&gt;
 </code></pre>
+
 {% endexample %}
 
 ## Variables
 
 For indicating variables use the `<var>` tag.
 
-{% example html %}
-<var>y</var> = <var>m</var><var>x</var> + <var>b</var>
-{% endexample %}
+{% example html %} <var>y</var> = <var>m</var><var>x</var> + <var>b</var> {% endexample %}
 
 ## User input
 
 Use the `<kbd>` to indicate input that is typically entered via keyboard.
 
-{% example html %}
-To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
-To edit settings, press <kbd><kbd>ctrl</kbd> + <kbd>,</kbd></kbd>
-{% endexample %}
+{% example html %} To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br> To edit settings, press <kbd><kbd>ctrl</kbd> + <kbd>,</kbd></kbd> {% endexample %}
 
 ## Sample output
 
 For indicating sample output from a program use the `<samp>` tag.
 
-{% example html %}
-<samp>This text is meant to be treated as sample output from a computer program.</samp>
-{% endexample %}
+{% example html %} <samp>This text is meant to be treated as sample output from a computer program.</samp> {% endexample %}

--- a/docs/4.0/content/figures.md
+++ b/docs/4.0/content/figures.md
@@ -10,6 +10,7 @@ Anytime you need to display a piece of content—like an image with an optional 
 Use the included `.figure` , `.figure-img` and `.figure-caption` classes to provide some baseline styles for the HTML5 `<figure>` and `<figcaption>` elements. Images in figures have no explicit size, so be sure to add the `.img-fluid` class to your `<img>` to make it responsive.
 
 {% example html %}
+
 <figure class="figure">
   <img data-src="holder.js/400x300" class="figure-img img-fluid rounded" alt="A generic square placeholder image with rounded corners in a figure.">
   <figcaption class="figure-caption">A caption for the above image.</figcaption>
@@ -19,6 +20,7 @@ Use the included `.figure` , `.figure-img` and `.figure-caption` classes to prov
 Aligning the figure's caption is easy with our [text utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/text/#text-alignment).
 
 {% example html %}
+
 <figure class="figure">
   <img data-src="holder.js/400x300" class="figure-img img-fluid rounded" alt="A generic square placeholder image with rounded corners in a figure.">
   <figcaption class="figure-caption text-right">A caption for the above image.</figcaption>

--- a/docs/4.0/content/images.md
+++ b/docs/4.0/content/images.md
@@ -14,15 +14,13 @@ Images in Bootstrap are made responsive with `.img-fluid`. `max-width: 100%;` an
   <img data-src="holder.js/100px250" class="img-fluid" alt="Generic responsive image">
 </div>
 
-{% highlight html %}
-<img src="..." class="img-fluid" alt="Responsive image">
-{% endhighlight %}
+{% highlight html %} <img src="..." class="img-fluid" alt="Responsive image"> {% endhighlight %}
 
 {% callout warning %}
+
 #### SVG images and IE 10
 
-In Internet Explorer 10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. This fix improperly sizes other image formats, so Bootstrap doesn't apply it automatically.
-{% endcallout %}
+In Internet Explorer 10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. This fix improperly sizes other image formats, so Bootstrap doesn't apply it automatically. {% endcallout %}
 
 ## Image thumbnails
 
@@ -32,9 +30,7 @@ In addition to our [border-radius utilities]({{ site.baseurl }}/docs/{{ site.doc
   <img data-src="holder.js/200x200" class="img-thumbnail" alt="A generic square placeholder image with a white border around it, making it resemble a photograph taken with an old instant camera">
 </div>
 
-{% highlight html %}
-<img src="..." alt="..." class="img-thumbnail">
-{% endhighlight %}
+{% highlight html %} <img src="..." alt="..." class="img-thumbnail"> {% endhighlight %}
 
 ## Aligning images
 
@@ -45,18 +41,13 @@ Align images with the [helper float classes]({{ site.baseurl }}/docs/{{ site.doc
   <img data-src="holder.js/200x200" class="rounded float-right" alt="A generic square placeholder image with rounded corners">
 </div>
 
-{% highlight html %}
-<img src="..." class="rounded float-left" alt="...">
-<img src="..." class="rounded float-right" alt="...">
-{% endhighlight %}
+{% highlight html %} <img src="..." class="rounded float-left" alt="..."> <img src="..." class="rounded float-right" alt="..."> {% endhighlight %}
 
 <div class="bd-example bd-example-images">
   <img data-src="holder.js/200x200" class="rounded mx-auto d-block" alt="A generic square placeholder image with rounded corners">
 </div>
 
-{% highlight html %}
-<img src="..." class="rounded mx-auto d-block" alt="...">
-{% endhighlight %}
+{% highlight html %} <img src="..." class="rounded mx-auto d-block" alt="..."> {% endhighlight %}
 
 <div class="bd-example bd-example-images">
   <div class="text-center">
@@ -65,18 +56,18 @@ Align images with the [helper float classes]({{ site.baseurl }}/docs/{{ site.doc
 </div>
 
 {% highlight html %}
+
 <div class="text-center">
   <img src="..." class="rounded" alt="...">
 </div>
 {% endhighlight %}
 
-
 ## Picture
 
 If you are using the `<picture>` element to specify multiple `<source>` elements for a specific `<img>`, make sure to add the `.img-*` classes to the `<img>` and not to the `<picture>` tag.
 
-{% highlight html %}
-​<picture>
+{% highlight html %} ​<picture>
+
   <source srcset="..." type="image/svg+xml">
   <img src="..." class="img-fluid img-thumbnail" alt="...">
 </picture>

--- a/docs/4.0/content/reboot.md
+++ b/docs/4.0/content/reboot.md
@@ -13,39 +13,25 @@ Reboot builds upon Normalize, providing many HTML elements with somewhat opinion
 
 Here are our guidelines and reasons for choosing what to override in Reboot:
 
-- Update some browser default values to use `rem`s instead of `em`s for scalable component spacing.
-- Avoid `margin-top`. Vertical margins can collapse, yielding unexpected results. More importantly though, a single direction of `margin` is a simpler mental model.
-- For easier scaling across device sizes, block elements should use `rem`s for `margin`s.
-- Keep declarations of `font`-related properties to a minimum, using `inherit` whenever possible.
+* Update some browser default values to use `rem`s instead of `em`s for scalable component spacing.
+* Avoid `margin-top`. Vertical margins can collapse, yielding unexpected results. More importantly though, a single direction of `margin` is a simpler mental model.
+* For easier scaling across device sizes, block elements should use `rem`s for `margin`s.
+* Keep declarations of `font`-related properties to a minimum, using `inherit` whenever possible.
 
 ## Page defaults
 
 The `<html>` and `<body>` elements are updated to provide better page-wide defaults. More specifically:
 
-- The `box-sizing` is globally set on every element—including `*::before` and `*::after`, to `border-box`. This ensures that the declared width of element is never exceeded due to padding or border.
-  - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach.
-- The `<body>` also sets a global `font-family`, `line-height`, and `text-align`. This is inherited later by some form elements to prevent font inconsistencies.
-- For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
+* The `box-sizing` is globally set on every element—including `*::before` and `*::after`, to `border-box`. This ensures that the declared width of element is never exceeded due to padding or border.
+  * No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach.
+* The `<body>` also sets a global `font-family`, `line-height`, and `text-align`. This is inherited later by some form elements to prevent font inconsistencies.
+* For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
 
 ## Native font stack
 
-The default web fonts (Helvetica Neue, Helvetica, and Arial) have been dropped in Bootstrap 4 and replaced with a "native font stack" for optimum text rendering on every device and OS. Read more about [native font stacks in this *Smashing Magazine* article](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/).
+The default web fonts (Helvetica Neue, Helvetica, and Arial) have been dropped in Bootstrap 4 and replaced with a "native font stack" for optimum text rendering on every device and OS. Read more about [native font stacks in this _Smashing Magazine_ article](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/).
 
-{% highlight sass %}
-$font-family-sans-serif:
-  // Safari for OS X and iOS (San Francisco)
-  -apple-system,
-  // Chrome < 56 for OS X (San Francisco)
-  BlinkMacSystemFont,
-  // Windows
-  "Segoe UI",
-  // Android
-  "Roboto",
-  // Basic web fallback
-  "Helvetica Neue", Arial, sans-serif,
-  // Emoji fonts
-  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
-{% endhighlight %}
+{% highlight sass %} $font-family-sans-serif: // Safari for OS X and iOS (San Francisco) -apple-system, // Chrome < 56 for OS X (San Francisco) BlinkMacSystemFont, // Windows "Segoe UI", // Android "Roboto", // Basic web fallback "Helvetica Neue", Arial, sans-serif, // Emoji fonts "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default; {% endhighlight %}
 
 This `font-family` is applied to the `<body>` and automatically inherited globally throughout Bootstrap. To switch the global `font-family`, update `$font-family-base` and recompile Bootstrap.
 
@@ -126,9 +112,8 @@ All lists—`<ul>`, `<ol>`, and `<dl>`—have their `margin-top` removed and a `
 5. Nulla volutpat aliquam velit
 6. Faucibus porta lacus fringilla vel
 7. Aenean sit amet erat nunc
-8. Eget porttitor lorem
-{% endmarkdown %}
-</div>
+8. Eget porttitor lorem {% endmarkdown %}
+   </div>
 
 For simpler styling, clear hierarchy, and better spacing, description lists have updated `margin`s. `<dd>`s reset `margin-left` to `0` and add `margin-bottom: .5rem`. `<dt>`s are **bolded**.
 
@@ -204,11 +189,11 @@ Tables are slightly adjusted to style `<caption>`s, collapse borders, and ensure
 
 Various form elements have been rebooted for simpler base styles. Here are some of the most notable changes:
 
-- `<fieldset>`s have no borders, padding, or margin so they can be easily used as wrappers for individual inputs or groups of inputs.
-- `<legend>`s, like fieldsets, have also been restyled to be displayed as a heading of sorts.
-- `<label>`s are set to `display: inline-block` to allow `margin` to be applied.
-- `<input>`s, `<select>`s, `<textarea>`s, and `<button>`s are mostly addressed by Normalize, but Reboot removes their `margin` and sets `line-height: inherit`, too.
-- `<textarea>`s are modified to only be resizable vertically as horizontal resizing often "breaks" page layout.
+* `<fieldset>`s have no borders, padding, or margin so they can be easily used as wrappers for individual inputs or groups of inputs.
+* `<legend>`s, like fieldsets, have also been restyled to be displayed as a heading of sorts.
+* `<label>`s are set to `display: inline-block` to allow `margin` to be applied.
+* `<input>`s, `<select>`s, `<textarea>`s, and `<button>`s are mostly addressed by Normalize, but Reboot removes their `margin` and sets `line-height: inherit`, too.
+* `<textarea>`s are modified to only be resizable vertically as horizontal resizing often "breaks" page layout.
 
 These changes, and more, are demonstrated below.
 
@@ -291,6 +276,7 @@ These changes, and more, are demonstrated below.
       <input type="submit" value="Input submit button" disabled>
       <input type="button" value="Input button" disabled>
     </p>
+
   </fieldset>
 </form>
 
@@ -337,15 +323,13 @@ The `<abbr>` element receives basic styling to make it stand out amongst paragra
 
 HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which is styled as `display: none` by default. Borrowing an idea from [PureCSS](https://purecss.io/), we improve upon this default by making `[hidden] { display: none !important; }` to help prevent its `display` from getting accidentally overridden. While `[hidden]` isn't natively supported by IE10, the explicit declaration in our CSS gets around that problem.
 
-{% highlight html %}
-<input type="text" hidden>
-{% endhighlight %}
+{% highlight html %} <input type="text" hidden> {% endhighlight %}
 
 {% callout warning %}
+
 #### jQuery incompatibility
 
-`[hidden]` is not compatible with jQuery's `$(...).hide()` and `$(...).show()` methods. Therefore, we don't currently especially endorse `[hidden]` over other techniques for managing the `display` of elements.
-{% endcallout %}
+`[hidden]` is not compatible with jQuery's `$(...).hide()` and `$(...).show()` methods. Therefore, we don't currently especially endorse `[hidden]` over other techniques for managing the `display` of elements. {% endcallout %}
 
 To merely toggle the visibility of an element, meaning its `display` is not modified and the element can still affect the flow of the document, use [the `.invisible` class]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/visibility/) instead.
 

--- a/docs/4.0/content/tables.md
+++ b/docs/4.0/content/tables.md
@@ -13,6 +13,7 @@ Due to the widespread use of tables across third-party widgets like calendars an
 Using the most basic table markup, here's how `.table`-based tables look in Bootstrap. **All table styles are inherited in Bootstrap 4**, meaning any nested tables will be styled in the same manner as the parent.
 
 {% example html %}
+
 <table class="table">
   <thead>
     <tr>
@@ -48,6 +49,7 @@ Using the most basic table markup, here's how `.table`-based tables look in Boot
 You can also invert the colors—with light text on dark backgrounds—with `.table-dark`.
 
 {% example html %}
+
 <table class="table table-dark">
   <thead>
     <tr>
@@ -85,6 +87,7 @@ You can also invert the colors—with light text on dark backgrounds—with `.ta
 Similar to tables and dark tables, use the modifier classes `.thead-light` or `.thead-dark` to make `<thead>`s appear light or dark gray.
 
 {% example html %}
+
 <table class="table">
   <thead class="thead-dark">
     <tr>
@@ -153,6 +156,7 @@ Similar to tables and dark tables, use the modifier classes `.thead-light` or `.
 Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
 
 {% example html %}
+
 <table class="table table-striped">
   <thead>
     <tr>
@@ -186,6 +190,7 @@ Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`
 {% endexample %}
 
 {% example html %}
+
 <table class="table table-striped table-dark">
   <thead>
     <tr>
@@ -223,6 +228,7 @@ Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`
 Add `.table-bordered` for borders on all sides of the table and cells.
 
 {% example html %}
+
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -261,6 +267,7 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 {% endexample %}
 
 {% example html %}
+
 <table class="table table-bordered table-dark">
   <thead>
     <tr>
@@ -303,6 +310,7 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 
 {% example html %}
+
 <table class="table table-hover">
   <thead>
     <tr>
@@ -335,6 +343,7 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 {% endexample %}
 
 {% example html %}
+
 <table class="table table-hover table-dark">
   <thead>
     <tr>
@@ -371,6 +380,7 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 Add `.table-sm` to make tables more compact by cutting cell padding in half.
 
 {% example html %}
+
 <table class="table table-sm">
   <thead>
     <tr>
@@ -403,6 +413,7 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 {% endexample %}
 
 {% example html %}
+
 <table class="table table-sm table-dark">
   <thead>
     <tr>
@@ -470,16 +481,20 @@ Use contextual classes to color table rows or individual cells.
         <td>Column content</td>
       </tr>{% endfor %}
     </tbody>
+
   </table>
 </div>
 
 {% highlight html %}
+
 <!-- On rows -->
+
 <tr class="table-active">...</tr>
 {% for color in site.data.theme-colors %}
 <tr class="table-{{ color.name }}">...</tr>{% endfor %}
 
 <!-- On cells (`td` or `th`) -->
+
 <tr>
   <td class="table-active">...</td>
   {% for color in site.data.theme-colors %}
@@ -559,7 +574,9 @@ Regular table background variants are not available with the dark table, however
 </div>
 
 {% highlight html %}
+
 <!-- On rows -->
+
 <tr class="bg-primary">...</tr>
 <tr class="bg-success">...</tr>
 <tr class="bg-warning">...</tr>
@@ -567,6 +584,7 @@ Regular table background variants are not available with the dark table, however
 <tr class="bg-info">...</tr>
 
 <!-- On cells (`td` or `th`) -->
+
 <tr>
   <td class="bg-primary">...</td>
   <td class="bg-success">...</td>
@@ -576,19 +594,18 @@ Regular table background variants are not available with the dark table, however
 </tr>
 {% endhighlight %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 Create responsive tables by adding `.table-responsive{-sm|-md|-lg|-xl}` to any `.table` to make them scroll horizontally at each `max-width` breakpoint of 575.99px, 767.99px, 991.99px, and 1119.99px, respectively.
 
-{% capture callout-include %}{% include callout-info-mediaqueries-breakpoints.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-info-mediaqueries-breakpoints.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 ## Captions
 
 A `<caption>` functions like a heading for a table. It helps users with screen readers to find a table and understand what it’s about and decide if they want to read it.
 
 {% example html %}
+
 <table class="table">
   <caption>List of users</caption>
   <thead>
@@ -627,10 +644,10 @@ A `<caption>` functions like a heading for a table. It helps users with screen r
 Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by adding `.table-responsive` class on `.table`. Or, pick a maximum breakpoint with which to have a responsive table up to by adding `.table-responsive{-sm|-md|-lg|-xl}`.
 
 {% callout warning %}
+
 #### Vertical clipping/truncation
 
-Responsive tables make use of `overflow-y: hidden`, which clips off any content that goes beyond the bottom or top edges of the table. In particular, this can clip off dropdown menus and other third-party widgets.
-{% endcallout %}
+Responsive tables make use of `overflow-y: hidden`, which clips off any content that goes beyond the bottom or top edges of the table. In particular, this can clip off dropdown menus and other third-party widgets. {% endcallout %}
 
 ### Always responsive
 
@@ -735,6 +752,7 @@ Responsive tables make use of `overflow-y: hidden`, which clips off any content 
 </div>
 
 {% highlight html %}
+
 <table class="table table-responsive">
   ...
 </table>
@@ -787,8 +805,8 @@ Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables u
 {% endunless %}{% endfor %}
 </div>
 
-{% highlight html %}
-{% for bp in site.data.breakpoints %}{% unless bp.breakpoint == "xs" %}
+{% highlight html %} {% for bp in site.data.breakpoints %}{% unless bp.breakpoint == "xs" %}
+
 <table class="table table-responsive{{ bp.abbr }}">
   ...
 </table>

--- a/docs/4.0/content/typography.md
+++ b/docs/4.0/content/typography.md
@@ -10,11 +10,11 @@ toc: true
 
 Bootstrap sets basic global display, typography, and link styles. When more control is needed, check out the [textual utility classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/text/).
 
-- Use a [native font stack]({{ site.baseurl }}/docs/{{ site.docs_version }}/content/reboot/#native-font-stack) that selects the best `font-family` for each OS and device.
-- For a more inclusive and accessible type scale, we assume the browser default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
-- Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
-- Set the global link color via `$link-color` and apply link underlines only on `:hover`.
-- Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
+* Use a [native font stack]({{ site.baseurl }}/docs/{{ site.docs_version }}/content/reboot/#native-font-stack) that selects the best `font-family` for each OS and device.
+* For a more inclusive and accessible type scale, we assume the browser default root `font-size` (typically 16px) so visitors can customize their browser defaults as needed.
+* Use the `$font-family-base`, `$font-size-base`, and `$line-height-base` attributes as our typographic base applied to the `<body>`.
+* Set the global link color via `$link-color` and apply link underlines only on `:hover`.
+* Use `$body-bg` to set a `background-color` on the `<body>` (`#fff` by default).
 
 These styles can be found within `_reboot.scss`, and the global variables are defined in `_variables.scss`. Make sure to set `$font-size-base` in `rem`.
 
@@ -70,6 +70,7 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 </table>
 
 {% highlight html %}
+
 <h1>h1. Bootstrap heading</h1>
 <h2>h2. Bootstrap heading</h2>
 <h3>h3. Bootstrap heading</h3>
@@ -81,6 +82,7 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 `.h1` through `.h6` classes are also available, for when you want to match the font styling of a heading but cannot use the associated HTML element.
 
 {% example html %}
+
 <p class="h1">h1. Bootstrap heading</p>
 <p class="h2">h2. Bootstrap heading</p>
 <p class="h3">h3. Bootstrap heading</p>
@@ -101,6 +103,7 @@ Use the included utility classes to recreate the small secondary heading text fr
 </div>
 
 {% highlight html %}
+
 <h3>
   Fancy display heading
   <small class="text-muted">With faded secondary text</small>
@@ -131,6 +134,7 @@ Traditional heading elements are designed to work best in the meat of your page 
 </div>
 
 {% highlight html %}
+
 <h1 class="display-1">Display 1</h1>
 <h1 class="display-2">Display 2</h1>
 <h1 class="display-3">Display 3</h1>
@@ -142,6 +146,7 @@ Traditional heading elements are designed to work best in the meat of your page 
 Make a paragraph stand out by adding `.lead`.
 
 {% example html %}
+
 <p class="lead">
   Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Duis mollis, est non commodo luctus.
 </p>
@@ -152,6 +157,7 @@ Make a paragraph stand out by adding `.lead`.
 Styling for common inline HTML5 elements.
 
 {% example html %}
+
 <p>You can use the mark tag to <mark>highlight</mark> text.</p>
 <p><del>This line of text is meant to be treated as deleted text.</del></p>
 <p><s>This line of text is meant to be treated as no longer accurate.</s></p>
@@ -177,6 +183,7 @@ Stylized implementation of HTML's `<abbr>` element for abbreviations and acronym
 Add `.initialism` to an abbreviation for a slightly smaller font-size.
 
 {% example html %}
+
 <p><abbr title="attribute">attr</abbr></p>
 <p><abbr title="HyperText Markup Language" class="initialism">HTML</abbr></p>
 {% endexample %}
@@ -186,6 +193,7 @@ Add `.initialism` to an abbreviation for a slightly smaller font-size.
 For quoting blocks of content from another source within your document. Wrap `<blockquote class="blockquote">` around any <abbr title="HyperText Markup Language">HTML</abbr> as the quote.
 
 {% example html %}
+
 <blockquote class="blockquote">
   <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
 </blockquote>
@@ -196,6 +204,7 @@ For quoting blocks of content from another source within your document. Wrap `<b
 Add a `<footer class="blockquote-footer">` for identifying the source. Wrap the name of the source work in `<cite>`.
 
 {% example html %}
+
 <blockquote class="blockquote">
   <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -207,6 +216,7 @@ Add a `<footer class="blockquote-footer">` for identifying the source. Wrap the 
 Use text utilities as needed to change the alignment of your blockquote.
 
 {% example html %}
+
 <blockquote class="blockquote text-center">
   <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -214,6 +224,7 @@ Use text utilities as needed to change the alignment of your blockquote.
 {% endexample %}
 
 {% example html %}
+
 <blockquote class="blockquote text-right">
   <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -227,6 +238,7 @@ Use text utilities as needed to change the alignment of your blockquote.
 Remove the default `list-style` and left margin on list items (immediate children only). **This only applies to immediate children list items**, meaning you will need to add the class for any nested lists as well.
 
 {% example html %}
+
 <ul class="list-unstyled">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing elit</li>
@@ -251,6 +263,7 @@ Remove the default `list-style` and left margin on list items (immediate childre
 Remove a list's bullets and apply some light `margin` with a combination of two classes, `.list-inline` and `.list-inline-item`.
 
 {% example html %}
+
 <ul class="list-inline">
   <li class="list-inline-item">Lorem ipsum</li>
   <li class="list-inline-item">Phasellus iaculis</li>
@@ -263,6 +276,7 @@ Remove a list's bullets and apply some light `margin` with a combination of two 
 Align terms and descriptions horizontally by using our grid system's predefined classes (or semantic mixins). For longer terms, you can optionally add a `.text-truncate` class to truncate the text with an ellipsis.
 
 {% example html %}
+
 <dl class="row">
   <dt class="col-sm-3">Description lists</dt>
   <dd class="col-sm-9">A description list is perfect for defining terms.</dd>
@@ -291,30 +305,14 @@ Align terms and descriptions horizontally by using our grid system's predefined 
 
 ## Responsive typography
 
-*Responsive typography* refers to scaling text and components by simply adjusting the root element's `font-size` within a series of media queries. Bootstrap doesn't do this for you, but it's fairly easy to add if you need it.
+_Responsive typography_ refers to scaling text and components by simply adjusting the root element's `font-size` within a series of media queries. Bootstrap doesn't do this for you, but it's fairly easy to add if you need it.
 
 Here's an example of it in practice. Choose whatever `font-size`s and media queries you wish.
 
-{% highlight scss %}
-html {
-  font-size: 1rem;
-}
+{% highlight scss %} html { font-size: 1rem; }
 
-@include media-breakpoint-up(sm) {
-  html {
-    font-size: 1.2rem;
-  }
-}
+@include media-breakpoint-up(sm) { html { font-size: 1.2rem; } }
 
-@include media-breakpoint-up(md) {
-  html {
-    font-size: 1.4rem;
-  }
-}
+@include media-breakpoint-up(md) { html { font-size: 1.4rem; } }
 
-@include media-breakpoint-up(lg) {
-  html {
-    font-size: 1.6rem;
-  }
-}
-{% endhighlight %}
+@include media-breakpoint-up(lg) { html { font-size: 1.6rem; } } {% endhighlight %}

--- a/docs/4.0/extend/approach.md
+++ b/docs/4.0/extend/approach.md
@@ -2,4 +2,3 @@
 layout: docs
 title: Approach
 ---
-

--- a/docs/4.0/extend/icons.md
+++ b/docs/4.0/extend/icons.md
@@ -11,18 +11,18 @@ Bootstrap doesn't include an icon library by default, but we have a handful of r
 
 We've tested and used these icon sets ourselves.
 
-- [Iconic](https://useiconic.com/open/)
-- [Octicons](https://octicons.github.com/)
-- [Entypo](http://www.entypo.com/)
+* [Iconic](https://useiconic.com/open/)
+* [Octicons](https://octicons.github.com/)
+* [Entypo](http://www.entypo.com/)
 
 ## More options
 
 While we haven't tried these out, they do look promising and provide multiple formats—including SVG.
 
-- [Bytesize](https://github.com/danklammer/bytesize-icons)
-- [Google Material icons](https://material.io/icons/)
-- [Ionicons](http://ionicons.com/)
-- [Feather](https://feathericons.com/)
-- [Dripicons](http://demo.amitjakhu.com/dripicons/)
-- [Ikons](http://ikons.piotrkwiatkowski.co.uk/)
-- [Glyph](http://glyph.smarticons.co/)
+* [Bytesize](https://github.com/danklammer/bytesize-icons)
+* [Google Material icons](https://material.io/icons/)
+* [Ionicons](http://ionicons.com/)
+* [Feather](https://feathericons.com/)
+* [Dripicons](http://demo.amitjakhu.com/dripicons/)
+* [Ikons](http://ikons.piotrkwiatkowski.co.uk/)
+* [Glyph](http://glyph.smarticons.co/)

--- a/docs/4.0/getting-started/accessibility.md
+++ b/docs/4.0/getting-started/accessibility.md
@@ -24,13 +24,14 @@ Because Bootstrap's components are purposely designed to be fairly generic, auth
 
 ### Color contrast
 
-Most colors that currently make up Bootstrap's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—lead to *insufficient* color contrast (below the recommended [WCAG 2.0 color contrast ratio of 4.5:1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)) when used against a light background. Authors will need to manually modify/extend these default colors to ensure adequate color contrast ratios.
+Most colors that currently make up Bootstrap's default palette—used throughout the framework for things such as button variations, alert variations, form validation indicators—lead to _insufficient_ color contrast (below the recommended [WCAG 2.0 color contrast ratio of 4.5:1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)) when used against a light background. Authors will need to manually modify/extend these default colors to ensure adequate color contrast ratios.
 
 ### Visually hidden content
 
 Content which should be visually hidden, but remain accessible to assistive technologies such as screen readers, can be styled using the `.sr-only` class. This can be useful in situations where additional visual information or cues (such as meaning denoted through the use of color) need to also be conveyed to non-visual users.
 
 {% highlight html %}
+
 <p class="text-danger">
   <span class="sr-only">Danger: </span>
   This action is not reversible
@@ -39,15 +40,13 @@ Content which should be visually hidden, but remain accessible to assistive tech
 
 For visually hidden interactive controls, such as traditional "skip" links, `.sr-only` can be combined with the `.sr-only-focusable` class. This will ensure that the control becomes visible once focused (for sighted keyboard users).
 
-{% highlight html %}
-<a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
-{% endhighlight %}
+{% highlight html %} <a class="sr-only sr-only-focusable" href="#content">Skip to main content</a> {% endhighlight %}
 
 ## Additional resources
 
-- [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20/)
-- [The A11Y Project](http://a11yproject.com/)
-- [MDN accessibility documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
-- [Tenon.io Accessibility Checker](https://tenon.io/)
-- [Colour Contrast Analyser (CCA)](https://developer.paciellogroup.com/resources/contrastanalyser/)
-- ["HTML Codesniffer" bookmarklet for identifying accessibility issues](https://github.com/squizlabs/HTML_CodeSniffer)
+* [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20/)
+* [The A11Y Project](http://a11yproject.com/)
+* [MDN accessibility documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+* [Tenon.io Accessibility Checker](https://tenon.io/)
+* [Colour Contrast Analyser (CCA)](https://developer.paciellogroup.com/resources/contrastanalyser/)
+* ["HTML Codesniffer" bookmarklet for identifying accessibility issues](https://github.com/squizlabs/HTML_CodeSniffer)

--- a/docs/4.0/getting-started/best-practices.md
+++ b/docs/4.0/getting-started/best-practices.md
@@ -7,14 +7,12 @@ group: getting-started
 
 We've designed and developed Bootstrap to work in a number of environments. Here are some of the best practices we've gathered from years of working on and using it ourselves.
 
-{% callout info %}
-**Heads up!** This copy is a work in progress.
-{% endcallout %}
+{% callout info %} **Heads up!** This copy is a work in progress. {% endcallout %}
 
 ### General outline
 
-- Working with CSS
-- Working with Sass files
-- Building new CSS components
-- Working with flexbox
-- Ask in [Slack](https://bootstrap-slack.herokuapp.com/)
+* Working with CSS
+* Working with Sass files
+* Building new CSS components
+* Working with flexbox
+* Ask in [Slack](https://bootstrap-slack.herokuapp.com/)

--- a/docs/4.0/getting-started/browsers-devices.md
+++ b/docs/4.0/getting-started/browsers-devices.md
@@ -105,7 +105,6 @@ Internet Explorer 10+ is supported; IE9 and down is not. Please be aware that so
 
 **If you require IE8-9 support, use Bootstrap 3.** It's the most stable version of our code and is still supported by our team for critical bugfixes and documentation changes. However, no new features will be added to it.
 
-
 ## Modals and dropdowns on mobile
 
 ### Overflow and scrolling
@@ -136,13 +135,7 @@ Even in some modern browsers, printing can be quirky.
 
 As of Safari v8.0, use of the fixed-width `.container` class can cause Safari to use an unusually small font size when printing. See [issue #14868]({{ site.repo }}/issues/14868) and [WebKit bug #138192](https://bugs.webkit.org/show_bug.cgi?id=138192) for more details. One potential workaround is the following CSS:
 
-{% highlight css %}
-@media print {
-  .container {
-    width: auto;
-  }
-}
-{% endhighlight %}
+{% highlight css %} @media print { .container { width: auto; } } {% endhighlight %}
 
 ## Android stock browser
 
@@ -153,6 +146,7 @@ Out of the box, Android 4.1 (and even some newer releases apparently) ship with 
 On `<select>` elements, the Android stock browser will not display the side controls if there is a `border-radius` and/or `border` applied. (See [this StackOverflow question](https://stackoverflow.com/questions/14744437/html-select-box-not-showing-drop-down-arrow-on-android-version-4-0-when-set-with) for details.) Use the snippet of code below to remove the offending CSS and render the `<select>` as an unstyled element on the Android stock browser. The user agent sniffing avoids interference with Chrome, Safari, and Mozilla browsers.
 
 {% highlight html %}
+
 <script>
 $(function () {
   var nua = navigator.userAgent
@@ -162,6 +156,7 @@ $(function () {
   }
 })
 </script>
+
 {% endhighlight %}
 
 Want to see an example? [Check out this JS Bin demo.](http://jsbin.com/OyaqoDO/2)

--- a/docs/4.0/getting-started/build-tools.md
+++ b/docs/4.0/getting-started/build-tools.md
@@ -15,7 +15,8 @@ To use our build system and run our documentation locally, you'll need a copy of
 1. [Download and install Node.js](https://nodejs.org/download/), which we use to manage our dependencies.
 2. Navigate to the root `/bootstrap` directory and run `npm install` to install our local dependencies listed in [package.json]({{ site.repo }}/blob/v{{ site.current_version }}/package.json).
 3. [Install Ruby][install-ruby], install [Bundler][gembundler] with `gem install bundler`, and finally run `bundle install`. This will install all Ruby dependencies, such as Jekyll and plugins.
-  - **Windows users:** Read [this guide](https://jekyllrb.com/docs/windows/) to get Jekyll up and running without problems.
+
+* **Windows users:** Read [this guide](https://jekyllrb.com/docs/windows/) to get Jekyll up and running without problems.
 
 When completed, you'll be able to run the various commands provided from the command line.
 
@@ -26,11 +27,11 @@ When completed, you'll be able to run the various commands provided from the com
 
 Our [package.json]({{ site.repo }}/blob/v{{ site.current_version }}/package.json) includes the following commands and tasks:
 
-| Task | Description |
-| --- | --- |
+| Task           | Description                                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npm run dist` | `npm run dist` creates the `/dist` directory with compiled files. **Uses [Sass](http://sass-lang.com/), [Autoprefixer][autoprefixer], and [UglifyJS](https://github.com/mishoo/UglifyJS2).** |
-| `npm test` | Same as `npm run dist` plus it runs tests locally |
-| `npm run docs` | Builds and lints CSS and JavaScript for docs. You can then run the documentation locally via `npm run docs-serve`. |
+| `npm test`     | Same as `npm run dist` plus it runs tests locally                                                                                                                                            |
+| `npm run docs` | Builds and lints CSS and JavaScript for docs. You can then run the documentation locally via `npm run docs-serve`.                                                                           |
 
 Run `npm run` to see all the npm scripts.
 

--- a/docs/4.0/getting-started/contents.md
+++ b/docs/4.0/getting-started/contents.md
@@ -12,27 +12,7 @@ Once downloaded, unzip the compressed folder and you'll see something like this:
 
 <!-- NOTE: This info is intentionally duplicated in the README. Copy any changes made here over to the README too. -->
 
-{% highlight plaintext %}
-bootstrap/
-├── css/
-│   ├── bootstrap.css
-│   ├── bootstrap.css.map
-│   ├── bootstrap.min.css
-│   ├── bootstrap.min.css.map
-│   ├── bootstrap-grid.css
-│   ├── bootstrap-grid.css.map
-│   ├── bootstrap-grid.min.css
-│   ├── bootstrap-grid.min.css.map
-│   ├── bootstrap-reboot.css
-│   ├── bootstrap-reboot.css.map
-│   ├── bootstrap-reboot.min.css
-│   └── bootstrap-reboot.min.css.map
-└── js/
-    ├── bootstrap.bundle.js
-    ├── bootstrap.bundle.min.js
-    ├── bootstrap.js
-    └── bootstrap.min.js
-{% endhighlight %}
+{% highlight plaintext %} bootstrap/ ├── css/ │ ├── bootstrap.css │ ├── bootstrap.css.map │ ├── bootstrap.min.css │ ├── bootstrap.min.css.map │ ├── bootstrap-grid.css │ ├── bootstrap-grid.css.map │ ├── bootstrap-grid.min.css │ ├── bootstrap-grid.min.css.map │ ├── bootstrap-reboot.css │ ├── bootstrap-reboot.css.map │ ├── bootstrap-reboot.min.css │ └── bootstrap-reboot.min.css.map └── js/ ├── bootstrap.bundle.js ├── bootstrap.bundle.min.js ├── bootstrap.js └── bootstrap.min.js {% endhighlight %}
 
 This is the most basic form of Bootstrap: precompiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (`bootstrap.*`), as well as compiled and minified CSS and JS (`bootstrap.min.*`). CSS [source maps](https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps) (`bootstrap.*.map`) are available for use with certain browsers' developer tools. Bundled JS files (`bootstrap.bundle.js` and minified `bootstrap.bundle.min.js`) include [Popper](https://popper.js.org/), but not [jQuery](https://jquery.com/).
 
@@ -120,15 +100,6 @@ Similarly, we have options for including some or all of our compiled JavaScript.
 
 The Bootstrap source code download includes the precompiled CSS and JavaScript assets, along with source Sass, JavaScript, and documentation. More specifically, it includes the following and more:
 
-{% highlight plaintext %}
-bootstrap/
-├── dist/
-│   ├── css/
-│   └── js/
-├── docs/
-│   └── examples/
-├── js/
-└── scss/
-{% endhighlight %}
+{% highlight plaintext %} bootstrap/ ├── dist/ │ ├── css/ │ └── js/ ├── docs/ │ └── examples/ ├── js/ └── scss/ {% endhighlight %}
 
 The `scss/` and `js/` are the source code for our CSS and JavaScript. The `dist/` folder includes everything listed in the precompiled download section above. The `docs/` folder includes the source code for our documentation, and `examples/` of Bootstrap usage. Beyond that, any other included file provides support for packages, license information, and development.

--- a/docs/4.0/getting-started/download.md
+++ b/docs/4.0/getting-started/download.md
@@ -10,8 +10,8 @@ toc: true
 
 Download ready-to-use compiled code for **Bootstrap v{{ site.current_version}}** to easily drop into your project, which includes:
 
-- Compiled and minified CSS bundles (see [CSS files comparison]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/contents/#comparison-of-css-files))
-- Compiled and minified JavaScript plugins
+* Compiled and minified CSS bundles (see [CSS files comparison]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/contents/#comparison-of-css-files))
+* Compiled and minified JavaScript plugins
 
 This doesn't include documentation, source files, or any optional JavaScript dependencies (jQuery and Popper.js).
 
@@ -21,8 +21,8 @@ This doesn't include documentation, source files, or any optional JavaScript dep
 
 Compile Bootstrap with your own asset pipeline by downloading our source Sass, JavaScript, and documentation files. This option requires some additional tooling:
 
-- Sass compiler (Libsass or Ruby Sass is supported) for compiling your CSS.
-- [Autoprefixer](https://github.com/postcss/autoprefixer) for CSS vendor prefixing
+* Sass compiler (Libsass or Ruby Sass is supported) for compiling your CSS.
+* [Autoprefixer](https://github.com/postcss/autoprefixer) for CSS vendor prefixing
 
 Should you require [build tools]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/build-tools/#tooling-setup), they are included for developing Bootstrap and its docs, but they're likely unsuitable for your own purposes.
 
@@ -33,6 +33,7 @@ Should you require [build tools]({{ site.baseurl }}/docs/{{ site.docs_version }}
 Skip the download with the Bootstrap CDN to deliver cached version of Bootstrap's compiled CSS and JS to your project.
 
 {% highlight html %}
+
 <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 <script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
 {% endhighlight %}
@@ -40,8 +41,11 @@ Skip the download with the Bootstrap CDN to deliver cached version of Bootstrap'
 If you're using our compiled JavaScript, don't forget to include CDN versions of jQuery and Popper.js before it.
 
 {% highlight html %}
+
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
+
 <script src="{{ site.cdn.popper }}" integrity="{{ site.cdn.popper_hash }}" crossorigin="anonymous"></script>
+
 {% endhighlight %}
 
 ## Package managers
@@ -52,30 +56,24 @@ Pull in Bootstrap's **source files** into nearly any project with some of the mo
 
 Install Bootstrap in your Node.js powered apps with [the npm package](https://www.npmjs.com/package/bootstrap):
 
-{% highlight sh %}
-npm install bootstrap@{{ site.current_version }}
-{% endhighlight %}
+{% highlight sh %} npm install bootstrap@{{ site.current_version }} {% endhighlight %}
 
 `require('bootstrap')` will load all of Bootstrap's jQuery plugins onto the jQuery object. The `bootstrap` module itself does not export anything. You can manually load Bootstrap's jQuery plugins individually by loading the `/js/*.js` files under the package's top-level directory.
 
 Bootstrap's `package.json` contains some additional metadata under the following keys:
 
-- `sass` - path to Bootstrap's main [Sass](http://sass-lang.com/) source file
-- `style` - path to Bootstrap's non-minified CSS that's been precompiled using the default settings (no customization)
+* `sass` - path to Bootstrap's main [Sass](http://sass-lang.com/) source file
+* `style` - path to Bootstrap's non-minified CSS that's been precompiled using the default settings (no customization)
 
 ### RubyGems
 
 Install Bootstrap in your Ruby apps using [Bundler](https://bundler.io/) (**recommended**) and [RubyGems](https://rubygems.org/) by adding the following line to your [`Gemfile`](https://bundler.io/gemfile.html):
 
-{% highlight ruby %}
-gem 'bootstrap', '~> {{ site.current_ruby_version }}'
-{% endhighlight %}
+{% highlight ruby %} gem 'bootstrap', '~> {{ site.current_ruby_version }}' {% endhighlight %}
 
 Alternatively, if you're not using Bundler, you can install the gem by running this command:
 
-{% highlight sh %}
-gem install bootstrap -v {{ site.current_ruby_version }}
-{% endhighlight %}
+{% highlight sh %} gem install bootstrap -v {{ site.current_ruby_version }} {% endhighlight %}
 
 [See the gem's README](https://github.com/twbs/bootstrap-rubygem/blob/master/README.md) for further details.
 
@@ -83,20 +81,14 @@ gem install bootstrap -v {{ site.current_ruby_version }}
 
 You can also install and manage Bootstrap's Sass and JavaScript using [Composer](https://getcomposer.org/):
 
-{% highlight sh %}
-composer require twbs/bootstrap:{{ site.current_version }}
-{% endhighlight %}
+{% highlight sh %} composer require twbs/bootstrap:{{ site.current_version }} {% endhighlight %}
 
 ### NuGet
 
 If you develop in .NET, you can also install and manage Bootstrap's [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/):
 
-{% highlight powershell %}
-Install-Package bootstrap -Pre
-{% endhighlight %}
+{% highlight powershell %} Install-Package bootstrap -Pre {% endhighlight %}
 
-{% highlight powershell %}
-Install-Package bootstrap.sass -Pre
-{% endhighlight %}
+{% highlight powershell %} Install-Package bootstrap.sass -Pre {% endhighlight %}
 
 The `-Pre` is required until Bootstrap v4 has a stable release.

--- a/docs/4.0/getting-started/introduction.md
+++ b/docs/4.0/getting-started/introduction.md
@@ -20,6 +20,7 @@ Looking to quickly add Bootstrap to your project? Use the Bootstrap CDN, provide
 Copy-paste the stylesheet `<link>` into your `<head>` before all other stylesheets to load our CSS.
 
 {% highlight html %}
+
 <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 {% endhighlight %}
 
@@ -30,9 +31,13 @@ Many of our components require the use of JavaScript to function. Specifically, 
 We use [jQuery's slim build](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/), but the full version is also supported.
 
 {% highlight html %}
+
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
+
 <script src="{{ site.cdn.popper }}" integrity="{{ site.cdn.popper_hash }}" crossorigin="anonymous"></script>
+
 <script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
+
 {% endhighlight %}
 
 Curious which components explicitly require jQuery, our JS, and Popper.js? Click the show components link below. If you're at all unsure about the general page structure, keep reading for an example page template.
@@ -57,7 +62,9 @@ Curious which components explicitly require jQuery, our JS, and Popper.js? Click
 Be sure to have your pages set up with the latest design and development standards. That means using an HTML5 doctype and including a viewport meta tag for proper responsive behaviors. Put it all together and your pages should look like this:
 
 {% highlight html %}
+
 <!doctype html>
+
 <html lang="en">
   <head>
     <!-- Required meta tags -->
@@ -68,6 +75,7 @@ Be sure to have your pages set up with the latest design and development standar
     <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 
     <title>Hello, world!</title>
+
   </head>
   <body>
     <h1>Hello, world!</h1>
@@ -77,6 +85,7 @@ Be sure to have your pages set up with the latest design and development standar
     <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
     <script src="{{ site.cdn.popper }}" integrity="{{ site.cdn.popper_hash }}" crossorigin="anonymous"></script>
     <script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
+
   </body>
 </html>
 {% endhighlight %}
@@ -85,14 +94,16 @@ That's all you need for overall page requirements. Visit the [Layout docs]({{ si
 
 ## Important globals
 
-Bootstrap employs a handful of important global styles and settings that you'll need to be aware of when using it, all of which are almost exclusively geared towards the *normalization* of cross browser styles. Let's dive in.
+Bootstrap employs a handful of important global styles and settings that you'll need to be aware of when using it, all of which are almost exclusively geared towards the _normalization_ of cross browser styles. Let's dive in.
 
 ### HTML5 doctype
 
 Bootstrap requires the use of the HTML5 doctype. Without it, you'll see some funky incomplete styling, but including it shouldn't cause any considerable hiccups.
 
 {% highlight html %}
+
 <!doctype html>
+
 <html lang="en">
   ...
 </html>
@@ -100,9 +111,10 @@ Bootstrap requires the use of the HTML5 doctype. Without it, you'll see some fun
 
 ### Responsive meta tag
 
-Bootstrap is developed *mobile first*, a strategy in which we optimize code for mobile devices first and then scale up components as necessary using CSS media queries. To ensure proper rendering and touch zooming for all devices, **add the responsive viewport meta tag** to your `<head>`.
+Bootstrap is developed _mobile first_, a strategy in which we optimize code for mobile devices first and then scale up components as necessary using CSS media queries. To ensure proper rendering and touch zooming for all devices, **add the responsive viewport meta tag** to your `<head>`.
 
 {% highlight html %}
+
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {% endhighlight %}
 
@@ -114,11 +126,7 @@ For more straightforward sizing in CSS, we switch the global `box-sizing` value 
 
 On the rare occasion you need to override it, use something like the following:
 
-{% highlight css %}
-.selector-for-some-widget {
-  box-sizing: content-box;
-}
-{% endhighlight %}
+{% highlight css %} .selector-for-some-widget { box-sizing: content-box; } {% endhighlight %}
 
 With the above snippet, nested elements—including generated content via `::before` and `::after`—will all inherit the specified `box-sizing` for that `.selector-for-some-widget`.
 
@@ -132,11 +140,11 @@ For improved cross-browser rendering, we use [Reboot]({{ site.baseurl }}/docs/{{
 
 Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.
 
-- Follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap).
-- Read and subscribe to [The Official Bootstrap Blog]({{ site.blog }}).
-- Join [the official Slack room]({{ site.slack }}).
-- Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.
-- Implementation help may be found at Stack Overflow (tagged [`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4)).
-- Developers should use the keyword `bootstrap` on packages which modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/browse/keyword/bootstrap) or similar delivery mechanisms for maximum discoverability.
+* Follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap).
+* Read and subscribe to [The Official Bootstrap Blog]({{ site.blog }}).
+* Join [the official Slack room]({{ site.slack }}).
+* Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.
+* Implementation help may be found at Stack Overflow (tagged [`bootstrap-4`](https://stackoverflow.com/questions/tagged/bootstrap-4)).
+* Developers should use the keyword `bootstrap` on packages which modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/browse/keyword/bootstrap) or similar delivery mechanisms for maximum discoverability.
 
 You can also follow [@getbootstrap on Twitter](https://twitter.com/getbootstrap) for the latest gossip and awesome music videos.

--- a/docs/4.0/getting-started/javascript.md
+++ b/docs/4.0/getting-started/javascript.md
@@ -22,15 +22,11 @@ Nearly all Bootstrap plugins can be enabled and configured through HTML alone wi
 
 However, in some situations it may be desirable to disable this functionality. To disable the data attribute API, unbind all events on the document namespaced with `data-api` like so:
 
-{% highlight js %}
-$(document).off('.data-api')
-{% endhighlight %}
+{% highlight js %} $(document).off('.data-api') {% endhighlight %}
 
 Alternatively, to target a specific plugin, just include the plugin's name as a namespace along with the data-api namespace like this:
 
-{% highlight js %}
-$(document).off('.alert.data-api')
-{% endhighlight %}
+{% highlight js %} $(document).off('.alert.data-api') {% endhighlight %}
 
 ## Events
 
@@ -38,27 +34,17 @@ Bootstrap provides custom events for most plugins' unique actions. Generally, th
 
 All infinitive events provide [`preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) functionality. This provides the ability to stop the execution of an action before it starts. Returning false from an event handler will also automatically call `preventDefault()`.
 
-{% highlight js %}
-$('#myModal').on('show.bs.modal', function (e) {
-  if (!data) return e.preventDefault() // stops modal from being shown
-})
-{% endhighlight %}
+{% highlight js %} $('#myModal').on('show.bs.modal', function (e) { if (!data) return e.preventDefault() // stops modal from being shown }) {% endhighlight %}
 
 ## Programmatic API
 
 We also believe you should be able to use all Bootstrap plugins purely through the JavaScript API. All public APIs are single, chainable methods, and return the collection acted upon.
 
-{% highlight js %}
-$('.btn.danger').button('toggle').addClass('fat')
-{% endhighlight %}
+{% highlight js %} $('.btn.danger').button('toggle').addClass('fat') {% endhighlight %}
 
 All methods should accept an optional options object, a string which targets a particular method, or nothing (which initiates a plugin with default behavior):
 
-{% highlight js %}
-$('#myModal').modal()                      // initialized with defaults
-$('#myModal').modal({ keyboard: false })   // initialized with no keyboard
-$('#myModal').modal('show')                // initializes and invokes show immediately
-{% endhighlight %}
+{% highlight js %} $('#myModal').modal() // initialized with defaults $('#myModal').modal({ keyboard: false }) // initialized with no keyboard $('#myModal').modal('show') // initializes and invokes show immediately {% endhighlight %}
 
 Each plugin also exposes its raw constructor on a `Constructor` property: `$.fn.popover.Constructor`. If you'd like to get a particular plugin instance, retrieve it directly from an element: `$('[rel="popover"]').data('popover')`.
 
@@ -68,57 +54,41 @@ All programmatic API methods are **asynchronous** and returns to the caller once
 
 In order to execute an action once the transition is complete, you can listen to the corresponding event.
 
-{% highlight js %}
-$('#myCollapse').on('shown.bs.collapse', function (e) {
-  // Action to execute once the collapsible area is expanded
-})
-{% endhighlight %}
+{% highlight js %} $('#myCollapse').on('shown.bs.collapse', function (e) { // Action to execute once the collapsible area is expanded }) {% endhighlight %}
 
 In addition a method call on a **transitioning component will be ignored**.
 
-{% highlight js %}
-$('#myCarousel').on('slid.bs.carousel', function (e) {
-  $('#myCarousel').carousel('2') // Will slide to the slide 2 as soon as the transition to slide 1 is finished
-})
+{% highlight js %} $('#myCarousel').on('slid.bs.carousel', function (e) { $('#myCarousel').carousel('2') // Will slide to the slide 2 as soon as the transition to slide 1 is finished })
 
-$('#myCarousel').carousel('1') // Will start sliding to the slide 1 and returns to the caller
-$('#myCarousel').carousel('2') // !! Will be ignored, as the transition to the slide 1 is not finished !!
-{% endhighlight %}
+$('#myCarousel').carousel('1') // Will start sliding to the slide 1 and returns to the caller $('#myCarousel').carousel('2') // !! Will be ignored, as the transition to the slide 1 is not finished !! {% endhighlight %}
 
 ### Default settings
 
 You can change the default settings for a plugin by modifying the plugin's `Constructor.Default` object:
 
-{% highlight js %}
-$.fn.modal.Constructor.Default.keyboard = false // changes default for the modal plugin's `keyboard` option to false
-{% endhighlight %}
+{% highlight js %} $.fn.modal.Constructor.Default.keyboard = false // changes default for the modal plugin's `keyboard` option to false {% endhighlight %}
 
 ## No conflict
 
 Sometimes it is necessary to use Bootstrap plugins with other UI frameworks. In these circumstances, namespace collisions can occasionally occur. If this happens, you may call `.noConflict` on the plugin you wish to revert the value of.
 
-{% highlight js %}
-var bootstrapButton = $.fn.button.noConflict() // return $.fn.button to previously assigned value
-$.fn.bootstrapBtn = bootstrapButton            // give $().bootstrapBtn the Bootstrap functionality
-{% endhighlight %}
+{% highlight js %} var bootstrapButton = $.fn.button.noConflict() // return $.fn.button to previously assigned value $.fn.bootstrapBtn = bootstrapButton // give $().bootstrapBtn the Bootstrap functionality {% endhighlight %}
 
 ## Version numbers
 
 The version of each of Bootstrap's jQuery plugins can be accessed via the `VERSION` property of the plugin's constructor. For example, for the tooltip plugin:
 
-{% highlight js %}
-$.fn.tooltip.Constructor.VERSION // => "{{ site.current_version }}"
-{% endhighlight %}
+{% highlight js %} $.fn.tooltip.Constructor.VERSION // => "{{ site.current_version }}" {% endhighlight %}
 
 ## No special fallbacks when JavaScript is disabled
 
 Bootstrap's plugins don't fall back particularly gracefully when JavaScript is disabled. If you care about the user experience in this case, use [`<noscript>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) to explain the situation (and how to re-enable JavaScript) to your users, and/or add your own custom fallbacks.
 
 {% callout warning %}
+
 #### Third-party libraries
 
-**Bootstrap does not officially support third-party JavaScript libraries** like Prototype or jQuery UI. Despite `.noConflict` and namespaced events, there may be compatibility problems that you need to fix on your own.
-{% endcallout %}
+**Bootstrap does not officially support third-party JavaScript libraries** like Prototype or jQuery UI. Despite `.noConflict` and namespaced events, there may be compatibility problems that you need to fix on your own. {% endcallout %}
 
 ## Util
 

--- a/docs/4.0/getting-started/theming.md
+++ b/docs/4.0/getting-started/theming.md
@@ -21,41 +21,19 @@ Utilize our source Sass files to take advantage of variables, maps, mixins, and 
 
 Whenever possible, avoid modifying Bootstrap's core files. For Sass, that means creating your own stylesheet that imports Bootstrap so you can modify and extend it. Assuming you've downloaded our source files or are using a package manager, you'll have a file structure that looks like this:
 
-{% highlight plaintext %}
-your-project/
-├── scss
-│   └── custom.scss
-└── node_modules/
-    └── bootstrap
-        ├── js
-        └── scss
-{% endhighlight %}
+{% highlight plaintext %} your-project/ ├── scss │ └── custom.scss └── node_modules/ └── bootstrap ├── js └── scss {% endhighlight %}
 
 In your `custom.scss`, you'll import Bootstrap's source Sass files. You have two options: include all of Bootstrap, or pick the parts you need. We encourage the latter, though be aware there are some requirements and dependencies across our components. You also will need to include some JavaScript for our plugins.
 
-{% highlight scss %}
-// Custom.scss
-// Option A: Include all of Bootstrap
+{% highlight scss %} // Custom.scss // Option A: Include all of Bootstrap
 
-@import "node_modules/bootstrap/scss/bootstrap";
-{% endhighlight %}
+@import "node_modules/bootstrap/scss/bootstrap"; {% endhighlight %}
 
-{% highlight scss %}
-// Custom.scss
-// Option B: Include parts of Bootstrap
+{% highlight scss %} // Custom.scss // Option B: Include parts of Bootstrap
 
-// Required
-@import "node_modules/bootstrap/scss/functions";
-@import "node_modules/bootstrap/scss/variables";
-@import "node_modules/bootstrap/scss/mixins";
+// Required @import "node_modules/bootstrap/scss/functions"; @import "node_modules/bootstrap/scss/variables"; @import "node_modules/bootstrap/scss/mixins";
 
-// Optional
-@import "node_modules/bootstrap/scss/reboot";
-@import "node_modules/bootstrap/scss/type";
-@import "node_modules/bootstrap/scss/images";
-@import "node_modules/bootstrap/scss/code";
-@import "node_modules/bootstrap/scss/grid";
-{% endhighlight %}
+// Optional @import "node_modules/bootstrap/scss/reboot"; @import "node_modules/bootstrap/scss/type"; @import "node_modules/bootstrap/scss/images"; @import "node_modules/bootstrap/scss/code"; @import "node_modules/bootstrap/scss/grid"; {% endhighlight %}
 
 With that setup in place, you can begin to modify any of the Sass variables and maps in your `custom.scss`. You can also start to add parts of Bootstrap under the `// Optional` section as needed.
 
@@ -67,14 +45,9 @@ Variable overrides within the same Sass file can come before or after the defaul
 
 Here's an example that changes the `background-color` and `color` for the `<body>` when importing and compiling Bootstrap via npm:
 
-{% highlight scss %}
-// Your variable overrides
-$body-bg: #000;
-$body-color: #111;
+{% highlight scss %} // Your variable overrides $body-bg: #000; $body-color: #111;
 
-// Bootstrap and its default variables
-@import "node_modules/bootstrap/scss/bootstrap";
-{% endhighlight %}
+// Bootstrap and its default variables @import "node_modules/bootstrap/scss/bootstrap"; {% endhighlight %}
 
 Repeat as necessary for any variable in Bootstrap, including the global options below.
 
@@ -84,67 +57,35 @@ Bootstrap 4 includes a handful of Sass maps, key value pairs that make it easier
 
 For example, to modify an existing color in our `$theme-colors` map, add the following to your custom Sass file:
 
-{% highlight scss %}
-$theme-colors: (
-  "primary": #0074d9,
-  "danger": #ff4136
-);
-{% endhighlight %}
+{% highlight scss %} $theme-colors: ( "primary": #0074d9, "danger": #ff4136 ); {% endhighlight %}
 
 To add a new color to `$theme-colors`, add the new key and value:
 
-{% highlight scss %}
-$theme-colors: (
-  "custom-color": #900
-);
-{% endhighlight %}
+{% highlight scss %} $theme-colors: ( "custom-color": #900 ); {% endhighlight %}
 
 ### Functions
 
 Bootstrap utilizes several Sass functions, but only a subset are applicable to general theming. We've included three functions for getting values from the color maps:
 
-{% highlight scss %}
-@function color($key: "blue") {
-  @return map-get($colors, $key);
-}
+{% highlight scss %} @function color($key: "blue") { @return map-get($colors, $key); }
 
-@function theme-color($key: "primary") {
-  @return map-get($theme-colors, $key);
-}
+@function theme-color($key: "primary") { @return map-get($theme-colors, $key); }
 
-@function gray($key: "100") {
-  @return map-get($grays, $key);
-}
-{% endhighlight %}
+@function gray($key: "100") { @return map-get($grays, $key); } {% endhighlight %}
 
 These allow you to pick one color from a Sass map much like how you'd use a color variable from v3.
 
-{% highlight scss %}
-.custom-element {
-  color: gray("100");
-  background-color: theme-color("dark");
-}
-{% endhighlight %}
+{% highlight scss %} .custom-element { color: gray("100"); background-color: theme-color("dark"); } {% endhighlight %}
 
 We also have another function for getting a particular _level_ of color from the `$theme-colors` map. Negative level values will lighten the color, while higher levels will darken.
 
-{% highlight scss %}
-@function theme-color-level($color-name: "primary", $level: 0) {
-  $color: theme-color($color-name);
-  $color-base: if($level > 0, #000, #fff);
-  $level: abs($level);
+{% highlight scss %} @function theme-color-level($color-name: "primary", $level: 0) { $color: theme-color($color-name); $color-base: if($level > 0, #000, #fff); $level: abs($level);
 
-  @return mix($color-base, $color, $level * $theme-color-interval);
-}
-{% endhighlight %}
+@return mix($color-base, $color, $level \* $theme-color-interval); } {% endhighlight %}
 
 In practice, you'd call the function and pass in two parameters: the name of the color from `$theme-colors` (e.g., primary or danger) and a numeric level.
 
-{% highlight scss %}
-.custom-element {
-  color: theme-color-level(primary, -10);
-}
-{% endhighlight %}
+{% highlight scss %} .custom-element { color: theme-color-level(primary, -10); } {% endhighlight %}
 
 Additional functions could be added in the future or your own custom Sass to create level functions for additional Sass maps, or even a generic one if you wanted to be more verbose.
 
@@ -154,29 +95,15 @@ One additional function we include in Bootstrap is the color contrast function, 
 
 For example, to generate color swatches from our `$theme-colors` map:
 
-{% highlight scss %}
-@each $color, $value in $theme-colors {
-  .swatch-#{$color} {
-    color: color-yiq($value);
-  }
-}
-{% endhighlight %}
+{% highlight scss %} @each $color, $value in $theme-colors { .swatch-#{$color} { color: color-yiq($value); } } {% endhighlight %}
 
 It can also be used for one-off contrast needs:
 
-{% highlight scss %}
-.custom-element {
-  color: color-yiq(#000); // returns `color: #fff`
-}
-{% endhighlight %}
+{% highlight scss %} .custom-element { color: color-yiq(#000); // returns `color: #fff` } {% endhighlight %}
 
 You can also specify a base color with our color map functions:
 
-{% highlight scss %}
-.custom-element {
-  color: color-yiq(theme-color("dark")); // returns `color: #fff`
-}
-{% endhighlight %}
+{% highlight scss %} .custom-element { color: color-yiq(theme-color("dark")); // returns `color: #fff` } {% endhighlight %}
 
 ## Sass options
 
@@ -184,17 +111,17 @@ Customize Bootstrap 4 with our built-in custom variables file and easily toggle 
 
 You can find and customize these variables for key global options in our `_variables.scss` file.
 
-| Variable                    | Values                             | Description                                                                            |
-| --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- |
+| Variable                    | Values                             | Description                                                                                                                                                 |
+| --------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `$spacer`                   | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [spacer utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/). |
-| `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                       |
-| `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                          |
-| `$enable-gradients`         | `true` or `false` (default)        | Enables predefined gradients via `background-image` styles on various components.      |
-| `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                |
-| `$enable-hover-media-query` | `true` or `false` (default)        | ...                                                                                    |
-| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g., `.container`, `.row`, `.col-md-1`, etc.).     |
-| `$enable-caret`             | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`.                                    |
-| `$enable-print-styles`      | `true` (default) or `false`        | Enables styles for optimizing printing.                                |
+| `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                                                                            |
+| `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                                                                               |
+| `$enable-gradients`         | `true` or `false` (default)        | Enables predefined gradients via `background-image` styles on various components.                                                                           |
+| `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                                                                                     |
+| `$enable-hover-media-query` | `true` or `false` (default)        | ...                                                                                                                                                         |
+| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g., `.container`, `.row`, `.col-md-1`, etc.).                                                  |
+| `$enable-caret`             | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`.                                                                                                         |
+| `$enable-print-styles`      | `true` (default) or `false`        | Enables styles for optimizing printing.                                                                                                                     |
 
 ## Color
 
@@ -216,19 +143,13 @@ All colors available in Bootstrap 4, are available as Sass variables and a Sass 
 
 Here's how you can use these in your Sass:
 
-{% highlight scss %}
-// With variable
-.alpha { color: $purple; }
+{% highlight scss %} // With variable .alpha { color: $purple; }
 
-// From the Sass map with our `color()` function
-.beta { color: color("purple"); }
-{% endhighlight %}
+// From the Sass map with our `color()` function .beta { color: color("purple"); } {% endhighlight %}
 
 [Color utility classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/colors/) are also available for setting `color` and `background-color`.
 
-{% callout info %}
-In the future, we'll aim to provide Sass maps and variables for shades of each color as we've done with the grayscale colors below.
-{% endcallout %}
+{% callout info %} In the future, we'll aim to provide Sass maps and variables for shades of each color as we've done with the grayscale colors below. {% endcallout %}
 
 ### Theme colors
 
@@ -256,23 +177,7 @@ An expansive set of gray variables and a Sass map in `scss/_variables.scss` for 
 
 Within `_variables.scss`, you'll find our color variables and Sass map. Here's an example of the `$colors` Sass map:
 
-{% highlight scss %}
-$colors: (
-  "blue": $blue,
-  "indigo": $indigo,
-  "purple": $purple,
-  "pink": $pink,
-  "red": $red,
-  "orange": $orange,
-  "yellow": $yellow,
-  "green": $green,
-  "teal": $teal,
-  "cyan": $cyan,
-  "white": $white,
-  "gray": $gray-600,
-  "gray-dark": $gray-800
-) !default;
-{% endhighlight %}
+{% highlight scss %} $colors: ( "blue": $blue, "indigo": $indigo, "purple": $purple, "pink": $pink, "red": $red, "orange": $orange, "yellow": $yellow, "green": $green, "teal": $teal, "cyan": $cyan, "white": $white, "gray": $gray-600, "gray-dark": $gray-800 ) !default; {% endhighlight %}
 
 Add, remove, or modify values within the map to update how they're used in many other components. Unfortunately at this time, not _every_ component utilizes this Sass map. Future updates will strive to improve upon this. Until then, plan on making use of the `${color}` variables and this Sass map.
 
@@ -286,34 +191,20 @@ Many of Bootstrap's components are built with a base-modifier class approach. Th
 
 Here are two examples of how we loop over the `$theme-colors` map to generate modifiers to the `.alert` component and all our `.bg-*` background utilities.
 
-{% highlight scss %}
-// Generate alert modifier classes
-@each $color, $value in $theme-colors {
-  .alert-#{$color} {
-    @include alert-variant(theme-color-level($color, -10), theme-color-level($color, -9), theme-color-level($color, 6));
-  }
-}
+{% highlight scss %} // Generate alert modifier classes @each $color, $value in $theme-colors { .alert-#{$color} { @include alert-variant(theme-color-level($color, -10), theme-color-level($color, -9), theme-color-level($color, 6)); } }
 
-// Generate `.bg-*` color utilities
-@each $color, $value in $theme-colors {
-  @include bg-variant('.bg-#{$color}', $value);
-}
-{% endhighlight %}
+// Generate `.bg-*` color utilities @each $color, $value in $theme-colors { @include bg-variant('.bg-#{$color}', $value); } {% endhighlight %}
 
 ### Responsive
 
 These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components or utilities. Take for example our responsive text alignment utilities where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.
 
-{% highlight scss %}
-@each $breakpoint in map-keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+{% highlight scss %} @each $breakpoint in map-keys($grid-breakpoints) { @include media-breakpoint-up($breakpoint) { $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .text#{$infix}-left   { text-align: left !important; }
     .text#{$infix}-right  { text-align: right !important; }
     .text#{$infix}-center { text-align: center !important; }
-  }
-}
-{% endhighlight %}
+
+} } {% endhighlight %}
 
 Should you need to modify your `$grid-breakpoints`, your changes will apply to all the loops iterating over that map.

--- a/docs/4.0/getting-started/webpack.md
+++ b/docs/4.0/getting-started/webpack.md
@@ -14,25 +14,15 @@ toc: true
 
 Import [Bootstrap's JavaScript]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/javascript/) by adding this line to your app's entry point (usually `index.js` or `app.js`):
 
-{% highlight js %}
-import 'bootstrap';
-{% endhighlight %}
+{% highlight js %} import 'bootstrap'; {% endhighlight %}
 
 Alternatively, you may **import plugins individually** as needed:
 
-{% highlight js %}
-import 'bootstrap/js/dist/util';
-import 'bootstrap/js/dist/dropdown';
-...
-{% endhighlight %}
+{% highlight js %} import 'bootstrap/js/dist/util'; import 'bootstrap/js/dist/dropdown'; ... {% endhighlight %}
 
-Bootstrap is dependent on [jQuery](https://jquery.com/) and [Popper](https://popper.js.org/),
-these are defined as `peerDependencies`, this means that you will have to make sure to add both of them
-to your `package.json` using `npm install --save jquery popper.js`.
+Bootstrap is dependent on [jQuery](https://jquery.com/) and [Popper](https://popper.js.org/), these are defined as `peerDependencies`, this means that you will have to make sure to add both of them to your `package.json` using `npm install --save jquery popper.js`.
 
-{% callout warning %}
-Notice that if you chose to **import plugins individually**, you must also install [exports-loader](https://github.com/webpack-contrib/exports-loader)
-{% endcallout %}
+{% callout warning %} Notice that if you chose to **import plugins individually**, you must also install [exports-loader](https://github.com/webpack-contrib/exports-loader) {% endcallout %}
 
 ## Importing Styles
 
@@ -42,57 +32,18 @@ To enjoy the full potential of Bootstrap and customize it to your needs, use the
 
 First, create your own `_custom.scss` and use it to override the [built-in custom variables]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/options/). Then, use your main sass file to import your custom variables, followed by Bootstrap:
 
-{% highlight scss %}
-@import "custom";
-@import "~bootstrap/scss/bootstrap";
-{% endhighlight %}
+{% highlight scss %} @import "custom"; @import "~bootstrap/scss/bootstrap"; {% endhighlight %}
 
 For Bootstrap to compile, make sure you install and use the required loaders: [sass-loader](https://github.com/webpack-contrib/sass-loader), [postcss-loader](https://github.com/postcss/postcss-loader) with [Autoprefixer](https://github.com/postcss/autoprefixer#webpack). With minimal setup, your webpack config should include this rule or similar:
 
-{% highlight js %}
-  ...
-  {
-    test: /\.(scss)$/,
-    use: [{
-      loader: 'style-loader', // inject CSS to page
-    }, {
-      loader: 'css-loader', // translates CSS into CommonJS modules
-    }, {
-      loader: 'postcss-loader', // Run post css actions
-      options: {
-        plugins: function () { // post css plugins, can be exported to postcss.config.js
-          return [
-            require('precss'),
-            require('autoprefixer')
-          ];
-        }
-      }
-    }, {
-      loader: 'sass-loader' // compiles Sass to CSS
-    }]
-  },
-  ...
-{% endhighlight %}
+{% highlight js %} ... { test: /\.(scss)$/, use: [{ loader: 'style-loader', // inject CSS to page }, { loader: 'css-loader', // translates CSS into CommonJS modules }, { loader: 'postcss-loader', // Run post css actions options: { plugins: function () { // post css plugins, can be exported to postcss.config.js return [ require('precss'), require('autoprefixer') ]; } } }, { loader: 'sass-loader' // compiles Sass to CSS }] }, ... {% endhighlight %}
 
 ### Importing Compiled CSS
 
 Alternatively, you may use Bootstrap's ready-to-use css by simply adding this line to your project's entry point:
 
-{% highlight js %}
-import 'bootstrap/dist/css/bootstrap.min.css';
-{% endhighlight %}
+{% highlight js %} import 'bootstrap/dist/css/bootstrap.min.css'; {% endhighlight %}
 
 In this case you may use your existing rule for `css` without any special modifications to webpack config except you don't need `sass-loader` just [style-loader](https://github.com/webpack-contrib/style-loader) and [css-loader](https://github.com/webpack-contrib/css-loader).
 
-{% highlight js %}
-  ...
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader']
-      }
-    ]
-  }
-  ...
-{% endhighlight %}
+{% highlight js %} ... module: { rules: [ { test: /\.css$/, use: ['style-loader', 'css-loader'] } ] } ... {% endhighlight %}

--- a/docs/4.0/layout/grid.md
+++ b/docs/4.0/layout/grid.md
@@ -34,16 +34,16 @@ The above example creates three equal-width columns on small, medium, large, and
 
 Breaking it down, here's how it works:
 
-- Containers provide a means to center and horizontally pad your site's contents. Use `.container` for a responsive pixel width or `.container-fluid` for `width: 100%` across all viewport and device sizes.
-- Rows are wrappers for columns. Each column has horizontal `padding` (called a gutter) for controlling the space between them. This `padding` is then counteracted on the rows with negative margins. This way, all the content in your columns is visually aligned down the left side.
-- In a grid layout, content must be placed within columns and only columns may be immediate children of rows.
-- Thanks to flexbox, grid columns without a specified `width` will automatically layout as equal width columns. For example, four instances of `.col-sm` will each automatically be 25% wide from the small breakpoint and up. See the [auto-layout columns](#auto-layout-columns) section for more examples.
-- Column classes indicate the number of columns you'd like to use out of the possible 12 per row. So, if you want three equal-width columns across, you can use `.col-4`.
-- Column `width`s are set in percentages, so they're always fluid and sized relative to their parent element.
-- Columns have horizontal `padding` to create the gutters between individual columns, however, you can remove the `margin` from rows and `padding` from columns with `.no-gutters` on the `.row`.
-- To make the grid responsive, there are five grid breakpoints, one for each [responsive breakpoint]({{ site.baseurl }}/docs/{{ site.docs_version }}/layout/overview/#responsive-breakpoints): all breakpoints (extra small), small, medium, large, and extra large.
-- Grid breakpoints are based on minimum width media queries, meaning **they apply to that one breakpoint and all those above it** (e.g., `.col-sm-4` applies to small, medium, large, and extra large devices, but not the first `xs` breakpoint).
-- You can use predefined grid classes (like `.col-4`) or [Sass mixins](#sass-mixins) for more semantic markup.
+* Containers provide a means to center and horizontally pad your site's contents. Use `.container` for a responsive pixel width or `.container-fluid` for `width: 100%` across all viewport and device sizes.
+* Rows are wrappers for columns. Each column has horizontal `padding` (called a gutter) for controlling the space between them. This `padding` is then counteracted on the rows with negative margins. This way, all the content in your columns is visually aligned down the left side.
+* In a grid layout, content must be placed within columns and only columns may be immediate children of rows.
+* Thanks to flexbox, grid columns without a specified `width` will automatically layout as equal width columns. For example, four instances of `.col-sm` will each automatically be 25% wide from the small breakpoint and up. See the [auto-layout columns](#auto-layout-columns) section for more examples.
+* Column classes indicate the number of columns you'd like to use out of the possible 12 per row. So, if you want three equal-width columns across, you can use `.col-4`.
+* Column `width`s are set in percentages, so they're always fluid and sized relative to their parent element.
+* Columns have horizontal `padding` to create the gutters between individual columns, however, you can remove the `margin` from rows and `padding` from columns with `.no-gutters` on the `.row`.
+* To make the grid responsive, there are five grid breakpoints, one for each [responsive breakpoint]({{ site.baseurl }}/docs/{{ site.docs_version }}/layout/overview/#responsive-breakpoints): all breakpoints (extra small), small, medium, large, and extra large.
+* Grid breakpoints are based on minimum width media queries, meaning **they apply to that one breakpoint and all those above it** (e.g., `.col-sm-4` applies to small, medium, large, and extra large devices, but not the first `xs` breakpoint).
+* You can use predefined grid classes (like `.col-4`) or [Sass mixins](#sass-mixins) for more semantic markup.
 
 Be aware of the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), like the [inability to use some HTML elements as flex containers](https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers).
 
@@ -303,6 +303,7 @@ Don't want your columns to simply stack in some grid tiers? Use a combination of
 </div>
 
 <!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
+
 <div class="row">
   <div class="col-6 col-md-4">.col-6 .col-md-4</div>
   <div class="col-6 col-md-4">.col-6 .col-md-4</div>
@@ -310,6 +311,7 @@ Don't want your columns to simply stack in some grid tiers? Use a combination of
 </div>
 
 <!-- Columns are always 50% wide, on mobile and desktop -->
+
 <div class="row">
   <div class="col-6">.col-6</div>
   <div class="col-6">.col-6</div>
@@ -438,18 +440,14 @@ Here's the source code for creating these styles. Note that column overrides are
 
 **Need an edge-to-edge design?** Drop the parent `.container` or `.container-fluid`.
 
-{% highlight sass %}
-.no-gutters {
-  margin-right: 0;
-  margin-left: 0;
+{% highlight sass %} .no-gutters { margin-right: 0; margin-left: 0;
 
-  > .col,
-  > [class*="col-"] {
+> .col, [class*="col-"] {
+
     padding-right: 0;
     padding-left: 0;
-  }
-}
-{% endhighlight %}
+
+} } {% endhighlight %}
 
 In practice, here's how it looks. Note you can continue to use this with all other predefined grid classes (including column widths, responsive tiers, reorders, and more).
 
@@ -487,6 +485,7 @@ Breaking columns to a new line in flexbox requires a small hack: add an element 
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
   <!-- Force next columns to break to new line -->
+
   <div class="w-100"></div>
 
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
@@ -504,6 +503,7 @@ You may also apply this break at specific breakpoints with our [responsive displ
   <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
 
   <!-- Force next columns to break to new line at md breakpoint and up -->
+
   <div class="w-100 d-none d-md-block"></div>
 
   <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
@@ -647,85 +647,40 @@ When using Bootstrap's source Sass files, you have the option of using Sass vari
 
 Variables and maps determine the number of columns, the gutter width, and the media query point at which to begin floating columns. We use these to generate the predefined grid classes documented above, as well as for the custom mixins listed below.
 
-{% highlight scss %}
-$grid-columns:      12;
-$grid-gutter-width: 30px;
+{% highlight scss %} $grid-columns: 12; $grid-gutter-width: 30px;
 
-$grid-breakpoints: (
-  // Extra small screen / phone
-  xs: 0,
-  // Small screen / phone
-  sm: 576px,
-  // Medium screen / tablet
-  md: 768px,
-  // Large screen / desktop
-  lg: 992px,
-  // Extra large screen / wide desktop
-  xl: 1200px
-);
+$grid-breakpoints: ( // Extra small screen / phone xs: 0, // Small screen / phone sm: 576px, // Medium screen / tablet md: 768px, // Large screen / desktop lg: 992px, // Extra large screen / wide desktop xl: 1200px );
 
-$container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px
-);
-{% endhighlight %}
+$container-max-widths: ( sm: 540px, md: 720px, lg: 960px, xl: 1140px ); {% endhighlight %}
 
 ### Mixins
 
 Mixins are used in conjunction with the grid variables to generate semantic CSS for individual grid columns.
 
-{% highlight scss %}
-// Creates a wrapper for a series of columns
-@include make-row();
+{% highlight scss %} // Creates a wrapper for a series of columns @include make-row();
 
-// Make the element grid-ready (applying everything but the width)
-@include make-col-ready();
-@include make-col($size, $columns: $grid-columns);
+// Make the element grid-ready (applying everything but the width) @include make-col-ready(); @include make-col($size, $columns: $grid-columns);
 
-// Get fancy by offsetting, or changing the sort order
-@include make-col-offset($size, $columns: $grid-columns);
-{% endhighlight %}
+// Get fancy by offsetting, or changing the sort order @include make-col-offset($size, $columns: $grid-columns); {% endhighlight %}
 
 ### Example usage
 
 You can modify the variables to your own custom values, or just use the mixins with their default values. Here's an example of using the default settings to create a two-column layout with a gap between.
 
-{% highlight scss %}
-.example-container {
-  width: 800px;
-  @include make-container();
-}
+{% highlight scss %} .example-container { width: 800px; @include make-container(); }
 
-.example-row {
-  @include make-row();
-}
+.example-row { @include make-row(); }
 
-.example-content-main {
-  @include make-col-ready();
+.example-content-main { @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
-    @include make-col(6);
-  }
-  @include media-breakpoint-up(lg) {
-    @include make-col(8);
-  }
-}
+@include media-breakpoint-up(sm) { @include make-col(6); } @include media-breakpoint-up(lg) { @include make-col(8); } }
 
-.example-content-secondary {
-  @include make-col-ready();
+.example-content-secondary { @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
-    @include make-col(6);
-  }
-  @include media-breakpoint-up(lg) {
-    @include make-col(4);
-  }
-}
-{% endhighlight %}
+@include media-breakpoint-up(sm) { @include make-col(6); } @include media-breakpoint-up(lg) { @include make-col(4); } } {% endhighlight %}
 
 {% example html %}
+
 <div class="example-container">
   <div class="example-row">
     <div class="example-content-main">Main content</div>
@@ -742,28 +697,14 @@ Using our built-in grid Sass variables and maps, it's possible to completely cus
 
 The number of grid columns can be modified via Sass variables. `$grid-columns` is used to generate the widths (in percent) of each individual column while `$grid-gutter-width` allows breakpoint-specific widths that are divided evenly across `padding-left` and `padding-right` for the column gutters.
 
-{% highlight scss %}
-$grid-columns: 12 !default;
-$grid-gutter-width: 30px !default;
-{% endhighlight %}
+{% highlight scss %} $grid-columns: 12 !default; $grid-gutter-width: 30px !default; {% endhighlight %}
 
 ### Grid tiers
 
 Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you'd update the `$grid-breakpoints` and `$container-max-widths` to something like this:
 
-{% highlight scss %}
-$grid-breakpoints: (
-  xs: 0,
-  sm: 480px,
-  md: 768px,
-  lg: 1024px
-);
+{% highlight scss %} $grid-breakpoints: ( xs: 0, sm: 480px, md: 768px, lg: 1024px );
 
-$container-max-widths: (
-  sm: 420px,
-  md: 720px,
-  lg: 960px
-);
-{% endhighlight %}
+$container-max-widths: ( sm: 420px, md: 720px, lg: 960px ); {% endhighlight %}
 
 When making any changes to the Sass variables or maps, you'll need to save your changes and recompile. Doing so will output a brand new set of predefined grid classes for column widths, offsets, and ordering. Responsive visibility utilities will also be updated to use the custom breakpoints. Make sure to set grid values in `px` (not `rem`, `em`, or `%`).

--- a/docs/4.0/layout/media-object.md
+++ b/docs/4.0/layout/media-object.md
@@ -13,6 +13,7 @@ The [media object](http://www.stubbornella.org/content/2010/06/25/the-media-obje
 Below is an example of a single media object. Only two classes are required—the wrapping `.media` and the `.media-body` around your content. Optional padding and margin can be controlled through [spacing utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/).
 
 {% example html %}
+
 <div class="media">
   <img class="mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
@@ -23,18 +24,19 @@ Below is an example of a single media object. Only two classes are required—th
 {% endexample %}
 
 {% callout warning %}
+
 ##### Flexbug #12: Inline elements aren't treated as flex items
 
 Internet Explorer 10-11 do not render inline elements like links or images (or `::before` and `::after` pseudo-elements) as flex items. The only workaround is to set a non-inline `display` value (e.g., `block`, `inline-block`, or `flex`). We suggest using `.d-flex`, one of our [display utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/), as an easy fix.
 
-**Source:** [Flexbugs on GitHub](https://github.com/philipwalton/flexbugs#12-inline-elements-are-not-treated-as-flex-items)
-{% endcallout %}
+**Source:** [Flexbugs on GitHub](https://github.com/philipwalton/flexbugs#12-inline-elements-are-not-treated-as-flex-items) {% endcallout %}
 
 ## Nesting
 
 Media objects can be infinitely nested, though we suggest you stop at some point. Place nested `.media` within the `.media-body` of a parent media object.
 
 {% example html %}
+
 <div class="media">
   <img class="mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
@@ -50,6 +52,7 @@ Media objects can be infinitely nested, though we suggest you stop at some point
         Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
       </div>
     </div>
+
   </div>
 </div>
 {% endexample %}
@@ -59,6 +62,7 @@ Media objects can be infinitely nested, though we suggest you stop at some point
 Media in a media object can be aligned with flexbox utilities to the top (default), middle, or end of your `.media-body` content.
 
 {% example html %}
+
 <div class="media">
   <img class="align-self-start mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
@@ -70,6 +74,7 @@ Media in a media object can be aligned with flexbox utilities to the top (defaul
 {% endexample %}
 
 {% example html %}
+
 <div class="media">
   <img class="align-self-center mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
@@ -81,6 +86,7 @@ Media in a media object can be aligned with flexbox utilities to the top (defaul
 {% endexample %}
 
 {% example html %}
+
 <div class="media">
   <img class="align-self-end mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">
   <div class="media-body">
@@ -96,6 +102,7 @@ Media in a media object can be aligned with flexbox utilities to the top (defaul
 Change the order of content in media objects by modifying the HTML itself, or by adding some custom flexbox CSS to set the `order` property (to an integer of your choosing).
 
 {% example html %}
+
 <div class="media">
   <div class="media-body">
     <h5 class="mt-0 mb-1">Media object</h5>
@@ -110,6 +117,7 @@ Change the order of content in media objects by modifying the HTML itself, or by
 Because the media object has so few structural requirements, you can also use these classes on list HTML elements. On your `<ul>` or `<ol>`, add the `.list-unstyled` to remove any browser default list styles, and then apply `.media` to your `<li>`s. As always, use spacing utilities wherever needed to fine tune.
 
 {% example html %}
+
 <ul class="list-unstyled">
   <li class="media">
     <img class="mr-3" data-src="holder.js/64x64" alt="Generic placeholder image">

--- a/docs/4.0/layout/overview.md
+++ b/docs/4.0/layout/overview.md
@@ -11,7 +11,7 @@ toc: true
 
 Containers are the most basic layout element in Bootstrap and are **required when using our default grid system**. Choose from a responsive, fixed-width container (meaning its `max-width` changes at each breakpoint) or fluid-width (meaning it's `100%` wide all the time).
 
-While containers *can* be nested, most layouts do not require a nested container.
+While containers _can_ be nested, most layouts do not require a nested container.
 
 <div class="bd-example">
   <div class="bd-example-container">
@@ -22,6 +22,7 @@ While containers *can* be nested, most layouts do not require a nested container
 </div>
 
 {% highlight html %}
+
 <div class="container">
   <!-- Content here -->
 </div>
@@ -38,11 +39,11 @@ Use `.container-fluid` for a full width container, spanning the entire width of 
 </div>
 
 {% highlight html %}
+
 <div class="container-fluid">
   ...
 </div>
 {% endhighlight %}
-
 
 ## Responsive breakpoints
 
@@ -50,113 +51,63 @@ Since Bootstrap is developed to be mobile first, we use a handful of [media quer
 
 Bootstrap primarily uses the following media query ranges—or breakpoints—in our source Sass files for our layout, grid system, and components.
 
-{% highlight scss %}
-// Extra small devices (portrait phones, less than 576px)
-// No media query since this is the default in Bootstrap
+{% highlight scss %} // Extra small devices (portrait phones, less than 576px) // No media query since this is the default in Bootstrap
 
-// Small devices (landscape phones, 576px and up)
-@media (min-width: 576px) { ... }
+// Small devices (landscape phones, 576px and up) @media (min-width: 576px) { ... }
 
-// Medium devices (tablets, 768px and up)
-@media (min-width: 768px) { ... }
+// Medium devices (tablets, 768px and up) @media (min-width: 768px) { ... }
 
-// Large devices (desktops, 992px and up)
-@media (min-width: 992px) { ... }
+// Large devices (desktops, 992px and up) @media (min-width: 992px) { ... }
 
-// Extra large devices (large desktops, 1200px and up)
-@media (min-width: 1200px) { ... }
-{% endhighlight %}
+// Extra large devices (large desktops, 1200px and up) @media (min-width: 1200px) { ... } {% endhighlight %}
 
 Since we write our source CSS in Sass, all our media queries are available via Sass mixins:
 
-{% highlight scss %}
-@include media-breakpoint-up(xs) { ... }
-@include media-breakpoint-up(sm) { ... }
-@include media-breakpoint-up(md) { ... }
-@include media-breakpoint-up(lg) { ... }
-@include media-breakpoint-up(xl) { ... }
+{% highlight scss %} @include media-breakpoint-up(xs) { ... } @include media-breakpoint-up(sm) { ... } @include media-breakpoint-up(md) { ... } @include media-breakpoint-up(lg) { ... } @include media-breakpoint-up(xl) { ... }
 
-// Example usage:
-@include media-breakpoint-up(sm) {
-  .some-class {
-    display: block;
-  }
-}
-{% endhighlight %}
+// Example usage: @include media-breakpoint-up(sm) { .some-class { display: block; } } {% endhighlight %}
 
-We occasionally use media queries that go in the other direction (the given screen size *or smaller*):
+We occasionally use media queries that go in the other direction (the given screen size _or smaller_):
 
-{% highlight scss %}
-// Extra small devices (portrait phones, less than 576px)
-@media (max-width: 575.99px) { ... }
+{% highlight scss %} // Extra small devices (portrait phones, less than 576px) @media (max-width: 575.99px) { ... }
 
-// Small devices (landscape phones, less than 768px)
-@media (max-width: 767.99px) { ... }
+// Small devices (landscape phones, less than 768px) @media (max-width: 767.99px) { ... }
 
-// Medium devices (tablets, less than 992px)
-@media (max-width: 991.99px) { ... }
+// Medium devices (tablets, less than 992px) @media (max-width: 991.99px) { ... }
 
-// Large devices (desktops, less than 1200px)
-@media (max-width: 1199.99px) { ... }
+// Large devices (desktops, less than 1200px) @media (max-width: 1199.99px) { ... }
 
-// Extra large devices (large desktops)
-// No media query since the extra-large breakpoint has no upper bound on its width
-{% endhighlight %}
+// Extra large devices (large desktops) // No media query since the extra-large breakpoint has no upper bound on its width {% endhighlight %}
 
-{% capture callout-include %}{% include callout-info-mediaqueries-breakpoints.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-info-mediaqueries-breakpoints.md %}{% endcapture %} {{ callout-include | markdownify }}
 
 Once again, these media queries are also available via Sass mixins:
 
-{% highlight scss %}
-@include media-breakpoint-down(xs) { ... }
-@include media-breakpoint-down(sm) { ... }
-@include media-breakpoint-down(md) { ... }
-@include media-breakpoint-down(lg) { ... }
-{% endhighlight %}
+{% highlight scss %} @include media-breakpoint-down(xs) { ... } @include media-breakpoint-down(sm) { ... } @include media-breakpoint-down(md) { ... } @include media-breakpoint-down(lg) { ... } {% endhighlight %}
 
 There are also media queries and mixins for targeting a single segment of screen sizes using the minimum and maximum breakpoint widths.
 
-{% highlight scss %}
-// Extra small devices (portrait phones, less than 576px)
-@media (max-width: 575.99px) { ... }
+{% highlight scss %} // Extra small devices (portrait phones, less than 576px) @media (max-width: 575.99px) { ... }
 
-// Small devices (landscape phones, 576px and up)
-@media (min-width: 576px) and (max-width: 767.99px) { ... }
+// Small devices (landscape phones, 576px and up) @media (min-width: 576px) and (max-width: 767.99px) { ... }
 
-// Medium devices (tablets, 768px and up)
-@media (min-width: 768px) and (max-width: 991.99px) { ... }
+// Medium devices (tablets, 768px and up) @media (min-width: 768px) and (max-width: 991.99px) { ... }
 
-// Large devices (desktops, 992px and up)
-@media (min-width: 992px) and (max-width: 1199.99px) { ... }
+// Large devices (desktops, 992px and up) @media (min-width: 992px) and (max-width: 1199.99px) { ... }
 
-// Extra large devices (large desktops, 1200px and up)
-@media (min-width: 1200px) { ... }
-{% endhighlight %}
+// Extra large devices (large desktops, 1200px and up) @media (min-width: 1200px) { ... } {% endhighlight %}
 
 These media queries are also available via Sass mixins:
 
-{% highlight scss %}
-@include media-breakpoint-only(xs) { ... }
-@include media-breakpoint-only(sm) { ... }
-@include media-breakpoint-only(md) { ... }
-@include media-breakpoint-only(lg) { ... }
-@include media-breakpoint-only(xl) { ... }
-{% endhighlight %}
+{% highlight scss %} @include media-breakpoint-only(xs) { ... } @include media-breakpoint-only(sm) { ... } @include media-breakpoint-only(md) { ... } @include media-breakpoint-only(lg) { ... } @include media-breakpoint-only(xl) { ... } {% endhighlight %}
 
 Similarly, media queries may span multiple breakpoint widths:
 
-{% highlight scss %}
-// Example
-// Apply styles starting from medium devices and up to extra large devices
-@media (min-width: 768px) and (max-width: 1199.99px) { ... }
-{% endhighlight %}
+{% highlight scss %} // Example // Apply styles starting from medium devices and up to extra large devices @media (min-width: 768px) and (max-width: 1199.99px) { ... } {% endhighlight %}
 
 The Sass mixin for targeting the same screen size range would be:
 
-{% highlight scss %}
-@include media-breakpoint-between(md, xl) { ... }
-{% endhighlight %}
+{% highlight scss %} @include media-breakpoint-between(md, xl) { ... } {% endhighlight %}
 
 ## Z-index
 
@@ -165,13 +116,13 @@ Several Bootstrap components utilize `z-index`, the CSS property that helps cont
 We don't encourage customization of these values; should you change one, you likely need to change them all.
 
 ```scss
-$zindex-dropdown:          1000 !default;
-$zindex-sticky:            1020 !default;
-$zindex-fixed:             1030 !default;
-$zindex-modal-backdrop:    1040 !default;
-$zindex-modal:             1050 !default;
-$zindex-popover:           1060 !default;
-$zindex-tooltip:           1070 !default;
+$zindex-dropdown: 1000 !default;
+$zindex-sticky: 1020 !default;
+$zindex-fixed: 1030 !default;
+$zindex-modal-backdrop: 1040 !default;
+$zindex-modal: 1050 !default;
+$zindex-popover: 1060 !default;
+$zindex-tooltip: 1070 !default;
 ```
 
 Background elements—like the backdrops that allow click-dismissing—tend to reside on a lower `z-index`s, while navigation and popovers utilize higher `z-index`s to ensure they overlay surrounding content.

--- a/docs/4.0/migration.md
+++ b/docs/4.0/migration.md
@@ -10,7 +10,7 @@ toc: true
 
 While Beta 2 saw the bulk of our breaking changes during the beta phase, but we still have a few that needed to be addressed in the Beta 3 release. These changes apply if you're updating to Beta 3 from Beta 2 or any older version of Bootstrap.
 
-- Removed the unused `$thumbnail-transition` variable. We weren't transitioning anything, so it was just extra code.
+* Removed the unused `$thumbnail-transition` variable. We weren't transitioning anything, so it was just extra code.
 
 ## Beta 2 changes
 
@@ -18,19 +18,18 @@ While in beta, we aim to have no breaking changes. However, things don't always 
 
 ### Breaking
 
-- Removed `$badge-color` variable and its usage on `.badge`. We use a color contrast function to pick a `color` based on the `background-color`, so the variable is unnecessary.
-- Renamed `grayscale()` function to `gray()` to avoid breaking conflict with the CSS native `grayscale` filter.
-- Renamed `.table-inverse`, `.thead-inverse`, and `.thead-default` to `.*-dark` and `.*-light`, matching our color schemes used elsewhere.
-- Responsive tables now generate classes for each grid breakpoint. This breaks from Beta 1 in that the `.table-responsive` you've been using is more like `.table-responsive-md`. You may now use `.table-responsive` or `.table-responsive-{sm,md,lg,xl}` as needed.
-- Dropped Bower support as the package manager has been deprecated for alternatives (e.g., Yarn or npm). [See bower/bower#2298](https://github.com/bower/bower/issues/2298) for details.
-- Bootstrap still requires jQuery 1.9.1 or higher, but you're advised to use version 3.x since v3.x's supported browsers are the ones Bootstrap supports plus v3.x has some security fixes.
-- Removed the unused `.form-control-label` class. If you did make use of this class, it was duplicate of the `.col-form-label` class that vertically centered a `<label>` with it's associated input in horizontal form layouts.
-- Changed the `color-yiq` from a mixin that included the `color` property to a function that returns a value, allowing you to use it for any CSS property. For example, instead of `color-yiq(#000)`, you'd write `color: color-yiq(#000);`.
+* Removed `$badge-color` variable and its usage on `.badge`. We use a color contrast function to pick a `color` based on the `background-color`, so the variable is unnecessary.
+* Renamed `grayscale()` function to `gray()` to avoid breaking conflict with the CSS native `grayscale` filter.
+* Renamed `.table-inverse`, `.thead-inverse`, and `.thead-default` to `.*-dark` and `.*-light`, matching our color schemes used elsewhere.
+* Responsive tables now generate classes for each grid breakpoint. This breaks from Beta 1 in that the `.table-responsive` you've been using is more like `.table-responsive-md`. You may now use `.table-responsive` or `.table-responsive-{sm,md,lg,xl}` as needed.
+* Dropped Bower support as the package manager has been deprecated for alternatives (e.g., Yarn or npm). [See bower/bower#2298](https://github.com/bower/bower/issues/2298) for details.
+* Bootstrap still requires jQuery 1.9.1 or higher, but you're advised to use version 3.x since v3.x's supported browsers are the ones Bootstrap supports plus v3.x has some security fixes.
+* Removed the unused `.form-control-label` class. If you did make use of this class, it was duplicate of the `.col-form-label` class that vertically centered a `<label>` with it's associated input in horizontal form layouts.
+* Changed the `color-yiq` from a mixin that included the `color` property to a function that returns a value, allowing you to use it for any CSS property. For example, instead of `color-yiq(#000)`, you'd write `color: color-yiq(#000);`.
 
 ### Highlights
 
-- Introduced new `pointer-events` usage on modals. The outer `.modal-dialog` passes through events with `pointer-events: none` for custom click handling (making it possible to just listen on the `.modal-backdrop` for any clicks), and then counteracts it for the actual `.modal-content` with `pointer-events: auto`.
-
+* Introduced new `pointer-events` usage on modals. The outer `.modal-dialog` passes through events with `pointer-events: none` for custom click handling (making it possible to just listen on the `.modal-backdrop` for any clicks), and then counteracts it for the actual `.modal-content` with `pointer-events: auto`.
 
 ## Summary
 
@@ -38,50 +37,50 @@ Here are the big ticket items you'll want to be aware of when moving from v3 to 
 
 ### Browser support
 
-- Dropped IE8, IE9, and iOS 6 support. v4 is now only IE10+ and iOS 7+. For sites needing either of those, use v3.
-- Added official support for Android v5.0 Lollipop's Browser and WebView. Earlier versions of the Android Browser and WebView remain only unofficially supported.
+* Dropped IE8, IE9, and iOS 6 support. v4 is now only IE10+ and iOS 7+. For sites needing either of those, use v3.
+* Added official support for Android v5.0 Lollipop's Browser and WebView. Earlier versions of the Android Browser and WebView remain only unofficially supported.
 
 ### Global changes
 
-- **Flexbox is enabled by default.** In general this means a move away from floats and more across our components.
-- Switched from [Less](http://lesscss.org/) to [Sass](http://sass-lang.com/) for our source CSS files.
-- Switched from `px` to `rem` as our primary CSS unit, though pixels are still used for media queries and grid behavior as device viewports are not affected by type size.
-- Global font-size increased from `14px` to `16px`.
-- Revamped grid tiers to add a fifth option (addressing smaller devices at `576px` and below) and removed the `-xs` infix from those classes. Example: `.col-6.col-sm-4.col-md-3`.
-- Replaced the separate optional theme with configurable options via SCSS variables (e.g., `$enable-gradients: true`).
-- Build system overhauled to use a series of npm scripts instead of Grunt. See `package.json` for all scripts, or our project readme for local development needs.
-- Non-responsive usage of Bootstrap is no longer supported.
-- Dropped the online Customizer in favor of more extensive setup documentation and customized builds.
-- Added dozens of new [utility classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/) for common CSS property-value pairs and margin/padding spacing shortcuts.
+* **Flexbox is enabled by default.** In general this means a move away from floats and more across our components.
+* Switched from [Less](http://lesscss.org/) to [Sass](http://sass-lang.com/) for our source CSS files.
+* Switched from `px` to `rem` as our primary CSS unit, though pixels are still used for media queries and grid behavior as device viewports are not affected by type size.
+* Global font-size increased from `14px` to `16px`.
+* Revamped grid tiers to add a fifth option (addressing smaller devices at `576px` and below) and removed the `-xs` infix from those classes. Example: `.col-6.col-sm-4.col-md-3`.
+* Replaced the separate optional theme with configurable options via SCSS variables (e.g., `$enable-gradients: true`).
+* Build system overhauled to use a series of npm scripts instead of Grunt. See `package.json` for all scripts, or our project readme for local development needs.
+* Non-responsive usage of Bootstrap is no longer supported.
+* Dropped the online Customizer in favor of more extensive setup documentation and customized builds.
+* Added dozens of new [utility classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/) for common CSS property-value pairs and margin/padding spacing shortcuts.
 
 ### Grid system
 
-- **Moved to flexbox.**
-  - Added support for flexbox in the grid mixins and predefined classes.
-  - As part of flexbox, included support for vertical and horizontal alignment classes.
-- **Updated grid class names and a new grid tier.**
-  - Added a new `sm` grid tier below `768px` for more granular control. We now have `xs`, `sm`, `md`, `lg`, and `xl`. This also means every tier has been bumped up one level (so `.col-md-6` in v3 is now `.col-lg-6` in v4).
-  - `xs` grid classes have been modified to not require the infix to more accurately represent that they start applying styles at `min-width: 0` and not a set pixel value. Instead of `.col-xs-6`, it's now `.col-6`. All other grid tiers require the infix (e.g., `sm`).
-- **Updated grid sizes, mixins, and variables.**
-  - Grid gutters now have a Sass map so you can specify specific gutter widths at each breakpoint.
-  - Updated grid mixins to utilize a `make-col-ready` prep mixin and a `make-col` to set the `flex` and `max-width` for individual column sizing.
-  - Changed grid system media query breakpoints and container widths to account for new grid tier and ensure columns are evenly divisible by `12` at their max width.
-  - Grid breakpoints and container widths are now handled via Sass maps (`$grid-breakpoints` and `$container-max-widths`) instead of a handful of separate variables. These replace the `@screen-*` variables entirely and allow you to fully customize the grid tiers.
-  - Media queries have also changed. Instead of repeating our media query declarations with the same value each time, we now have `@include media-breakpoint-up/down/only`. Now, instead of writing `@media (min-width: @screen-sm-min) { ... }`, you can write `@include media-breakpoint-up(sm) { ... }`.
+* **Moved to flexbox.**
+  * Added support for flexbox in the grid mixins and predefined classes.
+  * As part of flexbox, included support for vertical and horizontal alignment classes.
+* **Updated grid class names and a new grid tier.**
+  * Added a new `sm` grid tier below `768px` for more granular control. We now have `xs`, `sm`, `md`, `lg`, and `xl`. This also means every tier has been bumped up one level (so `.col-md-6` in v3 is now `.col-lg-6` in v4).
+  * `xs` grid classes have been modified to not require the infix to more accurately represent that they start applying styles at `min-width: 0` and not a set pixel value. Instead of `.col-xs-6`, it's now `.col-6`. All other grid tiers require the infix (e.g., `sm`).
+* **Updated grid sizes, mixins, and variables.**
+  * Grid gutters now have a Sass map so you can specify specific gutter widths at each breakpoint.
+  * Updated grid mixins to utilize a `make-col-ready` prep mixin and a `make-col` to set the `flex` and `max-width` for individual column sizing.
+  * Changed grid system media query breakpoints and container widths to account for new grid tier and ensure columns are evenly divisible by `12` at their max width.
+  * Grid breakpoints and container widths are now handled via Sass maps (`$grid-breakpoints` and `$container-max-widths`) instead of a handful of separate variables. These replace the `@screen-*` variables entirely and allow you to fully customize the grid tiers.
+  * Media queries have also changed. Instead of repeating our media query declarations with the same value each time, we now have `@include media-breakpoint-up/down/only`. Now, instead of writing `@media (min-width: @screen-sm-min) { ... }`, you can write `@include media-breakpoint-up(sm) { ... }`.
 
 ### Components
 
-- **Dropped panels, thumbnails, and wells** for a new all-encompassing component, [cards]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/card/).
-- **Dropped the Glyphicons icon font.** If you need icons, some options are:
-  - the upstream version of [Glyphicons](https://glyphicons.com/)
-  - [Octicons](https://octicons.github.com/)
-  - [Font Awesome](http://fontawesome.io/)
-  - See the [Extend page]({{ site.baseurl }}/docs/{{ site.docs_version }}/extend/icons/) for a list of alternatives. Have additional suggestions? Please open an issue or PR.
-- **Dropped the Affix jQuery plugin.**
-  - We recommend using `position: sticky` instead. [See the HTML5 Please entry](http://html5please.com/#sticky) for details and specific polyfill recommendations. One suggestion is to use an `@supports` rule for implementing it (e.g., `@supports (position: sticky) { ... }`)/
-  - If you were using Affix to apply additional, non-`position` styles, the polyfills might not support your use case. One option for such uses is the third-party [ScrollPos-Styler](https://github.com/acch/scrollpos-styler) library.
-- **Dropped the pager component** as it was essentially slightly customized buttons.
-- **Refactored nearly all components** to use more un-nested class selectors instead of over-specific children selectors.
+* **Dropped panels, thumbnails, and wells** for a new all-encompassing component, [cards]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/card/).
+* **Dropped the Glyphicons icon font.** If you need icons, some options are:
+  * the upstream version of [Glyphicons](https://glyphicons.com/)
+  * [Octicons](https://octicons.github.com/)
+  * [Font Awesome](http://fontawesome.io/)
+  * See the [Extend page]({{ site.baseurl }}/docs/{{ site.docs_version }}/extend/icons/) for a list of alternatives. Have additional suggestions? Please open an issue or PR.
+* **Dropped the Affix jQuery plugin.**
+  * We recommend using `position: sticky` instead. [See the HTML5 Please entry](http://html5please.com/#sticky) for details and specific polyfill recommendations. One suggestion is to use an `@supports` rule for implementing it (e.g., `@supports (position: sticky) { ... }`)/
+  * If you were using Affix to apply additional, non-`position` styles, the polyfills might not support your use case. One option for such uses is the third-party [ScrollPos-Styler](https://github.com/acch/scrollpos-styler) library.
+* **Dropped the pager component** as it was essentially slightly customized buttons.
+* **Refactored nearly all components** to use more un-nested class selectors instead of over-specific children selectors.
 
 ## By component
 
@@ -93,125 +92,125 @@ New to Bootstrap 4 is the [Reboot]({{ site.baseurl }}/docs/{{ site.docs_version 
 
 ### Typography
 
-- Moved all `.text-` utilities to the `_utilities.scss` file.
-- Dropped `.page-header` as, aside from the border, all its styles can be applied via utilities.
-- `.dl-horizontal` has been dropped. Instead, use `.row` on `<dl>` and use grid column classes (or mixins) on its `<dt>` and `<dd>` children.
-- Custom `<blockquote>` styling has moved to classes—`.blockquote` and the `.blockquote-reverse` modifier.
-- `.list-inline` now requires that its children list items have the new `.list-inline-item` class applied to them.
+* Moved all `.text-` utilities to the `_utilities.scss` file.
+* Dropped `.page-header` as, aside from the border, all its styles can be applied via utilities.
+* `.dl-horizontal` has been dropped. Instead, use `.row` on `<dl>` and use grid column classes (or mixins) on its `<dt>` and `<dd>` children.
+* Custom `<blockquote>` styling has moved to classes—`.blockquote` and the `.blockquote-reverse` modifier.
+* `.list-inline` now requires that its children list items have the new `.list-inline-item` class applied to them.
 
 ### Images
 
-- Renamed `.img-responsive` to `.img-fluid`.
-- Renamed `.img-rounded` to `.rounded`
-- Renamed `.img-circle` to `.rounded-circle`
+* Renamed `.img-responsive` to `.img-fluid`.
+* Renamed `.img-rounded` to `.rounded`
+* Renamed `.img-circle` to `.rounded-circle`
 
 ### Tables
 
-- Nearly all instances of the `>` selector have been removed, meaning nested tables will now automatically inherit styles from their parents. This greatly simplifies our selectors and potential customizations.
-- Responsive tables no longer require a wrapping element. Instead, just put the `.table-responsive` right on the `<table>`.
-- Renamed `.table-condensed` to `.table-sm` for consistency.
-- Added a new `.table-inverse` option.
-- Added table header modifiers: `.thead-default` and `.thead-inverse`.
-- Renamed contextual classes to have a `.table-`-prefix. Hence `.active`, `.success`, `.warning`, `.danger` and `.info` to `.table-active`, `.table-success`, `.table-warning`, `.table-danger` and `.table-info`.
+* Nearly all instances of the `>` selector have been removed, meaning nested tables will now automatically inherit styles from their parents. This greatly simplifies our selectors and potential customizations.
+* Responsive tables no longer require a wrapping element. Instead, just put the `.table-responsive` right on the `<table>`.
+* Renamed `.table-condensed` to `.table-sm` for consistency.
+* Added a new `.table-inverse` option.
+* Added table header modifiers: `.thead-default` and `.thead-inverse`.
+* Renamed contextual classes to have a `.table-`-prefix. Hence `.active`, `.success`, `.warning`, `.danger` and `.info` to `.table-active`, `.table-success`, `.table-warning`, `.table-danger` and `.table-info`.
 
 ### Forms
 
-- Moved element resets to the `_reboot.scss` file.
-- Renamed `.control-label` to `.col-form-label`.
-- Renamed `.input-lg` and `.input-sm` to `.form-control-lg` and `.form-control-sm`, respectively.
-- Dropped `.form-group-*` classes for simplicity's sake. Use `.form-control-*` classes instead now.
-- Dropped `.help-block` and replaced it with `.form-text` for block-level help text. For inline help text and other flexible options, use utility classes like `.text-muted`.
-- Dropped `.radio-inline` and `.checkbox-inline`.
-- Consolidated `.checkbox` and `.radio` into `.form-check` and the various `.form-check-*` classes.
-- Horizontal forms overhauled:
-  - Dropped the `.form-horizontal` class requirement.
-  - `.form-group` no longer applies styles from the `.row` via mixin, so `.row` is now required for horizontal grid layouts (e.g., `<div class="form-group row">`).
-  - Added new `.col-form-label` class to vertically center labels with `.form-control`s.
-  - Added new `.form-row` for compact form layouts with the grid classes (swap your `.row` for a `.form-row` and go).
-- Added custom forms support (for checkboxes, radios, selects, and file inputs).
-- Replaced `.has-error`, `.has-warning`, and `.has-success` classes with HTML5 form validation via CSS's `:invalid` and `:valid` pseudo-classes.
-- Renamed `.form-control-static` to `.form-control-plaintext`.
+* Moved element resets to the `_reboot.scss` file.
+* Renamed `.control-label` to `.col-form-label`.
+* Renamed `.input-lg` and `.input-sm` to `.form-control-lg` and `.form-control-sm`, respectively.
+* Dropped `.form-group-*` classes for simplicity's sake. Use `.form-control-*` classes instead now.
+* Dropped `.help-block` and replaced it with `.form-text` for block-level help text. For inline help text and other flexible options, use utility classes like `.text-muted`.
+* Dropped `.radio-inline` and `.checkbox-inline`.
+* Consolidated `.checkbox` and `.radio` into `.form-check` and the various `.form-check-*` classes.
+* Horizontal forms overhauled:
+  * Dropped the `.form-horizontal` class requirement.
+  * `.form-group` no longer applies styles from the `.row` via mixin, so `.row` is now required for horizontal grid layouts (e.g., `<div class="form-group row">`).
+  * Added new `.col-form-label` class to vertically center labels with `.form-control`s.
+  * Added new `.form-row` for compact form layouts with the grid classes (swap your `.row` for a `.form-row` and go).
+* Added custom forms support (for checkboxes, radios, selects, and file inputs).
+* Replaced `.has-error`, `.has-warning`, and `.has-success` classes with HTML5 form validation via CSS's `:invalid` and `:valid` pseudo-classes.
+* Renamed `.form-control-static` to `.form-control-plaintext`.
 
 ### Buttons
 
-- Renamed `.btn-default` to `.btn-secondary`.
-- Dropped the `.btn-xs` class entirely as `.btn-sm` is proportionally much smaller than v3's.
-- The [stateful button]({{ site.url }}/docs/3.3/javascript/#buttons-stateful) feature of the `button.js` jQuery plugin has been dropped. This includes the `$().button(string)` and `$().button('reset')` methods. We advise using a tiny bit of custom JavaScript instead, which will have the benefit of behaving exactly the way you want it to.
-  - Note that the other features of the plugin (button checkboxes, button radios, single-toggle buttons) have been retained in v4.
-- Change buttons' `[disabled]` to `:disabled` as IE9+ supports `:disabled`. However `fieldset[disabled]` is still necessary because [native disabled fieldsets are still buggy in IE11](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#Browser_compatibility).
+* Renamed `.btn-default` to `.btn-secondary`.
+* Dropped the `.btn-xs` class entirely as `.btn-sm` is proportionally much smaller than v3's.
+* The [stateful button]({{ site.url }}/docs/3.3/javascript/#buttons-stateful) feature of the `button.js` jQuery plugin has been dropped. This includes the `$().button(string)` and `$().button('reset')` methods. We advise using a tiny bit of custom JavaScript instead, which will have the benefit of behaving exactly the way you want it to.
+  * Note that the other features of the plugin (button checkboxes, button radios, single-toggle buttons) have been retained in v4.
+* Change buttons' `[disabled]` to `:disabled` as IE9+ supports `:disabled`. However `fieldset[disabled]` is still necessary because [native disabled fieldsets are still buggy in IE11](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#Browser_compatibility).
 
 ### Button group
 
-- Rewrote component with flexbox.
-- Removed `.btn-group-justified`. As a replacement you can use `<div class="btn-group d-flex" role="group"></div>` as a wrapper around elements with `.w-100`.
-- Dropped the `.btn-group-xs` class entirely given removal of `.btn-xs`.
-- Removed explicit spacing between button groups in button toolbars; use margin utilities now.
-- Improved documentation for use with other components.
+* Rewrote component with flexbox.
+* Removed `.btn-group-justified`. As a replacement you can use `<div class="btn-group d-flex" role="group"></div>` as a wrapper around elements with `.w-100`.
+* Dropped the `.btn-group-xs` class entirely given removal of `.btn-xs`.
+* Removed explicit spacing between button groups in button toolbars; use margin utilities now.
+* Improved documentation for use with other components.
 
 ### Dropdowns
 
-- Switched from parent selectors to singular classes for all components, modifiers, etc.
-- Simplified dropdown styles to no longer ship with upward or downward facing arrows attached to the dropdown menu.
-- Dropdowns can be built with `<div>`s or `<ul>`s now.
-- Rebuilt dropdown styles and markup to provide easy, built-in support for `<a>` and `<button>` based dropdown items.
-- Renamed `.divider` to `.dropdown-divider`.
-- Dropdown items now require `.dropdown-item`.
-- Dropdown toggles no longer require an explicit `<span class="caret"></span>`; this is now provided automatically via CSS's `::after` on `.dropdown-toggle`.
+* Switched from parent selectors to singular classes for all components, modifiers, etc.
+* Simplified dropdown styles to no longer ship with upward or downward facing arrows attached to the dropdown menu.
+* Dropdowns can be built with `<div>`s or `<ul>`s now.
+* Rebuilt dropdown styles and markup to provide easy, built-in support for `<a>` and `<button>` based dropdown items.
+* Renamed `.divider` to `.dropdown-divider`.
+* Dropdown items now require `.dropdown-item`.
+* Dropdown toggles no longer require an explicit `<span class="caret"></span>`; this is now provided automatically via CSS's `::after` on `.dropdown-toggle`.
 
 ### Grid system
 
-- Added a new `576px` grid breakpoint as `sm`, meaning there are now five total tiers (`xs`, `sm`, `md`, `lg`, and `xl`).
-- Renamed the responsive grid modifier classes from `.col-{breakpoint}-{modifier}-{size}` to `.{modifier}-{breakpoint}-{size}` for simpler grid classes.
-- Dropped push and pull modifier classes for the new flexbox-powered `order` classes. For example, instead of `.col-8.push-4` and `.col-4.pull-8`, you'd use `.col-8.order-2` and `.col-4.order-1`.
-- Added flexbox utility classes for grid system and components.
+* Added a new `576px` grid breakpoint as `sm`, meaning there are now five total tiers (`xs`, `sm`, `md`, `lg`, and `xl`).
+* Renamed the responsive grid modifier classes from `.col-{breakpoint}-{modifier}-{size}` to `.{modifier}-{breakpoint}-{size}` for simpler grid classes.
+* Dropped push and pull modifier classes for the new flexbox-powered `order` classes. For example, instead of `.col-8.push-4` and `.col-4.pull-8`, you'd use `.col-8.order-2` and `.col-4.order-1`.
+* Added flexbox utility classes for grid system and components.
 
 ### List groups
 
-- Rewrote component with flexbox.
-- Replaced `a.list-group-item` with an explicit class, `.list-group-item-action`, for styling link and button versions of list group items.
-- Added `.list-group-flush` class for use with cards.
+* Rewrote component with flexbox.
+* Replaced `a.list-group-item` with an explicit class, `.list-group-item-action`, for styling link and button versions of list group items.
+* Added `.list-group-flush` class for use with cards.
 
 ### Modal
 
-- Rewrote component with flexbox.
-- Given move to flexbox, alignment of dismiss icons in the header is likely broken as we're no longer using floats. Floated content comes first, but with flexbox that's no longer the case. Update your dismiss icons to come after modal titles to fix.
-- The `remote` option (which could be used to automatically load and inject external content into a modal) and the corresponding `loaded.bs.modal` event were removed. We recommend instead using client-side templating or a data binding framework, or calling [jQuery.load](https://api.jquery.com/load/) yourself.
+* Rewrote component with flexbox.
+* Given move to flexbox, alignment of dismiss icons in the header is likely broken as we're no longer using floats. Floated content comes first, but with flexbox that's no longer the case. Update your dismiss icons to come after modal titles to fix.
+* The `remote` option (which could be used to automatically load and inject external content into a modal) and the corresponding `loaded.bs.modal` event were removed. We recommend instead using client-side templating or a data binding framework, or calling [jQuery.load](https://api.jquery.com/load/) yourself.
 
 ### Navs
 
-- Rewrote component with flexbox.
-- Dropped nearly all `>` selectors for simpler styling via un-nested classes.
-- Instead of HTML-specific selectors like `.nav > li > a`, we use separate classes for `.nav`s, `.nav-item`s, and `.nav-link`s. This makes your HTML more flexible while bringing along increased extensibility.
+* Rewrote component with flexbox.
+* Dropped nearly all `>` selectors for simpler styling via un-nested classes.
+* Instead of HTML-specific selectors like `.nav > li > a`, we use separate classes for `.nav`s, `.nav-item`s, and `.nav-link`s. This makes your HTML more flexible while bringing along increased extensibility.
 
 ### Navbar
 
 The navbar has been entirely rewritten in flexbox with improved support for alignment, responsiveness, and customization.
 
-- Responsive navbar behaviors are now applied to the `.navbar` class via the **required** `.navbar-expand-{breakpoint}` where you choose where to collapse the navbar. Previously this was a Less variable modification and required recompiling.
-- `.navbar-default` is now `.navbar-light`, though `.navbar-dark` remains the same. **One of these is required on each navbar.** However, these classes no longer set `background-color`s; instead they essentially only affect `color`.
-- Navbars now require a background declaration of some kind. Choose from our background utilities (`.bg-*`) or set your own with the light/inverse classes above [for mad customization]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/navbar/#color-schemes).
-- Given flexbox styles, navbars can now use flexbox utilities for easy alignment options.
-- `.navbar-toggle` is now `.navbar-toggler` and has different styles and inner markup (no more three `<span>`s).
-- Dropped the `.navbar-form` class entirely. It's no longer necessary; instead, just use `.form-inline` and apply margin utilities as necessary.
-- Navbars no longer include `margin-bottom` or `border-radius` by default. Use utilities as necessary.
-- All examples featuring navbars have been updated to include new markup.
+* Responsive navbar behaviors are now applied to the `.navbar` class via the **required** `.navbar-expand-{breakpoint}` where you choose where to collapse the navbar. Previously this was a Less variable modification and required recompiling.
+* `.navbar-default` is now `.navbar-light`, though `.navbar-dark` remains the same. **One of these is required on each navbar.** However, these classes no longer set `background-color`s; instead they essentially only affect `color`.
+* Navbars now require a background declaration of some kind. Choose from our background utilities (`.bg-*`) or set your own with the light/inverse classes above [for mad customization]({{ site.baseurl }}/docs/{{ site.docs_version }}/components/navbar/#color-schemes).
+* Given flexbox styles, navbars can now use flexbox utilities for easy alignment options.
+* `.navbar-toggle` is now `.navbar-toggler` and has different styles and inner markup (no more three `<span>`s).
+* Dropped the `.navbar-form` class entirely. It's no longer necessary; instead, just use `.form-inline` and apply margin utilities as necessary.
+* Navbars no longer include `margin-bottom` or `border-radius` by default. Use utilities as necessary.
+* All examples featuring navbars have been updated to include new markup.
 
 ### Pagination
 
-- Rewrote component with flexbox.
-- Explicit classes (`.page-item`, `.page-link`) are now required on the descendants of `.pagination`s
-- Dropped the `.pager` component entirely as it was little more than customized outline buttons.
+* Rewrote component with flexbox.
+* Explicit classes (`.page-item`, `.page-link`) are now required on the descendants of `.pagination`s
+* Dropped the `.pager` component entirely as it was little more than customized outline buttons.
 
 ### Breadcrumbs
 
-- An explicit class, `.breadcrumb-item`, is now required on the descendants of `.breadcrumb`s
+* An explicit class, `.breadcrumb-item`, is now required on the descendants of `.breadcrumb`s
 
 ### Labels and badges
 
-- Renamed `.label` to `.badge` to disambiguate from the `<label>` element.
-- Dropped the `.badge` component as it was nearly identical to labels. Use the `.badge-pill` modifier together with the label component instead for that rounded look.
-- Badges are no longer floated automatically in list groups and other components. Utility classes are now required for that.
-- `.badge-default` has been dropped and `.badge-secondary` added to match component modifier classes used elsewhere.
+* Renamed `.label` to `.badge` to disambiguate from the `<label>` element.
+* Dropped the `.badge` component as it was nearly identical to labels. Use the `.badge-pill` modifier together with the label component instead for that rounded look.
+* Badges are no longer floated automatically in list groups and other components. Utility classes are now required for that.
+* `.badge-default` has been dropped and `.badge-secondary` added to match component modifier classes used elsewhere.
 
 ### Panels, thumbnails, and wells
 
@@ -219,48 +218,48 @@ Dropped entirely for the new card component.
 
 ### Panels
 
-- `.panel` to `.card`, now built with flexbox.
-- `.panel-default` removed and no replacement.
-- `.panel-group` removed and no replacement. `.card-group` is not a replacement, it is different.
-- `.panel-heading` to `.card-header`
-- `.panel-title` to `.card-title`. Depending on the desired look, you may also want to use [heading elements or classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/content/typography/#headings) (e.g. `<h3>`, `.h3`) or bold elements or classes (e.g. `<strong>`, `<b>`, [`.font-weight-bold`]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/text/#font-weight-and-italics)). Note that `.card-title`, while similarly named, produces a different look than `.panel-title`.
-- `.panel-body` to `.card-body`
-- `.panel-footer` to `.card-footer`
-- `.panel-primary`, `.panel-success`, `.panel-info`, `.panel-warning`, and `.panel-danger` have been dropped for `.bg-`, `.text-`, and `.border` utilities generated from our `$theme-colors` Sass map.
+* `.panel` to `.card`, now built with flexbox.
+* `.panel-default` removed and no replacement.
+* `.panel-group` removed and no replacement. `.card-group` is not a replacement, it is different.
+* `.panel-heading` to `.card-header`
+* `.panel-title` to `.card-title`. Depending on the desired look, you may also want to use [heading elements or classes]({{ site.baseurl }}/docs/{{ site.docs_version }}/content/typography/#headings) (e.g. `<h3>`, `.h3`) or bold elements or classes (e.g. `<strong>`, `<b>`, [`.font-weight-bold`]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/text/#font-weight-and-italics)). Note that `.card-title`, while similarly named, produces a different look than `.panel-title`.
+* `.panel-body` to `.card-body`
+* `.panel-footer` to `.card-footer`
+* `.panel-primary`, `.panel-success`, `.panel-info`, `.panel-warning`, and `.panel-danger` have been dropped for `.bg-`, `.text-`, and `.border` utilities generated from our `$theme-colors` Sass map.
 
 ### Progress
 
-- Replaced contextual `.progress-bar-*` classes with `.bg-*` utilities. For example, `class="progress-bar progress-bar-danger"` becomes `class="progress-bar bg-danger"`.
-- Replaced `.active` for animated progress bars with `.progress-bar-animated`.
+* Replaced contextual `.progress-bar-*` classes with `.bg-*` utilities. For example, `class="progress-bar progress-bar-danger"` becomes `class="progress-bar bg-danger"`.
+* Replaced `.active` for animated progress bars with `.progress-bar-animated`.
 
 ### Carousel
 
-- Overhauled the entire component to simplify design and styling. We have fewer styles for you to override, new indicators, and new icons.
-- All CSS has been un-nested and renamed, ensuring each class is prefixed with `.carousel-`.
-  - For carousel items, `.next`, `.prev`, `.left`, and `.right` are now `.carousel-item-next`, `.carousel-item-prev`, `.carousel-item-left`, and `.carousel-item-right`.
-  - `.item` is also now `.carousel-item`.
-  - For prev/next controls, `.carousel-control.right` and `.carousel-control.left` are now `.carousel-control-next` and `.carousel-control-prev`, meaning they no longer require a specific base class.
-- Removed all responsive styling, deferring to utilities (e.g., showing captions on certain viewports) and custom styles as needed.
-- Removed image overrides for images in carousel items, deferring to utilities.
-- Tweaked the Carousel example to include the new markup and styles.
+* Overhauled the entire component to simplify design and styling. We have fewer styles for you to override, new indicators, and new icons.
+* All CSS has been un-nested and renamed, ensuring each class is prefixed with `.carousel-`.
+  * For carousel items, `.next`, `.prev`, `.left`, and `.right` are now `.carousel-item-next`, `.carousel-item-prev`, `.carousel-item-left`, and `.carousel-item-right`.
+  * `.item` is also now `.carousel-item`.
+  * For prev/next controls, `.carousel-control.right` and `.carousel-control.left` are now `.carousel-control-next` and `.carousel-control-prev`, meaning they no longer require a specific base class.
+* Removed all responsive styling, deferring to utilities (e.g., showing captions on certain viewports) and custom styles as needed.
+* Removed image overrides for images in carousel items, deferring to utilities.
+* Tweaked the Carousel example to include the new markup and styles.
 
 ### Tables
 
-- Removed support for styled nested tables. All table styles are now inherited in v4 for simpler selectors.
-- Added inverse table variant.
+* Removed support for styled nested tables. All table styles are now inherited in v4 for simpler selectors.
+* Added inverse table variant.
 
 ### Utilities
 
-- **Display, hidden, and more:**
-  - Made display utilities responsive (e.g., `.d-none` and `d-{sm,md,lg,xl}-none`).
-  - Dropped the bulk of `.hidden-*` utilities for new [display utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/). For example, instead of `.hidden-sm-up`, use `.d-sm-none`. Renamed the `.hidden-print` utilities to use the display utility naming scheme. [More info under the Responsive utilities section of this page.](#responsive-utilities)
-  - Added `.float-{sm,md,lg,xl}-{left,right,none}` classes for responsive floats and removed `.pull-left` and `.pull-right` since they're redundant to `.float-left` and `.float-right`.
-- **Type:**
-  - Added responsive variations to our text alignment classes `.text-{sm,md,lg,xl}-{left,center,right}`.
-- **Alignment and spacing:**
-  - Added new [responsive margin and padding utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) for all sides, plus vertical and horizontal shorthands.
-  - Added boatload of [flexbox utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/).
-  - Dropped `.center-block` for the new `.mx-auto` class.
+* **Display, hidden, and more:**
+  * Made display utilities responsive (e.g., `.d-none` and `d-{sm,md,lg,xl}-none`).
+  * Dropped the bulk of `.hidden-*` utilities for new [display utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/display/). For example, instead of `.hidden-sm-up`, use `.d-sm-none`. Renamed the `.hidden-print` utilities to use the display utility naming scheme. [More info under the Responsive utilities section of this page.](#responsive-utilities)
+  * Added `.float-{sm,md,lg,xl}-{left,right,none}` classes for responsive floats and removed `.pull-left` and `.pull-right` since they're redundant to `.float-left` and `.float-right`.
+* **Type:**
+  * Added responsive variations to our text alignment classes `.text-{sm,md,lg,xl}-{left,center,right}`.
+* **Alignment and spacing:**
+  * Added new [responsive margin and padding utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/) for all sides, plus vertical and horizontal shorthands.
+  * Added boatload of [flexbox utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/flex/).
+  * Dropped `.center-block` for the new `.mx-auto` class.
 
 ### Vendor prefix mixins
 
@@ -272,15 +271,15 @@ Removed the following mixins: `animation`, `animation-delay`, `animation-directi
 
 Our documentation received an upgrade across the board as well. Here's the low down:
 
-- We're still using Jekyll, but we have plugins in the mix:
-  - `bugify.rb` is used to efficiently list out the entries on our [browser bugs]({{ site.baseurl }}/docs/{{ site.docs_version }}/browser-bugs/) page.
-  - `example.rb` is a custom fork of the default `highlight.rb` plugin, allowing for easier example-code handling.
-  - `callout.rb` is a similar custom fork of that, but designed for our special docs callouts.
-  - `markdown-block.rb` is used to to render Markdown snippets within HTML elements like tables.
-  - [jekyll-toc](https://github.com/toshimaru/jekyll-toc) is used to generate our table of contents.
-- All docs content has been rewritten in Markdown (instead of HTML) for easier editing.
-- Pages have been reorganized for simpler content and a more approachable hierarchy.
-- We moved from regular CSS to SCSS to take full advantage of Bootstrap's variables, mixins, and more.
+* We're still using Jekyll, but we have plugins in the mix:
+  * `bugify.rb` is used to efficiently list out the entries on our [browser bugs]({{ site.baseurl }}/docs/{{ site.docs_version }}/browser-bugs/) page.
+  * `example.rb` is a custom fork of the default `highlight.rb` plugin, allowing for easier example-code handling.
+  * `callout.rb` is a similar custom fork of that, but designed for our special docs callouts.
+  * `markdown-block.rb` is used to to render Markdown snippets within HTML elements like tables.
+  * [jekyll-toc](https://github.com/toshimaru/jekyll-toc) is used to generate our table of contents.
+* All docs content has been rewritten in Markdown (instead of HTML) for easier editing.
+* Pages have been reorganized for simpler content and a more approachable hierarchy.
+* We moved from regular CSS to SCSS to take full advantage of Bootstrap's variables, mixins, and more.
 
 ### Responsive utilities
 
@@ -288,13 +287,13 @@ All `@screen-` variables have been removed in v4.0.0. Use the `media-breakpoint-
 
 Our responsive utility classes have largely been removed in favor of explicit `display` utilities.
 
-- The `.hidden` and `.show` classes have been removed because they conflicted with jQuery's `$(...).hide()` and `$(...).show()` methods. Instead, try toggling the `[hidden]` attribute or use inline styles like `style="display: none;"` and `style="display: block;"`.
-- All `.hidden-` classes have been removed, save for the print utilities which have been renamed.
-  - Removed from v3: `.hidden-xs` `.hidden-sm` `.hidden-md` `.hidden-lg` `.visible-xs-block` `.visible-xs-inline` `.visible-xs-inline-block` `.visible-sm-block` `.visible-sm-inline` `.visible-sm-inline-block` `.visible-md-block` `.visible-md-inline` `.visible-md-inline-block` `.visible-lg-block` `.visible-lg-inline` `.visible-lg-inline-block`
-  - Removed from v4 alphas: `.hidden-xs-up` `.hidden-xs-down` `.hidden-sm-up` `.hidden-sm-down` `.hidden-md-up` `.hidden-md-down` `.hidden-lg-up` `.hidden-lg-down`
-- Print utilities no longer start with `.hidden-` or `.visible-`, but with `.d-print-`.
-  - Old names: `.visible-print-block`, `.visible-print-inline`, `.visible-print-inline-block`, `.hidden-print`
-  - New classes: `.d-print-block`, `.d-print-inline`, `.d-print-inline-block`, `.d-print-none`
+* The `.hidden` and `.show` classes have been removed because they conflicted with jQuery's `$(...).hide()` and `$(...).show()` methods. Instead, try toggling the `[hidden]` attribute or use inline styles like `style="display: none;"` and `style="display: block;"`.
+* All `.hidden-` classes have been removed, save for the print utilities which have been renamed.
+  * Removed from v3: `.hidden-xs` `.hidden-sm` `.hidden-md` `.hidden-lg` `.visible-xs-block` `.visible-xs-inline` `.visible-xs-inline-block` `.visible-sm-block` `.visible-sm-inline` `.visible-sm-inline-block` `.visible-md-block` `.visible-md-inline` `.visible-md-inline-block` `.visible-lg-block` `.visible-lg-inline` `.visible-lg-inline-block`
+  * Removed from v4 alphas: `.hidden-xs-up` `.hidden-xs-down` `.hidden-sm-up` `.hidden-sm-down` `.hidden-md-up` `.hidden-md-down` `.hidden-lg-up` `.hidden-lg-down`
+* Print utilities no longer start with `.hidden-` or `.visible-`, but with `.d-print-`.
+  * Old names: `.visible-print-block`, `.visible-print-inline`, `.visible-print-inline-block`, `.hidden-print`
+  * New classes: `.d-print-block`, `.d-print-inline`, `.d-print-inline-block`, `.d-print-none`
 
 Rather than using explicit `.visible-*` classes, you make an element visible by simply not hiding it at that screen size. You can combine one `.d-*-none` class with one `.d-*-block` class to show an element only on a given interval of screen sizes (e.g. `.d-none.d-md-block.d-xl-none` shows the element only on medium and large devices).
 

--- a/docs/4.0/utilities/borders.md
+++ b/docs/4.0/utilities/borders.md
@@ -48,12 +48,4 @@ Add classes to an element to easily round its corners.
   <img data-src="holder.js/75x75" class="rounded-0" alt="Example non-rounded image (overrides rounding applied elsewhere)">
 </div>
 
-{% highlight html %}
-<img src="..." alt="..." class="rounded">
-<img src="..." alt="..." class="rounded-top">
-<img src="..." alt="..." class="rounded-right">
-<img src="..." alt="..." class="rounded-bottom">
-<img src="..." alt="..." class="rounded-left">
-<img src="..." alt="..." class="rounded-circle">
-<img src="..." alt="..." class="rounded-0">
-{% endhighlight %}
+{% highlight html %} <img src="..." alt="..." class="rounded"> <img src="..." alt="..." class="rounded-top"> <img src="..." alt="..." class="rounded-right"> <img src="..." alt="..." class="rounded-bottom"> <img src="..." alt="..." class="rounded-left"> <img src="..." alt="..." class="rounded-circle"> <img src="..." alt="..." class="rounded-0"> {% endhighlight %}

--- a/docs/4.0/utilities/clearfix.md
+++ b/docs/4.0/utilities/clearfix.md
@@ -9,28 +9,18 @@ toc: true
 Easily clear `float`s by adding `.clearfix` **to the parent element**. Can also be used as a mixin.
 
 {% highlight html %}
+
 <div class="clearfix">...</div>
 {% endhighlight %}
 
-{% highlight scss %}
-// Mixin itself
-@mixin clearfix() {
-  &::after {
-    display: block;
-    content: "";
-    clear: both;
-  }
-}
+{% highlight scss %} // Mixin itself @mixin clearfix() { &::after { display: block; content: ""; clear: both; } }
 
-// Usage as a mixin
-.element {
-  @include clearfix;
-}
-{% endhighlight %}
+// Usage as a mixin .element { @include clearfix; } {% endhighlight %}
 
 The following example shows how the clearfix can be used. Without the clearfix the wrapping div would not span around the buttons which would cause a broken layout.
 
 {% example html %}
+
 <div class="bg-info clearfix">
   <button type="button" class="btn btn-secondary float-left">Example Button floated left</button>
   <button type="button" class="btn btn-secondary float-right">Example Button floated right</button>

--- a/docs/4.0/utilities/close-icon.md
+++ b/docs/4.0/utilities/close-icon.md
@@ -8,8 +8,4 @@ toc: true
 
 **Be sure to include text for screen readers**, as we've done with `aria-label`.
 
-{% example html %}
-<button type="button" class="close" aria-label="Close">
-  <span aria-hidden="true">&times;</span>
-</button>
-{% endexample %}
+{% example html %} <button type="button" class="close" aria-label="Close"> <span aria-hidden="true">&times;</span> </button> {% endexample %}

--- a/docs/4.0/utilities/colors.md
+++ b/docs/4.0/utilities/colors.md
@@ -8,8 +8,8 @@ toc: true
 
 ## Color
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <p class="text-{{ color.name }}{% if color.name == "light" %} bg-dark{% endif %}">.text-{{ color.name }}</p>{% endfor %}
 <p class="text-muted">.text-muted</p>
 <p class="text-white bg-dark">.text-white</p>
@@ -17,8 +17,8 @@ toc: true
 
 Contextual text classes also work well on anchors with the provided hover and focus states. **Note that the `.text-white` and `.text-muted` class has no link styling.**
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <p><a href="#" class="text-{{ color.name }}{% if color.name == "light" %} bg-dark{% endif %}">{{ color.name | capitalize }} link</a></p>{% endfor %}
 <p><a href="#" class="text-muted">Muted link</a></p>
 <p><a href="#" class="text-white bg-dark">White link</a></p>
@@ -28,8 +28,8 @@ Contextual text classes also work well on anchors with the provided hover and fo
 
 Similar to the contextual text color classes, easily set the background of an element to any contextual class. Anchor components will darken on hover, just like the text classes. Background utilities **do not set `color`**, so in some cases you'll want to use `.text-*` utilities.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="p-3 mb-2 bg-{{ color.name }} {% if color.name == "light" or color.name == "warning" %}text-dark{% else %}text-white{% endif %}">.bg-{{ color.name }}</div>{% endfor %}
 <div class="p-3 mb-2 bg-white text-dark">.bg-white</div>
 {% endexample %}
@@ -38,16 +38,15 @@ Similar to the contextual text color classes, easily set the background of an el
 
 When `$enable-gradients` is set to true, you'll be able to use `.bg-gradient-` utility classes. **By default, `$enable-gradients` is disabled and the example below is intentionally broken.** This is done for easier customization from the moment you start using Bootstrap. [Learn about our Sass options]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/theming/#sass-options) to enable these classes and more.
 
-{% example html %}
-{% for color in site.data.theme-colors %}
+{% example html %} {% for color in site.data.theme-colors %}
+
 <div class="p-3 mb-2 bg-gradient-{{ color.name }} {% if color.name == "light" or color.name == "warning" %}text-dark{% else %}text-white{% endif %}">.bg-gradient-{{ color.name }}</div>{% endfor %}
 {% endexample %}
 
 {% callout info %}
+
 #### Dealing with specificity
 
-Sometimes contextual classes cannot be applied due to the specificity of another selector. In some cases, a sufficient workaround is to wrap your element's content in a `<div>` with the class.
-{% endcallout %}
+Sometimes contextual classes cannot be applied due to the specificity of another selector. In some cases, a sufficient workaround is to wrap your element's content in a `<div>` with the class. {% endcallout %}
 
-{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %}
-{{ callout-include | markdownify }}
+{% capture callout-include %}{% include callout-warning-color-assistive-technologies.md %}{% endcapture %} {{ callout-include | markdownify }}

--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -19,7 +19,7 @@ As such, the classes are named using the format:
 * `.d-{value}` for `xs`
 * `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, and `xl`.
 
-Where *display* is one of:
+Where _display_ is one of:
 
 * `none`
 * `inline`
@@ -31,19 +31,17 @@ Where *display* is one of:
 * `flex`
 * `inline-flex`
 
-The media queries effect screen widths with the given breakpoint *or larger*. For example, `.d-lg-none` sets `display: none;` on both `lg` and `xl` screens.
+The media queries effect screen widths with the given breakpoint _or larger_. For example, `.d-lg-none` sets `display: none;` on both `lg` and `xl` screens.
 
 ## Examples
 
 {% example html %}
+
 <div class="d-inline p-2 bg-primary text-white">d-inline</div>
 <div class="d-inline p-2 bg-dark text-white">d-inline</div>
 {% endexample %}
 
-{% example html %}
-<span class="d-block p-2 bg-primary text-white">d-block</span>
-<span class="d-block p-2 bg-dark text-white">d-block</span>
-{% endexample %}
+{% example html %} <span class="d-block p-2 bg-primary text-white">d-block</span> <span class="d-block p-2 bg-dark text-white">d-block</span> {% endexample %}
 
 ## Hiding Elements
 
@@ -53,22 +51,23 @@ To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-
 
 To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none` will hide the element for all screen sizes except on medium and large devices.
 
-| Screen Size        | Class |
-| ---                | --- |
-| Hidden on all      | `.d-none` |
-| Hidden only on xs  | `.d-none .d-sm-block` |
-| Hidden only on sm  | `.d-sm-none .d-md-block` |
-| Hidden only on md  | `.d-md-none .d-lg-block` |
-| Hidden only on lg  | `.d-lg-none .d-xl-block` |
-| Hidden only on xl  | `.d-xl-none` |
-| Visible on all     | `.d-block` |
-| Visible only on xs | `.d-block .d-sm-none` |
+| Screen Size        | Class                            |
+| ------------------ | -------------------------------- |
+| Hidden on all      | `.d-none`                        |
+| Hidden only on xs  | `.d-none .d-sm-block`            |
+| Hidden only on sm  | `.d-sm-none .d-md-block`         |
+| Hidden only on md  | `.d-md-none .d-lg-block`         |
+| Hidden only on lg  | `.d-lg-none .d-xl-block`         |
+| Hidden only on xl  | `.d-xl-none`                     |
+| Visible on all     | `.d-block`                       |
+| Visible only on xs | `.d-block .d-sm-none`            |
 | Visible only on sm | `.d-none .d-sm-block .d-md-none` |
 | Visible only on md | `.d-none .d-md-block .d-lg-none` |
 | Visible only on lg | `.d-none .d-lg-block .d-xl-none` |
-| Visible only on xl | `.d-none .d-xl-block` |
+| Visible only on xl | `.d-none .d-xl-block`            |
 
 {% example html %}
+
 <div class="d-lg-none">hide on screens wider than lg</div>
 <div class="d-none d-lg-block">hide on screens smaller than lg</div>
 {% endexample %}
@@ -77,16 +76,17 @@ To show an element only on a given interval of screen sizes you can combine one 
 
 Change the `display` value of elements when printing with our print display utility classes.
 
-| Class | Print style |
-| --- | --- |
-| `.d-print-block` | Applies `display: block;` to the element when printing |
-| `.d-print-inline` | Applies `display: inline;` to the element when printing |
+| Class                   | Print style                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `.d-print-block`        | Applies `display: block;` to the element when printing        |
+| `.d-print-inline`       | Applies `display: inline;` to the element when printing       |
 | `.d-print-inline-block` | Applies `display: inline-block;` to the element when printing |
-| `.d-print-none` | Applies `display: none;` to the element when printing |
+| `.d-print-none`         | Applies `display: none;` to the element when printing         |
 
 The print and display classes can be combined.
 
 {% example html %}
+
 <div class="d-print-none">Screen Only (Hide on print only)</div>
 <div class="d-none d-print-block">Print Only (Hide on screen only)</div>
 <div class="d-none d-lg-block d-print-block">Hide up to large on screen, but always show on print</div>

--- a/docs/4.0/utilities/embed.md
+++ b/docs/4.0/utilities/embed.md
@@ -17,6 +17,7 @@ Rules are directly applied to `<iframe>`, `<embed>`, `<video>`, and `<object>` e
 Wrap any embed like an `<iframe>` in a parent element with `.embed-responsive` and an aspect ratio. The `.embed-responsive-item` isn't strictly required, but we encourage it.
 
 {% example html %}
+
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/zpOULjyy-n8?rel=0" allowfullscreen></iframe>
 </div>
@@ -27,22 +28,27 @@ Wrap any embed like an `<iframe>` in a parent element with `.embed-responsive` a
 Aspect ratios can be customized with modifier classes.
 
 {% highlight html %}
+
 <!-- 21:9 aspect ratio -->
+
 <div class="embed-responsive embed-responsive-21by9">
   <iframe class="embed-responsive-item" src="..."></iframe>
 </div>
 
 <!-- 16:9 aspect ratio -->
+
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="..."></iframe>
 </div>
 
 <!-- 4:3 aspect ratio -->
+
 <div class="embed-responsive embed-responsive-4by3">
   <iframe class="embed-responsive-item" src="..."></iframe>
 </div>
 
 <!-- 1:1 aspect ratio -->
+
 <div class="embed-responsive embed-responsive-1by1">
   <iframe class="embed-responsive-item" src="..."></iframe>
 </div>

--- a/docs/4.0/utilities/flex.md
+++ b/docs/4.0/utilities/flex.md
@@ -11,18 +11,21 @@ toc: true
 Apply `display` utilities to create a flexbox container and transform **direct children elements** into flex items. Flex containers and items are able to be modified further with additional flex properties.
 
 {% example html %}
+
 <div class="d-flex p-2 bd-highlight">I'm a flexbox container!</div>
 {% endexample %}
 
 {% example html %}
+
 <div class="d-inline-flex p-2 bd-highlight">I'm an inline flexbox container!</div>
 {% endexample %}
 
 Responsive variations also exist for `.d-flex` and `.d-inline-flex`.
 
 {% for bp in site.data.breakpoints %}
-- `.d{{ bp.abbr }}-flex`
-- `.d{{ bp.abbr }}-inline-flex`{% endfor %}
+
+* `.d{{ bp.abbr }}-flex`
+* `.d{{ bp.abbr }}-inline-flex`{% endfor %}
 
 ## Direction
 
@@ -31,6 +34,7 @@ Set the direction of flex items in a flex container with direction utilities. In
 Use `.flex-row` to set a horizontal direction (the browser default), or `.flex-row-reverse` to start the horizontal direction from the opposite side.
 
 {% example html %}
+
 <div class="d-flex flex-row bd-highlight mb-3">
   <div class="p-2 bd-highlight">Flex item 1</div>
   <div class="p-2 bd-highlight">Flex item 2</div>
@@ -43,9 +47,10 @@ Use `.flex-row` to set a horizontal direction (the browser default), or `.flex-r
 </div>
 {% endexample %}
 
-Use `.flex-column` to set a vertical direction, or `.flex-column-reverse`  to start the vertical direction from the opposite side.
+Use `.flex-column` to set a vertical direction, or `.flex-column-reverse` to start the vertical direction from the opposite side.
 
 {% example html %}
+
 <div class="d-flex flex-column bd-highlight mb-3">
   <div class="p-2 bd-highlight">Flex item 1</div>
   <div class="p-2 bd-highlight">Flex item 2</div>
@@ -61,10 +66,11 @@ Use `.flex-column` to set a vertical direction, or `.flex-column-reverse`  to st
 Responsive variations also exist for `flex-direction`.
 
 {% for bp in site.data.breakpoints %}
-- `.flex{{ bp.abbr }}-row`
-- `.flex{{ bp.abbr }}-row-reverse`
-- `.flex{{ bp.abbr }}-column`
-- `.flex{{ bp.abbr }}-column-reverse`{% endfor %}
+
+* `.flex{{ bp.abbr }}-row`
+* `.flex{{ bp.abbr }}-row-reverse`
+* `.flex{{ bp.abbr }}-column`
+* `.flex{{ bp.abbr }}-column-reverse`{% endfor %}
 
 ## Justify content
 
@@ -99,6 +105,7 @@ Use `justify-content` utilities on flexbox containers to change the alignment of
 </div>
 
 {% highlight html %}
+
 <div class="d-flex justify-content-start">...</div>
 <div class="d-flex justify-content-end">...</div>
 <div class="d-flex justify-content-center">...</div>
@@ -109,11 +116,12 @@ Use `justify-content` utilities on flexbox containers to change the alignment of
 Responsive variations also exist for `justify-content`.
 
 {% for bp in site.data.breakpoints %}
-- `.justify-content{{ bp.abbr }}-start`
-- `.justify-content{{ bp.abbr }}-end`
-- `.justify-content{{ bp.abbr }}-center`
-- `.justify-content{{ bp.abbr }}-between`
-- `.justify-content{{ bp.abbr }}-around`{% endfor %}
+
+* `.justify-content{{ bp.abbr }}-start`
+* `.justify-content{{ bp.abbr }}-end`
+* `.justify-content{{ bp.abbr }}-center`
+* `.justify-content{{ bp.abbr }}-between`
+* `.justify-content{{ bp.abbr }}-around`{% endfor %}
 
 ## Align items
 
@@ -148,6 +156,7 @@ Use `align-items` utilities on flexbox containers to change the alignment of fle
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-items-start">...</div>
 <div class="d-flex align-items-end">...</div>
 <div class="d-flex align-items-center">...</div>
@@ -158,11 +167,12 @@ Use `align-items` utilities on flexbox containers to change the alignment of fle
 Responsive variations also exist for `align-items`.
 
 {% for bp in site.data.breakpoints %}
-- `.align-items{{ bp.abbr }}-start`
-- `.align-items{{ bp.abbr }}-end`
-- `.align-items{{ bp.abbr }}-center`
-- `.align-items{{ bp.abbr }}-baseline`
-- `.align-items{{ bp.abbr }}-stretch`{% endfor %}
+
+* `.align-items{{ bp.abbr }}-start`
+* `.align-items{{ bp.abbr }}-end`
+* `.align-items{{ bp.abbr }}-center`
+* `.align-items{{ bp.abbr }}-baseline`
+* `.align-items{{ bp.abbr }}-stretch`{% endfor %}
 
 ## Align self
 
@@ -197,6 +207,7 @@ Use `align-self` utilities on flexbox items to individually change their alignme
 </div>
 
 {% highlight html %}
+
 <div class="align-self-start">Aligned flex item</div>
 <div class="align-self-end">Aligned flex item</div>
 <div class="align-self-center">Aligned flex item</div>
@@ -207,11 +218,12 @@ Use `align-self` utilities on flexbox items to individually change their alignme
 Responsive variations also exist for `align-self`.
 
 {% for bp in site.data.breakpoints %}
-- `.align-self{{ bp.abbr }}-start`
-- `.align-self{{ bp.abbr }}-end`
-- `.align-self{{ bp.abbr }}-center`
-- `.align-self{{ bp.abbr }}-baseline`
-- `.align-self{{ bp.abbr }}-stretch`{% endfor %}
+
+* `.align-self{{ bp.abbr }}-start`
+* `.align-self{{ bp.abbr }}-end`
+* `.align-self{{ bp.abbr }}-center`
+* `.align-self{{ bp.abbr }}-baseline`
+* `.align-self{{ bp.abbr }}-stretch`{% endfor %}
 
 ## Auto margins
 
@@ -220,6 +232,7 @@ Flexbox can do some pretty awesome things when you mix flex alignments with auto
 **Unfortunately, IE10 and IE11 do not properly support auto margins on flex items whose parent has a non-default `justify-content` value.** [See this StackOverflow answer](https://stackoverflow.com/a/37535548) for more details.
 
 {% example html %}
+
 <div class="d-flex bd-highlight mb-3">
   <div class="p-2 bd-highlight">Flex item</div>
   <div class="p-2 bd-highlight">Flex item</div>
@@ -244,6 +257,7 @@ Flexbox can do some pretty awesome things when you mix flex alignments with auto
 Vertically move one flex item to the top or bottom of a container by mixing `align-items`, `flex-direction: column`, and `margin-top: auto` or `margin-bottom: auto`.
 
 {% example html %}
+
 <div class="d-flex align-items-start flex-column bd-highlight mb-3" style="height: 200px;">
   <div class="mb-auto p-2 bd-highlight">Flex item</div>
   <div class="p-2 bd-highlight">Flex item</div>
@@ -282,6 +296,7 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 </div>
 
 {% highlight html %}
+
 <div class="d-flex flex-nowrap">
   ...
 </div>
@@ -308,6 +323,7 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 </div>
 
 {% highlight html %}
+
 <div class="d-flex flex-wrap">
   ...
 </div>
@@ -334,24 +350,26 @@ Change how flex items wrap in a flex container. Choose from no wrapping at all (
 </div>
 
 {% highlight html %}
+
 <div class="d-flex flex-wrap-reverse">
   ...
 </div>
 {% endhighlight %}
 
-
 Responsive variations also exist for `flex-wrap`.
 
 {% for bp in site.data.breakpoints %}
-- `.flex{{ bp.abbr }}-nowrap`
-- `.flex{{ bp.abbr }}-wrap`
-- `.flex{{ bp.abbr }}-wrap-reverse`{% endfor %}
+
+* `.flex{{ bp.abbr }}-nowrap`
+* `.flex{{ bp.abbr }}-wrap`
+* `.flex{{ bp.abbr }}-wrap-reverse`{% endfor %}
 
 ## Order
 
 Change the _visual_ order of specific flex items with a handful of `order` utilities. We only provide options for making an item first or last, as well as a reset to use the DOM order. As `order` takes any integer value (e.g., `5`), add custom CSS for any additional values needed.
 
 {% example html %}
+
 <div class="d-flex flex-nowrap bd-highlight">
   <div class="order-3 p-2 bd-highlight">First flex item</div>
   <div class="order-2 p-2 bd-highlight">Second flex item</div>
@@ -362,11 +380,12 @@ Change the _visual_ order of specific flex items with a handful of `order` utili
 Responsive variations also exist for `order`.
 
 {% for bp in site.data.breakpoints %}{% for i in (1..12) %}
-- `.order{{ bp.abbr }}-{{ i }}`{% endfor %}{% endfor %}
+
+* `.order{{ bp.abbr }}-{{ i }}`{% endfor %}{% endfor %}
 
 ## Align content
 
-Use `align-content` utilities on flexbox containers to align flex items *together* on the cross axis. Choose from `start` (browser default), `end`, `center`, `between`, `around`, or `stretch`. To demonstrate these utilities, we've enforced `flex-wrap: wrap` and increased the number of flex items.
+Use `align-content` utilities on flexbox containers to align flex items _together_ on the cross axis. Choose from `start` (browser default), `end`, `center`, `between`, `around`, or `stretch`. To demonstrate these utilities, we've enforced `flex-wrap: wrap` and increased the number of flex items.
 
 **Heads up!** This property has no effect on single rows of flex items.
 
@@ -391,6 +410,7 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-start flex-wrap">
   ...
 </div>
@@ -417,6 +437,7 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-end flex-wrap">...</div>
 {% endhighlight %}
 
@@ -441,6 +462,7 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-center flex-wrap">...</div>
 {% endhighlight %}
 
@@ -465,6 +487,7 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-between flex-wrap">...</div>
 {% endhighlight %}
 
@@ -489,6 +512,7 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-around flex-wrap">...</div>
 {% endhighlight %}
 
@@ -513,14 +537,16 @@ Use `align-content` utilities on flexbox containers to align flex items *togethe
 </div>
 
 {% highlight html %}
+
 <div class="d-flex align-content-stretch flex-wrap">...</div>
 {% endhighlight %}
 
 Responsive variations also exist for `align-content`.
 
 {% for bp in site.data.breakpoints %}
-- `.align-content{{ bp.abbr }}-start`
-- `.align-content{{ bp.abbr }}-end`
-- `.align-content{{ bp.abbr }}-center`
-- `.align-content{{ bp.abbr }}-around`
-- `.align-content{{ bp.abbr }}-stretch`{% endfor %}
+
+* `.align-content{{ bp.abbr }}-start`
+* `.align-content{{ bp.abbr }}-end`
+* `.align-content{{ bp.abbr }}-center`
+* `.align-content{{ bp.abbr }}-around`
+* `.align-content{{ bp.abbr }}-stretch`{% endfor %}

--- a/docs/4.0/utilities/float.md
+++ b/docs/4.0/utilities/float.md
@@ -15,6 +15,7 @@ These utility classes float an element to the left or right, or disable floating
 Toggle a float with a class:
 
 {% example html %}
+
 <div class="float-left">Float left on all viewport sizes</div><br>
 <div class="float-right">Float right on all viewport sizes</div><br>
 <div class="float-none">Don't float on all viewport sizes</div>
@@ -24,23 +25,14 @@ Toggle a float with a class:
 
 Or by Sass mixin:
 
-{% highlight scss %}
-.element {
-  @include float-left;
-}
-.another-element {
-  @include float-right;
-}
-.one-more {
-  @include float-none;
-}
-{% endhighlight %}
+{% highlight scss %} .element { @include float-left; } .another-element { @include float-right; } .one-more { @include float-none; } {% endhighlight %}
 
 ## Responsive
 
 Responsive variations also exist for each `float` value.
 
 {% example html %}
+
 <div class="float-sm-left">Float left on viewports sized SM (small) or wider</div><br>
 <div class="float-md-left">Float left on viewports sized MD (medium) or wider</div><br>
 <div class="float-lg-left">Float left on viewports sized LG (large) or wider</div><br>
@@ -50,6 +42,7 @@ Responsive variations also exist for each `float` value.
 Here are all the support classes;
 
 {% for bp in site.data.breakpoints %}
-- `.float{{ bp.abbr }}-left`
-- `.float{{ bp.abbr }}-right`
-- `.float{{ bp.abbr }}-none`{% endfor %}
+
+* `.float{{ bp.abbr }}-left`
+* `.float{{ bp.abbr }}-right`
+* `.float{{ bp.abbr }}-none`{% endfor %}

--- a/docs/4.0/utilities/image-replacement.md
+++ b/docs/4.0/utilities/image-replacement.md
@@ -9,18 +9,15 @@ toc: true
 Utilize the `.text-hide` class or mixin to help replace an element's text content with a background image.
 
 {% highlight html %}
+
 <h1 class="text-hide">Custom heading</h1>
 {% endhighlight %}
 
-{% highlight scss %}
-// Usage as a mixin
-.heading {
-  @include text-hide;
-}
-{% endhighlight %}
+{% highlight scss %} // Usage as a mixin .heading { @include text-hide; } {% endhighlight %}
 
 Use the `.text-hide` class to maintain the accessibility and SEO benefits of heading tags, but want to utilize a `background-image` instead of text.
 
 {% example html %}
+
 <h1 class="text-hide" style="background-image: url('/assets/brand/bootstrap-solid.svg'); width: 50px; height: 50px;">Bootstrap</h1>
 {% endexample %}

--- a/docs/4.0/utilities/position.md
+++ b/docs/4.0/utilities/position.md
@@ -11,6 +11,7 @@ toc: true
 Quick positioning classes are available, though they are not responsive.
 
 {% highlight html %}
+
 <div class="position-static">...</div>
 <div class="position-relative">...</div>
 <div class="position-absolute">...</div>
@@ -23,6 +24,7 @@ Quick positioning classes are available, though they are not responsive.
 Position an element at the top of the viewport, from edge to edge. Be sure you understand the ramifications of fixed position in your project; you may need to add aditional CSS.
 
 {% highlight html %}
+
 <div class="fixed-top">...</div>
 {% endhighlight %}
 
@@ -31,6 +33,7 @@ Position an element at the top of the viewport, from edge to edge. Be sure you u
 Position an element at the bottom of the viewport, from edge to edge. Be sure you understand the ramifications of fixed position in your project; you may need to add aditional CSS.
 
 {% highlight html %}
+
 <div class="fixed-bottom">...</div>
 {% endhighlight %}
 
@@ -41,5 +44,6 @@ Position an element at the top of the viewport, from edge to edge, but only afte
 **Microsoft Edge and IE11 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that properly can render it.
 
 {% highlight html %}
+
 <div class="sticky-top">...</div>
 {% endhighlight %}

--- a/docs/4.0/utilities/screenreaders.md
+++ b/docs/4.0/utilities/screenreaders.md
@@ -8,18 +8,8 @@ toc: true
 
 Hide an element to all devices **except screen readers** with `.sr-only`. Combine `.sr-only` with `.sr-only-focusable` to show the element again when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
 
-{%- comment -%}
-Necessary for following [accessibility best practices]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/#accessibility).
-{%- endcomment -%}
+{%- comment -%} Necessary for following [accessibility best practices]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/#accessibility). {%- endcomment -%}
 
-{% highlight html %}
-<a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
-{% endhighlight %}
+{% highlight html %} <a class="sr-only sr-only-focusable" href="#content">Skip to main content</a> {% endhighlight %}
 
-{% highlight scss %}
-// Usage as a mixin
-.skip-navigation {
-  @include sr-only;
-  @include sr-only-focusable;
-}
-{% endhighlight %}
+{% highlight scss %} // Usage as a mixin .skip-navigation { @include sr-only; @include sr-only-focusable; } {% endhighlight %}

--- a/docs/4.0/utilities/sizing.md
+++ b/docs/4.0/utilities/sizing.md
@@ -9,6 +9,7 @@ toc: true
 Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Includes support for `25%`, `50%`, `75%`, and `100%` by default. Modify those values as you need to generate different utilities here.
 
 {% example html %}
+
 <div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>
 <div class="w-50 p-3" style="background-color: #eee;">Width 50%</div>
 <div class="w-75 p-3" style="background-color: #eee;">Width 75%</div>
@@ -16,6 +17,7 @@ Width and height utilities are generated from the `$sizes` Sass map in `_variabl
 {% endexample %}
 
 {% example html %}
+
 <div style="height: 100px; background-color: rgba(255,0,0,0.1);">
   <div class="h-25 d-inline-block" style="width: 120px; background-color: rgba(0,0,255,.1)">Height 25%</div>
   <div class="h-50 d-inline-block" style="width: 120px; background-color: rgba(0,0,255,.1)">Height 50%</div>
@@ -26,11 +28,10 @@ Width and height utilities are generated from the `$sizes` Sass map in `_variabl
 
 You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
 
-{% example html %}
-<img class="mw-100" data-src="holder.js/1000px100?text=Max-width%20%3D%20100%25" alt="Max-width 100%">
-{% endexample %}
+{% example html %} <img class="mw-100" data-src="holder.js/1000px100?text=Max-width%20%3D%20100%25" alt="Max-width 100%"> {% endexample %}
 
 {% example html %}
+
 <div style="height: 100px; background-color: rgba(255,0,0,0.1);">
   <div class="mh-100" style="width: 100px; height: 200px; background-color: rgba(0,0,255,0.1);">Max-height 100%</div>
 </div>

--- a/docs/4.0/utilities/spacing.md
+++ b/docs/4.0/utilities/spacing.md
@@ -16,12 +16,12 @@ Spacing utilities that apply to all breakpoints, from `xs` to `xl`, have no brea
 
 The classes are named using the format `{property}{sides}-{size}` for `xs` and `{property}{sides}-{breakpoint}-{size}` for `sm`, `md`, `lg`, and `xl`.
 
-Where *property* is one of:
+Where _property_ is one of:
 
 * `m` - for classes that set `margin`
 * `p` - for classes that set `padding`
 
-Where *sides* is one of:
+Where _sides_ is one of:
 
 * `t` - for classes that set `margin-top` or `padding-top`
 * `b` - for classes that set `margin-bottom` or `padding-bottom`
@@ -31,7 +31,7 @@ Where *sides* is one of:
 * `y` - for classes that set both `*-top` and `*-bottom`
 * blank - for classes that set a `margin` or `padding` on all 4 sides of the element
 
-Where *size* is one of:
+Where _size_ is one of:
 
 * `0` - for classes that eliminate the `margin` or `padding` by setting it to `0`
 * `1` - (by default) for classes that set the `margin` or `padding` to `$spacer * .25`
@@ -47,24 +47,13 @@ Where *size* is one of:
 
 Here are some representative examples of these classes:
 
-{% highlight scss %}
-.mt-0 {
-  margin-top: 0 !important;
-}
+{% highlight scss %} .mt-0 { margin-top: 0 !important; }
 
-.ml-1 {
-  margin-left: ($spacer * .25) !important;
-}
+.ml-1 { margin-left: ($spacer \* .25) !important; }
 
-.px-2 {
-  padding-left: ($spacer * .5) !important;
-  padding-right: ($spacer * .5) !important;
-}
+.px-2 { padding-left: ($spacer _ .5) !important; padding-right: ($spacer _ .5) !important; }
 
-.p-3 {
-  padding: $spacer !important;
-}
-{% endhighlight %}
+.p-3 { padding: $spacer !important; } {% endhighlight %}
 
 ### Horizontal centering
 
@@ -77,6 +66,7 @@ Additionally, Bootstrap also includes an `.mx-auto` class for horizontally cente
 </div>
 
 {% highlight html %}
+
 <div class="mx-auto" style="width: 200px;">
   Centered element
 </div>

--- a/docs/4.0/utilities/text.md
+++ b/docs/4.0/utilities/text.md
@@ -11,12 +11,14 @@ toc: true
 Easily realign text to components with text alignment classes.
 
 {% example html %}
+
 <p class="text-justify">Ambitioni dedisse scripsisse iudicaretur. Cras mattis iudicium purus sit amet fermentum. Donec sed odio operae, eu vulputate felis rhoncus. Praeterea iter est quasdam res quas ex communi. At nos hinc posthac, sitientis piros Afros. Petierunt uti sibi concilium totius Galliae in diem certam indicere. Cras mattis iudicium purus sit amet fermentum.</p>
 {% endexample %}
 
 For left, right, and center alignment, responsive classes are available that use the same viewport width breakpoints as the grid system.
 
 {% example html %}
+
 <p class="text-left">Left aligned text on all viewport sizes.</p>
 <p class="text-center">Center aligned text on all viewport sizes.</p>
 <p class="text-right">Right aligned text on all viewport sizes.</p>
@@ -32,6 +34,7 @@ For left, right, and center alignment, responsive classes are available that use
 Prevent text from wrapping with a `.text-nowrap` class.
 
 {% example html %}
+
 <div class="row">
   <div class="col-1 text-nowrap">
     Curabitur blandit tempus ardua ridiculus sed magna.
@@ -45,7 +48,9 @@ Prevent text from wrapping with a `.text-nowrap` class.
 For longer content, you can add a `.text-truncate` class to truncate the text with an ellipsis. **Requires `display: inline-block` or `display: block`.**
 
 {% example html %}
+
 <!-- Block level -->
+
 <div class="row">
   <div class="col-2 text-truncate">
     Praeterea iter est quasdam res quas ex communi.
@@ -53,6 +58,7 @@ For longer content, you can add a `.text-truncate` class to truncate the text wi
 </div>
 
 <!-- Inline level -->
+
 <span class="d-inline-block text-truncate" style="max-width: 150px;">
   Praeterea iter est quasdam res quas ex communi.
 </span>
@@ -63,6 +69,7 @@ For longer content, you can add a `.text-truncate` class to truncate the text wi
 Transform text in components with text capitalization classes.
 
 {% example html %}
+
 <p class="text-lowercase">Lowercased text.</p>
 <p class="text-uppercase">Uppercased text.</p>
 <p class="text-capitalize">CapiTaliZed text.</p>
@@ -75,6 +82,7 @@ Note how `text-capitalize` only changes the first letter of each word, leaving t
 Quickly change the weight (boldness) of text or italicize text.
 
 {% example html %}
+
 <p class="font-weight-bold">Bold text.</p>
 <p class="font-weight-normal">Normal weight text.</p>
 <p class="font-weight-light">Light weight text.</p>

--- a/docs/4.0/utilities/vertical-align.md
+++ b/docs/4.0/utilities/vertical-align.md
@@ -11,18 +11,12 @@ Choose from `.align-baseline`, `.align-top`, `.align-middle`, `.align-bottom`, `
 
 With inline elements:
 
-{% example html %}
-<span class="align-baseline">baseline</span>
-<span class="align-top">top</span>
-<span class="align-middle">middle</span>
-<span class="align-bottom">bottom</span>
-<span class="align-text-top">text-top</span>
-<span class="align-text-bottom">text-bottom</span>
-{% endexample %}
+{% example html %} <span class="align-baseline">baseline</span> <span class="align-top">top</span> <span class="align-middle">middle</span> <span class="align-bottom">bottom</span> <span class="align-text-top">text-top</span> <span class="align-text-bottom">text-bottom</span> {% endexample %}
 
 With table cells:
 
 {% example html %}
+
 <table style="height: 100px;">
   <tbody>
     <tr>

--- a/docs/4.0/utilities/visibility.md
+++ b/docs/4.0/utilities/visibility.md
@@ -10,24 +10,11 @@ Set the `visibility` of elements with our visibility utilities. These do not mod
 Apply `.visible` or `.invisible` as needed.
 
 {% highlight html %}
+
 <div class="visible">...</div>
 <div class="invisible">...</div>
 {% endhighlight %}
 
-{% highlight scss %}
-// Class
-.visible {
-  visibility: visible;
-}
-.invisible {
-  visibility: hidden;
-}
+{% highlight scss %} // Class .visible { visibility: visible; } .invisible { visibility: hidden; }
 
-// Usage as a mixin
-.element {
-  @include invisible(visible);
-}
-.element {
-  @include invisible(hidden);
-}
-{% endhighlight %}
+// Usage as a mixin .element { @include invisible(visible); } .element { @include invisible(hidden); } {% endhighlight %}

--- a/js/tests/README.md
+++ b/js/tests/README.md
@@ -10,7 +10,6 @@ To run the unit test suite via [PhantomJS](http://phantomjs.org/), run `npm run 
 
 To run the unit test suite via a real web browser, open `index.html` in the browser.
 
-
 ## How do I add a new unit test?
 
 1. Locate and open the file dedicated to the plugin which you need to add tests to (`unit/<plugin-name>.js`).
@@ -31,31 +30,38 @@ To run the unit test suite via a real web browser, open `index.html` in the brow
 
 ```javascript
 // Synchronous test
-QUnit.test('should describe the unit being tested', function (assert) {
-  assert.expect(1)
-  var templateHTML = '<div class="alert alert-danger fade show">'
-      + '<a class="close" href="#" data-dismiss="alert">×</a>'
-      + '<p><strong>Template necessary for the test.</p>'
-      + '</div>'
-  var $alert = $(templateHTML).appendTo('#qunit-fixture').bootstrapAlert()
+QUnit.test('should describe the unit being tested', function(assert) {
+  assert.expect(1);
+  var templateHTML =
+    '<div class="alert alert-danger fade show">' +
+    '<a class="close" href="#" data-dismiss="alert">×</a>' +
+    '<p><strong>Template necessary for the test.</p>' +
+    '</div>';
+  var $alert = $(templateHTML)
+    .appendTo('#qunit-fixture')
+    .bootstrapAlert();
 
-  $alert.find('.close').trigger('click')
+  $alert.find('.close').trigger('click');
 
   // Make assertion
-  assert.strictEqual($alert.hasClass('show'), false, 'remove .show class on .close click')
-})
+  assert.strictEqual(
+    $alert.hasClass('show'),
+    false,
+    'remove .show class on .close click',
+  );
+});
 
 // Asynchronous test
-QUnit.test('should describe the unit being tested', function (assert) {
-  assert.expect(1)
-  var done = assert.async()
+QUnit.test('should describe the unit being tested', function(assert) {
+  assert.expect(1);
+  var done = assert.async();
 
   $('<div title="tooltip title"></div>')
     .appendTo('#qunit-fixture')
-    .on('shown.bs.tooltip', function () {
-      assert.ok(true, '"shown" event was fired after calling "show"')
-      done()
+    .on('shown.bs.tooltip', function() {
+      assert.ok(true, '"shown" event was fired after calling "show"');
+      done();
     })
-    .bootstrapTooltip('show')
-})
+    .bootstrapTooltip('show');
+});
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2308,6 +2309,910 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -5227,6 +6132,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
+      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -5347,6 +6258,7 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
+            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "js-minify-docs": "uglifyjs --mangle --comments \"/^!/\" --output assets/js/docs.min.js assets/js/vendor/anchor.min.js assets/js/vendor/clipboard.min.js assets/js/vendor/holder.min.js \"assets/js/src/*.js\"",
     "js-test": "phantomjs ./node_modules/qunit-phantomjs-runner/runner.js js/tests/index.html 60",
     "js-test-cloud": "ruby -r webrick -e \"s = WEBrick::HTTPServer.new(:Port => 3000, :DocumentRoot => Dir.pwd, :Logger => WEBrick::Log.new('/dev/null'), :AccessLog => []); trap('INT') { s.shutdown }; s.start\" & node build/saucelabs-unit-test.js",
+    "md-fix": "prettier --write \"**/*.md\"",
     "docs": "npm-run-all --parallel css-docs js-docs --sequential docs-compile docs-lint",
     "docs-compile": "bundle exec jekyll build",
     "postdocs-compile": "npm run docs-workbox-precache",
@@ -99,6 +100,7 @@
     "phantomjs-prebuilt": "^2.1.16",
     "popper.js": "^1.12.9",
     "postcss-cli": "^4.1.1",
+    "prettier": "^1.8.2",
     "qunit-phantomjs-runner": "^2.3.0",
     "qunitjs": "^2.4.1",
     "rollup": "^0.51.8",
@@ -129,6 +131,15 @@
     "js/**/*.js.map",
     "scss/**/*.scss"
   ],
+  "prettier": {
+    "bracketSpacing": false,
+    "printWidth": 80,
+    "proseWrap": false,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "all",
+    "useTabs": false
+  },
   "browserslist": [
     "Chrome >= 45",
     "Firefox ESR",


### PR DESCRIPTION
[Prettier](https://prettier.io) is now supporting Markdown files and used it with the [`proseWrap`](https://prettier.io/docs/en/options.html#prose-wrap) option set to `false` if you want otherwise we can change it.. but I think most of the editors now-days support the word wrap and especially for writing documentation it's a bit annoying when we have to manually think about the theoretical line width.

I can also add some commit hooks so every time something is ending up in the repo will be properly formatted.