### PR TITLE
[idea] Add inherit border color to Utils

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -77,7 +77,7 @@ $utilities: map-merge(
     "border-color": (
       property: border-color,
       class: border,
-      values: map-merge($theme-colors, ("white": $white))
+      values: map-merge($theme-colors, ("white": $white, "color-inherit": inherit))
     ),
     // Sizing utilities
     "width": (


### PR DESCRIPTION
Add class to change border color Easy with color.

_e.g._
```
<div class="border border-color-inherit text-warning">
<div class="border border-color-inherit text-white-50">
<div class="border border-color-inherit" style="color:#563d7c">

<div class="text-warning">
  <div class="border border-color-inherit">
```

Playground: https://jsfiddle.net/kpsgh75t/