### PR TITLE
Hide horizontal scrollbars on code snippets

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -235,14 +235,9 @@
 //
 
 .highlight {
-  padding: 1rem;
   margin-top: 1rem;
   margin-bottom: 1rem;
   background-color: $gray-100;
-
-  @include media-breakpoint-up(sm) {
-    padding: 1.5rem;
-  }
 }
 
 .highlight pre::-webkit-scrollbar {
@@ -261,12 +256,16 @@
 
 .highlight {
   pre {
-    padding: 0;
+    padding: 1rem;
     margin-top: 0;
     margin-bottom: 0;
     background-color: transparent;
     border: 0;
     scrollbar-width: none;
+
+    @include media-breakpoint-up(sm) {
+      padding: 1.5rem;
+    }
   }
 
   pre code {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -239,11 +239,14 @@
   margin-top: 1rem;
   margin-bottom: 1rem;
   background-color: $gray-100;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   @include media-breakpoint-up(sm) {
     padding: 1.5rem;
   }
+}
+
+.highlight pre::-webkit-scrollbar {
+  display: none;
 }
 
 .bd-content .highlight {
@@ -263,10 +266,12 @@
     margin-bottom: 0;
     background-color: transparent;
     border: 0;
+    scrollbar-width: none;
   }
 
   pre code {
     @include font-size(inherit);
     color: $gray-900; // Effectively the base text color
+    word-wrap: normal;
   }
 }


### PR DESCRIPTION
Works in Safari, Firefox, and Chrome so far. ~Pushing to test on my Windows machine.~ Edge and IE11 have full scrollbars always visible. Accessibility-wise, I'm not worried about folks not knowing they can scroll—the majority of our code snippets are quite long horizontally, so having them cut off is a clear indicator of _more_.