### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Ignore docs files
 /_gh_pages/
+# This is the old Jekyll docs dist folder;
+# keeping it here so that when we switch branches it doesn't show up
+/site/docs/**/dist/
 /site/static/**/dist/
 /resources/
 


### PR DESCRIPTION
Add the old Jekyll docs dist folder so that when we switch branches, it doesn't show up.