### PR TITLE
Revert issue #25687 (Docs Display Hiding elements)

### DIFF
--- a/docs/4.0/utilities/display.md
+++ b/docs/4.0/utilities/display.md
@@ -51,7 +51,7 @@ For faster mobile-friendly development, use responsive display classes for showi
 
 To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl}-none` classes for any responsive screen variation.
 
-To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-block` will hide the element for all screen sizes except on medium and large devices.
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none` will hide the element for all screen sizes except on medium and large devices.
 
 | Screen Size        | Class |
 | ---                | --- |


### PR DESCRIPTION
Roll back of issue #25687 

docs/4.0/utilities/display.md
line 54, the example, now is:

To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example ~~`.d-none .d-md-block .d-xl-block`~~ will hide the element for all screen sizes except on medium and large devices. 
**but also except on extra large devices**

But has to be rolled back to:

To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example **`.d-none .d-md-block .d-xl-none`** will hide the element for all screen sizes except on medium and large devices.

It will be visible on medium (md) and large (lg) devices **and invisible on extra large (xl) devices**