### PR TITLE
Deprecate `bg-variant()` mixin

### DIFF
--- a/scss/mixins/_background-variant.scss
+++ b/scss/mixins/_background-variant.scss
@@ -12,6 +12,7 @@
       background-color: darken($color, 10%) !important;
     }
   }
+  @include deprecate("The `bg-variant` mixin", "v4.3.2", "v5");
 }
 
 @mixin bg-gradient-variant($parent, $color) {


### PR DESCRIPTION
Add deprecate mixin for `bg-variant()` in `v4`

Closes #28444