### PR TITLE
The HTML5 Boilerplate Print CSS moved to a separate repo

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -1,6 +1,6 @@
 // stylelint-disable declaration-no-important, selector-no-qualifying-type
 
-// Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css
+// Source: https://github.com/h5bp/main.css/blob/master/src/_print.css
 
 // ==========================================================================
 // Print styles.


### PR DESCRIPTION
The HTML5 Boilerplate CSS has moved to a separate GitHub repo (h5bp/main.css) so the source link referenced here no longer works. This PR updates the link to the new correct location.