### PR TITLE
Support nuget contentFiles, used for some project types

### DIFF
--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -25,5 +25,9 @@
     <file src="dist\css\*.*" target="content\Content" />
     <file src="dist\js\bootstrap*.js" target="content\Scripts" />
     <file src="dist\js\bootstrap*.js.map" target="content\Scripts" />
+
+    <file src="dist\css\*.*" target="contentFiles\Content" />
+    <file src="dist\js\bootstrap*.js" target="contentFiles\Scripts" />
+    <file src="dist\js\bootstrap*.js.map" target="contentFiles\Scripts" />
   </files>
 </package>

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -25,5 +25,9 @@
     <file src="scss\**\*.scss" target="content\Content\bootstrap" />
     <file src="dist\js\bootstrap*.js" target="content\Scripts" />
     <file src="dist\js\bootstrap*.js.map" target="content\Scripts" />
+
+    <file src="scss\**\*.scss" target="contentFiles\Content\bootstrap" />
+    <file src="dist\js\bootstrap*.js" target="contentFiles\Scripts" />
+    <file src="dist\js\bootstrap*.js.map" target="contentFiles\Scripts" />
   </files>
 </package>


### PR DESCRIPTION
I received the following message:

> Hello,
> 
> I am PM with the NuGet team and I have seen multiple users complaining about the package not working with new project system (i.e. with Packagereference). E.g: https://twitter.com/caycedo/status/1011991725378809856
> 
> It would really help if you could update the package to contain another folder 'contentFiles' with all the contents in the 'content' folder? This will solve a lot of customers' pain. Let me know if I can help in anyway.
> 
> Thanks, Anand Gaurav PM | NuGet
