### PR TITLE
Move close icon to components in docs

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -1,5 +1,4 @@
 .close {
-  float: right;
   @include font-size($close-font-size);
   font-weight: $close-font-weight;
   line-height: 1;

--- a/site/content/docs/4.3/components/close-icon.md
+++ b/site/content/docs/4.3/components/close-icon.md
@@ -2,7 +2,7 @@
 layout: docs
 title: Close icon
 description: Use a generic close icon for dismissing content like modals and alerts.
-group: utilities
+group: components
 ---
 
 **Be sure to include text for screen readers**, as we've done with `aria-label`.

--- a/site/data/nav.yml
+++ b/site/data/nav.yml
@@ -35,6 +35,7 @@
     - title: Button group
     - title: Card
     - title: Carousel
+    - title: Close icon
     - title: Collapse
     - title: Dropdowns
     - title: Forms
@@ -56,7 +57,6 @@
   pages:
     - title: Borders
     - title: Clearfix
-    - title: Close icon
     - title: Colors
     - title: Display
     - title: Embed


### PR DESCRIPTION
The close icon is a component, not a utility.