### PR TITLE
feat: improvements of `.navbar-expand .dropdown-menu`

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -149,6 +149,62 @@
           padding-right: 0;
           padding-left: 0;
         }
+
+        .dropdown-menu {
+          padding-top: 0;
+          padding-bottom: 0;
+          margin-top: 0;
+          background-color: transparent;
+          border: 0;
+          border-radius: 0;
+        }
+
+        .dropdown-header,
+        .dropdown-item {
+          padding-right: $navbar-nav-link-padding-x;
+          padding-left: $navbar-nav-link-padding-x;
+          white-space: normal;
+        }
+
+        .dropdown-item {
+          background-color: transparent;
+        }
+
+        &.navbar-light {
+          .dropdown-item {
+            color: $navbar-light-color;
+
+            @include hover-focus {
+              color: $navbar-light-active-color;
+            }
+
+            &.active {
+              color: $navbar-light-active-color;
+            }
+          }
+
+          .dropdown-divider {
+            border-color: $navbar-light-toggler-border-color;
+          }
+        }
+
+        &.navbar-dark {
+          .dropdown-item {
+            color: $navbar-dark-color;
+
+            @include hover-focus {
+              color: $navbar-dark-active-color;
+            }
+
+            &.active {
+              color: $navbar-dark-active-color;
+            }
+          }
+
+          .dropdown-divider {
+            border-color: $navbar-dark-toggler-border-color;
+          }
+        }
       }
 
       @include media-breakpoint-up($next) {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -32,6 +32,31 @@
     align-items: center;
     justify-content: space-between;
   }
+
+  .dropdown-menu {
+    position: static;
+    float: none;
+    margin-top: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  @each $color, $value in $theme-colors {
+    &.bg-#{$color} .dropdown-menu {
+      background-color: $value;
+    }
+  }
+
+  .dropdown-header,
+  .dropdown-item {
+    padding-right: $navbar-nav-link-padding-x;
+    padding-left: $navbar-nav-link-padding-x;
+    white-space: normal;
+  }
+
+  .dropdown-item {
+    background-color: transparent;
+  }
 }
 
 
@@ -68,11 +93,6 @@
   .nav-link {
     padding-right: 0;
     padding-left: 0;
-  }
-
-  .dropdown-menu {
-    position: static;
-    float: none;
   }
 }
 
@@ -149,62 +169,6 @@
           padding-right: 0;
           padding-left: 0;
         }
-
-        .dropdown-menu {
-          padding-top: 0;
-          padding-bottom: 0;
-          margin-top: 0;
-          background-color: transparent;
-          border: 0;
-          border-radius: 0;
-        }
-
-        .dropdown-header,
-        .dropdown-item {
-          padding-right: $navbar-nav-link-padding-x;
-          padding-left: $navbar-nav-link-padding-x;
-          white-space: normal;
-        }
-
-        .dropdown-item {
-          background-color: transparent;
-        }
-
-        &.navbar-light {
-          .dropdown-item {
-            color: $navbar-light-color;
-
-            @include hover-focus {
-              color: $navbar-light-active-color;
-            }
-
-            &.active {
-              color: $navbar-light-active-color;
-            }
-          }
-
-          .dropdown-divider {
-            border-color: $navbar-light-toggler-border-color;
-          }
-        }
-
-        &.navbar-dark {
-          .dropdown-item {
-            color: $navbar-dark-color;
-
-            @include hover-focus {
-              color: $navbar-dark-active-color;
-            }
-
-            &.active {
-              color: $navbar-dark-active-color;
-            }
-          }
-
-          .dropdown-divider {
-            border-color: $navbar-dark-toggler-border-color;
-          }
-        }
       }
 
       @include media-breakpoint-up($next) {
@@ -214,19 +178,27 @@
         .navbar-nav {
           flex-direction: row;
 
-          .dropdown-menu {
-            position: absolute;
-          }
-
-          .dropdown-menu-right {
-            right: 0;
-            left: auto; // Reset the default from `.dropdown-menu`
-          }
-
           .nav-link {
             padding-right: $navbar-nav-link-padding-x;
             padding-left: $navbar-nav-link-padding-x;
           }
+        }
+
+        .dropdown-menu {
+          position: absolute;
+          margin-top: $navbar-padding-y;
+        }
+
+        .dropdown-menu-right {
+          right: 0;
+          left: auto; // Reset the default from `.dropdown-menu`
+        }
+
+        .dropdown-header,
+        .dropdown-item {
+          padding-right: $dropdown-item-padding-x;
+          padding-left: $dropdown-item-padding-x;
+          white-space: nowrap;
         }
 
         // For nesting containers, have to redeclare for alignment purposes
@@ -312,6 +284,26 @@
       }
     }
   }
+
+  .dropdown-header {
+    color: $navbar-light-color;
+  }
+
+  .dropdown-item {
+    color: $navbar-light-color;
+
+    @include hover-focus {
+      color: $navbar-light-active-color;
+    }
+
+    &.active {
+      color: $navbar-light-active-color;
+    }
+  }
+
+  .dropdown-divider {
+    border-color: $navbar-light-toggler-border-color;
+  }
 }
 
 // White links against a dark background
@@ -363,5 +355,25 @@
         color: $navbar-dark-active-color;
       }
     }
+  }
+
+  .dropdown-header {
+    color: $navbar-dark-color;
+  }
+
+  .dropdown-item {
+    color: $navbar-dark-color;
+
+    @include hover-focus {
+      color: $navbar-dark-active-color;
+    }
+
+    &.active {
+      color: $navbar-dark-active-color;
+    }
+  }
+
+  .dropdown-divider {
+    border-color: $navbar-dark-toggler-border-color;
   }
 }


### PR DESCRIPTION
I think we need some improvements on the `.navbar-expand .dropdown-menu` on mobile.
Imho it must feels like a submenu, not a dropdown like on desktop vieports.

### This is my proposal:

![after](https://user-images.githubusercontent.com/985838/34652991-4b58f6b2-f3ee-11e7-9896-423c5a5158b0.gif)

Later edit: and for desktop, with a contextual background:

![dropdown-bg](https://user-images.githubusercontent.com/985838/34874725-eb407daa-f7a2-11e7-99d1-e87881e1d005.gif)

### This was before:

![before](https://user-images.githubusercontent.com/985838/34652977-154d3b82-f3ee-11e7-992c-fbe7f0d9709d.gif)

You can also take a look at my [pen](https://codepen.io/zalog/full/dJZxWe).

Later edit: [pen v2](https://codepen.io/zalog/full/jYxYRJ)

What do you think?
  