### PR TITLE
Add v4-dev in bundlewatch config.

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -56,5 +56,11 @@
       "path": "./dist/js/bootstrap.min.js",
       "maxSize": "16.5 kB"
     }
-  ]
+  ],
+  "ci": {
+    "trackBranches": [
+      "master",
+      "v4-dev"
+    ]
+  }
 }


### PR DESCRIPTION
I'm not sure if this will fix the issue we have on v4-dev, but it's worth the try I guess