### PR TITLE
Add ARIA search landmark to documentation.

### DIFF
--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,4 +1,4 @@
-<form class="bd-search d-flex align-items-center">
+<form role="search" class="bd-search d-flex align-items-center">
   <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">
   <button class="btn btn-link bd-search-docs-toggle d-md-none p-0 ml-3" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
     {{ partial "icons/menu.svg" (dict "width" "30" "height" "30") }}


### PR DESCRIPTION
Reference: [WAI-ARIA Authoring Practices 1.1 § 4.3.8](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_search).

Addendum: `.bd-sidebar` and `bd-toc` don't appear to have enough roles, but I'm new at this whole ARIA thing so would prefer advice on this one.