### PR TITLE
fix(js): removes .modal .navbar-toggler margin

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -431,7 +431,6 @@ const Modal = (($) => {
         //   while $(DOMNode).css('padding-right') returns the calculated value or 0 if not set
         const fixedContent = [].slice.call(document.querySelectorAll(Selector.FIXED_CONTENT))
         const stickyContent = [].slice.call(document.querySelectorAll(Selector.STICKY_CONTENT))
-        const navbarToggler = [].slice.call(document.querySelectorAll(Selector.NAVBAR_TOGGLER))
 
         // Adjust fixed content padding
         $(fixedContent).each((index, element) => {
@@ -465,11 +464,8 @@ const Modal = (($) => {
       const fixedContent = [].slice.call(document.querySelectorAll(Selector.FIXED_CONTENT))
       $(fixedContent).each((index, element) => {
         const padding = $(element).data('padding-right')
-        if (typeof padding !== 'undefined') {
-          $(element)
-            .css('padding-right', padding)
-            .removeData('padding-right')
-        }
+        $(element).removeData('padding-right')
+        element.style.paddingRight = padding ? padding : ''
       })
 
       // Restore sticky content
@@ -483,9 +479,8 @@ const Modal = (($) => {
 
       // Restore body padding
       const padding = $(document.body).data('padding-right')
-      if (typeof padding !== 'undefined') {
-        $(document.body).css('padding-right', padding).removeData('padding-right')
-      }
+      $(document.body).removeData('padding-right')
+      document.body.style.paddingRight = padding ? padding : ''
     }
 
     _getScrollbarWidth() { // thx d.walsh

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -64,8 +64,7 @@ const Modal = (($) => {
     DATA_TOGGLE        : '[data-toggle="modal"]',
     DATA_DISMISS       : '[data-dismiss="modal"]',
     FIXED_CONTENT      : '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top',
-    STICKY_CONTENT     : '.sticky-top',
-    NAVBAR_TOGGLER     : '.navbar-toggler'
+    STICKY_CONTENT     : '.sticky-top'
   }
 
   /**
@@ -452,15 +451,6 @@ const Modal = (($) => {
             .css('margin-right', `${parseFloat(calculatedMargin) - this._scrollbarWidth}px`)
         })
 
-        // Adjust navbar-toggler margin
-        $(navbarToggler).each((index, element) => {
-          const actualMargin = element.style.marginRight
-          const calculatedMargin = $(element).css('margin-right')
-          $(element)
-            .data('margin-right', actualMargin)
-            .css('margin-right', `${parseFloat(calculatedMargin) + this._scrollbarWidth}px`)
-        })
-
         // Adjust body padding
         const actualPadding = document.body.style.paddingRight
         const calculatedPadding = $(document.body).css('padding-right')
@@ -482,8 +472,8 @@ const Modal = (($) => {
         }
       })
 
-      // Restore sticky content and navbar-toggler margin
-      const elements = [].slice.call(document.querySelectorAll(`${Selector.STICKY_CONTENT}, ${Selector.NAVBAR_TOGGLER}`))
+      // Restore sticky content
+      const elements = [].slice.call(document.querySelectorAll(`${Selector.STICKY_CONTENT}`))
       $(elements).each((index, element) => {
         const margin = $(element).data('margin-right')
         if (typeof margin !== 'undefined') {

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -521,48 +521,6 @@ $(function () {
       .bootstrapModal('show')
   })
 
-  QUnit.test('should adjust the inline margin of the navbar-toggler when opening and restore when closing', function (assert) {
-    assert.expect(2)
-    var done = assert.async()
-    var $element = $('<div class="navbar-toggler"></div>').appendTo('#qunit-fixture')
-    var originalMargin = $element.css('margin-right')
-
-    $('<div id="modal-test"/>')
-      .on('hidden.bs.modal', function () {
-        var currentMargin = $element.css('margin-right')
-        assert.strictEqual(currentMargin, originalMargin, 'navbar-toggler margin should be reset after closing')
-        $element.remove()
-        done()
-      })
-      .on('shown.bs.modal', function () {
-        var expectedMargin = parseFloat(originalMargin) + $(this).getScrollbarWidth() + 'px'
-        var currentMargin = $element.css('margin-right')
-        assert.strictEqual(currentMargin, expectedMargin, 'navbar-toggler margin should be adjusted while opening')
-        $(this).bootstrapModal('hide')
-      })
-      .bootstrapModal('show')
-  })
-
-  QUnit.test('should store the original margin of the navbar-toggler in data-margin-right before showing', function (assert) {
-    assert.expect(2)
-    var done = assert.async()
-    var $element = $('<div class="navbar-toggler"></div>').appendTo('#qunit-fixture')
-    var originalMargin = '0px'
-    $element.css('margin-right', originalMargin)
-
-    $('<div id="modal-test"/>')
-      .on('hidden.bs.modal', function () {
-        assert.strictEqual(typeof $element.data('margin-right'), 'undefined', 'data-margin-right should be cleared after closing')
-        $element.remove()
-        done()
-      })
-      .on('shown.bs.modal', function () {
-        assert.strictEqual($element.data('margin-right'), originalMargin, 'original navbar-toggler margin should be stored in data-margin-right')
-        $(this).bootstrapModal('hide')
-      })
-      .bootstrapModal('show')
-  })
-
   QUnit.test('should ignore values set via CSS when trying to restore body padding after closing', function (assert) {
     assert.expect(1)
     var done = assert.async()

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -21,7 +21,8 @@ $(function () {
         document.body.removeChild(scrollDiv)
         return scrollbarWidth
       }
-      // Simulate scrollbars in PhantomJS
+
+      // Simulate scrollbars
       $('html').css('padding-right', '16px')
     },
     beforeEach: function () {


### PR DESCRIPTION
The problem is that `.navbar-toggler` flips left when we open a bs modal dialog (gif or [pen](https://codepen.io/zalog/pen/LQqdJe) below).

I don't think we need to adjust `.navbar-toggler` in this case.
We'll always have a parent that manage to adjust the missing scroll width:

- in case of a `.fixed-*` we have padding-right on that
- in case of a no fixed navbar, we have padding-right on body

Here you have a [pen](https://codepen.io/zalog/pen/LQqdJe) and a demo:

![demo](https://user-images.githubusercontent.com/985838/36834990-5f2bfb6c-1d3d-11e8-8f17-87ef2a1da176.gif)

What do you think?