### PR TITLE
chore(node): use node 6 as it required in our package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 git:
   depth: 10
 node_js:
-  - "0.12"
+  - "6"
 before_install:
   # Remove ./node_modules/.bin from PATH so node-which doesn't replace Unix which and cause RVM to barf. See https://github.com/travis-ci/travis-ci/issues/5092
   - export PATH=$(python -c 'from sys import argv;from collections import OrderedDict as od;print(":".join(od((p,None) for p in argv[1].split(":") if p.startswith("/")).keys()))' "$PATH")


### PR DESCRIPTION
it does not fix all of our build issues on this v3 but it helps 😆 

fixed: https://travis-ci.org/twbs/bootstrap/jobs/375776929#L1668
new build issue: https://travis-ci.org/twbs/bootstrap/jobs/375780714#L1540

/CC @mdo, @XhmikosR 