### PR TITLE
Input Groups don't need to jankily prevent input button groups from w…

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -157,9 +157,6 @@
 .input-group-btn {
   position: relative;
   align-items: stretch;
-  // Jankily prevent input button groups from wrapping with `white-space` and
-  // `font-size` in combination with `inline-block` on buttons.
-  font-size: 0;
   white-space: nowrap;
 
   // Negative margin for spacing, position for bringing hovered/focused/actived


### PR DESCRIPTION
…rapping anymore with flexbox

This looks like leftovers from Bootstrap 3 when input-groups were table based.

https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_input-groups.scss#L137-L139