### PR TITLE
Fix custom select font sizes

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -216,6 +216,7 @@
   width: 100%;
   height: $custom-select-height;
   padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
+  font-size: $custom-select-font-size;
   font-weight: $custom-select-font-weight;
   line-height: $custom-select-line-height;
   color: $custom-select-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -565,6 +565,7 @@ $custom-switch-indicator-size:                  calc(#{$custom-control-indicator
 
 $custom-select-padding-y:           $input-btn-padding-y !default;
 $custom-select-padding-x:           $input-btn-padding-x !default;
+$custom-select-font-size:           $input-font-size !default;
 $custom-select-height:              $input-height !default;
 $custom-select-indicator-padding:   1rem !default; // Extra padding to account for the presence of the background-image based indicator
 $custom-select-font-weight:         $input-font-weight !default;
@@ -593,12 +594,12 @@ $custom-select-focus-box-shadow:    0 0 0 $custom-select-focus-width rgba($custo
 
 $custom-select-padding-y-sm:        $input-padding-y-sm !default;
 $custom-select-padding-x-sm:        $input-padding-x-sm !default;
-$custom-select-font-size-sm:        $input-btn-font-size-sm !default;
+$custom-select-font-size-sm:        $input-font-size-sm !default;
 $custom-select-height-sm:           $input-height-sm !default;
 
 $custom-select-padding-y-lg:        $input-padding-y-lg !default;
 $custom-select-padding-x-lg:        $input-padding-x-lg !default;
-$custom-select-font-size-lg:        $input-btn-font-size-lg !default;
+$custom-select-font-size-lg:        $input-font-size-lg !default;
 $custom-select-height-lg:           $input-height-lg !default;
 
 $custom-range-track-width:          100% !default;


### PR DESCRIPTION
The font sizes of custom selects are unchangeable. This PR syncs the custom select font size with `$input-font-size`.

Also `$custom-select-font-size-sm` is `$input-btn-font-size-sm` by default, while it should be `$input-btn-font-size`. Same for `$custom-select-font-size-lg`.