### PR TITLE
Update browsers + devices support page to remove IE10, IE11 Mobile

### DIFF
--- a/site/content/docs/4.3/getting-started/browsers-devices.md
+++ b/site/content/docs/4.3/getting-started/browsers-devices.md
@@ -34,7 +34,6 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
       <th>Firefox</th>
       <th>Safari</th>
       <th>Android Browser &amp; WebView</th>
-      <th>Microsoft Edge</th>
     </tr>
   </thead>
   <tbody>
@@ -44,7 +43,6 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
       <td>Supported</td>
       <td class="text-muted">&mdash;</td>
       <td>v6.0+</td>
-      <td>Supported</td>
     </tr>
     <tr>
       <th scope="row">iOS</th>
@@ -52,15 +50,6 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
       <td>Supported</td>
       <td>Supported</td>
       <td class="text-muted">&mdash;</td>
-      <td>Supported</td>
-    </tr>
-    <tr>
-      <th scope="row" class="text-nowrap">Windows 10 Mobile</th>
-      <td class="text-muted">&mdash;</td>
-      <td class="text-muted">&mdash;</td>
-      <td class="text-muted">&mdash;</td>
-      <td class="text-muted">&mdash;</td>
-      <td>Supported</td>
     </tr>
   </tbody>
 </table>
@@ -109,7 +98,7 @@ Unofficially, Bootstrap should look and behave well enough in Chromium and Chrom
 
 ## Internet Explorer
 
-Internet Explorer 11 is supported; IE10 and down is not. Please be aware that some CSS3 properties and HTML5 elements are not fully supported in IE10, or require prefixed properties for full functionality. Visit [Can I use...](https://caniuse.com/) for details on browser support of CSS3 and HTML5 features. **If you require IE8-9 support, use Bootstrap 3.**
+Internet Explorer 11 is supported; IE10 and down is not. Please be aware that some CSS3 properties and HTML5 elements are not fully supported in Internet Explorer, or require prefixed properties for full functionality. Visit [Can I use...](https://caniuse.com/) for details on browser support of CSS3 and HTML5 features. **If you require IE10 support, use Bootstrap 4.**
 
 ## Modals and dropdowns on mobile
 


### PR DESCRIPTION
This PR removes unsupported mobile browsers from supported tables based on the `.browserlistrc` config (https://browserl.ist/?q=%3E%3D+1%25%2C+last+1+major+version%2C+not+dead%2C+Chrome+%3E%3D+60%2C+Firefox+%3E%3D+60%2C+Edge+%3E%3D+15.15063%2C+Explorer+11%2C+iOS+%3E%3D+10%2C+Safari+%3E%3D+10%2C+Android+%3E%3D+6%2C+not+ExplorerMobile+%3C%3D+11).

Also updates info to remove IE10 from desktop support.