### PR TITLE
Fix inconsistent hr height with size attribute

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -70,12 +70,13 @@ hr {
   margin: $hr-margin-y 0;
   color: $hr-color; // 1
   background-color: currentColor;
-  border: 0;
+  border-style: solid none;
   opacity: $hr-opacity;
 }
 
 hr:not([size]) {
   height: $hr-height; // 2
+  border: 0;
 }
 
 


### PR DESCRIPTION
When hr used with size attribute results in height with 2px less than size specified, this is due to removal of border on hr elements.

Instead we can set its border-style to solid without remove it

[Code pen with fix](https://codepen.io/ashfahan/pen/bGbzqrQ)

Browser : Chrome [78.0.3904.21 Dev] , Chrome [Latest Stable]
OS: Windows 10 1903

_sorry about duplicate pull request previous one got overridden by one of my plugin_ 