### PR TITLE
Deprecate .text-hide

### DIFF
--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -7,5 +7,5 @@
   background-color: transparent;
   border: 0;
 
-  @warn "The `text-hide()` mixin has been deprecated as of v4.1.0. It will be removed entirely in v5."
+  @warn "The `text-hide()` mixin has been deprecated as of v4.1.0. It will be removed entirely in v5.";
 }

--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -6,4 +6,6 @@
   text-shadow: none;
   background-color: transparent;
   border: 0;
+
+  @warn "The `text-hide()` mixin has been deprecated as of v4.1.0. It will be removed entirely in v5."
 }


### PR DESCRIPTION
Adds an `@warn` to the mixin. Not much else to do here since it's not documented. Closes #24890.