### PR TITLE
Add documentation about viewport sizing utilities

### DIFF
--- a/site/docs/4.1/utilities/sizing.md
+++ b/site/docs/4.1/utilities/sizing.md
@@ -1,10 +1,12 @@
 ---
 layout: docs
 title: Sizing
-description: Easily make an element as wide or as tall (relative to its parent) with our width and height utilities.
+description: Easily make an element as wide or as tall with our width and height utilities.
 group: utilities
 toc: true
 ---
+
+## Relative to the parent
 
 Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
 
@@ -41,3 +43,14 @@ You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
 </div>
 {% endcapture %}
 {% include example.html content=example %}
+
+## Relative to the viewport
+
+You can also use utilities for set the width and height relative to the viewport.
+
+{% highlight html %}
+<div class="min-vw-100">Min-width 100vw</div>
+<div class="min-vh-100">Min-height 100vh</div>
+<div class="vw-100">Width 100vw</div>
+<div class="vh-100">Height 100vh</div>
+{% endhighlight %}

--- a/site/docs/4.1/utilities/sizing.md
+++ b/site/docs/4.1/utilities/sizing.md
@@ -46,7 +46,7 @@ You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
 
 ## Relative to the viewport
 
-You can also use utilities for set the width and height relative to the viewport.
+You can also use utilities to set the width and height relative to the viewport.
 
 {% highlight html %}
 <div class="min-vw-100">Min-width 100vw</div>


### PR DESCRIPTION
Add docs for #25548.

[Netlify demo](https://deploy-preview-27688--twbs-bootstrap4.netlify.com/docs/4.1/utilities/sizing/)

If I had not missed, all new classes added in 4.2 will be documented by this PR.