### PR TITLE
Actions: add npm cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,16 @@ jobs:
       - run: npm --version
       - run: java -version
 
+      - name: Set up npm cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v{{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.github/workflows/test.yml') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-v{{ matrix.node }}-${{ env.cache-name }}-
+            ${{ runner.OS }}-node-v{{ matrix.node }}-
+            ${{ runner.OS }}-
+
       - name: Install npm dependencies
         run: npm ci
 


### PR DESCRIPTION
For v4 I'll need to add gem caching which is what actually slows down v4 builds.

BTW it's probably redundant to have `package.json` in the cache key since the lock file will be modified if a dependency changes anyway. I will think about it a bit more and probably remove this.