### PR TITLE
Fix `th` alignment for Safari

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -344,11 +344,12 @@ caption {
   caption-side: bottom;
 }
 
-// Matches default `<td>` alignment by inheriting from the `<body>`, or the
-// closest parent with a set `text-align`.
+// Matches default `<td>` alignment by inheriting `text-align`.
+// 1. Fix alignment for Safari
 
 th {
   text-align: inherit;
+  text-align: -webkit-match-parent; // 1
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/30321.

Did some tests and it seemed only Safari had issues figuring out the default text alignment.