### PR TITLE
fix `.modal-dialog-centered` on IE10/11

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -54,6 +54,13 @@
   display: flex;
   align-items: center;
   min-height: calc(100% - (#{$modal-dialog-margin} * 2));
+
+  // Ensure `modal-dialog-centered` extends the full height of the view (IE10/11)
+  &::before {
+    display: block; // IE10
+    height: calc(100vh - (#{$modal-dialog-margin} * 2));
+    content: "";
+  }
 }
 
 // Actual modal
@@ -153,6 +160,11 @@
 
   .modal-dialog-centered {
     min-height: calc(100% - (#{$modal-dialog-margin-y-sm-up} * 2));
+
+    &::before {
+      height: calc(100vh - (#{$modal-dialog-margin-y-sm-up} * 2));
+    }
+
   }
 
   .modal-content {


### PR DESCRIPTION
Fixes #25569