### PR TITLE
Fix rounded corners on custom file in input group

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -46,9 +46,9 @@
     align-items: center;
 
     &:not(:last-child) .custom-file-label,
-    &:not(:last-child) .custom-file-label::before { @include border-right-radius(0); }
+    &:not(:last-child) .custom-file-label::after { @include border-right-radius(0); }
     &:not(:first-child) .custom-file-label,
-    &:not(:first-child) .custom-file-label::before { @include border-left-radius(0); }
+    &:not(:first-child) .custom-file-label::after { @include border-left-radius(0); }
   }
 }
 


### PR DESCRIPTION
This will be the PR we use to cherry-pick commits to our CSS from #25352. So far it includes:

- Small change to fix `border-radius` on the Browse button for custom file input inside input groups.

Fixes #25513.