### PR TITLE
Make custom control label padding override easier

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -67,7 +67,6 @@
 // Build the custom controls out of pseudo-elements.
 
 .custom-control-label {
-  position: relative;
   margin-bottom: 0;
   vertical-align: top;
 
@@ -75,7 +74,7 @@
   &::before {
     position: absolute;
     top: (($font-size-base * $line-height-base - $custom-control-indicator-size) / 2);
-    left: -$custom-control-gutter;
+    left: 0;
     display: block;
     width: $custom-control-indicator-size;
     height: $custom-control-indicator-size;
@@ -90,7 +89,7 @@
   &::after {
     position: absolute;
     top: (($font-size-base * $line-height-base - $custom-control-indicator-size) / 2);
-    left: -$custom-control-gutter;
+    left: 0;
     display: block;
     width: $custom-control-indicator-size;
     height: $custom-control-indicator-size;


### PR DESCRIPTION
Currently it's quite difficult to override or remove the space between the custom control indicator and the actual label. You have to change the `padding-left` of the `.custom-control` and the negative `left` positioning of the indicator background and foreground.

With this PR you only have to change the `padding-left` of the `.custom-control` to the indicator size + `x` to control the space between indicator and label. The indicator will always remain all the way left relative to the `.custom-control` itself.