### PR TITLE
Add ::after element for .bd-navbar to make sure alignation is correct

### DIFF
--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -2,6 +2,12 @@
   min-height: 4rem;
   background-color: $bd-purple-bright;
 
+  &::after {
+    min-height: inherit;
+    font-size: 0;
+    content: "";
+  }
+
   @include media-breakpoint-down(md) {
     .navbar-nav-scroll {
       width: 100%;


### PR DESCRIPTION
There's a problem in IE when min-height and align-items are combined, this breaks the alignation of the header on the docs.

This code fixes it by adding an ::after as workaround

closes #29856