### PR TITLE
Fix background position for form-validation

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -71,7 +71,7 @@
         padding-right: $input-height-inner;
         background-image: $icon;
         background-repeat: no-repeat;
-        background-position: center right $input-height-inner-quarter;
+        background-position: right $input-height-inner-quarter center;
         background-size: $input-height-inner-half $input-height-inner-half;
       }
 


### PR DESCRIPTION
`background-position: center right $input-height-inner-quarter;` is not valid `background-position` property.

After building `create-react-app`, it converts to `100% calc(.375em + .1875rem)`.

This PR fixes this issue.