### PR TITLE
Update jekyll-toc to v0.9.1 and add bd-callout to no_toc_section_class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'jekyll', '~> 3.8.4'
+  gem 'jekyll', '~> 3.8.5'
   gem 'jekyll-redirect-from', '~> 0.14.0'
   gem 'jekyll-sitemap', '~> 1.2.0'
-  gem 'jekyll-toc', '~> 0.9.0'
+  gem 'jekyll-toc', '~> 0.9.1'
   gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
-    jekyll-toc (0.9.0)
+    jekyll-toc (0.9.1)
       nokogiri (~> 1.8)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
@@ -72,10 +72,10 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  jekyll (~> 3.8.4)
+  jekyll (~> 3.8.5)
   jekyll-redirect-from (~> 0.14.0)
   jekyll-sitemap (~> 1.2.0)
-  jekyll-toc (~> 0.9.0)
+  jekyll-toc (~> 0.9.1)
   wdm (~> 0.1.1)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -62,4 +62,6 @@ cdn:
 toc:
   min_level:        2
   max_level:        4
-  no_toc_section_class: "bd-example"
+  no_toc_section_class: 
+    - "bd-example"
+    - "no_toc_section"

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,6 @@ cdn:
 toc:
   min_level:        2
   max_level:        4
-  no_toc_section_class: 
+  no_toc_section_class:
+    - "bd-callout"
     - "bd-example"
-    - "no_toc_section"

--- a/site/_includes/callout-danger-async-methods.md
+++ b/site/_includes/callout-danger-async-methods.md
@@ -1,5 +1,5 @@
 {% capture callout %}
-##### Asynchronous methods and transitions
+#### Asynchronous methods and transitions
 
 All API methods are **asynchronous** and start a **transition**. They return to the caller as soon as the transition is started but **before it ends**. In addition, a method call on a **transitioning component will be ignored**.
 

--- a/site/_includes/callout.html
+++ b/site/_includes/callout.html
@@ -4,6 +4,6 @@
   and type is one of: info (default), danger, warning
 {%- endcomment -%}
 {%- assign css_class = include.type | default: "info" -%}
-<div class="bd-callout bd-callout-{{ css_class }} no_toc_section">
+<div class="bd-callout bd-callout-{{ css_class }}">
   {{- include.content | markdownify -}}
 </div>

--- a/site/docs/4.1/components/forms.md
+++ b/site/docs/4.1/components/forms.md
@@ -737,7 +737,7 @@ By default, browsers will treat all native form controls (`<input>`, `<select>` 
 {% include callout.html content=callout type="warning" %}
 
 {% capture callout %}
-##### Cross-browser compatibility
+#### Cross-browser compatibility
 
 While Bootstrap will apply these styles in all browsers, Internet Explorer 11 and below don't fully support the `disabled` attribute on a `<fieldset>`. Use custom JavaScript to disable the fieldset in these browsers.
 {% endcapture %}

--- a/site/docs/4.1/components/popovers.md
+++ b/site/docs/4.1/components/popovers.md
@@ -99,7 +99,7 @@ sagittis lacus vel augue laoreet rutrum faucibus.">
 Use the `focus` trigger to dismiss popovers on the user's next click of a different element than the toggle element.
 
 {% capture callout %}
-##### Specific markup required for dismiss-on-next-click
+#### Specific markup required for dismiss-on-next-click
 
 For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 {% endcapture %}
@@ -253,7 +253,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </table>
 
 {% capture callout %}
-##### Data attributes for individual popovers
+#### Data attributes for individual popovers
 
 Options for individual popovers can alternatively be specified through the use of data attributes, as explained above.
 {% endcapture %}

--- a/site/docs/4.1/components/scrollspy.md
+++ b/site/docs/4.1/components/scrollspy.md
@@ -257,14 +257,14 @@ $('body').scrollspy({ target: '#navbar-example' })
 {% endhighlight %}
 
 {% capture callout %}
-##### Resolvable ID targets required
+#### Resolvable ID targets required
 
 Navbar links must have resolvable id targets. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`.
 {% endcapture %}
 {% include callout.html content=callout type="danger" %}
 
 {% capture callout %}
-##### Non-`:visible` target elements ignored
+#### Non-`:visible` target elements ignored
 
 Target elements that are not [`:visible` according to jQuery](https://api.jquery.com/visible-selector/) will be ignored and their corresponding nav items will never be highlighted.
 {% endcapture %}

--- a/site/docs/4.1/components/tooltips.md
+++ b/site/docs/4.1/components/tooltips.md
@@ -254,7 +254,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </table>
 
 {% capture callout %}
-##### Data attributes for individual tooltips
+#### Data attributes for individual tooltips
 
 Options for individual tooltips can alternatively be specified through the use of data attributes, as explained above.
 {% endcapture %}

--- a/site/docs/4.1/getting-started/javascript.md
+++ b/site/docs/4.1/getting-started/javascript.md
@@ -35,7 +35,7 @@ $(document).off('.alert.data-api')
 {% endhighlight %}
 
 {% capture callout %}
-##### Selectors
+## Selectors
 
 Currently to query DOM elements we use the native methods `querySelector` and `querySelectorAll` for performance reasons, so you have to use [valid selectors](https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier).
 If you use special selectors, for example: `collapse:Example` be sure to escape them.

--- a/site/docs/4.1/utilities/colors.md
+++ b/site/docs/4.1/utilities/colors.md
@@ -49,7 +49,7 @@ When `$enable-gradients` is set to `true` (default is `false`), you can use `.bg
 - `.bg-gradient-{{ color.name }}`{% endfor %}
 
 {% capture callout %}
-##### Dealing with specificity
+#### Dealing with specificity
 
 Sometimes contextual classes cannot be applied due to the specificity of another selector. In some cases, a sufficient workaround is to wrap your element's content in a `<div>` with the class.
 {% endcapture %}


### PR DESCRIPTION
@XhmikosR Hi, I've notices you already upgraded jekyll-toc to v0.9.1 but it looks like you haven't changed `_config.yml` setting, so I did make a change to `_config.yml` as a sample.

Hopefully it works as you expected.

ref. https://github.com/toshimaru/jekyll-toc/issues/70

Thanks.