### PR TITLE
Document example of datalists with form controls

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -407,6 +407,13 @@ select {
   word-wrap: normal;
 }
 
+// Remove the dropdown arrow in Chrome from inputs built with datalists.
+//
+// Source: https://stackoverflow.com/a/54997118
+
+[list]::-webkit-calendar-picker-indicator {
+  display: none;
+}
 
 // 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
 //    controls in Android 4.

--- a/site/content/docs/4.3/forms/form-control.md
+++ b/site/content/docs/4.3/forms/form-control.md
@@ -84,3 +84,23 @@ Keep in mind color inputs are [not supported in IE](https://caniuse.com/#feat=in
   <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">
 </form>
 {{< /example >}}
+
+## Datalists
+
+Datalists allow you to create a group of `<option>`s that can be accessed (and autocompleted) from within an `<input>`. These are similar to `<select>` elements, but come with more menu styling limitations and differences. While most browsers and operating systems include some support for `<datalist>` elements, their styling is inconsistent at best.
+
+Learn more about [support for datalist elements](https://caniuse.com/#feat=datalist).
+
+{{< example >}}
+<form>
+  <label for="exampleDataList">Datalist example</label>
+  <input class="form-control" list="datalistOptions" id="exampleDataList" placeholder="Type to search...">
+  <datalist id="datalistOptions">
+    <option value="San Francisco">
+    <option value="New York">
+    <option value="Seattle">
+    <option value="Los Angeles">
+    <option value="Chicago">
+  </datalist>
+</form>
+{{< /example >}}


### PR DESCRIPTION
As shown in Chrome (Safari looks like shit, Firefox a close second lol):

<img width="847" alt="Screen Shot 2019-07-16 at 3 05 28 PM" src="https://user-images.githubusercontent.com/98681/61333355-83a7cf00-a7db-11e9-9afb-0f39b3a59f27.png">

Changes:

- Add example to the new form control docs
- Reset the [list] selector in Reboot to hide the random dropdown arrow in Chrome

Any thoughts on what else might be needed docs-wise?

Preview: <https://deploy-preview-29058--twbs-bootstrap.netlify.com/docs/4.3/forms/form-control/#datalists>
