### PR TITLE
Dropdowns `display` default value

### DIFF
--- a/docs/4.1/components/dropdowns.md
+++ b/docs/4.1/components/dropdowns.md
@@ -826,7 +826,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     <tr>
       <td>display</td>
       <td>string</td>
-      <td>dynamic | static</td>
+      <td>'dynamic'</td>
       <td>By default, we use Popper.js for dynamic positioning. Disable this with `static`.</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Display default value is "dynamic".
While `dynamic | static` are the valid values.

See: https://github.com/twbs/bootstrap/blob/5f546f570860c0a71da254546c059e6781b0f3b4/js/src/dropdown.js#L79.