### PR TITLE
Remove redundant "Navbar divider" from "Contents"

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -4,7 +4,6 @@
 // Navbar brand
 // Navbar nav
 // Navbar text
-// Navbar divider
 // Responsive navbar
 // Navbar position
 // Navbar themes


### PR DESCRIPTION
I noticed this was left unnoticed after navbar divider mixin was dropped earlier