### PR TITLE
v4: Button checked state for back/refresh

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -39,11 +39,12 @@ const Selector = {
 }
 
 const Event = {
-  CHANGE_DATA_API     : `change${EVENT_KEY}${DATA_API_KEY}`,
-  CLICK_DATA_API      : `click${EVENT_KEY}${DATA_API_KEY}`,
-  FOCUS_BLUR_DATA_API : `focus${EVENT_KEY}${DATA_API_KEY} ` +
-                        `blur${EVENT_KEY}${DATA_API_KEY}`,
-  LOAD_DATA_API       : `load${EVENT_KEY}${DATA_API_KEY}`
+  CHANGE_DATA_API        : `change${EVENT_KEY}${DATA_API_KEY}`,
+  CLICK_DATA_API         : `click${EVENT_KEY}${DATA_API_KEY}`,
+  FOCUS_BLUR_DATA_API    : `focus${EVENT_KEY}${DATA_API_KEY} ` +
+                           `blur${EVENT_KEY}${DATA_API_KEY}`,
+  LOAD_PAGESHOW_DATA_API : `load${EVENT_KEY}${DATA_API_KEY} ` +
+                           `pageshow${EVENT_KEY}${DATA_API_KEY}`
 }
 
 /**
@@ -179,7 +180,7 @@ $(document)
       .toggleClass(ClassName.FOCUS, /^focus(in)?$/.test(event.type))
   })
 
-$(window).on(Event.LOAD_DATA_API, () => {
+$(window).on(Event.LOAD_PAGESHOW_DATA_API, () => {
   // Ensure correct active class is set to match the controls' actual values/states.
   $(Selector.DATA_TOGGLE_BUTTONS).each(function () {
     Button._update(this)

--- a/js/tests/visual/button.html
+++ b/js/tests/visual/button.html
@@ -19,7 +19,7 @@
       </button>
 
       <p>For checkboxes and radio buttons, ensure that keyboard behavior is functioning correctly.</p>
-      <p>Some browers, like Firefox will check or uncheck inputs to match last selection when the page is refreshed, so ensure that everything is in sync after a page refresh.</p>
+      <p>Browers will check or uncheck inputs to match the user's last selection when the page is navigated back to or refreshed (in Firefox's case). Try <a href="https://getbootstrap.com/">navigating away</a> and pressing back.</p>
       <p>Navigate to the checkboxes with the keyboard (generally, using <kbd>TAB</kbd> / <kbd>SHIFT + TAB</kbd>), and ensure that <kbd>SPACE</kbd> toggles the currently focused checkbox. Click on one of the checkboxes using the mouse, ensure that focus was correctly set on the actual checkbox, and that <kbd>SPACE</kbd> toggles the checkbox again. After refreshing the page, the checkbox state should be persisted by the browser.</p>
 
       <div class="btn-group" data-toggle="buttons">

--- a/js/tests/visual/button.html
+++ b/js/tests/visual/button.html
@@ -10,15 +10,20 @@
     <div class="container">
       <h1>Button <small>Bootstrap Visual Test</small></h1>
 
-      <button type="button" class="btn btn-primary" data-toggle="button" aria-pressed="false">
+      <button type="button" class="btn btn-outline-primary" data-toggle="button" aria-pressed="false">
         Single toggle
       </button>
 
+      <button type="button" class="btn btn-outline-primary disabled" data-toggle="button" aria-pressed="false">
+        Disabled toggle
+      </button>
+
       <p>For checkboxes and radio buttons, ensure that keyboard behavior is functioning correctly.</p>
-      <p>Navigate to the checkboxes with the keyboard (generally, using <kbd>TAB</kbd> / <kbd>SHIFT + TAB</kbd>), and ensure that <kbd>SPACE</kbd> toggles the currently focused checkbox. Click on one of the checkboxes using the mouse, ensure that focus was correctly set on the actual checkbox, and that <kbd>SPACE</kbd> toggles the checkbox again.</p>
+      <p>Some browers, like Firefox will check or uncheck inputs to match last selection when the page is refreshed, so ensure that everything is in sync after a page refresh.</p>
+      <p>Navigate to the checkboxes with the keyboard (generally, using <kbd>TAB</kbd> / <kbd>SHIFT + TAB</kbd>), and ensure that <kbd>SPACE</kbd> toggles the currently focused checkbox. Click on one of the checkboxes using the mouse, ensure that focus was correctly set on the actual checkbox, and that <kbd>SPACE</kbd> toggles the checkbox again. After refreshing the page, the checkbox state should be persisted by the browser.</p>
 
       <div class="btn-group" data-toggle="buttons">
-        <label class="btn btn-primary active">
+        <label class="btn btn-primary">
           <input type="checkbox" checked> Checkbox 1 (pre-checked)
         </label>
         <label class="btn btn-primary">
@@ -29,10 +34,10 @@
         </label>
       </div>
 
-      <p>Navigate to the radio button group with the keyboard (generally, using <kbd>TAB</kbd> / <kbd>SHIFT + TAB</kbd>). If no radio button was initially set to be selected, the first/last radio button should receive focus (depending on whether you navigated "forward" to the group with <kbd>TAB</kbd> or "backwards" using <kbd>SHIFT + TAB</kbd>). If a radio button was already selected, navigating with the keyboard should set focus to that particular radio button. Only one radio button in a group should receive focus at any given time.  Ensure that the selected radio button can be changed by using the <kbd>←</kbd> and <kbd>→</kbd> arrow keys. Click on one of the radio buttons with the mouse,  ensure that focus was correctly set on the actual radio button, and that <kbd>←</kbd> and <kbd>→</kbd> change the selected radio button again.</p>
+      <p>Navigate to the radio button group with the keyboard (generally, using <kbd>TAB</kbd> / <kbd>SHIFT + TAB</kbd>). If no radio button was initially set to be selected, the first/last radio button should receive focus (depending on whether you navigated "forward" to the group with <kbd>TAB</kbd> or "backwards" using <kbd>SHIFT + TAB</kbd>). If a radio button was already selected, navigating with the keyboard should set focus to that particular radio button. Only one radio button in a group should receive focus at any given time.  Ensure that the selected radio button can be changed by using the <kbd>←</kbd> and <kbd>→</kbd> arrow keys. Click on one of the radio buttons with the mouse,  ensure that focus was correctly set on the actual radio button, and that <kbd>←</kbd> and <kbd>→</kbd> change the selected radio button again. After changing the selected radio button, refreshing the page should result in the last-selected toggle button shown as active.</p>
 
       <div class="btn-group" data-toggle="buttons">
-        <label class="btn btn-primary active">
+        <label class="btn btn-primary">
           <input type="radio" name="options" id="option1" checked> Radio 1 (preselected)
         </label>
         <label class="btn btn-primary">
@@ -41,7 +46,20 @@
         <label class="btn btn-primary">
           <input type="radio" name="options" id="option3"> Radio 3
         </label>
+        <label class="btn btn-primary disabled">
+          <input type="radio" name="options" id="option4" disabled> Radio 4
+        </label>
       </div>
+
+      <p>We also support <code>div.btn &gt; input</code> structures:</p>
+
+      <div class="btn-group" data-toggle="buttons">
+        <div class="btn btn-primary">
+          <input type="checkbox" aria-label="Hello">
+          <span>Check</span>
+        </div>
+      </div>
+
     </div>
 
     <script src="../../../node_modules/jquery/dist/jquery.slim.min.js"></script>


### PR DESCRIPTION
Unlike any of the other browsers, Firefox will restore \<input>s' checked status after a page refresh. (This behaviour can be suppressed with autocomplete=off on the form or input.) You can see this in action on 4.4.1 by selecting the [last example radio](https://getbootstrap.com/docs/4.4/components/buttons/#checkbox-and-radio-buttons) then refreshing.

Other browsers and Firefox will restore the \<inputs>s' checked status after navigating away from a page then navigating back. There's #25122 documenting this, which we can resolve by updating the initial button state on window `pageshow` as-well as `load`.

Trying to fix all of those things lead me to this PR, where button toggles with label/input rely on change events to update state, and `.btn[data-toggle=button]` remains handled by click events.

First PR here so feedback on testing/style/anything gratefully received.

---

I made the mistake of branching off v4-dev. Apologies :relaxed: Hopefully #28463 lands and v5 drops the requirement for JavaScript for this control, otherwise I can rebase onto master.

If a CSS-only alternative proves difficult, the toggle control could be far simpler if only label\>input based markup is supported because we can then toggle the active class through the change event alone.