### PR TITLE
Change OS X to macOS

### DIFF
--- a/site/docs/4.1/content/reboot.md
+++ b/site/docs/4.1/content/reboot.md
@@ -33,9 +33,9 @@ The default web fonts (Helvetica Neue, Helvetica, and Arial) have been dropped i
 
 {% highlight sass %}
 $font-family-sans-serif:
-  // Safari for OS X and iOS (San Francisco)
+  // Safari for macOS and iOS (San Francisco)
   -apple-system,
-  // Chrome < 56 for OS X (San Francisco)
+  // Chrome < 56 for macOS (San Francisco)
   BlinkMacSystemFont,
   // Windows
   "Segoe UI",


### PR DESCRIPTION
It's been macOS for 3 years now and we use just 'macOS' elsewhere in the Bootstrap documentation.
https://en.wikipedia.org/wiki/MacOS