### PR TITLE
package.json: be more explicit with the files we include.

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,9 +146,9 @@
     "node": ">=6"
   },
   "files": [
-    "dist/",
-    "js/{src,dist}/",
-    "scss/"
+    "dist/{css,js}/*.{css,js,map}",
+    "js/{src,dist}/*.{js,map}",
+    "scss/**/*.scss"
   ],
   "bundlesize": [
     {


### PR DESCRIPTION
I noticed that the v4.1.3 npm tar had `.DS_Store` files in it; this should fix it.