### PR TITLE
Keep themed appearance for checkboxes when page is printed

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -21,6 +21,7 @@
   background-color: $form-check-input-bg;
   border: $form-check-input-border;
   appearance: none;
+  color-adjust: exact; // Keep themed appearance for print
 
   &[type="checkbox"] {
     @include border-radius($form-check-input-border-radius);
@@ -113,6 +114,7 @@
     background-position: left center;
     background-size: $form-switch-bg-size; // Get a 1px separation
     @include border-radius($form-switch-border-radius);
+    color-adjust: exact; // Keep themed appearance for print
     // Todo: Figure out how to tackle these, with or without mixin?
     // transition: $form-switch-transition;
     // transition-property: $form-switch-transition-property;


### PR DESCRIPTION
Before: https://twbs-bootstrap.netlify.com/docs/4.3/forms/checks/

![image](https://user-images.githubusercontent.com/11559216/69441244-a2e6d800-0d4a-11ea-8a30-78fff247fc56.png)

After: https://deploy-preview-29714--twbs-bootstrap.netlify.com/docs/4.3/forms/checks/

![image](https://user-images.githubusercontent.com/11559216/69441372-e6d9dd00-0d4a-11ea-94b6-094178165004.png)

Works in Chrome, FF & Chromium Edge. The themed checkboxes don't apply to EdgeHTML & IE in `v5`, these will have the native fallback.
