### PR TITLE
Sass: remove redundant stylelint inline suppressions.

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -176,7 +176,6 @@
   // Place margin between footer elements
   // This solution is far from ideal because of the universal selector usage,
   // but is needed to fix https://github.com/twbs/bootstrap/issues/24800
-  // stylelint-disable-next-line selector-max-universal
   > * {
     margin: $modal-footer-margin-between / 2;
   }

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -1,5 +1,3 @@
-// stylelint-disable selector-no-qualifying-type
-
 //
 // Textual form controls
 //

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -1,5 +1,3 @@
-// stylelint-disable declaration-no-important
-
 // Shorthand
 
 .fixed-top {

--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -1,5 +1,3 @@
-// stylelint-disable declaration-no-important
-
 .bd-masthead {
   padding: 3rem 0;
   background-image: linear-gradient(45deg, #fafafa, #f5f5f5);


### PR DESCRIPTION
`selector-max-universal` is set to `1` in our stylelint config  upstream BTW.

`-rd` works fine as long as one clears the local cache folder. But perhaps we should enable it anyway?