### PR TITLE
throw error when coverage is under our thresholds

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -57,14 +57,13 @@ module.exports = (config) => {
     coverageIstanbulReporter: {
       dir: jsCoveragePath,
       reports: ['lcov', 'text-summary'],
-      fixWebpackSourcePaths: true,
       thresholds: {
-        emitWarning: true,
+        emitWarning: false,
         global: {
-          statements: 80,
-          lines: 80,
-          branches: 80,
-          functions: 80
+          statements: 89,
+          lines: 89,
+          branches: 83,
+          functions: 84
         }
       }
     }


### PR DESCRIPTION
Before that, we just had warnings, now it'll throw an error on Travis if our coverage is too low

/CC @XhmikosR @bardiharborow 