### PR TITLE
Set .btn padding for default sized input-group

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -70,7 +70,7 @@
   > .btn {
     padding: $input-padding-y $input-padding-x;
   }
-  
+
   // Ensure buttons are always above inputs for more visually pleasing borders.
   // This isn't needed for `.input-group-text` since it shares the same border-color
   // as our inputs.

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -67,6 +67,10 @@
 .input-group-append {
   display: flex;
 
+  > .btn {
+    padding: $input-padding-y $input-padding-x;
+  }
+  
   // Ensure buttons are always above inputs for more visually pleasing borders.
   // This isn't needed for `.input-group-text` since it shares the same border-color
   // as our inputs.


### PR DESCRIPTION
This fixes an issue if the default value of `$btn-padding-y` or `$btn-padding-x` has been changed.

When overwriting the default .btn paddings:
```
$btn-padding-y: .625rem;
$btn-padding-x: 1.125rem;
```

This simple `input-group`
```
<div class="input-group">
    <input type="text" class="form-control" placeholder="Name" aria-label="Name" aria-describedby="button-addon2">
    <div class="input-group-append">
        <button class="btn btn-primary" type="button" id="button-addon2">Button</button>
    </div>
</div>
```

Will result in the following:
![image](https://user-images.githubusercontent.com/241080/76419055-ffc0d980-639f-11ea-8777-6e94b8a3215a.png)

The provided fix will result in this:
![image](https://user-images.githubusercontent.com/241080/76419128-241cb600-63a0-11ea-8784-398c8f3b9a7d.png)


This issue does only happen on the default size of `.input-group` with a `.btn`. There is already a solution for the sized ones: `.input-group-lg` (https://github.com/twbs/bootstrap/blob/2a2b0b5abe7b44b519c9e19e8876b75608979dd0/scss/forms/_input-group.scss#L135) and `.input-group-sm` (https://github.com/twbs/bootstrap/blob/2a2b0b5abe7b44b519c9e19e8876b75608979dd0/scss/forms/_input-group.scss#L154)

It seems like it was also fixed for the non sized `.input-group-text` but the default size `.btn` was not being thought of: https://github.com/twbs/bootstrap/blob/2a2b0b5abe7b44b519c9e19e8876b75608979dd0/scss/forms/_input-group.scss#L102
