### PR TITLE
Make disabled link in card examples non-focusable and add aria-disabled

### DIFF
--- a/site/docs/4.1/components/card.md
+++ b/site/docs/4.1/components/card.md
@@ -311,7 +311,7 @@ Add some navigation to a card's header (or block) with Bootstrap's [nav componen
         <a class="nav-link" href="#">Link</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link disabled" href="#">Disabled</a>
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
       </li>
     </ul>
   </div>
@@ -335,7 +335,7 @@ Add some navigation to a card's header (or block) with Bootstrap's [nav componen
         <a class="nav-link" href="#">Link</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link disabled" href="#">Disabled</a>
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
All other instances of disabled `<a href="#">` links in the docs (e.g. in the navs examples etc) has been addressed. This one slipped through...