### PR TITLE
Inaccurate note about color utils

### DIFF
--- a/docs/4.1/utilities/colors.md
+++ b/docs/4.1/utilities/colors.md
@@ -19,7 +19,7 @@ toc: true
 {% endcapture %}
 {% include example.html content=example %}
 
-Contextual text classes also work well on anchors with the provided hover and focus states. **Note that the `.text-white` and `.text-muted` class has no link styling.**
+Contextual text classes also work well on anchors with the provided hover and focus states.
 
 {% capture example %}
 {% for color in site.data.theme-colors %}


### PR DESCRIPTION
The docs say:
 **Note that the `.text-white` and `.text-muted` class has no link styling.** 
but that isn't true, they still have link styling. Either the docs are wrong, or the functionality is wrong. If it's the docs, here is a PR. :)

Hovered over the muted link...
![image](https://user-images.githubusercontent.com/379314/38900187-621283f0-424f-11e8-9303-a676d82b5634.png)

Hovered over the white link...
![image](https://user-images.githubusercontent.com/379314/38900198-6ac33e2c-424f-11e8-98c5-e6ad204a8799.png)
