### PR TITLE
Move from headings to divs to fix #24975

### DIFF
--- a/docs/4.0/components/list-group.md
+++ b/docs/4.0/components/list-group.md
@@ -136,7 +136,7 @@ Add nearly any HTML within, even for linked list groups like the one below, with
 <div class="list-group">
   <a href="#" class="list-group-item list-group-item-action flex-column align-items-start active">
     <div class="d-flex w-100 justify-content-between">
-      <h5 class="mb-1">List group item heading</h5>
+      <div class="h5 mb-1">List group item heading</div>
       <small>3 days ago</small>
     </div>
     <p class="mb-1">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>
@@ -144,7 +144,7 @@ Add nearly any HTML within, even for linked list groups like the one below, with
   </a>
   <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
     <div class="d-flex w-100 justify-content-between">
-      <h5 class="mb-1">List group item heading</h5>
+      <div class="h5 mb-1">List group item heading</div>
       <small class="text-muted">3 days ago</small>
     </div>
     <p class="mb-1">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>
@@ -152,7 +152,7 @@ Add nearly any HTML within, even for linked list groups like the one below, with
   </a>
   <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
     <div class="d-flex w-100 justify-content-between">
-      <h5 class="mb-1">List group item heading</h5>
+      <div class="h5 mb-1">List group item heading</div>
       <small class="text-muted">3 days ago</small>
     </div>
     <p class="mb-1">Donec id elit non mi porta gravida at eget metus. Maecenas sed diam eget risus varius blandit.</p>


### PR DESCRIPTION
Janky fix that we're using elsewhere to get around the Jekyll ToC shortcomings. Will need to revisit down the line.