### PR TITLE
Change .figure display

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -28,7 +28,8 @@
 
 .figure {
   // Ensures the caption's text aligns with the image.
-  display: inline-block;
+  // Allows the figure margin to be set to auto.
+  display: table;
 }
 
 .figure-img {


### PR DESCRIPTION
Setting the display of the figure to 'table' will allow auto margin to be applied:

```
<figure class="figure mx-auto p-3 bg-light">
...
</figure>
```

![image](https://user-images.githubusercontent.com/10347771/44512531-91d09680-a6c3-11e8-9d61-0f3d37bfb218.png)
