### PR TITLE
Improve reduced-motion case for spinners

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -53,3 +53,21 @@
   width: $spinner-width-sm;
   height: $spinner-height-sm;
 }
+
+@if $enable-prefers-reduced-motion-media-query {
+  @media (prefers-reduced-motion: reduce) {
+    .spinner-border,
+    .spinner-grow {
+      min-width: 10ch;
+      border: 0;
+      animation: none;
+
+      // `all` is safe here, since its support is better than the `prefers-reduced-motion` query's
+      // see https://caniuse.com/#feat=prefers-reduced-motion
+      // see https://caniuse.com/#feat=css-all
+      .sr-only {
+        all: initial !important; // stylelint-disable declaration-no-important
+      }
+    }
+  }
+}

--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -57,17 +57,25 @@
 @if $enable-prefers-reduced-motion-media-query {
   @media (prefers-reduced-motion: reduce) {
     .spinner-border,
-    .spinner-grow {
-      min-width: 10ch;
+    .spinner-border-sm,
+    .spinner-grow,
+    .spinner-grow-sm {
+      width: min-content;
+      background: none;
       border: 0;
+      opacity: 1;
       animation: none;
 
       // `all` is safe here, since its support is better than the `prefers-reduced-motion` query's
       // see https://caniuse.com/#feat=prefers-reduced-motion
       // see https://caniuse.com/#feat=css-all
-      .sr-only {
-        all: initial !important; // stylelint-disable declaration-no-important
+      // stylelint-disable declaration-no-important
+      .sr-only,
+      + .sr-only {
+        all: initial !important;
+        color: inherit !important;
       }
+      // stylelint-enable declaration-no-important
     }
   }
 }

--- a/site/content/docs/4.3/components/spinners.md
+++ b/site/content/docs/4.3/components/spinners.md
@@ -10,7 +10,7 @@ toc: true
 
 Bootstrap "spinners" can be used to show the loading state in your projects. They're built only with HTML and CSS, meaning you don't need any JavaScript to create them. You will, however, need some custom JavaScript to toggle their visibility. Their appearance, alignment, and sizing can be easily customized with our amazing utility classes.
 
-For accessibility purposes, each loader here includes `role="status"` and a nested `<span class="sr-only">Loading...</span>`.
+For accessibility purposes, each loader here includes `role="status"` and a nested `<span class="sr-only">Loading...</span>`. Moreover, spinners do honor the [`prefers-reduced-motion` media feature]({{< docsref "/getting-started/accessibility" >}}#reduced-motion): in that case, `animation` is disabled and the [visually hidden content]({{< docsref "/getting-started/accessibility" >}}#visually-hidden-content) gets displayed instead.
 
 ## Border spinner
 


### PR DESCRIPTION
Last but not least, this is a real feature request and not another docs enhancement.

Basically, it ensures that spinners honor the `prefers-reduced-motion` feature by stopping the animation — which kind of defeat the need for a visual spinner. The idea I came up with is to display the visually hidden text instead.

So it then litterally displays the `Loading…` text instead of the animated thing.