### PR TITLE
use absolute path to output lcov file for coveralls

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -1,14 +1,13 @@
 /* eslint-env node */
 /* eslint no-process-env: 0 */
 
+const path = require('path')
 const ip = require('ip')
 const {
   browsers,
   browsersKeys
 } = require('./browsers')
-const path = require('path')
 
-const jsCoveragePath = path.resolve(__dirname, '../coverage')
 const jqueryFile = process.env.USE_OLD_JQUERY ? 'https://code.jquery.com/jquery-1.9.1.min.js' : 'node_modules/jquery/dist/jquery.slim.min.js'
 const bundle = process.env.BUNDLE === 'true'
 const browserStack = process.env.BROWSER === 'true'
@@ -116,7 +115,7 @@ if (bundle) {
   conf.customLaunchers = customLaunchers
   conf.detectBrowsers = detectBrowsers
   conf.coverageIstanbulReporter = {
-    dir: jsCoveragePath,
+    dir: path.resolve(__dirname, '../coverage/'),
     reports: ['lcov', 'text-summary'],
     thresholds: {
       emitWarning: false,

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -6,7 +6,9 @@ const {
   browsers,
   browsersKeys
 } = require('./browsers')
+const path = require('path')
 
+const jsCoveragePath = path.resolve(__dirname, '../coverage')
 const jqueryFile = process.env.USE_OLD_JQUERY ? 'https://code.jquery.com/jquery-1.9.1.min.js' : 'node_modules/jquery/dist/jquery.slim.min.js'
 const bundle = process.env.BUNDLE === 'true'
 const browserStack = process.env.BROWSER === 'true'
@@ -114,7 +116,7 @@ if (bundle) {
   conf.customLaunchers = customLaunchers
   conf.detectBrowsers = detectBrowsers
   conf.coverageIstanbulReporter = {
-    dir: '../coverage/',
+    dir: jsCoveragePath,
     reports: ['lcov', 'text-summary'],
     thresholds: {
       emitWarning: false,


### PR DESCRIPTION
Without that we have this error: https://travis-ci.org/twbs/bootstrap/jobs/480784013#L1389

because there is no `lcov.info` file 

/CC @XhmikosR 