### PR TITLE
Improve spacing class inheritance

### DIFF
--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -9,65 +9,106 @@
     @each $prop, $abbrev in (margin: m, padding: p) {
       @each $size, $length in $spacers {
         .#{$abbrev}#{$infix}-#{$size} { #{$prop}: $length !important; }
-        .#{$abbrev}t#{$infix}-#{$size},
+      }
+    }
+    @each $size, $length in $spacers {
+      @if $size != 0 {
+        .m#{$infix}-n#{$size} { margin: -$length !important; }
+      }
+    }
+    .m#{$infix}-auto { margin: auto !important; }
+
+  }
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @each $prop, $abbrev in (margin: m, padding: p) {
+      @each $size, $length in $spacers {
         .#{$abbrev}y#{$infix}-#{$size} {
           #{$prop}-top: $length !important;
-        }
-        .#{$abbrev}r#{$infix}-#{$size},
-        .#{$abbrev}x#{$infix}-#{$size} {
-          #{$prop}-right: $length !important;
-        }
-        .#{$abbrev}b#{$infix}-#{$size},
-        .#{$abbrev}y#{$infix}-#{$size} {
           #{$prop}-bottom: $length !important;
         }
-        .#{$abbrev}l#{$infix}-#{$size},
         .#{$abbrev}x#{$infix}-#{$size} {
+          #{$prop}-right: $length !important;
           #{$prop}-left: $length !important;
         }
       }
     }
-
-    // Negative margins (e.g., where `.mb-n1` is negative version of `.mb-1`)
     @each $size, $length in $spacers {
       @if $size != 0 {
-        .m#{$infix}-n#{$size} { margin: -$length !important; }
-        .mt#{$infix}-n#{$size},
         .my#{$infix}-n#{$size} {
           margin-top: -$length !important;
-        }
-        .mr#{$infix}-n#{$size},
-        .mx#{$infix}-n#{$size} {
-          margin-right: -$length !important;
-        }
-        .mb#{$infix}-n#{$size},
-        .my#{$infix}-n#{$size} {
           margin-bottom: -$length !important;
         }
-        .ml#{$infix}-n#{$size},
         .mx#{$infix}-n#{$size} {
+          margin-right: -$length !important;
           margin-left: -$length !important;
         }
       }
     }
-
-    // Some special margin utils
-    .m#{$infix}-auto { margin: auto !important; }
-    .mt#{$infix}-auto,
     .my#{$infix}-auto {
       margin-top: auto !important;
-    }
-    .mr#{$infix}-auto,
-    .mx#{$infix}-auto {
-      margin-right: auto !important;
-    }
-    .mb#{$infix}-auto,
-    .my#{$infix}-auto {
       margin-bottom: auto !important;
     }
-    .ml#{$infix}-auto,
     .mx#{$infix}-auto {
+      margin-right: auto !important;
       margin-left: auto !important;
     }
+
+  }
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    @each $prop, $abbrev in (margin: m, padding: p) {
+      @each $size, $length in $spacers {
+        .#{$abbrev}t#{$infix}-#{$size} {
+          #{$prop}-top: $length !important;
+        }
+        .#{$abbrev}r#{$infix}-#{$size} {
+          #{$prop}-right: $length !important;
+        }
+        .#{$abbrev}b#{$infix}-#{$size} {
+          #{$prop}-bottom: $length !important;
+        }
+        .#{$abbrev}l#{$infix}-#{$size} {
+          #{$prop}-left: $length !important;
+        }
+      }
+    }
+    @each $size, $length in $spacers {
+      @if $size != 0 {
+        .mt#{$infix}-n#{$size} {
+          margin-top: -$length !important;
+        }
+        .mr#{$infix}-n#{$size} {
+          margin-right: -$length !important;
+        }
+        .mb#{$infix}-n#{$size} {
+          margin-bottom: -$length !important;
+        }
+        .ml#{$infix}-n#{$size} {
+          margin-left: -$length !important;
+        }
+      }
+    }
+    .mt#{$infix}-auto {
+      margin-top: auto !important;
+    }
+    .mr#{$infix}-auto {
+      margin-right: auto !important;
+    }
+    .mb#{$infix}-auto {
+      margin-bottom: auto !important;
+    }
+    .ml#{$infix}-auto {
+      margin-left: auto !important;
+    }
+
   }
 }


### PR DESCRIPTION
More specific spacing classes should be applied instead of those with broader range.

E.g. if you have:

```
<div class="m-md-1 mb-0"></div>
```

the bottom margin class will be overwrited by the all margins one in md viewport. The changed code fixes this.