### PR TITLE
coveralls: Add `COVERALLS_GIT_BRANCH`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,4 @@ jobs:
         if: matrix.node == 10 && github.repository == 'twbs/bootstrap' && github.event_name == 'push'
         env:
           COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+          COVERALLS_GIT_BRANCH: "${{ github.ref }}"


### PR DESCRIPTION
This does pass the ref, but not just the branch name, the whole ref, i.e `refs/head/master`.

This is an short-term fix until we switch to the official action.

Refs #29457 