### PR TITLE
Tiny grammar and punctuation tweaks to a comment.

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -4,7 +4,7 @@
 //    the active slide is heading.
 // 2. .active.carousel-item is the current slide.
 // 3. .active.carousel-item-left and .active.carousel-item-right is the current
-//    slide in it's in-transition state. Only one of these occur at a time.
+//    slide in its in-transition state. Only one of these occurs at a time.
 // 4. .carousel-item-next.carousel-item-left and .carousel-item-prev.carousel-item-right
 //    is the upcoming slide in transition.
 


### PR DESCRIPTION
1. It's == "it is"

2. The subject of the sentence is "Only one" (not "these") so the verb must agree with it.

Feel free to do nothing with this change, use it, etc - I just saw this while reading through the code.