### PR TITLE
examples: remove JS from blog and sticky footer.

### DIFF
--- a/site/docs/4.2/examples/blog/index.html
+++ b/site/docs/4.2/examples/blog/index.html
@@ -4,6 +4,7 @@ title: Blog Template
 extra_css:
   - "https://fonts.googleapis.com/css?family=Playfair+Display:700,900"
   - "blog.css"
+include_js: false
 ---
 
 <div class="container">

--- a/site/docs/4.2/examples/sticky-footer/index.html
+++ b/site/docs/4.2/examples/sticky-footer/index.html
@@ -4,6 +4,7 @@ title: Sticky Footer Template
 extra_css: "sticky-footer.css"
 html_class: "h-100"
 body_class: "d-flex flex-column h-100"
+include_js: false
 ---
 
 <!-- Begin page content -->


### PR DESCRIPTION
They don't use it.