### PR TITLE
[Sizing] Add max-width and max-height utilities

### DIFF
--- a/scss/utilities/_sizing.scss
+++ b/scss/utilities/_sizing.scss
@@ -8,8 +8,15 @@
   }
 }
 
-.mw-100 { max-width: 100% !important; }
-.mh-100 { max-height: 100% !important; }
+// Max-width and -height
+@each $prop, $abbrev in (max-width: mw, max-height: mh) {
+  @each $size, $length in $sizes {
+    // Exclude auto, as this is not a valid value for max-width or max-height
+    @if $size != auto {
+      .#{$abbrev}-#{$size} { #{$prop}: $length !important; }
+    }
+  }
+}
 
 // Viewport additional helpers
 

--- a/site/docs/4.1/utilities/sizing.md
+++ b/site/docs/4.1/utilities/sizing.md
@@ -30,16 +30,22 @@ Width and height utilities are generated from the `$sizes` Sass map in `_variabl
 {% endcapture %}
 {% include example.html content=example %}
 
-You can also use `max-width: 100%;` and `max-height: 100%;` utilities as needed.
+You can also use `max-width` and `max-height` utilities as needed.
 
 {% capture example %}
-{% include icons/placeholder.svg width="100%" height="100" class="mw-100" text="Max-width 100%" title="Max-width 100%" %}
+<div class="mw-25 p-3" style="width: 100%; background-color: #eee;">Max-width 25%</div>
+<div class="mw-50 p-3" style="width: 100%; background-color: #eee;">Max-width 50%</div>
+<div class="mw-75 p-3" style="width: 100%; background-color: #eee;">Max-width 75%</div>
+<div class="mw-100 p-3" style="width: 100%; background-color: #eee;">Max-width 100%</div>
 {% endcapture %}
 {% include example.html content=example %}
 
 {% capture example %}
 <div style="height: 100px; background-color: rgba(255,0,0,0.1);">
-  <div class="mh-100" style="width: 100px; height: 200px; background-color: rgba(0,0,255,0.1);">Max-height 100%</div>
+  <div class="mh-25 d-inline-block" style="width: 140px; height: 200px; background-color: rgba(0,0,255,.1);">Max-height 25%</div>
+  <div class="mh-50 d-inline-block" style="width: 140px; height: 200px; background-color: rgba(0,0,255,.1);">Max-height 50%</div>
+  <div class="mh-75 d-inline-block" style="width: 140px; height: 200px; background-color: rgba(0,0,255,.1);">Max-height 75%</div>
+  <div class="mh-100 d-inline-block" style="width: 140px; height: 200px; background-color: rgba(0,0,255,.1);">Max-height 100%</div>
 </div>
 {% endcapture %}
 {% include example.html content=example %}


### PR DESCRIPTION
Closes #27628.

This PR would add the max-width and max-height utilities:
```
mw-25 // max-width: 25% !important;
mw-50 // max-width: 50% !important;
mw-75 // max-width: 75% !important;
mw-100 // max-width: 100% !important;

mh-25 // max-height: 25% !important;
mh-50 // max-height: 50% !important;
mh-75 // max-height: 75% !important;
mh-100 // max-height: 100% !important;
```
Notice this doesn't include `m*-auto`, as `auto` not a valid value.

What do you guys think?