### PR TITLE
Remove useless quotes in font-stacks

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -8,8 +8,6 @@
     --#{$color}: #{$value};
   }
 
-  // Use `inspect` for lists so that quoted items keep the quotes.
-  // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
-  --font-family-sans-serif: #{inspect($font-family-sans-serif)};
-  --font-family-monospace: #{inspect($font-family-monospace)};
+  --font-family-sans-serif: #{$font-family-sans-serif};
+  --font-family-monospace: #{$font-family-monospace};
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -365,8 +365,8 @@ $embed-responsive-aspect-ratios: (
 // Font, line-height, and color for body text, headings, and more.
 
 // stylelint-disable value-keyword-case
-$font-family-sans-serif:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
-$font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
+$font-family-sans-serif:      -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji !default;
+$font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace !default;
 $font-family-base:            $font-family-sans-serif !default;
 // stylelint-enable value-keyword-case
 

--- a/site/content/docs/4.3/content/reboot.md
+++ b/site/content/docs/4.3/content/reboot.md
@@ -38,17 +38,17 @@ $font-family-sans-serif:
   // Chrome < 56 for macOS (San Francisco)
   BlinkMacSystemFont,
   // Windows
-  "Segoe UI",
+  Segoe UI,
   // Android
   Roboto,
   // Basic web fallback
-  "Helvetica Neue", Arial,
+  Helvetica Neue, Arial,
   // Linux
-  "Noto Sans",
+  Noto Sans,
   // Sans serif fallback
   sans-serif,
   // Emoji fonts
-  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+  Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji !default;
 {{< /highlight >}}
 
 This `font-family` is applied to the `<body>` and automatically inherited globally throughout Bootstrap. To switch the global `font-family`, update `$font-family-base` and recompile Bootstrap.


### PR DESCRIPTION
* [Matthias Bynens wrote about "unquote font family names in CSS"](https://mathiasbynens.be/notes/unquoted-font-family) back in 2012;
* and went with [a neat tool to check wheter your font-family name requires quotes or not](https://mothereff.in/font-family);
* FWIW, [StyleLint rule to check quotes in family names](https://stylelint.io/user-guide/rules/font-family-name-quotes) is [set to `where-recommended` in our StyleLint config](https://github.com/twbs/stylelint-config-twbs-bootstrap/blob/master/css/index.js#L22) → [PR #55 opened](https://github.com/twbs/stylelint-config-twbs-bootstrap/pull/55)