### PR TITLE
Drop `.booticon` styles

### DIFF
--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -51,17 +51,3 @@
 @import "syntax";
 @import "anchor";
 @import "algolia";
-
-// Temp
-.booticons-list {
-  .booticon {
-    display: inline;
-    width: 4rem;
-    padding: 1rem;
-    margin-right: 1rem;
-    margin-bottom: 1rem;
-    background-color: $white;
-    border: 1px solid rgba(0, 0, 0, .1);
-    @include border-radius(.25rem);
-  }
-}


### PR DESCRIPTION
Flagged as `Temp` by @mdo, I couldn't find any occurrence of this in the entire repo.

Should be safe to remove, shouldn't it?