### PR TITLE
Fix tooltip/popover arrow size and position

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -26,96 +26,88 @@
     display: block;
     width: $popover-arrow-width;
     height: $popover-arrow-height;
+    margin: 0 $border-radius-lg;
   }
 
   .arrow::before,
   .arrow::after {
     position: absolute;
     display: block;
+    content: "";
     border-color: transparent;
     border-style: solid;
-  }
-
-  .arrow::before {
-    content: "";
-    border-width: $popover-arrow-width;
-  }
-  .arrow::after {
-    content: "";
-    border-width: $popover-arrow-width;
   }
 
   // Popover directions
 
   &.bs-popover-top {
-    margin-bottom: $popover-arrow-width;
+    margin-bottom: $popover-arrow-height;
 
     .arrow {
-      bottom: 0;
+      bottom: calc((#{$popover-arrow-height} + #{$popover-border-width}) * -1);
     }
 
     .arrow::before,
     .arrow::after {
-      border-bottom-width: 0;
+      border-width: $popover-arrow-height $popover-arrow-width/2 0;
     }
 
     .arrow::before {
-      bottom: -$popover-arrow-width;
-      margin-left: -$popover-arrow-width;
+      bottom: 0;
       border-top-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      bottom: calc((#{$popover-arrow-width} - #{$popover-border-width}) * -1);
-      margin-left: -$popover-arrow-width;
+      bottom: $popover-border-width;
       border-top-color: $popover-arrow-color;
     }
   }
 
   &.bs-popover-right {
-    margin-left: $popover-arrow-width;
+    margin-left: $popover-arrow-height;
 
     .arrow {
-      left: 0;
+      left: calc((#{$popover-arrow-height} + #{$popover-border-width}) * -1);
+      width: $popover-arrow-height;
+      height: $popover-arrow-width;
+      margin: $border-radius-lg 0; // make sure the arrow does not touch the popover's rounded corners
     }
 
     .arrow::before,
     .arrow::after {
-      margin-top: -$popover-arrow-width;
-      border-left-width: 0;
+      border-width: $popover-arrow-width/2 $popover-arrow-height $popover-arrow-width/2 0;
     }
 
     .arrow::before {
-      left: -$popover-arrow-width;
+      left: 0;
       border-right-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      left: calc((#{$popover-arrow-width} - #{$popover-border-width}) * -1);
+      left: $popover-border-width;
       border-right-color: $popover-arrow-color;
     }
   }
 
   &.bs-popover-bottom {
-    margin-top: $popover-arrow-width;
+    margin-top: $popover-arrow-height;
 
     .arrow {
-      top: 0;
+      top: calc((#{$popover-arrow-height} + #{$popover-border-width}) * -1);
     }
 
     .arrow::before,
     .arrow::after {
-      margin-left: -$popover-arrow-width;
-      border-top-width: 0;
+      border-width: 0 $popover-arrow-width/2 $popover-arrow-height $popover-arrow-width/2;
     }
 
     .arrow::before {
-      top: -$popover-arrow-width;
+      top: 0;
       border-bottom-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      top: calc((#{$popover-arrow-width} - #{$popover-border-width}) * -1);
+      top: $popover-border-width;
       border-bottom-color: $popover-arrow-color;
     }
 
@@ -125,33 +117,35 @@
       top: 0;
       left: 50%;
       display: block;
-      width: 20px;
-      margin-left: -10px;
+      width: $popover-arrow-width;
+      margin-left: -$popover-arrow-width/2;
       content: "";
       border-bottom: $popover-border-width solid $popover-header-bg;
     }
   }
 
   &.bs-popover-left {
-    margin-right: $popover-arrow-width;
+    margin-right: $popover-arrow-height;
 
     .arrow {
-      right: 0;
+      right: calc((#{$popover-arrow-height} + #{$popover-border-width}) * -1);
+      width: $popover-arrow-height;
+      height: $popover-arrow-width;
+      margin: $border-radius-lg 0; // make sure the arrow does not touch the popover's rounded corners
     }
 
     .arrow::before,
     .arrow::after {
-      margin-top: -$popover-arrow-width;
-      border-right-width: 0;
+      border-width: $popover-arrow-width/2 0 $popover-arrow-width/2 $popover-arrow-height;
     }
 
     .arrow::before {
-      right: -$popover-arrow-width;
+      right: 0;
       border-left-color: $popover-arrow-outer-color;
     }
 
     .arrow::after {
-      right: calc((#{$popover-arrow-width} - #{$popover-border-width}) * -1);
+      right: $popover-border-width;
       border-left-color: $popover-arrow-color;
     }
   }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -28,55 +28,58 @@
   }
 
   &.bs-tooltip-top {
-    padding: $tooltip-arrow-width 0;
+    padding: $tooltip-arrow-height 0;
     .arrow {
       bottom: 0;
     }
 
     .arrow::before {
-      margin-left: -$tooltip-arrow-width;
+      top: 0;
       content: "";
-      border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
+      border-width: $tooltip-arrow-height $tooltip-arrow-width/2 0;
       border-top-color: $tooltip-arrow-color;
     }
   }
   &.bs-tooltip-right {
-    padding: 0 $tooltip-arrow-width;
+    padding: 0 $tooltip-arrow-height;
     .arrow {
       left: 0;
+      width: $tooltip-arrow-height;
+      height: $tooltip-arrow-width;
     }
 
     .arrow::before {
-      margin-top: -$tooltip-arrow-width;
+      right: 0;
       content: "";
-      border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
+      border-width: $tooltip-arrow-width/2 $tooltip-arrow-height $tooltip-arrow-width/2 0;
       border-right-color: $tooltip-arrow-color;
     }
   }
   &.bs-tooltip-bottom {
-    padding: $tooltip-arrow-width 0;
+    padding: $tooltip-arrow-height 0;
     .arrow {
       top: 0;
     }
 
     .arrow::before {
-      margin-left: -$tooltip-arrow-width;
+      bottom: 0;
       content: "";
-      border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
+      border-width: 0 $tooltip-arrow-width/2 $tooltip-arrow-height;
       border-bottom-color: $tooltip-arrow-color;
     }
   }
   &.bs-tooltip-left {
-    padding: 0 $tooltip-arrow-width;
+    padding: 0 $tooltip-arrow-height;
     .arrow {
       right: 0;
+      width: $tooltip-arrow-height;
+      height: $tooltip-arrow-width;
     }
 
     .arrow::before {
-      right: 0;
-      margin-top: -($tooltip-arrow-width);
+      left: 0;
       content: "";
-      border-width: $tooltip-arrow-width 0 $tooltip-arrow-width $tooltip-arrow-width;
+      border-width: $tooltip-arrow-width/2 0 $tooltip-arrow-width/2 $tooltip-arrow-height;
       border-left-color: $tooltip-arrow-color;
     }
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -682,8 +682,8 @@ $tooltip-padding-y:           .25rem !default;
 $tooltip-padding-x:           .5rem !default;
 $tooltip-margin:              0 !default;
 
-$tooltip-arrow-width:         .4rem !default;
-$tooltip-arrow-height:        $tooltip-arrow-width !default;
+$tooltip-arrow-width:         .8rem !default;
+$tooltip-arrow-height:        .4rem !default;
 $tooltip-arrow-color:         $tooltip-bg !default;
 
 
@@ -704,8 +704,8 @@ $popover-body-color:                $body-color !default;
 $popover-body-padding-y:            $popover-header-padding-y !default;
 $popover-body-padding-x:            $popover-header-padding-x !default;
 
-$popover-arrow-width:               .8rem !default;
-$popover-arrow-height:              .4rem !default;
+$popover-arrow-width:               1.6rem !default;
+$popover-arrow-height:              .8rem !default;
 $popover-arrow-color:               $popover-bg !default;
 
 $popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;


### PR DESCRIPTION
This overhauls the tooltip and popover arrows implementation, fixing a few problems:

**1. arrows were not properly aligned to the trigger.**

Fixes #25045 and fixes #23793

**2. the `.arrow` element did not match the size and position of the actual visible arrow.**

Before:
![image](https://user-images.githubusercontent.com/1325249/34321398-91d4436c-e80e-11e7-909f-3e241278275d.png)

After:
![image](https://user-images.githubusercontent.com/1325249/34321394-735c73d2-e80e-11e7-9199-0db87087c00a.png)

Same for tooltips. This possibly also fixes #23846, see https://github.com/twbs/bootstrap/issues/23846#issuecomment-327465549.

**3. Fixed `$popover-arrow-height` / `$tooltip-arrow-height`**

These Sass variables did not have any effect on the visual appearance. They were just used for the (wrong, see above) sizing of the `.arrow` element, which has absolutely no visible effect. Only `$...-arrow-width` had a visual effect, but it always determined implicitly both the width and height (height = width/2, so a 45° angle). 

Also the value for width was wrongly used, AFAICT. Setting it to `10px` would lead to an arrow `20px` wide. My understanding of these dimensions is that `$popover-arrow-width` should specify the width of the `.arrow` (for top or bottom placement), as can be seen on the second screenshot above.

This has been fixed here. But for anyone who has customized the arrows with these variables, this would be a somewhat breaking change (the width will be the half of it as it has been before). But still I think this has to be done, as this restores that the assigned values now exactly match the visual dimensions.