### PR TITLE
Update Yarn package link to link to the Bootstrap package

### DIFF
--- a/site/content/docs/4.3/getting-started/download.md
+++ b/site/content/docs/4.3/getting-started/download.md
@@ -65,7 +65,7 @@ Bootstrap's `package.json` contains some additional metadata under the following
 
 ### yarn
 
-Install Bootstrap in your Node.js powered apps with [the yarn package](https://yarnpkg.com/en/package/yarn):
+Install Bootstrap in your Node.js powered apps with [the yarn package](https://yarnpkg.com/en/package/bootstrap):
 
 {{< highlight sh >}}
 yarn add bootstrap


### PR DESCRIPTION
I think it makes more sense to link to the Bootstrap package on Yarn here (like the package link for NPM above)