### PR TITLE
Grid: switch to margin approach and CSS variables

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -25,12 +25,16 @@
       @each $key, $value in $gutters {
         .g#{$infix}-#{$key},
         .gx#{$infix}-#{$key} {
-          --grid-gutter-x: #{$value};
+          // Use 0px if $value is 0, to prevent the calc(... - 0) bug
+          // stylelint-disable-next-line length-zero-no-unit
+          --grid-gutter-x: #{if($value == 0, 0px, $value)};
         }
 
         .g#{$infix}-#{$key},
         .gy#{$infix}-#{$key} {
-          --grid-gutter-y: #{$value};
+          // Use 0px if $value is 0, to prevent the calc(... - 0) bug
+          // stylelint-disable-next-line length-zero-no-unit
+          --grid-gutter-y: #{if($value == 0, 0px, $value)};
         }
       }
     }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -25,22 +25,12 @@
       @each $key, $value in $gutters {
         .g#{$infix}-#{$key},
         .gx#{$infix}-#{$key} {
-          margin-right: -$value / 2;
-          margin-left: -$value / 2;
-
-          > * {
-            padding-right: $value / 2;
-            padding-left: $value / 2;
-          }
+          --grid-gutter-x: #{$value};
         }
 
         .g#{$infix}-#{$key},
         .gy#{$infix}-#{$key} {
-          margin-top: -$value;
-
-          > * {
-            margin-top: $value;
-          }
+          --grid-gutter-y: #{$value};
         }
       }
     }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,8 +1,10 @@
-// Row
-//
-// Rows contain your columns.
+
 
 @if $enable-grid-classes {
+  // Row
+  //
+  // Rows contain your columns.
+
   .row {
     @include make-row();
 
@@ -10,41 +12,9 @@
       @include make-col-ready();
     }
   }
-}
 
-// Gutters
-//
-// Make use of `.g-*`, `.gx-*` or `.gy-*` utilities to change spacing between the columns.
-
-@if $enable-grid-classes {
-  @each $breakpoint in map-keys($grid-breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-
-    @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
-
-      @each $key, $value in $gutters {
-        .g#{$infix}-#{$key},
-        .gx#{$infix}-#{$key} {
-          // Use 0px if $value is 0, to prevent the calc(... - 0) bug
-          // stylelint-disable-next-line length-zero-no-unit
-          --grid-gutter-x: #{if($value == 0, 0px, $value)};
-        }
-
-        .g#{$infix}-#{$key},
-        .gy#{$infix}-#{$key} {
-          // Use 0px if $value is 0, to prevent the calc(... - 0) bug
-          // stylelint-disable-next-line length-zero-no-unit
-          --grid-gutter-y: #{if($value == 0, 0px, $value)};
-        }
-      }
-    }
-  }
-}
-
-// Columns
-//
-// Common styles for small and large grid columns
-
-@if $enable-grid-classes {
+  // Columns
+  //
+  // Common styles for small and large grid columns
   @include make-grid-columns();
 }

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -83,6 +83,7 @@ $utilities: map-merge(
     "width": (
       property: width,
       class: w,
+      responsive: true,
       values: (
         25: 25%,
         50: 50%,

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -18,7 +18,7 @@
   // Prevent columns from becoming too narrow when at smaller grid tiers by
   // always setting `width: 100%;`. This works because we set the width
   // later on to override this initial width.
-  flex-shrink: 0;
+  flex: 0 0 100%;
   min-width: 0; // See https://github.com/twbs/bootstrap/issues/25410
   max-width: calc(100% - var(--grid-gutter-x)); // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
   margin-top: var(--grid-gutter-y);
@@ -58,6 +58,12 @@
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {
+
+      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
+      .col#{$infix} {
+        flex: 1 0 0;
+      }
+
       @for $i from 1 through $grid-row-columns {
         .row-cols#{$infix}-#{$i} {
           @include row-cols($i);
@@ -67,11 +73,6 @@
       .col#{$infix}-auto,
       .row-cols#{$infix}-auto > * {
         @include make-col-auto();
-      }
-
-      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
-      .col#{$infix} {
-        flex: 1 0 0;
       }
 
       @for $i from 1 through $columns {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -1,40 +1,40 @@
+// stylelint-disable function-blacklist
 /// Grid system
 //
 // Generate semantic grid columns with these mixins.
 
 @mixin make-row($gutter: $grid-gutter-width) {
+  --grid-gutter-x: #{$gutter};
+  --grid-gutter-y: #{$gutter};
   display: flex;
   flex-wrap: wrap;
-  margin-right: -$gutter / 2;
-  margin-left: -$gutter / 2;
+  margin-top: calc(var(--grid-gutter-y) * -1);
+  margin-left: calc(var(--grid-gutter-x) * -1);
 }
 
-@mixin make-col-ready($gutter: $grid-gutter-width) {
+@mixin make-col-ready($gutter: var(--grid-gutter-x)) {
   // Add box sizing if only the grid is loaded
   box-sizing: if(variable-exists(include-column-box-sizing) and $include-column-box-sizing, border-box, null);
   // Prevent columns from becoming too narrow when at smaller grid tiers by
   // always setting `width: 100%;`. This works because we set the width
   // later on to override this initial width.
   flex-shrink: 0;
-  width: 100%;
-  max-width: 100%; // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
-  padding-right: $gutter / 2;
-  padding-left: $gutter / 2;
+  min-width: 0; // See https://github.com/twbs/bootstrap/issues/25410
+  max-width: calc(100% - var(--grid-gutter-x)); // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
+  margin-top: var(--grid-gutter-y);
+  margin-left: var(--grid-gutter-x);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 auto;
-  width: percentage($size / $columns);
+  flex: 0 0 calc(#{percentage($size / $columns)} - var(--grid-gutter-x));
 }
 
 @mixin make-col-auto() {
   flex: 0 0 auto;
-  width: auto;
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  $num: $size / $columns;
-  margin-left: if($num == 0, 0, percentage($num));
+  margin-left: calc(#{percentage($size / $columns)} + var(--grid-gutter-x));
 }
 
 // Row columns
@@ -44,8 +44,7 @@
 // style grid.
 @mixin row-cols($count) {
   & > * {
-    flex: 0 0 auto;
-    width: 100% / $count;
+    flex: 0 0 calc(#{100% / $count} - var(--grid-gutter-x));
   }
 }
 
@@ -59,12 +58,6 @@
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {
-      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
-      .col#{$infix} {
-        flex: 1 0 0%; // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
-        min-width: 0; // See https://github.com/twbs/bootstrap/issues/25410
-      }
-
       .row-cols#{$infix}-auto > * {
         @include make-col-auto();
       }
@@ -73,6 +66,11 @@
         .row-cols#{$infix}-#{$i} {
           @include row-cols($i);
         }
+      }
+
+      // Provide basic `.col-{bp}` classes for equal-width flexbox columns
+      .col#{$infix} {
+        flex: 1 0 0;
       }
 
       .col#{$infix}-auto {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -58,23 +58,20 @@
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {
-      .row-cols#{$infix}-auto > * {
-        @include make-col-auto();
-      }
-
       @for $i from 1 through $grid-row-columns {
         .row-cols#{$infix}-#{$i} {
           @include row-cols($i);
         }
       }
 
+      .col#{$infix}-auto,
+      .row-cols#{$infix}-auto > * {
+        @include make-col-auto();
+      }
+
       // Provide basic `.col-{bp}` classes for equal-width flexbox columns
       .col#{$infix} {
         flex: 1 0 0;
-      }
-
-      .col#{$infix}-auto {
-        @include make-col-auto();
       }
 
       @for $i from 1 through $columns {
@@ -90,6 +87,27 @@
             @include make-col-offset($i, $columns);
           }
         }
+      }
+
+      // Gutters
+      //
+      // Make use of `.g-*`, `.gx-*` or `.gy-*` utilities to change spacing between the columns.
+      // Use 0px if $value is 0, to prevent the calc(... - 0) bug
+      @each $key, $value in $gutters {
+        // stylelint-disable length-zero-no-unit
+        .g#{$infix}-#{$key} {
+          --grid-gutter-x: #{if($value == 0, 0px, $value)};
+          --grid-gutter-y: #{if($value == 0, 0px, $value)};
+        }
+
+        .gx#{$infix}-#{$key} {
+          --grid-gutter-x: #{if($value == 0, 0px, $value)};
+        }
+
+        .gy#{$infix}-#{$key} {
+          --grid-gutter-y: #{if($value == 0, 0px, $value)};
+        }
+        // stylelint-enable length-zero-no-unit
       }
     }
   }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -1,5 +1,3 @@
-// stylelint-disable no-duplicate-selectors
-
 //
 // Grid examples
 //
@@ -11,6 +9,11 @@
       padding: .75rem;
       background-color: rgba(39, 41, 43, .03);
       border: 1px solid rgba(39, 41, 43, .1);
+
+      // Show class if divs are empty
+      &:empty::after {
+        content: attr(class);
+      }
     }
   }
 
@@ -22,6 +25,8 @@
 .bd-example-row-flex-cols .row {
   min-height: 10rem;
   background-color: rgba(255, 0, 0, .1);
+  // Counteract row margins:
+  box-shadow: inset $grid-gutter-width $grid-gutter-width $body-bg;
 }
 
 .bd-highlight {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -8,8 +8,7 @@
   .row {
     > .col,
     > [class^="col-"] {
-      padding-top: .75rem;
-      padding-bottom: .75rem;
+      padding: .75rem;
       background-color: rgba(39, 41, 43, .03);
       border: 1px solid rgba(39, 41, 43, .1);
     }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -15,7 +15,7 @@
   }
 
   .row + .row {
-    margin-top: 1rem;
+    margin-top: 0;
   }
 }
 
@@ -27,15 +27,6 @@
 .bd-highlight {
   background-color: rgba($bd-purple, .15);
   border: 1px solid rgba($bd-purple, .15);
-}
-
-.bd-example-responsive-containers {
-  [class^="container"] {
-    padding-top: .75rem;
-    padding-bottom: .75rem;
-    background-color: rgba(86, 61, 124, .15);
-    border: 1px solid rgba(86, 61, 124, .2);
-  }
 }
 
 // Grid mixins

--- a/site/content/docs/4.3/components/card.md
+++ b/site/content/docs/4.3/components/card.md
@@ -571,7 +571,7 @@ Use the Bootstrap grid system and its [`.row-cols` classes]({{< docsref "/layout
 Change it to `.row-cols-3` and you'll see the fourth card wrap.
 
 {{< example >}}
-<div class="row row-cols-md-3 g-4">
+<div class="row row-cols-md-3">
   <div class="card">
     {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
     <div class="card-body">
@@ -607,7 +607,7 @@ Change it to `.row-cols-3` and you'll see the fourth card wrap.
 Just like with card groups, card footers will automatically line up.
 
 {{< example >}}
-<div class="row row-cols-1 row-cols-md-3 g-4">
+<div class="row row-cols-1 row-cols-md-3">
   <div class="card">
     {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
     <div class="card-body">

--- a/site/content/docs/4.3/components/card.md
+++ b/site/content/docs/4.3/components/card.md
@@ -536,7 +536,7 @@ When using card groups with footers, their content will automatically line up.
 Use the Bootstrap grid system and its [`.row-cols` classes]({{< docsref "/layout/grid#row-columns" >}}) to control how many grid columns (wrapped around your cards) you show per row. For example, here's `.row-cols-1` laying out the cards on one column, and `.row-cols-md-2` splitting four cards to equal width across multiple rows, from the medium breakpoint up.
 
 {{< example >}}
-<div class="row row-cols-md-2 g-4">
+<div class="row row-cols-md-2">
   <div class="card">
     {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
     <div class="card-body">

--- a/site/content/docs/4.3/components/card.md
+++ b/site/content/docs/4.3/components/card.md
@@ -536,41 +536,33 @@ When using card groups with footers, their content will automatically line up.
 Use the Bootstrap grid system and its [`.row-cols` classes]({{< docsref "/layout/grid#row-columns" >}}) to control how many grid columns (wrapped around your cards) you show per row. For example, here's `.row-cols-1` laying out the cards on one column, and `.row-cols-md-2` splitting four cards to equal width across multiple rows, from the medium breakpoint up.
 
 {{< example >}}
-<div class="row row-cols-1 row-cols-md-2 g-4">
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+<div class="row row-cols-md-2 g-4">
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
 </div>
@@ -579,127 +571,71 @@ Use the Bootstrap grid system and its [`.row-cols` classes]({{< docsref "/layout
 Change it to `.row-cols-3` and you'll see the fourth card wrap.
 
 {{< example >}}
-<div class="row row-cols-1 row-cols-md-3 g-4">
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+<div class="row row-cols-md-3 g-4">
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content.</p>
     </div>
   </div>
-  <div class="col">
-    <div class="card">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
 </div>
 {{< /example >}}
 
-When you need equal height, add `.h-100` to the cards. If you want equal heights by default, you can set `$card-height: 100%` in Sass.
-
-{{< example >}}
-<div class="row row-cols-1 row-cols-md-3 g-4">
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
-    </div>
-  </div>
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a short card.</p>
-      </div>
-    </div>
-  </div>
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content.</p>
-      </div>
-    </div>
-  </div>
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="140" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
-    </div>
-  </div>
-</div>
-{{< /example >}}
 
 Just like with card groups, card footers will automatically line up.
 
 {{< example >}}
 <div class="row row-cols-1 row-cols-md-3 g-4">
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      </div>
-      <div class="card-footer">
-        <small class="text-muted">Last updated 3 mins ago</small>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    </div>
+    <div class="card-footer">
+      <small class="text-muted">Last updated 3 mins ago</small>
     </div>
   </div>
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
-      </div>
-      <div class="card-footer">
-        <small class="text-muted">Last updated 3 mins ago</small>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+    </div>
+    <div class="card-footer">
+      <small class="text-muted">Last updated 3 mins ago</small>
     </div>
   </div>
-  <div class="col">
-    <div class="card h-100">
-      {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
-      <div class="card-body">
-        <h5 class="card-title">Card title</h5>
-        <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
-      </div>
-      <div class="card-footer">
-        <small class="text-muted">Last updated 3 mins ago</small>
-      </div>
+  <div class="card">
+    {{< placeholder width="100%" height="180" class="card-img-top" text="Image cap" >}}
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+    </div>
+    <div class="card-footer">
+      <small class="text-muted">Last updated 3 mins ago</small>
     </div>
   </div>
 </div>

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -804,10 +804,10 @@ To nest your content with the default grid, add a new `.row` and set of `.col-sm
 The `.col-*` classes can also be used outside a `.row` to give an element a specific width. Whenever column classes are used as non direct children of a row, the paddings are omitted.
 
 {{< example >}}
-<div class="col-3 bg-light p-3 border">
+<div class="w-25 bg-light p-3 border">
   .col-3: width of 25%
 </div>
-<div class="col-sm-9 bg-light p-3 border">
+<div class="w-75 bg-light p-3 border">
   .col-sm-9: width of 75% above sm breakpoint
 </div>
 {{< /example >}}
@@ -816,7 +816,7 @@ The classes can be used together with utilities to create responsive floated ima
 
 {{< example >}}
 <div class="clearfix">
-  {{< placeholder width="100%" height="210" class="col-md-6 float-md-right mb-3 ml-md-3" text="Responsive floated image" >}}
+  {{< placeholder width="100%" height="210" class="w-md-50 float-md-right mb-3 ml-md-3" text="Responsive floated image" >}}
 
   <p>
     Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris paddenstoel nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -212,14 +212,14 @@ For grids that are the same from the smallest of devices to the largest, use the
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col">col</div>
-  <div class="col">col</div>
-  <div class="col">col</div>
-  <div class="col">col</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 <div class="row">
-  <div class="col-8">col-8</div>
-  <div class="col-4">col-4</div>
+  <div class="col-8"></div>
+  <div class="col-4"></div>
 </div>
 {{< /example >}}
 
@@ -229,13 +229,13 @@ Using a single set of `.col-sm-*` classes, you can create a basic grid system th
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-sm-8">col-sm-8</div>
-  <div class="col-sm-4">col-sm-4</div>
+  <div class="col-sm-8"></div>
+  <div class="col-sm-4"></div>
 </div>
 <div class="row">
-  <div class="col-sm">col-sm</div>
-  <div class="col-sm">col-sm</div>
-  <div class="col-sm">col-sm</div>
+  <div class="col-sm"></div>
+  <div class="col-sm"></div>
+  <div class="col-sm"></div>
 </div>
 {{< /example >}}
 
@@ -246,21 +246,21 @@ Don't want your columns to simply stack in some grid tiers? Use a combination of
 {{< example class="bd-example-row" >}}
 <!-- Stack the columns on mobile by making one full-width and the other half-width -->
 <div class="row">
-  <div class="col-md-8">.col-md-8</div>
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+  <div class="col-md-8"></div>
+  <div class="col-6 col-md-4"></div>
 </div>
 
 <!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
 <div class="row">
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+  <div class="col-6 col-md-4"></div>
+  <div class="col-6 col-md-4"></div>
+  <div class="col-6 col-md-4"></div>
 </div>
 
 <!-- Columns are always 50% wide, on mobile and desktop -->
 <div class="row">
-  <div class="col-6">.col-6</div>
-  <div class="col-6">.col-6</div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
 </div>
 {{< /example >}}
 
@@ -272,55 +272,55 @@ Use these row columns classes to quickly create basic grid layouts or to control
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-2">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-3">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-auto">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-4">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-4">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col-6">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col-6"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
 <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4">
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
-  <div class="col">Column</div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
@@ -362,14 +362,10 @@ $gutters: (
 
 `.gx-*` classes can be used to control the horizontal gutter widths:
 
-{{< example >}}
+{{< example class="bd-example-row" >}}
 <div class="row gx-5">
-  <div class="col">
-   <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
@@ -377,20 +373,12 @@ $gutters: (
 
 `.gy-*` classes can be used to control the vertical gutter widths:
 
-{{< example >}}
+{{< example class="bd-example-row" >}}
 <div class="row gy-5">
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
 </div>
 {{< /example >}}
 
@@ -398,20 +386,12 @@ $gutters: (
 
 `.g-*` classes can be used to control the horizontal gutter widths, for the following example we use a smaller gutter width, so there won't be a need to add the `.overflow-hidden` wrapper class.
 
-{{< example >}}
+{{< example class="bd-example-row" >}}
 <div class="row g-2">
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
-  <div class="col-6">
-    <div class="p-3 border bg-light">Custom column padding</div>
-  </div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
+  <div class="col-6"></div>
 </div>
 {{< /example >}}
 
@@ -419,38 +399,18 @@ $gutters: (
 
 Gutter classes can also be added to [row columns](#row-columns). In the following example, we use responsive row columns and responsive gutter classes.
 
-{{< example >}}
+{{< example class="bd-example-row" >}}
 <div class="row row-cols-2 row-cols-lg-5 g-2 g-lg-3">
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
-  <div class="col">
-    <div class="p-3 border bg-light">Row column</div>
-  </div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
@@ -462,8 +422,8 @@ In practice, here's how it looks. Note you can continue to use this with all oth
 
 {{< example class="bd-example-row" >}}
 <div class="row g-0">
-  <div class="col-sm-6 col-md-8">.col-sm-6 .col-md-8</div>
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+  <div class="col-sm-6 col-md-8"></div>
+  <div class="col-6 col-md-4"></div>
 </div>
 {{< /example >}}
 
@@ -475,51 +435,27 @@ Use flexbox alignment utilities to vertically and horizontally align columns. **
 
 {{< example class="bd-example-row bd-example-row-flex-cols" >}}
 <div class="row align-items-start">
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 <div class="row align-items-center">
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 <div class="row align-items-end">
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
-  <div class="col">
-    One of three columns
-  </div>
+  <div class="col"></div>
+  <div class="col"></div>
+  <div class="col"></div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row bd-example-row-flex-cols" >}}
 <div class="row">
-  <div class="col align-self-start">
-    One of three columns
-  </div>
-  <div class="col align-self-center">
-    One of three columns
-  </div>
-  <div class="col align-self-end">
-    One of three columns
-  </div>
+  <div class="col align-self-start"></div>
+  <div class="col align-self-center"></div>
+  <div class="col align-self-end"></div>
 </div>
 {{< /example >}}
 
@@ -527,44 +463,24 @@ Use flexbox alignment utilities to vertically and horizontally align columns. **
 
 {{< example class="bd-example-row" >}}
 <div class="row justify-content-start">
-  <div class="col-4">
-    One of two columns
-  </div>
-  <div class="col-4">
-    One of two columns
-  </div>
+  <div class="col-4"></div>
+  <div class="col-4"></div>
 </div>
 <div class="row justify-content-center">
-  <div class="col-4">
-    One of two columns
-  </div>
-  <div class="col-4">
-    One of two columns
-  </div>
+  <div class="col-4"></div>
+  <div class="col-4"></div>
 </div>
 <div class="row justify-content-end">
-  <div class="col-4">
-    One of two columns
-  </div>
-  <div class="col-4">
-    One of two columns
-  </div>
+  <div class="col-4"></div>
+  <div class="col-4"></div>
 </div>
 <div class="row justify-content-around">
-  <div class="col-4">
-    One of two columns
-  </div>
-  <div class="col-4">
-    One of two columns
-  </div>
+  <div class="col-4"></div>
+  <div class="col-4"></div>
 </div>
 <div class="row justify-content-between">
-  <div class="col-4">
-    One of two columns
-  </div>
-  <div class="col-4">
-    One of two columns
-  </div>
+  <div class="col-4"></div>
+  <div class="col-4"></div>
 </div>
 {{< /example >}}
 
@@ -574,26 +490,26 @@ If more than 12 columns are placed within a single row, each group of extra colu
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-9">.col-9</div>
-  <div class="col-4">.col-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
-  <div class="col-6">.col-6<br>Subsequent columns continue along the new line.</div>
+  <div class="col-9">col-9</div>
+  <div class="col-4">col-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
+  <div class="col-6">col-6<br>Subsequent columns continue along the new line.</div>
 </div>
 {{< /example >}}
 
 ### Column breaks
 
-Breaking columns to a new line in flexbox requires a small hack: add an element with `width: 100%` wherever you want to wrap your columns to a new line. Normally this is accomplished with multiple `.row`s, but not every implementation method can account for this.
+Breaking columns to a new line in flexbox requires a small hack: add an element with `width: 100%` and `margin: 0` wherever you want to wrap your columns to a new line. Normally this is accomplished with multiple `.row`s, but not every implementation method can account for this.
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+  <div class="col-6 col-sm-3"></div>
+  <div class="col-6 col-sm-3"></div>
 
   <!-- Force next columns to break to new line -->
-  <div class="w-100"></div>
+  <div class="w-100 m-0"></div>
 
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+  <div class="col-6 col-sm-3"></div>
+  <div class="col-6 col-sm-3"></div>
 </div>
 {{< /example >}}
 
@@ -601,14 +517,14 @@ You may also apply this break at specific breakpoints with our [responsive displ
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+  <div class="col-6 col-sm-4"></div>
+  <div class="col-6 col-sm-4"></div>
 
   <!-- Force next columns to break to new line at md breakpoint and up -->
   <div class="w-100 d-none d-md-block"></div>
 
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+  <div class="col-6 col-sm-4"></div>
+  <div class="col-6 col-sm-4"></div>
 </div>
 {{< /example >}}
 
@@ -658,15 +574,15 @@ Move columns to the right using `.offset-md-*` classes. These classes increase t
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-md-4">.col-md-4</div>
-  <div class="col-md-4 offset-md-4">.col-md-4 .offset-md-4</div>
+  <div class="col-md-4"></div>
+  <div class="col-md-4 offset-md-4"></div>
 </div>
 <div class="row">
-  <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
-  <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
+  <div class="col-md-3 offset-md-3"></div>
+  <div class="col-md-3 offset-md-3"></div>
 </div>
 <div class="row">
-  <div class="col-md-6 offset-md-3">.col-md-6 .offset-md-3</div>
+  <div class="col-md-6 offset-md-3"></div>
 </div>
 {{< /example >}}
 
@@ -674,12 +590,12 @@ In addition to column clearing at responsive breakpoints, you may need to reset 
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
-  <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
+  <div class="col-sm-5 col-md-6"></div>
+  <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0"></div>
 </div>
 <div class="row">
-  <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
-  <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
+  <div class="col-sm-6 col-md-5 col-lg-6"></div>
+  <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0"></div>
 </div>
 {{< /example >}}
 
@@ -689,16 +605,16 @@ With the move to flexbox in v4, you can use margin utilities like `.mr-auto` to 
 
 {{< example class="bd-example-row" >}}
 <div class="row">
-  <div class="col-md-4">.col-md-4</div>
-  <div class="col-md-4 ml-auto">.col-md-4 .ml-auto</div>
+  <div class="col-md-4"></div>
+  <div class="col-md-4 ml-auto"></div>
 </div>
 <div class="row">
-  <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
-  <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
+  <div class="col-md-3 ml-md-auto"></div>
+  <div class="col-md-3 ml-md-auto"></div>
 </div>
 <div class="row">
-  <div class="col-auto mr-auto">.col-auto .mr-auto</div>
-  <div class="col-auto">.col-auto</div>
+  <div class="col-auto mr-auto"></div>
+  <div class="col-auto"></div>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -13,17 +13,15 @@ Bootstrap's grid system uses a series of containers, rows, and columns to layout
 **New to or unfamiliar with flexbox?** [Read this CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-sm">
-      One of three columns
-    </div>
-    <div class="col-sm">
-      One of three columns
-    </div>
-    <div class="col-sm">
-      One of three columns
-    </div>
+<div class="row">
+  <div class="col-sm">
+    One of three columns
+  </div>
+  <div class="col-sm">
+    One of three columns
+  </div>
+  <div class="col-sm">
+    One of three columns
   </div>
 </div>
 {{< /example >}}
@@ -125,25 +123,23 @@ Utilize breakpoint-specific column classes for easy column sizing without an exp
 For example, here are two grid layouts that apply to every device and viewport, from `xs` to `xl`. Add any number of unit-less classes for each breakpoint you need and every column will be the same width.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col">
-      1 of 2
-    </div>
-    <div class="col">
-      2 of 2
-    </div>
+<div class="row">
+  <div class="col">
+    1 of 2
   </div>
-  <div class="row">
-    <div class="col">
-      1 of 3
-    </div>
-    <div class="col">
-      2 of 3
-    </div>
-    <div class="col">
-      3 of 3
-    </div>
+  <div class="col">
+    2 of 2
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    1 of 3
+  </div>
+  <div class="col">
+    2 of 3
+  </div>
+  <div class="col">
+    3 of 3
   </div>
 </div>
 {{< /example >}}
@@ -153,28 +149,26 @@ For example, here are two grid layouts that apply to every device and viewport, 
 Auto-layout for flexbox grid columns also means you can set the width of one column and have the sibling columns automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths. Note that the other columns will resize no matter the width of the center column.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col">
-      1 of 3
-    </div>
-    <div class="col-6">
-      2 of 3 (wider)
-    </div>
-    <div class="col">
-      3 of 3
-    </div>
+<div class="row">
+  <div class="col">
+    1 of 3
   </div>
-  <div class="row">
-    <div class="col">
-      1 of 3
-    </div>
-    <div class="col-5">
-      2 of 3 (wider)
-    </div>
-    <div class="col">
-      3 of 3
-    </div>
+  <div class="col-6">
+    2 of 3 (wider)
+  </div>
+  <div class="col">
+    3 of 3
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    1 of 3
+  </div>
+  <div class="col-5">
+    2 of 3 (wider)
+  </div>
+  <div class="col">
+    3 of 3
   </div>
 </div>
 {{< /example >}}
@@ -184,28 +178,26 @@ Auto-layout for flexbox grid columns also means you can set the width of one col
 Use `col-{breakpoint}-auto` classes to size columns based on the natural width of their content.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row justify-content-md-center">
-    <div class="col col-lg-2">
-      1 of 3
-    </div>
-    <div class="col-md-auto">
-      Variable width content
-    </div>
-    <div class="col col-lg-2">
-      3 of 3
-    </div>
+<div class="row justify-content-md-center">
+  <div class="col col-lg-2">
+    1 of 3
   </div>
-  <div class="row">
-    <div class="col">
-      1 of 3
-    </div>
-    <div class="col-md-auto">
-      Variable width content
-    </div>
-    <div class="col col-lg-2">
-      3 of 3
-    </div>
+  <div class="col-md-auto">
+    Variable width content
+  </div>
+  <div class="col col-lg-2">
+    3 of 3
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    1 of 3
+  </div>
+  <div class="col-md-auto">
+    Variable width content
+  </div>
+  <div class="col col-lg-2">
+    3 of 3
   </div>
 </div>
 {{< /example >}}
@@ -219,17 +211,15 @@ Bootstrap's grid includes five tiers of predefined classes for building complex 
 For grids that are the same from the smallest of devices to the largest, use the `.col` and `.col-*` classes. Specify a numbered class when you need a particularly sized column; otherwise, feel free to stick to `.col`.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col">col</div>
-    <div class="col">col</div>
-    <div class="col">col</div>
-    <div class="col">col</div>
-  </div>
-  <div class="row">
-    <div class="col-8">col-8</div>
-    <div class="col-4">col-4</div>
-  </div>
+<div class="row">
+  <div class="col">col</div>
+  <div class="col">col</div>
+  <div class="col">col</div>
+  <div class="col">col</div>
+</div>
+<div class="row">
+  <div class="col-8">col-8</div>
+  <div class="col-4">col-4</div>
 </div>
 {{< /example >}}
 
@@ -238,16 +228,14 @@ For grids that are the same from the smallest of devices to the largest, use the
 Using a single set of `.col-sm-*` classes, you can create a basic grid system that starts out stacked and becomes horizontal at the small breakpoint (`sm`).
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-sm-8">col-sm-8</div>
-    <div class="col-sm-4">col-sm-4</div>
-  </div>
-  <div class="row">
-    <div class="col-sm">col-sm</div>
-    <div class="col-sm">col-sm</div>
-    <div class="col-sm">col-sm</div>
-  </div>
+<div class="row">
+  <div class="col-sm-8">col-sm-8</div>
+  <div class="col-sm-4">col-sm-4</div>
+</div>
+<div class="row">
+  <div class="col-sm">col-sm</div>
+  <div class="col-sm">col-sm</div>
+  <div class="col-sm">col-sm</div>
 </div>
 {{< /example >}}
 
@@ -256,25 +244,23 @@ Using a single set of `.col-sm-*` classes, you can create a basic grid system th
 Don't want your columns to simply stack in some grid tiers? Use a combination of different classes for each tier as needed. See the example below for a better idea of how it all works.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <!-- Stack the columns on mobile by making one full-width and the other half-width -->
-  <div class="row">
-    <div class="col-md-8">.col-md-8</div>
-    <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-  </div>
+<!-- Stack the columns on mobile by making one full-width and the other half-width -->
+<div class="row">
+  <div class="col-md-8">.col-md-8</div>
+  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+</div>
 
-  <!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
-  <div class="row">
-    <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-    <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-    <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-  </div>
+<!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
+<div class="row">
+  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+</div>
 
-  <!-- Columns are always 50% wide, on mobile and desktop -->
-  <div class="row">
-    <div class="col-6">.col-6</div>
-    <div class="col-6">.col-6</div>
-  </div>
+<!-- Columns are always 50% wide, on mobile and desktop -->
+<div class="row">
+  <div class="col-6">.col-6</div>
+  <div class="col-6">.col-6</div>
 </div>
 {{< /example >}}
 
@@ -285,68 +271,56 @@ Use the responsive `.row-cols-*` classes to quickly set the number of columns th
 Use these row columns classes to quickly create basic grid layouts or to control your card layouts.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-2">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-2">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-3">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-3">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-auto">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-auto">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-4">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-4">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-4">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col-6">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-4">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col-6">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-1 row-cols-sm-2 row-cols-md-4">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-  </div>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-4">
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
+  <div class="col">Column</div>
 </div>
 {{< /example >}}
 
@@ -386,55 +360,36 @@ $gutters: (
 
 ### Horizontal gutters
 
-`.gx-*` classes can be used to control the horizontal gutter widths. The `.container` or `.container-fluid` parent may need to be adjusted if larger gutters are used too to avoid unwanted overflow, using a matching padding utility. For example, in the following example we've increased the padding with `.px-4`:
+`.gx-*` classes can be used to control the horizontal gutter widths:
 
 {{< example >}}
-<div class="container px-4">
-  <div class="row gx-5">
-    <div class="col">
-     <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
+<div class="row gx-5">
+  <div class="col">
+   <div class="p-3 border bg-light">Custom column padding</div>
   </div>
-</div>
-{{< /example >}}
-
-An alternative solution is to add a wrapper around the `.row` with the `.overflow-hidden` class:
-
-{{< example >}}
-<div class="container overflow-hidden">
-  <div class="row gx-5">
-    <div class="col">
-     <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Custom column padding</div>
   </div>
 </div>
 {{< /example >}}
 
 ### Vertical gutters
 
-`.gy-*` classes can be used to control the vertical gutter widths. Like the horizontal gutters, the vertical gutters can cause some overflow below the `.row` at the end of a page. If this occurs, you add a wrapper around `.row` with the `.overflow-hidden` class:
+`.gy-*` classes can be used to control the vertical gutter widths:
 
 {{< example >}}
-<div class="container overflow-hidden">
-  <div class="row gy-5">
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
+<div class="row gy-5">
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
   </div>
 </div>
 {{< /example >}}
@@ -444,20 +399,18 @@ An alternative solution is to add a wrapper around the `.row` with the `.overflo
 `.g-*` classes can be used to control the horizontal gutter widths, for the following example we use a smaller gutter width, so there won't be a need to add the `.overflow-hidden` wrapper class.
 
 {{< example >}}
-<div class="container">
-  <div class="row g-2">
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
-    <div class="col-6">
-      <div class="p-3 border bg-light">Custom column padding</div>
-    </div>
+<div class="row g-2">
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
+  </div>
+  <div class="col-6">
+    <div class="p-3 border bg-light">Custom column padding</div>
   </div>
 </div>
 {{< /example >}}
@@ -467,38 +420,36 @@ An alternative solution is to add a wrapper around the `.row` with the `.overflo
 Gutter classes can also be added to [row columns](#row-columns). In the following example, we use responsive row columns and responsive gutter classes.
 
 {{< example >}}
-<div class="container">
-  <div class="row row-cols-2 row-cols-lg-5 g-2 g-lg-3">
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
-    <div class="col">
-      <div class="p-3 border bg-light">Row column</div>
-    </div>
+<div class="row row-cols-2 row-cols-lg-5 g-2 g-lg-3">
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
+  </div>
+  <div class="col">
+    <div class="p-3 border bg-light">Row column</div>
   </div>
 </div>
 {{< /example >}}
@@ -506,8 +457,6 @@ Gutter classes can also be added to [row columns](#row-columns). In the followin
 ### No gutters
 
 The gutters between columns in our predefined grid classes can be removed with `.g-0`. This removes the negative `margin`s from `.row` and the horizontal `padding` from all immediate children columns.
-
-**Need an edge-to-edge design?** Drop the parent `.container` or `.container-fluid`.
 
 In practice, here's how it looks. Note you can continue to use this with all other predefined grid classes (including column widths, responsive tiers, reorders, and more).
 
@@ -525,55 +474,51 @@ Use flexbox alignment utilities to vertically and horizontally align columns. **
 ### Vertical alignment
 
 {{< example class="bd-example-row bd-example-row-flex-cols" >}}
-<div class="container">
-  <div class="row align-items-start">
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
+<div class="row align-items-start">
+  <div class="col">
+    One of three columns
   </div>
-  <div class="row align-items-center">
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
+  <div class="col">
+    One of three columns
   </div>
-  <div class="row align-items-end">
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
-    <div class="col">
-      One of three columns
-    </div>
+  <div class="col">
+    One of three columns
+  </div>
+</div>
+<div class="row align-items-center">
+  <div class="col">
+    One of three columns
+  </div>
+  <div class="col">
+    One of three columns
+  </div>
+  <div class="col">
+    One of three columns
+  </div>
+</div>
+<div class="row align-items-end">
+  <div class="col">
+    One of three columns
+  </div>
+  <div class="col">
+    One of three columns
+  </div>
+  <div class="col">
+    One of three columns
   </div>
 </div>
 {{< /example >}}
 
 {{< example class="bd-example-row bd-example-row-flex-cols" >}}
-<div class="container">
-  <div class="row">
-    <div class="col align-self-start">
-      One of three columns
-    </div>
-    <div class="col align-self-center">
-      One of three columns
-    </div>
-    <div class="col align-self-end">
-      One of three columns
-    </div>
+<div class="row">
+  <div class="col align-self-start">
+    One of three columns
+  </div>
+  <div class="col align-self-center">
+    One of three columns
+  </div>
+  <div class="col align-self-end">
+    One of three columns
   </div>
 </div>
 {{< /example >}}
@@ -581,46 +526,44 @@ Use flexbox alignment utilities to vertically and horizontally align columns. **
 ### Horizontal alignment
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row justify-content-start">
-    <div class="col-4">
-      One of two columns
-    </div>
-    <div class="col-4">
-      One of two columns
-    </div>
+<div class="row justify-content-start">
+  <div class="col-4">
+    One of two columns
   </div>
-  <div class="row justify-content-center">
-    <div class="col-4">
-      One of two columns
-    </div>
-    <div class="col-4">
-      One of two columns
-    </div>
+  <div class="col-4">
+    One of two columns
   </div>
-  <div class="row justify-content-end">
-    <div class="col-4">
-      One of two columns
-    </div>
-    <div class="col-4">
-      One of two columns
-    </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-4">
+    One of two columns
   </div>
-  <div class="row justify-content-around">
-    <div class="col-4">
-      One of two columns
-    </div>
-    <div class="col-4">
-      One of two columns
-    </div>
+  <div class="col-4">
+    One of two columns
   </div>
-  <div class="row justify-content-between">
-    <div class="col-4">
-      One of two columns
-    </div>
-    <div class="col-4">
-      One of two columns
-    </div>
+</div>
+<div class="row justify-content-end">
+  <div class="col-4">
+    One of two columns
+  </div>
+  <div class="col-4">
+    One of two columns
+  </div>
+</div>
+<div class="row justify-content-around">
+  <div class="col-4">
+    One of two columns
+  </div>
+  <div class="col-4">
+    One of two columns
+  </div>
+</div>
+<div class="row justify-content-between">
+  <div class="col-4">
+    One of two columns
+  </div>
+  <div class="col-4">
+    One of two columns
   </div>
 </div>
 {{< /example >}}
@@ -630,12 +573,10 @@ Use flexbox alignment utilities to vertically and horizontally align columns. **
 If more than 12 columns are placed within a single row, each group of extra columns will, as one unit, wrap onto a new line.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-9">.col-9</div>
-    <div class="col-4">.col-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
-    <div class="col-6">.col-6<br>Subsequent columns continue along the new line.</div>
-  </div>
+<div class="row">
+  <div class="col-9">.col-9</div>
+  <div class="col-4">.col-4<br>Since 9 + 4 = 13 &gt; 12, this 4-column-wide div gets wrapped onto a new line as one contiguous unit.</div>
+  <div class="col-6">.col-6<br>Subsequent columns continue along the new line.</div>
 </div>
 {{< /example >}}
 
@@ -644,34 +585,30 @@ If more than 12 columns are placed within a single row, each group of extra colu
 Breaking columns to a new line in flexbox requires a small hack: add an element with `width: 100%` wherever you want to wrap your columns to a new line. Normally this is accomplished with multiple `.row`s, but not every implementation method can account for this.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-    <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+<div class="row">
+  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
-    <!-- Force next columns to break to new line -->
-    <div class="w-100"></div>
+  <!-- Force next columns to break to new line -->
+  <div class="w-100"></div>
 
-    <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-    <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-  </div>
+  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 </div>
 {{< /example >}}
 
 You may also apply this break at specific breakpoints with our [responsive display utilities]({{< docsref "/utilities/display" >}}).
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-    <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+<div class="row">
+  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
 
-    <!-- Force next columns to break to new line at md breakpoint and up -->
-    <div class="w-100 d-none d-md-block"></div>
+  <!-- Force next columns to break to new line at md breakpoint and up -->
+  <div class="w-100 d-none d-md-block"></div>
 
-    <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-    <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-  </div>
+  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
 </div>
 {{< /example >}}
 
@@ -682,17 +619,15 @@ You may also apply this break at specific breakpoints with our [responsive displ
 Use `.order-` classes for controlling the **visual order** of your content. These classes are responsive, so you can set the `order` by breakpoint (e.g., `.order-1.order-md-2`). Includes support for `1` through `5` across all five grid tiers.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col">
-      First in DOM, no order applied
-    </div>
-    <div class="col order-5">
-      Second in DOM, with a larger order
-    </div>
-    <div class="col order-1">
-      Third in DOM, with an order of 1
-    </div>
+<div class="row">
+  <div class="col">
+    First in DOM, no order applied
+  </div>
+  <div class="col order-5">
+    Second in DOM, with a larger order
+  </div>
+  <div class="col order-1">
+    Third in DOM, with an order of 1
   </div>
 </div>
 {{< /example >}}
@@ -700,17 +635,15 @@ Use `.order-` classes for controlling the **visual order** of your content. Thes
 There are also responsive `.order-first` and `.order-last` classes that change the `order` of an element by applying `order: -1` and `order: 6`, respectively. These classes can also be intermixed with the numbered `.order-*` classes as needed.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col order-last">
-      First in DOM, ordered last
-    </div>
-    <div class="col">
-      Second in DOM, unordered
-    </div>
-    <div class="col order-first">
-      Third in DOM, ordered first
-    </div>
+<div class="row">
+  <div class="col order-last">
+    First in DOM, ordered last
+  </div>
+  <div class="col">
+    Second in DOM, unordered
+  </div>
+  <div class="col order-first">
+    Third in DOM, ordered first
   </div>
 </div>
 {{< /example >}}
@@ -724,33 +657,29 @@ You can offset grid columns in two ways: our responsive `.offset-` grid classes 
 Move columns to the right using `.offset-md-*` classes. These classes increase the left margin of a column by `*` columns. For example, `.offset-md-4` moves `.col-md-4` over four columns.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-md-4">.col-md-4</div>
-    <div class="col-md-4 offset-md-4">.col-md-4 .offset-md-4</div>
-  </div>
-  <div class="row">
-    <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
-    <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
-  </div>
-  <div class="row">
-    <div class="col-md-6 offset-md-3">.col-md-6 .offset-md-3</div>
-  </div>
+<div class="row">
+  <div class="col-md-4">.col-md-4</div>
+  <div class="col-md-4 offset-md-4">.col-md-4 .offset-md-4</div>
+</div>
+<div class="row">
+  <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
+  <div class="col-md-3 offset-md-3">.col-md-3 .offset-md-3</div>
+</div>
+<div class="row">
+  <div class="col-md-6 offset-md-3">.col-md-6 .offset-md-3</div>
 </div>
 {{< /example >}}
 
 In addition to column clearing at responsive breakpoints, you may need to reset offsets. See this in action in [the grid example]({{< docsref "/examples/grid" >}}).
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
-    <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
-  </div>
-  <div class="row">
-    <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
-    <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
-  </div>
+<div class="row">
+  <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
+  <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
+</div>
+<div class="row">
+  <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
+  <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
 </div>
 {{< /example >}}
 
@@ -759,19 +688,17 @@ In addition to column clearing at responsive breakpoints, you may need to reset 
 With the move to flexbox in v4, you can use margin utilities like `.mr-auto` to force sibling columns away from one another.
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-md-4">.col-md-4</div>
-    <div class="col-md-4 ml-auto">.col-md-4 .ml-auto</div>
-  </div>
-  <div class="row">
-    <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
-    <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
-  </div>
-  <div class="row">
-    <div class="col-auto mr-auto">.col-auto .mr-auto</div>
-    <div class="col-auto">.col-auto</div>
-  </div>
+<div class="row">
+  <div class="col-md-4">.col-md-4</div>
+  <div class="col-md-4 ml-auto">.col-md-4 .ml-auto</div>
+</div>
+<div class="row">
+  <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
+  <div class="col-md-3 ml-md-auto">.col-md-3 .ml-md-auto</div>
+</div>
+<div class="row">
+  <div class="col-auto mr-auto">.col-auto .mr-auto</div>
+  <div class="col-auto">.col-auto</div>
 </div>
 {{< /example >}}
 
@@ -780,19 +707,17 @@ With the move to flexbox in v4, you can use margin utilities like `.mr-auto` to 
 To nest your content with the default grid, add a new `.row` and set of `.col-sm-*` columns within an existing `.col-sm-*` column. Nested rows should include a set of columns that add up to 12 or fewer (it is not required that you use all 12 available columns).
 
 {{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row">
-    <div class="col-sm-3">
-      Level 1: .col-sm-3
-    </div>
-    <div class="col-sm-9">
-      <div class="row">
-        <div class="col-8 col-sm-6">
-          Level 2: .col-8 .col-sm-6
-        </div>
-        <div class="col-4 col-sm-6">
-          Level 2: .col-4 .col-sm-6
-        </div>
+<div class="row">
+  <div class="col-sm-3">
+    Level 1: .col-sm-3
+  </div>
+  <div class="col-sm-9">
+    <div class="row">
+      <div class="col-8 col-sm-6">
+        Level 2: .col-8 .col-sm-6
+      </div>
+      <div class="col-4 col-sm-6">
+        Level 2: .col-4 .col-sm-6
       </div>
     </div>
   </div>
@@ -801,36 +726,7 @@ To nest your content with the default grid, add a new `.row` and set of `.col-sm
 
 ## Standalone column classes
 
-The `.col-*` classes can also be used outside a `.row` to give an element a specific width. Whenever column classes are used as non direct children of a row, the paddings are omitted.
 
-{{< example >}}
-<div class="w-25 bg-light p-3 border">
-  .col-3: width of 25%
-</div>
-<div class="w-75 bg-light p-3 border">
-  .col-sm-9: width of 75% above sm breakpoint
-</div>
-{{< /example >}}
-
-The classes can be used together with utilities to create responsive floated images. Make sure to wrap the content in a [`.clearfix`]({{< docsref "/helpers/clearfix" >}}) wrapper to clear the float if the text is shorter.
-
-{{< example >}}
-<div class="clearfix">
-  {{< placeholder width="100%" height="210" class="w-md-50 float-md-right mb-3 ml-md-3" text="Responsive floated image" >}}
-
-  <p>
-    Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris paddenstoel nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  </p>
-
-  <p>
-    Sed posuere consectetur est at lobortis. Etiam porta sem malesuada magna mollis euismod. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Id nullam tellus relem amet commodo telemque olemit. Sed posuere consectetur est at lobortis. Maecenas sed diam eget risus varius blandit sit amet non magna. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
-  </p>
-
-  <p>
-    Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lantaarnpaal quam venenatis vestibulum. Donec sed odio dui. Maecenas faucibus mollis interdum. Nullam quis risus eget urna salsa tequila vel eu leo. Donec id elit non mi porta gravida at eget metus.
-  </p>
-</div>
-{{< /example >}}
 
 ## Sass mixins
 

--- a/site/content/docs/4.3/utilities/sizing.md
+++ b/site/content/docs/4.3/utilities/sizing.md
@@ -10,13 +10,41 @@ toc: true
 
 Width and height utilities are generated from the utility API in `_utilities.scss`. Includes support for `25%`, `50%`, `75%`, `100%`, and `auto` by default. Modify those values as you need to generate different utilities here.
 
+### Width utilities
+
 {{< example >}}
-<div class="w-25 p-3" style="background-color: #eee;">Width 25%</div>
-<div class="w-50 p-3" style="background-color: #eee;">Width 50%</div>
-<div class="w-75 p-3" style="background-color: #eee;">Width 75%</div>
-<div class="w-100 p-3" style="background-color: #eee;">Width 100%</div>
-<div class="w-auto p-3" style="background-color: #eee;">Width auto</div>
+<div class="w-25 p-3 bg-light border">Width 25%</div>
+<div class="w-50 p-3 bg-light border">Width 50%</div>
+<div class="w-75 p-3 bg-light border">Width 75%</div>
+<div class="w-100 p-3 bg-light border">Width 100%</div>
+<div class="w-auto p-3 bg-light border">Width auto</div>
 {{< /example >}}
+
+### Responsive width utilities
+
+Responsive variants can be used together with other utilities to create responsive floated images. In the following example the `w-md-50` set the width of the image to 50% above the `md` breakpoint. Make sure to wrap the content in a [`.clearfix`]({{< docsref "/helpers/clearfix" >}}) wrapper to clear the float if the text is shorter.
+
+{{< example >}}
+<div class="clearfix">
+  {{< placeholder width="100%" height="210" class="w-md-50 float-md-right mb-3 ml-md-3" text="Responsive floated image" >}}
+
+  <p>
+    Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue. Fusce dapibus, tellus ac cursus commodo, tortor mauris paddenstoel nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  </p>
+
+  <p>
+    Sed posuere consectetur est at lobortis. Etiam porta sem malesuada magna mollis euismod. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Id nullam tellus relem amet commodo telemque olemit. Sed posuere consectetur est at lobortis. Maecenas sed diam eget risus varius blandit sit amet non magna. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
+  </p>
+
+  <p>
+    Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lantaarnpaal quam venenatis vestibulum. Donec sed odio dui. Maecenas faucibus mollis interdum. Nullam quis risus eget urna salsa tequila vel eu leo. Donec id elit non mi porta gravida at eget metus.
+  </p>
+</div>
+{{< /example >}}
+
+### Height utilities
+
+Unlike the widths, height utilities have no responsive variants by default, but these can easily be turned on by switching on the `responsive` key in the [utility API]({{< docsref "/utilities/api" >}}).
 
 {{< example >}}
 <div style="height: 100px; background-color: rgba(255,0,0,0.1);">


### PR DESCRIPTION
### In draft, do not review yet

- Switch from paddings to left margin
	- This way the `.container` or `.overflow-hidden` are not needed as row wrappers anymore
	- Cards can be direct children of a `.row`
- Remove the `width`s from columns:
	- seperation between columns and width utilities
- Store gutter widths in variables
    - Works a little more flexible than the universal selector technique we had
- Enabled vertical gutters by default

Examples:
- Cards without wrapping divs: https://deploy-preview-30380--twbs-bootstrap.netlify.com//docs/4.3/components/card/#grid-cards
- Grid without wrapping container: https://deploy-preview-30380--twbs-bootstrap.netlify.com//docs/4.3/layout/grid/