### PR TITLE
Add dark carousel color scheme

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -196,3 +196,18 @@
   color: $carousel-caption-color;
   text-align: center;
 }
+
+
+// Dark carousel
+//
+// Useful for when your carousel images are very light and white text doesn't
+// have enough contrast.
+
+.carousel-dark {
+  .carousel-control-prev,
+  .carousel-control-next {
+    color: $carousel-dark-control-color;
+  }
+  .carousel-indicators li { background-color: $carousel-dark-indicator-active-bg; }
+  .carousel-caption { color: $carousel-dark-caption-color; }
+}

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -208,6 +208,16 @@
   .carousel-control-next {
     color: $carousel-dark-control-color;
   }
-  .carousel-indicators li { background-color: $carousel-dark-indicator-active-bg; }
-  .carousel-caption { color: $carousel-dark-caption-color; }
+  .carousel-control-prev-icon {
+    background-image: $carousel-dark-control-prev-icon-bg;
+  }
+  .carousel-control-next-icon {
+    background-image: $carousel-dark-control-next-icon-bg;
+  }
+  .carousel-indicators li {
+    background-color: $carousel-dark-indicator-active-bg;
+  }
+  .carousel-caption {
+    color: $carousel-dark-caption-color;
+  }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1020,7 +1020,8 @@ $breadcrumb-border-radius:          $border-radius !default;
 
 // Carousel
 
-$carousel-control-color:             $white !default;
+$carousel-fg:                        $white !default;
+$carousel-control-color:             $carousel-fg !default;
 $carousel-control-width:             15% !default;
 $carousel-control-opacity:           .5 !default;
 $carousel-control-hover-opacity:     .9 !default;
@@ -1030,11 +1031,11 @@ $carousel-indicator-width:           30px !default;
 $carousel-indicator-height:          3px !default;
 $carousel-indicator-hit-area-height: 10px !default;
 $carousel-indicator-spacer:          3px !default;
-$carousel-indicator-active-bg:       $white !default;
+$carousel-indicator-active-bg:       $carousel-fg !default;
 $carousel-indicator-transition:      opacity .6s ease !default;
 
 $carousel-caption-width:             70% !default;
-$carousel-caption-color:             $white !default;
+$carousel-caption-color:             $carousel-fg !default;
 
 $carousel-control-icon-width:        20px !default;
 
@@ -1044,6 +1045,10 @@ $carousel-control-next-icon-bg:      str-replace(url("data:image/svg+xml,%3csvg 
 $carousel-transition-duration:       .6s !default;
 $carousel-transition:                transform $carousel-transition-duration ease-in-out !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
 
+$carousel-dark-fg:                   $gray-800 !default;
+$carousel-dark-control-color:        $carousel-dark-fg !default;
+$carousel-dark-indicator-active-bg:  $carousel-dark-fg !default;
+$carousel-dark-caption-color:        $carousel-dark-fg !default;
 
 // Spinners
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1049,6 +1049,9 @@ $carousel-dark-fg:                   $gray-800 !default;
 $carousel-dark-control-color:        $carousel-dark-fg !default;
 $carousel-dark-indicator-active-bg:  $carousel-dark-fg !default;
 $carousel-dark-caption-color:        $carousel-dark-fg !default;
+$carousel-dark-control-prev-icon-bg: str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-dark-control-color}' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e"), "#", "%23") !default;
+$carousel-dark-control-next-icon-bg: str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-dark-control-color}' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e"), "#", "%23") !default;
+
 
 // Spinners
 

--- a/site/docs/4.1/components/carousel.md
+++ b/site/docs/4.1/components/carousel.md
@@ -221,6 +221,46 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 {% endcapture %}
 {% include example.html content=example %}
 
+### Dark carousel
+
+Have lighter background content for your carousels? Swap the white text, slide controls, and indicators for dark gray ones by adding `.carousel-dark`.
+
+{% capture example %}
+<div id="carouselExampleDark" class="carousel slide carousel-dark" data-ride="carousel">
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#999" background="#fff" text="First slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>First slide label</h5>
+        <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </div>
+    </div>
+    <div class="carousel-item">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#888" background="#f5f5f5" text="Second slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>Second slide label</h5>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </div>
+    </div>
+    <div class="carousel-item">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#777" background="#eee" text="Third slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>Third slide label</h5>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
+      </div>
+    </div>
+  </div>
+  <a class="carousel-control-prev" href="#carouselExampleDark" role="button" data-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="sr-only">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#carouselExampleDark" role="button" data-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="sr-only">Next</span>
+  </a>
+</div>
+{% endcapture %}
+{% include example.html content=example %}
 
 ## Usage
 


### PR DESCRIPTION
Fixes #25360.

Not 100% if I want this added yet, but wanted to see how it looked and what the reception was for folks. Docs and example can be seen at <https://deploy-preview-27878--twbs-bootstrap4.netlify.com/docs/4.1/components/carousel/#dark-carousel>.