### PR TITLE
Check for window before window.QUnit

### DIFF
--- a/js/src/util.js
+++ b/js/src/util.js
@@ -39,7 +39,7 @@ const Util = (($) => {
   }
 
   function transitionEndTest() {
-    if (window.QUnit) {
+    if (window && window.QUnit) {
       return false
     }
 

--- a/js/src/util.js
+++ b/js/src/util.js
@@ -39,7 +39,7 @@ const Util = (($) => {
   }
 
   function transitionEndTest() {
-    if (window && window.QUnit) {
+    if (typeof window !== 'undefined' && window.QUnit) {
       return false
     }
 


### PR DESCRIPTION
This fixes error ```window is undefined``` on env where the window is not available.