### PR TITLE
fix: ensure totype always return stringified null when null passed

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -10,7 +10,13 @@ const MILLISECONDS_MULTIPLIER = 1000
 const TRANSITION_END = 'transitionend'
 
 // Shoutout AngusCroll (https://goo.gl/pxwQGp)
-const toType = obj => ({}.toString.call(obj).match(/\s([a-z]+)/i)[1].toLowerCase())
+const toType = obj => {
+  if (obj === null || obj === undefined) {
+    return `${obj}`
+  }
+
+  return {}.toString.call(obj).match(/\s([a-z]+)/i)[1].toLowerCase()
+}
 
 /**
  * --------------------------------------------------------------------------

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -198,8 +198,9 @@ describe('Util', () => {
   })
 
   describe('typeCheckConfig', () => {
+    const namePlugin = 'collapse'
+
     it('should check type of the config object', () => {
-      const namePlugin = 'collapse'
       const defaultType = {
         toggle: 'boolean',
         parent: '(string|element)'
@@ -212,6 +213,34 @@ describe('Util', () => {
       expect(() => {
         Util.typeCheckConfig(namePlugin, config, defaultType)
       }).toThrow(new Error('COLLAPSE: Option "parent" provided type "number" but expected type "(string|element)".'))
+    })
+
+    it('should return null stringified when null passed', () => {
+      const defaultType = {
+        toggle: 'boolean',
+        parent: '(null|element)'
+      }
+      const config = {
+        toggle: true,
+        parent: null
+      }
+
+      Util.typeCheckConfig(namePlugin, config, defaultType)
+      expect().nothing()
+    })
+
+    it('should return undefined stringified when undefined passed', () => {
+      const defaultType = {
+        toggle: 'boolean',
+        parent: '(undefined|element)'
+      }
+      const config = {
+        toggle: true,
+        parent: undefined
+      }
+
+      Util.typeCheckConfig(namePlugin, config, defaultType)
+      expect().nothing()
     })
   })
 

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -215,7 +215,7 @@ describe('Util', () => {
       }).toThrow(new Error('COLLAPSE: Option "parent" provided type "number" but expected type "(string|element)".'))
     })
 
-    it('should return null stringified when null passed', () => {
+    it('should return null stringified when null is passed', () => {
       const defaultType = {
         toggle: 'boolean',
         parent: '(null|element)'
@@ -229,7 +229,7 @@ describe('Util', () => {
       expect().nothing()
     })
 
-    it('should return undefined stringified when undefined passed', () => {
+    it('should return undefined stringified when undefined is passed', () => {
       const defaultType = {
         toggle: 'boolean',
         parent: '(undefined|element)'


### PR DESCRIPTION
fixes: #29996