### PR TITLE
Use `mr` utility class throughout media object docs

### DIFF
--- a/site/docs/4.1/layout/media-object.md
+++ b/site/docs/4.1/layout/media-object.md
@@ -44,7 +44,7 @@ Media objects can be infinitely nested, though we suggest you stop at some point
     Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
 
     <div class="media mt-3">
-      <a class="pr-3" href="#">
+      <a class="mr-3" href="#">
         <img data-src="holder.js/64x64" alt="Generic placeholder image">
       </a>
       <div class="media-body">


### PR DESCRIPTION
The "Nesting" example of media objects in the 4.1 docs uses `pr-3` in the nested media object, whilst other examples use `mr-3` in the same circumstances.

Either `pr-3` or `mr-3` will work, but I think the docs should be consistent to avoid confusing future readers who might think the padding utility class is necessary when nesting. It will also help developers who are copy-pasting their code from the docs.

This change therefore switches to use the margin utility class, making the media object examples consistent.