### PR TITLE
Set background hover color for each table color variant

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -106,6 +106,7 @@
     }
   }
 }
+// stylelint-enable selector-max-type
 
 
 // Table backgrounds

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -86,11 +86,23 @@
 //
 // Placed here since it has to come after the potential zebra striping
 
+// stylelint-disable selector-max-type
 .table-hover {
   tbody tr {
     &:hover {
       color: $table-hover-color;
-      background-color: $table-hover-bg;
+
+      > th,
+      > td {
+        background-color: $table-hover-bg;
+
+        // Set background hover color for each table color variant
+        @each $color, $value in $theme-colors {
+          &.table-#{$color} {
+            background-color: darken(color-level($value, $table-bg-level), 5%);
+          }
+        }
+      }
     }
   }
 }

--- a/scss/mixins/_table-row.scss
+++ b/scss/mixins/_table-row.scss
@@ -19,21 +19,4 @@
       }
     }
   }
-
-  // Hover states for `.table-hover`
-  // Note: this is not available for cells or rows within `thead` or `tfoot`.
-  .table-hover {
-    $hover-background: darken($background, 5%);
-
-    .table-#{$state} {
-      &:hover {
-        background-color: $hover-background;
-
-        > td,
-        > th {
-          background-color: $hover-background;
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Instead of setting a background color on the tr tag, we set the background-color on the th or td tags below the tr tag. This way we can set the correct background-color for the th and td tags that also have color variant class (table-primary, table-secondary, ..)

closes #28160