### PR TITLE
Netlify: set Hugo's `baseURL` to the `DEPLOY_PRIME_URL` variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "release-zip": "cross-env-shell \"rm -rf bootstrap-$npm_package_version-dist && cp -r dist/ bootstrap-$npm_package_version-dist && zip -r9 bootstrap-$npm_package_version-dist.zip bootstrap-$npm_package_version-dist && rm -rf bootstrap-$npm_package_version-dist\"",
     "dist": "npm-run-all --parallel css js",
     "test": "npm-run-all lint dist js-test docs-build docs-lint",
-    "netlify": "npm-run-all dist release-sri docs-build",
+    "netlify": "cross-env-shell HUGO_BASEURL=$DEPLOY_PRIME_URL npm-run-all dist release-sri docs-build",
     "watch": "npm-run-all --parallel watch-*",
     "watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
     "watch-css-docs": "nodemon --watch site/assets/scss/ --ext scss --exec \"npm run css-lint\"",


### PR DESCRIPTION
So, this will allow each branch/preview to have its own base URL instead of the default one of the main site (getbootstrap.com).

It shouldn't affect anything in theory, since on Netlify's robots.txt has indexing blocked.

Ideally, we should backport this to v4-dev, but I'm not sure how easy it'll be, if at all possible. I will look into backporting it when I have some time.

Refs #29949 

Preview: <https://deploy-preview-30214--twbs-bootstrap.netlify.com/>