### PR TITLE
Replace reboot monospace hack with system font stack issue #26228

### DIFF
--- a/scss/_code.scss
+++ b/scss/_code.scss
@@ -1,11 +1,3 @@
-// Inline and block code styles
-code,
-kbd,
-pre,
-samp {
-  font-family: $font-family-monospace;
-}
-
 // Inline code
 code {
   font-size: $code-font-size;

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -232,15 +232,13 @@ a:not([href]):not([tabindex]) {
 // Code
 //
 
-// stylelint-disable font-family-no-duplicate-names
 pre,
 code,
 kbd,
 samp {
-  font-family: monospace, monospace; // Correct the inheritance and scaling of font size in all browsers.
+  font-family: $font-family-monospace;
   font-size: 1em; // Correct the odd `em` font sizing in all browsers.
 }
-// stylelint-enable font-family-no-duplicate-names
 
 pre {
   // Remove browser default top margin


### PR DESCRIPTION
All test pass.  Spot check on my personal site seems to be fine.  Saves a whole 50 bytes minified, and 10 bytes compressed.  🔢 

I left the odd "font-size: 1em" since I'm unclear exactly what this does.  It's likely wrong (want rem) or un-necessarly or both, but this is enough change for this commit.

Comments welcome.

Fixes #26228 


