### PR TITLE
Unnecessarily restrictive children method

### DIFF
--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -145,7 +145,7 @@ class Tab {
     if (container.nodeName === 'UL') {
       activeElements = $(container).find(Selector.ACTIVE_UL)
     } else {
-      activeElements = $(container).children(Selector.ACTIVE)
+      activeElements = $(container).find(Selector.ACTIVE)
     }
 
     const active = activeElements[0]


### PR DESCRIPTION
Children method severely limits the markup customization of this plugin. We should be using find instead. As previously highlighted by #27006.