### PR TITLE
`.text-break` fix

### DIFF
--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -63,8 +63,7 @@
 .text-decoration-none { text-decoration: none !important; }
 
 .text-break {
-  word-break: break-word !important; // IE & < Edge 18
-  overflow-wrap: break-word !important;
+  word-wrap: break-word !important;
 }
 
 // Reset

--- a/site/docs/4.4/utilities/text.md
+++ b/site/docs/4.4/utilities/text.md
@@ -68,7 +68,7 @@ For longer content, you can add a `.text-truncate` class to truncate the text wi
 
 ## Word break
 
-Prevent long strings of text from breaking your components' layout by using `.text-break` to set `overflow-wrap: break-word` (and `word-break: break-word` for IE & Edge compatibility).
+Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-wrap: break-word`.
 
 {% capture example %}
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>


### PR DESCRIPTION
Backport of https://github.com/twbs/bootstrap/pull/29325.

Closes https://github.com/twbs/bootstrap/issues/28304.