### PR TITLE
Switch versions & docs search

### DIFF
--- a/site/assets/scss/_algolia.scss
+++ b/site/assets/scss/_algolia.scss
@@ -15,10 +15,6 @@
   @include box-shadow($dropdown-box-shadow);
 
   @include media-breakpoint-up(md) {
-    // stylelint-disable declaration-no-important
-    right: 0 !important; // Override inline style
-    left: auto !important; // Override inline style
-    // stylelint-enable declaration-no-important
     width: 400px;
   }
 }

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -1,12 +1,10 @@
 <nav class="bd-subnavbar pt-2 pb-3 pb-md-2">
   <div class="container-xl d-flex align-items-md-center flex-wrap">
-    <div class="d-flex align-items-center mr-sm-auto order-2 order-md-0">
-      {{ partial "docs-versions" . }}
-    </div>
-
-    <form class="bd-search d-flex align-items-center mb-2 mb-md-0">
+    <form class="bd-search mb-2 mb-md-0 mr-auto">
       <input type="search" class="form-control" id="search-input" placeholder="Search docs..." aria-label="Search docs for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">
     </form>
+
+    {{ partial "docs-versions" . }}
 
     <button class="btn btn-link bd-search-docs-toggle d-md-none p-0 ml-3 order-3 ml-auto" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
      {{ partial "icons/menu.svg" (dict "width" "30" "height" "30") }}

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <button class="btn btn-bd-light dropdown-toggle" id="bd-versions" data-toggle="dropdown" aria-expanded="false">
+  <button class="btn btn-bd-light dropdown-toggle" id="bd-versions" data-toggle="dropdown" aria-expanded="false" data-display="static">
     Bootstrap v{{ .Site.Params.docs_version }}
   </button>
   <div class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions">


### PR DESCRIPTION
Something I never got used to: the search field moved from the left side to the right in the `v5` docs.

In the `v4` docs, everything related to navigation was positioned on the left side (main menu in the upper corner, search field just below the navigation, and then the subnavigation).

Can we move the search back to the left?