### PR TITLE
Docs: Fix the incorrect id in the vertically centered modal snippet

### DIFF
--- a/docs/4.0/components/modal.md
+++ b/docs/4.0/components/modal.md
@@ -249,7 +249,7 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+        <h5 class="modal-title" id="exampleModalCenterTitle">Modal title</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>


### PR DESCRIPTION
Make it equal to the value of `aria-labelledby`.