### PR TITLE
Close modal with keyboard=true & backdrop=static

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -326,7 +326,7 @@ class Modal {
 
   _setEscapeEvent() {
     if (this._isShown) {
-      $(this._element).on(Event.KEYDOWN_DISMISS, event => {
+      $(this._element).on(Event.KEYDOWN_DISMISS, (event) => {
         if (this._config.keyboard && event.which === ESCAPE_KEYCODE) {
           event.preventDefault()
           this.hide()

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -325,9 +325,12 @@ class Modal {
   }
 
   _setEscapeEvent() {
-    if (this._isShown && this._config.keyboard) {
-      $(this._element).on(Event.KEYDOWN_DISMISS, (event) => {
-        if (event.which === ESCAPE_KEYCODE) {
+    if (this._isShown) {
+      $(this._element).on(Event.KEYDOWN_DISMISS, event => {
+        if (this._config.keyboard && event.which === ESCAPE_KEYCODE) {
+          event.preventDefault()
+          this.hide()
+        } else if (!this._config.keyboard && event.which === ESCAPE_KEYCODE) {
           this._triggerBackdropTransition()
         }
       })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -856,52 +856,52 @@ $(function () {
       })
   })
 
-  QUnit.test("should close modal when escape key is pressed with keyboard = true and backdrop is static", function (assert) {
+  QUnit.test('should close modal when escape key is pressed with keyboard = true and backdrop is static', function (assert) {
     assert.expect(1)
     var done = assert.async()
     var $modal = $('<div class="modal"></div>').appendTo('#qunit-fixture')
 
     $modal
-      .on("shown.bs.modal", function() {
+      .on('shown.bs.modal', function () {
         $modal.trigger(
-          $.Event("keydown", {
-            which: 27
-          })
-        );
-        setTimeout(function() {
-          var modal = $modal.data("bs.modal");
-
-          assert.strictEqual(modal._isShown, false);
-          done();
-        }, 10);
-      })
-      .bootstrapModal({
-        backdrop: "static",
-        keyboard: true
-      });
-  })
-
-  QUnit.test("should not close modal when escape key is pressed with keyboard = false and backdrop = static", function (assert) {
-    assert.expect(1)
-    var done = assert.async()
-    var $modal = $('<div class="modal"></div>').appendTo('#qunit-fixture')
-
-    $modal
-      .on("shown.bs.modal", function() {
-        $modal.trigger(
-          $.Event("keydown", {
+          $.Event('keydown', {
             which: 27
           })
         )
-        setTimeout(function() {
-          var modal = $modal.data("bs.modal")
+        setTimeout(function () {
+          var modal = $modal.data('bs.modal')
+
+          assert.strictEqual(modal._isShown, false)
+          done()
+        }, 10)
+      })
+      .bootstrapModal({
+        backdrop: 'static',
+        keyboard: true
+      })
+  })
+
+  QUnit.test('should not close modal when escape key is pressed with keyboard = false and backdrop = static', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var $modal = $('<div class="modal"></div>').appendTo('#qunit-fixture')
+
+    $modal
+      .on('shown.bs.modal', function () {
+        $modal.trigger(
+          $.Event('keydown', {
+            which: 27
+          })
+        )
+        setTimeout(function () {
+          var modal = $modal.data('bs.modal')
 
           assert.strictEqual(modal._isShown, true)
           done()
         }, 10)
       })
       .bootstrapModal({
-        backdrop: "static",
+        backdrop: 'static',
         keyboard: false
       })
   })

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -855,4 +855,54 @@ $(function () {
         backdrop: 'static'
       })
   })
+
+  QUnit.test("should close modal when escape key is pressed with keyboard = true and backdrop is static", function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var $modal = $('<div class="modal"></div>').appendTo('#qunit-fixture')
+
+    $modal
+      .on("shown.bs.modal", function() {
+        $modal.trigger(
+          $.Event("keydown", {
+            which: 27
+          })
+        );
+        setTimeout(function() {
+          var modal = $modal.data("bs.modal");
+
+          assert.strictEqual(modal._isShown, false);
+          done();
+        }, 10);
+      })
+      .bootstrapModal({
+        backdrop: "static",
+        keyboard: true
+      });
+  })
+
+  QUnit.test("should not close modal when escape key is pressed with keyboard = false and backdrop = static", function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var $modal = $('<div class="modal"></div>').appendTo('#qunit-fixture')
+
+    $modal
+      .on("shown.bs.modal", function() {
+        $modal.trigger(
+          $.Event("keydown", {
+            which: 27
+          })
+        )
+        setTimeout(function() {
+          var modal = $modal.data("bs.modal")
+
+          assert.strictEqual(modal._isShown, true)
+          done()
+        }, 10)
+      })
+      .bootstrapModal({
+        backdrop: "static",
+        keyboard: false
+      })
+  })
 })

--- a/site/docs/4.4/components/modal.md
+++ b/site/docs/4.4/components/modal.md
@@ -802,7 +802,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>backdrop</td>
       <td>boolean or the string <code>'static'</code></td>
       <td>true</td>
-      <td>Includes a modal-backdrop element. Alternatively, specify <code>static</code> for a backdrop which doesn't close the modal on click or on escape key press.</td>
+      <td>Includes a modal-backdrop element. Alternatively, specify <code>static</code> for a backdrop which doesn't close the modal on click.</td>
     </tr>
     <tr>
       <td>keyboard</td>
@@ -897,7 +897,7 @@ Bootstrap's modal class exposes a few events for hooking into modal functionalit
     </tr>
     <tr>
       <td>hidePrevented.bs.modal</td>
-      <td>This event is fired when the modal is shown, its backdrop is <code>static</code> and a click outside the modal or an escape key press is performed.</td>
+      <td>This event is fired when the modal is shown, its backdrop is <code>static</code> and a click outside the modal or an escape key press is performed with the keyboard option or data-keyboard in false.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This avoid the no close of modal with options:
$('#my-modal').modal({
  backdrop: 'static',
  keyboard: true
})

fix issue: #29978 