### PR TITLE
Update browser compatibility note for position: sticky (Edge supports it now)

### DIFF
--- a/docs/4.0/utilities/position.md
+++ b/docs/4.0/utilities/position.md
@@ -38,7 +38,7 @@ Position an element at the bottom of the viewport, from edge to edge. Be sure yo
 
 Position an element at the top of the viewport, from edge to edge, but only after you scroll past it. The `.sticky-top` utility uses CSS's `position: sticky`, which isn't fully supported in all browsers.
 
-**IE11 and IE10 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that properly can render it.
+**IE11 and IE10 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that can render it properly.
 
 {% highlight html %}
 <div class="sticky-top">...</div>

--- a/docs/4.0/utilities/position.md
+++ b/docs/4.0/utilities/position.md
@@ -38,7 +38,7 @@ Position an element at the bottom of the viewport, from edge to edge. Be sure yo
 
 Position an element at the top of the viewport, from edge to edge, but only after you scroll past it. The `.sticky-top` utility uses CSS's `position: sticky`, which isn't fully supported in all browsers.
 
-**Microsoft Edge and IE11 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that properly can render it.
+**IE11 and IE10 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that properly can render it.
 
 {% highlight html %}
 <div class="sticky-top">...</div>


### PR DESCRIPTION
The latest shipping version of Edge supports position: sticky and I've successfully tested it with Bootstrap 4 and it works as intended. I added IE10 in place of Edge in that note as I assume that IE10 also has the `position: relative` fallback.
REF: https://caniuse.com/#search=sticky