### PR TITLE
Mark peer dependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,14 @@
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.16.0"
   },
+  "peerDependenciesMeta": {
+    "jquery": {
+      "optional": true
+    },
+    "popper.js": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",


### PR DESCRIPTION
This solves the log spam for people using Bootstrap without the JS functionality, with yarn. This can be annoying because not everybody on a large team knows these are harmless in their app, and it trains people to ignore other valid warnings. It only affects the display of warnings, so this is a safe change. Version compatibilities are still checked if the peer dependencies are installed.

```
[4/5] 🔗  Linking dependencies...
warning " > bootstrap@4.4.1" has unmet peer dependency "jquery@1.9.1 - 3".
warning " > bootstrap@4.4.1" has unmet peer dependency "popper.js@^1.16.0".
```

Reference:
https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md
https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md#1130

Related issue with complains about the log spam: https://github.com/twbs/bootstrap/issues/23557