### PR TITLE
improves media breakpoint mixin readibility

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -158,7 +158,7 @@
     margin-bottom: $card-deck-margin;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     flex-flow: row wrap;
     margin-right: -$card-deck-margin;
     margin-left: -$card-deck-margin;
@@ -190,7 +190,7 @@
     margin-bottom: $card-group-margin;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     flex-flow: row wrap;
     // The child selector allows nested `.card` within `.card-group`
     // to display properly.
@@ -250,7 +250,7 @@
     margin-bottom: $card-columns-margin;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     column-count: $card-columns-count;
     column-gap: $card-columns-gap;
     orphans: 1;

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -35,7 +35,7 @@
 }
 
 @each $breakpoint in map-keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
+  @include media-breakpoint-above($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .dropdown-menu#{$infix}-left {

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -272,7 +272,7 @@ textarea.form-control {
   }
 
   // Kick in the inline
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     label {
       display: flex;
       align-items: center;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -83,7 +83,7 @@
 // Change the layout of list group items from vertical (default) to horizontal.
 
 @each $breakpoint in map-keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
+  @include media-breakpoint-above($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .list-group-horizontal#{$infix} {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -187,7 +187,7 @@
 }
 
 // Scale up the modal
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-above(sm) {
   // Automatically set modal's width for larger viewports
   .modal-dialog {
     max-width: $modal-md;
@@ -217,13 +217,13 @@
   .modal-sm { max-width: $modal-sm; }
 }
 
-@include media-breakpoint-up(lg) {
+@include media-breakpoint-above(lg) {
   .modal-lg,
   .modal-xl {
     max-width: $modal-lg;
   }
 }
 
-@include media-breakpoint-up(xl) {
+@include media-breakpoint-above(xl) {
   .modal-xl { max-width: $modal-xl; }
 }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -139,7 +139,7 @@
     $infix: breakpoint-infix($next, $grid-breakpoints);
 
     &#{$infix} {
-      @include media-breakpoint-down($breakpoint) {
+      @include media-breakpoint-below($breakpoint) {
         > .container,
         > .container-fluid {
           padding-right: 0;
@@ -147,7 +147,7 @@
         }
       }
 
-      @include media-breakpoint-up($next) {
+      @include media-breakpoint-above($next) {
         flex-flow: row nowrap;
         justify-content: flex-start;
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -169,7 +169,7 @@
     $infix: breakpoint-infix($next, $grid-breakpoints);
 
     &#{$infix} {
-      @include media-breakpoint-down($breakpoint) {
+      @include media-breakpoint-below($breakpoint) {
         display: block;
         width: 100%;
         overflow-x: auto;

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -55,7 +55,7 @@
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
 // Makes the @content apply to the given breakpoint and wider.
-@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-above($name, $breakpoints: $grid-breakpoints) {
   $min: breakpoint-min($name, $breakpoints);
   @if $min {
     @media (min-width: $min) {
@@ -68,7 +68,7 @@
 
 // Media of at most the maximum breakpoint width. No query for the largest breakpoint.
 // Makes the @content apply to the given breakpoint and narrower.
-@mixin media-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
+@mixin media-breakpoint-below($name, $breakpoints: $grid-breakpoints) {
   $max: breakpoint-max($name, $breakpoints);
   @if $max {
     @media (max-width: $max) {
@@ -90,11 +90,11 @@
       @content;
     }
   } @else if $max == null {
-    @include media-breakpoint-up($lower, $breakpoints) {
+    @include media-breakpoint-above($lower, $breakpoints) {
       @content;
     }
   } @else if $min == null {
-    @include media-breakpoint-down($upper, $breakpoints) {
+    @include media-breakpoint-below($upper, $breakpoints) {
       @content;
     }
   }
@@ -112,11 +112,11 @@
       @content;
     }
   } @else if $max == null {
-    @include media-breakpoint-up($name, $breakpoints) {
+    @include media-breakpoint-above($name, $breakpoints) {
       @content;
     }
   } @else if $min == null {
-    @include media-breakpoint-down($name, $breakpoints) {
+    @include media-breakpoint-below($name, $breakpoints) {
       @content;
     }
   }

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -26,7 +26,7 @@
       @extend %grid-column;
     }
 
-    @include media-breakpoint-up($breakpoint, $breakpoints) {
+    @include media-breakpoint-above($breakpoint, $breakpoints) {
       // Provide basic `.col-{bp}` classes for equal-width flexbox columns
       .col#{$infix} {
         flex-basis: 0;

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -14,7 +14,7 @@
 // For each breakpoint, define the maximum width of the container in a media query
 @mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
   @each $breakpoint, $container-max-width in $max-widths {
-    @include media-breakpoint-up($breakpoint, $breakpoints) {
+    @include media-breakpoint-above($breakpoint, $breakpoints) {
       max-width: $container-max-width;
     }
   }

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -2,7 +2,7 @@
 @each $breakpoint in map-keys($grid-breakpoints) {
 
   // Generate media query if needed
-  @include media-breakpoint-up($breakpoint) {
+  @include media-breakpoint-above($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     // Loop over each utility property

--- a/site/content/docs/4.3/content/tables.md
+++ b/site/content/docs/4.3/content/tables.md
@@ -760,7 +760,7 @@ Across every breakpoint, use `.table-responsive` for horizontally scrolling tabl
 
 ### Breakpoint specific
 
-Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables up to a particular breakpoint. From that breakpoint and up, the table will behave normally and not scroll horizontally.
+Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables up to a particular breakpoint. From that breakpoint and above, the table will behave normally and not scroll horizontally.
 
 **These tables may appear broken until their responsive styles apply at specific viewport widths.**
 

--- a/site/content/docs/4.3/extend/approach.md
+++ b/site/content/docs/4.3/extend/approach.md
@@ -26,7 +26,7 @@ We'll dive into each of these more throughout, but at a high level, here's what 
 
 Bootstrap's responsive styles are built to be responsive, an approach that's often referred to as _mobile-first_. We use this term in our docs and largely agree with it, but at times it can be too broad. While not every component _must_ be entirely responsive in Bootstrap, this responsive approach is about reducing CSS overrides by pushing you to add styles as the viewport becomes larger.
 
-Across Bootstrap, you'll see this most clearly in our media queries. In most cases, we use `min-width` queries that begin to apply at a specific breakpoint and carry up through the higher breakpoints. For example, a `.d-none` applies from `min-width: 0` to infinity. On the other hand, a `.d-md-none` applies from the medium breakpoint and up.
+Across Bootstrap, you'll see this most clearly in our media queries. In most cases, we use `min-width` queries that begin to apply at a specific breakpoint and carry up through the higher breakpoints. For example, a `.d-none` applies from `min-width: 0` to infinity. On the other hand, a `.d-md-none` applies from the medium breakpoint and above.
 
 At times we'll use `max-width` when a component's inherent complexity requires it. At times, these overrides are functionally and mentally clearer to implement and support than rewriting core functionality from our components. We strive to limit this approach, but will use it from time to time.
 

--- a/site/content/docs/4.3/getting-started/theming.md
+++ b/site/content/docs/4.3/getting-started/theming.md
@@ -361,7 +361,7 @@ These Sass loops aren't limited to color maps, either. You can also generate res
 
 {{< highlight scss >}}
 @each $breakpoint in map-keys($grid-breakpoints) {
-  @include media-breakpoint-up($breakpoint) {
+  @include media-breakpoint-above($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .text#{$infix}-left   { text-align: left !important; }

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -739,10 +739,10 @@ You can modify the variables to your own custom values, or just use the mixins w
 .example-content-main {
   @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     @include make-col(6);
   }
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     @include make-col(8);
   }
 }
@@ -750,10 +750,10 @@ You can modify the variables to your own custom values, or just use the mixins w
 .example-content-secondary {
   @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     @include make-col(6);
   }
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     @include make-col(4);
   }
 }

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -37,7 +37,7 @@ Breaking it down, here's how it works:
 - Containers provide a means to center and horizontally pad your site's contents. Use `.container` for a responsive pixel width or `.container-fluid` for `width: 100%` across all viewport and device sizes.
 - Rows are wrappers for columns. Each column has horizontal `padding` (called a gutter) for controlling the space between them. This `padding` is then counteracted on the rows with negative margins. This way, all the content in your columns is visually aligned down the left side.
 - In a grid layout, content must be placed within columns and only columns may be immediate children of rows.
-- Thanks to flexbox, grid columns without a specified `width` will automatically layout as equal width columns. For example, four instances of `.col-sm` will each automatically be 25% wide from the small breakpoint and up. See the [auto-layout columns](#auto-layout-columns) section for more examples.
+- Thanks to flexbox, grid columns without a specified `width` will automatically layout as equal width columns. For example, four instances of `.col-sm` will each automatically be 25% wide from the small breakpoint and above. See the [auto-layout columns](#auto-layout-columns) section for more examples.
 - Column classes indicate the number of columns you'd like to use out of the possible 12 per row. So, if you want three equal-width columns across, you can use `.col-4`.
 - Column `width`s are set in percentages, so they're always fluid and sized relative to their parent element.
 - Columns have horizontal `padding` to create the gutters between individual columns, however, you can remove the `margin` from rows and `padding` from columns with `.no-gutters` on the `.row`.
@@ -529,7 +529,7 @@ You may also apply this break at specific breakpoints with our [responsive displ
     <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
     <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
 
-    <!-- Force next columns to break to new line at md breakpoint and up -->
+    <!-- Force next columns to break to new line at md breakpoint and above -->
     <div class="w-100 d-none d-md-block"></div>
 
     <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>

--- a/site/content/docs/4.3/layout/overview.md
+++ b/site/content/docs/4.3/layout/overview.md
@@ -71,16 +71,16 @@ Since we write our source CSS in Sass, all our media queries are available via S
 
 {{< highlight scss >}}
 // No media query necessary for xs breakpoint as it's effectively `@media (min-width: 0) { ... }`
-@include media-breakpoint-up(sm) { ... }
-@include media-breakpoint-up(md) { ... }
-@include media-breakpoint-up(lg) { ... }
-@include media-breakpoint-up(xl) { ... }
+@include media-breakpoint-above(sm) { ... }
+@include media-breakpoint-above(md) { ... }
+@include media-breakpoint-above(lg) { ... }
+@include media-breakpoint-above(xl) { ... }
 
 // Example: Hide starting at `min-width: 0`, and then show at the `sm` breakpoint
 .custom-class {
   display: none;
 }
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-above(sm) {
   .custom-class {
     display: block;
   }
@@ -113,14 +113,14 @@ We occasionally use media queries that go in the other direction (the given scre
 Once again, these media queries are also available via Sass mixins:
 
 {{< highlight scss >}}
-@include media-breakpoint-down(xs) { ... }
-@include media-breakpoint-down(sm) { ... }
-@include media-breakpoint-down(md) { ... }
-@include media-breakpoint-down(lg) { ... }
+@include media-breakpoint-below(xs) { ... }
+@include media-breakpoint-below(sm) { ... }
+@include media-breakpoint-below(md) { ... }
+@include media-breakpoint-below(lg) { ... }
 // No media query necessary for xl breakpoint as it has no upper bound on its width
 
 // Example: Style from medium breakpoint and down
-@include media-breakpoint-down(md) {
+@include media-breakpoint-below(md) {
   .custom-class {
     display: block;
   }

--- a/site/content/docs/4.3/layout/overview.md
+++ b/site/content/docs/4.3/layout/overview.md
@@ -119,7 +119,7 @@ Once again, these media queries are also available via Sass mixins:
 @include media-breakpoint-below(lg) { ... }
 // No media query necessary for xl breakpoint as it has no upper bound on its width
 
-// Example: Style from medium breakpoint and down
+// Example: Style from medium breakpoint and below
 @include media-breakpoint-below(md) {
   .custom-class {
     display: block;

--- a/site/static/docs/4.3/assets/scss/_ads.scss
+++ b/site/static/docs/4.3/assets/scss/_ads.scss
@@ -21,7 +21,7 @@
     text-decoration: none;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     max-width: 330px;
     @include border-radius(4px);
   }

--- a/site/static/docs/4.3/assets/scss/_algolia.scss
+++ b/site/static/docs/4.3/assets/scss/_algolia.scss
@@ -18,7 +18,7 @@
     border: 1px solid rgba(0, 0, 0, .1);
     box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .175);
 
-    @include media-breakpoint-up(md) {
+    @include media-breakpoint-above(md) {
       width: 175%;
     }
 

--- a/site/static/docs/4.3/assets/scss/_brand.scss
+++ b/site/static/docs/4.3/assets/scss/_brand.scss
@@ -34,7 +34,7 @@
     margin-bottom: 0;
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     display: table-cell;
     width: 1%;
 
@@ -81,7 +81,7 @@
   margin-left: .25rem;
   @include border-radius;
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     width: 6rem;
     height: 6rem;
   }

--- a/site/static/docs/4.3/assets/scss/_clipboard-js.scss
+++ b/site/static/docs/4.3/assets/scss/_clipboard-js.scss
@@ -11,7 +11,7 @@
     margin-top: 0;
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     display: block;
   }
 }

--- a/site/static/docs/4.3/assets/scss/_component-examples.scss
+++ b/site/static/docs/4.3/assets/scss/_component-examples.scss
@@ -43,11 +43,11 @@
 .example-content-main {
   @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     @include make-col(6);
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     @include make-col(8);
   }
 }
@@ -55,11 +55,11 @@
 .example-content-secondary {
   @include make-col-ready();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     @include make-col(6);
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     @include make-col(4);
   }
 }
@@ -115,7 +115,7 @@
   border-width: .2rem 0 0;
   @include clearfix();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     padding: 1.5rem;
     margin-right: 0;
     margin-left: 0;
@@ -217,7 +217,7 @@
     margin: 1rem -1rem -1rem;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     .fixed-top,
     .sticky-top {
       margin: -1.5rem -1.5rem 1rem;
@@ -314,7 +314,7 @@
   background-color: $gray-100;
   -ms-overflow-style: -ms-autohiding-scrollbar;
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     padding: 1.5rem;
   }
 }
@@ -323,7 +323,7 @@
   margin-right: (-$grid-gutter-width / 2);
   margin-left: (-$grid-gutter-width / 2);
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     margin-right: 0;
     margin-left: 0;
   }

--- a/site/static/docs/4.3/assets/scss/_content.scss
+++ b/site/static/docs/4.3/assets/scss/_content.scss
@@ -26,7 +26,7 @@
     max-width: 100%;
     margin-bottom: 1rem;
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-below(md) {
       display: block;
       overflow-x: auto;
 
@@ -95,7 +95,7 @@
     margin-bottom: .25rem;
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     > ul,
     > ol,
     > p {
@@ -115,7 +115,7 @@
   @include font-size(1.5rem);
   font-weight: 300;
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-above(lg) {
     max-width: 80%;
   }
 }

--- a/site/static/docs/4.3/assets/scss/_footer.scss
+++ b/site/static/docs/4.3/assets/scss/_footer.scss
@@ -21,7 +21,7 @@
     margin-bottom: 0;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     text-align: left;
   }
 }

--- a/site/static/docs/4.3/assets/scss/_masthead.scss
+++ b/site/static/docs/4.3/assets/scss/_masthead.scss
@@ -21,7 +21,7 @@
     margin-bottom: -3rem !important;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-above(sm) {
     padding-top: 5rem;
     padding-bottom: 5rem;
 
@@ -30,7 +30,7 @@
     }
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     .carbonad {
       margin-top: 3rem !important;
     }

--- a/site/static/docs/4.3/assets/scss/_nav.scss
+++ b/site/static/docs/4.3/assets/scss/_nav.scss
@@ -7,7 +7,7 @@
   background-color: $bd-purple;
   box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .05), inset 0 -1px 0 rgba(0, 0, 0, .1);
 
-  @include media-breakpoint-down(md) {
+  @include media-breakpoint-below(md) {
     padding-right: .5rem;
     padding-left: .5rem;
 
@@ -26,7 +26,7 @@
     }
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     @supports (position: sticky) {
       position: sticky;
       top: 0;

--- a/site/static/docs/4.3/assets/scss/_sidebar.scss
+++ b/site/static/docs/4.3/assets/scss/_sidebar.scss
@@ -61,7 +61,7 @@
   // background-color: #f5f2f9;
   border-bottom: 1px solid rgba(0, 0, 0, .1);
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     @supports (position: sticky) {
       position: sticky;
       top: 4rem;
@@ -71,7 +71,7 @@
     border-right: 1px solid rgba(0, 0, 0, .1);
   }
 
-  @include media-breakpoint-up(xl) {
+  @include media-breakpoint-above(xl) {
     flex: 0 1 320px;
   }
 }
@@ -82,7 +82,7 @@
   margin-right: -15px;
   margin-left: -15px;
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     @supports (position: sticky) {
       max-height: calc(100vh - 9rem);
       overflow-y: auto;
@@ -90,7 +90,7 @@
   }
 
   // Override collapse behaviors
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-above(md) {
     display: block !important;
   }
 }


### PR DESCRIPTION
I felt that its better to use media-breakpoint-above and media-breakpoint-below rather than media-breakpoint-up and media-breakpoint-down because in plain english the mixin give better idea when reading code along with media-breakpoint-between