### PR TITLE
Fix disabled `.btn` cursor

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -13,7 +13,6 @@
   text-align: center;
   white-space: $btn-white-space;
   vertical-align: middle;
-  cursor: if($enable-pointer-cursor-for-buttons, pointer, null);
   user-select: none;
   background-color: transparent;
   border: $btn-border-width solid transparent;
@@ -38,12 +37,17 @@
     @include box-shadow(none);
   }
 
-  &:not(:disabled):not(.disabled):active,
-  &:not(:disabled):not(.disabled).active {
-    @include box-shadow($btn-active-box-shadow);
+  &:not(:disabled):not(.disabled) {
+    // Re-add cursor style for checkbox and radio buttons
+    cursor: if($enable-pointer-cursor-for-buttons, pointer, null);
 
-    &:focus {
-      @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
+    &:active,
+    &.active {
+      @include box-shadow($btn-active-box-shadow);
+
+      &:focus {
+        @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/29833

Demo: 
- https://deploy-preview-29835--twbs-bootstrap.netlify.com/docs/4.3/components/buttons/#disabled-state
- Labels also still have the correct cursor: https://deploy-preview-29835--twbs-bootstrap.netlify.com/docs/4.3/components/buttons/#checkbox-and-radio-buttons