### PR TITLE
Fix custom file truncation

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -328,26 +328,28 @@
   right: 0;
   left: 0;
   z-index: 1;
+  display: flex;
+  justify-content: space-between; // Push the button to the right side
   height: $custom-file-height;
   padding: $custom-file-padding-y $custom-file-padding-x;
   font-family: $custom-file-font-family;
   font-weight: $custom-file-font-weight;
   line-height: $custom-file-line-height;
   color: $custom-file-color;
+  white-space: nowrap;
   background-color: $custom-file-bg;
   border: $custom-file-border-width solid $custom-file-border-color;
   @include border-radius($custom-file-border-radius);
   @include box-shadow($custom-file-box-shadow);
 
   &::after {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
+    position: relative;
     z-index: 3;
     display: block;
     height: $custom-file-height-inner;
     padding: $custom-file-padding-y $custom-file-padding-x;
+    // Use negatieve margins to undo paddings & add margin to the left to mimic the input padding
+    margin: #{-$custom-file-padding-y} #{-$custom-file-padding-x} #{-$custom-file-padding-y} $custom-file-padding-y;
     line-height: $custom-file-line-height;
     color: $custom-file-button-color;
     content: "Browse";

--- a/site/content/docs/4.3/components/forms.md
+++ b/site/content/docs/4.3/components/forms.md
@@ -1287,7 +1287,9 @@ The file input is the most gnarly of the bunch and requires additional JavaScrip
 {{< example >}}
 <div class="custom-file">
   <input type="file" class="custom-file-input" id="customFile">
-  <label class="custom-file-label" for="customFile">Choose file</label>
+  <label class="custom-file-label" for="customFile">
+    <span class="text-truncate">Choose file</span>
+  </label>
 </div>
 {{< /example >}}
 
@@ -1309,7 +1311,9 @@ Here's `lang(es)` in action on the custom file input for a Spanish translation:
 {{< example >}}
 <div class="custom-file">
   <input type="file" class="custom-file-input" id="customFileLang" lang="es">
-  <label class="custom-file-label" for="customFileLang">Seleccionar Archivo</label>
+  <label class="custom-file-label" for="customFileLang">
+    <span class="text-truncate">Seleccionar Archivo</span>
+  </label>
 </div>
 {{< /example >}}
 
@@ -1322,6 +1326,8 @@ Bootstrap also provides a way to translate the "Browse" text in HTML with the `d
 {{< example >}}
 <div class="custom-file">
   <input type="file" class="custom-file-input" id="customFileLangHTML">
-  <label class="custom-file-label" for="customFileLangHTML" data-browse="Bestand kiezen">Voeg je document toe</label>
+  <label class="custom-file-label" for="customFileLangHTML" data-browse="Bestand kiezen">
+    <span class="text-truncate">Voeg je document toe</span>
+  </label>
 </div>
 {{< /example >}}


### PR DESCRIPTION
Closes https://github.com/twbs/bootstrap/pull/28497

Alternative approach which doesn't depend on the width of the browse button. This solution is also compatible with the non-`.text-truncate` custom input, the text just gets cut off in that case.