### PR TITLE
Add blockquote-reverse

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -112,6 +112,20 @@ mark,
 .blockquote {
   margin-bottom: $spacer;
   font-size: $blockquote-font-size;
+
+  &.blockquote-reverse {
+    text-align: right;
+
+    .blockquote-footer {
+      &::before {
+        content: none;
+      }
+
+      &::after {
+        content: "\00A0 \2014"; // nbsp, em dash
+      }
+    }
+  }
 }
 
 .blockquote-footer {


### PR DESCRIPTION
The migration docs say this exists, but it doesn't. This simply reverses the text alignment and tells the footer to put the em-dash after the content, not before.

Fixes #25669