### PR TITLE
Allows both OL and UL lists for tab buttons

### DIFF
--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -80,7 +80,7 @@ class Tab {
     const selector = Util.getSelectorFromElement(this._element)
 
     if (listElement) {
-      const itemSelector = listElement.nodeName === 'UL' ? Selector.ACTIVE_UL : Selector.ACTIVE
+      const itemSelector = listElement.nodeName === 'UL' || listElement.nodeName === 'OL' ? Selector.ACTIVE_UL : Selector.ACTIVE
       previous = $.makeArray($(listElement).find(itemSelector))
       previous = previous[previous.length - 1]
     }
@@ -141,7 +141,7 @@ class Tab {
   // Private
 
   _activate(element, container, callback) {
-    const activeElements = container && container.nodeName === 'UL'
+    const activeElements = container && (container.nodeName === 'UL' || container.nodeName === 'OL')
       ? $(container).find(Selector.ACTIVE_UL)
       : $(container).children(Selector.ACTIVE)
 

--- a/site/docs/4.1/components/navs.md
+++ b/site/docs/4.1/components/navs.md
@@ -35,7 +35,7 @@ The base `.nav` component does not include any `.active` state. The following ex
 {% endcapture %}
 {% include example.html content=example %}
 
-Classes are used throughout, so your markup can be super flexible. Use `<ul>`s like above, or roll your own with say a `<nav>` element. Because the `.nav` uses `display: flex`, the nav links behave the same as nav items would, but without the extra markup.
+Classes are used throughout, so your markup can be super flexible. Use `<ul>`s like above, `<ol>` if the order of your items is important, or roll your own with a `<nav>` element. Because the `.nav` uses `display: flex`, the nav links behave the same as nav items would, but without the extra markup.
 
 {% capture example %}
 <nav class="nav">


### PR DESCRIPTION
Modifies tab.js to allow OL as a parent element for the tab list items.

Duplicates UL-based visual tests to provide OL-based versions.

Adds check for "show" class to tabs unit tests.