### PR TITLE
refine deprecated holder.js color syntax

### DIFF
--- a/site/docs/4.1/components/card.md
+++ b/site/docs/4.1/components/card.md
@@ -382,7 +382,7 @@ Turn an image into a card background and overlay your card's text. Depending on 
 
 {% capture example %}
 <div class="card bg-dark text-white">
-  <img class="card-img" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
+  <img class="card-img" data-src="holder.js/100px270?text=Card image" alt="Card image">
   <div class="card-img-overlay">
     <h5 class="card-title">Card title</h5>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>


### PR DESCRIPTION
* refine deprecated holder.js color syntax
  * remove `#55595c:#373a3c` which is only used once
* harmonize with all other holder.js examples