### PR TITLE
IE image fix

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@ layout: home
 
 <main class="bd-masthead" id="content" role="main">
   <div class="container">
-    <div class="row align-items-center">
+    <div class="row">
       <div class="col-6 mx-auto col-md-6 order-md-2">
         {% include icons/bootstrap-stack.svg width="512" height="430" class="img-fluid mb-3 mb-md-0" %}
       </div>


### PR DESCRIPTION
Fixes #29356

`v4-dev` implementation of https://github.com/twbs/bootstrap/issues/29356

This aligns the image to the top for tabletish devices, which looks fine imo.