### PR TITLE
Remove redundant border radius on pagination

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,7 +1,6 @@
 .pagination {
   display: flex;
   @include list-unstyled();
-  @include border-radius();
 }
 
 .page-link {


### PR DESCRIPTION
Pagination used to have box shadow back in the days which required this property, but nowadays it's redundant. (see https://github.com/twbs/bootstrap/blame/0cd186183c5e18f0517d6037d53f29c56adbac72/less/pagination.less#L17)