### PR TITLE
update holder.js image dimensions for sizing example

### DIFF
--- a/site/docs/4.1/utilities/sizing.md
+++ b/site/docs/4.1/utilities/sizing.md
@@ -31,7 +31,7 @@ Width and height utilities are generated from the `$sizes` Sass map in `_variabl
 You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
 
 {% capture example %}
-<img class="mw-100" data-src="holder.js/1000px100?text=Max-width%20%3D%20100%25" alt="Max-width 100%">
+<img class="mw-100" data-src="holder.js/100px100?text=Max-width%20%3D%20100%25" alt="Max-width 100%">
 {% endcapture %}
 {% include example.html content=example %}
 


### PR DESCRIPTION
* update holder.js image dimensions for sizing example
  * use `100%` instead of `1000%`
  * :memo: https://github.com/imsky/holder#fluid-placeholders


> minor catch while refine this
🔗 https://github.com/twbs/bootstrap/pull/27400