### PR TITLE
use $input-bg for $custom-select-bg

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -483,7 +483,7 @@ $custom-select-indicator-padding:   1rem !default; // Extra padding to account f
 $custom-select-line-height:         $input-btn-line-height !default;
 $custom-select-color:               $input-color !default;
 $custom-select-disabled-color:      $gray-600 !default;
-$custom-select-bg:                  $white !default;
+$custom-select-bg:                  $input-bg !default;
 $custom-select-disabled-bg:         $gray-200 !default;
 $custom-select-bg-size:             8px 10px !default; // In pixels because image dimensions
 $custom-select-indicator-color:     $gray-800 !default;


### PR DESCRIPTION
* use `$input-bg` for `$custom-select-bg`
* fixes readability on dark themes like e.g. 'darkly'
  * https://bootswatch.com/darkly/index.html#forms
  * https://bootswatch.com/slate/index.html#forms
  * https://bootswatch.com/superhero/index.html#forms
  * https://bootswatch.com/solar/index.html#forms

/cc @thomaspark