### PR TITLE
Added overflow hidden to resolve border radius conflicts

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -67,6 +67,7 @@
   background-color: $modal-content-bg;
   background-clip: padding-box;
   border: $modal-content-border-width solid $modal-content-border-color;
+  overflow: hidden;
   @include border-radius($border-radius-lg);
   @include box-shadow($modal-content-box-shadow-xs);
   // Remove focus outline from opened modal


### PR DESCRIPTION
# Issue

Modal by default does not include `overflow:hidden`. This can cause a conflict with the border radius on `modal-body` if any part of the modal background color is changed.

# Example

When `.modal-content` background is white, changing any other part of the modals background color such as Header or Footer it disabled the border radius, visually.

# Fix

Adding `overflow:hidden` to `.modal-content` does not create any conflicts with existing code but it does resolve instances when the modal header, footer, and body are not the same color.

# Screenshots

![screenshot 2018-02-27 10 29 18](https://user-images.githubusercontent.com/1872327/36737791-eb9accb2-1ba9-11e8-8a18-3090e6ef2695.png)
![screenshot 2018-02-27 10 28 59](https://user-images.githubusercontent.com/1872327/36737794-ebbf24e0-1ba9-11e8-87ec-77ce02e236b4.png)
![screenshot 2018-02-27 10 28 42](https://user-images.githubusercontent.com/1872327/36737796-ebcca516-1ba9-11e8-8d9f-b6ad839b9d5a.png)


