### PR TITLE
Add `deprecate()` mixin

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -2,6 +2,9 @@
 //
 // Used in conjunction with global variables to enable certain theme features.
 
+// Deprecate
+@import "mixins/deprecate";
+
 // Utilities
 @import "mixins/breakpoints";
 @import "mixins/hover";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -117,13 +117,7 @@ $enable-grid-classes:                         true !default;
 $enable-pointer-cursor-for-buttons:           true !default;
 $enable-print-styles:                         true !default;
 $enable-validation-icons:                     true !default;
-
-// Show deprecation messages
-//
-// Some mixins and functions will be removed in v5, the `deprecate()` mixin will warn you if you're using one of these.
-// These warnings can be suppressed by setting this variable to `false`:
-
-$show-deprecation-messages:                   true !default;
+$enable-deprecation-messages:                 true !default;
 
 
 // Spacing

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -118,6 +118,13 @@ $enable-pointer-cursor-for-buttons:           true !default;
 $enable-print-styles:                         true !default;
 $enable-validation-icons:                     true !default;
 
+// Show deprecation messages
+//
+// Some mixins and functions will be removed in v5, the `deprecate()` mixin will warn you if you're using one of these.
+// These warnings can be suppressed by setting this variable to `false`:
+
+$show-deprecation-messages:                   true !default;
+
 
 // Spacing
 //

--- a/scss/mixins/_deprecate.scss
+++ b/scss/mixins/_deprecate.scss
@@ -1,8 +1,10 @@
 // Deprecate mixin
 //
 // This mixin can be used to deprecate mixins or functions.
-@mixin deprecate($name, $deprecate-version, $remove-version) {
-  @if ($show-deprecation-messages != false) {
+// `$show-deprecation-messages` is a global variable, `$ignore-warning` is a variable that can be passed to
+// some deprecated mixins to suppress the warning (for example if the mixin is still be used in the current version of Bootstrap)
+@mixin deprecate($name, $deprecate-version, $remove-version, $ignore-warning) {
+  @if ($enable-deprecation-messages != false and $ignore-warning != true) {
     @warn "#{$name} has been deprecated as of #{$deprecate-version}. It will be removed entirely in #{$remove-version}.";
   }
 }

--- a/scss/mixins/_deprecate.scss
+++ b/scss/mixins/_deprecate.scss
@@ -1,7 +1,7 @@
 // Deprecate mixin
 //
 // This mixin can be used to deprecate mixins or functions.
-// `$show-deprecation-messages` is a global variable, `$ignore-warning` is a variable that can be passed to
+// `$enable-deprecation-messages` is a global variable, `$ignore-warning` is a variable that can be passed to
 // some deprecated mixins to suppress the warning (for example if the mixin is still be used in the current version of Bootstrap)
 @mixin deprecate($name, $deprecate-version, $remove-version, $ignore-warning) {
   @if ($enable-deprecation-messages != false and $ignore-warning != true) {

--- a/scss/mixins/_deprecate.scss
+++ b/scss/mixins/_deprecate.scss
@@ -1,0 +1,8 @@
+// Deprecate mixin
+//
+// This mixin can be used to deprecate mixins or functions.
+@mixin deprecate($name, $deprecate-version, $remove-version) {
+  @if ($show-deprecation-messages != false) {
+    @warn "#{$name} has been deprecated as of #{$deprecate-version}. It will be removed entirely in #{$remove-version}.";
+  }
+}

--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -7,7 +7,5 @@
   background-color: transparent;
   border: 0;
 
-  @if ($ignore-warning != true) {
-    @include deprecate("`text-hide()`", "v4.1.0", "v5");
-  }
+  @include deprecate("`text-hide()`", "v4.1.0", "v5", $ignore-warning);
 }

--- a/scss/mixins/_text-hide.scss
+++ b/scss/mixins/_text-hide.scss
@@ -8,6 +8,6 @@
   border: 0;
 
   @if ($ignore-warning != true) {
-    @warn "The `text-hide()` mixin has been deprecated as of v4.1.0. It will be removed entirely in v5.";
+    @include deprecate("`text-hide()`", "v4.1.0", "v5");
   }
 }

--- a/site/docs/4.2/getting-started/theming.md
+++ b/site/docs/4.2/getting-started/theming.md
@@ -243,7 +243,7 @@ You can find and customize these variables for key global options in Bootstrap's
 | `$enable-pointer-cursor-for-buttons`         | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |
 | `$enable-print-styles`                       | `true` (default) or `false`        | Enables styles for optimizing printing. |
 | `$enable-validation-icons`                   | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
-| `$enable-deprecation-messages`               | `true` or `false` (default)        | Some mixins and functions will be removed in `v5`, if this variable is set to `true` the `deprecate()` mixin will warn you if you're using one of these. |
+| `$enable-deprecation-messages`               | `true` or `false` (default)        | Set to `true` to show warnings when using any of the deprecated mixins and functions that are planned to be removed in `v5`. |
 
 ## Color
 

--- a/site/docs/4.2/getting-started/theming.md
+++ b/site/docs/4.2/getting-started/theming.md
@@ -243,6 +243,7 @@ You can find and customize these variables for key global options in Bootstrap's
 | `$enable-pointer-cursor-for-buttons`         | `true` (default) or `false`        | Add "hand" cursor to non-disabled button elements. |
 | `$enable-print-styles`                       | `true` (default) or `false`        | Enables styles for optimizing printing. |
 | `$enable-validation-icons`                   | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
+| `$enable-deprecation-messages`               | `true` or `false` (default)        | Some mixins and functions will be removed in `v5`, if this variable is set to `true` the `deprecate()` mixin will warn you if you're using one of these. |
 
 ## Color
 


### PR DESCRIPTION
We're probably going to drop a lot of mixins, and maybe some functions in `v5`. That's why I would like to introduce a `deprecate()` mixin. This mixin will allow us to deprecate mixins and functions now. Its goal is that all functions/mixins that will be droped in v5 include this mixin so that it'll be easy to check if people are relying on deprecated stuff in their codebase if they want to upgrade from Bootstrap 4 to 5. (They can update to the latest `v4` first where all the `deprecate()` mixins are included.)

I've put #28072, #28067 and #28066 hold for this (I acctually tought `$ignore-warning` was a global variable, which wasn't the case). Probably going to submit a lot more deprecation PRs (these won't be blocking the `4.3` release) 