### PR TITLE
set min-height for form-control textarea

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -160,6 +160,7 @@ select.form-control {
 
 textarea.form-control {
   height: auto;
+  min-height: $input-height;
 }
 
 // Form groups


### PR DESCRIPTION
* set `min-height` for `.form-control` textarea
  * prevent user from shrink textarea to minimum height

| **before**  | **after**  |
|---|---|
| <img width="485" alt="Screenshot 2019-07-24 at 16 40 50" src="https://user-images.githubusercontent.com/26371/61803405-59d15680-ae32-11e9-97ea-7550ff168356.png"> | <img width="486" alt="Screenshot 2019-07-24 at 16 41 13" src="https://user-images.githubusercontent.com/26371/61803412-5d64dd80-ae32-11e9-86e2-694f36f10040.png"> |