### PR TITLE
Add `karma-sabarivka-reporter` to ensure all source files under coverage

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -113,11 +113,18 @@ if (browserStack) {
     'karma-chrome-launcher',
     'karma-firefox-launcher',
     'karma-detect-browsers',
+    'karma-sabarivka-reporter',
     'karma-coverage-istanbul-reporter'
   )
-  reporters.push('coverage-istanbul')
+  reporters.push(
+    'sabarivka',
+    'coverage-istanbul'
+  )
   conf.customLaunchers = customLaunchers
   conf.detectBrowsers = detectBrowsers
+  conf.coverageReporter = {
+    include: 'src/**/*.js'
+  }
   conf.coverageIstanbulReporter = {
     dir: path.resolve(__dirname, '../coverage/'),
     reports: ['lcov', 'text-summary'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -958,6 +958,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -1397,6 +1403,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true,
       "optional": true
+    },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -7528,6 +7540,73 @@
         }
       }
     },
+    "karma-sabarivka-reporter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/karma-sabarivka-reporter/-/karma-sabarivka-reporter-3.2.0.tgz",
+      "integrity": "sha512-2d/ga87hE7pWqq7YZ6kgIQwlI89QrCkGto7snt0QShh4ttkNkygL/rc2+4YcTvKMUUXz5Ck4gzl3BQuq+JBIDQ==",
+      "dev": true,
+      "requires": {
+        "globby": "^11.0.0",
+        "istanbul-lib-instrument": "^4.0.1",
+        "predicates": "^2.0.3",
+        "typescript": "^3.8.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+          "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+          "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@babel/parser": "^7.7.5",
+            "@babel/template": "^7.7.4",
+            "@babel/traverse": "^7.7.4",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -10409,6 +10488,15 @@
       "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
       "dev": true
     },
+    "predicates": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/predicates/-/predicates-2.0.3.tgz",
+      "integrity": "sha512-eL+bhIiWrD+kx/olyYBcAFn258Oo9MTB7iehgBIaflVS8DBLuVtQvOpwgWwlya6YFUIiKaVoA3HaBNJuVNcyIA==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -13046,6 +13134,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "karma-jasmine": "^3.1.1",
     "karma-jasmine-html-reporter": "^1.5.3",
     "karma-rollup-preprocessor": "^7.0.5",
+    "karma-sabarivka-reporter": "^3.2.0",
     "linkinator": "^2.0.6",
     "lockfile-lint": "^4.2.2",
     "node-sass": "^4.13.1",


### PR DESCRIPTION
This project is fantastic and it's unit test coverage on very high level. Therefore, I've decided to create this PR and improve it a little more.
By adding this simple plugin, developers/architects of the project can ensure no new functionality (as new source file) will be added to the project without testing it.

**Explanation**:
With `karma` and `istanbul` reporter, if someone simply forgets to create `feature.spec.js` file for `feature.js` file - coverage result won't include `feature.js` source file