### PR TITLE
Outline button hover color

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -68,11 +68,7 @@ fieldset:disabled a.btn {
 
 @each $color, $value in $theme-colors {
   .btn-outline-#{$color} {
-    @if $color == "light" {
-      @include button-outline-variant($value, $gray-900);
-    } @else {
-      @include button-outline-variant($value, $white);
-    }
+    @include button-outline-variant($value);
   }
 }
 

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -54,14 +54,14 @@
   }
 }
 
-@mixin button-outline-variant($color, $color-hover: #fff, $active-background: $color, $active-border: $color) {
+@mixin button-outline-variant($color, $color-hover: color-yiq($color), $active-background: $color, $active-border: $color) {
   color: $color;
   background-color: transparent;
   background-image: none;
   border-color: $color;
 
   &:hover {
-    color: color-yiq($color);
+    color: $color-hover;
     background-color: $active-background;
     border-color: $active-border;
   }


### PR DESCRIPTION
Replaces #24754.

Pulled in the original commit from @agriffis and updated it with latest from `v4-dev`. After doing that, I had to update the usage of the mixin to remove a now unnecessary if/else block.