### PR TITLE
Nested list-group-horizontal in list-group-flush border fix

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -132,7 +132,7 @@
 // useful within other components (e.g., cards).
 
 .list-group-flush {
-  .list-group-item {
+  > .list-group-item {
     border-right-width: 0;
     border-left-width: 0;
     @include border-radius(0);
@@ -140,10 +140,8 @@
     &:first-child {
       border-top-width: 0;
     }
-  }
 
-  &:last-child {
-    .list-group-item:last-child {
+    &:last-child {
       border-bottom-width: 0;
     }
   }

--- a/site/content/docs/4.3/components/list-group.md
+++ b/site/content/docs/4.3/components/list-group.md
@@ -112,6 +112,58 @@ Add `.list-group-horizontal` to change the layout of list group items from verti
 {{< /list-group.inline >}}
 {{< /example >}}
 
+## Nested
+
+Listed group and listed group flush with nested lists inside of them.
+
+{{< example >}}
+<div class="container">
+  <div class="mb-2"><b>List Group</b></div>
+  <div class="list-group">
+    <div class="list-group-item">Group item</div>
+    <div class="list-group-item">
+      <b class="mb-2">List Group Horizontal</b>
+      <div class="list-group list-group-horizontal">
+        <div class="list-group-item">Group item 1</div>
+        <div class="list-group-item">Group item 2</div>
+        <div class="list-group-item">Group item 3</div>      
+      </div>
+    </div>  
+    <div class="list-group-item">
+      <b class="mb-2">List Group</b>
+      <div class="list-group">
+        <div class="list-group-item">Group item 1</div>
+        <div class="list-group-item">Group item 2</div>
+        <div class="list-group-item">Group item 3</div>      
+      </div>
+    </div>
+  </div>
+
+  <br class="my-4" />
+
+  <div class="mb-2"><b>List Group Flush</b></div>
+  <div class="list-group list-group-flush">
+    <div class="list-group-item">Group item</div>
+    <div class="list-group-item">
+      <b class="mb-2">List Group Horizontal</b>
+      <div class="list-group list-group-horizontal">
+        <div class="list-group-item">Group item 1</div>
+        <div class="list-group-item">Group item 2</div>
+        <div class="list-group-item">Group item 3</div>      
+      </div>
+    </div>
+    <div class="list-group-item">
+      <b class="mb-2">List Group</b>
+      <div class="list-group">
+        <div class="list-group-item">Group item 1</div>
+        <div class="list-group-item">Group item 2</div>
+        <div class="list-group-item">Group item 3</div>      
+      </div>
+    </div>
+  </div>
+</div>
+{{< /example >}}
+
 ## Contextual classes
 
 Use contextual classes to style list items with a stateful background and color.

--- a/site/content/docs/4.3/components/list-group.md
+++ b/site/content/docs/4.3/components/list-group.md
@@ -118,11 +118,11 @@ Listed group and listed group flush with nested lists inside of them.
 
 {{< example >}}
 <div class="container">
-  <div class="mb-2"><b>List Group</b></div>
-  <div class="list-group">
+  <h3>List Group</h3>
+  <div class="list-group mb-4">
     <div class="list-group-item">Group item</div>
     <div class="list-group-item">
-      <b class="mb-2">List Group Horizontal</b>
+      <h4>List Group Horizontal</h4>
       <div class="list-group list-group-horizontal">
         <div class="list-group-item">Group item 1</div>
         <div class="list-group-item">Group item 2</div>
@@ -130,7 +130,7 @@ Listed group and listed group flush with nested lists inside of them.
       </div>
     </div>  
     <div class="list-group-item">
-      <b class="mb-2">List Group</b>
+      <h4>List Group</h4>
       <div class="list-group">
         <div class="list-group-item">Group item 1</div>
         <div class="list-group-item">Group item 2</div>
@@ -139,13 +139,11 @@ Listed group and listed group flush with nested lists inside of them.
     </div>
   </div>
 
-  <br class="my-4" />
-
-  <div class="mb-2"><b>List Group Flush</b></div>
+  <h3>List Group Flush</h3>
   <div class="list-group list-group-flush">
     <div class="list-group-item">Group item</div>
     <div class="list-group-item">
-      <b class="mb-2">List Group Horizontal</b>
+      <h4>List Group Horizontal</h4>
       <div class="list-group list-group-horizontal">
         <div class="list-group-item">Group item 1</div>
         <div class="list-group-item">Group item 2</div>
@@ -153,7 +151,7 @@ Listed group and listed group flush with nested lists inside of them.
       </div>
     </div>
     <div class="list-group-item">
-      <b class="mb-2">List Group</b>
+      <h4>List Group</h4>
       <div class="list-group">
         <div class="list-group-item">Group item 1</div>
         <div class="list-group-item">Group item 2</div>


### PR DESCRIPTION
Added styles only to the top level element of the list. 
Removed following lines:

https://github.com/twbs/bootstrap/blob/dfc1149597774bb3549c2cb42c73cf89b98c6615/scss/_list-group.scss#L145-L149

and added the border width of 0 to the last `.list-group-item` child.

closes #30027
closes #27126 because the double border does not occur in the code update.

[Netlify link](https://deploy-preview-30039--twbs-bootstrap.netlify.com/docs/4.3/components/list-group/#nested)
