### PR TITLE
ESLint: specify `--report-unused-disable-directives`

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -20,7 +20,6 @@ const toType = obj => ({}.toString.call(obj).match(/\s([a-z]+)/i)[1].toLowerCase
 
 const getUID = prefix => {
   do {
-    // eslint-disable-next-line no-bitwise
     prefix += ~~(Math.random() * MAX_UID) // "~~" acts like a faster Math.floor() here
   } while (document.getElementById(prefix))
 
@@ -170,7 +169,6 @@ const findShadowRoot = element => {
   return findShadowRoot(element.parentNode)
 }
 
-// eslint-disable-next-line no-empty-function
 const noop = () => function () {}
 
 const reflow = element => element.offsetHeight

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "js-compile-standalone-esm": "rollup --environment ESM:true,BUNDLE:false --config build/rollup.config.js --sourcemap",
     "js-compile-bundle": "rollup --environment BUNDLE:true --config build/rollup.config.js --sourcemap",
     "js-compile-plugins": "node build/build-plugins.js",
-    "js-lint": "eslint --cache --cache-location .cache/.eslintcache .",
+    "js-lint": "eslint --cache --cache-location .cache/.eslintcache --report-unused-disable-directives .",
     "js-minify": "npm-run-all --parallel js-minify-main js-minify-docs",
     "js-minify-main": "npm-run-all js-minify-standalone* js-minify-bundle",
     "js-minify-standalone": "terser --compress typeofs=false --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js",


### PR DESCRIPTION
An alternative would be to use `reportUnusedDisableDirectives` in eslint 6.3.0, which doesn't fail the build. But I think it's better this way.