### PR TITLE
Fix link to constraint validation API

### DIFF
--- a/docs/4.0/components/forms.md
+++ b/docs/4.0/components/forms.md
@@ -711,7 +711,7 @@ Here's how form validation works with Bootstrap:
 - Bootstrap scopes the `:invalid` and `:valid` styles to parent `.was-validated` class, usually applied to the `<form>`. Otherwise, any required field without a value shows up as invalid on page load. This way, you may choose when to activate them (typically after form submission is attempted).
 - As a fallback, `.is-invalid` and `.is-valid` classes may be used instead of the pseudo-classes for [server side validation](#server-side). They do not require a `.was-validated` parent class.
 - Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.
-- All modern browsers support the [constraint validation API](https://www.w3.org/TR/html5/forms.html#the-constraint-validation-api), a series of JavaScript methods for validating form controls.
+- All modern browsers support the [constraint validation API](https://w3c.github.io/html/sec-forms.html#the-constraint-validation-api), a series of JavaScript methods for validating form controls.
 - Feedback messages may utilize the [browser defaults](#browser-defaults) (different for each browser, and unstylable via CSS) or our custom feedback styles with additional HTML and CSS.
 - You may provide custom validity messages with `setCustomValidity` in JavaScript.
 


### PR DESCRIPTION
I was reading your lovely docs and noticed [this link](https://www.w3.org/TR/html5/forms.html#the-constraint-validation-api) has died. It seems W3C moved their documentation; the new address is [here](https://w3c.github.io/html/sec-forms.html#the-constraint-validation-api).