### PR TITLE
Add examples of disabled tooltip and popover triggers

### DIFF
--- a/docs/4.0/components/popovers.md
+++ b/docs/4.0/components/popovers.md
@@ -111,6 +111,17 @@ $('.popover-dismiss').popover({
 })
 {% endhighlight %}
 
+### Disabled elements
+
+Elements with the `disabled` attribute aren't interactive, meaning users cannot hover or click them to trigger a popover (or tooltip). As a workaround, you'll want to trigger the popover from a wrapper `<div>` or `<span>` and override the `pointer-events` on the disabled element.
+
+For disabled popover triggers, you may also prefer `data-trigger="hover"` so that the popover appears as immediate visual feedback to your users as they may not expect to _click_ on a disabled element.
+
+{% example html %}
+<span class="d-inline-block" data-toggle="popover" data-content="Disabled popover">
+  <button class="btn btn-primary" style="pointer-events: none;" type="button" disabled>Disabled button</button>
+</span>
+{% endexample %}
 
 ## Usage
 

--- a/docs/4.0/components/tooltips.md
+++ b/docs/4.0/components/tooltips.md
@@ -109,6 +109,18 @@ You should only add tooltips to HTML elements that are traditionally keyboard-fo
 </div>
 {% endhighlight %}
 
+### Disabled elements
+
+Elements with the `disabled` attribute aren't interactive, meaning users cannot hover or click them to trigger a tooltip (or popover). As a workaround, you'll want to trigger the tooltip from a wrapper `<div>` or `<span>` and override the `pointer-events` on the disabled element.
+
+<div class="tooltip-demo">
+{% example html %}
+<span class="d-inline-block" data-toggle="tooltip" title="Disabled tooltip">
+  <button class="btn btn-primary" style="pointer-events: none;" type="button" disabled>Disabled button</button>
+</span>
+{% endexample %}
+</div>
+
 ### Options
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-animation=""`.


### PR DESCRIPTION
Closes #25015 with a dedicated section to both tooltip and popover docs.

<img width="930" alt="screen shot 2017-12-27 at 5 08 07 pm" src="https://user-images.githubusercontent.com/98681/34397185-a3441074-eb28-11e7-8c06-0349fe19627f.png">
