### PR TITLE
Mention min-height issue in IE10/11 for flex containers

### DIFF
--- a/site/docs/4.1/layout/grid.md
+++ b/site/docs/4.1/layout/grid.md
@@ -340,7 +340,7 @@ Here's an example of customizing the Bootstrap grid at the large (`lg`) breakpoi
 
 ## Alignment
 
-Use flexbox alignment utilities to vertically and horizontally align columns.
+Use flexbox alignment utilities to vertically and horizontally align columns. **Internet Explorer 10-11 do not support vertical alignment of flex items when the flex container has a `min-height` as shown below.** [See Flexbugs #3 for more details.](https://github.com/philipwalton/flexbugs#flexbug-3)
 
 ### Vertical alignment
 


### PR DESCRIPTION
Adds a small docs callout for how IE10/11 ignore the `min-height`. I could've simply moved us to `height` instead, but this seems helpful to callout while keeping the docs layout bulletproof.

Fixes #26468.