### PR TITLE
Sort ascending `$grid-breakpoints` and `$container-max-widths` maps

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -48,6 +48,57 @@
   @return $string;
 }
 
+// map-sort-by-values
+// Sorts a map ascending by values
+// Used for grid-breakpoints and container-max-widths sorting
+//
+// @param {Map} $map - Initial map
+// @return {Map} - Sorted map
+@function map-sort-by-values($map) {
+  // Transform map to zipped list
+  $keys: ();
+  $values: ();
+
+  @each $key, $val in $map {
+    $keys: append($keys, $key);
+    $values: append($values, $val);
+  }
+
+  $list: zip($keys, $values);
+
+  // Sort zipped list and create sorted map
+  $sortedMap: ();
+  @while length($list) > 0 {
+
+    // Find smallest pair
+    $smallestPair: nth($list, 1);
+    @each $pair in $list {
+      $value: nth($pair, 2);
+      $smallestValue: nth($smallestPair, 2);
+      @if $value < $smallestValue {
+        $smallestPair: $pair;
+      }
+    }
+
+    // Add smallest pair to sorted map
+    $key: nth($smallestPair, 1);
+    $value: nth($smallestPair, 2);
+    $sortedMap: map-merge($sortedMap, ($key: $value));
+
+    // Remove from list smallest pair
+    $newList: ();
+    $smallestPairIndex: index($list, $smallestPair);
+    @for $i from 1 through length($list) {
+      @if $i != $smallestPairIndex {
+        $newList: append($newList, nth($list, $i), "space");
+      }
+    }
+    $list: $newList;
+  }
+
+  @return $sortedMap;
+}
+
 // Color contrast
 @function color-yiq($color, $dark: $yiq-text-dark, $light: $yiq-text-light) {
   $r: red($color);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -197,6 +197,7 @@ $grid-breakpoints: map-merge(
   ),
   $grid-breakpoints
 );
+$grid-breakpoints: map-sort-by-values($grid-breakpoints);
 
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints);
@@ -217,6 +218,7 @@ $container-max-widths: map-merge(
   ),
   $container-max-widths
 );
+$container-max-widths: map-sort-by-values($container-max-widths);
 
 @include _assert-ascending($container-max-widths, "$container-max-widths");
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -197,6 +197,7 @@ $grid-breakpoints: map-merge(
   ),
   $grid-breakpoints
 );
+// stylelint-disable-next-line scss/dollar-variable-default
 $grid-breakpoints: map-sort-by-values($grid-breakpoints);
 
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
@@ -218,6 +219,7 @@ $container-max-widths: map-merge(
   ),
   $container-max-widths
 );
+// stylelint-disable-next-line scss/dollar-variable-default
 $container-max-widths: map-sort-by-values($container-max-widths);
 
 @include _assert-ascending($container-max-widths, "$container-max-widths");


### PR DESCRIPTION
~~Extend `$grid-breakpoints` and `$container-max-widths` maps, as `$theme-colors`~~ see #26714 

When extending `$grid-breakpoints` and `$container-max-widths` we must
be sure that they are sorted ascending, added a new function that sorts maps by their values.
Now `_assert-ascending` call it seems to be obsolete if we sort maps before that

If user extends mentioned vars after `variables` import
`map-sort-by-values` must be called again to be sure they are sorted