### PR TITLE
Sync modal header & footer border colors with $border-color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -914,7 +914,7 @@ $modal-content-box-shadow-sm-up:    0 .5rem 1rem rgba($black, .5) !default;
 
 $modal-backdrop-bg:                 $black !default;
 $modal-backdrop-opacity:            .5 !default;
-$modal-header-border-color:         $gray-200 !default;
+$modal-header-border-color:         $border-color !default;
 $modal-footer-border-color:         $modal-header-border-color !default;
 $modal-header-border-width:         $modal-content-border-width !default;
 $modal-footer-border-width:         $modal-header-border-width !default;


### PR DESCRIPTION
The `$modal-header-border-color`(`$gray-200`) and `$modal-footer-border-color`(`$gray-200`)  differ from `$border-color`(`$gray-300`) which doesn't look consistent when you're using the `.border` utility class or tables in modals.



