### PR TITLE
remove custom browserlist for our esm build

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -11,42 +11,18 @@ const ESM = process.env.ESM === 'true'
 let fileDest = `bootstrap${ESM ? '.esm' : ''}`
 const external = ['popper.js']
 const plugins = [
-  babel(ESM ?
-    {
-      // Only transpile our source code
-      exclude: 'node_modules/**',
-      babelrc: false,
-      presets: [
-        [
-          '@babel/env',
-          {
-            loose: true,
-            modules: false,
-            targets: {
-              browsers: [
-                'Chrome >= 60',
-                'Safari >= 10.1',
-                'iOS >= 10.3',
-                'Firefox >= 54',
-                'Edge >= 15'
-              ]
-            }
-          }
-        ]
-      ]
-    } :
-    {
-    // Only transpile our source code
-      exclude: 'node_modules/**',
-      // Include only required helpers
-      externalHelpersWhitelist: [
-        'defineProperties',
-        'createClass',
-        'inheritsLoose',
-        'defineProperty',
-        'objectSpread'
-      ]
-    })
+  babel({
+  // Only transpile our source code
+    exclude: 'node_modules/**',
+    // Include only required helpers
+    externalHelpersWhitelist: [
+      'defineProperties',
+      'createClass',
+      'inheritsLoose',
+      'defineProperty',
+      'objectSpread'
+    ]
+  })
 ]
 const globals = {
   'popper.js': 'Popper'

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "27.5 kB"
+      "maxSize": "28 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",

--- a/package.json
+++ b/package.json
@@ -197,11 +197,11 @@
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "27 kB"
+      "maxSize": "27.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
-      "maxSize": "18 kB"
+      "maxSize": "19 kB"
     },
     {
       "path": "./dist/js/bootstrap.js",


### PR DESCRIPTION
According to those articles:
 - https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features
 - https://webpack.js.org/guides/author-libraries/#final-steps

the `module` field in our package.json is used by bundlers too, so we shouldn't have a different browserlist for our ESM build, because our users won't be able to use it with our older browsers