### PR TITLE
Add overflow-auto and overflow-hidden utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -6,6 +6,7 @@
 @import "utilities/embed";
 @import "utilities/flex";
 @import "utilities/float";
+@import "utilities/overflow";
 @import "utilities/position";
 @import "utilities/screenreaders";
 @import "utilities/shadows";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -991,6 +991,12 @@ $pre-color:                         $gray-900 !default;
 $pre-scrollable-max-height:         340px !default;
 
 
+// Utilities
+
+$overflows: auto, hidden !default;
+$positions: static, relative, absolute, fixed, sticky !default;
+
+
 // Printing
 
 $print-page-size:                   a3 !default;

--- a/scss/utilities/_overflow.scss
+++ b/scss/utilities/_overflow.scss
@@ -1,0 +1,5 @@
+// stylelint-disable declaration-no-important
+
+@each $value in $overflows {
+  .overflow-#{$value} { overflow: $value !important; }
+}

--- a/scss/utilities/_position.scss
+++ b/scss/utilities/_position.scss
@@ -1,11 +1,6 @@
 // stylelint-disable declaration-no-important
 
 // Common values
-
-// Sass list not in variables since it's not intended for customization.
-// stylelint-disable-next-line scss/dollar-variable-default
-$positions: static, relative, absolute, fixed, sticky;
-
 @each $position in $positions {
   .position-#{$position} { position: $position !important; }
 }

--- a/site/_data/nav.yml
+++ b/site/_data/nav.yml
@@ -62,6 +62,7 @@
     - title: Flex
     - title: Float
     - title: Image replacement
+    - title: Overflow
     - title: Position
     - title: Screenreaders
     - title: Shadows

--- a/site/docs/4.1/utilities/overflow.md
+++ b/site/docs/4.1/utilities/overflow.md
@@ -1,0 +1,25 @@
+---
+layout: docs
+title: Overflow
+description: Use these shorthand utilities for quickly configuring how content overflows an element.
+group: utilities
+toc: true
+---
+
+Barebones `overflow` functionality is provided for two values by default, and they are not responsive.
+
+<div class="bd-example d-md-flex">
+  <div class="overflow-auto p-3 mb-3 mb-md-0 mr-md-3 bg-light" style="max-width: 260px; max-height: 100px;">
+    This is an example of using <code>.overflow-auto</code> on an element with set width and height dimensions. By design, this content will vertically scroll.
+  </div>
+  <div class="overflow-hidden p-3 bg-light" style="max-width: 260px; max-height: 100px;">
+    This is an example of using <code>.overflow-hidden</code> on an element with set width and height dimensions.
+  </div>
+</div>
+
+{% highlight html %}
+<div class="overflow-auto">...</div>
+<div class="overflow-hidden">...</div>
+{% endhighlight %}
+
+Using Sass variables, you may customize the overflow utilities by changing the `$overflows` variable in `_variables.scss`.


### PR DESCRIPTION
New PR that replaces #26509 because the fork was deleted. This doesn't carbon-copy that PR's changes though. Instead, I've opted for two utilities to start—`.overflow-auto` and `.overflow-hidden`. No responsiveness, no `x`/`y` variants, and not every option. This PR also adds documentation which was missing from previous efforts.

I've also moved the `$positions` Sass list to the `_variables.scss` file alongside the new `$overflows` list. Folks can then customize both easily enough and gain more options.

Fixes #26479.