### PR TITLE
Add Microsoft Edge for MacOS to supported browsers

### DIFF
--- a/site/content/docs/4.3/getting-started/browsers-devices.md
+++ b/site/content/docs/4.3/getting-started/browsers-devices.md
@@ -87,7 +87,7 @@ Similarly, the latest versions of most desktop browsers are supported.
       <td>Supported</td>
       <td>Supported</td>
       <td class="text-muted">&mdash;</td>
-      <td class="text-muted">&mdash;</td>
+      <td>Supported</td>
       <td>Supported</td>
       <td>Supported</td>
     </tr>


### PR DESCRIPTION
The new Chromium-based Edge has been available as a beta for sometime and general availability of the final version is expected to ship from Jan 15. I think it makes sense to add it as a supported browser once it's out of beta.
REF: https://blogs.windows.com/windowsexperience/2019/11/04/introducing-the-new-microsoft-edge-and-bing/

(made this change against the v4 branch so it can be updated in the docs for the v4.4.2 release though I realise this would also need to be ported to the v5 branch)