### PR TITLE
Add browser-specific appearance styles to .custom-select

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -178,6 +178,8 @@
     border-radius: 0;
   }
   @include box-shadow($custom-select-box-shadow);
+  -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
 
   &:focus {


### PR DESCRIPTION
scss/_custom-forms.scss is lacking the browser-specific versions "webkit" and "moz" of the appearance style for .custom-select. When I do an import of "~bootstrap/scss/bootstrap", the <select> menu shows up with the native dropdown button (e.g., using Mozilla Firefox). When I do an import of "~bootstrap/dist/css/bootstrap.min.css" instead, all looks fine (without the native dropdown button).