### PR TITLE
Example Cover: Update cover.css - allow extended content

### DIFF
--- a/site/docs/4.1/examples/cover/cover.css
+++ b/site/docs/4.1/examples/cover/cover.css
@@ -26,7 +26,7 @@ a:hover {
 
 html,
 body {
-  height: 100%;
+  min-height: 100vh;
   background-color: #333;
 }
 


### PR DESCRIPTION
This change must go along with removing width and height classes (w-100 h-100) from wrapper div.container on index.html (line 21).
It allows longer content to fit seamlessly inside MAIN element, stretching body shadow accordingly.
I know this example is for building "simple and beautiful home pages", but it might be useful to have them longer.