### PR TITLE
Replace img-fluid by w-100 in Carousel docs to conform with HTML example

### DIFF
--- a/docs/4.0/components/carousel.md
+++ b/docs/4.0/components/carousel.md
@@ -24,7 +24,7 @@ Carousels don't automatically normalize slide dimensions. As such, you may need 
 
 ### Slides only
 
-Here's a carousel with slides only. Note the presence of the `.d-block` and `.img-fluid` on carousel images to prevent browser default image alignment.
+Here's a carousel with slides only. Note the presence of the `.d-block` and `.w-100` on carousel images to prevent browser default image alignment.
 
 {% example html %}
 <div id="carouselExampleSlidesOnly" class="carousel slide" data-ride="carousel">


### PR DESCRIPTION
Here is the documentation part concerned: https://getbootstrap.com/docs/4.0/components/carousel/#slides-only

Before this PR, there was a mismatch, in Carousel docs - "Slides only" section, between the introduction stating that img-fluid is present and the code example with w-100 instead.
So, we use w-100 to conform with the code example and to be consistent with this commit: https://github.com/twbs/bootstrap/pull/22392/commits/0857713a38444bf76bb1a51183aed8a0c26fe06f