### PR TITLE
Update _grid.scss

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -21,6 +21,9 @@
 }
 
 @mixin make-row() {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   flex-wrap: wrap;
   margin-right: ($grid-gutter-width / -2);
@@ -33,11 +36,14 @@
   // always setting `width: 100%;`. This works because we use `flex` values
   // later on to override this initial width.
   width: 100%;
+  min-height: 1px; // Prevent collapsing
   padding-right: ($grid-gutter-width / 2);
   padding-left: ($grid-gutter-width / 2);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
+  -webkit-flex: 0 0 percentage($size / $columns);
+  -ms-flex: 0 0 percentage($size / $columns);
   flex: 0 0 percentage($size / $columns);
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari


### PR DESCRIPTION
Added vendor prefixes due to issues with flex not rendering on iOS 6 on Chrome or Safari. Tested on physical iOS on Chrome and Safari, and on Browserstack through multiple versions and can confirm my additions to this file rectify this. Examples below:

With prefixes - https://i.imgur.com/lfuQZ2Q.png
Without prefixes - https://i.imgur.com/VBDzwVn.png