### PR TITLE
Disable ascending check if the previous unit was a percentual value

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -8,7 +8,7 @@
   $prev-key: null;
   $prev-num: null;
   @each $key, $num in $map {
-    @if $prev-num == null or unit($num) == "%" {
+    @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
       // Do nothing
     } @else if not comparable($prev-num, $num) {
       @warn "Potentially invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} whose unit makes it incomparable to #{$prev-num}, the value of the previous key '#{$prev-key}' !";


### PR DESCRIPTION
Fixes #28399 

This prevents the `comparable` check in the `_assert-ascending` if the previous value was a percentual value.

This removes compilation warnings when providing mixed percentual/pixel values to `$container-max-widths`.