### PR TITLE
Carousel fixes

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -283,14 +283,11 @@ class Carousel {
       if (this._pointerEvent && (event.originalEvent.pointerType === PointerType.TOUCH || event.originalEvent.pointerType === PointerType.PEN)) {
         this.touchStartX = event.originalEvent.clientX
       } else if (!this._pointerEvent) {
-        event.preventDefault()
         this.touchStartX = event.originalEvent.touches[0].clientX
       }
     }
 
     const move = (event) => {
-      event.preventDefault()
-
       // ensure swiping with one touch and not pinching
       if (event.originalEvent.touches && event.originalEvent.touches.length > 1) {
         this.touchDeltaX = 0

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -16,7 +16,7 @@
 }
 
 .carousel.pointer-event {
-  touch-action: none;
+  touch-action: pan-y;
 }
 
 .carousel-inner {


### PR DESCRIPTION
Replace touch-action: none with pan-y, remove preventDefault from touch event handling

This makes scrolling and carousels coexist. Some minor drawbacks. that I guess we can live with:

- it doesn't prevent browser gestures in touch-events scenarios (primarily iOS, where swiping from the side will trigger the browser's back/forward functionality, but this is common across these scenarios)
- Firefox on touchscreen-enabled laptops/desktops with high-dpi will throw `pointercancel` and abort a swipe gesture as soon as there's even a minimal amount of vertical movement to the swipe - this seems to be a bug/overeager behavior on the part of FX; testing on a medium-dpi Android, Firefox there seems to behave sanely

Closes https://github.com/twbs/bootstrap/issues/27531

/cc @MartijnCuppens @Johann-S 