### PR TITLE
Update dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,6 +12,7 @@ update_configs:
       - "XhmikosR"
     default_labels:
       - "dependencies"
+      - "v5"
     ignored_updates:
       - match:
           dependency_name: "karma-browserstack-launcher"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,4 +15,4 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "karma-browserstack-launcher"
-          version_requirement: "1.5.1"
+          version_requirement: "> 1.4.0 < 1.5.2"


### PR DESCRIPTION
Now it should properly ignore the current published karma-browserstack-launcher versions