### PR TITLE
Embedded examples cleanup

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -247,19 +247,7 @@
   @include media-breakpoint-up(sm) {
     padding: 1rem 1.5rem;
   }
-}
 
-.bd-content .highlight {
-  margin-right: (-$grid-gutter-width / 2);
-  margin-left: (-$grid-gutter-width / 2);
-
-  @include media-breakpoint-up(sm) {
-    margin-right: 0;
-    margin-left: 0;
-  }
-}
-
-.highlight {
   pre {
     padding: 0;
     margin-top: 0;
@@ -271,5 +259,15 @@
   pre code {
     @include font-size(inherit);
     color: $gray-900; // Effectively the base text color
+  }
+}
+
+.bd-content .highlight {
+  margin-right: (-$grid-gutter-width / 2);
+  margin-left: (-$grid-gutter-width / 2);
+
+  @include media-breakpoint-up(sm) {
+    margin-right: 0;
+    margin-left: 0;
   }
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -99,7 +99,7 @@
   }
 
   + .highlight,
-  + .clipboard + .highlight {
+  + .bd-clipboard + .highlight {
     margin-top: 0;
   }
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -124,18 +124,18 @@
     position: static;
     display: block;
   }
-}
 
-// Images
-.bd-example {
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  // Images
   > svg + svg,
   > img + img {
     margin-left: .5rem;
   }
-}
 
-// Buttons
-.bd-example {
+  // Buttons
   > .btn,
   > .btn-group {
     margin-top: .25rem;
@@ -144,19 +144,17 @@
   > .btn-toolbar + .btn-toolbar {
     margin-top: .5rem;
   }
-}
 
-// List groups
-.bd-example > .list-group {
-  max-width: 400px;
-}
+  // List groups
+  > .list-group {
+    max-width: 400px;
+  }
 
-.bd-example > [class*="list-group-horizontal"] {
-  max-width: 100%;
-}
+  > [class*="list-group-horizontal"] {
+    max-width: 100%;
+  }
 
-// Navbars
-.bd-example {
+  // Navbars
   .fixed-top,
   .sticky-top {
     position: static;
@@ -177,12 +175,12 @@
       margin: 1rem -1.5rem -1.5rem;
     }
   }
-}
 
-// Pagination
-.bd-example .pagination {
-  margin-top: .5rem;
-  margin-bottom: .5rem;
+  // Pagination
+  .pagination {
+    margin-top: .5rem;
+    margin-bottom: .5rem;
+  }
 }
 
 .bd-example-modal {
@@ -247,7 +245,7 @@
   -ms-overflow-style: -ms-autohiding-scrollbar;
 
   @include media-breakpoint-up(sm) {
-    padding: 1.5rem;
+    padding: 1rem 1.5rem;
   }
 }
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -120,7 +120,7 @@
     display: block;
   }
 
-  > *:last-child {
+  > :last-child {
     margin-bottom: 0;
   }
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -82,15 +82,20 @@
   position: relative;
   padding: 1rem;
   margin: 1rem (-$grid-gutter-width / 2) 0;
-  border: solid $gray-100;
-  border-width: .2rem 0 0;
+  border: solid $gray-300;
+  border-width: 1px 0 0;
   @include clearfix();
 
   @include media-breakpoint-up(sm) {
     padding: 1.5rem;
     margin-right: 0;
     margin-left: 0;
-    border-width: .2rem;
+    border-width: 1px;
+    @include border-top-radius(.25rem);
+
+    + .bd-clipboard + .highlight {
+      @include border-bottom-radius(.25rem);
+    }
   }
 
   + .highlight,

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -98,11 +98,6 @@
     }
   }
 
-  + .highlight,
-  + .bd-clipboard + .highlight {
-    margin-top: 0;
-  }
-
   + p {
     margin-top: 2rem;
   }
@@ -239,7 +234,6 @@
 
 .highlight {
   padding: 1rem;
-  margin-top: 1rem;
   margin-bottom: 1rem;
   background-color: $gray-100;
   -ms-overflow-style: -ms-autohiding-scrollbar;


### PR DESCRIPTION
Few visual tweaks to our docs' embedded examples and code snippets:

- Thinner, darker border around the demo
- Removed `margin-bottom` on all `:last-child` within
- Tightened vertical padding on `.highlight` on desktop viewports
- Fixed a busted class
- Nested more CSS

<img width="813" alt="Screen Shot 2020-03-03 at 3 37 12 PM" src="https://user-images.githubusercontent.com/98681/75831089-738f3080-5d67-11ea-8722-cbd8acb76ded.png">
