### PR TITLE
Add .modal-dialog-centered class to vertically centered modal example.

### DIFF
--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -246,7 +246,7 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
 
 <!-- Modal -->
 <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>


### PR DESCRIPTION
Vertically centered modal example code requires .modal-dialog-centered class with the .modal-dialog class to correspond with the working example.