### PR TITLE
Pagination move `.page-link:focus` outline value to variable `$pagina…

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -23,7 +23,7 @@
 
   &:focus {
     z-index: 2;
-    outline: 0;
+    outline: $pagination-focus-outline;
     box-shadow: $pagination-focus-box-shadow;
   }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -633,6 +633,7 @@ $pagination-border-width:           $border-width !default;
 $pagination-border-color:           $gray-300 !default;
 
 $pagination-focus-box-shadow:       $input-btn-focus-box-shadow !default;
+$pagination-focus-outline:          0 !default;
 
 $pagination-hover-color:            $link-hover-color !default;
 $pagination-hover-bg:               $gray-200 !default;


### PR DESCRIPTION
…tion-focus-outline` so we can unset it via Sass and don't have to re-implement browser defaults

Previous to https://github.com/twbs/bootstrap/issues/24838, using `.page-link` with an anchor tag didn't apply a focus outline when clicked with mouse. This lets those that don't want the focus outline on click unset it via Sass.

Demo: http://getbootstrap.com/docs/4.0/components/pagination/