### PR TITLE
Headings hierarchy in licence.md

### DIFF
--- a/site/content/docs/4.3/about/license.md
+++ b/site/content/docs/4.3/about/license.md
@@ -7,18 +7,18 @@ group: about
 
 Bootstrap is released under the MIT license and is copyright {{< year >}} Twitter. Boiled down to smaller chunks, it can be described with the following conditions.
 
-#### It requires you to:
+## It requires you to:
 
 * Keep the license and copyright notice included in Bootstrap's CSS and JavaScript files when you use them in your works
 
-#### It permits you to:
+## It permits you to:
 
 - Freely download and use Bootstrap, in whole or in part, for personal, private, company internal, or commercial purposes
 - Use Bootstrap in packages or distributions that you create
 - Modify the source code
 - Grant a sublicense to modify and distribute Bootstrap to third parties not included in the license
 
-#### It forbids you to:
+## It forbids you to:
 
 - Hold the authors and license owners liable for damages as Bootstrap is provided without warranty
 - Hold the creators or copyright holders of Bootstrap liable
@@ -26,7 +26,7 @@ Bootstrap is released under the MIT license and is copyright {{< year >}} Twitte
 - Use any marks owned by Twitter in any way that might state or imply that Twitter endorses your distribution
 - Use any marks owned by Twitter in any way that might state or imply that you created the Twitter software in question
 
-#### It does not require you to:
+## It does not require you to:
 
 - Include the source of Bootstrap itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it
 - Submit changes that you make to Bootstrap back to the Bootstrap project (though such feedback is encouraged)


### PR DESCRIPTION
Very simple and specific improvement to the licence page, which stepped from `h1` to `h4`.

FYI, I also noticed a few other headings hierarchy failures when using some callouts, in which heading level is defined in Markdown without taking the context of the page in which they're included.

For example, calling `callout-danger-async-methods.md` after a `h2` will break headings hierarchy by stepping to `h4`.

I tried a bit but struggled with Hugo specificities: we're include a Markdown partial through a partial shortcode (why? is it only to pass context?) inside a callout shortcode. So passing an argument to handle heading level in partial isn't easy.

I don't know if I should try to handle arguments in the `partial` shortcode, or if I should move those callouts to `.html` and calling them directly with the `partial` method (without the partial shortcode in the middle).

I can't help more with this, but at least the Licence page is easy to imrpove :)