### PR TITLE
Make tabs ARIA accessible.

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -79,8 +79,8 @@
         .find('[data-toggle="tab"]')
         .attr('aria-selected', false)
       // Deactive previous tabpanel.
-      var tabpanel = $('#' + $($active).first().find('a').attr('aria-controls'));
-      tabpanel.attr('aria-expanded', false);
+      var $active_tabpanel = $('#' + $($active).first().find('a').attr('aria-controls'));
+      $active_tabpanel.attr('aria-expanded', false);
 
       // Activate next tab.
       element
@@ -88,8 +88,8 @@
         .find('[data-toggle="tab"]')
         .attr('aria-selected', true)
       // Activate next tabpanel.
-      var tabpanel = $('#' + $(element).first().find('a').attr('aria-controls'));
-      tabpanel.attr('aria-expanded', true);
+      var element_tabpanel = $('#' + $(element).first().find('a').attr('aria-controls'));
+      element_tabpanel.attr('aria-expanded', true);
 
       // Animate transition.
       if (transition) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -70,19 +70,28 @@
       && ($active.length && $active.hasClass('fade') || !!container.find('> .fade').length)
 
     function next() {
+      // Deactivate previous tab.
       $active
         .removeClass('active')
         .find('> .dropdown-menu > .active')
         .removeClass('active')
         .end()
         .find('[data-toggle="tab"]')
-        .attr('aria-expanded', false)
+        .attr('aria-selected', false)
+      // Deactive previous tabpanel.
+      var tabpanel = $('#' + $($active).first().find('a').attr('aria-controls'));
+      tabpanel.attr('aria-expanded', false);
 
+      // Activate next tab.
       element
         .addClass('active')
         .find('[data-toggle="tab"]')
-        .attr('aria-expanded', true)
+        .attr('aria-selected', true)
+      // Activate next tabpanel.
+      var tabpanel = $('#' + $(element).first().find('a').attr('aria-controls'));
+      tabpanel.attr('aria-expanded', true);
 
+      // Animate transition.
       if (transition) {
         element[0].offsetWidth // reflow for transition
         element.addClass('in')
@@ -90,6 +99,7 @@
         element.removeClass('fade')
       }
 
+      // Activate tab's dropdown.
       if (element.parent('.dropdown-menu').length) {
         element
           .closest('li.dropdown')

--- a/js/tab.js
+++ b/js/tab.js
@@ -79,8 +79,8 @@
         .find('[data-toggle="tab"]')
         .attr('aria-selected', false)
       // Deactive previous tabpanel.
-      var $active_tabpanel = $('#' + $($active).first().find('a').attr('aria-controls'));
-      $active_tabpanel.attr('aria-expanded', false);
+      var $activeTabpanel = $('#' + $($active).first().find('a').attr('aria-controls'));
+      $activeTabpanel.attr('aria-expanded', false);
 
       // Activate next tab.
       element
@@ -88,8 +88,8 @@
         .find('[data-toggle="tab"]')
         .attr('aria-selected', true)
       // Activate next tabpanel.
-      var element_tabpanel = $('#' + $(element).first().find('a').attr('aria-controls'));
-      element_tabpanel.attr('aria-expanded', true);
+      var elementTabpanel = $('#' + $(element).first().find('a').attr('aria-controls'));
+      elementTabpanel.attr('aria-expanded', true);
 
       // Animate transition.
       if (transition) {


### PR DESCRIPTION
Bootstrap Tabs almost conforms to the ARIA spec for tabs but not quite:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role#Description

To match the spec the following changes have been made:
- Change the `tab` from using `aria-expanded` to `aria-selected`
- Connect to `tabpanel`s via the `tab`'s `aria-controls` value
- Change the `tabpanel` from using an `.active` css class to `aria-expanded` (in addition)

The HTML will need to ensure that their `tab`'s `aria-controls` and `tabpanel`'s `id` match.
