### PR TITLE
Move hand cursor for buttons to reboot

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -34,11 +34,6 @@
     @include box-shadow(none);
   }
 
-  // Opinionated: add "hand" cursor to non-disabled .btn elements
-  &:not(:disabled):not(.disabled) {
-    cursor: pointer;
-  }
-
   &:not(:disabled):not(.disabled):active,
   &:not(:disabled):not(.disabled).active {
     @include box-shadow($btn-active-box-shadow);

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -17,9 +17,6 @@
     @include hover-focus {
       opacity: .75;
     }
-
-    // Opinionated: add "hand" cursor to non-disabled .close elements
-    cursor: pointer;
   }
 }
 

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -116,11 +116,6 @@
   @include hover-focus {
     text-decoration: none;
   }
-
-  // Opinionated: add "hand" cursor to non-disabled .navbar-toggler elements
-  &:not(:disabled):not(.disabled) {
-    cursor: pointer;
-  }
 }
 
 // Keep as a separate element so folks can easily override it with another icon

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -27,11 +27,6 @@
     outline: $pagination-focus-outline;
     box-shadow: $pagination-focus-box-shadow;
   }
-
-  // Opinionated: add "hand" cursor to non-disabled .page-link elements
-  &:not(:disabled):not(.disabled) {
-    cursor: pointer;
-  }
 }
 
 .page-item {

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -341,6 +341,18 @@ button,
   -webkit-appearance: button; // 2
 }
 
+// Opinionated: add "hand" cursor to non-disabled button elements.
+@if $enable-pointer-cursor-for-buttons {
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"] {
+    &:not(:disabled) {
+      cursor: pointer;
+    }
+  }
+}
+
 // Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
 button::-moz-focus-inner,
 [type="button"]::-moz-focus-inner,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -114,6 +114,7 @@ $enable-transitions:                          true !default;
 $enable-prefers-reduced-motion-media-query:   true !default;
 $enable-hover-media-query:                    false !default; // Deprecated, no longer affects any compiled CSS
 $enable-grid-classes:                         true !default;
+$enable-pointer-cursor-for-buttons:           true !default;
 $enable-print-styles:                         true !default;
 $enable-validation-icons:                     true !default;
 

--- a/site/docs/4.2/assets/scss/_clipboard-js.scss
+++ b/site/docs/4.2/assets/scss/_clipboard-js.scss
@@ -25,7 +25,6 @@
   padding: .25rem .5rem;
   font-size: 75%;
   color: #818a91;
-  cursor: pointer;
   background-color: transparent;
   border: 0;
   @include border-radius;

--- a/site/docs/4.2/content/reboot.md
+++ b/site/docs/4.2/content/reboot.md
@@ -206,6 +206,7 @@ Various form elements have been rebooted for simpler base styles. Here are some 
 - `<label>`s are set to `display: inline-block` to allow `margin` to be applied.
 - `<input>`s, `<select>`s, `<textarea>`s, and `<button>`s are mostly addressed by Normalize, but Reboot removes their `margin` and sets `line-height: inherit`, too.
 - `<textarea>`s are modified to only be resizable vertically as horizontal resizing often "breaks" page layout.
+- `<button>`s and `<input>` button elements have `cursor: pointer` when `:not(:disabled)`.
 
 These changes, and more, are demonstrated below.
 

--- a/site/docs/4.2/content/reboot.md
+++ b/site/docs/4.2/content/reboot.md
@@ -280,12 +280,14 @@ These changes, and more, are demonstrated below.
     <p>
       <button type="submit">Button submit</button>
       <input type="submit" value="Input submit button">
+      <input type="reset" value="Input reset button">
       <input type="button" value="Input button">
     </p>
 
     <p>
       <button type="submit" disabled>Button submit</button>
       <input type="submit" value="Input submit button" disabled>
+      <input type="reset" value="Input reset button" disabled>
       <input type="button" value="Input button" disabled>
     </p>
   </fieldset>

--- a/site/docs/4.2/getting-started/theming.md
+++ b/site/docs/4.2/getting-started/theming.md
@@ -229,19 +229,20 @@ Customize Bootstrap 4 with our built-in custom variables file and easily toggle 
 
 You can find and customize these variables for key global options in Bootstrap's `scss/_variables.scss` file.
 
-| Variable                    | Values                             | Description                                                                            |
-| --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- |
-| `$spacer`                   | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [spacer utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/). |
-| `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components. |
-| `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components. |
-| `$enable-gradients`         | `true` or `false` (default)        | Enables predefined gradients via `background-image` styles on various components. |
-| `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components. |
-| `$enable-prefers-reduced-motion-media-query`       | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/accessibility/#reduced-motion), which suppresses certain animations/transitions based on the users' browser/operating system preferences. |
-| `$enable-hover-media-query` | `true` or `false` (default)        | **Deprecated** |
-| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g., `.container`, `.row`, `.col-md-1`, etc.). |
-| `$enable-caret`             | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`. |
-| `$enable-print-styles`      | `true` (default) or `false`        | Enables styles for optimizing printing. |
-| `$enable-validation-icons`  | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
+| Variable                                     | Values                             | Description                                                                            |
+| -------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------- |
+| `$spacer`                                    | `1rem` (default), or any value > 0 | Specifies the default spacer value to programmatically generate our [spacer utilities]({{ site.baseurl }}/docs/{{ site.docs_version }}/utilities/spacing/). |
+| `$enable-rounded`                            | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components. |
+| `$enable-shadows`                            | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components. |
+| `$enable-gradients`                          | `true` or `false` (default)        | Enables predefined gradients via `background-image` styles on various components. |
+| `$enable-transitions`                        | `true` (default) or `false`        | Enables predefined `transition`s on various components. |
+| `$enable-prefers-reduced-motion-media-query` | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/accessibility/#reduced-motion), which suppresses certain animations/transitions based on the users' browser/operating system preferences. |
+| `$enable-hover-media-query`                  | `true` or `false` (default)        | **Deprecated** |
+| `$enable-grid-classes`                       | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g., `.container`, `.row`, `.col-md-1`, etc.). |
+| `$enable-caret`                              | `true` (default) or `false`        | Enables pseudo element caret on `.dropdown-toggle`. |
+| `$enable-pointer-cursor-for-buttons`         | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |
+| `$enable-print-styles`                       | `true` (default) or `false`        | Enables styles for optimizing printing. |
+| `$enable-validation-icons`                   | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
 
 ## Color
 


### PR DESCRIPTION
Fixes #26998, fixes #22693

- This PR adds a hand cursor for all buttons
- Adds `$enable-hand-cursor-for-buttons` variable which allows developers to still use the default cursor for all buttons.
- Adds a reset button example to the [reboot page](http://getbootstrap.com/docs/4.1/content/reboot/#forms)
- Moved all the separated declarations to `scss/_reboot.scss`.

Closes #25598