### PR TITLE
fix(util): use querySelector for ids

### DIFF
--- a/js/src/util.js
+++ b/js/src/util.js
@@ -84,7 +84,7 @@ const Util = (($) => {
       }
 
       const validSelector = selector
-      if (selector.charAt(0) === '#') {
+      if (selector.charAt(0) === '#' && selector.indexOf(',') === -1) {
         selector = selector.substr(1)
         method = 'getElementById'
       }

--- a/js/tests/unit/util.js
+++ b/js/tests/unit/util.js
@@ -32,6 +32,19 @@ $(function () {
     assert.ok(spy.called)
   })
 
+  QUnit.test('Util.getSelectorFromElement should use querySelector when there are multi ids', function (assert) {
+    assert.expect(2)
+
+    var spy = sinon.spy(document, 'querySelector')
+
+    var $el = $('<div data-target="#j7, #j8"></div>').appendTo($('#qunit-fixture'))
+    $('<div id="j7" />').appendTo($('#qunit-fixture'))
+    $('<div id="j8" />').appendTo($('#qunit-fixture'))
+
+    assert.strictEqual(Util.getSelectorFromElement($el[0]), '#j7, #j8')
+    assert.ok(spy.called)
+  })
+
   QUnit.test('Util.typeCheckConfig should thrown an error when a bad config is passed', function (assert) {
     assert.expect(1)
     var namePlugin = 'collapse'


### PR DESCRIPTION
We should not use `getElementById` for selectors with multi ids

/CC @XhmikosR 