### PR TITLE
Remove `dialog` from the HTML5 shim style

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -42,7 +42,7 @@ html {
 
 // stylelint-disable selector-list-comma-newline-after
 // Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
-article, aside, dialog, figcaption, figure, footer, header, hgroup, main, nav, section {
+article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
   display: block;
 }
 // stylelint-enable selector-list-comma-newline-after


### PR DESCRIPTION
`<dialog>`, in browsers that support it, has user agent styles of `dialog { display:block; ...} dialog:not([open]) { display:none; }`
by forcing it to `display:block` in the shim, the dialog is shown even when closed. There's no clean way to shim this for non-supporting browsers,
but arguably these browsers would have further problems with pure `<dialog>` usage anyway, and it's up to authors to then use different elements/shims.

Closes https://github.com/twbs/bootstrap/issues/26264