### PR TITLE
Fix text break in Firefox

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -63,9 +63,8 @@
 .text-decoration-none { text-decoration: none !important; }
 
 .text-break {
-  // Add `hyphens: auto;` as workaround to force Firefox to break:
-  hyphens: auto;
-  word-break: break-word !important;
+  word-break: break-word !important; // IE & < Edge 18
+  overflow-wrap: break-word !important;
 }
 
 // Reset

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -63,6 +63,7 @@
 .text-decoration-none { text-decoration: none !important; }
 
 .text-break {
+  // Add `hyphens: auto;` as workaround to force Firefox to break:
   hyphens: auto;
   word-break: break-word !important;
 }

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -62,7 +62,10 @@
 
 .text-decoration-none { text-decoration: none !important; }
 
-.text-break { word-break: break-word !important; }
+.text-break {
+  hyphens: auto;
+  word-break: break-word !important;
+}
 
 // Reset
 

--- a/site/docs/4.2/utilities/text.md
+++ b/site/docs/4.2/utilities/text.md
@@ -68,7 +68,7 @@ For longer content, you can add a `.text-truncate` class to truncate the text wi
 
 ## Word break
 
-Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-break: break-word`.
+Prevent long strings of text from breaking your components' layout by using `.text-break` to set `overflow-wrap: break-word` (and `word-break: break-word` for IE & Edge compatibility).
 
 {% capture example %}
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>


### PR DESCRIPTION
`word-break: break-word` doesn't work in Firefox, but I think `hyphens: auto;`  is an acceptable workaround. I guess `!important` won't be nessesary for `hyphens: auto;`, but not 100% sure.