### PR TITLE
Added a class to stick table headers on top

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -166,6 +166,21 @@
 }
 
 
+// Fixed header
+//
+// Stick table headers on top so only the <tbody> (and <tfoot>) scrolls.
+
+.table {
+  .thead-fixed {
+    th, td {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+  }
+}
+
+
 // Responsive tables
 //
 // Generate series of `.table-responsive-*` classes for configuring the screen


### PR DESCRIPTION
The class `.thead-fixed` must be applied on `<thead>` tags so its cells stick to te top of the parent container.