### PR TITLE
fix issues with calc

### DIFF
--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -9,6 +9,7 @@ module.exports = (ctx) => ({
   plugins: {
     autoprefixer: {
       cascade: false
-    }
+    },
+    'postcss-calc': {}
   }
 })

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "nodemon": "^1.17.3",
     "npm-run-all": "^4.1.2",
     "popper.js": "^1.14.3",
+    "postcss-calc": "^6.0.1",
     "postcss-cli": "^5.0.0",
     "qunitjs": "^2.4.1",
     "rollup": "^0.58.0",


### PR DESCRIPTION
Fixes: #26206.

[postcss-calc](https://github.com/postcss/postcss-calc) uses [reduce-css-calc](https://github.com/MoOx/reduce-css-calc) to reduce CSS `calc()` function. This also removes zero-values thus fixes #26206.

This also seems to solve the issue of nested calc functions. (Fixes #25717)
