### PR TITLE
fix color interpolation warning

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,11 +1,11 @@
 :root {
   // Custom variable values only support SassScript inside `#{}`.
   @each $color, $value in $colors {
-    --#{$color}: #{$value};
+    #{--#{$color}}: #{$value};
   }
 
   @each $color, $value in $theme-colors {
-    --#{$color}: #{$value};
+    #{--#{$color}}: #{$value};
   }
 
   @each $bp, $value in $grid-breakpoints {


### PR DESCRIPTION
[scss/_root.scss](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_root.scss#L4) is generate this warning for each iteration of `$colors`. 

* fix from https://github.com/twbs/bootstrap/issues/24549#issuecomment-347057261
* using [sass](https://rubygems.org/gems/sass/versions/3.5.4) `v3.5.4`

```
WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `blue' in interpolation here.
It may end up represented as #0000ff, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "blue").
If you really want to use the color value here, use `"" + $color'.
```
<details>
<summary>full log output for each `$color`</summary>

```
WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `blue' in interpolation here.
It may end up represented as #0000ff, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "blue").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `indigo' in interpolation here.
It may end up represented as #4b0082, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "indigo").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `purple' in interpolation here.
It may end up represented as #800080, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "purple").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `pink' in interpolation here.
It may end up represented as #ffc0cb, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "pink").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `red' in interpolation here.
It may end up represented as #ff0000, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "red").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `orange' in interpolation here.
It may end up represented as #ffa500, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "orange").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `yellow' in interpolation here.
It may end up represented as #ffff00, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "yellow").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `green' in interpolation here.
It may end up represented as #008000, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "green").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `teal' in interpolation here.
It may end up represented as #008080, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "teal").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `cyan' in interpolation here.
It may end up represented as #00ffff, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "cyan").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `white' in interpolation here.
It may end up represented as #ffffff, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "white").
If you really want to use the color value here, use `"" + $color'.

WARNING on line 4, column 7 of gems/bootstrap-4.0.0.beta2/assets/stylesheets/bootstrap/_root.scss:
You probably don't mean to use the color value `gray' in interpolation here.
It may end up represented as #808080, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "gray").
If you really want to use the color value here, use `"" + $color'.
```

</details>

#### References
:link: https://github.com/twbs/bootstrap-rubygem/issues/130