### PR TITLE
Fix typo of example in hiding doc

### DIFF
--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -51,7 +51,7 @@ For faster mobile-friendly development, use responsive display classes for showi
 
 To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-none` classes for any responsive screen variation.
 
-To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none` will hide the element for all screen sizes except on medium and large devices.
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-block` will hide the element for all screen sizes except on medium and large devices.
 
 | Screen Size        | Class |
 | ---                | --- |


### PR DESCRIPTION
There was I think I small typo mistake in following sentence of the documentation `bootstrap/docs/4.0/utilities/display.md`

To show an element only on a given interval of screen sizes you can combine one .d-*-none class with a .d-*-* class, for example .d-none .d-md-block **.d-xl-none** will **hide** the element for all screen sizes **except** on medium and **large** devices.

Therefore I modified `.d-xl-none` to `.d-xl-block`