### PR TITLE
Move dropdown offset function logic into private function

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -319,24 +319,30 @@ class Dropdown {
     return $(this._element).closest('.navbar').length > 0
   }
 
-  _getPopperConfig() {
-    const offsetConf = {}
+  _getOffset() {
+    const offset = {}
+
     if (typeof this._config.offset === 'function') {
-      offsetConf.fn = (data) => {
+      offset.fn = (data) => {
         data.offsets = {
           ...data.offsets,
-          ...this._config.offset(data.offsets) || {}
+          ...this._config.offset(data.offsets, this._element) || {}
         }
+
         return data
       }
     } else {
-      offsetConf.offset = this._config.offset
+      offset.offset = this._config.offset
     }
 
+    return offset
+  }
+
+  _getPopperConfig() {
     const popperConfig = {
       placement: this._getPlacement(),
       modifiers: {
-        offset: offsetConf,
+        offset: this._getOffset(),
         flip: {
           enabled: this._config.flip
         },
@@ -352,6 +358,7 @@ class Dropdown {
         enabled: false
       }
     }
+
     return popperConfig
   }
 

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -1361,4 +1361,59 @@ $(function () {
     $dropdown.hide()
     assert.ok($dropdown.parent('.dropdown').hasClass('show'))
   })
+
+  QUnit.test('should create offset modifier correctly when offset option is a function', function (assert) {
+    assert.expect(2)
+
+    var getOffset = function (offsets) {
+      return offsets
+    }
+
+    var dropdownHTML =
+      '<div class="dropdown">' +
+      '  <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
+      '  <div class="dropdown-menu">' +
+      '    <a class="dropdown-item" href="#">Another link</a>' +
+      '  </div>' +
+      '</div>'
+
+    var $dropdown = $(dropdownHTML)
+      .appendTo('#qunit-fixture')
+      .find('[data-toggle="dropdown"]')
+      .bootstrapDropdown({
+        offset: getOffset
+      })
+
+    var dropdown = $dropdown.data('bs.dropdown')
+    var offset = dropdown._getOffset()
+
+    assert.ok(typeof offset.offset === 'undefined')
+    assert.ok(typeof offset.fn === 'function')
+  })
+
+  QUnit.test('should create offset modifier correctly when offset option is not a function', function (assert) {
+    assert.expect(2)
+
+    var dropdownHTML =
+      '<div class="dropdown">' +
+      '  <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
+      '  <div class="dropdown-menu">' +
+      '    <a class="dropdown-item" href="#">Another link</a>' +
+      '  </div>' +
+      '</div>'
+
+    var myOffset = 42
+    var $dropdown = $(dropdownHTML)
+      .appendTo('#qunit-fixture')
+      .find('[data-toggle="dropdown"]')
+      .bootstrapDropdown({
+        offset: myOffset
+      })
+
+    var dropdown = $dropdown.data('bs.dropdown')
+    var offset = dropdown._getOffset()
+
+    assert.strictEqual(offset.offset, myOffset)
+    assert.ok(typeof offset.fn === 'undefined')
+  })
 })

--- a/site/docs/4.2/components/dropdowns.md
+++ b/site/docs/4.2/components/dropdowns.md
@@ -845,7 +845,11 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>offset</td>
       <td>number | string | function</td>
       <td>0</td>
-      <td>Offset of the dropdown relative to its target. For more information refer to Popper.js's <a href="https://popper.js.org/popper-documentation.html#modifiers..offset.offset">offset docs</a>.</td>
+      <td>
+        <p>Offset of the dropdown relative to its target.</p>
+        <p>When a function is used to determine the offset, it is called with an object containing the offset data as its first argument. The function must return an object with the same structure. The triggering element DOM node is passed as the second argument.</p>
+        <p>For more information refer to Popper.js's <a href="https://popper.js.org/popper-documentation.html#modifiers..offset.offset">offset docs</a>.</p>
+      </td>
     </tr>
     <tr>
       <td>flip</td>


### PR DESCRIPTION
This makes the dropdown offset function work the same as for tooltips as in #28130.