### PR TITLE
Add new Horizontal List Group class.

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -12,6 +12,94 @@
 }
 
 
+// Horizontal List Group
+//
+// Extends .list-group and other list group classes.
+
+.list-group-horizontal {
+  flex-direction: row;
+
+  .list-group-item {
+    margin-right: -$list-group-border-width;
+    margin-bottom: 0;
+
+    &:first-child {
+      @include border-left-radius($list-group-border-radius);
+      @include border-top-right-radius(0);
+    }
+
+    &:last-child {
+      margin-right: 0;
+      @include border-right-radius($list-group-border-radius);
+      @include border-bottom-left-radius(0);
+    }
+  }
+
+  &.list-group-flush {
+    @include border-radius(0);
+
+    .list-group-item {
+      border: $list-group-border-width solid $list-group-border-color;
+      border-top: 0;
+      border-bottom: 0;
+    }
+  }
+}
+
+
+// Responsve Horizontal List Group
+//
+// Add .list-group-horizontal-responsive to any .list-group-horizontal.
+
+.list-group-horizontal-responsive {
+  @each $breakpoint in map-keys($grid-breakpoints) {
+    $next: breakpoint-next($breakpoint, $grid-breakpoints);
+    $infix: breakpoint-infix($next, $grid-breakpoints);
+
+    &#{$infix} {
+      @include media-breakpoint-down($breakpoint) {
+        flex-direction: column;
+
+        &.list-group-flush {
+          .list-group-item {
+            border: $list-group-border-width solid $list-group-border-color;
+
+            &:first-child {
+              border-top: $list-group-border-width solid $list-group-border-color;
+              @include border-top-radius($list-group-border-radius);
+              @include border-bottom-left-radius(0);
+            }
+
+            &:last-child {
+              margin-bottom: 0;
+              border-bottom: $list-group-border-width solid $list-group-border-color;
+              @include border-bottom-radius($list-group-border-radius);
+              @include border-top-right-radius(0);
+            }
+          }
+        }
+
+        .list-group-item {
+          margin-right: 0;
+          margin-bottom: -$list-group-border-width;
+
+          &:first-child {
+            @include border-top-radius($list-group-border-radius);
+            @include border-bottom-left-radius(0);
+          }
+
+          &:last-child {
+            margin-bottom: 0;
+            @include border-bottom-radius($list-group-border-radius);
+            @include border-top-right-radius(0);
+          }
+        }
+      }
+    }
+  }
+}
+
+
 // Interactive list items
 //
 // Use anchor or button elements instead of `li`s or `div`s to create interactive

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -37,3 +37,15 @@
     border-bottom-left-radius: $radius;
   }
 }
+
+@mixin border-top-right-radius($radius) {
+  @if $enable-rounded {
+    border-top-right-radius: $radius;
+  }
+}
+
+@mixin border-bottom-left-radius($radius) {
+  @if $enable-rounded {
+    border-bottom-left-radius: $radius;
+  }
+}

--- a/site/docs/4.2/components/list-group.md
+++ b/site/docs/4.2/components/list-group.md
@@ -87,7 +87,7 @@ With `<button>`s, you can also make use of the `disabled` attribute instead of t
 
 ## Flush
 
-Add `.list-group-flush` to remove some borders and rounded corners to render list group items edge-to-edge in a parent container (e.g., cards).
+Add `.list-group-flush` to remove some borders and rounded corners to render list group items edge-to-edge in a parent container (e.g., cards). You can also attach this class to a `.list-group-horizontal`.
 
 {% capture example %}
 <ul class="list-group list-group-flush">
@@ -96,6 +96,55 @@ Add `.list-group-flush` to remove some borders and rounded corners to render lis
   <li class="list-group-item">Morbi leo risus</li>
   <li class="list-group-item">Porta ac consectetur ac</li>
   <li class="list-group-item">Vestibulum at eros</li>
+</ul>
+{% endcapture %}
+{% include example.html content=example %}
+
+## Horizontal List Group
+
+Add `.list-group-horizontal` to any `.list-group` to make it horizontal.
+
+{% capture example %}
+<ul class="list-group list-group-horizontal">
+  <li class="list-group-item">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+  <li class="list-group-item">Morbi leo risus</li>
+</ul>
+{% endcapture %}
+{% include example.html content=example %}
+
+## Responsive Horizontal List Group
+
+Add `.list-group-horizontal-responsive` to any `.list-group-horizontal` to automatically make it responsive. You can also add one of our breakpoint variants to choose when to make it responsive, e.g: `.list-group-horizontal-responsive{-sm|-md|-lg|-xl}`. Resize your browser window to see the responsive behaviour.
+
+{% capture example %}
+<ul class="list-group list-group-horizontal list-group-horizontal-responsive-sm">
+  <li class="list-group-item">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+</ul>
+{% endcapture %}
+{% include example.html content=example %}
+
+{% capture example %}
+<ul class="list-group list-group-horizontal list-group-horizontal-responsive-md">
+  <li class="list-group-item">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+</ul>
+{% endcapture %}
+{% include example.html content=example %}
+
+{% capture example %}
+<ul class="list-group list-group-horizontal list-group-horizontal-responsive-lg">
+  <li class="list-group-item">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
+</ul>
+{% endcapture %}
+{% include example.html content=example %}
+
+{% capture example %}
+<ul class="list-group list-group-horizontal list-group-horizontal-responsive-xl">
+  <li class="list-group-item">Cras justo odio</li>
+  <li class="list-group-item">Dapibus ac facilisis in</li>
 </ul>
 {% endcapture %}
 {% include example.html content=example %}


### PR DESCRIPTION
Hi 👋 

**:rocket: Preview:** https://deploy-preview-27683--twbs-bootstrap4.netlify.com/docs/4.2/components/list-group/#horizontal-list-group

Back in September I opened a new feature request about adding a **new horizontal list group class** to the existing list group (see: https://github.com/twbs/bootstrap/issues/27291) as I felt that although this could be done with pure utility classes it was difficult to get the border radius to match up.

Here, I am opening a new PR containing **my first attempt/implementation** at adding a few new classes in addition to the existing `.list-group` class which **shouldn't** contain any breaking change, but rather extend the current classes.

**Here's a breakdown of the initial changes that this PR contains (open to additional contributors):**

- [x] Add new `.list-group-horizontal` modifier class.
- [x] Add new `.list-group-horizontal-responsive` class for dealing with responsive horizontal list groups _(this also works with the existing `-sm|-md|-lg|-xl` variants)_
- [x] Add support for the `.list-group-flush` class to horizontal list group.
- [x] Update List Group docs with the new **Horizontal List Group** and **Responsive** variant.
- [x] Test with existing modifier classes such as: `.active`, `.disabled` and with `<a>` elements.
- [x] Add new border-radius mixins to support the new classes.
- [x] Utilise as many existing variables and primary extend only.
