### PR TITLE
Add `--mangle-props regex="/^_/"` in terser for our core dist files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-lint-docs": "eslint --cache --cache-location .cache/.eslintcache site/",
     "js-minify": "npm-run-all --parallel js-minify-main js-minify-docs",
     "js-minify-main": "npm-run-all js-minify-standalone* js-minify-bundle",
-    "js-minify-standalone": "terser --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
+    "js-minify-standalone": "terser --compress typeofs=false --mangle --mangle-props regex=\"/^_/\" --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
     "js-minify-standalone-esm": "terser --compress --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.esm.js.map,includeSources,url=bootstrap.esm.min.js.map\" --output dist/js/bootstrap.esm.min.js dist/js/bootstrap.esm.js",
     "js-minify-bundle": "terser --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.bundle.js.map,includeSources,url=bootstrap.bundle.min.js.map\" --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js",
     "js-minify-docs": "cross-env-shell terser --mangle --comments \\\"/^!/\\\" --output site/static/docs/$npm_package_version_short/assets/js/docs.min.js site/static/docs/$npm_package_version_short/assets/js/vendor/anchor.min.js site/static/docs/$npm_package_version_short/assets/js/vendor/clipboard.min.js site/static/docs/$npm_package_version_short/assets/js/vendor/bs-custom-file-input.min.js \"site/static/docs/$npm_package_version_short/assets/js/src/*.js\"",


### PR DESCRIPTION
bootstrap.min.js: 17.03KB -> 16.35KB (gzip)

For the bundle I'm not sure we should enable it since we need to make sure Popper follows the same scheme.

The gains are pretty big, though. We should really look into enabling this.

- [ ] test the minified dist file to make sure everything works

Fixes #23635