### PR TITLE
Mock GA object when in Hugo server mode

### DIFF
--- a/site/layouts/partials/analytics.html
+++ b/site/layouts/partials/analytics.html
@@ -5,4 +5,8 @@
   ga('send', 'pageview');
 </script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>
+{{- else -}}
+<script>
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+</script>
 {{- end -}}


### PR DESCRIPTION
The project started using Hugo after #28014
Now when in development mode the JavaScript errors occurs when using some links on the website:

```text
Uncaught ReferenceError: ga is not defined
    at HTMLAnchorElement.onclick ((index):75)
onclick | @ | (index):75
```

This minor change removes these errors during development.

Thanks!