### PR TITLE
adds back `.form-text`

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -1,4 +1,5 @@
 @import "forms/labels";
+@import "forms/form-text";
 @import "forms/form-control";
 @import "forms/form-select";
 @import "forms/form-check";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -566,6 +566,7 @@ $btn-transition:              color .15s ease-in-out, background-color .15s ease
 // Forms
 
 $form-text-margin-top:                  .25rem !default;
+$form-text-font-size:                   null !default;
 $form-text-color:                       $text-muted !default;
 
 $form-label-margin-bottom:              .5rem !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -565,6 +565,8 @@ $btn-transition:              color .15s ease-in-out, background-color .15s ease
 
 // Forms
 
+$form-text-margin-top:                  .25rem !default;
+
 $form-label-margin-bottom:              .5rem !default;
 $form-label-font-size:                  null !default;
 $form-label-font-style:                 null !default;
@@ -668,8 +670,6 @@ $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www
 $form-switch-checked-color:       $component-active-color !default;
 $form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
 $form-switch-checked-bg-position: right center !default;
-
-$form-text-margin-top:                  .25rem !default;
 
 $form-check-inline-margin-right:        1rem !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -567,6 +567,7 @@ $btn-transition:              color .15s ease-in-out, background-color .15s ease
 
 $form-text-margin-top:                  .25rem !default;
 $form-text-font-size:                   null !default;
+$form-text-font-style:                  null !default;
 $form-text-color:                       $text-muted !default;
 
 $form-label-margin-bottom:              .5rem !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -566,6 +566,7 @@ $btn-transition:              color .15s ease-in-out, background-color .15s ease
 // Forms
 
 $form-text-margin-top:                  .25rem !default;
+$form-text-color:                       $text-muted !default;
 
 $form-label-margin-bottom:              .5rem !default;
 $form-label-font-size:                  null !default;

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -5,4 +5,5 @@
 .form-text {
   display: block;
   margin-top: $form-text-margin-top;
+  color: $form-text-color;
 }

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -1,0 +1,8 @@
+//
+// Form text
+//
+
+.form-text {
+  display: block;
+  margin-top: $form-text-margin-top;
+}

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -5,5 +5,6 @@
 .form-text {
   display: block;
   margin-top: $form-text-margin-top;
+  @include font-size($form-text-font-size);
   color: $form-text-color;
 }

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -6,5 +6,6 @@
   display: block;
   margin-top: $form-text-margin-top;
   @include font-size($form-text-font-size);
+  font-style: $form-text-font-style;
   color: $form-text-color;
 }

--- a/site/content/docs/4.3/forms/layout.md
+++ b/site/content/docs/4.3/forms/layout.md
@@ -18,7 +18,7 @@ Since Bootstrap applies `display: block` and `width: 100%` to almost all our for
 
 ## Utilities
 
-[Margin utilities]({{< docsref "/utilities/spacing" >}}) are the easiest way to add some structure to forms. They provide basic grouping of labels, controls, optional help text, and form validation messaging. We recommend sticking to `margin-bottom` utilities, and using a single direction throughout the form for consistency.
+[Margin utilities]({{< docsref "/utilities/spacing" >}}) are the easiest way to add some structure to forms. They provide basic grouping of labels, controls, optional form text, and form validation messaging. We recommend sticking to `margin-bottom` utilities, and using a single direction throughout the form for consistency.
 
 Feel free to build your forms however you like, with `<fieldset>`s, `<div>`s, or nearly any other element.
 

--- a/site/content/docs/4.3/forms/overview.md
+++ b/site/content/docs/4.3/forms/overview.md
@@ -51,17 +51,17 @@ Here's a quick example to demonstrate Bootstrap's form styles. Keep reading for 
 </form>
 {{< /example >}}
 
-## Help text
+## Form text
 
-Block-level help text in forms can be created using `.form-text` (previously known as `.help-block` in v3). Inline help text can be flexibly implemented using any inline HTML element and utility classes like `.text-*`.
+Block-level form text in forms can be created using `.form-text`.
 
 {{< callout warning >}}
-##### Associating help text with form controls
+##### Associating form text with form controls
 
-Help text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this help text when the user focuses or enters the control.
+Form text should be explicitly associated with the form control it relates to using the `aria-describedby` attribute. This will ensure that assistive technologies—such as screen readers—will announce this form text when the user focuses or enters the control.
 {{< /callout >}}
 
-Help text below inputs can be styled with `.form-text`. This class includes `display: block` and adds some top margin for easy spacing from the inputs above.
+Form text below inputs can be styled with `.form-text`. This class includes `display: block` and adds some top margin for easy spacing from the inputs above.
 
 {{< example >}}
 <label for="inputPassword5" class="form-label">Password</label>

--- a/site/content/docs/4.3/forms/overview.md
+++ b/site/content/docs/4.3/forms/overview.md
@@ -37,7 +37,7 @@ Here's a quick example to demonstrate Bootstrap's form styles. Keep reading for 
   <div class="mb-3">
     <label for="exampleInputEmail1" class="form-label">Email address</label>
     <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp">
-    <small id="emailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>
+    <small id="emailHelp" class="form-text">We'll never share your email with anyone else.</small>
   </div>
   <div class="mb-3">
     <label for="exampleInputPassword1" class="form-label">Password</label>
@@ -53,7 +53,7 @@ Here's a quick example to demonstrate Bootstrap's form styles. Keep reading for 
 
 ## Help text
 
-Block-level help text in forms can be created using `.form-text` (previously known as `.help-block` in v3). Inline help text can be flexibly implemented using any inline HTML element and utility classes like `.text-muted`.
+Block-level help text in forms can be created using `.form-text` (previously known as `.help-block` in v3). Inline help text can be flexibly implemented using any inline HTML element and utility classes like `.text-*`.
 
 {{< callout warning >}}
 ##### Associating help text with form controls
@@ -66,7 +66,7 @@ Help text below inputs can be styled with `.form-text`. This class includes `dis
 {{< example >}}
 <label for="inputPassword5" class="form-label">Password</label>
 <input type="password" id="inputPassword5" class="form-control" aria-describedby="passwordHelpBlock">
-<small id="passwordHelpBlock" class="form-text text-muted">
+<small id="passwordHelpBlock" class="form-text">
   Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces, special characters, or emoji.
 </small>
 {{< /example >}}

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -101,7 +101,6 @@ Changes to Reboot, typography, tables, and more.
 - Dropped `.form-row` for the more flexible grid gutters.
 - Dropped `.form-inline` for the more flexible grid.
 - Dropped support for `.form-control-plaintext` inside `.input-group`s.
-- Dropped `.form-text` as existing utilities cover this use class's former use case (e.g., `.mt-2`, `.text-small`, and/or `.text-muted`).
 - Dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
 - Form labels now require the `.form-label` class. Sass variables are now available to style form labels to your needs. [See #30476](https://github.com/twbs/bootstrap/pull/30476)
 


### PR DESCRIPTION
This PR adds back `.form-text` css class.

- deploy [preview](https://deploy-preview-30565--twbs-bootstrap.netlify.com/docs/4.3/forms/overview/)
- closes https://github.com/twbs/bootstrap/issues/30477