### PR TITLE
Render inline svg like img

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -275,6 +275,7 @@ img {
 }
 
 svg:not(:root) {
+  vertical-align: middle;
   overflow: hidden; // Hide the overflow in IE
 }
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -275,8 +275,8 @@ img {
 }
 
 svg:not(:root) {
-  vertical-align: middle;
   overflow: hidden; // Hide the overflow in IE
+  vertical-align: middle;
 }
 
 


### PR DESCRIPTION
This PR aligns `img` tags and inline `svg` tags equally. 

Codepen demo:
Before:
https://codepen.io/MartijnCuppens/pen/ZxpLRM?editors=1000

After:
https://codepen.io/MartijnCuppens/pen/RMGpKg?editors=1000
