### PR TITLE
Responsive table migration guide

### DIFF
--- a/docs/4.0/migration.md
+++ b/docs/4.0/migration.md
@@ -144,7 +144,6 @@ New to Bootstrap 4 is the [Reboot]({{ site.baseurl }}/docs/{{ site.docs_version 
 ### Tables
 
 - Nearly all instances of the `>` selector have been removed, meaning nested tables will now automatically inherit styles from their parents. This greatly simplifies our selectors and potential customizations.
-- Responsive tables no longer require a wrapping element. Instead, just put the `.table-responsive` right on the `<table>`.
 - Renamed `.table-condensed` to `.table-sm` for consistency.
 - Added a new `.table-inverse` option.
 - Added table header modifiers: `.thead-default` and `.thead-inverse`.


### PR DESCRIPTION
Clarify migration docs to remove mention of .table-responsive being for the parent element vs the table element itself.

Fixes #25509.