### PR TITLE
Remove unnecessary `align-middle` class from Navbar docs

### DIFF
--- a/docs/4.0/components/navbar.md
+++ b/docs/4.0/components/navbar.md
@@ -239,7 +239,7 @@ Various buttons are supported as part of these navbar forms, too. This is also a
 <nav class="navbar navbar-light bg-light">
   <form class="form-inline">
     <button class="btn btn-outline-success" type="button">Main button</button>
-    <button class="btn btn-sm align-middle btn-outline-secondary" type="button">Smaller button</button>
+    <button class="btn btn-sm btn-outline-secondary" type="button">Smaller button</button>
   </form>
 </nav>
 {% endexample %}


### PR DESCRIPTION
The [forms docs on Navbar](http://getbootstrap.com/docs/4.0/components/navbar/#forms) has an example of buttons with an `align-middle` utility class.

I think that a `vertical-align` in this context is unnecessary.