### PR TITLE
Prevent select word wrap in Safari

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -331,6 +331,14 @@ select {
   text-transform: none; // Remove the inheritance of text transform in Firefox
 }
 
+// Remove the inheritance of word-wrap in Safari.
+//
+// Details at https://github.com/twbs/bootstrap/issues/24990
+select {
+  word-wrap: normal;
+}
+
+
 // 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
 //    controls in Android 4.
 // 2. Correct the inability to style clickable types in iOS and Safari.


### PR DESCRIPTION
Fixes #24990.
Closes #25063

#25063 only fixes this for `<select>`s in `.card`s, but this behaviour should never occur, so it's better to deal with this in reboot.