### PR TITLE
Trim trailing whitespace from markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,3 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
We don't have trailing whitespaces for any markdown file. It's also quite annoying  the trailing whitespaces aren't removed when writing documentation.