### PR TITLE
Change toast border radius to use $border-radius

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -898,7 +898,7 @@ $toast-color:                       null !default;
 $toast-background-color:            rgba($white, .85) !default;
 $toast-border-width:                1px !default;
 $toast-border-color:                rgba(0, 0, 0, .1) !default;
-$toast-border-radius:               .25rem !default;
+$toast-border-radius:               $border-radius !default;
 $toast-box-shadow:                  0 .25rem .75rem rgba($black, .1) !default;
 
 $toast-header-color:                $gray-600 !default;


### PR DESCRIPTION
Currently, $toast-border-radius uses the value of .25rem. This is inconsistent with other variables such as $btn-border-radius and $input-border-radius, which uses the "global" $border-radius variable.