### PR TITLE
docs a11y fixes

### DIFF
--- a/site/content/docs/4.3/examples/navbars/index.html
+++ b/site/content/docs/4.3/examples/navbars/index.html
@@ -56,7 +56,7 @@ extra_css:
         </li>
       </ul>
       <form>
-        <input class="form-control" type="text" placeholder="Search">
+        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
       </form>
     </div>
   </div>
@@ -90,7 +90,7 @@ extra_css:
         </li>
       </ul>
       <form>
-        <input class="form-control" type="text" placeholder="Search">
+        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
       </form>
     </div>
   </div>
@@ -124,7 +124,7 @@ extra_css:
         </li>
       </ul>
       <form>
-        <input class="form-control" type="text" placeholder="Search">
+        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
       </form>
     </div>
   </div>
@@ -158,7 +158,7 @@ extra_css:
         </li>
       </ul>
       <form>
-        <input class="form-control" type="text" placeholder="Search">
+        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
       </form>
     </div>
   </div>
@@ -192,7 +192,7 @@ extra_css:
         </li>
       </ul>
       <form>
-        <input class="form-control" type="text" placeholder="Search">
+        <input class="form-control" type="text" placeholder="Search" aria-label="Search">
       </form>
     </div>
   </div>

--- a/site/content/docs/4.3/forms/form-control.md
+++ b/site/content/docs/4.3/forms/form-control.md
@@ -24,9 +24,9 @@ toc: true
 Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 
 {{< example >}}
-<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg">
-<input class="form-control" type="text" placeholder="Default input">
-<input class="form-control form-control-sm" type="text" placeholder=".form-control-sm">
+<input class="form-control form-control-lg" type="text" placeholder=".form-control-lg" aria-label=".form-control-lg example">
+<input class="form-control" type="text" placeholder="Default input" aria-label="deafult input example">
+<input class="form-control form-control-sm" type="text" placeholder=".form-control-sm" aria-label=".form-control-sm example">
 {{< /example >}}
 
 ## Readonly
@@ -34,7 +34,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 Add the `readonly` boolean attribute on an input to prevent modification of the input's value. Read-only inputs appear lighter (just like disabled inputs), but retain the standard cursor.
 
 {{< example >}}
-<input class="form-control" type="text" placeholder="Readonly input here..." readonly>
+<input class="form-control" type="text" placeholder="Readonly input here..." aria-label="readonly input example" readonly>
 {{< /example >}}
 
 ## Readonly plain text

--- a/site/content/docs/4.3/forms/form-control.md
+++ b/site/content/docs/4.3/forms/form-control.md
@@ -9,16 +9,14 @@ toc: true
 ## Example
 
 {{< example >}}
-<form>
-  <div class="mb-3">
-    <label for="exampleFormControlInput1">Email address</label>
-    <input type="email" class="form-control" id="exampleFormControlInput1" placeholder="name@example.com">
-  </div>
-  <div class="mb-3">
-    <label for="exampleFormControlTextarea1">Example textarea</label>
-    <textarea class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
-  </div>
-</form>
+<div class="mb-3">
+  <label for="exampleFormControlInput1">Email address</label>
+  <input type="email" class="form-control" id="exampleFormControlInput1" placeholder="name@example.com">
+</div>
+<div class="mb-3">
+  <label for="exampleFormControlTextarea1">Example textarea</label>
+  <textarea class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
+</div>
 {{< /example >}}
 
 ## Sizing
@@ -44,7 +42,6 @@ Add the `readonly` boolean attribute on an input to prevent modification of the 
 If you want to have `<input readonly>` elements in your form styled as plain text, use the `.form-control-plaintext` class to remove the default form field styling and preserve the correct margin and padding.
 
 {{< example >}}
-<form>
   <div class="mb-3 row">
     <label for="staticEmail" class="col-sm-2 col-form-label">Email</label>
     <div class="col-sm-10">
@@ -57,7 +54,6 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
       <input type="password" class="form-control" id="inputPassword">
     </div>
   </div>
-</form>
 {{< /example >}}
 
 {{< example >}}
@@ -79,10 +75,8 @@ If you want to have `<input readonly>` elements in your form styled as plain tex
 ## Color
 
 {{< example >}}
-<form>
-  <label for="exampleColorInput">Color picker</label>
-  <input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">
-</form>
+<label for="exampleColorInput">Color picker</label>
+<input type="color" class="form-control form-control-color" id="exampleColorInput" value="#563d7c" title="Choose your color">
 {{< /example >}}
 
 ## Datalists
@@ -92,15 +86,13 @@ Datalists allow you to create a group of `<option>`s that can be accessed (and a
 Learn more about [support for datalist elements](https://caniuse.com/#feat=datalist).
 
 {{< example >}}
-<form>
-  <label for="exampleDataList">Datalist example</label>
-  <input class="form-control" list="datalistOptions" id="exampleDataList" placeholder="Type to search...">
-  <datalist id="datalistOptions">
-    <option value="San Francisco">
-    <option value="New York">
-    <option value="Seattle">
-    <option value="Los Angeles">
-    <option value="Chicago">
-  </datalist>
-</form>
+<label for="exampleDataList">Datalist example</label>
+<input class="form-control" list="datalistOptions" id="exampleDataList" placeholder="Type to search...">
+<datalist id="datalistOptions">
+  <option value="San Francisco">
+  <option value="New York">
+  <option value="Seattle">
+  <option value="Los Angeles">
+  <option value="Chicago">
+</datalist>
 {{< /example >}}

--- a/site/content/docs/4.3/forms/layout.md
+++ b/site/content/docs/4.3/forms/layout.md
@@ -40,10 +40,10 @@ More complex forms can be built using our grid classes. Use these for form layou
 {{< example >}}
 <div class="row">
   <div class="col">
-    <input type="text" class="form-control" placeholder="First name">
+    <input type="text" class="form-control" placeholder="First name" aria-label="First name">
   </div>
   <div class="col">
-    <input type="text" class="form-control" placeholder="Last name">
+    <input type="text" class="form-control" placeholder="Last name" aria-label="Last name">
   </div>
 </div>
 {{< /example >}}
@@ -55,10 +55,10 @@ By adding [gutter modifier classes]({{< docsref "/layout/grid#gutters" >}}), you
 {{< example >}}
 <div class="row g-3">
   <div class="col">
-    <input type="text" class="form-control" placeholder="First name">
+    <input type="text" class="form-control" placeholder="First name" aria-label="First name">
   </div>
   <div class="col">
-    <input type="text" class="form-control" placeholder="Last name">
+    <input type="text" class="form-control" placeholder="Last name" aria-label="Last name">
   </div>
 </div>
 {{< /example >}}
@@ -204,13 +204,13 @@ As shown in the previous examples, our grid system allows you to place any numbe
 {{< example >}}
 <div class="row g-3">
   <div class="col-sm-7">
-    <input type="text" class="form-control" placeholder="City">
+    <input type="text" class="form-control" placeholder="City" aria-label="City">
   </div>
   <div class="col-sm">
-    <input type="text" class="form-control" placeholder="State">
+    <input type="text" class="form-control" placeholder="State" aria-label="State">
   </div>
   <div class="col-sm">
-    <input type="text" class="form-control" placeholder="Zip">
+    <input type="text" class="form-control" placeholder="Zip" aria-label="Zip">
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/4.3/forms/layout.md
+++ b/site/content/docs/4.3/forms/layout.md
@@ -23,16 +23,14 @@ Since Bootstrap applies `display: block` and `width: 100%` to almost all our for
 Feel free to build your forms however you like, with `<fieldset>`s, `<div>`s, or nearly any other element.
 
 {{< example >}}
-<form>
-  <div class="mb-3">
-    <label for="formGroupExampleInput">Example label</label>
-    <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input placeholder">
-  </div>
-  <div class="mb-3">
-    <label for="formGroupExampleInput2">Another label</label>
-    <input type="text" class="form-control" id="formGroupExampleInput2" placeholder="Another input placeholder">
-  </div>
-</form>
+<div class="mb-3">
+  <label for="formGroupExampleInput">Example label</label>
+  <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input placeholder">
+</div>
+<div class="mb-3">
+  <label for="formGroupExampleInput2">Another label</label>
+  <input type="text" class="form-control" id="formGroupExampleInput2" placeholder="Another input placeholder">
+</div>
 {{< /example >}}
 
 ## Form grid
@@ -40,14 +38,14 @@ Feel free to build your forms however you like, with `<fieldset>`s, `<div>`s, or
 More complex forms can be built using our grid classes. Use these for form layouts that require multiple columns, varied widths, and additional alignment options. **Requires the `$enable-grid-classes` Sass variable to be enabled** (on by default).
 
 {{< example >}}
-<form class="row">
+<div class="row">
   <div class="col">
     <input type="text" class="form-control" placeholder="First name">
   </div>
   <div class="col">
     <input type="text" class="form-control" placeholder="Last name">
   </div>
-</form>
+</div>
 {{< /example >}}
 
 ## Gutters
@@ -55,14 +53,14 @@ More complex forms can be built using our grid classes. Use these for form layou
 By adding [gutter modifier classes]({{< docsref "/layout/grid#gutters" >}}), you can have control over the gutter width in as well the inline as block direction. **Also requires the `$enable-grid-classes` Sass variable to be enabled** (on by default).
 
 {{< example >}}
-<form class="row g-3">
+<div class="row g-3">
   <div class="col">
     <input type="text" class="form-control" placeholder="First name">
   </div>
   <div class="col">
     <input type="text" class="form-control" placeholder="Last name">
   </div>
-</form>
+</div>
 {{< /example >}}
 
 More complex layouts can also be created with the grid system.
@@ -179,26 +177,24 @@ At times, you maybe need to use margin or padding utilities to create that perfe
 Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s or `<legend>`s to correctly follow the size of `.form-control-lg` and `.form-control-sm`.
 
 {{< example >}}
-<form>
-  <div class="row mb-3">
-    <label for="colFormLabelSm" class="col-sm-2 col-form-label col-form-label-sm">Email</label>
-    <div class="col-sm-10">
-      <input type="email" class="form-control form-control-sm" id="colFormLabelSm" placeholder="col-form-label-sm">
-    </div>
+<div class="row mb-3">
+  <label for="colFormLabelSm" class="col-sm-2 col-form-label col-form-label-sm">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control form-control-sm" id="colFormLabelSm" placeholder="col-form-label-sm">
   </div>
-  <div class="row mb-3">
-    <label for="colFormLabel" class="col-sm-2 col-form-label">Email</label>
-    <div class="col-sm-10">
-      <input type="email" class="form-control" id="colFormLabel" placeholder="col-form-label">
-    </div>
+</div>
+<div class="row mb-3">
+  <label for="colFormLabel" class="col-sm-2 col-form-label">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control" id="colFormLabel" placeholder="col-form-label">
   </div>
-  <div class="row">
-    <label for="colFormLabelLg" class="col-sm-2 col-form-label col-form-label-lg">Email</label>
-    <div class="col-sm-10">
-      <input type="email" class="form-control form-control-lg" id="colFormLabelLg" placeholder="col-form-label-lg">
-    </div>
+</div>
+<div class="row">
+  <label for="colFormLabelLg" class="col-sm-2 col-form-label col-form-label-lg">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control form-control-lg" id="colFormLabelLg" placeholder="col-form-label-lg">
   </div>
-</form>
+</div>
 {{< /example >}}
 
 ## Column sizing
@@ -206,7 +202,7 @@ Be sure to use `.col-form-label-sm` or `.col-form-label-lg` to your `<label>`s o
 As shown in the previous examples, our grid system allows you to place any number of `.col`s within a `.row`. They'll split the available width equally between them. You may also pick a subset of your columns to take up more or less space, while the remaining `.col`s equally split the rest, with specific column classes like `.col-sm-7`.
 
 {{< example >}}
-<form class="row g-3">
+<div class="row g-3">
   <div class="col-sm-7">
     <input type="text" class="form-control" placeholder="City">
   </div>
@@ -216,7 +212,7 @@ As shown in the previous examples, our grid system allows you to place any numbe
   <div class="col-sm">
     <input type="text" class="form-control" placeholder="Zip">
   </div>
-</form>
+</div>
 {{< /example >}}
 
 ## Auto-sizing

--- a/site/content/docs/4.3/forms/overview.md
+++ b/site/content/docs/4.3/forms/overview.md
@@ -103,7 +103,7 @@ By default, browsers will treat all native form controls (`<input>`, `<select>`,
 
 {{< example >}}
 <form>
-  <fieldset disabled>
+  <fieldset disabled aria-label="Disabled fieldset example">
     <div class="mb-3">
       <label for="disabledTextInput">Disabled input</label>
       <input type="text" id="disabledTextInput" class="form-control" placeholder="Disabled input">

--- a/site/content/docs/4.3/forms/overview.md
+++ b/site/content/docs/4.3/forms/overview.md
@@ -74,7 +74,7 @@ Help text below inputs can be styled with `.form-text`. This class includes `dis
 Inline text can use any typical inline HTML element (be it a `<small>`, `<span>`, or something else) with nothing more than a utility class.
 
 {{< example >}}
-<form class="row g-3 align-items-center">
+<div class="row g-3 align-items-center">
   <div class="col-auto">
     <label for="inputPassword6" class="col-form-label">Password</label>
   </div>
@@ -86,7 +86,7 @@ Inline text can use any typical inline HTML element (be it a `<small>`, `<span>`
       Must be 8-20 characters long.
     </small>
   </div>
-</form>
+</div>
 {{< /example >}}
 
 ## Disabled forms

--- a/site/content/docs/4.3/forms/select.md
+++ b/site/content/docs/4.3/forms/select.md
@@ -11,7 +11,7 @@ toc: true
 Custom `<select>` menus need only a custom class, `.form-select` to trigger the custom styles. Custom styles are limited to the `<select>`'s initial appearance and cannot modify the `<option>`s due to browser limitations.
 
 {{< example >}}
-<select class="form-select">
+<select class="form-select" aria-label="Default select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
@@ -24,14 +24,14 @@ Custom `<select>` menus need only a custom class, `.form-select` to trigger the 
 You may also choose from small and large custom selects to match our similarly sized text inputs.
 
 {{< example >}}
-<select class="form-select form-select-lg mb-3">
+<select class="form-select form-select-lg mb-3" aria-label=".form-select-lg example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
   <option value="3">Three</option>
 </select>
 
-<select class="form-select form-select-sm">
+<select class="form-select form-select-sm" aria-label=".form-select-sm example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
@@ -42,7 +42,7 @@ You may also choose from small and large custom selects to match our similarly s
 The `multiple` attribute is also supported:
 
 {{< example >}}
-<select class="form-select" multiple>
+<select class="form-select" multiple aria-label="multiple select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>
@@ -53,7 +53,7 @@ The `multiple` attribute is also supported:
 As is the `size` attribute:
 
 {{< example >}}
-<select class="form-select" size="3">
+<select class="form-select" size="3" aria-label="size 3 select example">
   <option selected>Open this select menu</option>
   <option value="1">One</option>
   <option value="2">Two</option>

--- a/site/content/docs/4.3/forms/validation.md
+++ b/site/content/docs/4.3/forms/validation.md
@@ -280,7 +280,7 @@ Validation styles are available for the following form controls and components:
   </div>
 
   <div class="mb-3">
-    <select class="form-select" required>
+    <select class="form-select" required aria-label="select example">
       <option value="">Open this select menu</option>
       <option value="1">One</option>
       <option value="2">Two</option>

--- a/site/content/docs/4.3/forms/validation.md
+++ b/site/content/docs/4.3/forms/validation.md
@@ -297,6 +297,10 @@ Validation styles are available for the following form controls and components:
     </label>
     <div class="invalid-feedback">Example invalid form file feedback</div>
   </div>
+
+  <div class="mb-3">
+    <button class="btn btn-primary" type="submit" disabled>Submit form</button>
+  </div>
 </form>
 {{< /example >}}
 

--- a/site/content/docs/4.3/getting-started/browsers-devices.md
+++ b/site/content/docs/4.3/getting-started/browsers-devices.md
@@ -29,11 +29,11 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
 <table class="table">
   <thead>
     <tr>
-      <th></th>
-      <th>Chrome</th>
-      <th>Firefox</th>
-      <th>Safari</th>
-      <th>Android Browser &amp; WebView</th>
+      <th scope="col"></th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Safari</th>
+      <th scope="col">Android Browser &amp; WebView</th>
     </tr>
   </thead>
   <tbody>
@@ -61,12 +61,12 @@ Similarly, the latest versions of most desktop browsers are supported.
 <table class="table">
   <thead>
     <tr>
-      <th></th>
-      <th>Chrome</th>
-      <th>Firefox</th>
-      <th>Microsoft Edge</th>
-      <th>Opera</th>
-      <th>Safari</th>
+      <th scope="col"></th>
+      <th scope="col">Chrome</th>
+      <th scope="col">Firefox</th>
+      <th scope="col">Microsoft Edge</th>
+      <th scope="col">Opera</th>
+      <th scope="col">Safari</th>
     </tr>
   </thead>
   <tbody>

--- a/site/content/docs/4.3/helpers/embed.md
+++ b/site/content/docs/4.3/helpers/embed.md
@@ -18,7 +18,7 @@ Wrap any embed like an `<iframe>` in a parent element with `.embed-responsive` a
 
 {{< example >}}
 <div class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/zpOULjyy-n8?rel=0" allowfullscreen></iframe>
+  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/zpOULjyy-n8?rel=0" title="YouTube video" allowfullscreen></iframe>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/4.3/layout/grid.md
+++ b/site/content/docs/4.3/layout/grid.md
@@ -57,24 +57,24 @@ See how aspects of the Bootstrap grid system work across multiple devices with a
 <table class="table">
   <thead>
     <tr>
-      <th></th>
-      <th>
+      <th scope="col"></th>
+      <th scope="col">
         Extra small<br>
         <span class="font-weight-normal">&lt;576px</span>
       </th>
-      <th>
+      <th scope="col">
         Small<br>
         <span class="font-weight-normal">&ge;576px</span>
       </th>
-      <th>
+      <th scope="col">
         Medium<br>
         <span class="font-weight-normal">&ge;768px</span>
       </th>
-      <th>
+      <th scope="col">
         Large<br>
         <span class="font-weight-normal">&ge;992px</span>
       </th>
-      <th>
+      <th scope="col">
         Extra large<br>
         <span class="font-weight-normal">&ge;1200px</span>
       </th>


### PR DESCRIPTION
some more fixes for the simpler pa11y errors referenced in recent https://github.com/twbs/bootstrap/pull/29315 discussion

note that some other outstanding errors (and even some of the tweaks here) are not necessarily hard failures (e.g. the `scope` attribute on `<th>` is not really mandatory/necessary, and the need for a submit button when the only form control present is a single text/search input is debatable) ... seems pa11y is a bit overzealous with its errors when they're not necessarily failures