### PR TITLE
Form control heights

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -161,6 +161,10 @@ select.form-control {
     height: auto;
   }
 }
+
+textarea.form-control {
+  height: auto;
+}
 // stylelint-enable no-duplicate-selectors
 
 // Form groups

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -7,6 +7,7 @@
 .form-control {
   display: block;
   width: 100%;
+  height: $input-height;
   padding: $input-padding-y $input-padding-x;
   font-size: $font-size-base;
   line-height: $input-line-height;
@@ -57,10 +58,6 @@
 }
 
 select.form-control {
-  &:not([size]):not([multiple]) {
-    height: $input-height;
-  }
-
   &:focus::-ms-value {
     // Suppress the nested default white text on blue background highlight given to
     // the selected option text when the (still closed) <select> receives focus
@@ -139,35 +136,32 @@ select.form-control {
 // Build on `.form-control` with modifier classes to decrease or increase the
 // height and font-size of form controls.
 //
-// The `.form-group-* form-control` variations are sadly duplicated to avoid the
-// issue documented in https://github.com/twbs/bootstrap/issues/15074.
+// Repeated in `_input_group.scss` to avoid Sass extend issues.
 
 .form-control-sm {
+  height: $input-height-sm;
   padding: $input-padding-y-sm $input-padding-x-sm;
   font-size: $font-size-sm;
   line-height: $input-line-height-sm;
   @include border-radius($input-border-radius-sm);
 }
 
-select.form-control-sm {
-  &:not([size]):not([multiple]) {
-    height: $input-height-sm;
-  }
-}
-
 .form-control-lg {
+  height: $input-height-lg;
   padding: $input-padding-y-lg $input-padding-x-lg;
   font-size: $font-size-lg;
   line-height: $input-line-height-lg;
   @include border-radius($input-border-radius-lg);
 }
 
-select.form-control-lg {
-  &:not([size]):not([multiple]) {
-    height: $input-height-lg;
+// stylelint-disable no-duplicate-selectors
+select.form-control {
+  &[size],
+  &[multiple] {
+    height: auto;
   }
 }
-
+// stylelint-enable no-duplicate-selectors
 
 // Form groups
 //

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -122,7 +122,11 @@
 .input-group-lg > .input-group-append > .input-group-text,
 .input-group-lg > .input-group-prepend > .btn,
 .input-group-lg > .input-group-append > .btn {
-  @extend .form-control-lg;
+  height: $input-height-lg;
+  padding: $input-padding-y-lg $input-padding-x-lg;
+  font-size: $font-size-lg;
+  line-height: $input-line-height-lg;
+  @include border-radius($input-border-radius-lg);
 }
 
 .input-group-sm > .form-control,
@@ -130,7 +134,11 @@
 .input-group-sm > .input-group-append > .input-group-text,
 .input-group-sm > .input-group-prepend > .btn,
 .input-group-sm > .input-group-append > .btn {
-  @extend .form-control-sm;
+  height: $input-height-sm;
+  padding: $input-padding-y-sm $input-padding-x-sm;
+  font-size: $font-size-sm;
+  line-height: $input-line-height-sm;
+  @include border-radius($input-border-radius-sm);
 }
 
 


### PR DESCRIPTION
Somehow I missed that #18842 and #18843 were still open. In my testing of the macOS Mojave beta, Safari has fixed their issue with the sizing, but Chrome still has the issue. It also apparently is a bug marked as won't fix. Thus, the only sensible solution to consistent `.form-control` heights across all supported input `type`s in a single browser is to specify `height`s. I've been resisting this thinking it'd be resolved by browsers, but that's no longer the case.

Here's what's changed:

- Applies the already present `$input-height` to `.form-control`.
- Consolidates the `<select>` `size` and `multiple` overrides into just the `.form-control` base class instead of `-sm`/`-lg` modifiers.
- Removes the Sass `@extend`s from input groups since it picks up too many selectors, namely our `<select>` overrides.

[Seen this demo of the changed CSS and inputs/selects.](https://codepen.io/anon/pen/yEmvEb)

[Related test JS Bin example.](http://jsbin.com/kayim/5/edit?html,css,output)

Closes #18843, fixes #18842, fixes #25923, fixes #26648, and fixes #26209.