### PR TITLE
Example Cover: Update index.html

### DIFF
--- a/site/docs/4.1/examples/cover/index.html
+++ b/site/docs/4.1/examples/cover/index.html
@@ -18,7 +18,7 @@
 
   <body class="text-center">
 
-    <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
+    <div class="cover-container d-flex p-3 mx-auto flex-column">
       <header class="masthead mb-auto">
         <div class="inner">
           <h3 class="masthead-brand">Cover</h3>


### PR DESCRIPTION
Sizing classes seem to be redundant on .cover-container using flexbox.
Also, it allows the use of "min-height: 100vh" in cover.css (line 29) to extend content vertically without braking the layout.