### PR TITLE
Separate background color from background shorthand in custom select

### DIFF
--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -14,7 +14,8 @@
   line-height: $form-select-line-height;
   color: $form-select-color;
   vertical-align: middle;
-  background: $form-select-bg escape-svg($form-select-indicator) $form-select-background;
+  background: escape-svg($form-select-indicator) $form-select-background;
+  background-color: $form-select-bg;
   border: $form-select-border-width solid $form-select-border-color;
   @include border-radius($form-select-border-radius, 0);
   @include box-shadow($form-select-box-shadow);


### PR DESCRIPTION
In Firefox and Chrome, the custom select displays correctly but not with Safari 13.0.4 and Microsoft EdgeHTML 18.18363. Moving background color to its own line after the background shorthand fixes the issue.

Before PR:
![background](https://user-images.githubusercontent.com/368084/73625505-05394000-45fa-11ea-8b18-ec101b70e796.jpg)

> background: var(--atum-bg-dark) url(../images/select-bg.svg) no-repeat right center/116rem;

After PR:
![background-color](https://user-images.githubusercontent.com/368084/73625510-09fdf400-45fa-11ea-81e8-e14eb88d12b2.jpg)

> background: url(../images/select-bg.svg) no-repeat right center/116rem;
background-color: var(--atum-bg-dark);
