### PR TITLE
Remove attribute selectors from buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -126,12 +126,3 @@ fieldset:disabled a.btn {
     margin-top: $btn-block-spacing-y;
   }
 }
-
-// Specificity overrides
-input[type="submit"],
-input[type="reset"],
-input[type="button"] {
-  &.btn-block {
-    width: 100%;
-  }
-}


### PR DESCRIPTION
We needed this, back in the days when this was still present in our code (see https://github.com/twbs/bootstrap/issues/4666):
https://github.com/twbs/bootstrap/blob/fd49d4a44f7fe73054b861461b9ec0f36a1bb29a/less/forms.less#L102-L108

But nowadays it's redundant.