### PR TITLE
fix(input-group): Support form-control-plaintext as a sibling

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -23,6 +23,7 @@
     margin-bottom: 0;
 
     + .form-control,
+    + .form-control-plaintext,
     + .custom-select,
     + .custom-file {
       margin-left: -$input-border-width;


### PR DESCRIPTION
PR #25871 added support for `.form-control-plaintext` inside an input-group (addressing issue #25870), but it did not include handling the situation of multiple inputs in the same input group (where `.form-control-plaintext` is not the first input).

This PR adds in the missing line to handle this situation.