### PR TITLE
Remove outline from select box in FF

### DIFF
--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -61,7 +61,7 @@
   // Remove outline from select box in FF
   &:-moz-focusring {
     color: transparent;
-    text-shadow: 0 0 0 $black;
+    text-shadow: 0 0 0 $form-select-color;
   }
 }
 

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -57,6 +57,12 @@
   &::-ms-expand {
     display: none;
   }
+
+  // Remove outline from select box in FF
+  &:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 $black;
+  }
 }
 
 .form-select-sm {


### PR DESCRIPTION
Firefox added a gray border to custom select. This fix removes it.

More info here: https://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002

**Before:**
<img width="221" alt="Screenshot 2019-09-25 at 23 32 05" src="https://user-images.githubusercontent.com/1282324/65641614-8ac63700-dfed-11e9-99b2-21ad2fa086bb.png">

**After:**
<img width="211" alt="Screenshot 2019-09-25 at 23 31 52" src="https://user-images.githubusercontent.com/1282324/65641627-91ed4500-dfed-11e9-8f08-d3f376d021dc.png">
