### PR TITLE
Remove unnecessary reduce motion when $enable-transition: false

### DIFF
--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -6,11 +6,11 @@
     } @else {
       transition: $transition;
     }
-  }
 
-  @if $enable-prefers-reduced-motion-media-query {
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    @if $enable-prefers-reduced-motion-media-query {
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
     }
   }
 }


### PR DESCRIPTION
When `$enable-transition: false`, 
```scss
@media (prefers-reduced-motion: reduce) {
   transition: none;
}
```
is unnecessary.

