### PR TITLE
set min-height for form-control textarea

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -505,9 +505,9 @@ progress {
 // Fix height of inputs with a type of datetime-local, date, month, week, or time
 // See https://github.com/twbs/bootstrap/issues/18842
 
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-  height: 0;
+::-webkit-datetime-edit {
+  overflow: visible;
+  line-height: 0;
 }
 
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -7,7 +7,7 @@
 .form-control {
   display: block;
   width: 100%;
-  height: $input-height;
+  min-height: $input-height;
   padding: $input-padding-y $input-padding-x;
   font-family: $input-font-family;
   @include font-size($input-font-size);
@@ -96,7 +96,7 @@
 // Repeated in `_input_group.scss` to avoid Sass extend issues.
 
 .form-control-sm {
-  height: $input-height-sm;
+  min-height: $input-height-sm;
   padding: $input-padding-y-sm $input-padding-x-sm;
   @include font-size($input-font-size-sm);
   line-height: $input-line-height-sm;
@@ -104,13 +104,9 @@
 }
 
 .form-control-lg {
-  height: $input-height-lg;
+  min-height: $input-height-lg;
   padding: $input-padding-y-lg $input-padding-x-lg;
   @include font-size($input-font-size-lg);
   line-height: $input-line-height-lg;
   @include border-radius($input-border-radius-lg);
-}
-
-textarea.form-control {
-  height: auto;
 }

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -123,9 +123,12 @@
 // Remix the default form control sizing classes into new ones for easier
 // manipulation.
 
-.input-group-lg > .form-control:not(textarea),
-.input-group-lg > .form-select {
+.input-group-lg > .form-control {
   min-height: $input-height-lg;
+}
+
+.input-group-lg > .form-select {
+  height: $input-height-lg;
 }
 
 .input-group-lg > .form-control,
@@ -140,9 +143,12 @@
   @include border-radius($input-border-radius-lg);
 }
 
-.input-group-sm > .form-control:not(textarea),
-.input-group-sm > .form-select {
+.input-group-sm > .form-control {
   min-height: $input-height-sm;
+}
+
+.input-group-sm > .form-select {
+  height: $input-height-sm;
 }
 
 .input-group-sm > .form-control,

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -125,7 +125,7 @@
 
 .input-group-lg > .form-control:not(textarea),
 .input-group-lg > .form-select {
-  height: $input-height-lg;
+  min-height: $input-height-lg;
 }
 
 .input-group-lg > .form-control,
@@ -142,7 +142,7 @@
 
 .input-group-sm > .form-control:not(textarea),
 .input-group-sm > .form-select {
-  height: $input-height-sm;
+  min-height: $input-height-sm;
 }
 
 .input-group-sm > .form-control,


### PR DESCRIPTION
* set `min-height` for `.form-control` textarea
  * prevent user from shrink textarea 
  * set minimum height equals default input height

| **before**  | **after**  |
|---|---|
| <img width="485" alt="Screenshot 2019-07-24 at 16 40 50" src="https://user-images.githubusercontent.com/26371/61803405-59d15680-ae32-11e9-97ea-7550ff168356.png"> | <img width="486" alt="Screenshot 2019-07-24 at 16 41 13" src="https://user-images.githubusercontent.com/26371/61803412-5d64dd80-ae32-11e9-86e2-694f36f10040.png"> |
| <img width="483" alt="Screenshot 2019-07-24 at 17 36 03" src="https://user-images.githubusercontent.com/26371/61807337-96548080-ae39-11e9-8680-cc431e5e35ed.png">  | <img width="481" alt="Screenshot 2019-07-24 at 17 35 18" src="https://user-images.githubusercontent.com/26371/61807354-9ce2f800-ae39-11e9-82d9-a6c6ef4e9d2d.png">  |

📷 Chrome 75 / Mac OS X 10.14.6