### PR TITLE
Selector improvement linked badge

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -14,7 +14,7 @@
   vertical-align: baseline;
   @include border-radius($badge-border-radius);
 
-  &[href] {
+  @at-root a#{&} {
     @include hover-focus {
       text-decoration: none;
     }

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -2,7 +2,7 @@
   color: color-yiq($bg);
   background-color: $bg;
 
-  &[href] {
+  @at-root a#{&} {
     @include hover-focus {
       color: color-yiq($bg);
       background-color: darken($bg, 10%);


### PR DESCRIPTION
Selector improvement, isolated from PR #27136

`a.badge` instead of `.badge[href]`