### PR TITLE
Add responsive sizing classes

### DIFF
--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -2,9 +2,14 @@
 
 // Width and height
 
-@each $prop, $abbrev in (width: w, height: h) {
-  @each $size, $length in $sizes {
-    .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    @each $prop, $abbrev in (width: w, height: h) {
+      @each $size, $length in $sizes {
+        .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fix #26429 

Adds responsive sizing utility classes:

- `.w{-sm|-md|-lg|-xl}-{25|50|75|100|auto}`
- `.h{-sm|-md|-lg|-xl}-{25|50|75|100|auto}`