### PR TITLE
Only validate required form controls

### DIFF
--- a/docs/4.0/components/forms.md
+++ b/docs/4.0/components/forms.md
@@ -707,7 +707,7 @@ We **highly recommend** custom validation styles as native browser defaults are 
 
 Here's how form validation works with Bootstrap:
 
-- HTML form validation is applied via CSS's two pseudo-classes, `:invalid` and `:valid`. It applies to `<input>`, `<select>`, and `<textarea>` elements.
+- HTML form validation is applied via CSS's two pseudo-classes, `:invalid` and `:valid`. It applies to `<input>`, `<select>`, and `<textarea>` elements with the `required` attribute.
 - Bootstrap scopes the `:invalid` and `:valid` styles to parent `.was-validated` class, usually applied to the `<form>`. Otherwise, any required field without a value shows up as invalid on page load. This way, you may choose when to activate them (typically after form submission is attempted).
 - As a fallback, `.is-invalid` and `.is-valid` classes may be used instead of the pseudo-classes for [server side validation](#server-side). They do not require a `.was-validated` parent class.
 - Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -50,8 +50,8 @@
     border-radius: .2rem;
   }
 
-  .form-control,
-  .custom-select {
+  .form-control:required,
+  .custom-select:required {
     .was-validated &:#{$state},
     &.is-#{$state} {
       border-color: $color;
@@ -70,7 +70,7 @@
 
 
   // TODO: redo check markup lol crap
-  .form-check-input {
+  .form-check-input:required {
     .was-validated &:#{$state},
     &.is-#{$state} {
       + .form-check-label {
@@ -80,7 +80,7 @@
   }
 
   // custom radios and checks
-  .custom-control-input {
+  .custom-control-input:required {
     .was-validated &:#{$state},
     &.is-#{$state} {
       ~ .custom-control-indicator {


### PR DESCRIPTION
This changes the form validation styles to only apply to elements with an explicit `required` attribute. While working on a new form example for #24898, it caught me off guard that we were saying _optional_ inputs were `valid` when in fact there's nothing to actually validate. This change ensures that only required inputs, selects, textareas, and custom form controls are validated and effectively treats all non-`required` form controls as opt-in for form validation styles.

Here's the before and after to show you what I mean. Note how the second address line and two checkboxes shouldn't be green as it implies we performed validation on `value`s that don't exist.

| Before | After |
| --- | --- |
| <img width="638" alt="screen shot 2017-11-28 at 2 04 25 pm" src="https://user-images.githubusercontent.com/98681/33346620-31272d54-d445-11e7-801c-1f0810957a8c.png"> | <img width="638" alt="screen shot 2017-11-28 at 2 05 01 pm" src="https://user-images.githubusercontent.com/98681/33346619-310c95d4-d445-11e7-988c-877d78dc8a67.png"> |
