### PR TITLE
Keep input group & form label font size in sync with form control font size

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -95,14 +95,14 @@ select.form-control {
 .col-form-label-lg {
   padding-top: calc(#{$input-padding-y-lg} + #{$input-border-width});
   padding-bottom: calc(#{$input-padding-y-lg} + #{$input-border-width});
-  font-size: $font-size-lg;
+  font-size: $input-font-size-lg;
   line-height: $input-line-height-lg;
 }
 
 .col-form-label-sm {
   padding-top: calc(#{$input-padding-y-sm} + #{$input-border-width});
   padding-bottom: calc(#{$input-padding-y-sm} + #{$input-border-width});
-  font-size: $font-size-sm;
+  font-size: $input-font-size-sm;
   line-height: $input-line-height-sm;
 }
 

--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -134,7 +134,7 @@
 .input-group-lg > .input-group-append > .btn {
   height: $input-height-lg;
   padding: $input-padding-y-lg $input-padding-x-lg;
-  font-size: $font-size-lg;
+  font-size: $input-font-size-lg;
   line-height: $input-line-height-lg;
   @include border-radius($input-border-radius-lg);
 }
@@ -146,7 +146,7 @@
 .input-group-sm > .input-group-append > .btn {
   height: $input-height-sm;
   padding: $input-padding-y-sm $input-padding-x-sm;
-  font-size: $font-size-sm;
+  font-size: $input-font-size-sm;
   line-height: $input-line-height-sm;
   @include border-radius($input-border-radius-sm);
 }


### PR DESCRIPTION
Closes #27575 and also keeps the font size of horizontal form labels in sync:
https://getbootstrap.com/docs/4.1/components/forms/#horizontal-form-label-sizing


Thanks for reporting this issue, @ysds! 