### PR TITLE
Docs: add missing `role="button"` in navbar dropdown example

### DIFF
--- a/docs/4.1/components/navbar.md
+++ b/docs/4.1/components/navbar.md
@@ -185,7 +185,7 @@ You may also utilize dropdowns in your navbar nav. Dropdown menus require a wrap
         <a class="nav-link" href="#">Pricing</a>
       </li>
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Dropdown link
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">


### PR DESCRIPTION
Closes https://github.com/twbs/bootstrap/issues/26830