### PR TITLE
refactor(button-group): cleaning up

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -1,5 +1,3 @@
-// stylelint-disable selector-no-qualifying-type
-
 // Make the div behave like a button
 .btn-group,
 .btn-group-vertical {
@@ -13,9 +11,7 @@
 
     // Bring the hover, focused, and "active" buttons to the front to overlay
     // the borders properly
-    @include hover() {
-      z-index: 1;
-    }
+    &:hover,
     &:focus,
     &:active,
     &.active {
@@ -153,8 +149,8 @@
   > .btn-group > .btn {
     margin-bottom: 0; // Override default `<label>` value
 
-    input[type="radio"],
-    input[type="checkbox"] {
+    [type="radio"],
+    [type="checkbox"] {
       position: absolute;
       clip: rect(0, 0, 0, 0);
       pointer-events: none;


### PR DESCRIPTION
Two changes:
1. the `hover()` mixin used to apply the exact same styles than `:focus, :active, .active` stack above — which  doesn't use dedicated mixins… Removing mixin here seems a good thing since we can simplify selectors stack and reduce complexity a bit;
2. a stylelint check is disabled for useless qualifying selector: `[type="radio"]` and `[type="checkbox"]` obviously applies to `input` elements, and removing this element selector doesn't prevent selector to match.

Tried this locally without seeing any regression. Did I miss something?