### PR TITLE
Make meaning of tooltip's 'selector' option more clear in Bootstrap 3

### DIFF
--- a/docs/_includes/js/tooltips.html
+++ b/docs/_includes/js/tooltips.html
@@ -169,7 +169,7 @@ $('#example').tooltip(options)
           <td>selector</td>
           <td>string</td>
           <td>false</td>
-          <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to enable dynamic HTML content to have tooltips added. See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="http://jsbin.com/zopod/1/edit">an informative example</a>.</td>
+          <td>If a selector is provided, tooltip objects will be delegated to the specified targets. In practice, this is used to also apply tooltips to dynamically added DOM elements (<code>jQuery.on</code> support). See <a href="https://github.com/twbs/bootstrap/issues/4215">this</a> and <a href="http://jsbin.com/zopod/1/edit">an informative example</a>.</td>
         </tr>
         <tr>
           <td>template</td>


### PR DESCRIPTION
Based on #4215
Backport changes made to docs v4 to v3 (#27573)