### PR TITLE
Remove redundant radius properties

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -97,12 +97,12 @@
 
       .list-group-item {
         &:first-child {
-          @include border-left-radius($list-group-border-radius);
+          @include border-bottom-left-radius($list-group-border-radius);
           @include border-top-right-radius(0);
         }
 
         &:last-child {
-          @include border-right-radius($list-group-border-radius);
+          @include border-top-right-radius($list-group-border-radius);
           @include border-bottom-left-radius(0);
         }
 


### PR DESCRIPTION
Some properties are already set on `.list-group-item`, they can be removed safely.

Demo: https://deploy-preview-28956--twbs-bootstrap.netlify.com/docs/4.3/components/list-group/#horizontal