### PR TITLE
Docs for close icon

### DIFF
--- a/site/content/docs/4.3/components/alerts.md
+++ b/site/content/docs/4.3/components/alerts.md
@@ -11,7 +11,7 @@ toc: true
 
 ## Examples
 
-Alerts are available for any length of text, as well as an optional dismiss button. For proper styling, use one of the eight **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts JavaScript plugin](#dismissing).
+Alerts are available for any length of text, as well as an optional close button. For proper styling, use one of the eight **required** contextual classes (e.g., `.alert-success`). For inline dismissal, use the [alerts JavaScript plugin](#dismissing).
 
 {{< example >}}
 {{< alerts.inline >}}
@@ -58,8 +58,8 @@ Alerts can also contain additional HTML elements like headings, paragraphs and d
 Using the alert JavaScript plugin, it's possible to dismiss any alert inline. Here's how:
 
 - Be sure you've loaded the alert plugin, or the compiled Bootstrap JavaScript.
-- Add a dismiss button and the `.alert-dismissible` class, which adds extra padding to the right of the alert and positions the `.close` button.
-- On the dismiss button, add the `data-dismiss="alert"` attribute, which triggers the JavaScript functionality. Be sure to use the `<button>` element with it for proper behavior across all devices.
+- Add a [close button]({{< docsref "/components/close-button" >}}) and the `.alert-dismissible` class, which adds extra padding to the right of the alert and positions the close button.
+- On the close button, add the `data-dismiss="alert"` attribute, which triggers the JavaScript functionality. Be sure to use the `<button>` element with it for proper behavior across all devices.
 - To animate alerts when dismissing them, be sure to add the `.fade` and `.show` classes.
 
 You can see this in action with a live demo:

--- a/site/content/docs/4.3/components/close-button.md
+++ b/site/content/docs/4.3/components/close-button.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
-title: Close icon
-description: Use a generic close icon for dismissing content like modals and alerts.
+title: Close button
+description: A generic close button for dismissing content like modals and alerts.
 group: components
 ---
 

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -46,7 +46,7 @@
     - title: Button group
     - title: Card
     - title: Carousel
-    - title: Close icon
+    - title: Close button
     - title: Collapse
     - title: Dropdowns
     - title: Icons


### PR DESCRIPTION
Change the name to a "close button" for clarity and consistency.

It is free to backport this to v4.