### PR TITLE
Fix Chrome's rendering of .card-columns

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -261,6 +261,8 @@
   @include media-breakpoint-up(sm) {
     column-count: $card-columns-count;
     column-gap: $card-columns-gap;
+    orphans: 1;
+    widows: 1;
 
     .card {
       display: inline-block; // Don't let them vertically span multiple columns


### PR DESCRIPTION
Uses orphans/widows trick from @fran-worley at https://github.com/twbs/bootstrap/issues/20925#issuecomment-333492739. Demo of the fix at https://codepen.io/emdeoh/pen/gezLEj.

Fixes #20925.