### PR TITLE
Use `box-shadow` mixin for form controls

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -29,10 +29,10 @@
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color;
     outline: 0;
-    // Avoid using mixin so we can pass custom focus shadow properly
     @if $enable-shadows {
-      box-shadow: $input-box-shadow, $input-focus-box-shadow;
+      @include box-shadow($input-box-shadow, $input-focus-box-shadow);
     } @else {
+      // Avoid using mixin so we can pass custom focus shadow properly
       box-shadow: $input-focus-box-shadow;
     }
   }


### PR DESCRIPTION
This PR fixes css property `box-shadow` become invalid.
That happends if one of `$input-box-shadow` or `$input-focus-box-shadow` is `none`.
Our `box-shadow` mixin verifies for `length($string) == 1` and it covers that case.

LE: Oh, this relates with #30394 

cc:// @mdo @ysds 