### PR TITLE
Add support and docs for color input

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -528,6 +528,12 @@ progress {
   -webkit-appearance: none;
 }
 
+// Remove padding around color pickers in webkit browsers
+
+::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
 // 1. Change font properties to `inherit` in Safari.
 // 2. Correct the inability to style clickable types in iOS and Safari.
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -110,3 +110,8 @@
   line-height: $input-line-height-lg;
   @include border-radius($input-border-radius-lg);
 }
+
+.form-control-color {
+  max-width: 3rem;
+  padding: ($input-padding-y / 2) ($input-padding-x / 2);
+}

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -113,5 +113,13 @@
 
 .form-control-color {
   max-width: 3rem;
-  padding: ($input-padding-y / 2) ($input-padding-x / 2);
+  padding: $input-padding-y;
+}
+
+.form-control-color::-moz-color-swatch {
+  @include border-radius($input-border-radius);
+}
+
+.form-control-color::-webkit-color-swatch {
+  @include border-radius($input-border-radius);
 }

--- a/site/content/docs/4.3/forms/form-control.md
+++ b/site/content/docs/4.3/forms/form-control.md
@@ -76,15 +76,11 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 
 ## Color
 
-On macOS:
-
-- Chrome shows the native color picker
-- Safari shows a custom color picker that points to the input
-- Firefox shows the native color picker
+Keep in mind color inputs are [not supported in IE](https://caniuse.com/#feat=input-color).
 
 {{< example >}}
 <form>
   <label for="exampleColorInput">Color picker</label>
-  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c">
+  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">
 </form>
 {{< /example >}}

--- a/site/content/docs/4.3/forms/form-control.md
+++ b/site/content/docs/4.3/forms/form-control.md
@@ -73,3 +73,18 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
   <button type="submit" class="btn btn-primary mb-3">Confirm identity</button>
 </form>
 {{< /example >}}
+
+## Color
+
+On macOS:
+
+- Chrome shows the native color picker
+- Safari shows a custom color picker that points to the input
+- Firefox shows the native color picker
+
+{{< example >}}
+<form>
+  <label for="exampleColorInput">Color picker</label>
+  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c">
+</form>
+{{< /example >}}


### PR DESCRIPTION
As shown in Safari:

<img width="880" alt="Screen Shot 2019-07-16 at 3 22 15 PM" src="https://user-images.githubusercontent.com/98681/61334001-958a7180-a7dd-11e9-9ac4-016c1c1fc97d.png">

- [x] Add new `.form-control-color` modifier class to limit the width
- [x] Add basic code example
- [ ] Document styling details, browser support, etc

/cc @twbs/css-review 

Preview: <https://deploy-preview-29059--twbs-bootstrap.netlify.com/docs/4.3/forms/form-control/#color>
