### PR TITLE
v5: Docs nav updates

### DIFF
--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,4 +1,4 @@
-<nav class="collapse bd-links pb-3" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="collapse bd-links" id="bd-docs-nav" aria-label="Main navigation">
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 

--- a/site/static/docs/4.3/assets/scss/_navbar.scss
+++ b/site/static/docs/4.3/assets/scss/_navbar.scss
@@ -1,0 +1,46 @@
+.bd-navbar {
+  min-height: 4rem;
+  background-color: $bd-purple-bright;
+
+  @include media-breakpoint-down(md) {
+    .navbar-nav-scroll {
+      width: 100%;
+      height: 2.5rem;
+      margin-top: .25rem;
+      overflow: hidden;
+
+      .navbar-nav {
+        padding-bottom: 2rem;
+        overflow-x: auto;
+        white-space: nowrap;
+        -webkit-overflow-scrolling: touch;
+      }
+    }
+  }
+
+  .navbar-nav {
+    .nav-link {
+      padding-right: .5rem;
+      padding-left: .5rem;
+      color: $bd-purple-light;
+
+      &.active,
+      &:hover,
+      &:focus {
+        color: $white;
+        background-color: transparent;
+      }
+
+      &.active {
+        font-weight: 600;
+      }
+    }
+  }
+
+  .navbar-nav-svg {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    vertical-align: text-top;
+  }
+}

--- a/site/static/docs/4.3/assets/scss/_navbar.scss
+++ b/site/static/docs/4.3/assets/scss/_navbar.scss
@@ -22,7 +22,7 @@
     .nav-link {
       padding-right: .5rem;
       padding-left: .5rem;
-      color: $bd-purple-light;
+      color: rgba($white, .85);
 
       &.active,
       &:hover,

--- a/site/static/docs/4.3/assets/scss/_sidebar.scss
+++ b/site/static/docs/4.3/assets/scss/_sidebar.scss
@@ -10,6 +10,8 @@
       position: sticky;
       top: 5rem;
       z-index: 1000;
+      height: calc(100vh - 7rem);
+      overflow-y: auto;
     }
   }
 

--- a/site/static/docs/4.3/assets/scss/_sidebar.scss
+++ b/site/static/docs/4.3/assets/scss/_sidebar.scss
@@ -74,7 +74,7 @@
 
     &:hover,
     &:focus {
-      color: rgba($white, .85);
+      color: rgba($black, .85);
       text-decoration: none;
       background-color: rgba($bd-purple-bright, .1);
     }

--- a/site/static/docs/4.3/assets/scss/_sidebar.scss
+++ b/site/static/docs/4.3/assets/scss/_sidebar.scss
@@ -1,16 +1,12 @@
 // stylelint-disable declaration-no-important
 
-.bd-sidebar {
-  order: 0;
-}
-
 .bd-links {
   @include media-breakpoint-up(md) {
     @supports (position: sticky) {
       position: sticky;
       top: 5rem;
       z-index: 1000;
-      height: calc(100vh - 7rem);
+      height: calc(100vh - 5rem);
       overflow-y: auto;
     }
   }
@@ -21,21 +17,21 @@
   }
 }
 
-.bd-sidenav {
+:not(.active) > .bd-sidenav {
   display: none;
 }
 
 .bd-sidenav-group-link {
   padding: .25rem .625rem .25rem .5rem;
   font-weight: 600;
-  color: rgba(0, 0, 0, .65);
+  color: rgba($black, .65);
   @include border-radius(.25rem);
 
   > * { pointer-events: none; }
 
   &:hover,
   &:focus {
-    color: rgba(0, 0, 0, .85);
+    color: rgba($black, .85);
     text-decoration: none;
     background-color: rgba($bd-purple-bright, .1);
   }
@@ -60,11 +56,7 @@
     }
 
     > .bd-sidenav-group-link {
-      color: rgba(0, 0, 0, .85);
-    }
-
-    > .bd-sidenav {
-      display: block;
+      color: rgba($black, .85);
     }
   }
 }
@@ -77,12 +69,12 @@
     display: inline-block;
     padding: .25rem .5rem;
     @include font-size(.875rem);
-    color: rgba(0, 0, 0, .65);
+    color: rgba($black, .65);
     @include border-radius(.25rem);
 
     &:hover,
     &:focus {
-      color: rgba(0, 0, 0, .85);
+      color: rgba($white, .85);
       text-decoration: none;
       background-color: rgba($bd-purple-bright, .1);
     }
@@ -92,6 +84,6 @@
   > .active:hover > a,
   > .active:focus > a {
     font-weight: 600;
-    color: rgba(0, 0, 0, .85);
+    color: rgba($black, .85);
   }
 }

--- a/site/static/docs/4.3/assets/scss/_sidebar.scss
+++ b/site/static/docs/4.3/assets/scss/_sidebar.scss
@@ -6,7 +6,7 @@
       position: sticky;
       top: 5rem;
       z-index: 1000;
-      height: calc(100vh - 5rem);
+      height: calc(100vh - 7rem);
       overflow-y: auto;
     }
   }

--- a/site/static/docs/4.3/assets/scss/_subnav.scss
+++ b/site/static/docs/4.3/assets/scss/_subnav.scss
@@ -1,7 +1,3 @@
-//
-// Main navbar
-//
-
 .bd-subnavbar {
   background-color: rgba(#fff, .75);
   backdrop-filter: blur(1rem);
@@ -62,52 +58,5 @@
   &:focus {
     color: $blue;
     text-decoration: none;
-  }
-}
-
-.bd-navbar {
-  min-height: 4rem;
-  background-color: $bd-purple-bright;
-
-  @include media-breakpoint-down(md) {
-    .navbar-nav-scroll {
-      width: 100%;
-      height: 2.5rem;
-      margin-top: .25rem;
-      overflow: hidden;
-
-      .navbar-nav {
-        padding-bottom: 2rem;
-        overflow-x: auto;
-        white-space: nowrap;
-        -webkit-overflow-scrolling: touch;
-      }
-    }
-  }
-
-  .navbar-nav {
-    .nav-link {
-      padding-right: .5rem;
-      padding-left: .5rem;
-      color: $bd-purple-light;
-
-      &.active,
-      &:hover,
-      &:focus {
-        color: $white;
-        background-color: transparent;
-      }
-
-      &.active {
-        font-weight: 600;
-      }
-    }
-  }
-
-  .navbar-nav-svg {
-    display: inline-block;
-    width: 1rem;
-    height: 1rem;
-    vertical-align: text-top;
   }
 }

--- a/site/static/docs/4.3/assets/scss/docs.scss
+++ b/site/static/docs/4.3/assets/scss/docs.scss
@@ -30,7 +30,8 @@
 
 // Load docs components
 @import "variables";
-@import "nav";
+@import "navbar";
+@import "subnav";
 @import "masthead";
 @import "ads";
 @import "content";


### PR DESCRIPTION
- Slightly improves navbar link color contrast (still need to do better, will explore tweaking the new purple)
- Moves subnav styles into new `_subnav.scss`
- Renames `_nav.scss` to `_navbar.scss` for docs styles
- Restores `height` and `overflow-y` for sidebar scrolling

@XhmikosR Didn't want to push to your docs PR, but if you want, I can `cherry-pick` and move it over.