### PR TITLE
.browserslistrc: bump the minimum supported version to 16.16299

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,7 +5,7 @@ last 1 major version
 not dead
 Chrome >= 60
 Firefox >= 60
-Edge >= 15.15063
+Edge >= 16.16299
 Explorer 11
 iOS >= 10
 Safari >= 10


### PR DESCRIPTION
This is what is currently supported by Microsoft https://en.wikipedia.org/wiki/Microsoft_Edge#Release_history

Refs #29314