### PR TITLE
Outline active focus

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -79,7 +79,7 @@
   &:not([disabled]):not(.disabled):active,
   &:not([disabled]):not(.disabled).active,
   .show > &.dropdown-toggle {
-    color: color-yiq($color-hover);
+    color: color-yiq($active-background);
     background-color: $active-background;
     border-color: $active-border;
     // Avoid using mixin so we can pass custom focus shadow properly

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -82,8 +82,11 @@
     color: color-yiq($active-background);
     background-color: $active-background;
     border-color: $active-border;
-    // Avoid using mixin so we can pass custom focus shadow properly
-    box-shadow: 0 0 0 $btn-focus-width rgba($color, .5);
+
+    &:focus {
+      // Avoid using mixin so we can pass custom focus shadow properly
+      box-shadow: 0 0 0 $btn-focus-width rgba($color, .5);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #25135.

- This matches the default button styles, moving the `:focus` outline to be only on the `:active` state when it's truly focused.
- Also fixes a color contrast issue on the `:active` state of outline buttons. The `color` is now contrasting from the `$active-background`.

See fixes at https://codepen.io/emdeoh/pen/mpmLde?editors=1100.

/cc @mudrz @719media