### PR TITLE
Fix scrollspy test on firefox (v4 without jquery)

### DIFF
--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -556,7 +556,7 @@ $(function () {
     $scrollspy
       .bootstrapScrollspy({
         target: '#navigation',
-        offset: $scrollspy.position().top
+        offset: $scrollspy[0].offsetTop
       })
       .one('scroll', function () {
         assert.strictEqual($('.active').length, 1, '"active" class on only one element present')


### PR DESCRIPTION
Related to https://github.com/twbs/bootstrap/pull/23586#issuecomment-371472645
Seems that jQuery `position()` method calculates position including sub-pixels on firefox and returning floating point numbers as offsets, while native offsetTop property does not.
Maybe should we remove jQuery from our unit tests and add some compatibility tests using the jQuery interface?