### PR TITLE
Added display heading responsive class

### DIFF
--- a/docs/4.0/content/typography.md
+++ b/docs/4.0/content/typography.md
@@ -109,7 +109,7 @@ Use the included utility classes to recreate the small secondary heading text fr
 
 ## Display headings
 
-Traditional heading elements are designed to work best in the meat of your page content. When you need a heading to stand out, consider using a **display heading**—a larger, slightly more opinionated heading style.
+Traditional heading elements are designed to work best in the meat of your page content. When you need a heading to stand out, consider using a **display heading**—a larger, slightly more opinionated heading style
 
 <div class="bd-example bd-example-type">
   <table class="table">
@@ -135,6 +135,24 @@ Traditional heading elements are designed to work best in the meat of your page 
 <h1 class="display-2">Display 2</h1>
 <h1 class="display-3">Display 3</h1>
 <h1 class="display-4">Display 4</h1>
+{% endhighlight %}
+
+### Responsive Display
+
+Display headings doesn't shrink on small screens by default, but you can add `.display-responsive` class to your heading to automatically resize them in small screens.
+
+<div class="bd-example bd-example-type">
+  <table class="table">
+    <tbody>
+      <tr>
+        <td><span class="display-2 display-responsive">Large text for a display heading</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% highlight html %}
+<h2 class="display-2 display-responsive2">Display 2</h1>
 {% endhighlight %}
 
 ## Lead

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -26,27 +26,20 @@ h6, .h6 { font-size: $h6-font-size; }
 }
 
 // Type display classes
-.display-1 {
-  font-size: $display1-size;
-  font-weight: $display1-weight;
-  line-height: $display-line-height;
+@each $display-key, $display-value in $display-sizes {
+  .lol-display-#{$display-key} {
+    font-size: map_get($display-value, 'size');
+    font-weight: map_get($display-value, 'weight');
+      &.display-responsive {
+        @include media-breakpoint-down(sm) {
+          font-size: map_get($display-value, 'size')/1.3;
+        }
+        @include media-breakpoint-down(xs) {
+          font-size: map_get($display-value, 'size')/1.8;
+        }
+      }
+  }
 }
-.display-2 {
-  font-size: $display2-size;
-  font-weight: $display2-weight;
-  line-height: $display-line-height;
-}
-.display-3 {
-  font-size: $display3-size;
-  font-weight: $display3-weight;
-  line-height: $display-line-height;
-}
-.display-4 {
-  font-size: $display4-size;
-  font-weight: $display4-weight;
-  line-height: $display-line-height;
-}
-
 
 //
 // Horizontal rules

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -26,16 +26,16 @@ h6, .h6 { font-size: $h6-font-size; }
 }
 
 // Type display classes
-@each $display-key, $display-value in $display-sizes {
-  .lol-display-#{$display-key} {
+@each $display-key, $display-value in $display-texts {
+  .display-#{$display-key} {
     font-size: map_get($display-value, 'size');
     font-weight: map_get($display-value, 'weight');
       &.display-responsive {
         @include media-breakpoint-down(sm) {
-          font-size: map_get($display-value, 'size')/1.3;
+          font-size: map_get($display-value, 'size')/1.25;
         }
         @include media-breakpoint-down(xs) {
-          font-size: map_get($display-value, 'size')/1.8;
+          font-size: map_get($display-value, 'size')/1.75;
         }
       }
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -256,15 +256,13 @@ $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
 $headings-color:              inherit !default;
 
-$display1-size:               6rem !default;
-$display2-size:               5.5rem !default;
-$display3-size:               4.5rem !default;
-$display4-size:               3.5rem !default;
+$display-sizes: (
+  1: (size: 6rem, weight: 300),
+  2: (size: 5.5rem, weight: 300),
+  3: (size: 4.5rem, weight: 300),
+  4: (size: 3.5rem, weight: 300),
+) !default;
 
-$display1-weight:             300 !default;
-$display2-weight:             300 !default;
-$display3-weight:             300 !default;
-$display4-weight:             300 !default;
 $display-line-height:         $headings-line-height !default;
 
 $lead-font-size:              ($font-size-base * 1.25) !default;


### PR DESCRIPTION
This allows to user display headings that will automatically shrink it's size (if the user opts to) using `.display-responsive`. This will only work on small screens (xs, sm).