### PR TITLE
Update _buttons.scss

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -58,7 +58,7 @@
   color: $color;
   border-color: $color;
 
-  &:hover {
+  @include hover {
     color: $color-hover;
     background-color: $active-background;
     border-color: $active-border;


### PR DESCRIPTION
I'm trying to deal with the iOS Safari issue with leaving sticky hover on various elements like buttons. I was overriding the hover (and hover-focus) mixins to utilize my own methods, but ran into an issue because the hover mixin is not used on the button-outline-variant mixin.

This PR corrects this issue.