### PR TITLE
Make `.close` hover focus styles less specific

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -5,19 +5,20 @@
   line-height: 1;
   color: $close-color;
   text-shadow: $close-text-shadow;
-  opacity: .5;
+  opacity: $close-opacity;
 
-  // Override <a>'s hover style
-  @include hover {
-    color: $close-color;
+  @include hover-focus {
+    color: $close-hover-color;
     text-decoration: none;
+    opacity: $close-hover-opacity;
+  }
+
+  &.disabled,
+  &:disabled {
+    opacity: $close-disabled-opacity;
   }
 
   &:not(:disabled):not(.disabled) {
-    @include hover-focus {
-      opacity: .75;
-    }
-
     // Opinionated: add "hand" cursor to non-disabled .close elements
     cursor: pointer;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1058,7 +1058,12 @@ $close-font-size:                   $font-size-base * 1.5 !default;
 $close-font-weight:                 $font-weight-bold !default;
 $close-color:                       $black !default;
 $close-text-shadow:                 0 1px 0 $white !default;
+$close-opacity:                     .5 !default;
 
+$close-hover-color:                 $close-color !default;
+$close-hover-opacity:               .75 !default;
+
+$close-disabled-opacity:            $close-opacity !default;
 
 // Code
 


### PR DESCRIPTION
This pull removes the `&:not(:disabled):not(.disabled)` selector on the `.close` component and styles `:disabled`/`.disabled` directly because the `:not` pseudo classes are too hard to overwrite (breaks for people that extended `.close` based on the old version).

Also added variables:
```
$close-opacity
$close-hover-color
$close-hover-opacity
$close-disabled-opacity
```

Fixes #27784 