### PR TITLE
Add white-space reset to accordion header button

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -305,6 +305,10 @@
 
     .card-header {
       margin-bottom: -$card-border-width;
+
+      .btn {
+        white-space: normal;
+      }
     }
   }
 }


### PR DESCRIPTION
This will fix the overflow that occurs if the content of `.card-header` is too long, because we're using `white-space: nowrap` on normal a `.btn`. This is fixed by resetting `white-space` to `normal`, which allows for multiple lines in a button.

Example of overflow from docs:

![image](https://i.imgur.com/bDAEaV2.png)