### PR TITLE
Add a `netlify` npm script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "release-zip": "cross-env-shell \"shx rm -rf bootstrap-$npm_package_version-dist && shx cp -r dist/ bootstrap-$npm_package_version-dist && zip -r9 bootstrap-$npm_package_version-dist.zip bootstrap-$npm_package_version-dist && shx rm -rf bootstrap-$npm_package_version-dist\"",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all lint dist js-test docs-build docs-lint bundlesize",
+    "netlify": "npm run dist && npm run release-sri && npm run docs-production",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm run css-main\"",
     "watch-css-docs": "nodemon --watch \"site/static/**/assets/scss/\" --ext scss --exec \"npm run css-docs\"",


### PR DESCRIPTION
This will streamline our netlify build command for the active branches, and since I couldn't make it work properly with netlify.toml, I went with this solution.