### PR TITLE
Revert "Don't run Google Analytics locally. (#28384)

### DIFF
--- a/site/layouts/partials/analytics.html
+++ b/site/layouts/partials/analytics.html
@@ -1,8 +1,6 @@
-{{- if not .Site.IsServer -}}
 <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
   ga('create', 'UA-146052-10', 'getbootstrap.com');
   ga('send', 'pageview');
 </script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>
-{{- end -}}


### PR DESCRIPTION
Reverts #28384.

Second of two PRs to supersede #28486.