### PR TITLE
[WIP] Flexible CSS transition control

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -113,7 +113,7 @@ class Dropdown {
     this._config = this._getConfig(config)
     this._menu = this._getMenuElement()
     this._inNavbar = this._detectNavbar()
-    this._transition = new Transition(this._menu, this._config.transitionName)
+    this._transition = new Transition(this._config.transitionName)
 
     this._addEventListeners()
     Data.setData(element, DATA_KEY, this)
@@ -206,7 +206,7 @@ class Dropdown {
         .forEach(elem => EventHandler.on(elem, 'mouseover', null, noop()))
     }
 
-    this._transition.startEnter()
+    this._transition.startEnter(this._menu)
 
     this._element.focus()
     this._element.setAttribute('aria-expanded', true)
@@ -214,7 +214,7 @@ class Dropdown {
     Manipulator.toggleClass(this._menu, ClassName.SHOW)
     Manipulator.toggleClass(parent, ClassName.SHOW)
 
-    this._transition.endEnter(() => {
+    this._transition.endEnter(this._menu, () => {
       EventHandler.trigger(parent, Event.SHOWN, relatedTarget)
     })
   }
@@ -235,9 +235,9 @@ class Dropdown {
       return
     }
 
-    this._transition.startLeave()
+    this._transition.startLeave(this._menu)
 
-    this._transition.endLeave(() => {
+    this._transition.endLeave(this._menu, () => {
       if (this._popper) {
         this._popper.destroy()
       }
@@ -443,13 +443,17 @@ class Dropdown {
 
       toggles[i].setAttribute('aria-expanded', 'false')
 
-      if (context._popper) {
-        context._popper.destroy()
-      }
+      context._transition.startLeave(dropdownMenu)
 
-      dropdownMenu.classList.remove(ClassName.SHOW)
-      parent.classList.remove(ClassName.SHOW)
-      EventHandler.trigger(parent, Event.HIDDEN, relatedTarget)
+      context._transition.endLeave(dropdownMenu, () => {
+        if (context._popper) {
+          context._popper.destroy()
+        }
+
+        dropdownMenu.classList.remove(ClassName.SHOW)
+        parent.classList.remove(ClassName.SHOW)
+        EventHandler.trigger(parent, Event.HIDDEN, relatedTarget)
+      })
     }
   }
 

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -64,7 +64,7 @@ class Toast {
     this._element = element
     this._config = this._getConfig(config)
     this._timeout = null
-    this._transition = new Transition(this._element, this._config.transitionName)
+    this._transition = new Transition(this._config.transitionName)
     this._setListeners()
     Data.setData(element, DATA_KEY, this)
   }
@@ -92,11 +92,11 @@ class Toast {
       return
     }
 
-    this._transition.startEnter()
+    this._transition.startEnter(this._element)
 
     this._element.classList.add(ClassName.SHOW)
 
-    this._transition.endEnter(() => {
+    this._transition.endEnter(this._element, () => {
       EventHandler.trigger(this._element, Event.SHOWN)
 
       if (this._config.autohide) {
@@ -118,9 +118,9 @@ class Toast {
       return
     }
 
-    this._transition.startLeave()
+    this._transition.startLeave(this._element)
 
-    this._transition.endLeave(() => {
+    this._transition.endLeave(this._element, () => {
       this._element.classList.remove(ClassName.SHOW)
       EventHandler.trigger(this._element, Event.HIDDEN)
     })

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -8,9 +8,9 @@
 import {
   getjQuery,
   TRANSITION_END,
+  nextAnimationFrame,
   emulateTransitionEnd,
   getTransitionDurationFromElement,
-  reflow,
   typeCheckConfig
 } from './util/index'
 import Data from './dom/data'
@@ -37,22 +37,19 @@ const Event = {
 }
 
 const ClassName = {
-  FADE: 'fade',
-  HIDE: 'hide',
-  SHOW: 'show',
-  SHOWING: 'showing'
+  SHOW: 'show'
 }
 
 const DefaultType = {
-  animation: 'boolean',
   autohide: 'boolean',
-  delay: 'number'
+  delay: 'number',
+  transitionName: 'string'
 }
 
 const Default = {
-  animation: true,
   autohide: true,
-  delay: 500
+  delay: 500,
+  transitionName: 'fade'
 }
 
 const Selector = {
@@ -97,14 +94,24 @@ class Toast {
       return
     }
 
-    if (this._config.animation) {
-      this._element.classList.add(ClassName.FADE)
+    if (this._config.transitionName) {
+      this._element.classList.add(`${this._config.transitionName}-enter`)
+      this._element.classList.add(`${this._config.transitionName}-enter-active`)
+    }
+
+    this._element.classList.add(ClassName.SHOW)
+    const transitionDuration = getTransitionDurationFromElement(this._element)
+
+    if (this._config.transitionName) {
+      nextAnimationFrame(() => {
+        this._element.classList.remove(`${this._config.transitionName}-enter`)
+        this._element.classList.add(`${this._config.transitionName}-enter-to`)
+      })
     }
 
     const complete = () => {
-      this._element.classList.remove(ClassName.SHOWING)
-      this._element.classList.add(ClassName.SHOW)
-
+      this._element.classList.remove(`${this._config.transitionName}-enter-active`)
+      this._element.classList.remove(`${this._config.transitionName}-enter-to`)
       EventHandler.trigger(this._element, Event.SHOWN)
 
       if (this._config.autohide) {
@@ -114,12 +121,7 @@ class Toast {
       }
     }
 
-    this._element.classList.remove(ClassName.HIDE)
-    reflow(this._element)
-    this._element.classList.add(ClassName.SHOWING)
-    if (this._config.animation) {
-      const transitionDuration = getTransitionDurationFromElement(this._element)
-
+    if (transitionDuration) {
       EventHandler.one(this._element, TRANSITION_END, complete)
       emulateTransitionEnd(this._element, transitionDuration)
     } else {
@@ -138,15 +140,28 @@ class Toast {
       return
     }
 
+    if (this._config.transitionName) {
+      this._element.classList.add(`${this._config.transitionName}-leave`)
+      this._element.classList.add(`${this._config.transitionName}-leave-active`)
+    }
+
+    const transitionDuration = getTransitionDurationFromElement(this._element)
+
+    if (this._config.transitionName) {
+      nextAnimationFrame(() => {
+        this._element.classList.remove(`${this._config.transitionName}-leave`)
+        this._element.classList.add(`${this._config.transitionName}-leave-to`)
+      })
+    }
+
     const complete = () => {
-      this._element.classList.add(ClassName.HIDE)
+      this._element.classList.remove(`${this._config.transitionName}-leave-active`)
+      this._element.classList.remove(`${this._config.transitionName}-leave-to`)
+      this._element.classList.remove(ClassName.SHOW)
       EventHandler.trigger(this._element, Event.HIDDEN)
     }
 
-    this._element.classList.remove(ClassName.SHOW)
-    if (this._config.animation) {
-      const transitionDuration = getTransitionDurationFromElement(this._element)
-
+    if (transitionDuration) {
       EventHandler.one(this._element, TRANSITION_END, complete)
       emulateTransitionEnd(this._element, transitionDuration)
     } else {

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -80,6 +80,16 @@ const getTransitionDurationFromElement = element => {
   return (parseFloat(transitionDuration) + parseFloat(transitionDelay)) * MILLISECONDS_MULTIPLIER
 }
 
+const raf = window.requestAnimationFrame ?
+  window.requestAnimationFrame.bind(window) :
+  setTimeout
+
+const nextAnimationFrame = callback => {
+  raf(() => {
+    raf(callback)
+  })
+}
+
 const triggerTransitionEnd = element => {
   const evt = document.createEvent('HTMLEvents')
 
@@ -195,6 +205,7 @@ export {
   getTransitionDurationFromElement,
   triggerTransitionEnd,
   isElement,
+  nextAnimationFrame,
   emulateTransitionEnd,
   typeCheckConfig,
   makeArray,

--- a/js/src/util/transition.js
+++ b/js/src/util/transition.js
@@ -14,8 +14,7 @@ import {
 import EventHandler from '../dom/event-handler'
 
 class Transition {
-  constructor(element, transitionName) {
-    this._element = element
+  constructor(transitionName) {
     this._transitionName = transitionName
     this._transitionClass = {
       enter: `${this._transitionName}-enter`,
@@ -30,60 +29,78 @@ class Transition {
 
   // Public
 
-  startEnter() {
+  startEnter(element) {
+    this._clearClass(element)
+    this._cancelCallback(element)
+
     if (this._transitionName) {
-      this._element.classList.add(this._transitionClass.enter)
-      this._element.classList.add(this._transitionClass.enterActive)
+      element.classList.add(this._transitionClass.enter)
+      element.classList.add(this._transitionClass.enterActive)
     }
 
-    this._transitionDuration = getTransitionDurationFromElement(this._element)
+    this._transitionDuration = getTransitionDurationFromElement(element)
 
     if (this._transitionName) {
       nextAnimationFrame(() => {
-        this._element.classList.remove(this._transitionClass.enter)
-        this._element.classList.add(this._transitionClass.enterTo)
+        element.classList.remove(this._transitionClass.enter)
+        element.classList.add(this._transitionClass.enterTo)
       })
     }
   }
 
-  startLeave() {
+  startLeave(element) {
+    this._clearClass(element)
+    this._cancelCallback(element)
+
     if (this._transitionName) {
-      this._element.classList.add(this._transitionClass.leave)
-      this._element.classList.add(this._transitionClass.leaveActive)
+      element.classList.add(this._transitionClass.leave)
+      element.classList.add(this._transitionClass.leaveActive)
     }
 
-    this._transitionDuration = getTransitionDurationFromElement(this._element)
+    this._transitionDuration = getTransitionDurationFromElement(element)
 
     if (this._transitionName) {
       nextAnimationFrame(() => {
-        this._element.classList.remove(this._transitionClass.leave)
-        this._element.classList.add(this._transitionClass.leaveTo)
+        element.classList.remove(this._transitionClass.leave)
+        element.classList.add(this._transitionClass.leaveTo)
       })
     }
   }
 
-  endEnter(callback) {
-    this._endEnterLeave(callback, [this._transitionClass.enterActive, this._transitionClass.enterTo])
+  endEnter(element, callback) {
+    this._endEnterLeave(element, [this._transitionClass.enterActive, this._transitionClass.enterTo], callback)
   }
 
-  endLeave(callback) {
-    this._endEnterLeave(callback, [this._transitionClass.leaveActive, this._transitionClass.leaveTo])
+  endLeave(element, callback) {
+    this._endEnterLeave(element, [this._transitionClass.leaveActive, this._transitionClass.leaveTo], callback)
   }
 
   // Private
 
-  _endEnterLeave(callback, classList) {
+  _endEnterLeave(element, classList, callback) {
     const transitionEnd = () => {
-      classList.forEach(className => this._element.classList.remove(className))
-      callback()
+      classList.forEach(className => element.classList.remove(className))
+      if (callback) {
+        callback()
+      }
     }
 
     if (this._transitionDuration) {
-      EventHandler.one(this._element, TRANSITION_END, transitionEnd)
-      emulateTransitionEnd(this._element, this._transitionDuration)
+      EventHandler.one(element, TRANSITION_END, transitionEnd)
+      emulateTransitionEnd(element, this._transitionDuration)
     } else {
       transitionEnd()
     }
+  }
+
+  _clearClass(element) {
+    Object.keys(this._transitionClass).forEach(key => {
+      element.classList.remove(this._transitionClass[key])
+    })
+  }
+
+  _cancelCallback(element) {
+    EventHandler.off(element, TRANSITION_END)
   }
 }
 

--- a/js/src/util/transition.js
+++ b/js/src/util/transition.js
@@ -1,0 +1,90 @@
+/**
+ * --------------------------------------------------------------------------
+ * Bootstrap (v4.3.1): util/transition.js
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import {
+  TRANSITION_END,
+  emulateTransitionEnd,
+  getTransitionDurationFromElement,
+  nextAnimationFrame
+} from './index'
+import EventHandler from '../dom/event-handler'
+
+class Transition {
+  constructor(element, transitionName) {
+    this._element = element
+    this._transitionName = transitionName
+    this._transitionClass = {
+      enter: `${this._transitionName}-enter`,
+      enterTo: `${this._transitionName}-enter-to`,
+      enterActive: `${this._transitionName}-enter-active`,
+      leave: `${this._transitionName}-leave`,
+      leaveTo: `${this._transitionName}-leave-to`,
+      leaveActive: `${this._transitionName}-leave-active`
+    }
+    this._transitionDuration = 0
+  }
+
+  // Public
+
+  startEnter() {
+    if (this._transitionName) {
+      this._element.classList.add(this._transitionClass.enter)
+      this._element.classList.add(this._transitionClass.enterActive)
+    }
+
+    this._transitionDuration = getTransitionDurationFromElement(this._element)
+
+    if (this._transitionName) {
+      nextAnimationFrame(() => {
+        this._element.classList.remove(this._transitionClass.enter)
+        this._element.classList.add(this._transitionClass.enterTo)
+      })
+    }
+  }
+
+  startLeave() {
+    if (this._transitionName) {
+      this._element.classList.add(this._transitionClass.leave)
+      this._element.classList.add(this._transitionClass.leaveActive)
+    }
+
+    this._transitionDuration = getTransitionDurationFromElement(this._element)
+
+    if (this._transitionName) {
+      nextAnimationFrame(() => {
+        this._element.classList.remove(this._transitionClass.leave)
+        this._element.classList.add(this._transitionClass.leaveTo)
+      })
+    }
+  }
+
+  endEnter(callback) {
+    this._endEnterLeave(callback, [this._transitionClass.enterActive, this._transitionClass.enterTo])
+  }
+
+  endLeave(callback) {
+    this._endEnterLeave(callback, [this._transitionClass.leaveActive, this._transitionClass.leaveTo])
+  }
+
+  // Private
+
+  _endEnterLeave(callback, classList) {
+    const transitionEnd = () => {
+      classList.forEach(className => this._element.classList.remove(className))
+      callback()
+    }
+
+    if (this._transitionDuration) {
+      EventHandler.one(this._element, TRANSITION_END, transitionEnd)
+      emulateTransitionEnd(this._element, this._transitionDuration)
+    } else {
+      transitionEnd()
+    }
+  }
+}
+
+export default Transition

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -45,7 +45,7 @@ describe('Toast', () => {
 
     it('should close toast when close element with data-dismiss attribute is set', done => {
       fixtureEl.innerHTML = [
-        '<div class="toast" data-delay="1" data-autohide="false" data-animation="false">',
+        '<div class="toast" data-delay="1" data-autohide="false" data-transitionName="">',
         '  <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">',
         '    close',
         '  </button>',
@@ -79,7 +79,7 @@ describe('Toast', () => {
       Toast.Default.delay = defaultDelay
 
       fixtureEl.innerHTML = [
-        '<div class="toast" data-autohide="false" data-animation="false">',
+        '<div class="toast" data-autohide="false" data-transitionName="">',
         '  <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">',
         '    close',
         '  </button>',
@@ -122,7 +122,7 @@ describe('Toast', () => {
 
     it('should not add fade class', done => {
       fixtureEl.innerHTML = [
-        '<div class="toast" data-delay="1" data-animation="false">',
+        '<div class="toast" data-delay="1" data-transitionName="">',
         '  <div class="toast-body">',
         '    a simple toast',
         '  </div>',
@@ -142,7 +142,7 @@ describe('Toast', () => {
 
     it('should not trigger shown if show is prevented', done => {
       fixtureEl.innerHTML = [
-        '<div class="toast" data-delay="1" data-animation="false">',
+        '<div class="toast" data-delay="1" data-transitionName="">',
         '  <div class="toast-body">',
         '    a simple toast',
         '  </div>',
@@ -212,7 +212,7 @@ describe('Toast', () => {
 
     it('should not trigger hidden if hide is prevented', done => {
       fixtureEl.innerHTML = [
-        '<div class="toast" data-delay="1" data-animation="false">',
+        '<div class="toast" data-delay="1" data-transitionName="">',
         '  <div class="toast-body">',
         '    a simple toast',
         '  </div>',

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -251,8 +251,10 @@ describe('Tooltip', () => {
       tooltip.toggle()
     })
 
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+
     it('should call toggle and hide the tooltip when trigger is "click"', done => {
-      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"/>'
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">to</a>'
 
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl, {
@@ -481,19 +483,18 @@ describe('Tooltip', () => {
       tooltip.show()
     })
 
-    it('should show a tooltip without the animation', done => {
+    it('should show a tooltip without the transition', done => {
       fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"/>'
 
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl, {
-        animation: false
+        transitionName: ''
       })
 
       tooltipEl.addEventListener('shown.bs.tooltip', () => {
         const tip = document.querySelector('.tooltip')
 
         expect(tip).toBeDefined()
-        expect(tip.classList.contains('fade')).toEqual(false)
         done()
       })
 
@@ -653,12 +654,12 @@ describe('Tooltip', () => {
       tooltip.show()
     })
 
-    it('should hide a tooltip without animation', done => {
+    it('should hide a tooltip without transition', done => {
       fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"/>'
 
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl, {
-        animation: false
+        transitionName: ''
       })
 
       tooltipEl.addEventListener('shown.bs.tooltip', () => tooltip.hide())
@@ -683,7 +684,7 @@ describe('Tooltip', () => {
 
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl, {
-        animation: false
+        transitionName: ''
       })
 
       tooltipEl.addEventListener('shown.bs.tooltip', () => tooltip.hide())
@@ -792,7 +793,6 @@ describe('Tooltip', () => {
       const tip = tooltip.getTipElement()
 
       expect(tip.classList.contains('show')).toEqual(false)
-      expect(tip.classList.contains('fade')).toEqual(false)
       expect(tip.querySelector('.tooltip-inner').textContent).toEqual('Another tooltip')
     })
   })

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -19,7 +19,6 @@
   top: 100%;
   left: 0;
   z-index: $zindex-dropdown;
-  display: none; // none by default, but block on "open" of the menu
   min-width: $dropdown-min-width;
   padding: $dropdown-padding-y 0;
   margin: $dropdown-spacer 0 0; // override default ul
@@ -32,6 +31,10 @@
   border: $dropdown-border-width solid $dropdown-border-color;
   @include border-radius($dropdown-border-radius);
   @include box-shadow($dropdown-box-shadow);
+
+  &:not(.show) {
+    display: none;
+  }
 }
 
 @each $breakpoint in map-keys($grid-breakpoints) {

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -8,23 +8,13 @@
   border: $toast-border-width solid $toast-border-color;
   box-shadow: $toast-box-shadow;
   backdrop-filter: blur(10px);
-  opacity: 0;
   @include border-radius($toast-border-radius);
 
   &:not(:last-child) {
     margin-bottom: $toast-padding-x;
   }
 
-  &.showing {
-    opacity: 1;
-  }
-
-  &.show {
-    display: block;
-    opacity: 1;
-  }
-
-  &.hide {
+  &:not(.show) {
     display: none;
   }
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -10,9 +10,11 @@
   @include font-size($tooltip-font-size);
   // Allow breaking very long words so they don't overflow the tooltip's bounds
   word-wrap: break-word;
-  opacity: 0;
+  opacity: $tooltip-opacity;
 
-  &.show { opacity: $tooltip-opacity; }
+  &:not(.show) {
+    display: none;
+  }
 
   .tooltip-arrow {
     position: absolute;

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -6,6 +6,27 @@
   }
 }
 
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  @include transition($transition-fade);
+}
+
+.slide-down-enter,
+.slide-down-leave-to {
+  opacity: 0;
+  transform: translateY(-30px);
+}
+
+.slide-down-enter-active,
+.slide-down-leave-active {
+  @include transition($transition-base);
+}
+
 .collapse {
   &:not(.show) {
     display: none;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -336,7 +336,7 @@ $caret-vertical-align:        $caret-width * .85 !default;
 $caret-spacing:               $caret-width * .85 !default;
 
 $transition-base:             all .2s ease-in-out !default;
-$transition-fade:             opacity .15s linear !default;
+$transition-fade:             opacity .24s linear !default;
 $transition-collapse:         height .35s ease !default;
 
 $embed-responsive-aspect-ratios: (

--- a/site/content/docs/4.3/components/dropdowns.md
+++ b/site/content/docs/4.3/components/dropdowns.md
@@ -861,6 +861,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>null</td>
       <td>To change Bootstrap's default Popper.js config, see <a href="https://popper.js.org/popper-documentation.html#Popper.Defaults">Popper.js's configuration</a></td>
     </tr>
+    <tr>
+      <td>transitionName</td>
+      <td>string</td>
+      <td>
+        <code>fade</code>
+      </td>
+      <td>The prefix of the class names for CSS Transition when show/hide. If set to <code>""</code>, it doesn't add the classes.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/site/content/docs/4.3/components/toasts.md
+++ b/site/content/docs/4.3/components/toasts.md
@@ -231,7 +231,7 @@ var toastList = toastElList.map(function (toastEl) {
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-animation=""`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-autohide=""`.
 
 <table class="table">
   <thead>
@@ -243,12 +243,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>animation</td>
-      <td>boolean</td>
-      <td>true</td>
-      <td>Apply a CSS fade transition to the toast</td>
-    </tr>
     <tr>
       <td>autohide</td>
       <td>boolean</td>
@@ -262,6 +256,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <code>500</code>
       </td>
       <td>Delay hiding the toast (ms)</td>
+    </tr>
+    <tr>
+      <td>transitionName</td>
+      <td>string</td>
+      <td>
+        <code>fade</code>
+      </td>
+      <td>The prefix of the class names for CSS Transition when show/hide. If set to <code>""</code>, it doesn't add the classes.</td>
     </tr>
   </tbody>
 </table>

--- a/site/content/docs/4.3/components/tooltips.md
+++ b/site/content/docs/4.3/components/tooltips.md
@@ -142,7 +142,7 @@ Elements with the `disabled` attribute aren't interactive, meaning users cannot 
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-animation=""`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-`, as in `data-title=""`.
 
 {{< callout warning >}}
 Note that for security reasons the `sanitize`, `sanitizeFn` and `whiteList` options cannot be supplied using data attributes.
@@ -158,12 +158,6 @@ Note that for security reasons the `sanitize`, `sanitizeFn` and `whiteList` opti
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>animation</td>
-      <td>boolean</td>
-      <td>true</td>
-      <td>Apply a CSS fade transition to the tooltip</td>
-    </tr>
     <tr>
       <td>container</td>
       <td>string | element | false</td>
@@ -283,6 +277,14 @@ Note that for security reasons the `sanitize`, `sanitizeFn` and `whiteList` opti
       <td>null | object</td>
       <td>null</td>
       <td>To change Bootstrap's default Popper.js config, see <a href="https://popper.js.org/popper-documentation.html#Popper.Defaults">Popper.js's configuration</a></td>
+    </tr>
+    <tr>
+      <td>transitionName</td>
+      <td>string</td>
+      <td>
+        <code>fade</code>
+      </td>
+      <td>The prefix of the class names for CSS Transition when show/hide. If set to <code>""</code>, it doesn't add the classes.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This is an experimental PR for #28968.

This allows more control over CSS classes to achieve flexible CSS Transitions. The following GIF shows two transition patterns:

* `fade-xxx` classes: fadeIn/Out
* `slide-down-xxx` classes: slideDown/Up

Also you can use your custom transition name (`my-custom-transition-xxxx)`

![transition](https://user-images.githubusercontent.com/4065765/61565155-251c7280-aab3-11e9-9203-9fcdc4e309a1.gif)

Demo: https://codepen.io/anon/pen/dxYqYz?editors=1111

* [x] Dropdown
* [ ] Modal
* [ ] Popover
* [x] Toast
* [x] Tooltip
* [ ] Unit test