### PR TITLE
fix(buttons): fix button unit test onclic input event

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -68,21 +68,21 @@ class Button {
       Selector.DATA_TOGGLE
     )
 
+    const input = SelectorEngine.findOne(Selector.INPUT, this._element)
+
     if (rootElement) {
       const activeElement = SelectorEngine.findOne(Selector.ACTIVE, rootElement)
 
       if (activeElement) {
         activeElement.classList.remove(ClassName.ACTIVE)
       }
+    }
 
-      const input = SelectorEngine.findOne(Selector.INPUT, this._element)
-
-      if (input) {
-        if (input.checked) {
-          this._element.classList.add(ClassName.ACTIVE)
-        } else {
-          this._element.classList.remove(ClassName.ACTIVE)
-        }
+    if (input) {
+      if (input.checked) {
+        this._element.classList.add(ClassName.ACTIVE)
+      } else {
+        this._element.classList.remove(ClassName.ACTIVE)
       }
     } else {
       this._element.classList.toggle(ClassName.ACTIVE)

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -111,7 +111,7 @@ $(function () {
     var groupHTML =
       '<div class="btn-group" data-toggle="buttons">' +
       '  <label class="btn btn-primary active">' +
-      '    <input type="radio" name="options" id="option1" checked="true"> Option 1' +
+      '    <input type="radio" name="options" id="option1" checked> Option 1' +
       '  </label>' +
       '  <label class="btn btn-primary">' +
       '    <input type="radio" name="options" id="option2"> Option 2' +
@@ -130,21 +130,21 @@ $(function () {
     assert.ok($btn1.hasClass('active'), 'btn1 has active class')
     assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
     assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
-    assert.ok(!inputBtn2.checked, 'btn2 is not checked')
+    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
 
-    inputBtn2.dispatchEvent(new Event('click'))
-
-    assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
-    assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is not checked')
-    assert.ok($btn2.hasClass('active'), 'btn2 has active class')
-    assert.ok(inputBtn2.checked, 'btn2 is checked')
-
-    inputBtn2.dispatchEvent(new Event('click')) // clicking an already checked radio should not un-check it
+    inputBtn2.click()
 
     assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
     assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is not checked')
     assert.ok($btn2.hasClass('active'), 'btn2 has active class')
-    assert.ok(inputBtn2.checked, 'btn2 is checked')
+    assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
+
+    inputBtn2.click() // clicking an already checked radio should not un-check it
+
+    assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
+    assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is not checked')
+    assert.ok($btn2.hasClass('active'), 'btn2 has active class')
+    assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
   })
 
   QUnit.test('should only toggle selectable inputs', function (assert) {


### PR DESCRIPTION
fix one unit test down due to onclic event

Don't remove the latest unit test failing : 
```
  QUnit.test('should toggle aria-pressed on buttons with container', function (assert) {
    assert.expect(1)
    var groupHTML = '<div class="btn-group" data-toggle="buttons">' +
        '<button id="btn1" class="btn btn-secondary" type="button">One</button>' +
        '<button class="btn btn-secondary" type="button">Two</button>' +
      '</div>'
    $('#qunit-fixture').append(groupHTML)
    $('#btn1').bootstrapButton('toggle')
    assert.strictEqual($('#btn1').attr('aria-pressed'), 'true')
  })
```

Not sure if that structure need to be available? If yes need to fix the plugin, if no need to remove the test