### PR TITLE
Input group - fix margins

### DIFF
--- a/docs/4.1/components/input-group.md
+++ b/docs/4.1/components/input-group.md
@@ -25,6 +25,14 @@ Place one add-on or button on either side of an input. You may also place one on
   </div>
 </div>
 
+<div class="input-group mb-3">
+  <input type="text" class="form-control" aria-label="Min value" placeholder="Min value">
+  <div class="input-group-prepend">
+    <span class="input-group-text">to</span>
+  </div>
+  <input type="text" class="form-control" aria-label="Max value" placeholder="Max value">
+</div>
+
 <label for="basic-url">Your vanity URL</label>
 <div class="input-group mb-3">
   <div class="input-group-prepend">

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -78,8 +78,14 @@
   }
 }
 
-.input-group-prepend { margin-right: -$input-border-width; }
-.input-group-append { margin-left: -$input-border-width; }
+.input-group-prepend,
+.input-group-append:not(:last-child) {
+  margin-right: -$input-border-width;
+}
+.input-group-append,
+.input-group-prepend:not(:first-child) {
+  margin-left: -$input-border-width;
+}
 
 
 // Textual addons


### PR DESCRIPTION
Hi.
With the help of input-group i want to make something like this (perfect variant already fixed)
![joxi_screenshot_1528964290145](https://user-images.githubusercontent.com/2445241/41400812-ca94c0b0-6fc6-11e8-9d65-bb8673dbc194.png)
But there is a problem with double borders
![joxi_screenshot_1528963219807](https://user-images.githubusercontent.com/2445241/41400864-f0e8f63c-6fc6-11e8-99a0-525d7524ff21.png)
So i've fixed it, and now it looks like this - without double margins
![joxi_screenshot_1528965389632](https://user-images.githubusercontent.com/2445241/41400961-3886f5a2-6fc7-11e8-9c28-41fc3eefa845.png)
