### PR TITLE
Set max-width for .table-responsive

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -172,6 +172,7 @@
       @include media-breakpoint-down($breakpoint) {
         display: block;
         width: 100%;
+        max-width: max-content;
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
 


### PR DESCRIPTION
Responsive tables, without a max-width property, have a gap on the right when the viewer width is bigger than the table's width.
[![Without max-width (screenshot)](https://gyazo.com/e03c5a304f799852bb3c985277c447d4/raw)](https://gyazo.com/e03c5a304f799852bb3c985277c447d4)
[![With max-width (screenshot)](https://gyazo.com/54f3c50fae7532c98d080ea46835a88e/raw)](https://gyazo.com/54f3c50fae7532c98d080ea46835a88e)