### PR TITLE
broken-link-checker: force follow links.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "start": "npm-run-all --parallel watch docs-serve",
-    "blc": "blc --exclude-external --filter-level 3 --get --ordered --recursive --host-requests 4 --input http://localhost:3000/",
+    "blc": "blc --exclude-external --filter-level 3 --follow --get --ordered --recursive --host-requests 4 --input http://localhost:3000/",
     "http-server": "http-server --silent -p 3000",
     "bundlesize": "bundlesize",
     "check-broken-links": "npm-run-all --parallel --race \"http-server -- _gh_pages/\" blc",


### PR DESCRIPTION
After 3256a2c, blc honored robots.txt thus it didn't crawl anything.
Ignore robots.txt to work around the issue.

Fixes #27585 