### PR TITLE
Use double quotes in `.stylelintrc`

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -12,10 +12,10 @@
       "transition"
     ],
     "function-blacklist": ["calc"],
-    'scss/dollar-variable-default': [
+    "scss/dollar-variable-default": [
       true,
       {
-        'ignore': 'local'
+        "ignore": "local"
       }
     ]
   }


### PR DESCRIPTION
This rule should also be backported in `v4-dev`. Shall we do a new PR or cherry-pick https://github.com/twbs/bootstrap/pull/29612 and this PR, @XhmikosR?