### PR TITLE
FEATURE: Provide also `breakpoint-prev`

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -29,6 +29,7 @@
 //    sm
 
 @function breakpoint-prev($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
+  $n: index($breakpoint-names, $name);
   @if ($n == 1) {
     @return null;
   }

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -30,9 +30,9 @@
 
 @function breakpoint-prev($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
   @if ($n == 1) {
-      @return null;
-    }
-    @return if($n <= length($breakpoint-names), nth($breakpoint-names, $n - 1), null);
+    @return null;
+  }
+  @return if($n <= length($breakpoint-names), nth($breakpoint-names, $n - 1), null);
 }
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -19,6 +19,22 @@
   @return if($n != null and $n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
 }
 
+// Name of the previous breakpoint, or null for the first breakpoint.
+//
+//    >> breakpoint-prev(md)
+//    sm
+//    >> breakpoint-prev(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    xs
+//    >> breakpoint-prev(md, $breakpoint-names: (xs sm md lg xl))
+//    sm
+
+@function breakpoint-prev($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
+  @if ($n == 1) {
+      @return null;
+    }
+    @return if($n <= length($breakpoint-names), nth($breakpoint-names, $n - 1), null);
+}
+
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.
 //
 //    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))


### PR DESCRIPTION
When you use Bootstrap as a layout tool, with all it mixins, I come often in the situation where I want to select the previous breakpoint. For example, I set a variable for the breakpoint of a navigation and want to use the `media-breakpoint-down` mixin. Without this function, I have to set a second variable with the lower breakpoint. With this function, I can set it dynamically:

```scss
$variable: lg;

@include media-breakpoint-down(breakpoint-prev($variable)) {
   // Content
}
```