### PR TITLE
prevents .table-striped to be automatically applied to inner tables

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -76,7 +76,7 @@
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
 .table-striped {
-  tbody tr:nth-of-type(#{$table-striped-order}) {
+  & > tbody > tr:nth-of-type(#{$table-striped-order}) {
     background-color: $table-accent-bg;
   }
 }
@@ -146,7 +146,7 @@
   }
 
   &.table-striped {
-    tbody tr:nth-of-type(#{$table-striped-order}) {
+    & > tbody > tr:nth-of-type(#{$table-striped-order}) {
       background-color: $table-dark-accent-bg;
     }
   }


### PR DESCRIPTION
It seems we had no clean way to remove the striped behaviour from inner tables once it's added to a parent table. Now it's possible to add it manually, if wanted.