### PR TITLE
[WIP] v5: Carousel improvements for easier customization

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -13,6 +13,7 @@
 
 .carousel {
   position: relative;
+  color: $carousel-color;
 }
 
 .carousel.pointer-event {
@@ -128,13 +129,14 @@
   display: inline-block;
   width: $carousel-control-icon-width;
   height: $carousel-control-icon-width;
-  background: no-repeat 50% / 100% 100%;
+  fill: $carousel-control-icon-color;
+  // background: no-repeat 50% / 100% 100%;
 }
 .carousel-control-prev-icon {
-  background-image: escape-svg($carousel-control-prev-icon-bg);
+  // background-image: escape-svg($carousel-control-prev-icon-bg);
 }
 .carousel-control-next-icon {
-  background-image: escape-svg($carousel-control-next-icon-bg);
+  // background-image: escape-svg($carousel-control-next-icon-bg);
 }
 
 
@@ -158,7 +160,8 @@
   list-style: none;
 
   li {
-    box-sizing: content-box;
+    position: relative;
+    // box-sizing: content-box;
     flex: 0 1 auto;
     width: $carousel-indicator-width;
     height: $carousel-indicator-height;
@@ -166,13 +169,26 @@
     margin-left: $carousel-indicator-spacer;
     text-indent: -999px;
     cursor: pointer;
-    background-color: $carousel-indicator-active-bg;
-    background-clip: padding-box;
+    // background-color: $carousel-indicator-active-bg;
+    // background-clip: padding-box;
+    border-bottom: $carousel-indicator-height solid;
     // Use transparent borders to increase the hit area by 10px on top and bottom.
-    border-top: $carousel-indicator-hit-area-height solid transparent;
-    border-bottom: $carousel-indicator-hit-area-height solid transparent;
+    // border-top: $carousel-indicator-hit-area-height solid transparent;
+    // border-bottom: $carousel-indicator-hit-area-height solid transparent;
     opacity: .5;
     @include transition($carousel-indicator-transition);
+
+    &::after {
+      position: absolute;
+      top: -$carousel-indicator-hit-area-height;
+      right: -$carousel-indicator-hit-area-height / 2;
+      bottom: -$carousel-indicator-hit-area-height;
+      left: -$carousel-indicator-hit-area-height / 2;
+      display: block;
+      height: $carousel-indicator-hit-area-height * 3;
+      content: "";
+      background-color: rgba(255, 0, 0, .1);
+    }
   }
 
   .active {

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -124,12 +124,13 @@
 }
 
 // Icons for within
+.carousel-control-icon,
 .carousel-control-prev-icon,
 .carousel-control-next-icon {
   display: inline-block;
   width: $carousel-control-icon-width;
   height: $carousel-control-icon-width;
-  fill: $carousel-control-icon-color;
+  // fill: $carousel-control-icon-color;
   // background: no-repeat 50% / 100% 100%;
 }
 .carousel-control-prev-icon {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1084,7 +1084,7 @@ $carousel-indicator-transition:      opacity .6s ease !default;
 $carousel-caption-width:             70% !default;
 $carousel-caption-color:             inherit !default;
 
-$carousel-control-icon-width:        1.5rem !default;
+$carousel-control-icon-width:        3rem !default;
 $carousel-control-icon-color:        currentColor !default;
 
 $carousel-control-prev-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'><path d='M5.25 0l-4 4 4 4 1.5-1.5L4.25 4l2.5-2.5L5.25 0z'/></svg>") !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1066,30 +1066,32 @@ $breadcrumb-border-radius:          $border-radius !default;
 
 // Carousel
 
-$carousel-control-color:             $white !default;
+$carousel-color:                     $white !default;
+
+$carousel-control-color:             inherit !default;
 $carousel-control-width:             15% !default;
 $carousel-control-opacity:           .5 !default;
 $carousel-control-hover-opacity:     .9 !default;
 $carousel-control-transition:        opacity .15s ease !default;
 
-$carousel-indicator-width:           30px !default;
-$carousel-indicator-height:          3px !default;
-$carousel-indicator-hit-area-height: 10px !default;
-$carousel-indicator-spacer:          3px !default;
-$carousel-indicator-active-bg:       $white !default;
+$carousel-indicator-width:           2rem !default;
+$carousel-indicator-height:          .25rem !default;
+$carousel-indicator-hit-area-height: .25rem !default;
+$carousel-indicator-spacer:          .25rem !default;
+$carousel-indicator-active-bg:       inherit !default;
 $carousel-indicator-transition:      opacity .6s ease !default;
 
 $carousel-caption-width:             70% !default;
-$carousel-caption-color:             $white !default;
+$carousel-caption-color:             inherit !default;
 
-$carousel-control-icon-width:        20px !default;
+$carousel-control-icon-width:        1.5rem !default;
+$carousel-control-icon-color:        currentColor !default;
 
 $carousel-control-prev-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'><path d='M5.25 0l-4 4 4 4 1.5-1.5L4.25 4l2.5-2.5L5.25 0z'/></svg>") !default;
 $carousel-control-next-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'><path d='M2.75 0l-1.5 1.5L3.75 4l-2.5 2.5L2.75 8l4-4-4-4z'/></svg>") !default;
 
 $carousel-transition-duration:       .6s !default;
 $carousel-transition:                transform $carousel-transition-duration ease-in-out !default; // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
-
 
 // Spinners
 

--- a/site/content/docs/4.3/components/carousel.md
+++ b/site/content/docs/4.3/components/carousel.md
@@ -208,6 +208,51 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 </div>
 {{< /example >}}
 
+### Changing colors
+
+Change the color of a carousel's next and previous controls, indicators, and captions with a single `.text-*` utility on the `.carousel`. Need more control? Apply text utilities and custom styles more selectively.
+
+{% capture example %}
+<div id="carouselExampleColors" class="carousel slide text-dark" data-ride="carousel">
+  <ol class="carousel-indicators">
+    <li data-target="#carouselExampleColors" data-slide-to="0" class="active"></li>
+    <li data-target="#carouselExampleColors" data-slide-to="1"></li>
+    <li data-target="#carouselExampleColors" data-slide-to="2"></li>
+  </ol>
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#999" background="#f5f5f5" text="First slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>First slide label</h5>
+        <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+      </div>
+    </div>
+    <div class="carousel-item">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#888" background="#f1f1f1" text="Second slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>Second slide label</h5>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </div>
+    </div>
+    <div class="carousel-item">
+      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#777" background="#eee" text="Third slide" %}
+      <div class="carousel-caption d-none d-md-block">
+        <h5>Third slide label</h5>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
+      </div>
+    </div>
+  </div>
+  <a class="carousel-control-prev" href="#carouselExampleColors" role="button" data-slide="prev">
+    <svg class="carousel-control-prev-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z"/></svg>
+    <span class="sr-only">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#carouselExampleColors" role="button" data-slide="next">
+    <svg class="carousel-control-next-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z"/></svg>
+    <span class="sr-only">Next</span>
+  </a>
+</div>
+{% endcapture %}
+{% include example.html content=example %}
 
 ## Usage
 

--- a/site/content/docs/4.3/components/carousel.md
+++ b/site/content/docs/4.3/components/carousel.md
@@ -212,8 +212,8 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 Change the color of a carousel's next and previous controls, indicators, and captions with a single `.text-*` utility on the `.carousel`. Need more control? Apply text utilities and custom styles more selectively.
 
-{% capture example %}
-<div id="carouselExampleColors" class="carousel slide text-dark" data-ride="carousel">
+{{< example >}}
+<div id="carouselExampleColors" class="carousel slide text-white" data-ride="carousel">
   <ol class="carousel-indicators">
     <li data-target="#carouselExampleColors" data-slide-to="0" class="active"></li>
     <li data-target="#carouselExampleColors" data-slide-to="1"></li>
@@ -221,21 +221,21 @@ Change the color of a carousel's next and previous controls, indicators, and cap
   </ol>
   <div class="carousel-inner">
     <div class="carousel-item active">
-      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#999" background="#f5f5f5" text="First slide" %}
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}
       <div class="carousel-caption d-none d-md-block">
         <h5>First slide label</h5>
         <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
       </div>
     </div>
     <div class="carousel-item">
-      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#888" background="#f1f1f1" text="Second slide" %}
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#444" background="#666" text="Second slide" >}}
       <div class="carousel-caption d-none d-md-block">
         <h5>Second slide label</h5>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>
     </div>
     <div class="carousel-item">
-      {% include icons/placeholder.svg width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#777" background="#eee" text="Third slide" %}
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#333" background="#555" text="Third slide" >}}
       <div class="carousel-caption d-none d-md-block">
         <h5>Third slide label</h5>
         <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
@@ -243,16 +243,19 @@ Change the color of a carousel's next and previous controls, indicators, and cap
     </div>
   </div>
   <a class="carousel-control-prev" href="#carouselExampleColors" role="button" data-slide="prev">
-    <svg class="carousel-control-prev-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z"/></svg>
+    <svg class="carousel-control-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11 4l-3 6 3 6"></path>
+    </svg>
     <span class="sr-only">Previous</span>
   </a>
   <a class="carousel-control-next" href="#carouselExampleColors" role="button" data-slide="next">
-    <svg class="carousel-control-next-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z"/></svg>
+    <svg class="carousel-control-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M9 16l3-6-3-6"></path>
+    </svg>
     <span class="sr-only">Next</span>
   </a>
 </div>
-{% endcapture %}
-{% include example.html content=example %}
+{{< /example >}}
 
 ## Usage
 


### PR DESCRIPTION
**WIP, do not merge.**

This PR starts some work to revamp the carousel to use `currentColor`, allowing us to better use utilities to change text, control, and indicator colors. Can't recall where I left this off previously, so need to dig back in before I get a checklist of todos going. At the very least I'll need to consider some migration docs.