### PR TITLE
Move hovered badge's text-decoration CSS to base styles

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -14,6 +14,12 @@
   vertical-align: baseline;
   @include border-radius($badge-border-radius);
 
+  &[href] {
+    @include hover-focus {
+      text-decoration: none;
+    }
+  }
+
   // Empty badges collapse automatically
   &:empty {
     display: none;

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -5,7 +5,6 @@
   &[href] {
     @include hover-focus {
       color: color-yiq($bg);
-      text-decoration: none;
       background-color: darken($bg, 10%);
     }
   }


### PR DESCRIPTION
Each color does not need to have the text-decoration CSS. It should be defined in the base styles.

This change greatly expands color flexibility:

![image](https://user-images.githubusercontent.com/4065765/44832180-bc42c680-ac64-11e8-962f-cfdff2875783.png)

```html
<a href="#" class="badge text-white bg-primary">Primary</a>
<a href="#" class="badge text-primary bg-transprent border border-primary">Outlined</a>
<a href="#" class="badge text-white" style="background-color: #1dcaff">Twitter</a>
<a href="#" class="badge text-white" style="background-color: #3b5998">Facebook</a>
<a href="#" class="badge text-white" style="background-color: #563d7c">Bootstrap</a>
<a href="#" class="badge text-white" style="background-color: #563D7C">css</a>
<a href="#" class="badge text-body" style="background-color: #FFC40D">js</a>
```

Demo: https://codepen.io/anon/pen/bxBBZa

Related: #23886, #27136 and the comment in the [v5 ideas](https://github.com/twbs/bootstrap/projects/11):
> Improve components by removing all their most commonly overridden properties, thus relying more on utilities.  ...
