### PR TITLE
Accessibility: add `aria-label` for tooltips

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -584,8 +584,8 @@ class Tooltip extends BaseComponent {
 
     if (title || originalTitleType !== 'string') {
       this._element.setAttribute('data-bs-original-title', title || '')
-      if (this._element.getAttribute('title') && !this._element.getAttribute('aria-label') && !this._element.textContent) {
-        this._element.setAttribute('aria-label', this._element.getAttribute('title'))
+      if (title && !this._element.getAttribute('aria-label') && !this._element.textContent) {
+        this._element.setAttribute('aria-label', title)
       }
 
       this._element.setAttribute('title', '')

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -584,8 +584,8 @@ class Tooltip extends BaseComponent {
 
     if (title || originalTitleType !== 'string') {
       this._element.setAttribute('data-bs-original-title', title || '')
-      if (!this._element.getAttribute('aria-label') && !this._element.textContent) {
-        this._element.setAttribute('aria-label', this._element.getAttribute('title') || '')
+      if (this._element.getAttribute('title') && !this._element.getAttribute('aria-label') && !this._element.textContent) {
+        this._element.setAttribute('aria-label', this._element.getAttribute('title'))
       }
 
       this._element.setAttribute('title', '')

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -584,6 +584,10 @@ class Tooltip extends BaseComponent {
 
     if (title || originalTitleType !== 'string') {
       this._element.setAttribute('data-bs-original-title', title || '')
+      if (!this._element.getAttribute('aria-label') && !this._element.textContent) {
+        this._element.setAttribute('aria-label', this._element.getAttribute('title') || '')
+      }
+
       this._element.setAttribute('title', '')
     }
   }

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1050,6 +1050,59 @@ describe('Tooltip', () => {
     })
   })
 
+  describe('aria-label', () => {
+    it('should add the aria-label attribute for referencing original title', done => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+
+      tooltipEl.addEventListener('shown.bs.tooltip', () => {
+        const tooltipShown = document.querySelector('.tooltip')
+
+        expect(tooltipShown).toBeDefined()
+        expect(tooltipEl.getAttribute('aria-label')).toEqual('Another tooltip')
+        done()
+      })
+
+      tooltip.show()
+    })
+
+    it('should not add the aria-label attribute if the attribute already exists', done => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" aria-label="Different label" title="Another tooltip"></a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+
+      tooltipEl.addEventListener('shown.bs.tooltip', () => {
+        const tooltipShown = document.querySelector('.tooltip')
+
+        expect(tooltipShown).toBeDefined()
+        expect(tooltipEl.getAttribute('aria-label')).toEqual('Different label')
+        done()
+      })
+
+      tooltip.show()
+    })
+
+    it('should not add the aria-label attribute if the element has text content', done => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">text content</a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+
+      tooltipEl.addEventListener('shown.bs.tooltip', () => {
+        const tooltipShown = document.querySelector('.tooltip')
+
+        expect(tooltipShown).toBeDefined()
+        expect(tooltipEl.getAttribute('aria-label')).toBeNull()
+        done()
+      })
+
+      tooltip.show()
+    })
+  })
+
   describe('jQueryInterface', () => {
     it('should create a tooltip', () => {
       fixtureEl.innerHTML = '<div></div>'


### PR DESCRIPTION
Update to tooltip.js and tests to add an aria-label attribute that contains the original title of the element, but only if the element doesn't have an existing, valid aria-label attribute.

This is to address cases where screen readers are not capturing the aria-describedby attribute that is added when the tooltip is triggered.  This should also avoid a label not being read because of any race conditions between the screen reader and the appearance of the tooltip.

~~In the case the aria-describedby attribute is added as intended, it overrides the aria-label, so there should be no collision between the two methods of labeling.~~ The aria-label attribute is added conditionally to avoid conflicting with other ways someone might already be adding aria-label attributes to their elements.