### PR TITLE
Prevent unnecessary CSS output for emphasized links

### DIFF
--- a/scss/mixins/_text-emphasis.scss
+++ b/scss/mixins/_text-emphasis.scss
@@ -6,9 +6,11 @@
   #{$parent} {
     color: $color !important;
   }
-  a#{$parent} {
-    @include hover-focus {
-      color: darken($color, $emphasized-link-hover-darken-percentage) !important;
+  @if $emphasized-link-hover-darken-percentage != 0 {
+    a#{$parent} {
+      @include hover-focus {
+        color: darken($color, $emphasized-link-hover-darken-percentage) !important;
+      }
     }
   }
 }


### PR DESCRIPTION
If `$emphasized-link-hover-darken-percentage` is 0 or 0%, the overwrite for `a` is not necessary:

```css
.text-primary {
  color: #0d67cb !important;
}

a.text-primary:hover, a.text-primary:focus {
  color: #0d67cb !important; // No need
}
```

This PR prevents unnecessary CSS output when `$emphasized-link-hover-darken-percentage` is 0 or 0%