### PR TITLE
Add text-decoration to .btn-link.

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -76,6 +76,7 @@ fieldset:disabled a.btn {
 .btn-link {
   font-weight: $font-weight-normal;
   color: $link-color;
+  text-decoration: $link-decoration;
 
   @include hover {
     color: $link-hover-color;


### PR DESCRIPTION
Mirrors [scss/_reboot.scss#L184](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_reboot.scss#L184). Fixes #28157.