### PR TITLE
Fix double-transition bug

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -23,7 +23,6 @@
   display: none;
   align-items: center;
   width: 100%;
-  @include transition($carousel-transition);
   backface-visibility: hidden;
   perspective: 1000px;
 }
@@ -32,6 +31,7 @@
 .carousel-item-next,
 .carousel-item-prev {
   display: block;
+  @include transition($carousel-transition);
 }
 
 .carousel-item-next,


### PR DESCRIPTION
Fixes #26451

By applying the transition: CSS property only to classes that are
active during sliding, we avoid an unnecessary, non-zero-time
animation that although mostly invisible, does interfere with e.g.
z-index based parallax carousels (see
https://codepen.io/domq/pen/ZoJrQZ)