### PR TITLE
enhance sizing

### DIFF
--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -2,9 +2,17 @@
 
 // Width and height
 
-@each $prop, $abbrev in (width: w, height: h) {
-  @each $size, $length in $sizes {
-    .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @each $prop, $abbrev in (width: w, height: h) {
+      @each $size, $length in $sizes {
+        .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
+      }
+
+      .#{$abbrev}#{$infix}-auto { #{$prop}: auto !important; }
+    }
   }
 }
 


### PR DESCRIPTION
Add `notation` and `auto size` to Sizing (width and height), like **Spacing**, so we can use `<div  class="w-sm-100 w-md-50 w-xl-auto">` to do something amazing.

I think that will be more convenient and friendly :)