### PR TITLE
Remove broken link entry for translations (documentation).

### DIFF
--- a/site/_data/translations.yml
+++ b/site/_data/translations.yml
@@ -8,11 +8,6 @@
   description: Bootstrap 4 · 全球最流行的 HTML、CSS 和 JS 工具库。
   url: https://code.z01.com/v4/
 
-- name: Chinese
-  code: zh
-  description: Bootstrap 4 中文文档教程
-  url: https://wiki.jikexueyuan.com/project/bootstrap4/
-
 - name: Brazilian Portuguese
   code: pt-BR
   description: Bootstrap 4 Português do Brasil


### PR DESCRIPTION
Unfortunately, a link to a Chinese translation of the documentation seems dead, leading to a 404 error. I tried to find out if the url had changed... no success.

Related to PR #21696.