### PR TITLE
tooltip dispose:removing only own event handler

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -237,7 +237,7 @@ class Tooltip {
     Data.removeData(this.element, this.constructor.DATA_KEY)
 
     EventHandler.off(this.element, this.constructor.EVENT_KEY)
-    EventHandler.off(SelectorEngine.closest(this.element, '.modal'), 'hide.bs.modal')
+    EventHandler.off(SelectorEngine.closest(this.element, '.modal'), 'hide.bs.modal.tooltip')
 
     if (this.tip) {
       this.tip.parentNode.removeChild(this.tip)
@@ -559,7 +559,7 @@ class Tooltip {
     })
 
     EventHandler.on(SelectorEngine.closest(this.element, '.modal'),
-      'hide.bs.modal',
+      'hide.bs.modal.tooltip',
       () => {
         if (this.element) {
           this.hide()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -237,7 +237,7 @@ class Tooltip {
     Data.removeData(this.element, this.constructor.DATA_KEY)
 
     EventHandler.off(this.element, this.constructor.EVENT_KEY)
-    EventHandler.off(SelectorEngine.closest(this.element, '.modal'), 'hide.bs.modal.tooltip')
+    EventHandler.off(SelectorEngine.closest(this.element, '.modal'), 'hide.bs.modal', this._hideModalHandler)
 
     if (this.tip) {
       this.tip.parentNode.removeChild(this.tip)
@@ -558,13 +558,15 @@ class Tooltip {
       }
     })
 
-    EventHandler.on(SelectorEngine.closest(this.element, '.modal'),
-      'hide.bs.modal.tooltip',
-      () => {
-        if (this.element) {
-          this.hide()
-        }
+    this._hideModalHandler = () => {
+      if (this.element) {
+        this.hide()
       }
+    }
+
+    EventHandler.on(SelectorEngine.closest(this.element, '.modal'),
+      'hide.bs.modal',
+      this._hideModalHandler
     )
 
     if (this.config.selector) {


### PR DESCRIPTION
If the tooltip component is in a modal, only the listeners created by the tooltip component should to be removed in the dispose method.
For example, if we subscribe to the _**hide.bs.modal**_ event of the **_modal_** component and call the **_dispose_** method of a **_tooltip_** component inside, the _**hide.bs.modal**_ event subscription is lost.

Using of  [event namespace feature of jquery](https://api.jquery.com/event.namespace/) ensures that  only the handler created in _setListeners function is removed in dispose function.