### PR TITLE
Prevent useless property rendering

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -304,10 +304,10 @@ $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
 $headings-margin-bottom:      $spacer / 2 !default;
-$headings-font-family:        inherit !default;
+$headings-font-family:        null !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
-$headings-color:              inherit !default;
+$headings-color:              null !default;
 
 $display1-size:               6rem !default;
 $display2-size:               5.5rem !default;


### PR DESCRIPTION
`font-family` and `color` of headings shouldn't be rendered by default.