### PR TITLE
Compressed Sass output support

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -77,7 +77,7 @@ $utilities: map-merge(
     "border-color": (
       property: border-color,
       class: border,
-      values: map-merge($theme-colors, (white: $white))
+      values: map-merge($theme-colors, ("white": $white))
     ),
     // Sizing utilities
     "width": (
@@ -385,12 +385,12 @@ $utilities: map-merge(
       values: map-merge(
         $theme-colors,
         (
-          white: $white,
-          body: $body-color,
-          muted: $text-muted,
-          black-50: rgba($black, .5),
-          white-50: rgba($white, .5),
-          reset: inherit,
+          "white": $white,
+          "body": $body-color,
+          "muted": $text-muted,
+          "black-50": rgba($black, .5),
+          "white-50": rgba($white, .5),
+          "reset": inherit,
         )
       )
     ),
@@ -410,9 +410,9 @@ $utilities: map-merge(
       values: map-merge(
         $theme-colors,
         (
-          body: $body-bg,
-          white: $white,
-          transparent: transparent
+          "body": $body-bg,
+          "white": $white,
+          "transparent": transparent
         )
       )
     ),


### PR DESCRIPTION
If the output style is changed from `expanded` to `compressed` here
https://github.com/twbs/bootstrap/blob/f1f320461066aec558a2a11cfb2f73c841434732/package.json#L24

the build fails, because keywords like `white` are converted to `#fff`. By converting the keys to strings, Sass won't recognize the keys as colors anymore.

I've opened https://github.com/twbs/bootstrap/issues/29701 to have a look at testing this by default.
