### PR TITLE
Make jquery and popper.js dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5912,6 +5912,11 @@
         "topo": "2.x.x"
       }
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
     "js-base64": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
@@ -7893,8 +7898,7 @@
     "popper.js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
-      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY=",
-      "dev": true
+      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
     },
     "portfinder": {
       "version": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "url": "https://github.com/twbs/bootstrap/issues"
   },
   "license": "MIT",
-  "dependencies": {},
-  "peerDependencies": {
+  "dependencies": {
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.14.4"
   },
@@ -126,7 +125,6 @@
     "node-sass": "^4.9.3",
     "nodemon": "^1.18.4",
     "npm-run-all": "^4.1.3",
-    "popper.js": "^1.14.4",
     "postcss-cli": "^6.0.0",
     "qunit": "^2.6.2",
     "rollup": "^0.66.4",


### PR DESCRIPTION
Reading through issues, https://github.com/twbs/bootstrap/issues/23204 where it was decided to make `jQuery` and `popper.js` peer dependencies, I think that the main reason for the decision was to minimize the number of packages installed by `npm`. However, `peerDependencies` are required too, and emit a warning if they are not found... they are not really optional, so it does not solve the problem.
Also, peer dependencies are mostly designed for cases like when using `react-router`, you will inevitably be using `react` too... but in this case, chances are that even if you use `bootstrap`, you will not be using those other 2 dependencies on their own.
Moreover, both `jQuery` and `popper.js` are marked as `external` in https://github.com/twbs/bootstrap/blob/v4-dev/build/rollup.config.js, so they are not really bundled in. In a way they could even be considered `devDependencies`, because neither package is used in practice... but in principle they are imported in the source files, so they are technically normal deps.
This is not a breaking change, since it does not change the usage of the package in any way.