### PR TITLE
Fix Edge bounce and restore original transition easing

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -23,55 +23,32 @@
   position: relative;
   width: 100%;
   overflow: hidden;
+  @include clearfix();
 }
 
 .carousel-item {
   position: relative;
   display: none;
-  align-items: center;
+  float: left;
   width: 100%;
-  backface-visibility: hidden;
-  perspective: 1000px;
+  margin-right: -100%;
+  @include transition($carousel-transition);
 }
 
 .carousel-item.active,
 .carousel-item-next,
 .carousel-item-prev {
   display: block;
-  @include transition($carousel-transition);
 }
 
-.carousel-item-next,
-.carousel-item-prev {
-  position: absolute;
-  top: 0;
-}
-
-.carousel-item-next.carousel-item-left,
-.carousel-item-prev.carousel-item-right {
-  transform: translateX(0);
-
-  @supports (transform-style: preserve-3d) {
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-.carousel-item-next,
+.carousel-item-next:not(.carousel-item-left),
 .active.carousel-item-right {
   transform: translateX(100%);
-
-  @supports (transform-style: preserve-3d) {
-    transform: translate3d(100%, 0, 0);
-  }
 }
 
-.carousel-item-prev,
+.carousel-item-prev:not(.carousel-item-right),
 .active.carousel-item-left {
   transform: translateX(-100%);
-
-  @supports (transform-style: preserve-3d) {
-    transform: translate3d(-100%, 0, 0);
-  }
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1007,7 +1007,7 @@ $carousel-control-prev-icon-bg:      str-replace(url("data:image/svg+xml,%3csvg 
 $carousel-control-next-icon-bg:      str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e"), "#", "%23") !default;
 
 $carousel-transition-duration:       .6s !default;
-$carousel-transition:                transform $carousel-transition-duration ease !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
+$carousel-transition:                transform $carousel-transition-duration ease-in-out !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
 
 
 // Close


### PR DESCRIPTION
https://github.com/twbs/bootstrap/pull/22392 didn't solve the bounce effect and changed the transition from `ease-in-out` to `ease`. This PR restores the original transition.

The bounce in #27156 is caused by the switch from `position: absolute` to `position: relative` which causes a repaint. This PR uses a float based technique which will only change the transform. 

I also removed `align-items: center;`, `.carousel-item` doesn't use flexbox.

Fixes #27156.