### PR TITLE
Utility class border radius

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -445,6 +445,7 @@ $utilities: map-merge(
     ),
     "border-radius": (
       property: border-radius,
+      class: br,
       responsive: true,
       values: (
         null: $border-radius,
@@ -458,22 +459,22 @@ $utilities: map-merge(
     ),
     "rounded-top": (
       property: border-top-left-radius border-top-right-radius,
-      class: rounded-top,
+      class: br-top,
       values: (null: $border-radius)
     ),
     "rounded-right": (
       property: border-top-right-radius border-bottom-right-radius,
-      class: rounded-right,
+      class: br-right,
       values: (null: $border-radius)
     ),
     "rounded-bottom": (
       property: border-bottom-right-radius border-bottom-left-radius,
-      class: rounded-bottom,
+      class: br-bottom,
       values: (null: $border-radius)
     ),
     "rounded-left": (
       property: border-bottom-left-radius border-top-left-radius,
-      class: rounded-left,
+      class: br-left,
       values: (null: $border-radius)
     ),
     "visibility": (

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -443,16 +443,17 @@ $utilities: map-merge(
       class: font,
       values: (monospace: $font-family-monospace)
     ),
-    "rounded": (
+    "border-radius": (
       property: border-radius,
-      class: rounded,
+      responsive: true,
       values: (
         null: $border-radius,
-        sm: $border-radius-sm,
-        lg: $border-radius-lg,
+        0: 0,
+        1: $border-radius-sm,
+        2: $border-radius,
+        3: $border-radius-lg,
         circle: 50%,
         pill: $rounded-pill,
-        0: 0,
       )
     ),
     "rounded-top": (

--- a/site/content/docs/4.3/components/badge.md
+++ b/site/content/docs/4.3/components/badge.md
@@ -55,11 +55,11 @@ Use our background utility classes to quickly change the appearance of a badge. 
 
 ## Pill badges
 
-Use the `.rounded-pill` utility class to make badges more rounded with a larger `border-radius`.
+Use the `.border-radius-pill` utility class to make badges more rounded with a larger `border-radius`.
 
 {{< example >}}
 {{< badge.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<span class="badge rounded-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
+<span class="badge border-radius-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
 {{< /badge.inline >}}
 {{< /example >}}

--- a/site/content/docs/4.3/components/badge.md
+++ b/site/content/docs/4.3/components/badge.md
@@ -55,11 +55,11 @@ Use our background utility classes to quickly change the appearance of a badge. 
 
 ## Pill badges
 
-Use the `.border-radius-pill` utility class to make badges more rounded with a larger `border-radius`.
+Use the `.br-pill` utility class to make badges more rounded with a larger `border-radius`.
 
 {{< example >}}
 {{< badge.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<span class="badge border-radius-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
+<span class="badge br-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
 {{< /badge.inline >}}
 {{< /example >}}

--- a/site/content/docs/4.3/components/list-group.md
+++ b/site/content/docs/4.3/components/list-group.md
@@ -152,15 +152,15 @@ Add badges to any list group item to show unread counts, activity, and more with
 <ul class="list-group">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Cras justo odio
-    <span class="badge bg-primary border-radius-pill">14</span>
+    <span class="badge bg-primary br-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Dapibus ac facilisis in
-    <span class="badge bg-primary border-radius-pill">2</span>
+    <span class="badge bg-primary br-pill">2</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Morbi leo risus
-    <span class="badge bg-primary border-radius-pill">1</span>
+    <span class="badge bg-primary br-pill">1</span>
   </li>
 </ul>
 {{< /example >}}

--- a/site/content/docs/4.3/components/list-group.md
+++ b/site/content/docs/4.3/components/list-group.md
@@ -152,15 +152,15 @@ Add badges to any list group item to show unread counts, activity, and more with
 <ul class="list-group">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Cras justo odio
-    <span class="badge bg-primary rounded-pill">14</span>
+    <span class="badge bg-primary border-radius-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Dapibus ac facilisis in
-    <span class="badge bg-primary rounded-pill">2</span>
+    <span class="badge bg-primary border-radius-pill">2</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Morbi leo risus
-    <span class="badge bg-primary rounded-pill">1</span>
+    <span class="badge bg-primary border-radius-pill">1</span>
   </li>
 </ul>
 {{< /example >}}

--- a/site/content/docs/4.3/examples/carousel/index.html
+++ b/site/content/docs/4.3/examples/carousel/index.html
@@ -93,19 +93,19 @@ extra_css:
     <!-- Three columns of text below the carousel -->
     <div class="row">
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
         <h2>Heading</h2>
         <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>

--- a/site/content/docs/4.3/examples/carousel/index.html
+++ b/site/content/docs/4.3/examples/carousel/index.html
@@ -93,19 +93,19 @@ extra_css:
     <!-- Three columns of text below the carousel -->
     <div class="row">
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="br-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="br-circle" >}}
         <h2>Heading</h2>
         <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="border-radius-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="br-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>

--- a/site/content/docs/4.3/examples/checkout/index.html
+++ b/site/content/docs/4.3/examples/checkout/index.html
@@ -19,7 +19,7 @@ body_class: "bg-light"
     <div class="col-md-4 order-md-2 mb-4">
       <h4 class="d-flex justify-content-between align-items-center mb-3">
         <span class="text-muted">Your cart</span>
-        <span class="badge bg-secondary border-radius-pill">3</span>
+        <span class="badge bg-secondary br-pill">3</span>
       </h4>
       <ul class="list-group mb-3">
         <li class="list-group-item d-flex justify-content-between lh-sm">

--- a/site/content/docs/4.3/examples/checkout/index.html
+++ b/site/content/docs/4.3/examples/checkout/index.html
@@ -19,7 +19,7 @@ body_class: "bg-light"
     <div class="col-md-4 order-md-2 mb-4">
       <h4 class="d-flex justify-content-between align-items-center mb-3">
         <span class="text-muted">Your cart</span>
-        <span class="badge bg-secondary rounded-pill">3</span>
+        <span class="badge bg-secondary border-radius-pill">3</span>
       </h4>
       <ul class="list-group mb-3">
         <li class="list-group-item d-flex justify-content-between lh-sm">

--- a/site/content/docs/4.3/examples/offcanvas/index.html
+++ b/site/content/docs/4.3/examples/offcanvas/index.html
@@ -51,7 +51,7 @@ body_class: "bg-light"
     <a class="nav-link active" href="#">Dashboard</a>
     <a class="nav-link" href="#">
       Friends
-      <span class="badge bg-light text-dark border-radius-pill align-text-bottom">27</span>
+      <span class="badge bg-light text-dark br-pill align-text-bottom">27</span>
     </a>
     <a class="nav-link" href="#">Explore</a>
     <a class="nav-link" href="#">Suggestions</a>

--- a/site/content/docs/4.3/examples/offcanvas/index.html
+++ b/site/content/docs/4.3/examples/offcanvas/index.html
@@ -51,7 +51,7 @@ body_class: "bg-light"
     <a class="nav-link active" href="#">Dashboard</a>
     <a class="nav-link" href="#">
       Friends
-      <span class="badge bg-light text-dark rounded-pill align-text-bottom">27</span>
+      <span class="badge bg-light text-dark border-radius-pill align-text-bottom">27</span>
     </a>
     <a class="nav-link" href="#">Explore</a>
     <a class="nav-link" href="#">Suggestions</a>

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -142,8 +142,8 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 - Added `.bg-body` for quickly setting the `<body>`'s background to additional elements.
-- Renamed the `.rounded` utility class to `.border-radius` for clarity. See [here]({{< docsref "/utilities/borders#border-radius" >}}).
-- Removed `.rounded-sm` and `.rounded-lg`, replaced them with new border-radius utilities (`.border-radius-0`, `.border-radius-1`, `.border-radius-2`, `.border-radius-3`) See [here]({{< docsref "/utilities/borders#sizes" >}}).
+- Renamed the `.rounded` utility class to `.br`. See [here]({{< docsref "/utilities/borders#border-radius" >}}).
+- Removed `.rounded-sm` and `.rounded-lg`, replaced them with new border-radius utilities (`.br-0`, `.br-1`, `.br-2`, `.br-3`) See [here]({{< docsref "/utilities/borders#sizes" >}}).
 - **Todo:** Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
 - **Todo:** Split utilities into property-value utility classes and helpers
 

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -142,6 +142,8 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 - Added `.bg-body` for quickly setting the `<body>`'s background to additional elements.
+- Renamed the `.rounded` utility class to `.border-radius` for clarity. See [here]({{< docsref "/utilities/borders#border-radius" >}}).
+- Removed `.rounded-sm` and `.rounded-lg`, replaced them with new border-radius utilities (`.border-radius-0`, `.border-radius-1`, `.border-radius-2`, `.border-radius-3`) See [here]({{< docsref "/utilities/borders#sizes" >}}).
 - **Todo:** Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
 - **Todo:** Split utilities into property-value utility classes and helpers
 

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -48,14 +48,14 @@ Change the border color using utilities built on our theme colors.
 Add classes to an element to easily round its corners.
 
 {{< example >}}
-{{< placeholder width="75" height="75" class="border-radius" title="Example rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-top" title="Example top rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-right" title="Example right rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-bottom" title="Example bottom rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-left" title="Example left rounded image" >}}
-{{< placeholder width="75" height="75" class="border-radius-circle" title="Completely round image" >}}
-{{< placeholder width="150" height="75" class="border-radius-pill" title="Rounded pill image" >}}
-{{< placeholder width="75" height="75" class="border-radius-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="br" title="Example rounded image" >}}
+{{< placeholder width="75" height="75" class="br-top" title="Example top rounded image" >}}
+{{< placeholder width="75" height="75" class="br-right" title="Example right rounded image" >}}
+{{< placeholder width="75" height="75" class="br-bottom" title="Example bottom rounded image" >}}
+{{< placeholder width="75" height="75" class="br-left" title="Example left rounded image" >}}
+{{< placeholder width="75" height="75" class="br-circle" title="Completely round image" >}}
+{{< placeholder width="150" height="75" class="br-pill" title="Rounded pill image" >}}
+{{< placeholder width="75" height="75" class="br-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
 {{< /example >}}
 
 
@@ -64,8 +64,8 @@ Add classes to an element to easily round its corners.
 Use the border-radius factors for larger or smaller border-radius sizes. Sizes range from `0` to `3`.
 
 {{< example >}}
-{{< placeholder width="75" height="75" class="border-radius-0" title="Example non-rounded image" >}}
-{{< placeholder width="75" height="75" class="border-radius-1" title="Example small rounded image" >}}
-{{< placeholder width="75" height="75" class="border-radius-2" title="Example default rounded image" >}}
-{{< placeholder width="75" height="75" class="border-radius-3" title="Example large rounded image" >}}
+{{< placeholder width="75" height="75" class="br-0" title="Example non-rounded image" >}}
+{{< placeholder width="75" height="75" class="br-1" title="Example small rounded image" >}}
+{{< placeholder width="75" height="75" class="br-2" title="Example default rounded image" >}}
+{{< placeholder width="75" height="75" class="br-3" title="Example large rounded image" >}}
 {{< /example >}}

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -48,22 +48,24 @@ Change the border color using utilities built on our theme colors.
 Add classes to an element to easily round its corners.
 
 {{< example >}}
-{{< placeholder width="75" height="75" class="rounded" title="Example rounded image" >}}
+{{< placeholder width="75" height="75" class="border-radius" title="Example rounded image" >}}
 {{< placeholder width="75" height="75" class="rounded-top" title="Example top rounded image" >}}
 {{< placeholder width="75" height="75" class="rounded-right" title="Example right rounded image" >}}
 {{< placeholder width="75" height="75" class="rounded-bottom" title="Example bottom rounded image" >}}
 {{< placeholder width="75" height="75" class="rounded-left" title="Example left rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-circle" title="Completely round image" >}}
-{{< placeholder width="150" height="75" class="rounded-pill" title="Rounded pill image" >}}
-{{< placeholder width="75" height="75" class="rounded-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="border-radius-circle" title="Completely round image" >}}
+{{< placeholder width="150" height="75" class="border-radius-pill" title="Rounded pill image" >}}
+{{< placeholder width="75" height="75" class="border-radius-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
 {{< /example >}}
 
 
 ## Sizes
 
-Use `.rounded-lg` or `.rounded-sm` for larger or smaller border-radius.
+Use the border-radius factors for larger or smaller border-radius sizes. Sizes range from `0` to `3`.
 
 {{< example >}}
-{{< placeholder width="75" height="75" class="rounded-sm" title="Example small rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-lg" title="Example large rounded image" >}}
+{{< placeholder width="75" height="75" class="border-radius-0" title="Example non-rounded image" >}}
+{{< placeholder width="75" height="75" class="border-radius-1" title="Example small rounded image" >}}
+{{< placeholder width="75" height="75" class="border-radius-2" title="Example default rounded image" >}}
+{{< placeholder width="75" height="75" class="border-radius-3" title="Example large rounded image" >}}
 {{< /example >}}


### PR DESCRIPTION
Closes #29989

Updated the docs pages by searching for the `.rounded` classes and replacing them by the new `.border-radius` classes.

See 
https://deploy-preview-30048--twbs-bootstrap.netlify.com/docs/4.3/utilities/borders/#border-radius
https://deploy-preview-30048--twbs-bootstrap.netlify.com/docs/4.3/utilities/borders/#sizes