### PR TITLE
v5: Icons docs cleanup

### DIFF
--- a/site/content/docs/4.3/extend/icons.md
+++ b/site/content/docs/4.3/extend/icons.md
@@ -5,11 +5,21 @@ description: Guidance and suggestions for using external icon libraries with Boo
 group: extend
 ---
 
-Bootstrap doesn't include an icon library by default, but we have a handful of recommendations for you to choose from. While most icon sets include multiple file formats, we prefer SVG implementations for their improved accessibility and vector support.
+While Bootstrap doesn't include an icon set by default, we do have our own comprehensive icon library called Bootstrap Icons. Feel free to use them or any other icon set in your project. We've included details for Bootstrap Icons and other preferred icon sets below.
 
-## Preferred
+While most icon sets include multiple file formats, we prefer SVG implementations for their improved accessibility and vector support.
 
-We've tested and used these icon sets ourselves.
+## Bootstrap Icons
+
+Bootstrap Icons is a growing library of SVG icons that are designed by [@mdo](https://github.com/mdo) and maintained by [the Bootstrap Team](https://github.com/twbs/members). The beginnings of this icon set come from Bootstrap's very own components—our forms, carousels, and more. Bootstrap has very few icon needs out of the box, so we didn't need much. However, once we got going, we couldn't stop making more.
+
+Oh, and did we mention they're completely open source? Licensed under MIT, just like Bootstrap, our icon set is available to everyone.
+
+[Learn more about Bootstrap Icons](https://icons.getbootstrap.com/), including how to install them and recommended usage.
+
+## Alternatives
+
+We've tested and used these icon sets ourselves as preferred alternatives to Bootstrap Icons.
 
 {{< markdown >}}
 {{< icons.inline >}}
@@ -23,7 +33,7 @@ We've tested and used these icon sets ourselves.
 
 ## More options
 
-While we haven't tried these out, they do look promising and provide multiple formats—including SVG.
+While we haven't tried these out ourselves, they do look promising and provide multiple formats, including SVG.
 
 {{< markdown >}}
 {{< icons.inline type="more" />}}

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -104,11 +104,6 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 
 - Removed the card columns in favor of a Masonry grid [See #28922](https://github.com/twbs/bootstrap/pull/28922).
 
-### Icons (New!)
-
-- Added new Bootstrap icons to the project for our documentation, form controls, and more.
-- Removed Open Iconic icons from project source code for form controls.
-
 ### Jumbotron
 
 - The jumbotron component is removed in favor of utility classes like `.bg-light` for the background color and `.p-*` classes to control padding.


### PR DESCRIPTION
This PR cleans up some lingering pieces around icons in Bootstrap. First, it removes mention of a new icon set from the Migration page. Second, it better documents the existence of the forthcoming Bootstrap Icons.
