### PR TITLE
Disabled nav link with pointer-events

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -226,6 +226,7 @@
 
       &.disabled {
         color: $navbar-light-disabled-color;
+        pointer-events: none;
       }
     }
 


### PR DESCRIPTION
**bootstrap/scss/_navbar.scss** is providing only **color** property for disabled nav links. When there is an href attribute, HTML keeps the tag inactive "as visual" but keeps it active and clickable "as functional".

```
  .navbar-nav {
    .nav-link {
      color: $navbar-light-color;

      @include hover-focus {
        color: $navbar-light-hover-color;
      }

      &.disabled {
        color: $navbar-light-disabled-color;
      }
    }
```

To make these lines more useful and meaningful, pointer-events property should also be added so the link with disabled class would really be inactive .

```
      &.disabled {
        color: $navbar-light-disabled-color;
        pointer-events: none;
      }
```