### PR TITLE
Fix custom file input z-index

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -35,6 +35,11 @@
     z-index: 3;
   }
 
+  // Bring the custom file input above the label
+  > .custom-file .custom-file-input:focus {
+    z-index: 4;
+  }
+
   > .form-control,
   > .custom-select {
     &:not(:last-child) { @include border-right-radius(0); }


### PR DESCRIPTION
Fixes #26912.

**What happend?**
Box-shadow of custom file inputs are added to the label instead of the input itself. The z-index of the label was increased to overlap buttons (see #26361), but the z-index of the custom file input didn't increase. Therefore the label was clicked and this focuses the file input, but didn't trigger the file browser.

**The fix**
I've increased the z-index of the custom file input so that the file input works again.

Demo: https://codepen.io/MartijnCuppens/pen/qyaZzv

Tested in latest Chrome/Firefox/IE/Edge/Safari

Kudos to @ysds for adding the ticket number in his commit, this made it a lot easier to find out what was wrong