### PR TITLE
A couple of docs tweaks

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -8,7 +8,7 @@
 
     {% include docs-navbar.html %}
 
-    {% if page.layout == "simple" or page.layout == "examples" %}
+    {% if page.layout == "simple" %}
       {{ content }}
     {% else %}
       <main id="content" role="main">

--- a/site/docs/4.1/components/badge.md
+++ b/site/docs/4.1/components/badge.md
@@ -10,23 +10,15 @@ toc: true
 
 Badges scale to match the size of the immediate parent element by using relative font sizing and `em` units.
 
-<div class="bd-example">
-<div class="h1">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h2">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h3">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h4">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h5">Example heading <span class="badge badge-secondary">New</span></div>
-<div class="h6">Example heading <span class="badge badge-secondary">New</span></div>
-</div>
-
-{% highlight html %}
+{% capture example %}
 <h1>Example heading <span class="badge badge-secondary">New</span></h1>
 <h2>Example heading <span class="badge badge-secondary">New</span></h2>
 <h3>Example heading <span class="badge badge-secondary">New</span></h3>
 <h4>Example heading <span class="badge badge-secondary">New</span></h4>
 <h5>Example heading <span class="badge badge-secondary">New</span></h5>
 <h6>Example heading <span class="badge badge-secondary">New</span></h6>
-{% endhighlight %}
+{% endcapture %}
+{% include example.html content=example %}
 
 Badges can be used as part of links or buttons to provide a counter.
 

--- a/site/docs/4.1/content/typography.md
+++ b/site/docs/4.1/content/typography.md
@@ -94,19 +94,13 @@ All HTML headings, `<h1>` through `<h6>`, are available.
 
 Use the included utility classes to recreate the small secondary heading text from Bootstrap 3.
 
-<div class="bd-example">
-  <span class="h3">
-    Fancy display heading
-    <small class="text-muted">With faded secondary text</small>
-  </span>
-</div>
-
-{% highlight html %}
+{% capture example %}
 <h3>
   Fancy display heading
   <small class="text-muted">With faded secondary text</small>
 </h3>
-{% endhighlight %}
+{% endcapture %}
+{% include example.html content=example %}
 
 ## Display headings
 


### PR DESCRIPTION
* Use the example shortcode in more places.
  Now that we don't have the ToC issue with the examples' headers in ToC, we can safely do this.no_toc_section_class
* Remove unneeded check.
  Leftover from after 43c20b9.