### PR TITLE
Fix card list group borders & radii

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -19,15 +19,18 @@
     margin-left: 0;
   }
 
-  > .list-group:first-child {
-    .list-group-item:first-child {
-      @include border-top-radius($card-border-radius);
-    }
-  }
+  > .list-group {
+    border-top: inherit;
+    border-bottom: inherit;
 
-  > .list-group:last-child {
-    .list-group-item:last-child {
-      @include border-bottom-radius($card-border-radius);
+    &:first-child {
+      border-top-width: 0;
+      @include border-top-radius($card-inner-border-radius);
+    }
+
+    &:last-child  {
+      border-bottom-width: 0;
+      @include border-bottom-radius($card-inner-border-radius);
     }
   }
 }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -9,6 +9,7 @@
   // No need to set list-style: none; since .list-group-item is block level
   padding-left: 0; // reset padding because ul and ol
   margin-bottom: 0;
+  @include border-radius($list-group-border-radius);
 }
 
 
@@ -52,11 +53,11 @@
   border: $list-group-border-width solid $list-group-border-color;
 
   &:first-child {
-    @include border-top-radius($list-group-border-radius);
+    @include border-top-radius(inherit);
   }
 
   &:last-child {
-    @include border-bottom-radius($list-group-border-radius);
+    @include border-bottom-radius(inherit);
   }
 
   &.disabled,
@@ -132,18 +133,12 @@
 // useful within other components (e.g., cards).
 
 .list-group-flush {
+  @include border-radius(0);
+
   .list-group-item {
-    border-right-width: 0;
-    border-left-width: 0;
-    @include border-radius(0);
+    border-width: 0 0 $list-group-border-width;
 
-    &:first-child {
-      border-top-width: 0;
-    }
-  }
-
-  &:last-child {
-    .list-group-item:last-child {
+    &:last-child {
       border-bottom-width: 0;
     }
   }


### PR DESCRIPTION
Fix the top border in the card list groups (https://getbootstrap.com/docs/4.4/components/card/#kitchen-sink). 

I've inherited the border-radius from the `.list-group`, this makes the selectors a lot less complex.

- https://deploy-preview-30497--twbs-bootstrap.netlify.com/docs/4.3/components/list-group/#flush
- https://deploy-preview-30497--twbs-bootstrap.netlify.com/docs/4.3/components/card/#kitchen-sink