### PR TITLE
Travis: stop using a separate stage for Browser tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,10 @@ install:
   - npm install
 script:
   - npm test
-  - if [[ "$TRAVIS_NODE_VERSION" = "8" && "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]]; then npm run check-broken-links; fi
+  - if [[ "$TRAVIS_NODE_VERSION" = "8" ]]; then npm run check-broken-links; fi
+  - if [[ "$TRAVIS_NODE_VERSION" = "8" && "$TRAVIS_EVENT_TYPE" = "push" && ! `git log --format=%B --no-merges -n 1 | grep '\[skip browser\]'` ]]; then npm run js-test-cloud; fi
 after_success:
-  - if [[ "$TRAVIS_NODE_VERSION" = "8" && "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]]; then npm run coveralls; fi
-stages:
-  - test
-  - name: browser
-    if: type = push
-jobs:
-  include:
-    - stage: browser
-      node_js: 8
-      script: if ! git log --format=%B --no-merges -n 1 | grep '\[skip browser\]'; then npm run js-test-cloud; fi
+  - if [[ "$TRAVIS_NODE_VERSION" = "8" ]]; then npm run coveralls; fi
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "js-test-karma-old": "cross-env USE_OLD_JQUERY=true npm run js-test-karma",
     "js-test-karma-bundle": "cross-env BUNDLE=true npm run js-test-karma",
     "js-test-karma-bundle-old": "cross-env BUNDLE=true USE_OLD_JQUERY=true npm run js-test-karma",
-    "prejs-test-cloud": "npm run js-compile && npm run js-test-karma",
     "js-test-cloud": "cross-env BROWSER=true npm run js-test-karma",
     "lint": "npm-run-all --parallel js-lint* css-lint*",
     "coveralls": "shx cat js/coverage/lcov.info | coveralls",


### PR DESCRIPTION
This should be faster, around 90-150 seconds per build.

My only concern is if we ever want to allow Browser tests to fail, but I doubt it anyway.