### PR TITLE
update to v4.4.1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@
 
 Several quick start options are available:
 
-- [Download the latest release.](https://github.com/twbs/bootstrap/archive/v4.3.1.zip)
+- [Download the latest release.](https://github.com/twbs/bootstrap/archive/v4.4.1.zip)
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com/): `npm install bootstrap`
-- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@4.3.1`
-- Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:4.3.1`
+- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@4.4.1`
+- Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:4.4.1`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap` Sass: `Install-Package bootstrap.sass`
 
 Read the [Getting started page](https://getbootstrap.com/docs/4.3/getting-started/introduction/) for information on the framework contents, templates and examples, and more.


### PR DESCRIPTION
There prob should be a way to automate this, esp since some release portals are staggered (eg docs still have only v4.3).
But for now, here it is.