### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,14 @@
 # keeping it here so that when we switch branches it doesn't show up
 /site/docs/**/dist/
 /site/static/**/dist/
+# Hugo resources folder
 /resources/
+
+# Ignore ruby/bundler files;
+# keeping them here so that when we switch branches they don't show up
+/.bundle/
+/vendor/
+/.ruby-version
 
 # Numerous always-ignore extensions
 *.diff


### PR DESCRIPTION
Add back ruby/bundler folders so that they don't show up when we switch branches.

This can be removed when v4 hits EOL, along with the old Jekyll docs dist folder.