### PR TITLE
Print color fix dark tables and dark theads

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -112,11 +112,28 @@
         background-color: $white !important;
       }
     }
+
     .table-bordered {
       th,
       td {
         border: 1px solid $gray-300 !important;
       }
+    }
+
+    .table-dark {
+      color: inherit;
+
+      th,
+      td,
+      thead th,
+      tbody + tbody {
+        border-color: $table-border-color;
+      }
+    }
+
+    .table .thead-dark th {
+      color: inherit;
+      border-color: $table-border-color;
     }
 
     // Bootstrap specific changes end


### PR DESCRIPTION
Fixes #25453, alternative for #25557.

Print styles are kept in `_print.scss` in this PR.


Demo: https://codepen.io/MartijnCuppens/pen/pLZJva (emulate print styles in browser to see the effect)