### PR TITLE
Call toast hide() after `delay` time

### DIFF
--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -127,7 +127,21 @@ class Toast {
     }
 
     EventHandler.trigger(this._element, Event.HIDE)
-    this._close()
+
+    const complete = () => {
+      this._element.classList.add(ClassName.HIDE)
+      EventHandler.trigger(this._element, Event.HIDDEN)
+    }
+
+    this._element.classList.remove(ClassName.SHOW)
+    if (this._config.animation) {
+      const transitionDuration = getTransitionDurationFromElement(this._element)
+
+      EventHandler.one(this._element, TRANSITION_END, complete)
+      emulateTransitionEnd(this._element, transitionDuration)
+    } else {
+      complete()
+    }
   }
 
   dispose() {
@@ -170,23 +184,6 @@ class Toast {
       Selector.DATA_DISMISS,
       () => this.hide()
     )
-  }
-
-  _close() {
-    const complete = () => {
-      this._element.classList.add(ClassName.HIDE)
-      EventHandler.trigger(this._element, Event.HIDDEN)
-    }
-
-    this._element.classList.remove(ClassName.SHOW)
-    if (this._config.animation) {
-      const transitionDuration = getTransitionDurationFromElement(this._element)
-
-      EventHandler.one(this._element, TRANSITION_END, complete)
-      emulateTransitionEnd(this._element, transitionDuration)
-    } else {
-      complete()
-    }
   }
 
   // Static

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -103,7 +103,9 @@ class Toast {
       EventHandler.trigger(this._element, Event.SHOWN)
 
       if (this._config.autohide) {
-        this.hide()
+        this._timeout = setTimeout(() => {
+          this.hide()
+        }, this._config.delay)
       }
     }
 
@@ -119,20 +121,13 @@ class Toast {
     }
   }
 
-  hide(withoutTimeout) {
+  hide() {
     if (!this._element.classList.contains(ClassName.SHOW)) {
       return
     }
 
     EventHandler.trigger(this._element, Event.HIDE)
-
-    if (withoutTimeout) {
-      this._close()
-    } else {
-      this._timeout = setTimeout(() => {
-        this._close()
-      }, this._config.delay)
-    }
+    this._close()
   }
 
   dispose() {
@@ -173,7 +168,7 @@ class Toast {
       this._element,
       Event.CLICK_DISMISS,
       Selector.DATA_DISMISS,
-      () => this.hide(true)
+      () => this.hide()
     )
   }
 


### PR DESCRIPTION
The hide callback function should be called when start closing the toast.

Fixes #28629