### PR TITLE
Print tweaks

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -82,6 +82,11 @@
 
     // Bootstrap specific changes start
 
+    // Specify a min-width to make printing more consistent across browsers
+    body {
+      min-width: $print-body-min-width;
+    }
+
     // Bootstrap components
     .navbar {
       display: none;

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -83,9 +83,17 @@
 
     // Bootstrap specific changes start
 
-    // Specify a min-width to make printing more consistent across browsers
+    // Specify a size and min-width to make printing closer across browsers.
+    // We don't set margin here because it breaks `size` in Chrome. We also
+    // don't use `!important` on `size` as it breaks in Chrome.
+    @page {
+      size: $print-page-size;
+    }
     body {
-      min-width: $print-body-min-width;
+      min-width: $print-body-min-width !important;
+    }
+    .container {
+      min-width: $print-body-min-width !important;
     }
 
     // Bootstrap components

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -20,9 +20,10 @@
       box-shadow: none !important;
     }
 
-    a,
-    a:visited {
-      text-decoration: underline;
+    a {
+      &:not(.btn) {
+        text-decoration: underline;
+      }
     }
 
     // Bootstrap specific; comment the following selector out

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -880,3 +880,7 @@ $kbd-bg:                            $gray-900 !default;
 
 $pre-color:                         $gray-900 !default;
 $pre-scrollable-max-height:         340px !default;
+
+
+// Printing
+$print-body-min-width:              map-get($grid-breakpoints, "lg") !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -883,4 +883,5 @@ $pre-scrollable-max-height:         340px !default;
 
 
 // Printing
+$print-page-size:                   a3 !default;
 $print-body-min-width:              map-get($grid-breakpoints, "lg") !default;


### PR DESCRIPTION
Adds two new variables for printing—page `size` and `min-width` for the `<body>` and `.container`. Using the docs homepage as my example, this printed the most similar in macOS Chrome and Safari. I'll check in on Windows browsers before merging.

While working on this, a few things came to light:

- Safari doesn't respect `@page`'s `size`, hence the `min-width`s.
- Chrome is super finicky with `@page`. Adding `margin` or `!important` broke the `size` property.

I'm expecting even more issues across other browsers as I get into them.

Hopefully fixes #23864 and fixes #23992.

/cc @tigermarques @michaelkrieger