### PR TITLE
wip: adds `$nav-link-*` vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7047,9 +7047,9 @@
       }
     },
     "karma": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-5.0.1.tgz",
-      "integrity": "sha512-xrDGtZ0mykEQjx1BUHOP1ITi39MDsCGocmSvLJWHxUQpxuKwxk3ZUrC6HI2VWh1plLC6+7cA3B19m12yzO/FRw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-5.0.2.tgz",
+      "integrity": "sha512-RpUuCuGJfN3WnjYPGIH+VBF8023Lfm3TQH6D1kcNL+FxtEPc2UUz/nVjbVAGXH4Pm+Q7FVOAQjdAeFUpXpQ3IA==",
       "dev": true,
       "requires": {
         "body-parser": "^1.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10316,9 +10316,9 @@
       }
     },
     "remark-parse": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.0.tgz",
-      "integrity": "sha512-Ck14G1Ns/GEPXhSw6m1Uv28kMtVk63e59NyL+QlhBBwBdIUXROM6MPfBehPhW6TW2d73batMdZsKwuxl5i3tEA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.1.tgz",
+      "integrity": "sha512-Ye/5W57tdQZWsfkuVyRq9SUWRgECHnDsMuyUMzdSKpTbNPkZeGtoYfsrkeSi4+Xyl0mhcPPddHITXPcCPHrl3w==",
       "dev": true,
       "requires": {
         "ccount": "^1.0.0",
@@ -11955,9 +11955,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.3.2.tgz",
-      "integrity": "sha512-kpO3/Gz2ZY40EWUwFYYkgpzhf8ZDUyKpcui5+pS0XKJBj/EMYmZpOJoL8IFAz2yApYeg91NVy5yAjE39hDzWvQ==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.3.3.tgz",
+      "integrity": "sha512-j8Oio2T1YNiJc6iXDaPYd74Jg4zOa1bByNm/g9/Nvnq4tDPsIjMi46jhRZyPPktGPwjJ5FwcmCqIRlH6PVP8mA==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "hammer-simulator": "0.0.1",
     "hugo-bin": "^0.57.0",
     "ip": "^1.1.5",
-    "karma": "^5.0.1",
+    "karma": "^5.0.2",
     "karma-browserstack-launcher": "1.4.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "rollup-plugin-istanbul": "^2.0.1",
     "serve": "^11.3.0",
     "shelljs": "^0.8.3",
-    "stylelint": "^13.3.2",
+    "stylelint": "^13.3.3",
     "stylelint-config-twbs-bootstrap": "^2.0.1",
     "terser": "^4.6.11",
     "vnu-jar": "20.3.16"

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -20,6 +20,7 @@
 
   &:hover,
   &:focus {
+    color: $nav-link-hover-color;
     text-decoration: if($link-hover-decoration == underline, none, null);
   }
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -14,6 +14,7 @@
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;
+  font-style: $nav-link-font-style;
   font-weight: $nav-link-font-weight;
   color: $nav-link-color;
   text-decoration: if($link-decoration == none, null, none);

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -14,6 +14,7 @@
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;
+  @include font-size($nav-link-font-size);
   font-style: $nav-link-font-style;
   font-weight: $nav-link-font-weight;
   color: $nav-link-color;

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -14,6 +14,7 @@
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;
+  color: $nav-link-color;
   text-decoration: if($link-decoration == none, null, none);
   @include transition($nav-link-transition);
 

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -14,6 +14,7 @@
 .nav-link {
   display: block;
   padding: $nav-link-padding-y $nav-link-padding-x;
+  font-weight: $nav-link-font-weight;
   color: $nav-link-color;
   text-decoration: if($link-decoration == none, null, none);
   @include transition($nav-link-transition);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -817,6 +817,7 @@ $zindex-tooltip:                    1070 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$nav-link-font-weight:              null !default;
 $nav-link-color:                    $primary !default;
 $nav-link-hover-color:              darken($primary, 15%) !default;
 $nav-link-disabled-color:           $gray-600 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -817,6 +817,7 @@ $zindex-tooltip:                    1070 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$nav-link-color:                    null !default;
 $nav-link-disabled-color:           $gray-600 !default;
 
 $nav-tabs-border-color:             $gray-300 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -817,6 +817,7 @@ $zindex-tooltip:                    1070 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$nav-link-font-style:               null !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    $primary !default;
 $nav-link-hover-color:              darken($primary, 15%) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -817,6 +817,7 @@ $zindex-tooltip:                    1070 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
+$nav-link-font-size:                null !default;
 $nav-link-font-style:               null !default;
 $nav-link-font-weight:              null !default;
 $nav-link-color:                    $primary !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -817,7 +817,8 @@ $zindex-tooltip:                    1070 !default;
 $nav-link-padding-y:                .5rem !default;
 $nav-link-padding-x:                1rem !default;
 $nav-link-transition:               color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
-$nav-link-color:                    null !default;
+$nav-link-color:                    $primary !default;
+$nav-link-hover-color:              darken($primary, 15%) !default;
 $nav-link-disabled-color:           $gray-600 !default;
 
 $nav-tabs-border-color:             $gray-300 !default;


### PR DESCRIPTION
This PR adds a new vars for `$nav-link-*`'s:
```
$nav-link-font-size:                null !default;
$nav-link-font-style:               null !default;
$nav-link-font-weight:              null !default;
$nav-link-color:                    $primary !default;
$nav-link-hover-color:              darken($primary, 15%) !default;
```

This PR depends on https://github.com/twbs/bootstrap/pull/30622