### PR TITLE
Fixes examples issue #25684

### DIFF
--- a/docs/4.0/examples/dashboard/dashboard.css
+++ b/docs/4.0/examples/dashboard/dashboard.css
@@ -23,8 +23,7 @@ body {
 }
 
 .sidebar-sticky {
-  position: -webkit-sticky;
-  position: sticky;
+  position: relative;
   top: 48px; /* Height of navbar */
   height: calc(100vh - 48px);
   padding-top: .5rem;

--- a/scss/utilities/_position.scss
+++ b/scss/utilities/_position.scss
@@ -29,9 +29,10 @@ $positions: static, relative, absolute, fixed, sticky;
 }
 
 .sticky-top {
+  position: relative;
   @supports (position: sticky) {
     position: sticky;
-    top: 0;
-    z-index: $zindex-sticky;
   }
+  top: 0;
+  z-index: $zindex-sticky;
 }


### PR DESCRIPTION
Fix for [#25684](https://github.com/twbs/bootstrap/issues/25684)
For IE in _position.scss and remove overhead of using sticky
position in .sidebar-sticky for FireFox.