### PR TITLE
`.input-group-text` vars

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -96,11 +96,11 @@
   font-size: $font-size-base; // Match inputs
   font-weight: $font-weight-normal;
   line-height: $input-line-height;
-  color: $input-group-addon-color;
+  color: $input-group-text-color;
   text-align: center;
   white-space: nowrap;
-  background-color: $input-group-addon-bg;
-  border: $input-border-width solid $input-group-addon-border-color;
+  background-color: $input-group-text-bg;
+  border: $input-border-width solid $input-group-text-border-color;
   @include border-radius($input-border-radius);
 
   // Nuke default margins from checkboxes and radios to vertically center within.

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -443,9 +443,9 @@ $form-check-inline-input-margin-x:      .3125rem !default;
 
 $form-group-margin-bottom:              1rem !default;
 
-$input-group-addon-color:               $input-color !default;
-$input-group-addon-bg:                  $gray-200 !default;
-$input-group-addon-border-color:        $input-border-color !default;
+$input-group-text-color:                $input-color !default;
+$input-group-text-bg:                   $gray-200 !default;
+$input-group-text-border-color:         $input-border-color !default;
 
 $custom-control-gutter:                 1.5rem !default;
 $custom-control-spacer-x:               1rem !default;
@@ -535,7 +535,7 @@ $custom-file-border-color:          $input-border-color !default;
 $custom-file-border-radius:         $input-border-radius !default;
 $custom-file-box-shadow:            $input-box-shadow !default;
 $custom-file-button-color:          $custom-file-color !default;
-$custom-file-button-bg:             $input-group-addon-bg !default;
+$custom-file-button-bg:             $input-group-text-bg !default;
 $custom-file-text: (
   en: "Browse"
 ) !default;


### PR DESCRIPTION
The first commit renames `$input-group-addon-*` to `$input-group-text-*` to keep up with the new class `.input-group-text`.

The second commit it's just a simple aligning.

Later edit: I deleted the second commit.