### PR TITLE
Fix shortcodes/example.html class bug.

### DIFF
--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -23,20 +23,21 @@
 
   {{- if (strings.Contains $input `<svg class="bd-placeholder-img`) -}}
     {{- $.Scratch.Set "highlight_content" "" -}}
-    {{- $image_class := "" -}}
 
     {{- $modified_content := replace $input `<svg class="bd-placeholder-img` `✂️<svg class="bd-placeholder-img` -}}
     {{- $modified_content = replace $modified_content "</svg>\n" "</svg>✂️" -}}
     {{- $modified_content = split $modified_content "✂️" -}}
 
-    {{- if (strings.Contains $input `<svg class="bd-placeholder-img `) -}}
-      {{- $image_class = replace $input "bd-placeholder-img " "bd-placeholder-img ✂️ " -}}
-      {{- $image_class = split (replace $image_class `" width="` `✂️" width="`) "✂️" -}}
-      {{- $image_class = replace (index $image_class 1) "bd-placeholder-img-lg" "" -}}
-      {{- $image_class = trim $image_class " " -}}
-    {{- end -}}
-
     {{- range $i, $content_chunk := $modified_content -}}
+      {{- $image_class := "" -}}
+
+      {{- if (strings.Contains $content_chunk `<svg class="bd-placeholder-img `) -}}
+        {{- $image_class = replace $content_chunk "bd-placeholder-img " "bd-placeholder-img ✂️ " -}}
+        {{- $image_class = split (replace $image_class `" width="` `✂️" width="`) "✂️" -}}
+        {{- $image_class = replace (index $image_class 1) "bd-placeholder-img-lg" "" -}}
+        {{- $image_class = trim $image_class " " -}}
+      {{- end -}}
+
       {{- if (strings.Contains $content_chunk `<svg class="bd-placeholder-img`) -}}
         {{- if $image_class -}}
           {{- $.Scratch.Add "highlight_content" (printf `<img src="..." class="%s" alt="...">` $image_class) -}}


### PR DESCRIPTION
It always used the first placeholder's class before.

Fixes #29342 
