### PR TITLE
A better `.navbar` align and a small optimization

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -171,7 +171,7 @@
         }
 
         .navbar-collapse {
-          display: flex !important;  // stylelint-disable-line declaration-no-important
+          display: flex !important; // stylelint-disable-line declaration-no-important
 
           // Changes flex-bases to auto because of an IE10 bug
           flex-basis: auto;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -31,6 +31,8 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
+    padding-right: 0;
+    padding-left: 0;
   }
 }
 
@@ -143,14 +145,6 @@
     $infix: breakpoint-infix($next, $grid-breakpoints);
 
     &#{$infix} {
-      @include media-breakpoint-down($breakpoint) {
-        > .container,
-        > .container-fluid {
-          padding-right: 0;
-          padding-left: 0;
-        }
-      }
-
       @include media-breakpoint-up($next) {
         flex-flow: row nowrap;
         justify-content: flex-start;
@@ -172,6 +166,8 @@
         > .container,
         > .container-fluid {
           flex-wrap: nowrap;
+          padding-right: ($grid-gutter-width / 2);
+          padding-left: ($grid-gutter-width / 2);
         }
 
         .navbar-collapse {

--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -51,7 +51,7 @@
     }
     pre,
     blockquote {
-      border: $border-width solid $gray-500;   // Bootstrap custom code; using `$border-width` instead of 1px
+      border: $border-width solid $gray-500; // Bootstrap custom code; using `$border-width` instead of 1px
       page-break-inside: avoid;
     }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -715,7 +715,7 @@ $nav-divider-margin-y:              ($spacer / 2) !default;
 // Navbar
 
 $navbar-padding-y:                  ($spacer / 2) !default;
-$navbar-padding-x:                  $spacer !default;
+$navbar-padding-x:                  ($grid-gutter-width / 2) !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
 


### PR DESCRIPTION
On `.navbar`, I think we should use the same padding like on `.container`.
If we use a bigger `.$grid-gutter-width`, or smaller, the differences are visible.

### Commit 1

#### Before
Check [this pen](https://codepen.io/zalog/full/XVqMLX), or:

![before](https://user-images.githubusercontent.com/985838/34838210-f8b32e4e-f705-11e7-87e7-a794747ef6e3.png)


#### After
Check [this pen](https://codepen.io/zalog/full/baMedp), or:

![after](https://user-images.githubusercontent.com/985838/34838439-c3b17916-f706-11e7-801a-ea8e29a23340.png)

### Commit 2

A mobile first approach and with that, a small optimisation on the min css file. About 0.5kb :)

### Commit 3

The third commit, well I'm not sure, but I think it's about Star Trek :)