### PR TITLE
Force reflow for toast fade-in animation

### DIFF
--- a/js/src/toast/toast.js
+++ b/js/src/toast/toast.js
@@ -10,6 +10,7 @@ import {
   TRANSITION_END,
   emulateTransitionEnd,
   getTransitionDurationFromElement,
+  reflow,
   typeCheckConfig
 } from '../util/index'
 import Data from '../dom/data'
@@ -114,6 +115,7 @@ class Toast {
     }
 
     this._element.classList.remove(ClassName.HIDE)
+    reflow(this._element)
     this._element.classList.add(ClassName.SHOWING)
     if (this._config.animation) {
       const transitionDuration = getTransitionDurationFromElement(this._element)


### PR DESCRIPTION
Fixes #28987

Demo (has `transition-duration: 1s` for debug)
* Current: https://codepen.io/anon/pen/zgrJjB
* After: https://codepen.io/anon/pen/xvZayd