### PR TITLE
Dropdown. Skip element disabled via attribute when using keyboard navigation

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -57,7 +57,7 @@ const Dropdown = (($) => {
     FORM_CHILD    : '.dropdown form',
     MENU          : '.dropdown-menu',
     NAVBAR_NAV    : '.navbar-nav',
-    VISIBLE_ITEMS : '.dropdown-menu .dropdown-item:not(.disabled)'
+    VISIBLE_ITEMS : '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
   }
 
   const AttachmentMap = {

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -544,39 +544,6 @@ $(function () {
     $dropdown.trigger('click')
   })
 
-  QUnit.test('should skip disabled element when using keyboard navigation', function (assert) {
-    assert.expect(2)
-    var done = assert.async()
-    var dropdownHTML = '<div class="tabs">' +
-        '<div class="dropdown">' +
-        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
-        '<div class="dropdown-menu">' +
-        '<a class="dropdown-item disabled" href="#">Disabled link</a>' +
-        '<a class="dropdown-item" href="#">Another link</a>' +
-        '</div>' +
-        '</div>' +
-        '</div>'
-    var $dropdown = $(dropdownHTML)
-      .appendTo('#qunit-fixture')
-      .find('[data-toggle="dropdown"]')
-      .bootstrapDropdown()
-
-    $dropdown
-      .parent('.dropdown')
-      .on('shown.bs.dropdown', function () {
-        assert.ok(true, 'shown was fired')
-        $dropdown.trigger($.Event('keydown', {
-          which: 40
-        }))
-        $dropdown.trigger($.Event('keydown', {
-          which: 40
-        }))
-        assert.ok(!$(document.activeElement).is('.disabled'), '.disabled is not focused')
-        done()
-      })
-    $dropdown.trigger('click')
-  })
-
   QUnit.test('should focus next/previous element when using keyboard navigation', function (assert) {
     assert.expect(4)
     var done = assert.async()
@@ -612,6 +579,41 @@ $(function () {
           which: 38
         }))
         assert.ok($(document.activeElement).is($('#item1')), 'item1 is focused')
+        done()
+      })
+    $dropdown.trigger('click')
+  })
+
+  QUnit.test('should skip disabled element when using keyboard navigation', function (assert) {
+    assert.expect(3)
+    var done = assert.async()
+    var dropdownHTML = '<div class="tabs">' +
+        '<div class="dropdown">' +
+        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
+        '<div class="dropdown-menu">' +
+        '<a class="dropdown-item disabled" href="#">Disabled link</a>' +
+        '<button class="dropdown-item" type="button" disabled>Disabled button</button>' +
+        '<a id="item1" class="dropdown-item" href="#">Another link</a>' +
+        '</div>' +
+        '</div>' +
+        '</div>'
+    var $dropdown = $(dropdownHTML)
+      .appendTo('#qunit-fixture')
+      .find('[data-toggle="dropdown"]')
+      .bootstrapDropdown()
+
+    $dropdown
+      .parent('.dropdown')
+      .on('shown.bs.dropdown', function () {
+        assert.ok(true, 'shown was fired')
+        $dropdown.trigger($.Event('keydown', {
+          which: 40
+        }))
+        assert.ok($(document.activeElement).is($('#item1')), '#item1 is focused')
+        $dropdown.trigger($.Event('keydown', {
+          which: 40
+        }))
+        assert.ok($(document.activeElement).is($('#item1')), '#item1 is still focused')
         done()
       })
     $dropdown.trigger('click')


### PR DESCRIPTION
http://getbootstrap.com/docs/4.0/components/dropdowns/#menu-items
> Historically dropdown menu contents had to be links, but that’s no longer the case with v4. Now you can optionally use `<button>` elements in your dropdowns instead of just `<a>`s.