### PR TITLE
Removes hardcoded value for .nav-link padding

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -168,8 +168,8 @@
           }
 
           .nav-link {
-            padding-right: .5rem;
-            padding-left: .5rem;
+            padding-right: $navbar-nav-link-padding-x;
+            padding-left: $navbar-nav-link-padding-x;
           }
         }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -585,6 +585,8 @@ $nav-pills-link-active-bg:          $component-active-bg !default;
 $navbar-padding-y:                  ($spacer / 2) !default;
 $navbar-padding-x:                  $spacer !default;
 
+$navbar-nav-link-padding-x:         .5rem !default;
+
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;


### PR DESCRIPTION
`.nav-link` padding within navbar is hardcoded to `.5rem`.

@mdo I've created a new variable for this value, but I was unsure if we should use `$nav-link-padding-x / 2` What do you think?