### PR TITLE
Fix incorrect visibility utility description regarding screen readers

### DIFF
--- a/docs/4.1/utilities/visibility.md
+++ b/docs/4.1/utilities/visibility.md
@@ -5,7 +5,7 @@ description: Control the visibility, without modifying the display, of elements 
 group: utilities
 ---
 
-Set the `visibility` of elements with our visibility utilities. These do not modify the `display` value at all and are helpful for hiding content from most users, but still keeping them for screen readers.
+Set the `visibility` of elements with our visibility utilities. These utility classes do not modify the `display` value at all and do not affect layout – `.invisible` elements still take up space in the page. Content will be hidden both visually and for assistive technology/screen reader users.
 
 Apply `.visible` or `.invisible` as needed.
 


### PR DESCRIPTION
Somewhere in the transition from 3.x to 4.x an error creeped into the documentation for `.invisible`, falsely stating that `.invisible` content is still exposed to screen readers. This fixes the mistake, and just subtly expands the description to clarify that a change in visibility does not affect layout (things still occupy space, despite being invisible)
Closes #26734