### PR TITLE
Cleanup .btn-link hover/focus properties

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -82,19 +82,15 @@ fieldset:disabled a.btn {
 .btn-link {
   font-weight: $font-weight-normal;
   color: $link-color;
-  background-color: transparent;
 
   @include hover {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
-    background-color: transparent;
-    border-color: transparent;
   }
 
   &:focus,
   &.focus {
     text-decoration: $link-hover-decoration;
-    border-color: transparent;
     box-shadow: none;
   }
 


### PR DESCRIPTION
The `background-color` and `border-color` properties of `.btn-link` are redundant. This PR removes them. 

Closes https://github.com/twbs/bootstrap/issues/27220