### PR TITLE
Netlify: force Node.js 10 version via .nvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 # Folders to ignore
 /js/coverage/
 /node_modules/
+/.nvmrc

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "release-zip": "cross-env-shell \"shx rm -rf bootstrap-$npm_package_version-dist && shx cp -r dist/ bootstrap-$npm_package_version-dist && zip -r9 bootstrap-$npm_package_version-dist.zip bootstrap-$npm_package_version-dist && shx rm -rf bootstrap-$npm_package_version-dist\"",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all lint dist js-test docs-build docs-lint",
-    "netlify": "shx echo 10 > .nvmrc && npm-run-all dist release-sri docs-production",
+    "netlify": "cross-env-shell \"shx echo \\\"$npm_package_engines_node\\\" > .nvmrc\" && npm-run-all dist release-sri docs-production",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
     "watch-css-docs": "nodemon --watch site/assets/scss/ --ext scss --exec \"npm run css-lint\"",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "release-zip": "cross-env-shell \"shx rm -rf bootstrap-$npm_package_version-dist && shx cp -r dist/ bootstrap-$npm_package_version-dist && zip -r9 bootstrap-$npm_package_version-dist.zip bootstrap-$npm_package_version-dist && shx rm -rf bootstrap-$npm_package_version-dist\"",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all lint dist js-test docs-build docs-lint",
-    "netlify": "npm-run-all dist release-sri docs-production",
+    "netlify": "shx echo 10 > .nvmrc && npm-run-all dist release-sri docs-production",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
     "watch-css-docs": "nodemon --watch site/assets/scss/ --ext scss --exec \"npm run css-lint\"",


### PR DESCRIPTION
Not sure if there's a better way. It doesn't seem we can do this via an environment variable.

Fixes #29507 

BTW another approach I experimented with was using `$npm_package_engines_node`. This works as long as the node version isn't a range, i.e. if it is `10` it works fine.
