### PR TITLE
Fix prefers-reduced-motion for animated progress bars

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -36,8 +36,10 @@
   .progress-bar-animated {
     animation: progress-bar-stripes $progress-bar-animation-timing;
 
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
+    @if $enable-prefers-reduced-motion-media-query {
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Check prefers-reduced-motion variable before adding reduced motion media query for animated progress bars

(should have been caught back when https://github.com/twbs/bootstrap/pull/27986 was merged, sorry)

closes #28528