### PR TITLE
package.json: add Firefox in browserslist section.

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
     "scss/"
   ],
   "browserslist": [
+    "last 1 major version",
+    ">= 1%",
     "Chrome >= 45",
     "Firefox >= 38",
     "Edge >= 12",
@@ -153,11 +155,11 @@
     },
     {
       "path": "./dist/css/bootstrap-reboot.css",
-      "maxSize": "5 kB"
+      "maxSize": "3 kB"
     },
     {
       "path": "./dist/css/bootstrap-reboot.min.css",
-      "maxSize": "5 kB"
+      "maxSize": "3 kB"
     },
     {
       "path": "./dist/css/bootstrap.css",
@@ -165,7 +167,7 @@
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "20 kB"
+      "maxSize": "21 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   ],
   "browserslist": [
     "Chrome >= 45",
-    "Firefox ESR",
+    "Firefox >= 38",
     "Edge >= 12",
     "Explorer >= 10",
     "iOS >= 9",


### PR DESCRIPTION
Firefox v38 is older than the ESR, so basically replace ESR with v38.

The dist file change with the Firefox >= 38 addition is the following:

```diff
 dist/css/bootstrap.css | 7 +++++++
 1 file changed, 7 insertions(+)

diff --git a/dist/css/bootstrap.css b/dist/css/bootstrap.css
index e37b3d46c..c93e561cd 100644
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -1874,6 +1874,11 @@ pre code {
   opacity: 1;
 }
 
+.form-control::-moz-placeholder {
+  color: #868e96;
+  opacity: 1;
+}
+
 .form-control:-ms-input-placeholder {
   color: #868e96;
   opacity: 1;
@@ -4406,8 +4411,10 @@ tbody.collapse.show {
 @media (min-width: 576px) {
   .card-columns {
     -webkit-column-count: 3;
+    -moz-column-count: 3;
     column-count: 3;
     -webkit-column-gap: 1.25rem;
+    -moz-column-gap: 1.25rem;
     column-gap: 1.25rem;
   }
   .card-columns .card {

```

Fixes #24911, fixes #25017.