### PR TITLE
Docs: simplify a few Hugo `range`s.

### DIFF
--- a/site/content/docs/4.3/content/tables.md
+++ b/site/content/docs/4.3/content/tables.md
@@ -770,10 +770,10 @@ Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables u
 **These tables may appear broken until their responsive styles apply at specific viewport widths.**
 
 {{< tables.inline >}}
-{{ range $bp := $.Site.Data.breakpoints }}
-{{ if not (eq $bp "xs") }}
+{{ range $.Site.Data.breakpoints }}
+{{ if not (eq . "xs") }}
 <div class="bd-example">
-  <div class="table-responsive{{ $bp.abbr }}">
+  <div class="table-responsive{{ .abbr }}">
     <table class="table">
       <thead>
         <tr>
@@ -832,9 +832,9 @@ Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables u
 
 {{< highlight html >}}
 {{< tables.inline >}}
-{{- range $bp := $.Site.Data.breakpoints -}}
-{{- if not (eq $bp "xs") }}
-<div class="table-responsive{{ $bp.abbr }}">
+{{- range $.Site.Data.breakpoints -}}
+{{- if not (eq . "xs") }}
+<div class="table-responsive{{ .abbr }}">
   <table class="table">
     ...
   </table>

--- a/site/content/docs/4.3/utilities/flex.md
+++ b/site/content/docs/4.3/utilities/flex.md
@@ -438,8 +438,8 @@ Responsive variations also exist for `order`.
 {{< markdown >}}
 {{< flex.inline >}}
 {{- range $bp := $.Site.Data.breakpoints -}}
-{{- range $i, $num := seq 0 5 }}
-- `.order{{ $bp.abbr }}-{{ $i }}`
+{{- range (seq 0 5) }}
+- `.order{{ $bp.abbr }}-{{ . }}`
 {{- end -}}
 {{- end -}}
 {{< /flex.inline >}}
@@ -450,8 +450,8 @@ Additionally there are also responsive `.order-first` and `.order-last` classes 
 {{< markdown >}}
 {{< flex.inline >}}
 {{- range $bp := $.Site.Data.breakpoints -}}
-{{- range $i := slice "first" "last" }}
-- `.order{{ $bp.abbr }}-{{ $i }}`
+{{- range (slice "first" "last") }}
+- `.order{{ $bp.abbr }}-{{ . }}`
 {{- end -}}
 {{- end -}}
 {{< /flex.inline >}}

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -28,7 +28,7 @@
     {{- $modified_content = replace $modified_content "</svg>\n" "</svg>✂️" -}}
     {{- $modified_content = split $modified_content "✂️" -}}
 
-    {{- range $i, $content_chunk := $modified_content -}}
+    {{- range $content_chunk := $modified_content -}}
       {{- $image_class := "" -}}
 
       {{- if (strings.Contains $content_chunk `<svg class="bd-placeholder-img `) -}}


### PR DESCRIPTION
Not sure if this helps with performance, but we don't use the variables assigned in the `range`s.

Note that I kept them is some cases where I think it makes things clearer to read.