### PR TITLE
Update dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -13,6 +13,7 @@ update_configs:
     default_labels:
       - "dependencies"
       - "v5"
+    version_requirement_updates: "increase_versions"
     ignored_updates:
       - match:
           dependency_name: "karma-browserstack-launcher"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,4 +16,4 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "karma-browserstack-launcher"
-          version_requirement: "> 1.4.0 < 1.5.2"
+          version_requirement: "1.5.1"


### PR DESCRIPTION
The first patch resulted in invalid config, fixes #29538

The second patch is so that dependabot follows what we did before manually.

Untested, so I hope everything works fine and we are done with the dependabot config