### PR TITLE
Add `.card-footer` color

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -90,6 +90,7 @@
 
 .card-footer {
   padding: $card-cap-padding-y $card-cap-padding-x;
+  color: $card-cap-color;
   background-color: $card-cap-bg;
   border-top: $card-border-width solid $card-border-color;
 


### PR DESCRIPTION
Adds the same color from `.card-header` and keeps a cap consistency.