### PR TITLE
Add `semantic` class for reduced markup

### DIFF
--- a/scss/_semantic.scss
+++ b/scss/_semantic.scss
@@ -1,0 +1,30 @@
+$semantic-selector: ".semantic" !default;
+
+$semantic-implications: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$semantic-implications: map-merge(
+  (
+    ".blockquote > footer": ".blockquote-footer",
+    "blockquote > footer": ".blockquote-footer",
+    ".list-inline > li": ".list-inline-item",
+    ".figure > img": ".figure-img",
+    "figure > img": ".figure-img",
+    ".figure > figcaption": ".figure-caption",
+    "figure > figcaption": ".figure-caption",
+    ".breadcrumb > li": ".breadcrumb-item",
+    ".list-group > li": ".list-group-item",
+  ),
+  $semantic-implications
+);
+
+
+@each $selectors, $implied in $semantic-implications {
+  @each $selector in $selectors {
+    $i: str-index($selector, " ") or -1;
+    $selector: str-insert($selector, $semantic-selector, $i);
+
+    #{$selector} {
+      @extend #{$implied};
+    }
+  }
+}

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -52,3 +52,7 @@
 // Utilities
 
 @import "utilities/api";
+
+
+// Semantic styling
+@import "semantic";


### PR DESCRIPTION
By design, Bootstrap supports opt-in styling via explicit classes, rather than implicit styling via semantic HTML.  Opt-in styling is more robust, because implicit styling can be difficult to undo / opt out of, and may cause conflicts with third-party code.  However, styling entirely via explicit classes can result in more verbose markup.  The `semantic` class provides a middle ground between the two approaches, enabling implicit styling in limited scopes.  It changes nothing about the way Bootstrap currently works, but adds a way for users to style their content via semantic HTML.

For example, styling breadcrumbs via explicit classes:

```html
<ol class="breadcrumb">
  <li class="breadcrumb-item"><a href="#">Home</a></li>
  <li class="breadcrumb-item"><a href="#">Library</a></li>
  <li class="breadcrumb-item active" aria-current="page">Data</li>
</ol>
```

Versus styling breadcrumbs via the `semantic` class:

```html
<ol class="breadcrumb semantic">
  <li><a href="#">Home</a></li>
  <li><a href="#">Library</a></li>
  <li class="active" aria-current="page">Data</li>
</ol>
```

The list of semantic implication rules in this commit is small.  It is intended to grow with community input.

---

TODO:
- [ ] docs?
- [ ] tests?
- [ ] relocate Sass variables?
- [ ] additional implication rules?
