### PR TITLE
Docs: explicitly apply CSS `::before` styles for syntax highlighting just to `<code>` element

### DIFF
--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -64,14 +64,14 @@
 .css .o + .nt,
 .css .nt + .nt { color: #999; }
 
-.language-bash::before,
-.language-sh::before {
+code.language-bash::before,
+code.language-sh::before {
   color: #009;
   content: "$ ";
   user-select: none;
 }
 
-.language-powershell::before {
+code.language-powershell::before {
   color: #009;
   content: "PM> ";
   user-select: none;


### PR DESCRIPTION
Currently, the classes are added to both `<pre>` and `<code>`, resulting in a doubling-up of the `::before` content.

See for instance http://getbootstrap.com/docs/4.0/getting-started/download/

![capture](https://user-images.githubusercontent.com/895831/34421916-3616e0e8-ec0a-11e7-9ac5-5fe037bb5491.PNG)
