### PR TITLE
Remove http from search

### DIFF
--- a/site/static/docs/4.3/assets/js/src/search.js
+++ b/site/static/docs/4.3/assets/js/src/search.js
@@ -34,13 +34,13 @@
     },
     transformData: function (hits) {
       return hits.map(function (hit) {
-        var currentSiteUrl = getOrigin()
+        var currentUrl = getOrigin()
         var liveUrl = 'https://getbootstrap.com'
 
         // When in production, return the result as is,
         // otherwise remove our url from it.
         // eslint-disable-next-line no-negated-condition
-        hit.url = currentSiteUrl.indexOf(liveUrl) !== -1 ?
+        hit.url = currentUrl.indexOf(liveUrl) !== -1 ?
           hit.url :
           hit.url.replace(liveUrl, '')
 

--- a/site/static/docs/4.3/assets/js/src/search.js
+++ b/site/static/docs/4.3/assets/js/src/search.js
@@ -34,12 +34,15 @@
     },
     transformData: function (hits) {
       return hits.map(function (hit) {
-        var siteurl = getOrigin()
-        var urlRE = /^https?:\/\/getbootstrap\.com/
+        var currentSiteUrl = getOrigin()
+        var liveUrl = 'https://getbootstrap.com'
 
         // When in production, return the result as is,
         // otherwise remove our url from it.
-        hit.url = siteurl.match(urlRE) ? hit.url : hit.url.replace(urlRE, '')
+        // eslint-disable-next-line no-negated-condition
+        hit.url = currentSiteUrl.indexOf(liveUrl) !== -1 ?
+          hit.url :
+          hit.url.replace(liveUrl, '')
 
         // Prevent jumping to first header
         if (hit.anchor === 'content') {
@@ -50,6 +53,7 @@
         return hit
       })
     },
-    debug: false // Set debug to true if you want to inspect the dropdown
+    // Set debug to `true` if you want to inspect the dropdown
+    debug: false
   })
 })()


### PR DESCRIPTION
We only use https now.

I will backport this to v4 and v3 too so that we are in sync.