### PR TITLE
Add new .text-break utility for applying word-break: break-word

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -62,6 +62,8 @@
 
 .text-decoration-none { text-decoration: none !important; }
 
+.text-break    { word-break: break-word !important; }
+
 // Reset
 
 .text-reset { color: inherit !important; }

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -62,7 +62,7 @@
 
 .text-decoration-none { text-decoration: none !important; }
 
-.text-break    { word-break: break-word !important; }
+.text-break { word-break: break-word !important; }
 
 // Reset
 

--- a/site/docs/4.1/utilities/text.md
+++ b/site/docs/4.1/utilities/text.md
@@ -66,6 +66,15 @@ For longer content, you can add a `.text-truncate` class to truncate the text wi
 {% endcapture %}
 {% include example.html content=example %}
 
+## Word break
+
+Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-break: break-word`.
+
+{% capture example %}
+<p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+{% endcapture %}
+{% include example.html content=example %}
+
 ## Text transform
 
 Transform text in components with text capitalization classes.


### PR DESCRIPTION
If we need to be changing the breaking of content, we shouldn't be doing it piece meal on our components. A utility helps in the interim, hence this PR, but v5 will likely see this added to the `<body>` element in Reboot to solve the problem across the entire project. (At that point we'll likely need the opposite utility, too).

Fixes #19315.