### PR TITLE
Sync `$table-border-color` with `$border-color`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -358,7 +358,7 @@ $table-hover-bg:              rgba($black, .075) !default;
 $table-active-bg:             $table-hover-bg !default;
 
 $table-border-width:          $border-width !default;
-$table-border-color:          $gray-300 !default;
+$table-border-color:          $border-color !default;
 
 $table-head-bg:               $gray-200 !default;
 $table-head-color:            $gray-700 !default;


### PR DESCRIPTION
`$border-color` is `$gray-300` and `$table-border-color` is `$gray-300`, but if you change `$border-color`, `$table-border-color` doesn't change.