### PR TITLE
Remove redundant properties from `.embed-responsive`

### DIFF
--- a/scss/helpers/_embed.scss
+++ b/scss/helpers/_embed.scss
@@ -2,10 +2,7 @@
 
 .embed-responsive {
   position: relative;
-  display: block;
   width: 100%;
-  padding: 0;
-  overflow: hidden;
 
   &::before {
     display: block;
@@ -19,7 +16,6 @@
   video {
     position: absolute;
     top: 0;
-    bottom: 0;
     left: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
We copied the `.embed-responsive` code from somewhere else, but there are a lot of redundant properties in it:

- No need to set `display: block;` on a `<div>`
- No need to remove `padding` from a `<div>`
- No need to set `overflow: hidden;` because the inner content is spread in `.embed-responsive`
- No need for `bottom: 0;`, because we already have `height: 100%;`