### PR TITLE
Add license headers in js/dist files

### DIFF
--- a/build/banner.js
+++ b/build/banner.js
@@ -1,0 +1,11 @@
+const path  = require('path')
+const pkg   = require(path.resolve(__dirname, '../package.json'))
+const year  = new Date().getFullYear()
+
+module.exports = function () {
+  return `/*!
+  * Bootstrap v${pkg.version} (${pkg.homepage})
+  * Copyright 2011-${year} ${pkg.author}
+  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+  */`
+}

--- a/build/banner.js
+++ b/build/banner.js
@@ -2,10 +2,12 @@ const path  = require('path')
 const pkg   = require(path.resolve(__dirname, '../package.json'))
 const year  = new Date().getFullYear()
 
-module.exports = function () {
+function getBanner(pluginFilename) {
   return `/*!
-  * Bootstrap v${pkg.version} (${pkg.homepage})
+  * Bootstrap${pluginFilename ? ` ${pluginFilename}` : ''} v${pkg.version} (${pkg.homepage})
   * Copyright 2011-${year} ${pkg.author}
   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
   */`
 }
+
+module.exports = getBanner

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -8,8 +8,8 @@
 const rollup  = require('rollup')
 const path    = require('path')
 const babel   = require('rollup-plugin-babel')
-const TEST    = process.env.NODE_ENV === 'test'
 const banner  = require(path.resolve(__dirname, './banner.js'))
+const TEST    = process.env.NODE_ENV === 'test'
 
 const plugins = [
   babel({
@@ -62,18 +62,20 @@ Object.keys(bsPlugins)
       globals[bsPlugins.Tooltip] = 'Tooltip'
     }
 
+    const pluginFilename = `${pluginKey.toLowerCase()}.js`
+
     rollup.rollup({
       input: bsPlugins[pluginKey],
       plugins,
       external
     }).then((bundle) => {
       bundle.write({
-        banner,
+        banner: banner(pluginFilename),
         format,
         name: pluginKey,
         sourcemap: true,
         globals,
-        file: path.resolve(__dirname, `${rootPath}${pluginKey.toLowerCase()}.js`)
+        file: path.resolve(__dirname, `${rootPath}${pluginFilename}`)
       })
         .then(() => console.log(`Building ${pluginKey} plugin... Done!`))
         .catch((err) => console.error(`${pluginKey}: ${err}`))

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -8,7 +8,7 @@
 const rollup  = require('rollup')
 const path    = require('path')
 const babel   = require('rollup-plugin-babel')
-const banner  = require(path.resolve(__dirname, './banner.js'))
+const banner  = require('./banner.js')
 const TEST    = process.env.NODE_ENV === 'test'
 
 const plugins = [

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -9,6 +9,7 @@ const rollup  = require('rollup')
 const path    = require('path')
 const babel   = require('rollup-plugin-babel')
 const TEST    = process.env.NODE_ENV === 'test'
+const banner  = require(path.resolve(__dirname, './banner.js'))
 
 const plugins = [
   babel({
@@ -67,6 +68,7 @@ Object.keys(bsPlugins)
       external
     }).then((bundle) => {
       bundle.write({
+        banner,
         format,
         name: pluginKey,
         sourcemap: true,

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,7 +1,7 @@
 const path    = require('path')
 const babel   = require('rollup-plugin-babel')
 const resolve = require('rollup-plugin-node-resolve')
-const banner  = require(path.resolve(__dirname, './banner.js'))
+const banner  = require('./banner.js')
 
 const BUNDLE  = process.env.BUNDLE === 'true'
 

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -1,10 +1,9 @@
 const path    = require('path')
 const babel   = require('rollup-plugin-babel')
 const resolve = require('rollup-plugin-node-resolve')
+const banner  = require(path.resolve(__dirname, './banner.js'))
 
-const pkg     = require(path.resolve(__dirname, '../package.json'))
 const BUNDLE  = process.env.BUNDLE === 'true'
-const year    = new Date().getFullYear()
 
 let fileDest  = 'bootstrap.js'
 const external = ['jquery', 'popper.js']
@@ -36,11 +35,7 @@ if (BUNDLE) {
 module.exports = {
   input: path.resolve(__dirname, '../js/src/index.js'),
   output: {
-    banner: `/*!
-  * Bootstrap v${pkg.version} (${pkg.homepage})
-  * Copyright 2011-${year} ${pkg.author}
-  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-  */`,
+    banner,
     file: path.resolve(__dirname, `../dist/js/${fileDest}`),
     format: 'umd',
     globals,


### PR DESCRIPTION
By implementing the same approach of rollup.config.js it can be replicated in build-plugins.js, with this approach individual plugins display license headers as expected.

Fixes #27301 