### PR TITLE
Fix date inputs heights in safari

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -466,19 +466,6 @@ button,
   border-style: none;
 }
 
-// Remove the default appearance of temporal inputs to avoid a Mobile Safari
-// bug where setting a custom line-height prevents text from being vertically
-// centered within the input.
-// See https://bugs.webkit.org/show_bug.cgi?id=139848
-// and https://github.com/twbs/bootstrap/issues/11266
-
-input[type="date"],
-input[type="time"],
-input[type="datetime-local"],
-input[type="month"] {
-  -webkit-appearance: textfield;
-}
-
 // 1. Textareas should really only resize vertically so they don't break their (horizontal) containers.
 
 textarea {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -15,6 +15,7 @@
   background-color: $input-bg;
   background-clip: padding-box;
   border: $input-border-width solid $input-border-color;
+  appearance: none; // Fix appearance for date inputs in Safari
 
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @include border-radius($input-border-radius, 0);


### PR DESCRIPTION
It seems https://github.com/twbs/bootstrap/issues/11266 is solved in the meantime and this was causing the inputs to shrink (date & time inputs):
![image](https://user-images.githubusercontent.com/11559216/76101917-78eeb400-5fcf-11ea-9802-db459c8e1b85.png)
