### PR TITLE
Use Iconic github page instead of site

### DIFF
--- a/site/docs/4.1/extend/icons.md
+++ b/site/docs/4.1/extend/icons.md
@@ -12,7 +12,7 @@ Bootstrap doesn't include an icon library by default, but we have a handful of r
 We've tested and used these icon sets ourselves.
 
 - [Font Awesome](https://fontawesome.com/)
-- [Iconic](https://useiconic.com/open/)
+- [Iconic](https://github.com/iconic/open-iconic)
 - [Octicons](https://octicons.github.com/)
 
 ## More options


### PR DESCRIPTION
The SSL certificate of the useiconic.com is expired since July 2, 2018 (https://github.com/iconic/open-iconic/issues/40). We link to this site in the icons docs page (https://getbootstrap.com/docs/4.1/extend/icons/). Maybe it's safer to link to the github project page?
