### PR TITLE
Refer to reason why a card has `min-width`

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -6,7 +6,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  min-width: 0;
+  min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
   word-wrap: break-word;
   background-color: $card-bg;
   background-clip: border-box;


### PR DESCRIPTION
`min-width: 0` is a browser default. There's no reason to add this. (it was added here https://github.com/twbs/bootstrap/commit/891bca435fb4a13ef60e1bc65b522c6be1e31bb3)