### PR TITLE
Don't render a background by default

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -356,7 +356,7 @@ $table-cell-padding:          .75rem !default;
 $table-cell-padding-sm:       .3rem !default;
 
 $table-color:                 $body-color !default;
-$table-bg:                    transparent !default;
+$table-bg:                    null !default;
 $table-accent-bg:             rgba($black, .05) !default;
 $table-hover-color:           $table-color !default;
 $table-hover-bg:              rgba($black, .075) !default;


### PR DESCRIPTION
Another place where we can make use of `null` to prevent rendering of a property.