### PR TITLE
Remove scss variable defined twice

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -366,7 +366,6 @@ $table-dark-accent-bg:        rgba($white, .05) !default;
 $table-dark-hover-color:      $table-dark-color !default;
 $table-dark-hover-bg:         rgba($white, .075) !default;
 $table-dark-border-color:     lighten($table-dark-bg, 7.5%) !default;
-$table-dark-color:            $white !default;
 
 $table-striped-order:         odd !default;
 


### PR DESCRIPTION
Just remove a doublon that seems unnecessary into the `variables.scss` file