### PR TITLE
Add default value for `$ignore-warning`

### DIFF
--- a/scss/mixins/_deprecate.scss
+++ b/scss/mixins/_deprecate.scss
@@ -3,7 +3,7 @@
 // This mixin can be used to deprecate mixins or functions.
 // `$enable-deprecation-messages` is a global variable, `$ignore-warning` is a variable that can be passed to
 // some deprecated mixins to suppress the warning (for example if the mixin is still be used in the current version of Bootstrap)
-@mixin deprecate($name, $deprecate-version, $remove-version, $ignore-warning) {
+@mixin deprecate($name, $deprecate-version, $remove-version, $ignore-warning: false) {
   @if ($enable-deprecation-messages != false and $ignore-warning != true) {
     @warn "#{$name} has been deprecated as of #{$deprecate-version}. It will be removed entirely in #{$remove-version}.";
   }


### PR DESCRIPTION
I missed this in #28092, `$ignore-warning` should have a default value, otherwise you'll always need to define it.