### PR TITLE
reboot: Make a:focus behave the same as a:hover

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -201,7 +201,7 @@ a {
   background-color: transparent; // Remove the gray background on active links in IE 10.
   -webkit-text-decoration-skip: objects; // Remove gaps in links underline in iOS 8+ and Safari 8+.
 
-  @include hover {
+  @include hover-focus {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }


### PR DESCRIPTION
It seems like we want to have keyboard focus affect basic links the same way that mouse hover does.

If this is on purpose, can we document this? The only thing I could find was about btn-link and that situation resulted in an underline being added for focus.