### PR TITLE
Darken table border-color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -302,7 +302,7 @@ $table-hover-bg:              rgba($black, .075) !default;
 $table-active-bg:             $table-hover-bg !default;
 
 $table-border-width:          $border-width !default;
-$table-border-color:          $gray-200 !default;
+$table-border-color:          $gray-300 !default;
 
 $table-head-bg:               $gray-200 !default;
 $table-head-color:            $gray-700 !default;


### PR DESCRIPTION
Fixes #25016 which noticed a `.thead-light` and `border-color` of the `.table-border` are the same color.