### PR TITLE
Update autoprefixer link to `.browserslistrc` file

### DIFF
--- a/site/docs/4.1/getting-started/build-tools.md
+++ b/site/docs/4.1/getting-started/build-tools.md
@@ -38,7 +38,7 @@ Run `npm run` to see all the npm scripts.
 
 Bootstrap uses [Autoprefixer][autoprefixer] (included in our build process) to automatically add vendor prefixes to some CSS properties at build time. Doing so saves us time and code by allowing us to write key parts of our CSS a single time while eliminating the need for vendor mixins like those found in v3.
 
-We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [/package.json]({{ site.repo }}/blob/v{{ site.current_version }}/package.json) for details.
+We maintain the list of browsers supported through Autoprefixer in a separate file within our GitHub repository. See [/.browserslistrc]({{ site.repo }}/blob/v{{ site.current_version }}/.browserslistrc) for details.
 
 ## Local documentation
 


### PR DESCRIPTION
Hello folks,

I was following the docs about [Build Tools / Autoprefixer](https://getbootstrap.com/docs/4.1/getting-started/build-tools/#autoprefixer) and came across this link [See /package.json for details](https://github.com/twbs/bootstrap/blob/v4.1.3/package.json).

I think this link does not make much sense as `browserslist` setup for Autoprefixer was moved to a separate file on this commit https://github.com/twbs/bootstrap/commit/6cf8700fd9fd096855d6510ceef9c1ff225f8e40 

Please let me know your thoughts on this.

Thanks 