### PR TITLE
Add `docs-github-serve` script for local serving the github target.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "docs-compile": "bundle exec jekyll build",
     "postdocs-compile": "npm run docs-workbox-precache",
     "docs-github": "shx echo \"github: true\" > twbsconfig.yml && npm run docs-compile -- --config _config.yml,twbsconfig.yml && shx rm ./twbsconfig.yml",
+    "docs-github-serve": "bundle exec jekyll serve --skip-initial-build --no-watch",
     "docs-lint": "npm-run-all docs-lint-*",
     "docs-lint-htmllint": "htmllint --rc build/.htmllintrc \"_gh_pages/**/*.html\" \"js/tests/**/*.html\"",
     "docs-lint-vnu-jar": "node build/vnu-jar.js",


### PR DESCRIPTION
This is mostly so that we can quickly test the github build without having to use other ways.

It assumes `docs-github` has been run, and it doesn't watch for changes.