### PR TITLE
Brush up vertical rhythm of form-check in docs. Closes #25546

### DIFF
--- a/docs/4.0/components/forms.md
+++ b/docs/4.0/components/forms.md
@@ -25,7 +25,7 @@ Here's a quick example to demonstrate Bootstrap's form styles. Keep reading for 
     <label for="exampleInputPassword1">Password</label>
     <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
   </div>
-  <div class="form-check">
+  <div class="form-group form-check">
     <input type="checkbox" class="form-check-input" id="exampleCheck1">
     <label class="form-check-label" for="exampleCheck1">Check me out</label>
   </div>


### PR DESCRIPTION
This is a small PR.
It adds `form-group` to add the same vertical space to the `form-check` as in other grouped controls
used in form sample markup.

Please refer to #25546 for details.

Thanks!