### PR TITLE
Update copy sizing utilities

### DIFF
--- a/site/content/docs/4.3/utilities/sizing.md
+++ b/site/content/docs/4.3/utilities/sizing.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Relative to the parent
 
-Width and height utilities are generated from the `$sizes` Sass map in `_variables.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
+Width and height utilities are generated from the utility API in `_utilities.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
 
 {{< example >}}
 <div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>


### PR DESCRIPTION
The `$sizes` Sass map doesn't exist anymore in `v5`.