### PR TITLE
Remove IE11 flexbugs workarounds

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -163,8 +163,7 @@
     // The child selector allows nested `.card` within `.card-group`
     // to display properly.
     > .card {
-      // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
-      flex: 1 0 0%;
+      flex: 1;
       margin-bottom: 0;
 
       + .card {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -65,7 +65,7 @@
     @include media-breakpoint-up($breakpoint, $breakpoints) {
       // Provide basic `.col-{bp}` classes for equal-width flexbox columns
       .col#{$infix} {
-        flex: 1 0 0%; // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
+        flex: 1;
         min-width: 0; // See https://github.com/twbs/bootstrap/issues/25410
       }
 


### PR DESCRIPTION
Not sure about this one: IE11 only workarounds for flexbugs.

Keeping them would drastically improve the backward compatibility, however v5 officially drops IE11 support and we're still trying to decrease filesize… This one doesn't do much, so feel free to close or merge this :)