### PR TITLE
fix popover arrow by selecting the first element child

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -111,8 +111,7 @@ const ClassName = {
 }
 
 const Selector = {
-  TOOLTIP_INNER: '.tooltip-inner',
-  TOOLTIP_ARROW: '.tooltip-arrow'
+  TOOLTIP_INNER: '.tooltip-inner'
 }
 
 const Trigger = {
@@ -310,7 +309,7 @@ class Tooltip {
             behavior: this.config.fallbackPlacement
           },
           arrow: {
-            element: Selector.TOOLTIP_ARROW
+            element: `.${this.constructor.NAME}-arrow`
           },
           preventOverflow: {
             boundariesElement: this.config.boundary

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -77,6 +77,14 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 - **Todo:** Removed `.badge-pill` for the `.rounded-pill` utility class
 - **Todo:** Removed badge's hover and focus styles for `a.badge` and `button.badge`.
 
+### Popovers
+
+- Renamed `.arrow` to `.popover-arrow`
+
+### Tooltips
+
+- Renamed `.arrow` to `.tooltip-arrow`
+
 ## Utilities
 
 - **Todo:** Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore


### PR DESCRIPTION
I use the `tip.firstChild` element as arrow, it's better than passing a selector to Popper.js

Fixes: #28692

/CC @wojtask9