### PR TITLE
Update list-group-flush top/bottom item border setting

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -125,13 +125,13 @@
     }
   }
 
-  &:first-child {
+  &:first-of-type {
     .list-group-item:first-child {
       border-top: 0;
     }
   }
 
-  &:last-child {
+  &:last-of-type {
     .list-group-item:last-child {
       margin-bottom: 0;
       border-bottom: 0;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -120,20 +120,15 @@
     border-left: 0;
     @include border-radius(0);
 
+    &:first-child {
+      border-top-width: 0;
+
+      .list-group-flush + & {
+        border-top-width: $list-group-border-width;
+      }
+    }
+
     &:last-child {
-      margin-bottom: -$list-group-border-width;
-    }
-  }
-
-  &:first-of-type {
-    .list-group-item:first-child {
-      border-top: 0;
-    }
-  }
-
-  &:last-of-type {
-    .list-group-item:last-child {
-      margin-bottom: 0;
       border-bottom: 0;
     }
   }


### PR DESCRIPTION
Change `*-child` to `*-of-type` selector.

This fixes an issue with appearing of top/bottom border of first/last item if flush list group is inside the content.

![list](https://user-images.githubusercontent.com/17578344/36482608-99fc982c-171c-11e8-8975-87e32deac598.PNG)
