### PR TITLE
Cleanup stylelint comments

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -25,11 +25,10 @@
 // If you want the anchor version, it requires `href="#"`.
 // See https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
 
-// stylelint-disable property-no-vendor-prefix, selector-no-qualifying-type
+// stylelint-disable-next-line selector-no-qualifying-type
 button.close {
   padding: 0;
   background-color: transparent;
   border: 0;
-  -webkit-appearance: none;
+  appearance: none;
 }
-// stylelint-enable

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -105,7 +105,7 @@
 }
 
 // When enabled Popper.js, reset basic dropdown position
-// stylelint-disable no-duplicate-selectors
+// stylelint-disable-next-line no-duplicate-selectors
 .dropdown-menu {
   &[x-placement^="top"],
   &[x-placement^="right"],
@@ -115,7 +115,6 @@
     bottom: auto;
   }
 }
-// stylelint-enable no-duplicate-selectors
 
 // Dividers (basically an `<hr>`) within the dropdown
 .dropdown-divider {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -155,7 +155,7 @@ select.form-control {
   @include border-radius($input-border-radius-lg);
 }
 
-// stylelint-disable no-duplicate-selectors
+// stylelint-disable-next-line no-duplicate-selectors
 select.form-control {
   &[size],
   &[multiple] {
@@ -163,10 +163,10 @@ select.form-control {
   }
 }
 
+// stylelint-disable-next-line no-duplicate-selectors
 textarea.form-control {
   height: auto;
 }
-// stylelint-enable no-duplicate-selectors
 
 // Form groups
 //

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -40,12 +40,11 @@ html {
   }
 }
 
-// stylelint-disable selector-list-comma-newline-after
 // Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
+// stylelint-disable-next-line selector-list-comma-newline-after
 article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
   display: block;
 }
-// stylelint-enable selector-list-comma-newline-after
 
 // Body
 //
@@ -95,12 +94,11 @@ hr {
 //
 // By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
 // margin for easier control within type scales as it avoids margin collapsing.
-// stylelint-disable selector-list-comma-newline-after
+// stylelint-disable-next-line selector-list-comma-newline-after
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
   margin-bottom: $headings-margin-bottom;
 }
-// stylelint-enable selector-list-comma-newline-after
 
 // Reset margins on paragraphs
 //
@@ -163,12 +161,10 @@ dfn {
   font-style: italic; // Add the correct font style in Android 4.3-
 }
 
-// stylelint-disable font-weight-notation
 b,
 strong {
   font-weight: bolder; // Add the correct font weight in Chrome, Edge, and Safari
 }
-// stylelint-enable font-weight-notation
 
 small {
   font-size: 80%; // Add the correct font size in all browsers

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -80,7 +80,7 @@
     }
   }
 
-  // stylelint-disable selector-no-qualifying-type
+  // stylelint-disable-next-line selector-no-qualifying-type
   textarea.form-control {
     .was-validated &:#{$state},
     &.is-#{$state} {
@@ -90,7 +90,6 @@
       }
     }
   }
-  // stylelint-enable selector-no-qualifying-type
 
   .custom-select {
     .was-validated &:#{$state},


### PR DESCRIPTION
`stylelint-disable` and `stylelint-enable` is used a lot while this can also be achived with `stylelint-disable-next-line` 

I've also added some comments to clarify why I made some changes.