### PR TITLE
Remove specific height of .form-select

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -585,7 +585,6 @@ $form-select-padding-y:           $input-padding-y !default;
 $form-select-padding-x:           $input-padding-x !default;
 $form-select-font-family:         $input-font-family !default;
 $form-select-font-size:           $input-font-size !default;
-$form-select-height:              $input-height !default;
 $form-select-indicator-padding:   1rem !default; // Extra padding to account for the presence of the background-image based indicator
 $form-select-font-weight:         $input-font-weight !default;
 $form-select-line-height:         $input-line-height !default;
@@ -615,12 +614,10 @@ $form-select-focus-box-shadow:    0 0 0 $form-select-focus-width $input-btn-focu
 $form-select-padding-y-sm:        $input-padding-y-sm !default;
 $form-select-padding-x-sm:        $input-padding-x-sm !default;
 $form-select-font-size-sm:        $input-font-size-sm !default;
-$form-select-height-sm:           $input-height-sm !default;
 
 $form-select-padding-y-lg:        $input-padding-y-lg !default;
 $form-select-padding-x-lg:        $input-padding-x-lg !default;
 $form-select-font-size-lg:        $input-font-size-lg !default;
-$form-select-height-lg:           $input-height-lg !default;
 
 $form-range-track-width:          100% !default;
 $form-range-track-height:         .5rem !default;

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -6,7 +6,6 @@
 .form-select {
   display: inline-block;
   width: 100%;
-  height: $form-select-height;
   padding: $form-select-padding-y ($form-select-padding-x + $form-select-indicator-padding) $form-select-padding-y $form-select-padding-x;
   font-family: $form-select-font-family;
   @include font-size($form-select-font-size);
@@ -42,7 +41,6 @@
 
   &[multiple],
   &[size]:not([size="1"]) {
-    height: auto;
     padding-right: $form-select-padding-x;
     background-image: none;
   }
@@ -59,7 +57,6 @@
 }
 
 .form-select-sm {
-  height: $form-select-height-sm;
   padding-top: $form-select-padding-y-sm;
   padding-bottom: $form-select-padding-y-sm;
   padding-left: $form-select-padding-x-sm;
@@ -67,7 +64,6 @@
 }
 
 .form-select-lg {
-  height: $form-select-height-lg;
   padding-top: $form-select-padding-y-lg;
   padding-bottom: $form-select-padding-y-lg;
   padding-left: $form-select-padding-x-lg;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -122,8 +122,7 @@
 // Remix the default form control sizing classes into new ones for easier
 // manipulation.
 
-.input-group-lg > .form-control:not(textarea),
-.input-group-lg > .form-select {
+.input-group-lg > .form-control:not(textarea) {
   height: $input-height-lg;
 }
 
@@ -139,8 +138,7 @@
   @include border-radius($input-border-radius-lg);
 }
 
-.input-group-sm > .form-control:not(textarea),
-.input-group-sm > .form-select {
+.input-group-sm > .form-control:not(textarea) {
   height: $input-height-sm;
 }
 


### PR DESCRIPTION
Those `height`s have been setted for fix the #18842. But it should not be needed for `.form-select`s.

I'll check in BrowserStack.

demo:
* https://codepen.io/anon/pen/NQdVdX
* https://deploy-preview-29167--twbs-bootstrap.netlify.com/docs/4.3/forms/select/
* https://deploy-preview-29167--twbs-bootstrap.netlify.com/docs/4.3/forms/input-group/
