### PR TITLE
Drop `.pre-scrollable` class

### DIFF
--- a/scss/_code.scss
+++ b/scss/_code.scss
@@ -38,9 +38,3 @@ pre {
     word-break: normal;
   }
 }
-
-// Enable scrollable blocks of code
-.pre-scrollable {
-  max-height: $pre-scrollable-max-height;
-  overflow-y: scroll;
-}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1106,4 +1106,3 @@ $kbd-color:                         $white !default;
 $kbd-bg:                            $gray-900 !default;
 
 $pre-color:                         null !default;
-$pre-scrollable-max-height:         340px !default;

--- a/site/content/docs/4.3/content/code.md
+++ b/site/content/docs/4.3/content/code.md
@@ -16,7 +16,7 @@ For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 
 ## Code blocks
 
-Use `<pre>`s for multiple lines of code. Once again, be sure to escape any angle brackets in the code for proper rendering. You may optionally add the `.pre-scrollable` class, which will set a max-height of 340px and provide a y-axis scrollbar.
+Use `<pre>`s for multiple lines of code. Once again, be sure to escape any angle brackets in the code for proper rendering.
 
 {{< example >}}
 <pre><code>&lt;p&gt;Sample text here...&lt;/p&gt;

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -57,6 +57,7 @@ Changes to Reboot, typography, tables, and more.
 - **Todo:** Make RFS enabled by default
 - Reset default horizontal `padding-left` on `<ul>` and `<ol>` elements from browser default `40px` to `2rem`.
 - Simplified table styles (no more 2px border on `thead > th` elements) and tightened cell padding.
+- Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
 
 ## Forms
 


### PR DESCRIPTION
So that https://github.com/twbs/bootstrap/pull/28917 can be merged. This class is probably not used that much, we don't even use it in our docs ourselves. Custom css can be written to replace this class.

TODO:
- [x] Document in migration