### PR TITLE
Make generating form row styles dependent on $enable-grid-classes

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -181,16 +181,18 @@ textarea.form-control {
 //
 // Special replacement for our grid system's `.row` for tighter form layouts.
 
-.form-row {
-  display: flex;
-  flex-wrap: wrap;
-  margin-right: -$form-grid-gutter-width / 2;
-  margin-left: -$form-grid-gutter-width / 2;
+@if $enable-grid-classes {
+  .form-row {
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: -$form-grid-gutter-width / 2;
+    margin-left: -$form-grid-gutter-width / 2;
 
-  > .col,
-  > [class*="col-"] {
-    padding-right: $form-grid-gutter-width / 2;
-    padding-left: $form-grid-gutter-width / 2;
+    > .col,
+    > [class*="col-"] {
+      padding-right: $form-grid-gutter-width / 2;
+      padding-left: $form-grid-gutter-width / 2;
+    }
   }
 }
 


### PR DESCRIPTION
If the `$enable-grid-classes` is set `false`, it is no use generating those styles. 

No need to backport to v4 because this includes potential breaking changes.