### PR TITLE
Wall of Browser Bugs: position:sticky support landed in MS Edge

### DIFF
--- a/_data/browser-features.yml
+++ b/_data/browser-features.yml
@@ -22,16 +22,6 @@
   browser: >
     Edge
   summary: >
-    Implement [sticky positioning](http://html5please.com/#position:sticky) from CSS Positioned Layout Level 3
-  upstream_bug: >
-    UserVoice#6263621
-  origin: >
-    Bootstrap#17021
-
--
-  browser: >
-    Edge
-  summary: >
     Implement the HTML5 [`<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
   upstream_bug: >
     UserVoice#6508895


### PR DESCRIPTION
Patch to remove it from "Most wanted features" now that `position: sticky` support is in Microsoft Edge 16.

~~(Also includes #24751.)~~