### PR TITLE
Removed menu item from navbar example

### DIFF
--- a/docs/examples/navbar/index.html
+++ b/docs/examples/navbar/index.html
@@ -50,7 +50,6 @@
           <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
               <li class="active"><a href="#">Home</a></li>
-              <li><a href="#">About</a></li>
               <li><a href="#">Contact</a></li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dropdown <span class="caret"></span></a>


### PR DESCRIPTION
The number/size of menu items in the navbar example was causing the navbar-right element to wrap on to two lines when the browser window width was 768px - 991px