### PR TITLE
Carousel indicators transition

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -192,7 +192,7 @@
     cursor: pointer;
     background-color: $carousel-indicator-active-bg;
     opacity: .5;
-    transition: $carousel-indicator-transition;
+    @include transition($carousel-indicator-transition);
 
     // Use pseudo classes to increase the hit area by 10px on top and bottom.
     &::before {

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -190,7 +190,9 @@
     margin-left: $carousel-indicator-spacer;
     text-indent: -999px;
     cursor: pointer;
-    background-color: rgba($carousel-indicator-active-bg, .5);
+    background-color: $carousel-indicator-active-bg;
+    opacity: .5;
+    transition: $carousel-indicator-transition;
 
     // Use pseudo classes to increase the hit area by 10px on top and bottom.
     &::before {
@@ -214,7 +216,7 @@
   }
 
   .active {
-    background-color: $carousel-indicator-active-bg;
+    opacity: 1;
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -913,6 +913,7 @@ $carousel-indicator-width:          30px !default;
 $carousel-indicator-height:         3px !default;
 $carousel-indicator-spacer:         3px !default;
 $carousel-indicator-active-bg:      $white !default;
+$carousel-indicator-transition:     opacity .6s ease !default;
 
 $carousel-caption-width:            70% !default;
 $carousel-caption-color:            $white !default;


### PR DESCRIPTION
Closes #26901

- Added a `$carousel-indicator-transition` variable
- Used `opacity` to prevent repaints while transitioning
- Used the transition mixin

Demo: https://codepen.io/MartijnCuppens/pen/ajNXZj