### PR TITLE
Fix leftover reference to v4.0.0-alpha.6

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -13,7 +13,7 @@ import Util from './util'
 
 /**
  * --------------------------------------------------------------------------
- * Bootstrap (v4.0.0-alpha.6): index.js
+ * Bootstrap (v4.0.0): index.js
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  * --------------------------------------------------------------------------
  */


### PR DESCRIPTION
Running `./build/change-version.js v4.0.0-alpha.6 v4.0.0` fixed this, so the version change script works fine. 

I'm presuming instead this change was just omitted from 35f80bb12e4e, and then wouldn't have been caught by subsequent runs of that script, since it only ever replaces the exact old version string specified.

I discarded `change-version.js`'s modifications to the dist files, since they'll be updated at the next dist commit (and I presume it's preferable to keep them in sync).