### PR TITLE
Add docs/3 and docs/4 pages that link to the correct version

### DIFF
--- a/docs/3/index.html
+++ b/docs/3/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Bootstrap · Content moved</title>
+    <link rel="canonical" href="https://getbootstrap.com/docs/3.3/">
+    <meta http-equiv="refresh" content="0; url=https://getbootstrap.com/docs/3.3/">
+    <meta name="robots" content="noindex">
+    <style>
+      html {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        width: 100vw;
+        height: 100vh;
+        text-align: center;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      h1 {
+        margin-top: 0;
+        margin-bottom: .5rem;
+      }
+      a {
+        color: #007bff;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Redirecting&hellip;</h1>
+    <a href="https://getbootstrap.com/docs/3.3/">Click here if you are not redirected</a>
+    <script>window.location="https://getbootstrap.com/docs/3.3/";</script>
+  </body>
+</html>

--- a/docs/4/index.html
+++ b/docs/4/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Bootstrap · Content moved</title>
+    <link rel="canonical" href="https://getbootstrap.com/docs/4.1/getting-started/introduction/">
+    <meta http-equiv="refresh" content="0; url=https://getbootstrap.com/docs/4.1/getting-started/introduction/">
+    <meta name="robots" content="noindex">
+    <style>
+      html {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        width: 100vw;
+        height: 100vh;
+        text-align: center;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      }
+      h1 {
+        margin-top: 0;
+        margin-bottom: .5rem;
+      }
+      a {
+        color: #007bff;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Redirecting&hellip;</h1>
+    <a href="https://getbootstrap.com/docs/4.1/getting-started/introduction/">Click here if you are not redirected</a>
+    <script>window.location="https://getbootstrap.com/docs/4.1/getting-started/introduction/";</script>
+  </body>
+</html>


### PR DESCRIPTION
This adds two more redirections that make it slightly easier to get to a page with just link editing (one wouldn’t need to remember that 3.3 and 4.1 are the latest versions in their respective branches).

(I hope I’m not the only person who would do link editing like this.)