### PR TITLE
Fix one-by-one flush lists items borders

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -89,16 +89,16 @@
     border-right: 0;
     border-left: 0;
     @include border-radius(0);
-  }
 
-  &:first-child {
-    .list-group-item:first-child {
-      border-top: 0;
+    &:first-child {
+      border-top-width: 0;
+
+      .list-group-flush + & {
+        border-top-width: $list-group-border-width;
+      }
     }
-  }
 
-  &:last-child {
-    .list-group-item:last-child {
+    &:last-child {
       border-bottom: 0;
     }
   }


### PR DESCRIPTION
Here is a [pen](https://codepen.io/kvlsrg/pen/bLKzQw) with a problem.

Also this PR fixes issue with first/last item top/bottom border if list used with other content (closes #25678)