### PR TITLE
Create Gray Background Classes

### DIFF
--- a/scss/utilities/_background.scss
+++ b/scss/utilities/_background.scss
@@ -4,6 +4,10 @@
   @include bg-variant(".bg-#{$color}", $value);
 }
 
+@each $gray, $value in $grays {
+  @include bg-variant(".bg-gray#{$gray}", $value);
+}
+
 @if $enable-gradients {
   @each $color, $value in $theme-colors {
     @include bg-gradient-variant(".bg-gradient-#{$color}", $value);


### PR DESCRIPTION
I had a need for a Background Color utility class for a gray color. So I noticed that the `$theme-colors` map was being looped into the `bg-variant` mixin and but not the `$grays` map. I think it could be useful to others to have the bg-variant mixin classes created for the `$grays` like the `$theme-colors` to give more utilities for the all colors they define in variables.

This is my first Pull Request so please let me know if I need to do anything differently and your thoughts!