### PR TITLE
Inherit $card-cap-color color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -795,7 +795,7 @@ $card-border-radius:                $border-radius !default;
 $card-border-color:                 rgba($black, .125) !default;
 $card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 $card-cap-bg:                       rgba($black, .03) !default;
-$card-cap-color:                    $body-color !default;
+$card-cap-color:                    inherit !default;
 $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;


### PR DESCRIPTION
https://github.com/twbs/bootstrap/pull/26573 broke all the coloured cards. If we use inherit by default, we're safe.

![image](https://user-images.githubusercontent.com/11559216/48646787-252b1680-e9ea-11e8-996d-b10e85463b51.png)


Fix: https://deploy-preview-27681--twbs-bootstrap4.netlify.com/docs/4.1/components/card/#background-and-color
