### PR TITLE
Remove `.table-dark` as table variant

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -101,7 +101,7 @@
 // Exact selectors below required to override `.table-striped` and prevent
 // inheritance to nested tables.
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $table-theme-colors {
   @include table-row-variant($color, color-level($value, $table-bg-level), color-level($value, $table-border-level));
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -478,6 +478,8 @@ $table-dark-hover-color:      $table-dark-color !default;
 $table-dark-hover-bg:         rgba($white, .075) !default;
 $table-dark-border-color:     lighten($table-dark-bg, 7.5%) !default;
 
+$table-theme-colors:          map-remove($theme-colors, dark) !default;
+
 $table-striped-order:         odd !default;
 
 $table-caption-color:         $text-muted !default;

--- a/site/content/docs/4.3/content/tables.md
+++ b/site/content/docs/4.3/content/tables.md
@@ -461,11 +461,13 @@ Use contextual classes to color table rows or individual cells.
       </tr>
 {{< table.inline >}}
   {{- range (index $.Site.Data "theme-colors") }}
+    {{ if ne .name "dark" }}
       <tr class="table-{{ .name }}">
         <th scope="row">{{ .name | title }}</th>
         <td>Cell</td>
         <td>Cell</td>
       </tr>
+    {{ end }}
   {{- end -}}
 {{< /table.inline >}}
     </tbody>
@@ -477,7 +479,7 @@ Use contextual classes to color table rows or individual cells.
 <tr class="table-active">...</tr>
 {{< table.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<tr class="table-{{ .name }}">...</tr>
+{{ if ne .name "dark" }}<tr class="table-{{ .name }}">...</tr>{{ end }}
 {{- end -}}
 {{< /table.inline >}}
 
@@ -486,7 +488,7 @@ Use contextual classes to color table rows or individual cells.
   <td class="table-active">...</td>
 {{< table.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-  <td class="table-{{ .name }}">...</td>
+  {{ if ne .name "dark" }}<td class="table-{{ .name }}">...</td>{{ end }}
 {{- end -}}
 {{< /table.inline >}}
 </tr>


### PR DESCRIPTION
Remove `.table-dark` as [color variant](https://twbs-bootstrap.netlify.com/docs/4.3/content/tables/#variants). `.table-dark` was already used for [inverted tables](https://twbs-bootstrap.netlify.com/docs/4.3/content/tables/#inverted).

Closes https://github.com/twbs/bootstrap/issues/27879