### PR TITLE
Add table-hover-color variables

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -5,6 +5,7 @@
 .table {
   width: 100%;
   margin-bottom: $spacer;
+  color: $table-color;
   background-color: $table-bg; // Reset for nesting within parents with `background-color`.
 
   th,

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -88,6 +88,7 @@
 .table-hover {
   tbody tr {
     @include hover {
+      color: $table-hover-color;
       background-color: $table-hover-bg;
     }
   }
@@ -152,6 +153,7 @@
   &.table-hover {
     tbody tr {
       @include hover {
+        color: $table-dark-hover-color;
         background-color: $table-dark-hover-bg;
       }
     }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -352,8 +352,10 @@ $hr-margin-y:                 $spacer !default;
 $table-cell-padding:          .75rem !default;
 $table-cell-padding-sm:       .3rem !default;
 
+$table-color:                 $body-color !default;
 $table-bg:                    transparent !default;
 $table-accent-bg:             rgba($black, .05) !default;
+$table-hover-color:           $table-color !default;
 $table-hover-bg:              rgba($black, .075) !default;
 $table-active-bg:             $table-hover-bg !default;
 
@@ -363,11 +365,12 @@ $table-border-color:          $gray-300 !default;
 $table-head-bg:               $gray-200 !default;
 $table-head-color:            $gray-700 !default;
 
+$table-dark-color:            $white !default;
 $table-dark-bg:               $gray-900 !default;
 $table-dark-accent-bg:        rgba($white, .05) !default;
+$table-dark-hover-color:      $table-dark-color !default;
 $table-dark-hover-bg:         rgba($white, .075) !default;
 $table-dark-border-color:     lighten($gray-900, 7.5%) !default;
-$table-dark-color:            $white !default;
 
 $table-striped-order:         odd !default;
 


### PR DESCRIPTION
Fixes #26465.

Strictly speaking, this might constitute new features with the new variables, so we may need to do this in v4.2 or a v4.3. Lemme know your thoughts, @twbs/css-review.