### PR TITLE
Fix negative margin example

### DIFF
--- a/site/docs/4.2/utilities/spacing.md
+++ b/site/docs/4.2/utilities/spacing.md
@@ -98,8 +98,8 @@ Here's an example of customizing the Bootstrap grid at the medium (`md`) breakpo
 
 {% capture example %}
 <div class="row mx-md-n5">
-  <div class="col py-3 px-md-5 border bg-light">Custom column padding</div>
-  <div class="col py-3 px-md-5 border bg-light">Custom column padding</div>
+  <div class="col px-md-5"><div class="p-3 border bg-light">Custom column padding</div></div>
+  <div class="col px-md-5"><div class="p-3 border bg-light">Custom column padding</div></div>
 </div>
 {% endcapture %}
 {% include example.html content=example %}


### PR DESCRIPTION
Negative margin example wasn't displaying correctly due to border and background styling being applied directly to the `.col` element. Made a child element and applied the styling to it

Original: https://getbootstrap.com/docs/4.2/utilities/spacing/#negative-margin
Demo: https://deploy-preview-28140--twbs-bootstrap4.netlify.com/docs/4.2/utilities/spacing/#negative-margin
