### PR TITLE
Cleanup responsive tables

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -174,23 +174,14 @@
 // Generate series of `.table-responsive-*` classes for configuring the screen
 // size of where your table will overflow.
 
-.table-responsive {
-  @each $breakpoint in map-keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+@each $breakpoint in map-keys($grid-breakpoints) {
+  $next: breakpoint-next($breakpoint, $grid-breakpoints);
+  $infix: breakpoint-infix($next, $grid-breakpoints);
 
-    &#{$infix} {
-      @include media-breakpoint-down($breakpoint) {
-        display: block;
-        width: 100%;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-
-        // Prevent double border on horizontal scroll due to use of `display: block;`
-        > .table-bordered {
-          border: 0;
-        }
-      }
+  @include media-breakpoint-down($breakpoint) {
+    .table-responsive#{$infix} {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
   }
 }


### PR DESCRIPTION
In https://github.com/twbs/bootstrap/pull/25058, the `.table-reponsive` class was moved from the table to a wrapper div.

- `display: block;` and `width: 100%;` have become redundant since the wrapper is a div
- The double border fix isn't needed either since the table keeps its `display` value
- I've also simplified the Sass class concatenation.

https://deploy-preview-30482--twbs-bootstrap.netlify.com/docs/4.3/content/tables/#breakpoint-specific