### PR TITLE
Specify host 0.0.0.0 for Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ permalink:      pretty
 # Server
 source:         "."
 destination:    ./_gh_pages
+host:           0.0.0.0
 port:           9001
 baseurl:        ""
 url:            "https://getbootstrap.com"


### PR DESCRIPTION
Allows for remote connections on same network (used to be the default behavior, but Jekyll now seems to default to 127.0.0.1 which means it does not react to incoming external requests)