### PR TITLE
Deprecate size mixin

### DIFF
--- a/scss/mixins/_size.scss
+++ b/scss/mixins/_size.scss
@@ -3,4 +3,5 @@
 @mixin size($width, $height: $width) {
   width: $width;
   height: $height;
+  @include deprecate("`size()`", "v4.3.0", "v5");
 }


### PR DESCRIPTION
I guess someone who uses mixins will also know the `width` and `height` properties 😃