### PR TITLE
Deprecate form-control-focus mixin

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -31,7 +31,7 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  @include form-control-focus();
+  @include form-control-focus($ignore-warning: true);
 
   // Placeholder
   &::placeholder {

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -10,7 +10,7 @@
 //
 // Example usage: change the default blue border and shadow to white for better
 // contrast against a dark gray background.
-@mixin form-control-focus() {
+@mixin form-control-focus($ignore-warning: false) {
   &:focus {
     color: $input-focus-color;
     background-color: $input-focus-bg;
@@ -23,6 +23,7 @@
       box-shadow: $input-focus-box-shadow;
     }
   }
+  @include deprecate("The `form-control-focus()` mixin", "v4.3.2", "v5", $ignore-warning);
 }
 
 


### PR DESCRIPTION
@mdo once mentioned to remove this function in `v5` because it's only used once, so let's warn people using `v4` about it.