### PR TITLE
box-shadow mixin fix

### DIFF
--- a/scss/mixins/_box-shadow.scss
+++ b/scss/mixins/_box-shadow.scss
@@ -2,9 +2,15 @@
   @if $enable-shadows {
     $result: ();
 
-    @for $i from 1 through length($shadow) {
-      @if nth($shadow, $i) != "none" {
-        $result: append($result, nth($shadow, $i), "comma");
+    @if (length($shadow) == 1) {
+      // we can pass @include box-shadow(none);
+      $result: $shadow;
+    } @else {
+      // filter to avoid invalid properties for example box-shadow: none, 1px 1px black;
+      @for $i from 1 through length($shadow) {
+        @if nth($shadow, $i) != "none" {
+          $result: append($result, nth($shadow, $i), "comma");
+        }
       }
     }
     @if (length($result) > 0) {

--- a/scss/mixins/_box-shadow.scss
+++ b/scss/mixins/_box-shadow.scss
@@ -3,10 +3,10 @@
     $result: ();
 
     @if (length($shadow) == 1) {
-      // we can pass @include box-shadow(none);
+      // We can pass `@include box-shadow(none);`
       $result: $shadow;
     } @else {
-      // filter to avoid invalid properties for example box-shadow: none, 1px 1px black;
+      // Filter to avoid invalid properties for example `box-shadow: none, 1px 1px black;`
       @for $i from 1 through length($shadow) {
         @if nth($shadow, $i) != "none" {
           $result: append($result, nth($shadow, $i), "comma");


### PR DESCRIPTION
My previous fix was to optimistic. Please look at https://github.com/twbs/bootstrap/pull/27972#issuecomment-452106061

Sometimes we want pass `none` to switch off `box-shadow`.
We don't want only properties like `box-shadow: none, 1px 1px black;`  because this is invalid property for browsers