### PR TITLE
Fixes inline labels with a custom select

### DIFF
--- a/docs/4.1/components/forms.md
+++ b/docs/4.1/components/forms.md
@@ -570,7 +570,7 @@ And of course [custom form controls](#custom-forms) are supported.
 <form>
   <div class="form-row align-items-center">
     <div class="col-auto my-1">
-      <label class="mr-sm-2" for="inlineFormCustomSelect">Preference</label>
+      <label class="mr-sm-2 sr-only" for="inlineFormCustomSelect">Preference</label>
       <select class="custom-select mr-sm-2" id="inlineFormCustomSelect">
         <option selected>Choose...</option>
         <option value="1">One</option>


### PR DESCRIPTION
Since the custom select has a `width: 100%` [here](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_custom-forms.scss#L166) the [custom select goes to a new line when there is a label](http://getbootstrap.com/docs/4.1/components/forms/#auto-sizing):

![screen shot 2018-05-28 at 9 15 55 am](https://user-images.githubusercontent.com/1832037/40614253-79798c54-6258-11e8-910a-5e4829db8f5b.png)

This PR adds a `sr-only` to the label to make it look like this:

![screen shot 2018-05-28 at 9 17 50 am](https://user-images.githubusercontent.com/1832037/40614275-a5ed8d44-6258-11e8-88df-d94cbfdd00f0.png)

This is not a fix to the problem, it's just fixing the docs. An author can use the label with the custom select if they use the `form-inline` class.