### PR TITLE
Add focus states to custom docs buttons

### DIFF
--- a/assets/scss/_buttons.scss
+++ b/assets/scss/_buttons.scss
@@ -13,6 +13,10 @@
     background-color: $bd-purple-bright;
     border-color: $bd-purple-bright;
   }
+
+  &:focus {
+    box-shadow: 0 0 0 3px rgba($bd-purple-bright, .25);
+  }
 }
 
 .btn-bd-download {
@@ -25,5 +29,9 @@
     color: $bd-dark;
     background-color: $bd-download;
     border-color: $bd-download;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 3px rgba($bd-download, .25);
   }
 }


### PR DESCRIPTION
The custom buttons for the docs don't have a focus state in the color of the button, this PR fixes this.

Before:
![image](https://user-images.githubusercontent.com/11559216/36630003-4e62fc5e-195f-11e8-9339-46284b3b1703.png)
![image](https://user-images.githubusercontent.com/11559216/36630007-59fd1dc4-195f-11e8-84fb-627c04afca5f.png)

After:
![image](https://user-images.githubusercontent.com/11559216/36630014-6aebbba4-195f-11e8-8a1a-a6a889e0cdda.png)
![image](https://user-images.githubusercontent.com/11559216/36630015-731dfb52-195f-11e8-82a4-43a1acda5e0f.png)

