### PR TITLE
Rename .text-monospace to .font-monospace

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -403,7 +403,7 @@ $utilities: map-merge(
     ),
     "font-family": (
       property: font-family,
-      class: text,
+      class: font,
       values: (monospace: $font-family-monospace)
     ),
     "rounded": (

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -91,6 +91,7 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 
 ## Utilities
 
+- Renamed `.text-monospace` to `.font-monospace`
 - **Todo:** Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
 - **Todo:** Split utilities into property-value utility classes and helpers
 

--- a/site/content/docs/4.3/utilities/text.md
+++ b/site/content/docs/4.3/utilities/text.md
@@ -80,10 +80,10 @@ Quickly change the weight (boldness) of text or italicize text.
 
 ## Monospace
 
-Change a selection to our monospace font stack with `.text-monospace`.
+Change a selection to our monospace font stack with `.font-monospace`.
 
 {{< example >}}
-<p class="text-monospace">This is in monospace</p>
+<p class="font-monospace">This is in monospace</p>
 {{< /example >}}
 
 ## Reset color


### PR DESCRIPTION
This is a revisit of #26619.

`font` makes more sense than `text` 😉 