### PR TITLE
#25658 More responsive card columns

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -259,13 +259,18 @@
   }
 
   @include media-breakpoint-up(sm) {
-    column-count: $card-columns-count;
+    column-count: $card-columns-sm-count;
     column-gap: $card-columns-gap;
 
     .card {
       display: inline-block; // Don't let them vertically span multiple columns
       width: 100%; // Don't let their width change
     }
+  }
+
+  @include media-breakpoint-up(md) {
+    column-count: $card-columns-md-count;
+    column-gap: $card-columns-gap;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -695,7 +695,8 @@ $card-img-overlay-padding:          1.25rem !default;
 $card-group-margin:                 ($grid-gutter-width / 2) !default;
 $card-deck-margin:                  $card-group-margin !default;
 
-$card-columns-count:                3 !default;
+$card-columns-md-count:                3 !default;
+$card-columns-sm-count:                2 !default;
 $card-columns-gap:                  1.25rem !default;
 $card-columns-margin:               $card-spacer-y !default;
 


### PR DESCRIPTION
Replace $columns-count with $columns-sm-count and $columns-md-count that responsively span cards in 2 and 3 columns respectively. 
Include media-breakpoint mixin for sm and md devices to use the new variables