### PR TITLE
Side modals

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -63,6 +63,58 @@
   }
 }
 
+.modal-dialog-left-side {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+  min-height: 100%;
+  // stylelint-disable-next-line declaration-no-important
+  margin: 0 !important;
+
+  .modal-content {
+    // IE fix:
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      min-height: 100vh;
+    }
+    border-width: 0;
+    border-radius: 0;
+  }
+
+  .modal.fade & {
+    transform: translate(-$modal-side-animation-offset, 0);
+  }
+}
+
+.modal-dialog-right-side {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  width: 100%;
+  min-height: 100%;
+  // stylelint-disable-next-line declaration-no-important
+  margin: 0 !important;
+
+  .modal-content {
+    // IE fix:
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      min-height: 100vh;
+    }
+    border-width: 0;
+    border-radius: 0;
+  }
+
+  .modal.fade & {
+    transform: translate($modal-side-animation-offset, 0);
+  }
+}
+
+.modal.show .modal-dialog {
+  transform: translate(0, 0);
+}
+
 // Actual modal
 .modal-content {
   position: relative;
@@ -124,7 +176,7 @@
   position: relative;
   // Enable `flex-grow: 1` so that the body take up as much space as possible
   // when should there be a fixed height on `.modal-dialog`.
-  flex: 1 1 auto;
+  flex: 1 0 auto;
   padding: $modal-inner-padding;
 }
 
@@ -164,6 +216,18 @@
 
     &::before {
       height: calc(100vh - (#{$modal-dialog-margin-y-sm-up} * 2));
+    }
+  }
+
+  .modal-dialog-left-side {
+    .modal-content {
+      border-width: 0 $modal-content-border-width 0 0;
+    }
+  }
+
+  .modal-dialog-right-side {
+    .modal-content {
+      border-width: 0 0 0 $modal-content-border-width;
     }
   }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -894,6 +894,7 @@ $modal-sm:                          300px !default;
 
 $modal-fade-transform:              translate(0, -50px) !default;
 $modal-show-transform:              none !default;
+$modal-side-animation-offset:       100px !default;
 $modal-transition:                  transform .3s ease-out !default;
 
 

--- a/site/docs/4.1/components/modal.md
+++ b/site/docs/4.1/components/modal.md
@@ -605,6 +605,158 @@ Our default modal without modifier class constitutes the "medium" size modal.
   </div>
 </div>
 
+## Side modals
+
+Modals can also be positioned to the side of the page. Therefore the modifier classes `.modal-dialog-left-side` or `.modal-dialog-right-side` can be placed on a `.modal-dialog`. These side modals are compatible with the sizes classes.
+
+<div class="bd-example">
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-left-side">Left side modal</button>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-right-side">Right side modal</button>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-left-side-sm">Small left side modal</button>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-right-side-lg">Large right side modal</button>
+</div>
+
+{% highlight html %}
+<!-- Left side modal -->
+<button class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-left-side">Left side modal</button>
+
+<div class="modal fade bd-example-modal-left-side" tabindex="-1" role="dialog" aria-labelledby="myLeftSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-left-side">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+
+<!-- Right side modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-right-side">Right side modal</button>
+
+<div class="modal fade bd-example-modal-right-side" tabindex="-1" role="dialog" aria-labelledby="myRightSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-right-side">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+
+<!-- Small left side modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-left-side-sm">Small left side modal</button>
+
+<div class="modal fade bd-example-modal-left-side-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallLeftSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-left-side modal-sm">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+
+<!-- Large right side modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-right-side-lg">Large right side modal</button>
+
+<div class="modal fade bd-example-modal-right-side-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeRightSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-right-side modal-lg">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+{% endhighlight %}
+
+<div class="modal fade bd-example-modal-left-side" tabindex="-1" role="dialog" aria-labelledby="myLeftSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-left-side">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <h5 class="modal-title h4" id="myLeftSideModalLabel">Left side modal</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>
+          Modal footers are pushed to the bottom of side modals.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade bd-example-modal-right-side" tabindex="-1" role="dialog" aria-labelledby="myRightSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-right-side">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <h5 class="modal-title h4" id="myRightSideModalLabel">Right side modal</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade bd-example-modal-left-side-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallLeftSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-left-side modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title h4" id="mySmallLeftSideModalLabel">Small modal</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>
+          This is an example of a small modal on the left side.
+        </p>
+
+        <p>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Vestibulum id ligula porta felis euismod semper. Nullam quis risus eget urna mollis ornare vel eu leo. Cras mattis consectetur purus sit amet fermentum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+        </p>
+
+        <p>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec sed odio dui. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean lacinia bibendum nulla sed consectetur.
+        </p>
+
+        <p>
+        Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nullam quis risus eget urna mollis ornare vel eu leo. Donec id elit non mi porta gravida at eget metus. Curabitur blandit tempus porttitor. Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+        </p>
+
+        <p>
+        Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Donec id elit non mi porta gravida at eget metus. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis.
+        </p>
+
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade bd-example-modal-right-side-lg" tabindex="-1" role="dialog" aria-labelledby="myLargeRightSideModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-right-side modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title h4" id="myLargeRightSideModalLabel">Large right side modal</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Usage
 
 The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.


### PR DESCRIPTION
Closes #27033, closes #24718

Implementation "drawer modals". 

I used this hack to make sure the `.modal-footer` sticks to the bottom in IE. I wrapped this in a media query to prevent strange behaviour on mobile browsers (see screenshot here https://css-tricks.com/the-trick-to-viewport-units-on-mobile/#post-274409)
```css
// IE fix:
@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
  min-height: 100vh;
}
```

Side modals can be positioned on the left and right side of the screen and are compatible with the sizing classes.