### PR TITLE
Function map-get-multiple now returns the correct variable (#29246)

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "./dist/css/bootstrap-grid.css",
-      "maxSize": "8 kB"
+      "maxSize": "6.5 kB"
     },
     {
       "path": "./dist/css/bootstrap-grid.min.css",
-      "maxSize": "7.2 kB"
+      "maxSize": "6 kB"
     },
     {
       "path": "./dist/css/bootstrap-reboot.css",

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -50,7 +50,7 @@
       $result: map-merge($result, ($key: $value));
     }
   }
-  @return $map;
+  @return $result;
 }
 
 // Replace `$search` with `$replace` in `$string`


### PR DESCRIPTION
Simple fix for a simple issue. The return value of [map-get-multiple in scss/_functions.scss](https://github.com/twbs/bootstrap/commit/769c8d824600fbf521e3976cc4a3c6152ed4e8ce#diff-a03a8906cbb01aad0132bc80e31d0e2aR46-R54) was wrong. The function didn't do anything.

Fixes #29246