### PR TITLE
Remove https://glyph.smarticons.co/ from list of suggestions

### DIFF
--- a/site/data/icons.yml
+++ b/site/data/icons.yml
@@ -17,8 +17,6 @@ more:
     website: http://demo.amitjakhu.com/dripicons/
   - name: Ikons
     website: http://ikons.piotrkwiatkowski.co.uk/
-  - name: Glyph
-    website: https://glyph.smarticons.co/
   - name: Icons8
     website: https://icons8.com/
   - name: icofont


### PR DESCRIPTION
The domain is now for sale and is triggers warnings in Firefox and Chrome