### PR TITLE
Remove note about Opera 12 not supporting CSS3 animations

### DIFF
--- a/docs/4.0/components/progress.md
+++ b/docs/4.0/components/progress.md
@@ -123,8 +123,6 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
 
 The striped gradient can also be animated. Add `.progress-bar-animated` to `.progress-bar` to animate the stripes right to left via CSS3 animations.
 
-**Animated progress bars don't work in Opera 12**—as they don't support CSS3 animations.
-
 <div class="bd-example">
   <div class="progress">
     <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div>


### PR DESCRIPTION
Removed '**Animated progress bars don't work in Opera 12**—as they don't support CSS3 animations.' note.

Bootstrap 4 doesn't (and doesn't need to) support the ancient Opera 12 released in 2012 with a 0.04% marketshare so no need to mention.