### PR TITLE
set color to form-control-plaintext

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -121,6 +121,7 @@ select.form-control {
   padding-bottom: $input-padding-y;
   margin-bottom: 0; // match inputs if this class comes on inputs with default margins
   line-height: $input-line-height;
+  color: $input-plaintext-color;
   background-color: transparent;
   border: solid transparent;
   border-width: $input-border-width 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -414,6 +414,7 @@ $input-focus-width:                     $input-btn-focus-width !default;
 $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
 
 $input-placeholder-color:               $gray-600 !default;
+$input-plaintext-color:                 $body-color !default;
 
 $input-height-border:                   $input-border-width * 2 !default;
 


### PR DESCRIPTION
* set color to `.form-control-plaintext`
* add `$input-plaintext-color` default to `$body-color`
* fixes readability on dark themes like e.g. 'darkly'
  * https://bootswatch.com/darkly/index.html#forms
  * https://bootswatch.com/slate/index.html#forms
  * https://bootswatch.com/superhero/index.html#forms
  * https://bootswatch.com/solar/index.html#forms

/cc @thomaspark