### PR TITLE
Fix Typos across Bootstrap repository

### DIFF
--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -767,7 +767,7 @@ $(function () {
     $trigger3[0].click()
   })
 
-  QUnit.test('should set aria-expanded="true" to triggers targeting shown collaspe and aria-expanded="false" only when all the targeted collapses are shown', function (assert) {
+  QUnit.test('should set aria-expanded="true" to triggers targeting shown collapse and aria-expanded="false" only when all the targeted collapses are shown', function (assert) {
     assert.expect(9)
     var done = assert.async()
 

--- a/site/content/docs/4.3/getting-started/webpack.md
+++ b/site/content/docs/4.3/getting-started/webpack.md
@@ -26,7 +26,7 @@ import Alert from 'bootstrap/js/dist/alert';
 ...
 {{< /highlight >}}
 
-Bootstrap depended on [Popper](https://popper.js.org/), which is specified in the `peerDependencies` property.
+Bootstrap depends on [Popper](https://popper.js.org/), which is specified in the `peerDependencies` property.
 This means that you will have to make sure to add both of them to your `package.json` using `npm install popper.js`.
 
 ## Importing Styles

--- a/site/content/docs/4.3/getting-started/webpack.md
+++ b/site/content/docs/4.3/getting-started/webpack.md
@@ -26,7 +26,7 @@ import Alert from 'bootstrap/js/dist/alert';
 ...
 {{< /highlight >}}
 
-Bootstrap depended on [Popper](https://popper.js.org/), which is speicified in the `peerDependencies` property.
+Bootstrap depended on [Popper](https://popper.js.org/), which is specified in the `peerDependencies` property.
 This means that you will have to make sure to add both of them to your `package.json` using `npm install popper.js`.
 
 ## Importing Styles

--- a/site/content/docs/4.3/getting-started/webpack.md
+++ b/site/content/docs/4.3/getting-started/webpack.md
@@ -26,7 +26,7 @@ import Alert from 'bootstrap/js/dist/alert';
 ...
 {{< /highlight >}}
 
-Bootstrap dependends on [Popper](https://popper.js.org/), which is speicified in the `peerDependencies` property.
+Bootstrap depended on [Popper](https://popper.js.org/), which is speicified in the `peerDependencies` property.
 This means that you will have to make sure to add both of them to your `package.json` using `npm install popper.js`.
 
 ## Importing Styles

--- a/site/content/docs/4.3/utilities/flex.md
+++ b/site/content/docs/4.3/utilities/flex.md
@@ -445,7 +445,7 @@ Responsive variations also exist for `order`.
 {{< /flex.inline >}}
 {{< /markdown >}}
 
-Additionaly there are also responsive `.order-first` and `.order-last` classes that change the `order` of an element by applying `order: -1` and `order: 6`, respectively.
+Additionally there are also responsive `.order-first` and `.order-last` classes that change the `order` of an element by applying `order: -1` and `order: 6`, respectively.
 
 {{< markdown >}}
 {{< flex.inline >}}


### PR DESCRIPTION
**Fix Typos** across Bootstrap

```
bootstrap/js/tests/unit/collapse.js:770:74: "collaspe" is a misspelling of "collapse"
bootstrap/site/content/docs/4.3/getting-started/webpack.md:29:10: "dependends" is a misspelling of "depended"
bootstrap/site/content/docs/4.3/utilities/flex.md:448:0: "Additionaly" is a misspelling of "Additionally"
```