### PR TITLE
Use `box-shadow` mixin for `.form-select`

### DIFF
--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -28,8 +28,9 @@
     border-color: $form-select-focus-border-color;
     outline: 0;
     @if $enable-shadows {
-      box-shadow: $form-select-box-shadow, $form-select-focus-box-shadow;
+      @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);
     } @else {
+      // Avoid using mixin so we can pass custom focus shadow properly
       box-shadow: $form-select-focus-box-shadow;
     }
 


### PR DESCRIPTION
This PR fixes css property box-shadow become invalid when `$enable-shadows: true;` and one of `$form-select-box-shadow` or `$form-select-focus-box-shadow` are `null`.