### PR TITLE
Extend `.container-fluid` instead of duplicating complete rules

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -17,7 +17,7 @@
   // Responsive containers that are 100% wide until a breakpoint
   @each $breakpoint, $container-max-width in $container-max-widths {
     .container-#{$breakpoint} {
-      @include make-container();
+      @extend .container-fluid;
     }
 
     @include media-breakpoint-up($breakpoint, $grid-breakpoints) {


### PR DESCRIPTION
This change just outputs less css:

Instead of
```css
.container-fluid {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

.container-sm {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

@media (min-width: 576px) {
  .container-sm {
    max-width: 540px;
  }
}

.container-md {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

@media (min-width: 768px) {
  .container-md {
    max-width: 720px;
  }
}

.container-lg {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

@media (min-width: 992px) {
  .container-lg {
    max-width: 960px;
  }
}

.container-xl {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

@media (min-width: 1200px) {
  .container-xl {
    max-width: 1140px;
  }
}
```
it generates
```css
.container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
  width: 100%;
  padding-right: 15px;
  padding-left: 15px;
  margin-right: auto;
  margin-left: auto;
}

@media (min-width: 576px) {
  .container-sm {
    max-width: 540px;
  }
}

@media (min-width: 768px) {
  .container-md {
    max-width: 720px;
  }
}

@media (min-width: 992px) {
  .container-lg {
    max-width: 960px;
  }
}

@media (min-width: 1200px) {
  .container-xl {
    max-width: 1140px;
  }
}
```