### PR TITLE
#25842 Remove max-width from table class

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -4,7 +4,6 @@
 
 .table {
   width: 100%;
-  max-width: 100%;
   margin-bottom: $spacer;
   background-color: $table-bg; // Reset for nesting within parents with `background-color`.
 


### PR DESCRIPTION
max-width: 100% was causing issues on 
macOs safari
iOs safari

Removed max-width and tested for possible side-effects on:
os: macOs
browsers: Safari, Chrome, Opera, Firefox

and iPhoneX safari (on browserStack)

Fixes #25842