### PR TITLE
add `.text-wrap` class

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -9,6 +9,7 @@
 // Alignment
 
 .text-justify  { text-align: justify !important; }
+.text-wrap     { white-space: normal !important; }
 .text-nowrap   { white-space: nowrap !important; }
 .text-truncate { @include text-truncate; }
 

--- a/site/docs/4.1/utilities/text.md
+++ b/site/docs/4.1/utilities/text.md
@@ -34,7 +34,7 @@ For left, right, and center alignment, responsive classes are available that use
 Wrap text with a `.text-wrap` class.
 
 {% capture example %}
-<div class="text-wrap bd-highlight" style="width: 6rem;">
+<div class="badge badge-primary text-wrap" style="width: 6rem;">
   This text should wrap.
 </div>
 {% endcapture %}

--- a/site/docs/4.1/utilities/text.md
+++ b/site/docs/4.1/utilities/text.md
@@ -31,6 +31,15 @@ For left, right, and center alignment, responsive classes are available that use
 
 ## Text wrapping and overflow
 
+Wrap text with a `.text-wrap` class.
+
+{% capture example %}
+<div class="text-wrap bd-highlight" style="width: 6rem;">
+  This text should wrap.
+</div>
+{% endcapture %}
+{% include example.html content=example %}
+
 Prevent text from wrapping with a `.text-nowrap` class.
 
 {% capture example %}


### PR DESCRIPTION
this is the opposite of `.text-nowrap`, and a forces elements to wrap onto new lines.

One use case for this is extra long button text. Bootstrap buttons by default do no wrap, so this class could be used to override that behavior.

references issue #19315