### PR TITLE
Removed second instance of "dependencies" and "peerDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,10 +93,6 @@
     "url": "https://github.com/twbs/bootstrap/issues"
   },
   "license": "MIT",
-  "dependencies": {},
-  "peerDependencies": {
-    "popper.js": "^1.15.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
"dependencies" and "peerDependencies" were mentioned twice in the package.json file.