### PR TITLE
Update popovers.md

### DIFF
--- a/site/content/docs/4.3/components/popovers.md
+++ b/site/content/docs/4.3/components/popovers.md
@@ -299,7 +299,7 @@ Options for individual popovers can alternatively be specified through the use o
 
 #### show
 
-Reveals an element's popover. **Returns to the caller before the popover has actually been shown** (i.e. before the `shown.bs.popover` event occurs). This is considered a "manual" triggering of the popover. Popovers whose both title and content are zero-length are never displayed.
+Reveals an element's popover. **Returns to the caller before the popover has actually been shown** (i.e. before the `shown.bs.popover` event occurs). This is considered a "manual" triggering of the popover. Popovers whose title and content both are zero-length are never displayed.
 
 {{< highlight js >}}myPopover.show(){{< /highlight >}}
 


### PR DESCRIPTION
Fixed minor grammatical error.

Popovers whose both title and content are zero-length are never displayed.

=> 

Popovers whose title and content both are zero-length are never displayed.