### PR TITLE
Add breadbrumb in docs search results

### DIFF
--- a/site/docs/4.1/assets/scss/_algolia.scss
+++ b/site/docs/4.1/assets/scss/_algolia.scss
@@ -66,10 +66,23 @@
     text-align: left !important;
   }
 
+  .algolia-docsearch-suggestion--subcategory-inline {
+    display: block !important;
+    font-size: .875rem;
+    color: $gray-700;
+
+    &::after {
+      padding: 0 .25rem;
+      content: "/";
+    }
+  }
+
   .algolia-docsearch-suggestion--content {
+    display: flex;
+    flex-wrap: wrap;
     float: none !important;
     width: 100% !important;
-    padding: 0 !important;
+    padding: .25rem 1rem !important;
 
     // Vertical divider between column header and content
     &::before {
@@ -93,18 +106,19 @@
 
   .algolia-docsearch-suggestion--title {
     display: block;
-    padding: .25rem 1rem !important;
     margin-bottom: 0 !important;
     font-size: .875rem !important;
     font-weight: 400 !important;
   }
 
   .algolia-docsearch-suggestion--text {
-    padding: 0 1rem .5rem !important;
-    margin-top: -.25rem;
-    font-size: .875rem !important;
+    flex: 0 0 100%;
+    max-width: 100%;
+    padding: .2rem 0;
+    font-size: .8125rem !important;
     font-weight: 400;
     line-height: 1.25 !important;
+    color: $gray-600;
   }
 
   .algolia-docsearch-footer {


### PR DESCRIPTION
Make the subcategory visable and theme it like a breadcrumb. Made some screenshots which makes it easier to compare.

### List
See original issue (#23389), it was not clear from where the list pages came from.

**List before:**
<img src="https://user-images.githubusercontent.com/11559216/44423822-68125500-a587-11e8-9e54-97433a3dfefd.png" width="330" />

**List after:**
<img src="https://user-images.githubusercontent.com/11559216/44423197-bb83a380-a585-11e8-8502-217d6df9b632.png" width="330" />

### Left
This is just an example how it is displayed if the highlighted text is in the text and not in the title

**Left before:**
<img src="https://user-images.githubusercontent.com/11559216/44423262-f685d700-a585-11e8-8545-24ed2542bdd9.png" width="330" />

**Left after:**
<img src="https://user-images.githubusercontent.com/11559216/44423321-20d79480-a586-11e8-84d9-b9109240ba0f.png" width="330" />

### Alert
Without breadcrumb it was not clear why some results showed up. 

**Alert before:**
<img src="https://user-images.githubusercontent.com/11559216/44423413-5aa89b00-a586-11e8-9a8c-3dd0d00091a3.png" width="330" />

**Alert after:**
<img src="https://user-images.githubusercontent.com/11559216/44423456-701dc500-a586-11e8-9299-dd18cc1e4292.png" width="330" />

Closes #23389


