### PR TITLE
fix(css): adds a new opacity var

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -496,9 +496,10 @@ $input-btn-font-family:       null !default;
 $input-btn-font-size:         $font-size-base !default;
 $input-btn-line-height:       $line-height-base !default;
 
-$input-btn-focus-width:       .2rem !default;
-$input-btn-focus-color:       rgba($component-active-bg, .25) !default;
-$input-btn-focus-box-shadow:  0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
+$input-btn-focus-width:         .2rem !default;
+$input-btn-focus-color-opacity: .25 !default;
+$input-btn-focus-color:         rgba($component-active-bg, $input-btn-focus-color-opacity) !default;
+$input-btn-focus-box-shadow:    0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
 
 $input-btn-padding-y-sm:      .25rem !default;
 $input-btn-padding-x-sm:      .5rem !default;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -58,7 +58,7 @@
 
       &:focus {
         border-color: $color;
-        box-shadow: 0 0 0 $input-focus-width rgba($color, .25);
+        box-shadow: 0 0 0 $input-focus-width rgba($color, $input-btn-focus-color-opacity);
       }
     }
   }


### PR DESCRIPTION
This PR fixes beeing able to control `.is-valid` & `.is-invalid` input:focus opacity and removes hardcoded .25.

If it's ok, I can propagate this also on the other elements in `mixins/_forms.scss`.

Thanks for your time.