### PR TITLE
Fix broken links to Less and Sass

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@ title: Bootstrap &middot; The world's most popular mobile-first and responsive f
       <div class="col-sm-4">
         <img src="assets/img/sass-less.png" alt="Sass and Less support" class="img-responsive">
         <h3>Preprocessors</h3>
-        <p>Bootstrap ships with vanilla CSS, but its source code utilizes the two most popular CSS preprocessors, <a href="../{ site.docs_version }/css/#less">Less</a> and <a href="../{ site.docs_version }/css/#sass">Sass</a>. Quickly get started with precompiled CSS or build on the source.</p>
+        <p>Bootstrap ships with vanilla CSS, but its source code utilizes the two most popular CSS preprocessors, <a href="../{{ site.docs_version }}/css/#less">Less</a> and <a href="../{{ site.docs_version }}/css/#sass">Sass</a>. Quickly get started with precompiled CSS or build on the source.</p>
       </div>
       <div class="col-sm-4">
         <img src="assets/img/devices.png" alt="Responsive across devices" class="img-responsive">

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@ title: Bootstrap &middot; The world's most popular mobile-first and responsive f
       <div class="col-sm-4">
         <img src="assets/img/sass-less.png" alt="Sass and Less support" class="img-responsive">
         <h3>Preprocessors</h3>
-        <p>Bootstrap ships with vanilla CSS, but its source code utilizes the two most popular CSS preprocessors, <a href="../css/#less">Less</a> and <a href="../css/#sass">Sass</a>. Quickly get started with precompiled CSS or build on the source.</p>
+        <p>Bootstrap ships with vanilla CSS, but its source code utilizes the two most popular CSS preprocessors, <a href="../{ site.docs_version }/css/#less">Less</a> and <a href="../{ site.docs_version }/css/#sass">Sass</a>. Quickly get started with precompiled CSS or build on the source.</p>
       </div>
       <div class="col-sm-4">
         <img src="assets/img/devices.png" alt="Responsive across devices" class="img-responsive">


### PR DESCRIPTION
Broken links can be seen in the preprocessors parts of https://getbootstrap.com/docs/3.3/