### PR TITLE
Update subnav to remove breadcrumb and just keep versions and search

### DIFF
--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -1,19 +1,15 @@
 <nav class="bd-subnavbar pt-2 pb-3 pb-md-2">
   <div class="container-xl d-flex align-items-md-center flex-wrap">
     <div class="d-flex align-items-center mr-sm-auto order-2 order-md-0">
-      <div class="d-none d-md-block">
+      <!-- <div class="d-none d-md-block mr-1">
         <a class="link-dark" href="/" onclick="ga('send', 'event', 'Subnav', 'click', 'Bootstrap');">Bootstrap</a>
-        {{ partial "icons/booticon-chevron-right.svg" (dict "class" "booticon d-inline-block mx-2 flex-shrink-0" "width" "12px" "height" "12px") }}
-      </div>
-
-      <a class="link-dark" href="/docs/{{ .Site.Params.docs_version }}/getting-started/introduction/" onclick="ga('send', 'event', 'Subnav', 'click', 'Documentation');">Documentation</a>
-      {{ partial "icons/booticon-chevron-right.svg" (dict "class" "booticon d-inline-block mx-2 flex-shrink-0" "width" "12px" "height" "12px") }}
+      </div> -->
 
       {{ partial "docs-versions" . }}
     </div>
 
     <form class="bd-search d-flex align-items-center mb-2 mb-md-0">
-      <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">
+      <input type="search" class="form-control" id="search-input" placeholder="Search docs..." aria-label="Search docs for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">
     </form>
 
     <button class="btn btn-link bd-search-docs-toggle d-md-none p-0 ml-3 order-3 ml-auto" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -1,10 +1,6 @@
 <nav class="bd-subnavbar pt-2 pb-3 pb-md-2">
   <div class="container-xl d-flex align-items-md-center flex-wrap">
     <div class="d-flex align-items-center mr-sm-auto order-2 order-md-0">
-      <!-- <div class="d-none d-md-block mr-1">
-        <a class="link-dark" href="/" onclick="ga('send', 'event', 'Subnav', 'click', 'Bootstrap');">Bootstrap</a>
-      </div> -->
-
       {{ partial "docs-versions" . }}
     </div>
 

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -1,6 +1,6 @@
 <div class="dropdown">
-  <button class="btn btn-link dropdown-toggle p-0 link-dark" id="bd-versions" data-toggle="dropdown" aria-expanded="false">
-    v{{ .Site.Params.docs_version }}
+  <button class="btn btn-bd-light dropdown-toggle" id="bd-versions" data-toggle="dropdown" aria-expanded="false">
+    Bootstrap v{{ .Site.Params.docs_version }}
   </button>
   <div class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions">
     <a class="dropdown-item active" href="/docs/{{ .Site.Params.docs_version }}/">Latest (5.0.x)</a>

--- a/site/layouts/partials/icons/booticon-chevron-right.svg
+++ b/site/layouts/partials/icons/booticon-chevron-right.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg"{{ with .width }} width="{{ . }}"{{ end }}{{ with .height }} height="{{ . }}"{{ end }}{{ with .class }} class="{{ . }}"{{ end }} viewBox="0 0 16 16" role="img"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 14l6-6-6-6"/></svg>

--- a/site/static/docs/4.3/assets/scss/_buttons.scss
+++ b/site/static/docs/4.3/assets/scss/_buttons.scss
@@ -35,3 +35,20 @@
     box-shadow: 0 0 0 3px rgba($bd-download, .25);
   }
 }
+
+.btn-bd-light {
+  color: $gray-600;
+  border-color: $gray-300;
+
+  .show > &,
+  &:hover,
+  &:active {
+    color: $bd-purple-bright;
+    background-color: #fff;
+    border-color: $bd-purple-bright;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 3px rgba($bd-purple-bright, .25);
+  }
+}

--- a/site/static/docs/4.3/assets/scss/_buttons.scss
+++ b/site/static/docs/4.3/assets/scss/_buttons.scss
@@ -44,7 +44,7 @@
   &:hover,
   &:active {
     color: $bd-purple-bright;
-    background-color: #fff;
+    background-color: $white;
     border-color: $bd-purple-bright;
   }
 

--- a/site/static/docs/4.3/assets/scss/_subnav.scss
+++ b/site/static/docs/4.3/assets/scss/_subnav.scss
@@ -3,10 +3,6 @@
   backdrop-filter: blur(1rem);
   box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .05), inset 0 -1px 0 rgba(0, 0, 0, .15);
 
-  .booticon {
-    opacity: .25;
-  }
-
   .dropdown-menu {
     @include font-size(.875rem);
     box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .05);


### PR DESCRIPTION
<img width="1527" alt="Screen Shot 2019-09-03 at 9 09 31 AM" src="https://user-images.githubusercontent.com/98681/64190695-ca08ca00-ce2b-11e9-8673-3b69600418d0.png">

Closes #29336.

Preview: https://deploy-preview-29368--twbs-bootstrap.netlify.com/
