### PR TITLE
Docs/examples: remove misleading jumbotron-heading classname

### DIFF
--- a/site/docs/4.3/examples/album/album.css
+++ b/site/docs/4.3/examples/album/album.css
@@ -15,7 +15,7 @@
   margin-bottom: 0;
 }
 
-.jumbotron-heading {
+.jumbotron h1 {
   font-weight: 300;
 }
 

--- a/site/docs/4.3/examples/album/index.html
+++ b/site/docs/4.3/examples/album/index.html
@@ -40,7 +40,7 @@ extra_css: "album.css"
 
   <section class="jumbotron text-center">
     <div class="container">
-      <h1 class="jumbotron-heading">Album example</h1>
+      <h1>Album example</h1>
       <p class="lead text-muted">Something short and leading about the collection below—its contents, the creator, etc. Make it short and sweet, but not too short so folks don’t simply skip over it entirely.</p>
       <p>
         <a href="#" class="btn btn-primary my-2">Main call to action</a>


### PR DESCRIPTION
Closes https://github.com/twbs/bootstrap/issues/28737