### PR TITLE
Drop support for .form-control-plaintext inside .input-group

### DIFF
--- a/scss/_input-group.scss
+++ b/scss/_input-group.scss
@@ -12,7 +12,6 @@
   width: 100%;
 
   > .form-control,
-  > .form-control-plaintext,
   > .custom-select,
   > .custom-file {
     position: relative; // For focus state's z-index

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -56,6 +56,7 @@ Changes to Reboot, typography, tables, and more.
 
 ## Forms
 
+- Dropped support for `.form-control-plaintext` inside `.input-group`
 - **Todo:** Move forms documentation to it's own top-level section
 - **Todo:** Rearrange source Sass files (under `scss/forms/`)
 - **Todo:** Combine native and custom checkboxes and radios


### PR DESCRIPTION
Drop support for `.form-control-plaintext` inside `.input-group`, because this cause #28205.

Closes #28205