### PR TITLE
Revert "Simplify .gitattributes."

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,15 @@
 # Enforce Unix newlines
-* text=auto eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.rb    text eol=lf
+*.scss  text eol=lf
+*.svg   text eol=lf
+*.txt   text eol=lf
+*.xml   text eol=lf
+*.yml   text eol=lf
 
 # Don't diff or textually merge source maps
 *.map   binary


### PR DESCRIPTION
This reverts commit 1c78f703e08f1288208c60655967ff590cbe69cc.

Unfortunately some Linux distros use an ancient git version and this change requires git >= 2.10.

We should revisit later.

Refs #27486