### PR TITLE
Make use of jekyll-toc's `no_toc_section` class.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ group :development, :test do
   gem 'jekyll', '~> 3.8.4'
   gem 'jekyll-redirect-from', '~> 0.14.0'
   gem 'jekyll-sitemap', '~> 1.2.0'
-  gem 'jekyll-toc', '~> 0.7.1'
+  gem 'jekyll-toc', '~> 0.8.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
-    jekyll-toc (0.7.1)
+    jekyll-toc (0.8.0)
       nokogiri (~> 1.7)
     jekyll-watch (2.1.1)
       listen (~> 3.0)
@@ -74,7 +74,7 @@ DEPENDENCIES
   jekyll (~> 3.8.4)
   jekyll-redirect-from (~> 0.14.0)
   jekyll-sitemap (~> 1.2.0)
-  jekyll-toc (~> 0.7.1)
+  jekyll-toc (~> 0.8.0)
 
 BUNDLED WITH
    1.16.6

--- a/site/_includes/callout.html
+++ b/site/_includes/callout.html
@@ -4,6 +4,6 @@ where content is a capture with the content
 and type is one of: info (default), danger, warning
 {%- endcomment -%}
 {%- assign css_class = include.type | default: "info" -%}
-<div class="bd-callout bd-callout-{{ css_class }}">
+<div class="bd-callout bd-callout-{{ css_class }} no_toc_section">
   {{- include.content | markdownify -}}
 </div>

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -11,7 +11,7 @@ optional: hide_markup - disabled (default)
 {%- assign preview_class = include.class -%}
 
 {%- if include.hide_preview == null -%}
-<div{% if preview_id %} id="{{ preview_id }}"{% endif %} class="bd-example{% if preview_class %} {{ preview_class }}{% endif %}">
+<div{% if preview_id %} id="{{ preview_id }}"{% endif %} class="bd-example no_toc_section{% if preview_class %} {{ preview_class }}{% endif %}">
   {{- include.content -}}
 </div>
 {%- endif -%}

--- a/site/docs/4.1/assets/scss/_sidebar.scss
+++ b/site/docs/4.1/assets/scss/_sidebar.scss
@@ -23,10 +23,6 @@
 
   ul {
     padding-left: 1rem;
-
-    ul {
-      display: none;
-    }
   }
 }
 


### PR DESCRIPTION
TODO:

* [x] Update to the stable jekyll-toc version when it's out
* [x] Verify all ToCs are fine