### PR TITLE
Added ability override breakpoints/container-width

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -197,7 +197,7 @@ $grid-breakpoints: map-merge(
     xl: 1200px
   ),
   $grid-breakpoints
-);
+) !default;
 
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints);
@@ -217,7 +217,7 @@ $container-max-widths: map-merge(
     xl: 1140px
   ),
   $container-max-widths
-);
+) !default;
 
 @include _assert-ascending($container-max-widths, "$container-max-widths");
 


### PR DESCRIPTION
If developer need to remove a breakpoint (for example: to make grid without xl breakpoint), he cannot overide it from another file, if we add !default in variables file everyting will be ok!

Next code will get xl from _variables.scss
(
    sm: 540px,
    md: 720px,
    lg: 960px,
)