### PR TITLE
Fix margin above toast when previous toast is hidden

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -10,8 +10,8 @@
   backdrop-filter: blur(10px);
   opacity: 0;
 
-  + .toast {
-    margin-top: $toast-padding-x;
+  &:not(:last-child) {
+    margin-bottom: $toast-padding-x;
   }
 
   &.showing {


### PR DESCRIPTION
There's a margin above the second toast if we dismiss the first: https://deploy-preview-27792--twbs-bootstrap4.netlify.com/docs/4.1/components/toasts/#stacking

Demo solution: https://deploy-preview-27820--twbs-bootstrap4.netlify.com/docs/4.1/components/toasts/#stacking

Closes #27807