### PR TITLE
v5: Drop IE10 & IE11

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -21,16 +21,6 @@
     }
   }
 
-  // IE9-11 hack to properly handle hyperlink underlines for breadcrumbs built
-  // without `<ul>`s. The `::before` pseudo-element generates an element
-  // *within* the .breadcrumb-item and thereby inherits the `text-decoration`.
-  //
-  // To trick IE into suppressing the underline, we give the pseudo-element an
-  // underline and then immediately remove it.
-  + .breadcrumb-item:hover::before {
-    text-decoration: underline;
-  }
-  // stylelint-disable-next-line no-duplicate-selectors
   + .breadcrumb-item:hover::before {
     text-decoration: none;
   }

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -31,12 +31,10 @@
       .col#{$infix} {
         flex-basis: 0;
         flex-grow: 1;
-        max-width: 100%;
       }
       .col#{$infix}-auto {
         flex: 0 0 auto;
         width: auto;
-        max-width: 100%; // Reset earlier grid tiers
       }
 
       @for $i from 1 through $columns {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -39,10 +39,6 @@
 
 @mixin make-col($size, $columns: $grid-columns) {
   flex: 0 0 percentage($size / $columns);
-  // Add a `max-width` to ensure content within each column does not blow out
-  // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
-  // do not appear to require this.
-  max-width: percentage($size / $columns);
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {


### PR DESCRIPTION
**WIP, do not merge yet.**

- Removes IE10/11 from our supported browsers list.
- Removes an IE-specific hack for breadcrumbs.
- Removes the `max-width` from grid classes, though this may need to be revisited because comments indicate it applies to Firefox, too.
