### PR TITLE
Made the button selectors more explicit

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -378,9 +378,12 @@ select {
 //    controls in Android 4.
 // 2. Correct the inability to style clickable types in iOS and Safari.
 button,
-[type="button"], // 1
-[type="reset"],
-[type="submit"] {
+button[type="button"], // 1
+button[type="reset"],
+button[type="submit"],
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
   -webkit-appearance: button; // 2
 }
 


### PR DESCRIPTION
[type="button"] also matches `<i type="button">` as well,
which is not intended and will soon be invalid.
This change makes the button selector only match actual button types.

Example -
http://dixi-bg.com/

More examples may be found on the list at the bottom of this page -
https://www.chromestatus.com/metrics/feature/timeline/popularity/2774


And what do you know, even GitHub suffers from that. See -


[type="button"] also matches <i type="button"> as well, which is not intended and will soon be invalid.
This change makes the button selector only match actual button types.

Example -
http://dixi-bg.com/

More examples may be found on the list at the bottom of this page -
https://www.chromestatus.com/metrics/feature/timeline/popularity/2774


![image](https://user-images.githubusercontent.com/184400/61289387-e72cff00-a7d1-11e9-8b4b-a68fb658bfa4.png)
