### PR TITLE
Documentation skip links

### DIFF
--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -6,4 +6,8 @@
   padding: map-get($spacers, 2);
   color: $white;
   background-color: $bd-purple;
+
+  &:hover {
+    color: $white;
+  }
 }

--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -1,9 +1,9 @@
 .skippy {
   position: fixed;
-  top: map-get($spacers, 2);
-  left: map-get($spacers, 2);
+  top: .5rem;
+  left: .5rem;
   z-index: $zindex-fixed;
-  padding: map-get($spacers, 2);
+  padding: .5rem;
   color: $white;
   background-color: $bd-purple;
 

--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -1,17 +1,9 @@
 .skippy {
-  display: block;
-  padding: 1em;
+  position: fixed;
+  top: map-get($spacers, 2);
+  left: map-get($spacers, 2);
+  z-index: $zindex-fixed;
+  padding: map-get($spacers, 2);
   color: $white;
-  text-align: center;
   background-color: $bd-purple;
-  outline: 0;
-
-  &:hover {
-    color: $white;
-  }
-}
-
-.skippy-text {
-  padding: .5em;
-  outline: 1px dotted;
 }

--- a/site/content/docs/4.3/examples/blog/index.html
+++ b/site/content/docs/4.3/examples/blog/index.html
@@ -11,13 +11,13 @@ include_js: false
   <header class="blog-header py-3">
     <div class="row flex-nowrap justify-content-between align-items-center">
       <div class="col-4 pt-1">
-        <a class="text-muted" href="#">Subscribe</a>
+        <a class="link-secondary" href="#">Subscribe</a>
       </div>
       <div class="col-4 text-center">
         <a class="blog-header-logo text-dark" href="#">Large</a>
       </div>
       <div class="col-4 d-flex justify-content-end align-items-center">
-        <a class="text-muted" href="#" aria-label="Search">
+        <a class="link-secondary" href="#" aria-label="Search">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="mx-3" role="img" viewBox="0 0 24 24"><title>Search</title><circle cx="10.5" cy="10.5" r="7.5"/><path d="M21 21l-5.2-5.2"/></svg>
         </a>
         <a class="btn btn-sm btn-outline-secondary" href="#">Sign up</a>
@@ -27,18 +27,18 @@ include_js: false
 
   <div class="nav-scroller py-1 mb-2">
     <nav class="nav d-flex justify-content-between">
-      <a class="p-2 text-muted" href="#">World</a>
-      <a class="p-2 text-muted" href="#">U.S.</a>
-      <a class="p-2 text-muted" href="#">Technology</a>
-      <a class="p-2 text-muted" href="#">Design</a>
-      <a class="p-2 text-muted" href="#">Culture</a>
-      <a class="p-2 text-muted" href="#">Business</a>
-      <a class="p-2 text-muted" href="#">Politics</a>
-      <a class="p-2 text-muted" href="#">Opinion</a>
-      <a class="p-2 text-muted" href="#">Science</a>
-      <a class="p-2 text-muted" href="#">Health</a>
-      <a class="p-2 text-muted" href="#">Style</a>
-      <a class="p-2 text-muted" href="#">Travel</a>
+      <a class="p-2 link-secondary" href="#">World</a>
+      <a class="p-2 link-secondary" href="#">U.S.</a>
+      <a class="p-2 link-secondary" href="#">Technology</a>
+      <a class="p-2 link-secondary" href="#">Design</a>
+      <a class="p-2 link-secondary" href="#">Culture</a>
+      <a class="p-2 link-secondary" href="#">Business</a>
+      <a class="p-2 link-secondary" href="#">Politics</a>
+      <a class="p-2 link-secondary" href="#">Opinion</a>
+      <a class="p-2 link-secondary" href="#">Science</a>
+      <a class="p-2 link-secondary" href="#">Health</a>
+      <a class="p-2 link-secondary" href="#">Style</a>
+      <a class="p-2 link-secondary" href="#">Travel</a>
     </nav>
   </div>
 

--- a/site/content/docs/4.3/examples/dashboard/index.html
+++ b/site/content/docs/4.3/examples/dashboard/index.html
@@ -69,7 +69,7 @@ extra_js:
 
         <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
           <span>Saved reports</span>
-          <a class="d-flex align-items-center text-muted" href="#" aria-label="Add a new report">
+          <a class="link-secondary" href="#" aria-label="Add a new report">
             <span data-feather="plus-circle"></span>
           </a>
         </h6>

--- a/site/content/docs/4.3/examples/pricing/index.html
+++ b/site/content/docs/4.3/examples/pricing/index.html
@@ -80,30 +80,30 @@ include_js: false
       <div class="col-6 col-md">
         <h5>Features</h5>
         <ul class="list-unstyled text-small">
-          <li><a class="text-muted" href="#">Cool stuff</a></li>
-          <li><a class="text-muted" href="#">Random feature</a></li>
-          <li><a class="text-muted" href="#">Team feature</a></li>
-          <li><a class="text-muted" href="#">Stuff for developers</a></li>
-          <li><a class="text-muted" href="#">Another one</a></li>
-          <li><a class="text-muted" href="#">Last time</a></li>
+          <li><a class="link-secondary" href="#">Cool stuff</a></li>
+          <li><a class="link-secondary" href="#">Random feature</a></li>
+          <li><a class="link-secondary" href="#">Team feature</a></li>
+          <li><a class="link-secondary" href="#">Stuff for developers</a></li>
+          <li><a class="link-secondary" href="#">Another one</a></li>
+          <li><a class="link-secondary" href="#">Last time</a></li>
         </ul>
       </div>
       <div class="col-6 col-md">
         <h5>Resources</h5>
         <ul class="list-unstyled text-small">
-          <li><a class="text-muted" href="#">Resource</a></li>
-          <li><a class="text-muted" href="#">Resource name</a></li>
-          <li><a class="text-muted" href="#">Another resource</a></li>
-          <li><a class="text-muted" href="#">Final resource</a></li>
+          <li><a class="link-secondary" href="#">Resource</a></li>
+          <li><a class="link-secondary" href="#">Resource name</a></li>
+          <li><a class="link-secondary" href="#">Another resource</a></li>
+          <li><a class="link-secondary" href="#">Final resource</a></li>
         </ul>
       </div>
       <div class="col-6 col-md">
         <h5>About</h5>
         <ul class="list-unstyled text-small">
-          <li><a class="text-muted" href="#">Team</a></li>
-          <li><a class="text-muted" href="#">Locations</a></li>
-          <li><a class="text-muted" href="#">Privacy</a></li>
-          <li><a class="text-muted" href="#">Terms</a></li>
+          <li><a class="link-secondary" href="#">Team</a></li>
+          <li><a class="link-secondary" href="#">Locations</a></li>
+          <li><a class="link-secondary" href="#">Privacy</a></li>
+          <li><a class="link-secondary" href="#">Terms</a></li>
         </ul>
       </div>
     </div>

--- a/site/content/docs/4.3/examples/product/index.html
+++ b/site/content/docs/4.3/examples/product/index.html
@@ -107,39 +107,39 @@ extra_css:
     <div class="col-6 col-md">
       <h5>Features</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Cool stuff</a></li>
-        <li><a class="text-muted" href="#">Random feature</a></li>
-        <li><a class="text-muted" href="#">Team feature</a></li>
-        <li><a class="text-muted" href="#">Stuff for developers</a></li>
-        <li><a class="text-muted" href="#">Another one</a></li>
-        <li><a class="text-muted" href="#">Last time</a></li>
+        <li><a class="link-secondary" href="#">Cool stuff</a></li>
+        <li><a class="link-secondary" href="#">Random feature</a></li>
+        <li><a class="link-secondary" href="#">Team feature</a></li>
+        <li><a class="link-secondary" href="#">Stuff for developers</a></li>
+        <li><a class="link-secondary" href="#">Another one</a></li>
+        <li><a class="link-secondary" href="#">Last time</a></li>
       </ul>
     </div>
     <div class="col-6 col-md">
       <h5>Resources</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Resource</a></li>
-        <li><a class="text-muted" href="#">Resource name</a></li>
-        <li><a class="text-muted" href="#">Another resource</a></li>
-        <li><a class="text-muted" href="#">Final resource</a></li>
+        <li><a class="link-secondary" href="#">Resource name</a></li>
+        <li><a class="link-secondary" href="#">Resource</a></li>
+        <li><a class="link-secondary" href="#">Another resource</a></li>
+        <li><a class="link-secondary" href="#">Final resource</a></li>
       </ul>
     </div>
     <div class="col-6 col-md">
       <h5>Resources</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Business</a></li>
-        <li><a class="text-muted" href="#">Education</a></li>
-        <li><a class="text-muted" href="#">Government</a></li>
-        <li><a class="text-muted" href="#">Gaming</a></li>
+        <li><a class="link-secondary" href="#">Business</a></li>
+        <li><a class="link-secondary" href="#">Education</a></li>
+        <li><a class="link-secondary" href="#">Government</a></li>
+        <li><a class="link-secondary" href="#">Gaming</a></li>
       </ul>
     </div>
     <div class="col-6 col-md">
       <h5>About</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Team</a></li>
-        <li><a class="text-muted" href="#">Locations</a></li>
-        <li><a class="text-muted" href="#">Privacy</a></li>
-        <li><a class="text-muted" href="#">Terms</a></li>
+        <li><a class="link-secondary" href="#">Team</a></li>
+        <li><a class="link-secondary" href="#">Locations</a></li>
+        <li><a class="link-secondary" href="#">Privacy</a></li>
+        <li><a class="link-secondary" href="#">Terms</a></li>
       </ul>
     </div>
   </div>

--- a/site/content/docs/4.3/getting-started/contents.md
+++ b/site/content/docs/4.3/getting-started/contents.md
@@ -78,10 +78,10 @@ Bootstrap includes a handful of options for including some or all of our compile
         <div><code class="font-weight-normal text-nowrap">bootstrap-grid.css</code></div>
         <div><code class="font-weight-normal text-nowrap">bootstrap-grid.min.css</code></div>
       </th>
-      <td><a class="text-muted" href="{{< docsref "/layout/grid" >}}">Only grid system</a></td>
+      <td><a class="link-secondary" href="{{< docsref "/layout/grid" >}}">Only grid system</a></td>
       <td class="text-muted">&mdash;</td>
       <td class="text-muted">&mdash;</td>
-      <td><a class="text-muted" href="{{< docsref "/utilities/flex" >}}">Only flex utilities</a></td>
+      <td><a class="link-secondary" href="{{< docsref "/utilities/flex" >}}">Only flex utilities</a></td>
     </tr>
     <tr>
       <th scope="row">
@@ -99,7 +99,7 @@ Bootstrap includes a handful of options for including some or all of our compile
         <div><code class="font-weight-normal text-nowrap">bootstrap-reboot.min.css</code></div>
       </th>
       <td class="text-muted">&mdash;</td>
-      <td><a class="text-muted" href="{{< docsref "/content/reboot" >}}">Only Reboot</a></td>
+      <td><a class="link-secondary" href="{{< docsref "/content/reboot" >}}">Only Reboot</a></td>
       <td class="text-muted">&mdash;</td>
       <td class="text-muted">&mdash;</td>
     </tr>

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -1,5 +1,5 @@
 <header class="navbar navbar-expand navbar-dark bd-navbar">
-  <div class="container-xl flex-wrap flex-md-nowrap">
+  <nav class="container-xl flex-wrap flex-md-nowrap" aria-label="Main navigation">
     <a class="navbar-brand mr-2" href="/" aria-label="Bootstrap">
       {{ partial "icons/bootstrap-logo-solid.svg" (dict "class" "d-block" "width" "32" "height" "32") }}
     </a>
@@ -54,5 +54,5 @@
     </ul>
 
     <a class="btn btn-bd-download d-none d-lg-inline-block mb-3 mb-md-0 ml-md-3" href="/docs/{{ .Site.Params.docs_version }}/getting-started/download/">Download</a>
-  </div>
+  </nav>
 </header>

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,4 +1,4 @@
-<nav class="collapse bd-links" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="collapse bd-links" id="bd-docs-nav" aria-label="Docs navigation">
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -1,4 +1,4 @@
-<nav class="bd-subnavbar pt-2 pb-3 pb-md-2">
+<nav class="bd-subnavbar pt-2 pb-3 pb-md-2" aria-label="Secondary navigation">
   <div class="container-xl d-flex align-items-md-center flex-wrap">
     <form class="bd-search mb-2 mb-md-0 mr-auto">
       <input type="search" class="form-control" id="search-input" placeholder="Search docs..." aria-label="Search docs for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">

--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -21,7 +21,7 @@
         <p class="text-muted mb-0">
           Currently <strong>v{{ .Site.Params.current_version }}</strong>
           <span class="px-1">&middot;</span>
-          <a href="/docs/versions/" class="text-muted">Previous releases</a>
+          <a href="/docs/versions/" class="link-secondary">Previous releases</a>
         </p>
       </div>
     </div>

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,3 +1,9 @@
 <a class="skippy sr-only-focusable" href="#content">
   <span class="skippy-text">Skip to main content</span>
 </a>
+
+{{ if (eq .Page.Layout "docs") }}
+  <a class="skippy sr-only-focusable" href="#bd-docs-nav">
+    <span class="skippy-text">Skip to main navigation</span>
+  </a>
+{{- end }}

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,5 +1,5 @@
 <a class="skippy sr-only-focusable" href="#content">Skip to main content</a>
 
 {{ if (eq .Page.Layout "docs") }}
-  <a class="skippy sr-only-focusable" href="#bd-docs-nav">Skip to docs navigation</a>
+  <a class="skippy sr-only-focusable d-none d-md-block" href="#bd-docs-nav">Skip to docs navigation</a>
 {{- end }}

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,5 +1,5 @@
 <a class="skippy sr-only-focusable" href="#content">Skip to main content</a>
 
 {{ if (eq .Page.Layout "docs") }}
-  <a class="skippy sr-only-focusable" href="#bd-docs-nav">Skip to main navigation</a>
+  <a class="skippy sr-only-focusable" href="#bd-docs-nav">Skip to docs navigation</a>
 {{- end }}

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,9 +1,5 @@
-<a class="skippy sr-only-focusable" href="#content">
-  <span class="skippy-text">Skip to main content</span>
-</a>
+<a class="skippy sr-only-focusable" href="#content">Skip to main content</a>
 
 {{ if (eq .Page.Layout "docs") }}
-  <a class="skippy sr-only-focusable" href="#bd-docs-nav">
-    <span class="skippy-text">Skip to main navigation</span>
-  </a>
+  <a class="skippy sr-only-focusable" href="#bd-docs-nav">Skip to main navigation</a>
 {{- end }}


### PR DESCRIPTION
Mostly usability improvements — at least some tries:

- new skip-link to the main navigation, in documentation page;
- new skip-link to search form (on pages that display it);
- refactored skip-links pattern, mainly to ease their use for screen magnifiers users (which can't see them appearing since when using it, they are likely to be on the top left corner of the document).

This is more convenient to use, and also simplify both markup and styles — however maybe opinionated?

Each of these is a separate commit so let me know if I should revert one of those.

Ping @patrickhlauke again :)

Preview: <https://deploy-preview-30073--twbs-bootstrap.netlify.com/>