### PR TITLE
Remove .border-bottom & .border-top classes from examples

### DIFF
--- a/docs/4.1/examples/blog/blog.css
+++ b/docs/4.1/examples/blog/blog.css
@@ -68,9 +68,6 @@ h1, h2, h3, h4, h5, h6 {
   .h-md-250 { height: 250px; }
 }
 
-.border-top { border-top: 1px solid #e5e5e5; }
-.border-bottom { border-bottom: 1px solid #e5e5e5; }
-
 .box-shadow { box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05); }
 
 /*

--- a/docs/4.1/examples/checkout/form-validation.css
+++ b/docs/4.1/examples/checkout/form-validation.css
@@ -2,10 +2,6 @@
   max-width: 960px;
 }
 
-.border-top { border-top: 1px solid #e5e5e5; }
-.border-bottom { border-bottom: 1px solid #e5e5e5; }
-.border-top-gray { border-top-color: #adb5bd; }
-
 .box-shadow { box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05); }
 
 .lh-condensed { line-height: 1.25; }

--- a/docs/4.1/examples/dashboard/dashboard.css
+++ b/docs/4.1/examples/dashboard/dashboard.css
@@ -98,10 +98,3 @@ body {
   border-color: transparent;
   box-shadow: 0 0 0 3px rgba(255, 255, 255, .25);
 }
-
-/*
- * Utilities
- */
-
-.border-top { border-top: 1px solid #e5e5e5; }
-.border-bottom { border-bottom: 1px solid #e5e5e5; }

--- a/docs/4.1/examples/offcanvas/offcanvas.css
+++ b/docs/4.1/examples/offcanvas/offcanvas.css
@@ -70,8 +70,6 @@ body {
 
 .bg-purple { background-color: #6f42c1; }
 
-.border-bottom { border-bottom: 1px solid #e5e5e5; }
-
 .box-shadow { box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05); }
 
 .lh-100 { line-height: 1; }

--- a/docs/4.1/examples/pricing/pricing.css
+++ b/docs/4.1/examples/pricing/pricing.css
@@ -19,7 +19,4 @@ html {
   min-width: 220px;
 }
 
-.border-top { border-top: 1px solid #e5e5e5; }
-.border-bottom { border-bottom: 1px solid #e5e5e5; }
-
 .box-shadow { box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05); }

--- a/docs/4.1/examples/product/product.css
+++ b/docs/4.1/examples/product/product.css
@@ -60,9 +60,6 @@
  * Extra utilities
  */
 
-.border-top { border-top: 1px solid #e5e5e5; }
-.border-bottom { border-bottom: 1px solid #e5e5e5; }
-
 .box-shadow { box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05); }
 
 .flex-equal > * {


### PR DESCRIPTION
There are `.border-top` and `.border-bottom` utility classes in the examples css, but these utility classes are overwritten by bootstraps utility classes. This PR removes these classes. 

`.border-top-gray` class is also removed, this class is never used in the html.