### PR TITLE
Adds additional wording to the Introduction JS section

### DIFF
--- a/docs/4.1/getting-started/introduction.md
+++ b/docs/4.1/getting-started/introduction.md
@@ -37,6 +37,8 @@ We use [jQuery's slim build](https://blog.jquery.com/2016/06/09/jquery-3-0-final
 
 Curious which components explicitly require jQuery, our JS, and Popper.js? Click the show components link below. If you're at all unsure about the general page structure, keep reading for an example page template.
 
+Our `bootstrap.bundle.js` and `bootstrap.bundle.min.js` include [Popper](https://popper.js.org/), but not [jQuery](https://jquery.com/). For more information about what's included in Bootstrap, please see our [contents]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/contents/#precompiled-bootstrap) section.
+
 <details>
 <summary class="text-primary mb-3">Show components requiring JavaScript</summary>
 {% capture markdown %}


### PR DESCRIPTION
- This PR adds additional docs wording to the Introduction section in the Bootstrap docs to make it clearer at a glance what the `bootstrap.bundle.js` contains.

Fixes #26679