### PR TITLE
Docs: always show anchors

### DIFF
--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -163,7 +163,8 @@
   })
 
   anchors.options = {
-    icon: '#'
+    icon: '#',
+    visible: 'always'
   }
   anchors.add('.bd-content > h2, .bd-content > h3, .bd-content > h4, .bd-content > h5')
 


### PR DESCRIPTION
I think this is better UE. We might want to change the color though. Or show the anchor before the header.

Preview: <https://deploy-preview-29940--twbs-bootstrap.netlify.com/docs/4.3/getting-started/introduction/>