### PR TITLE
vnu.jar: Update ignores.

### DIFF
--- a/build/vnu-jar.js
+++ b/build/vnu-jar.js
@@ -14,7 +14,7 @@ const vnu = require('vnu-jar')
 
 childProcess.exec('java -version', (error, stdout, stderr) => {
   if (error) {
-    console.error('Skipping vnu-jar test; Java is missing.')
+    console.warn('Skipping vnu-jar test; Java is missing.')
     return
   }
 
@@ -36,9 +36,7 @@ childProcess.exec('java -version', (error, stdout, stderr) => {
     'The “time” input type is not supported in all browsers.*',
     // IE11 doesn't recognise <main> / give the element an implicit "main" landmark.
     // Explicit role="main" is redundant for other modern browsers, but still valid.
-    'The “main” role is unnecessary for element “main”.',
-    // Ignore the wrong lanuage code warnings for now; they happen randomly.
-    'This document appears to be written in.*'
+    'The “main” role is unnecessary for element “main”.'
   ].join('|')
 
   const args = [
@@ -46,6 +44,8 @@ childProcess.exec('java -version', (error, stdout, stderr) => {
     vnu,
     '--asciiquotes',
     '--skip-non-html',
+    // Ignore the language code warnings
+    '--no-langdetect',
     '--Werror',
     `--filterpattern "${ignores}"`,
     '_gh_pages/',

--- a/build/vnu-jar.js
+++ b/build/vnu-jar.js
@@ -14,7 +14,7 @@ const vnu = require('vnu-jar')
 
 childProcess.exec('java -version', (error, stdout, stderr) => {
   if (error) {
-    console.warn('Skipping vnu-jar test; Java is missing.')
+    console.error('Skipping vnu-jar test; Java is missing.')
     return
   }
 


### PR DESCRIPTION
Pass the `--no-langdetect` flag instead of ignoring the warning manually.

