### PR TITLE
fix: allow popper.js@1.16.1-lts

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {},
   "peerDependencies": {
     "jquery": "1.9.1 - 3",
-    "popper.js": "^1.16.0"
+    "popper.js": "^1.16.0 || 1.16.1-lts"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",
@@ -176,7 +176,7 @@
     "dependencies": {},
     "peerDependencies": {
       "jquery": "1.9.1 - 3",
-      "popper.js": "^1.16.0"
+      "popper.js": "^1.16.0 || 1.16.1-lts"
     }
   }
 }

--- a/site/docs/4.5/getting-started/webpack.md
+++ b/site/docs/4.5/getting-started/webpack.md
@@ -28,7 +28,7 @@ import 'bootstrap/js/dist/alert';
 
 Bootstrap depends on [jQuery](https://jquery.com/) and [Popper](https://popper.js.org/),
 which are specified in the `peerDependencies` property; this means that you will have to make sure to add both of them
-to your `package.json` using `npm install --save jquery popper.js`.
+to your `package.json` using `npm install --save jquery popper.js@1.16.1-lts`.
 
 ## Importing Styles
 


### PR DESCRIPTION
The docs should be updated as well, so that users are instructed to install `popper.js@1.16.1-lts`. This will allow your consumers to not get notified about the deprecation notice included in the `stable` release branch of Popper.