### PR TITLE
Update DocSearch.js to latest version

### DIFF
--- a/site/docs/4.1/assets/js/src/search.js
+++ b/site/docs/4.1/assets/js/src/search.js
@@ -32,12 +32,6 @@
     algoliaOptions: {
       facetFilters: ['version:' + siteDocsVersion]
     },
-    handleSelected: function (input, event, suggestion) {
-      var url = suggestion.url
-      url = suggestion.isLvl1 ? url.split('#')[0] : url
-      // If it's a title we remove the anchor so it does not jump.
-      window.location.href = url
-    },
     transformData: function (hits) {
       return hits.map(function (hit) {
         var siteurl = getOrigin()
@@ -46,6 +40,12 @@
         // When in production, return the result as is,
         // otherwise remove our url from it.
         hit.url = siteurl.match(urlRE) ? hit.url : hit.url.replace(urlRE, '')
+
+        // Prevent jumping to first header
+        if (hit.anchor === 'content') {
+          hit.url = hit.url.replace(/#content$/, '')
+          hit.anchor = null
+        }
 
         return hit
       })


### PR DESCRIPTION
The latest (2.6.2) docsearch.js version now displays results as standard `<a href>` links, allowing users to `ctrl`-click on them to trigger default browser behavior of opening in a new tab. This has been a been a long awaited feature and is now live.

To maintain backward compatibility, this behavior has only been enabled to users that didn't define their own `handleSelected` method. Because the Bootstrap documentation uses its own `handleSelected`, you won't be able to `ctrl`-clicks results as of today :/

This PR updates your `docsearch()` code to take advantage of the new `<a href>` template, by removing your custom `handleSelected` and moving its behavior to the `transformData` call. Namely, what you wanted to avoid was jumping to the first `<h1>` of the pages ([source](https://github.com/algolia/docsearch-configs/pull/174#issuecomment-313186706)), which would prevent users from seeing the header. This PR checks if the suggestion targets the `#content` anchor (meaning it goes to this first `<h1>`) and if so, removes it.

Behavior should be the same, but at least now you can enjoy the `ctrl`-click :)