### PR TITLE
Fix tab fade out

### DIFF
--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -162,6 +162,7 @@ class Tab {
       const transitionDuration = Util.getTransitionDurationFromElement(active)
 
       $(active)
+        .removeClass(`${ClassName.SHOW}`)
         .one(Util.TRANSITION_END, complete)
         .emulateTransitionEnd(transitionDuration)
     } else {
@@ -171,7 +172,7 @@ class Tab {
 
   _transitionComplete(element, active, callback) {
     if (active) {
-      $(active).removeClass(`${ClassName.SHOW} ${ClassName.ACTIVE}`)
+      $(active).removeClass(`${ClassName.ACTIVE}`)
 
       const dropdownChild = $(active.parentNode).find(
         Selector.DROPDOWN_ACTIVE_CHILD

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -162,7 +162,7 @@ class Tab {
       const transitionDuration = Util.getTransitionDurationFromElement(active)
 
       $(active)
-        .removeClass(`${ClassName.SHOW}`)
+        .removeClass(ClassName.SHOW)
         .one(Util.TRANSITION_END, complete)
         .emulateTransitionEnd(transitionDuration)
     } else {
@@ -172,7 +172,7 @@ class Tab {
 
   _transitionComplete(element, active, callback) {
     if (active) {
-      $(active).removeClass(`${ClassName.ACTIVE}`)
+      $(active).removeClass(ClassName.ACTIVE)
 
       const dropdownChild = $(active.parentNode).find(
         Selector.DROPDOWN_ACTIVE_CHILD


### PR DESCRIPTION
The tab fadeout doesn't work because the `.show` class isn't removed. This causes some lag before the new tab is faded in.

**Current behaviour:**
https://getbootstrap.com/docs/4.1/components/navs/#javascript-behavior

**Behaviour with fix:**
https://deploy-preview-27533--twbs-bootstrap4.netlify.com/docs/4.1/components/navs/#javascript-behavior
Beautiful, isn't it?

Closes #26525