### PR TITLE
Fix variable name in display utility class naming

### DIFF
--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -19,7 +19,7 @@ As such, the classes are named using the format:
 * `.d-{value}` for `xs`
 * `.d-{breakpoint}-{value}` for `sm`, `md`, `lg`, and `xl`.
 
-Where *display* is one of:
+Where *value* is one of:
 
 * `none`
 * `inline`


### PR DESCRIPTION
Current_ edition:

> As such, the classes are named using the format:
> 
>     .d-{value} for xs
>     .d-{breakpoint}-{value} for sm, md, lg, and xl.
> 
> Where **_display_** is one of:
> <...>