### PR TITLE
Just pass `$ignore-warning` instead of also defining it

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -57,7 +57,7 @@
 // Misc
 
 .text-hide {
-  @include text-hide($ignore-warning: true);
+  @include text-hide(true);
 }
 
 .text-decoration-none { text-decoration: none !important; }


### PR DESCRIPTION
`$ignore-warning` shouldn't be set here, it's an include.