### PR TITLE
Remove screen from media query

### DIFF
--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -9,7 +9,7 @@
   }
 
   @if $enable-prefers-reduced-motion-media-query {
-    @media screen and (prefers-reduced-motion: reduce) {
+    @media (prefers-reduced-motion: reduce) {
       transition: none;
     }
   }


### PR DESCRIPTION
We don't use `screen` anywhere else in our media queries and there's no reason why we should disable it if the device is not a screen.