### PR TITLE
prevent text selection for floating labels example

### DIFF
--- a/site/docs/4.1/examples/floating-labels/floating-labels.css
+++ b/site/docs/4.1/examples/floating-labels/floating-labels.css
@@ -41,6 +41,7 @@ body {
   line-height: 1.5;
   color: #495057;
   cursor: text; /* Match the input under the label */
+  user-select: none;
   border: 1px solid transparent;
   border-radius: .25rem;
   transition: all .1s ease-in-out;

--- a/site/docs/4.1/examples/floating-labels/floating-labels.css
+++ b/site/docs/4.1/examples/floating-labels/floating-labels.css
@@ -40,8 +40,8 @@ body {
   margin-bottom: 0; /* Override default `<label>` margin */
   line-height: 1.5;
   color: #495057;
+  pointer-events: none;
   cursor: text; /* Match the input under the label */
-  user-select: none;
   border: 1px solid transparent;
   border-radius: .25rem;
   transition: all .1s ease-in-out;


### PR DESCRIPTION
* prevent text selection for floating labels
  * expand the click target by not selecting the label text

🤓 feedback welcome