### PR TITLE
Prevent text selection in placeholder images

### DIFF
--- a/site/_layouts/examples.html
+++ b/site/_layouts/examples.html
@@ -16,6 +16,10 @@
       .bd-placeholder-img {
         font-size: 1.125rem;
         text-anchor: middle;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
 
       @media (min-width: 768px) {

--- a/site/docs/4.2/assets/scss/_placeholder-img.scss
+++ b/site/docs/4.2/assets/scss/_placeholder-img.scss
@@ -7,6 +7,7 @@
 .bd-placeholder-img {
   @include font-size(1.125rem);
   text-anchor: middle;
+  user-select: none;
 }
 
 .bd-placeholder-img-lg {


### PR DESCRIPTION
Disable the ability to select the text in the placeholder images.