### PR TITLE
custom switches - add a right aligned option?

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -188,6 +188,22 @@
     }
   }
 
+  &.right {
+    padding-left: 0;
+    .custom-control-label {
+      padding-right: $custom-switch-width + $custom-control-gutter;
+      &::before {
+        right: 0;
+        left: auto;
+      }
+
+      &::after {
+        right: calc(#{($custom-switch-width / 2)} + #{$custom-control-indicator-border-width});
+        left: auto;
+      }
+    }
+  }
+
   .custom-control-input:checked ~ .custom-control-label {
     &::after {
       background-color: $custom-control-indicator-bg;

--- a/site/docs/4.2/components/forms.md
+++ b/site/docs/4.2/components/forms.md
@@ -1238,6 +1238,20 @@ A switch has the markup of a custom checkbox but uses the `.custom-switch` class
 {% endcapture %}
 {% include example.html content=example %}
 
+Add the `.right` class to render a toggle switch with label text before.
+
+{% capture example %}
+<div class="custom-control custom-switch right">
+  <input type="checkbox" class="custom-control-input" id="customSwitch3">
+  <label class="custom-control-label" for="customSwitch3">Toggle this switch element right aligned</label>
+</div>
+<div class="custom-control custom-switch right">
+  <input type="checkbox" class="custom-control-input" disabled id="customSwitch4">
+  <label class="custom-control-label" for="customSwitch4">Disabled switch element right aligned</label>
+</div>
+{% endcapture %}
+{% include example.html content=example %}
+
 ### Select menu
 
 Custom `<select>` menus need only a custom class, `.custom-select` to trigger the custom styles. Custom styles are limited to the `<select>`'s initial appearance and cannot modify the `<option>`s due to browser limitations.


### PR DESCRIPTION
I propose to add an option to new custom switches component `right` class to position label before the switch for rtl website or any other needs.

Here's what it looks like : 
![image](https://user-images.githubusercontent.com/11272238/51135937-8846f700-183b-11e9-9463-0f040bbe91d5.png)

Don't know if it's better to align also the label on the right and keep the gutter to align?
Let me know or edit that PR if needed
