### PR TITLE
De-dupe .table-dark, add new border color utilities, and update table docs

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -108,60 +108,6 @@
 @include table-row-variant(active, $table-active-bg);
 
 
-// Dark styles
-//
-// Same table markup, but inverted color scheme: dark background and light text.
-
-// stylelint-disable-next-line no-duplicate-selectors
-.table {
-  .thead-dark {
-    th {
-      color: $table-dark-color;
-      background-color: $table-dark-bg;
-      border-color: $table-dark-border-color;
-    }
-  }
-
-  .thead-light {
-    th {
-      color: $table-head-color;
-      background-color: $table-head-bg;
-      border-color: $table-border-color;
-    }
-  }
-}
-
-.table-dark {
-  color: $table-dark-color;
-  background-color: $table-dark-bg;
-
-  th,
-  td,
-  thead th {
-    border-color: $table-dark-border-color;
-  }
-
-  &.table-bordered {
-    border: 0;
-  }
-
-  &.table-striped {
-    tbody tr:nth-of-type(#{$table-striped-order}) {
-      background-color: $table-dark-accent-bg;
-    }
-  }
-
-  &.table-hover {
-    tbody tr {
-      &:hover {
-        color: $table-dark-hover-color;
-        background-color: $table-dark-hover-bg;
-      }
-    }
-  }
-}
-
-
 // Responsive tables
 //
 // Generate series of `.table-responsive-*` classes for configuring the screen

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -1,3 +1,5 @@
+// stylelint-disable comment-empty-line-before
+
 //
 // Basic Bootstrap table
 //
@@ -8,11 +10,17 @@
   color: $table-color;
   vertical-align: $table-cell-vertical-align;
   background-color: $table-bg; // Reset for nesting within parents with `background-color`.
+  border-color: $table-border-color;
 
   th,
   td {
     padding: $table-cell-padding;
-    border-bottom: $table-border-width solid $table-border-color;
+    // Table cells will only inherit if you use longhand properties
+    /* clean-css ignore:start */
+    border-color: inherit;
+    border-bottom-style: solid;
+    border-bottom-width: $table-border-width;
+    /* clean-css ignore:end */
   }
 
   tbody {
@@ -21,11 +29,14 @@
 
   thead th {
     vertical-align: bottom;
-    border-bottom-color: $table-head-border-color;
   }
 
   tbody + tbody {
-    border-top: (2 * $table-border-width) solid $table-border-color;
+    /* clean-css ignore:start */
+    border-color: inherit;
+    border-top-style: solid;
+    border-top-width: (2 * $table-border-width);
+    /* clean-css ignore:end */
   }
 }
 
@@ -47,18 +58,14 @@
 // Add or remove borders all around the table and between all the columns.
 
 .table-bordered {
-  border: $table-border-width solid $table-border-color;
+  border-width: $table-border-width;
 
   th,
   td {
-    border: $table-border-width solid $table-border-color;
-  }
-
-  thead {
-    th,
-    td {
-      border-bottom-width: 2 * $table-border-width;
-    }
+    /* clean-css ignore:start */
+    border-style: solid;
+    border-width: $table-border-width;
+    /* clean-css ignore:end */
   }
 }
 
@@ -75,25 +82,33 @@
 //
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
+// stylelint-disable selector-max-type
 .table-striped {
-  tbody tr:nth-of-type(#{$table-striped-order}) {
-    background-color: $table-accent-bg;
+  > tbody > tr:nth-of-type(#{$table-striped-order}) {
+    > td,
+    > th {
+      background-image: linear-gradient($table-accent-bg, $table-accent-bg);
+    }
   }
 }
+// stylelint-enable selector-max-type
 
 
 // Hover effect
 //
 // Placed here since it has to come after the potential zebra striping
 
+// stylelint-disable selector-max-type
 .table-hover {
-  tbody tr {
-    &:hover {
+  > tbody > tr:hover {
+    > td,
+    > th {
       color: $table-hover-color;
-      background-color: $table-hover-bg;
+      background-image: linear-gradient($table-hover-bg, $table-hover-bg);
     }
   }
 }
+// stylelint-enable selector-max-type
 
 
 // Table backgrounds

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -77,7 +77,15 @@ $utilities: map-merge(
     "border-color": (
       property: border-color,
       class: border,
-      values: map-merge($theme-colors, ("white": $white))
+      values: map-merge(
+        $theme-colors,
+        (
+          "white": $white,
+          "gray-500": $gray-500,
+          "gray-700": $gray-700,
+          "black": $black
+        )
+      )
     ),
     // Sizing utilities
     "width": (
@@ -412,6 +420,9 @@ $utilities: map-merge(
         (
           "body": $body-bg,
           "white": $white,
+          "black": black,
+          "gray-400": $gray-400,
+          "gray-600": $gray-600,
           "transparent": transparent
         )
       )

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -457,10 +457,10 @@ $table-cell-padding-sm:       .25rem !default;
 
 $table-cell-vertical-align:   top !default;
 
-$table-color:                 $body-color !default;
+$table-color:                 null !default;
 $table-bg:                    null !default;
 $table-accent-bg:             rgba($black, .05) !default;
-$table-hover-color:           $table-color !default;
+$table-hover-color:           null !default;
 $table-hover-bg:              rgba($black, .075) !default;
 $table-active-bg:             $table-hover-bg !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -467,17 +467,6 @@ $table-active-bg:             $table-hover-bg !default;
 $table-border-width:          $border-width !default;
 $table-border-color:          $border-color !default;
 
-$table-head-bg:               $gray-200 !default;
-$table-head-color:            $gray-700 !default;
-$table-head-border-color:     $gray-700 !default;
-
-$table-dark-color:            $white !default;
-$table-dark-bg:               $gray-800 !default;
-$table-dark-accent-bg:        rgba($white, .05) !default;
-$table-dark-hover-color:      $table-dark-color !default;
-$table-dark-hover-bg:         rgba($white, .075) !default;
-$table-dark-border-color:     lighten($table-dark-bg, 7.5%) !default;
-
 $table-striped-order:         odd !default;
 
 $table-caption-color:         $text-muted !default;

--- a/scss/mixins/_table-row.scss
+++ b/scss/mixins/_table-row.scss
@@ -1,39 +1,11 @@
-// Tables
-
 @mixin table-row-variant($state, $background, $border: null) {
   // Exact selectors below required to override `.table-striped` and prevent
   // inheritance to nested tables.
   .table-#{$state} {
-    &,
-    > th,
-    > td {
-      background-color: $background;
-    }
+    background-color: $background;
 
     @if $border != null {
-      th,
-      td,
-      thead th,
-      tbody + tbody {
-        border-color: $border;
-      }
-    }
-  }
-
-  // Hover states for `.table-hover`
-  // Note: this is not available for cells or rows within `thead` or `tfoot`.
-  .table-hover {
-    $hover-background: darken($background, 5%);
-
-    .table-#{$state} {
-      &:hover {
-        background-color: $hover-background;
-
-        > td,
-        > th {
-          background-color: $hover-background;
-        }
-      }
+      border-color: $border;
     }
   }
 }

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -59,6 +59,10 @@
       }
     }
 
+    thead {
+      border-color: $gray-900;
+    }
+
     // Prevent breaking of code
     td:first-child > code {
       white-space: nowrap;

--- a/site/content/docs/4.3/content/tables.md
+++ b/site/content/docs/4.3/content/tables.md
@@ -8,7 +8,9 @@ toc: true
 
 ## Overview
 
-Due to the widespread use of `<table>` elements across third-party widgets like calendars and date pickers, Bootstrap's tables are **opt-in**. Add the base class `.table` to any `<table>`, then extend with our optional modifier classes or custom styles. **All table styles are inherited in Bootstrap**, meaning any nested tables will be styled in the same manner as the parent.
+Due to the widespread use of `<table>` elements across third-party widgets like calendars and date pickers, Bootstrap's tables are **opt-in**. Add the base class `.table` to any `<table>`, then extend with our optional modifier classes or custom styles.
+
+**All table styles are inherited in Bootstrap**, meaning any nested tables will be styled in the same manner as the parent. This keeps our selectors fast and lean, and ensures any custom CSS you need is as lightweight as possible, too.
 
 Using the most basic table markup, here's how `.table`-based tables look in Bootstrap.
 
@@ -45,14 +47,47 @@ Using the most basic table markup, here's how `.table`-based tables look in Boot
 </table>
 {{< /example >}}
 
+Since `.table` styles are inherited, nested tables are styled just like their parent. In addition, we've explicitly written our CSS to allow `border` styles to be inherited (normally `border-color` defaults to the current text `color`).
+
+For example, to make your table headers stand out more, consider using a `.border-dark` utility on just the `<thead>` (or if you prefer, on every `<th>`).
+
+{{< example >}}
+<table class="table">
+  <thead class="border-dark">
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+Can't add classes yourself? Change it via custom Sass or CSS.
+
+{{< highlight scss >}}
+thead {
+  border-color: $gray-900;
+}
+{{< /highlight >}}
+
 ## Options
 
 ### Inverted
 
-You can also invert the colors—with light text on dark backgrounds—with `.table-dark`.
+Invert the colors of a table—with light text on dark backgrounds—via [utility classes]({{< docsref "/utilities/api" >}}). Below we've added three classes to accomplish this: `.bg-dark`, `.text-white`, and `.border-gray-700`.
 
 {{< example >}}
-<table class="table table-dark">
+<table class="table bg-dark text-white border-gray-700">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -84,45 +119,10 @@ You can also invert the colors—with light text on dark backgrounds—with `.ta
 </table>
 {{< /example >}}
 
-### Striped rows
+And because this happens with utilities, you have some flexibility in how you style your tables relative to their context. For example, **assuming your page is already dark gray** with lighter text, you don't need to set every utility on the `<table>`—just `.border-gray-700`.
 
-Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
-
-{{< example >}}
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">First</th>
-      <th scope="col">Last</th>
-      <th scope="col">Handle</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>Larry</td>
-      <td>the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</table>
-{{< /example >}}
-
-{{< example >}}
-<table class="table table-striped table-dark">
+{{< example class="bg-dark text-white" >}}
+<table class="table border-gray-700">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -190,8 +190,10 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 </table>
 {{< /example >}}
 
-{{< example >}}
-<table class="table table-bordered table-dark">
+For this dark table, we've assumed a `background-color` and `color` is set by a parent element like `<body>` to help show the `<table>`'s outer border. If that's not the case for you, remember to add `.bg-dark` and `.text-white` to the `<table>`.
+
+{{< example class="bg-dark text-white" >}}
+<table class="table table-bordered border-gray-700">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -261,7 +263,7 @@ Add `.table-borderless` for a table without borders.
 `.table-borderless` can also be used on dark tables.
 
 {{< example >}}
-<table class="table table-borderless table-dark">
+<table class="table table-borderless bg-dark text-white">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -292,9 +294,118 @@ Add `.table-borderless` for a table without borders.
 </table>
 {{< /example >}}
 
+### Striped rows
+
+Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`. You can customize which rows are highlighted by changing the `$table-striped-order` variable from `odd` (default) to `even`.
+
+To ensure background colors also work with striped rows, we use a `background-image` gradient that will overlay onto any `background-color`.
+
+{{< example >}}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td>Larry</td>
+      <td>the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+Works on dark backgrounds:
+
+{{< example >}}
+<table class="table table-striped bg-dark text-white border-gray-700">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td>Larry</td>
+      <td>the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+And also works with table color classes:
+
+{{< example >}}
+<table class="table table-striped">
+  <thead class="table-primary">
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-primary">
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr class="table-primary">
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr class="table-primary">
+      <th scope="row">3</th>
+      <td>Larry</td>
+      <td>the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
 ### Hoverable rows
 
-Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
+Add `.table-hover` to enable a hover state on table rows within a `<tbody>`. To ensure background colors also work with hovered rows, we use a `background-image` gradient that will overlay onto any `background-color`.
 
 {{< example >}}
 <table class="table table-hover">
@@ -328,8 +439,10 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 </table>
 {{< /example >}}
 
+And with hoverable striped tables:
+
 {{< example >}}
-<table class="table table-hover table-dark">
+<table class="table table-striped table-hover">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -340,6 +453,74 @@ Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
   </thead>
   <tbody>
     <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td colspan="2">Larry the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+`.table-hover` also works on dark tables:
+
+{{< example >}}
+<table class="table table-hover bg-dark text-white border-gray-700">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td colspan="2">Larry the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+As well as table row colors:
+
+{{< example >}}
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-primary">
       <th scope="row">1</th>
       <td>Mark</td>
       <td>Otto</td>
@@ -435,9 +616,9 @@ Table cells of `<thead>` are always vertical aligned to the bottom. Table cells 
 </div>
 {{< /example >}}
 
-### Variants
+## Theme colors
 
-Use contextual classes to color table rows or individual cells.
+Use contextual classes from the [our theme colors]({{< docsref "/getting-started/theming" >}}) (generated by the `$theme-colors` Sass map) to color your table rows or individual cells.
 
 <div class="bd-example">
   <table class="table">
@@ -492,10 +673,10 @@ Use contextual classes to color table rows or individual cells.
 </tr>
 {{< /highlight >}}
 
-Regular table background variants are not available with the dark table, however, you may use [text or background utilities]({{< docsref "/utilities/colors" >}}) to achieve similar styles.
+For dark tables, we recommend using our [text or background utilities]({{< docsref "/utilities/colors" >}}) to achieve similar styles.
 
 <div class="bd-example">
-  <table class="table table-dark">
+  <table class="table bg-dark border-gray-700 text-white">
     <thead>
       <tr>
         <th scope="col">#</th>
@@ -575,15 +756,75 @@ Regular table background variants are not available with the dark table, however
 {{< partial "callout-warning-color-assistive-technologies.md" >}}
 {{< /callout >}}
 
+## Nesting
+
+{{< example >}}
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+    <tr>
+      <td colspan="4">
+        <table class="table mb-0">
+          <thead>
+            <tr>
+              <th scope="col">Header</th>
+              <th scope="col">Header</th>
+              <th scope="col">Header</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">A</th>
+              <td>First</td>
+              <td>Last</td>
+            </tr>
+            <tr>
+              <th scope="row">B</th>
+              <td>First</td>
+              <td>Last</td>
+            </tr>
+            <tr>
+              <th scope="row">C</th>
+              <td>First</td>
+              <td>Last</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td>Larry</td>
+      <td>the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+
 ## Anatomy
 
 ### Table head
 
-Similar to tables and dark tables, use the modifier classes `.thead-light` or `.thead-dark` to make `<thead>`s appear light or dark gray.
+Similar to tables and dark tables, use utility classes to create different colors `<thead>` elements. Here we're using a combination of background-color (`.bg-*`), border-color (`.border-*`), and text color (`.color-`) to create different looks.
 
 {{< example >}}
 <table class="table">
-  <thead class="thead-dark">
+  <thead class="bg-dark text-white border-black">
     <tr>
       <th scope="col">#</th>
       <th scope="col">First</th>
@@ -614,7 +855,7 @@ Similar to tables and dark tables, use the modifier classes `.thead-light` or `.
 </table>
 
 <table class="table">
-  <thead class="thead-light">
+  <thead class="bg-light border-gray-500">
     <tr>
       <th scope="col">#</th>
       <th scope="col">First</th>
@@ -635,6 +876,47 @@ Similar to tables and dark tables, use the modifier classes `.thead-light` or `.
       <td>Thornton</td>
       <td>@fat</td>
     </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td>Larry</td>
+      <td>the Bird</td>
+      <td>@twitter</td>
+    </tr>
+  </tbody>
+</table>
+{{< /example >}}
+
+### Table bodies
+
+When multiple `<tbody>`s are present, we automatically add a thicker border between them. By default, this border is twice as think as the rest of the table borders.
+
+{{< example >}}
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First</th>
+      <th scope="col">Last</th>
+      <th scope="col">Handle</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">1</th>
+      <td>Mark</td>
+      <td>Otto</td>
+      <td>@mdo</td>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+      <th scope="row">2</th>
+      <td>Jacob</td>
+      <td>Thornton</td>
+      <td>@fat</td>
+    </tr>
+  </tbody>
+  <tbody>
     <tr>
       <th scope="row">3</th>
       <td>Larry</td>

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -32,7 +32,7 @@ Use border utilities to add or remove an element's borders. Choose from all bord
 
 ## Border color
 
-Change the border color using utilities built on our theme colors.
+Change the border color using utilities built on our theme colors. We've also included a subset of our gray colors to provide more flexibility.
 
 {{< example class="bd-example-border-utils" >}}
 {{< border.inline >}}
@@ -40,7 +40,11 @@ Change the border color using utilities built on our theme colors.
 <span class="border border-{{ .name }}"></span>
 {{- end -}}
 {{< /border.inline >}}
+
 <span class="border border-white"></span>
+<span class="border border-gray-500"></span>
+<span class="border border-gray-700"></span>
+<span class="border border-black"></span>
 {{< /example >}}
 
 ## Border-radius

--- a/site/content/docs/4.3/utilities/colors.md
+++ b/site/content/docs/4.3/utilities/colors.md
@@ -33,6 +33,8 @@ Similar to the contextual text color classes, easily set the background of an el
 <div class="p-3 mb-2 bg-{{ .name }} {{ if or (eq .name "light") (eq .name "warning") }}text-dark{{ else }}text-white{{ end }}">.bg-{{ .name }}</div>
 {{- end -}}
 {{< /colors.inline >}}
+<div class="p-3 mb-2 bg-gray-600 text-white">.bg-gray-600</div>
+<div class="p-3 mb-2 bg-gray-400 text-dark">.bg-gray-400</div>
 <div class="p-3 mb-2 bg-white text-dark">.bg-white</div>
 <div class="p-3 mb-2 bg-transparent text-dark">.bg-transparent</div>
 {{< /example >}}


### PR DESCRIPTION
Alternative to #30193. _This ended up being a couple changes in one, hence the length title, but the two are connected._

---

### De-duped .table-dark

Rather than deviate from the `$theme-colors` pattern we have elsewhere, this PR removes the `.table-dark` for changing the background, color, and border of a `.table`. Instead, this can be accomplished through all utilities.

Also removes thead-dark/thead-light modifiers for utilities.

### New border-color utils

To support the utilities-driven approach for replacing `.table-dark`, I've added a few new `border-color` utilities. These are a subset of our available grays, but I do believe they provide an improved set of options without including all the grays (and thus duplicating `$gray-900` and `$dark` options). The new options have been added to the borders utilities docs page.

### New background-color utils

To match the border utilities, I've added one tint lighter for two gray backgrounds (didn't add `$gray-100` as it's the same as `$light`). This way you can choose from additional gray backgrounds and still have a slight contrast in the border colors. Definitely interested in thoughts on this.

### Updated table docs

This also obviously updates the examples in the tables docs to reflect the new dark table approach, but also clarifies how inheritance comes into play with the table styles and the table borders. It also adds a new multiple `<tbody>` example and tweaks a few other bits and pieces.

https://deploy-preview-30342--twbs-bootstrap.netlify.com/docs/4.3/content/tables/

---

Closes #28480, fixes #27879, nullifies #30046, fixes #28160, and fixes #24529.