### PR TITLE
Prevent wrapping if caret is included

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -7,6 +7,8 @@
 }
 
 .dropdown-toggle {
+  white-space: nowrap;
+
   // Generate the caret automatically
   @include caret;
 }


### PR DESCRIPTION
Closes https://github.com/twbs/bootstrap/issues/28021

With this change, the text won't wrap for `.dropdown-toggle`.

Ping @twbs/css-review for thoughts