### PR TITLE
use bsCustomFileInput in our docs

### DIFF
--- a/site/docs/4.1/assets/js/src/application.js
+++ b/site/docs/4.1/assets/js/src/application.js
@@ -10,7 +10,7 @@
  * details, see https://creativecommons.org/licenses/by/3.0/.
  */
 
-/* global ClipboardJS: false, anchors: false, Holder: false */
+/* global ClipboardJS: false, anchors: false, Holder: false, bsCustomFileInput: false */
 
 (function ($) {
   'use strict'
@@ -108,5 +108,7 @@
       font: 'Helvetica',
       fontweight: 'normal'
     })
+
+    bsCustomFileInput.init()
   })
 }(jQuery))


### PR DESCRIPTION
I forgot here to use it: https://github.com/twbs/bootstrap/pull/27264 😟 

Now it works: https://deploy-preview-27631--twbs-bootstrap4.netlify.com/docs/4.1/components/forms/#file-browser