### PR TITLE
Outline buttons & colored links: set bg-dark where appropriate

### DIFF
--- a/site/content/docs/4.3/components/buttons.md
+++ b/site/content/docs/4.3/components/buttons.md
@@ -46,11 +46,11 @@ When using button classes on `<a>` elements that are used to trigger in-page fun
 
 In need of a button, but not the hefty background colors they bring? Replace the default modifier classes with the `.btn-outline-*` ones to remove all background images and colors on any button.
 
-{{< example >}}
+{{< example class="d-flex justify-content-between align-items-center" >}}
 {{< buttons.inline >}}
-{{- range (index $.Site.Data "theme-colors") }}
+{{- range (index $.Site.Data "theme-colors") }}{{ if (or (eq .name "light") (eq .name "warning") (eq .name "info")) }}<div class="bg-dark p-2">{{ end }}
 <button type="button" class="btn btn-outline-{{ .name }}">{{ .name | title }}</button>
-{{- end -}}
+{{ if (or (eq .name "light") (eq .name "warning") (eq .name "info")) }}</div>{{ end }}{{- end -}}
 {{< /buttons.inline >}}
 {{< /example >}}
 

--- a/site/content/docs/4.3/helpers/colored-links.md
+++ b/site/content/docs/4.3/helpers/colored-links.md
@@ -8,10 +8,10 @@ toc: false
 
 You can use the `.link-*` classes to colorize links. Unlike the [`.text-*` classes]({{< docsref "/utilities/colors#colors" >}}), these classes have a `:hover` and `:focus` state.
 
-{{< example >}}
+{{< example class="d-flex justify-content-between align-items-center" >}}
 {{< colored-links.inline >}}
-{{- range (index $.Site.Data "theme-colors") }}
+{{- range (index $.Site.Data "theme-colors") }}{{ if (or (eq .name "light") (eq .name "warning") (eq .name "info")) }}<div class="bg-dark p-2">{{ end }}
 <a href="#" class="link-{{ .name }}">{{ .name | title }} link</a>
-{{- end -}}
+{{ if (or (eq .name "light") (eq .name "warning") (eq .name "info")) }}</div>{{ end }}{{- end -}}
 {{< /colored-links.inline >}}
 {{< /example >}}


### PR DESCRIPTION
As mentionned in #30548, some components examples need a better background. `link-light` is totally invisible in `master` right now!

This is a first attempt, adding a simple container with `.bg-dark` for `info`, `light` and `warning` variants. Not very pleasant visually I guess, feel free to discuss :)

Preview:

* https://deploy-preview-30551--twbs-bootstrap.netlify.com/docs/4.3/components/buttons/#outline-buttons
* https://deploy-preview-30551--twbs-bootstrap.netlify.com/docs/4.3/helpers/colored-links/