### PR TITLE
Use `display: block;` for form elements

### DIFF
--- a/scss/forms/_form-file.scss
+++ b/scss/forms/_form-file.scss
@@ -1,9 +1,6 @@
 .form-file {
   position: relative;
-  display: inline-block;
-  width: 100%;
   height: $form-file-height;
-  margin-bottom: 0;
 }
 
 .form-file-input {

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -4,7 +4,7 @@
 // https://primer.github.io/.
 
 .form-select {
-  display: inline-block;
+  display: block;
   width: 100%;
   height: $form-select-height;
   padding: $form-select-padding-y ($form-select-padding-x + $form-select-indicator-padding) $form-select-padding-y $form-select-padding-x;


### PR DESCRIPTION
`.form-select` and `.form-file` have `display: inline-block` applied to. This results in an inconsistent behaviour in `col-auto` because the label length influences the col width, even when the label is smaller:
https://codepen.io/MartijnCuppens/pen/wvamMpQ

`.form-file` is a div, so several properties can be removed. They were added in the past because it used to be a label.

Not sure if we should backport this, could be a BC.