### PR TITLE
Row columns 3

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -46,16 +46,6 @@
     @include make-row();
   }
 
-  @each $breakpoint in map-keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-    @for $i from 1 through $grid-row-columns {
-      .row-cols#{$infix}-#{$i} {
-        @include row-cols($i);
-      }
-    }
-  }
-
   // Remove the negative margin from default .row, then the horizontal padding
   // from all immediate children columns (to prevent runaway style inheritance).
   .no-gutters {

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -33,6 +33,13 @@
         flex-grow: 1;
         max-width: 100%;
       }
+
+      @for $i from 1 through $grid-row-columns {
+        .row-cols#{$infix}-#{$i} {
+          @include row-cols($i);
+        }
+      }
+
       .col#{$infix}-auto {
         flex: 0 0 auto;
         width: auto;

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -56,7 +56,8 @@
 // numberof columns. Supports wrapping to new lines, but does not do a Masonry
 // style grid.
 @mixin row-cols($count) {
-  & > [class^="col"] {
-    flex: 0 0 calc(100% / #{$count});
+  & > * {
+    flex: 0 0 100% / $count;
+    max-width: 100% / $count;
   }
 }

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -369,6 +369,19 @@ Use these row columns classes to quickly create basic grid layouts or to control
 {{< /example >}}
 </div>
 
+<div class="bd-example-row">
+{{< example >}}
+<div class="container">
+  <div class="row row-cols-4">
+    <div class="col">Column</div>
+    <div class="col">Column</div>
+    <div class="col-6">Column</div>
+    <div class="col">Column</div>
+  </div>
+</div>
+{{< /example >}}
+</div>
+
 You can also use the accompanying Sass mixin, `row-cols()`:
 
 {{< highlight scss >}}


### PR DESCRIPTION
#29073 can not override specific cols width. This PR allows this. e.g.

```html
  <div class="row row-cols-4">
    <div class="col">Column</div>
    <div class="col">Column</div>
    <div class="col-6">Column</div> /* override col width */
    <div class="col">Column</div>
  </div>
```

https://deploy-preview-29317--twbs-bootstrap.netlify.com/docs/4.3/layout/grid/#row-columns

The difference from #29274 is that `row-cols-` still needs `.col` or` .col-` class for consistency with our traditional rule.