### PR TITLE
Prevent markdown styling in scss-docs attributes

### DIFF
--- a/site/content/docs/4.3/forms/validation.md
+++ b/site/content/docs/4.3/forms/validation.md
@@ -372,8 +372,8 @@ Please note that we do not recommend customizing these values without also modif
 
 This is the Sass map from `_variables.scss`. Override this and recompile your Sass to generate different states:
 
-{{< scss-docs name="form-validation-states" file="scss/_variables.scss" >}}
+{{< scss-docs name=`form-validation-states` file=`scss/_variables.scss` >}}
 
 This is the loop from `forms/_validation.scss.scss`. Any modifications to the above Sass map will be reflected in your compiled CSS via this loop:
 
-{{< scss-docs name="form-validation-states-loop" file="scss/forms/_validation.scss" >}}
+{{< scss-docs name=`form-validation-states-loop` file=`scss/forms/_validation.scss` >}}

--- a/site/content/docs/4.3/getting-started/theming.md
+++ b/site/content/docs/4.3/getting-started/theming.md
@@ -172,7 +172,7 @@ In Bootstrap 5, we've dropped the `color()`, `theme-color()` and `gray()` functi
 
 We also have a function for getting a particular _level_ of color. Negative level values will lighten the color, while higher levels will darken.
 
-{{< scss-docs name="color-level" file="scss/_functions.scss" >}}
+{{< scss-docs name=`color-level` file=`scss/_functions.scss` >}}
 
 In practice, you'd call the function and pass in two parameters: the name of the color from `$theme-colors` (e.g., primary or danger) and a numeric level.
 
@@ -384,15 +384,15 @@ Many of Bootstrap's components are built with a base-modifier class approach. Th
 
 Here are two examples of how we loop over the `$theme-colors` map to generate modifiers to the `.alert` and `.list-group` components.
 
-{{< scss-docs name="alert-modifiers" file="scss/_alert.scss" >}}
+{{< scss-docs name=`alert-modifiers` file=`scss/_alert.scss` >}}
 
-{{< scss-docs name="list-group-modifiers" file="scss/_list-group.scss" >}}
+{{< scss-docs name=`list-group-modifiers` file=`scss/_list-group.scss` >}}
 
 ### Responsive
 
 These Sass loops aren't limited to color maps, either. You can also generate responsive variations of your components. Take for example our responsive alignment of the dropdowns where we mix an `@each` loop for the `$grid-breakpoints` Sass map with a media query include.
 
-{{< scss-docs name="responsive-breakpoints" file="scss/_dropdown.scss" >}}
+{{< scss-docs name=`responsive-breakpoints` file=`scss/_dropdown.scss` >}}
 
 Should you need to modify your `$grid-breakpoints`, your changes will apply to all the loops iterating over that map.
 
@@ -407,7 +407,7 @@ Here are the variables we include (note that the `:root` is required). They're l
 {{< highlight css >}}
 {{< root.inline >}}
 {{- $css := readFile "dist/css/bootstrap.css" -}}
-{{- $match := findRE ":root {([^}]*)}" $css 1 -}}
+{{- $match := findRE `:root {([^}]*)}` $css 1 -}}
 
 {{- if (eq (len $match) 0) -}}
 {{- errorf "Got no matches for :root in %q!" $.Page.Path -}}

--- a/site/content/docs/4.3/helpers/clearfix.md
+++ b/site/content/docs/4.3/helpers/clearfix.md
@@ -16,7 +16,7 @@ Use in HTML:
 
 The mixin source code:
 
-{{< scss-docs name="clearfix" file="scss/mixins/_clearfix.scss" >}}
+{{< scss-docs name=`clearfix` file=`scss/mixins/_clearfix.scss` >}}
 
 Use the mixin in SCSS:
 

--- a/site/content/docs/4.3/helpers/embed.md
+++ b/site/content/docs/4.3/helpers/embed.md
@@ -50,4 +50,4 @@ Aspect ratios can be customized with modifier classes. By default the following 
 
 Within `_variables.scss`, you can change the aspect ratios you want to use. Here's an example of the `$embed-responsive-aspect-ratios` map:
 
-{{< scss-docs name="embed-responsive-aspect-ratios" file="scss/_variables.scss" >}}
+{{< scss-docs name=`embed-responsive-aspect-ratios` file=`scss/_variables.scss` >}}

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -1,5 +1,6 @@
 {{- /*
-  Usage: `scss-docs name="name" file="file/_location.scss"`
+  Usage: "scss-docs name=`name` file=`file/_location.scss`"
+    We use backticks in the attributes to prevent markdown styling from being triggered.
 
     Prints everything between `// scss-docs-start "name"` and `// scss-docs-end "name"`
     comments in the docs.


### PR DESCRIPTION
The underscores in the scss-docs sortcode triggered markdown styling. To prevent this from happening, we can better switch to backticks, which will prevent this from happening.