### PR TITLE
Correct children selector

### DIFF
--- a/docs/4.0/extend/approach.md
+++ b/docs/4.0/extend/approach.md
@@ -73,4 +73,4 @@ Specifically regarding custom CSS, utilities can help combat increasing file siz
 
 ## Flexible HTML
 
-While not always possible, we strive to avoid being overly dogmatic in our HTML requirements for components. Thus, we focus on single classes in our CSS selectors and try to avoid immediate children selectors (`~`). This gives you more flexibility in your implementation and helps keep our CSS simpler and less specific.
+While not always possible, we strive to avoid being overly dogmatic in our HTML requirements for components. Thus, we focus on single classes in our CSS selectors and try to avoid immediate children selectors (`>`). This gives you more flexibility in your implementation and helps keep our CSS simpler and less specific.


### PR DESCRIPTION
The [general sibling combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_selectors) was used instead of the [child combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_selectors).
