### PR TITLE
Remove confusing "Equal-width multi-line" section from Grid docs.

### DIFF
--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -145,24 +145,6 @@ For example, here are two grid layouts that apply to every device and viewport, 
 </div>
 {{< /example >}}
 
-### Equal-width multi-line
-
-Create equal-width columns that span multiple lines by inserting a `.w-100` where you want the columns to break to a new line. Make the breaks responsive by mixing `.w-100` with some [responsive display utilities]({{< docsref "/utilities/display" >}}).
-
-There was a [Safari flexbox bug](https://github.com/philipwalton/flexbugs#flexbug-11) that prevented this from working without an explicit `flex-basis` or `border`. There are workarounds for older browser versions, but they shouldn't be necessary if your target browsers don't fall into the buggy versions.
-
-{{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col">col</div>
-    <div class="col">col</div>
-    <div class="w-100"></div>
-    <div class="col">col</div>
-    <div class="col">col</div>
-  </div>
-</div>
-{{< /example >}}
-
 ### Setting one column width
 
 Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.


### PR DESCRIPTION
Reading the grid docs from top to bottom, this section made no sense to me. I didn't understand why you wouldn't just use multiple rows, and I had no idea what w-100 meant, or how you'd "mix" it with "responsive display utilities".

Then I continued reading and got to https://getbootstrap.com/docs/4.4/layout/grid/#column-breaks which explains the same concept but with a much better explanation and examples (including the responsive display utilities).

It looks like the "Equal-width multi-line" section was added in 9010978c1a to resolve to #21967 as a way to document the existence of a Safari bug.  But that bug has long since been fixed (Safari 10.1 came out in May 2017) and so I think it's reasonable to just drop this section and rely on the better docs further down in the guide.