### PR TITLE
Rename the text helper page

### DIFF
--- a/site/content/docs/4.3/helpers/text-truncation.md
+++ b/site/content/docs/4.3/helpers/text-truncation.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
-title: Text
-description: Documentation and examples for common text utilities to control alignment, wrapping, weight, and more.
+title: Text truncation
+description: Quickly truncation the long text with an ellipsis. 
 group: helpers
 toc: true
 ---

--- a/site/content/docs/4.3/helpers/text-truncation.md
+++ b/site/content/docs/4.3/helpers/text-truncation.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Text truncation
-description: Quickly truncation the long text with an ellipsis. 
+description: Truncate long strings of text with an ellipsis.
 group: helpers
 toc: true
 ---

--- a/site/data/nav.yml
+++ b/site/data/nav.yml
@@ -60,7 +60,7 @@
     - title: Position
     - title: Screen readers
     - title: Stretched link
-    - title: Text
+    - title: Text truncation
 
 - title: Utilities
   pages:


### PR DESCRIPTION
Update the description and make it to a specific page about the `.text-truncate` for clearly difference with text utilities.

/CC @MartijnCuppens 