### PR TITLE
Fixed input-height-sm and input-height-lg calculations

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -621,8 +621,8 @@ $input-height-inner-half:               add($input-line-height * .5em, $input-pa
 $input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y / 2) !default;
 
 $input-height:                          add($input-line-height * 1em, add($input-padding-y * 2, $input-height-border, false)) !default;
-$input-height-sm:                       add($input-line-height * 1em, add($input-btn-padding-y-sm * 2, $input-height-border, false)) !default;
-$input-height-lg:                       add($input-line-height * 1em, add($input-btn-padding-y-lg * 2, $input-height-border, false)) !default;
+$input-height-sm:                       add($input-line-height * 1em, add($input-padding-y-sm * 2, $input-height-border, false)) !default;
+$input-height-lg:                       add($input-line-height * 1em, add($input-padding-y-lg * 2, $input-height-border, false)) !default;
 
 $input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 


### PR DESCRIPTION
I believe that `input-height-sm` should use `input-padding-y-sm` and NOT `input-btn-padding-y-sm`, because one can override `input-padding-y-sm` which defaults to `input-btn-padding-y-sm`.

The same goes for the `input-height-lg` calculation