### PR TITLE
feat: .navbar-{dark|light} .btn-link

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -212,7 +212,8 @@
       color: $navbar-light-hover-color;
     }
 
-    &.disabled {
+    &.disabled,
+    &:disabled {
       color: $navbar-light-disabled-color;
     }
   }
@@ -265,7 +266,8 @@
       color: $navbar-dark-hover-color;
     }
 
-    &.disabled {
+    &.disabled,
+    &:disabled {
       color: $navbar-dark-disabled-color;
     }
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -204,19 +204,20 @@
     }
   }
 
-  .navbar-nav {
-    .nav-link {
-      color: $navbar-light-color;
+  .nav-link,
+  .btn-link {
+    color: $navbar-light-color;
 
-      @include hover-focus {
-        color: $navbar-light-hover-color;
-      }
-
-      &.disabled {
-        color: $navbar-light-disabled-color;
-      }
+    @include hover-focus {
+      color: $navbar-light-hover-color;
     }
 
+    &.disabled {
+      color: $navbar-light-disabled-color;
+    }
+  }
+
+  .navbar-nav {
     .show > .nav-link,
     .active > .nav-link,
     .nav-link.show,
@@ -256,19 +257,20 @@
     }
   }
 
-  .navbar-nav {
-    .nav-link {
-      color: $navbar-dark-color;
+  .nav-link,
+  .btn-link {
+    color: $navbar-dark-color;
 
-      @include hover-focus {
-        color: $navbar-dark-hover-color;
-      }
-
-      &.disabled {
-        color: $navbar-dark-disabled-color;
-      }
+    @include hover-focus {
+      color: $navbar-dark-hover-color;
     }
 
+    &.disabled {
+      color: $navbar-dark-disabled-color;
+    }
+  }
+
+  .navbar-nav {
     .show > .nav-link,
     .active > .nav-link,
     .nav-link.show,


### PR DESCRIPTION
Makes `.navbar-light/dark .btn-link` to take the same color as `.nav-link`.

Please take a look at this pen: https://codepen.io/zalog/pen/mGaaVv.
Now, in case our `btn-link` is black, it won't be visible on `.navbar-dark`.