### PR TITLE
Restore `.bd-lead` font size.

### DIFF
--- a/site/docs/4.3/assets/scss/_content.scss
+++ b/site/docs/4.3/assets/scss/_content.scss
@@ -112,7 +112,7 @@
 }
 
 .bd-lead {
-  @include font-size(1.125rem);
+  @include font-size(1.5rem);
   font-weight: 300;
 
   @include media-breakpoint-up(lg) {


### PR DESCRIPTION
Restore font size from the 4.2 docs.
/cc @XhmikosR 