### PR TITLE
Replaced fixed 'bolder' font weight value in reboot with variable. 

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -161,7 +161,7 @@ blockquote {
 
 b,
 strong {
-  font-weight: bolder; // Add the correct font weight in Chrome, Edge, and Safari
+  font-weight: $font-weight-bolder; // Add the correct font weight in Chrome, Edge, and Safari
 }
 
 small {


### PR DESCRIPTION
The default font weight value for `<strong>` `<br>` in reboot was set by a fixed value we now use the variable `$font-weight-bolder` to let users override this value.

Fixes #27774