### PR TITLE
Simplify custom file inner height for generated browse button

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -286,7 +286,7 @@
     bottom: 0;
     z-index: 3;
     display: block;
-    height: calc(#{$custom-file-height} - #{$custom-file-border-width} * 2);
+    height: $custom-file-height-inner;
     padding: $custom-file-padding-y $custom-file-padding-x;
     line-height: $custom-file-line-height;
     color: $custom-file-button-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -526,6 +526,7 @@ $custom-range-thumb-focus-box-shadow: 0 0 0 1px $body-bg, $input-btn-focus-box-s
 $custom-range-thumb-active-bg:        lighten($component-active-bg, 35%) !default;
 
 $custom-file-height:                $input-height !default;
+$custom-file-height-inner:          $input-height-inner !default;
 $custom-file-focus-border-color:    $input-focus-border-color !default;
 $custom-file-focus-box-shadow:      $input-btn-focus-box-shadow !default;
 


### PR DESCRIPTION
Closes #25724 which had us doing more unnecessary math:

```diff
-  height: calc(calc(2.25rem + 2px) - 1px * 2);
+  height: calc(2.25rem + 2px - 1px * 2);
```

By instead extending the `$input-height-inner` variable:

```diff
-  height: calc(calc(2.25rem + 2px) - 1px * 2);
+  height: 2.25rem;
```

Fixes #25717.

/cc @MartijnCuppens 