### PR TITLE
Removed the error of first-item still having a top-border(in List group flush)

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -136,8 +136,10 @@
     border-right-width: 0;
     border-left-width: 0;
     @include border-radius(0);
+  }
 
-    &:first-child {
+  &:first-child {
+    .list-group-item:first-child {
       border-top-width: 0;
     }
   }


### PR DESCRIPTION
The manual showed that the first item doesn't have a top border. But it still existed. Committed necessary changes in the  scss/_list-group.scss file to resolve the issue.

Fixes #26961.