### PR TITLE
Fix white screen when use radio with overflow-scrolling

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -21,7 +21,7 @@
 
 .custom-control-input {
   position: absolute;
-  z-index: -1; // Put the input behind the label so it doesn't overlay text
+  pointer-events: none;
   opacity: 0;
 
   &:checked ~ .custom-control-label::before {


### PR DESCRIPTION
this issue is produced when we use `-webkit-overflow-scrolling: touch` within `z-index: -1` 

Example:
https://jsfiddle.net/fvck7rq3/3/
https://drive.google.com/file/d/15HNgzmi8fX7_CPte9pS7ZA_MYX6fPpAp/view

**Device**
iPhone XS / IOS 12.0
iPhone 7 / 12.1.1
iPhone 8 / 12.1.4 (16D57)
