### PR TITLE
Responsive images with .embed-responsive

### DIFF
--- a/scss/utilities/_embed.scss
+++ b/scss/utilities/_embed.scss
@@ -24,6 +24,7 @@
     width: 100%;
     height: 100%;
     border: 0;
+    object-fit: cover;
   }
 }
 


### PR DESCRIPTION
Hi!
I've added `object-fit: cover` to `.embed-responsive-item`. It's useful, when you want to responsive images with exact ratio. Without this fix images are crushed. 

Demo:
http://jsfiddle.net/jhybufos/

Preview:

![screenshot 2018-11-14 at 10 16 31](https://user-images.githubusercontent.com/1282324/48472347-60fd8a80-e7f6-11e8-8a73-67d0b4ec9555.png)

Code:
```
<div class="embed-responsive embed-responsive-1by1">
   <img src="https://placehold.it/1280x600" alt="" class="embed-responsive-item">
</div>
```

