### PR TITLE
Disable linter on .text-hide to prevent error

### DIFF
--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable font-family-no-missing-generic-family-keyword */
+
 // CSS image replacement
 @mixin text-hide() {
   // stylelint-disable-next-line font-family-no-missing-generic-family-keyword


### PR DESCRIPTION
Was causing our npm scripts to fail.