### PR TITLE
Enable eslint no-console rule except for build directory

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "xo/browser"
   ],
   "rules": {
+    "no-console": "error",
     "capitalized-comments": "off",
     "function-call-argument-newline": "off",
     "indent": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,6 @@
     "xo/browser"
   ],
   "rules": {
-    "no-console": "error",
     "capitalized-comments": "off",
     "function-call-argument-newline": "off",
     "indent": [
@@ -29,6 +28,7 @@
       "always-multiline"
     ],
     "new-cap": "off",
+    "no-console": "error",
     "object-curly-spacing": [
       "error",
       "always"

--- a/build/.eslintrc.json
+++ b/build/.eslintrc.json
@@ -6,5 +6,8 @@
   "parserOptions": {
     "sourceType": "script"
   },
-  "extends": "../.eslintrc.json"
+  "extends": "../.eslintrc.json",
+  "rules": {
+    "no-console": "off"
+  }
 }


### PR DESCRIPTION
Resolves #29583 

I have added the following config to the global `.eslintrc.json` file:
```
"no-console": "error"
```
As a result there were few errors inside `build` directory, which are now fixed by disabling this rule inside directory.