### PR TITLE
remove superflous transition parameter

### DIFF
--- a/site/assets/scss/_anchor.scss
+++ b/site/assets/scss/_anchor.scss
@@ -1,7 +1,7 @@
 .anchorjs-link {
   font-weight: 400;
   color: rgba($link-color, .5);
-  @include transition(color .15s ease-in-out, opacity .15s ease-in-out);
+  @include transition(color .15s ease-in-out);
 
   &:hover {
     color: $link-color;


### PR DESCRIPTION
Hi,

only `color` is transitioned on `:hover`.

Have a nice weekend
midzer
