### PR TITLE
Add ARM support for Chrome Launcher

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -28,7 +28,7 @@ const detectBrowsers = {
   usePhantomJS: false,
   postDetection(availableBrowser) {
     if (typeof process.env.TRAVIS_JOB_ID !== 'undefined' || availableBrowser.includes('Chrome')) {
-      return ['ChromeHeadless']
+      return ['HeadlessChrome']
     }
 
     if (availableBrowser.includes('Firefox')) {
@@ -40,6 +40,11 @@ const detectBrowsers = {
 }
 
 const customLaunchers = {
+  HeadlessChrome: {
+    base: 'ChromeHeadless',
+    flags: ['--no-sandbox']
+  },
+
   FirefoxHeadless: {
     base: 'Firefox',
     flags: ['-headless']


### PR DESCRIPTION
Hi,

Bootstrap is supported by chrome browser, to launch chrome in ARM we need --no-sandbox flag.
Added custom launcher with ---no-sandbox flag in the karma.conf.js file.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>