### PR TITLE
Match input font size for .input-group-text

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -104,7 +104,7 @@
   align-items: center;
   padding: $input-padding-y $input-padding-x;
   margin-bottom: 0; // Allow use of <label> elements by overriding our default margin-bottom
-  font-size: $font-size-base; // Match inputs
+  font-size: $input-font-size; // Match inputs
   font-weight: $font-weight-normal;
   line-height: $input-line-height;
   color: $input-group-addon-color;


### PR DESCRIPTION
If `$input-font-size` is changed, the font size of input groups with `.input-group-text` won't change. 