### PR TITLE
Fix dropdown unit test

### DIFF
--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -88,10 +88,11 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     var $button = $('button[data-toggle="dropdown"]')
+    $button[0].focus()
     // Key escape
-    $button.trigger('focus').trigger($.Event('keydown', {
-      which: 27
-    }))
+    var keydown = new Event('keydown')
+    keydown.which = 27
+    $button[0].dispatchEvent(keydown)
     assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown after escape pressed')
     done()
   })


### PR DESCRIPTION
swap jQuery's `trigger(...)` with the more verbose native `dispatchEvent(...)`, as the former may not always behave/bubble correctly (observed while trying to write unit tests for keyboard handling of ARIA tab
navigation), which may lead to this test passing even though it fails in real usage.