### PR TITLE
Wrong value for word-break property in the .text-break class.

### DIFF
--- a/dist/css/bootstrap-utilities.css
+++ b/dist/css/bootstrap-utilities.css
@@ -1151,7 +1151,7 @@
 
 .text-break {
   overflow-wrap: break-word !important;
-  word-break: break-word !important;
+  word-break: break-all !important;
 }
 
 .font-monospace {

--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -6979,7 +6979,7 @@ a.close.disabled {
 
 .text-break {
   overflow-wrap: break-word !important;
-  word-break: break-word !important;
+  word-break: break-all !important;
 }
 
 .font-monospace {

--- a/site/content/docs/4.3/utilities/text.md
+++ b/site/content/docs/4.3/utilities/text.md
@@ -47,7 +47,7 @@ Prevent text from wrapping with a `.text-nowrap` class.
 
 ## Word break
 
-Prevent long strings of text from breaking your components' layout by using `.text-break` to set `overflow-wrap: break-word` (and `word-break: break-word` for IE & Edge compatibility).
+Prevent long strings of text from breaking your components' layout by using `.text-break` to set `overflow-wrap: break-word` (and `word-break: break-all` for IE & Edge compatibility).
 
 {{< example >}}
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>


### PR DESCRIPTION
Wrong value for word-break property in the .text-break class. Affects IE & Edge.