### PR TITLE
Removes `.text-reset` references

### DIFF
--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -73,6 +73,7 @@ Changes to Reboot, typography, tables, and more.
 - Dropped `.pre-scrollable` class. [See #29135](https://github.com/twbs/bootstrap/pull/29135)
 - `.text-*` utilities do not add hover and focus states to links anymore. `.link-*` helper classes can be used instead. [See #29267](https://github.com/twbs/bootstrap/pull/29267)
 - Drop `.text-justify` class. [See #229793](https://github.com/twbs/bootstrap/pull/29793)
+- Dropped `.text-reset` as ...
 
 ## Forms
 

--- a/site/content/docs/4.3/utilities/text.md
+++ b/site/content/docs/4.3/utilities/text.md
@@ -96,16 +96,6 @@ Change a selection to our monospace font stack with `.font-monospace`.
 <p class="font-monospace">This is in monospace</p>
 {{< /example >}}
 
-## Reset color
-
-Reset a text or link's color with `.text-reset`, so that it inherits the color from its parent.
-
-{{< example >}}
-<p class="text-muted">
-  Muted text with a <a href="#" class="text-reset">reset link</a>.
-</p>
-{{< /example >}}
-
 ## Text decoration
 
 Decorate text in components with text decoration classes.


### PR DESCRIPTION
This PR removes `.text-reset` references from docs and adds a line in migration. 

If we'll remove this class, please give me some feedback of what we need to write in migration doc.

[deploy-preview](https://deploy-preview-30398--twbs-bootstrap.netlify.com/docs/4.3/utilities/text/#monospace)

Thanks for your time.