### PR TITLE
Prevent rendering of color property by default for card heading

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -825,7 +825,7 @@ $card-border-radius:                $border-radius !default;
 $card-border-color:                 rgba($black, .125) !default;
 $card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 $card-cap-bg:                       rgba($black, .03) !default;
-$card-cap-color:                    inherit !default;
+$card-cap-color:                    null !default;
 $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;


### PR DESCRIPTION
Another place where we can make use of `null` to prevent rendering of a property.