### PR TITLE
v5: Add .fs-* utilities for font-size and rename font-weight/-style utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -395,7 +395,7 @@ $utilities: map-merge(
     ),
     "font-style": (
       property: font-style,
-      class: f,
+      class: fst,
       values: italic normal
     ),
     "font-weight": (

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -387,6 +387,11 @@ $utilities: map-merge(
       values: $spacers
     ),
     // Text
+    "font-size": (
+      property: font-size,
+      class: fs,
+      values: $font-sizes
+    ),
     "font-weight": (
       property: font-weight,
       values: (

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -399,7 +399,7 @@ $utilities: map-merge(
       values: italic normal
     ),
     "font-weight": (
-      property: fw,
+      property: font-weight,
       values: (
         light: $font-weight-light,
         lighter: $font-weight-lighter,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -388,12 +388,18 @@ $utilities: map-merge(
     ),
     // Text
     "font-size": (
+      rfs: true,
       property: font-size,
       class: fs,
       values: $font-sizes
     ),
+    "font-style": (
+      property: font-style,
+      class: f,
+      values: italic normal
+    ),
     "font-weight": (
-      property: font-weight,
+      property: fw,
       values: (
         light: $font-weight-light,
         lighter: $font-weight-lighter,
@@ -466,11 +472,6 @@ $utilities: map-merge(
     "text-decoration": (
       property: text-decoration,
       values: none underline line-through
-    ),
-    "font-style": (
-      property: font-style,
-      class: font,
-      values: italic normal
     ),
     "word-wrap": (
       property: word-wrap word-break,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -425,6 +425,17 @@ $h4-font-size:                $font-size-base * 1.5 !default;
 $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
+// scss-docs-start font-sizes
+$font-sizes: (
+  1: $h1-font-size,
+  2: $h2-font-size,
+  3: $h3-font-size,
+  4: $h4-font-size,
+  5: $h5-font-size,
+  6: $h6-font-size
+) !default;
+// scss-docs-end font-sizes
+
 $headings-margin-bottom:      $spacer / 2 !default;
 $headings-font-family:        null !default;
 $headings-font-style:         null !default;

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -25,6 +25,13 @@ toc: true
 
 - The longstanding [Missing border radius on input group with validation feedback bug](https://github.com/twbs/bootstrap/issues/25110) is finally fixed by adding an additional `.has-validation` class to input groups with validation.
 
+### Utilities
+
+- **Text utilities:**
+  - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
+  - Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
+  - Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
+
 ## v5.0.0-alpha2
 
 ### Sass
@@ -138,6 +145,9 @@ toc: true
   - Some great examples have been added to the docs to show these off.
 - [#31484](https://github.com/twbs/bootstrap/pull/31484): Added new [`border-width` utility]({{< docsref "/utilities/borders#border-width" >}}).
 - [#31473](https://github.com/twbs/bootstrap/pull/31473): The `.d-none` utility was moved in our CSS to give it more weight over other display utilities.
+   Renamed `.text-monospace` to `.font-monospace`.
+- Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
+- New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 
 ---
 
@@ -323,15 +333,6 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 ### Grid
 
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
-
-### Fonts and text
-
-- Added `.fs-*` utilities for `font-size`.
-- Renamed `.font-weight-*` utilities as `.fw-*` for brevity.
-- Renamed `.font-style-*` utilities as `.fst-*` for brevity.
-- Renamed `.text-monospace` to `.font-monospace`.
-- New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
-- Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
 
 ### Misc
 

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -21,12 +21,17 @@ toc: true
 
 - Introduce `$enable-smooth-scroll`, which applies `scroll-behavior: smooth` globally—except for users asking for reduced motion through `prefers-reduced-motion` media query. [See #31877](https://github.com/twbs/bootstrap/pull/31877)
 
+<<<<<<< HEAD
 ### Forms
 
 - The longstanding [Missing border radius on input group with validation feedback bug](https://github.com/twbs/bootstrap/issues/25110) is finally fixed by adding an additional `.has-validation` class to input groups with validation.
 
 ### Utilities
 
+=======
+### Utilities
+
+>>>>>>> Update migration guide for more details, splitting alpha 2 stuff back to the appropriate section in Migration guide
 - **Text utilities:**
   - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
   - Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
@@ -145,7 +150,7 @@ toc: true
   - Some great examples have been added to the docs to show these off.
 - [#31484](https://github.com/twbs/bootstrap/pull/31484): Added new [`border-width` utility]({{< docsref "/utilities/borders#border-width" >}}).
 - [#31473](https://github.com/twbs/bootstrap/pull/31473): The `.d-none` utility was moved in our CSS to give it more weight over other display utilities.
-   Renamed `.text-monospace` to `.font-monospace`.
+- Renamed `.text-monospace` to `.font-monospace`.
 - Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -320,12 +320,19 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 
 ### Utilities
 
-- Renamed `.text-monospace` to `.font-monospace`
+### Grid
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
+
+### Fonts and text
+- Added `.fs-*` utilities for `font-size`.
+- Renamed `.font-weight-*` utilities as `.fw-*` for brevity.
+- Renamed `.font-style-*` utilities as `.f-*` for brevity.
+- Renamed `.text-monospace` to `.font-monospace`
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
+- Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
+
+### Misc
 - Added `.bg-body` for quickly setting the `<body>`'s background to additional elements.
-- Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
-- Split utilities into property-value utility classes and helpers
 - Negative margin utilities are disabled by default. You can re-enable them by setting `$enable-negative-margins: true`, but keep in mind this can increase the file size quite a lot.
 
 ### Docs

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -321,17 +321,20 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 ### Utilities
 
 ### Grid
+
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
 
 ### Fonts and text
+
 - Added `.fs-*` utilities for `font-size`.
 - Renamed `.font-weight-*` utilities as `.fw-*` for brevity.
-- Renamed `.font-style-*` utilities as `.f-*` for brevity.
-- Renamed `.text-monospace` to `.font-monospace`
+- Renamed `.font-style-*` utilities as `.fst-*` for brevity.
+- Renamed `.text-monospace` to `.font-monospace`.
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
-- Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
+- Removed `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore.
 
 ### Misc
+
 - Added `.bg-body` for quickly setting the `<body>`'s background to additional elements.
 - Negative margin utilities are disabled by default. You can re-enable them by setting `$enable-negative-margins: true`, but keep in mind this can increase the file size quite a lot.
 

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -63,6 +63,23 @@ Transform text in components with text capitalization classes.
 
 Note how `.text-capitalize` only changes the first letter of each word, leaving the case of any other letters unaffected.
 
+## Font size
+
+Quickly change the `font-size` of text. While our heading classes (e.g., `.h1`–`.h6`) apply `font-size`, `font-weight`, and `line-height`, these utilities _only_ apply `font-size`.
+
+{{< example >}}
+<p class="fs-1">.fs-1 text</p>
+<p class="fs-2">.fs-2 text</p>
+<p class="fs-3">.fs-3 text</p>
+<p class="fs-4">.fs-4 text</p>
+<p class="fs-5">.fs-5 text</p>
+<p class="fs-6">.fs-6 text</p>
+{{< /example >}}
+
+Customize your available `font-size`s by modifying the `$font-sizes` Sass map.
+
+{{< scss-docs name="font-sizes" file="scss/_variables.scss" >}}
+
 ## Font weight and italics
 
 Quickly change the weight (boldness) of text or italicize text.

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -82,7 +82,7 @@ Customize your available `font-size`s by modifying the `$font-sizes` Sass map.
 
 ## Font weight and italics
 
-Quickly change the `font-weight` or `font-style` of text with these utilities. `font-style` utilities are abbreviated as `.f-*` and `font-weight` utilities are abbreviated as `.fw-*`.
+Quickly change the `font-weight` or `font-style` of text with these utilities. `font-style` utilities are abbreviated as `.fst-*` and `font-weight` utilities are abbreviated as `.fw-*`.
 
 {{< example >}}
 <p class="fw-bold">Bold text.</p>
@@ -90,8 +90,8 @@ Quickly change the `font-weight` or `font-style` of text with these utilities. `
 <p class="fw-normal">Normal weight text.</p>
 <p class="fw-light">Light weight text.</p>
 <p class="fw-lighter">Lighter weight text (relative to the parent element).</p>
-<p class="f-italic">Italic text.</p>
-<p class="f-normal">Text without font style</p>
+<p class="fst-italic">Italic text.</p>
+<p class="fst-normal">Text without font style</p>
 {{< /example >}}
 
 ## Line height

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -82,16 +82,16 @@ Customize your available `font-size`s by modifying the `$font-sizes` Sass map.
 
 ## Font weight and italics
 
-Quickly change the weight (boldness) of text or italicize text.
+Quickly change the `font-weight` or `font-style` of text with these utilities. `font-style` utilities are abbreviated as `.f-*` and `font-weight` utilities are abbreviated as `.fw-*`.
 
 {{< example >}}
-<p class="font-weight-bold">Bold text.</p>
-<p class="font-weight-bolder">Bolder weight text (relative to the parent element).</p>
-<p class="font-weight-normal">Normal weight text.</p>
-<p class="font-weight-light">Light weight text.</p>
-<p class="font-weight-lighter">Lighter weight text (relative to the parent element).</p>
-<p class="font-italic">Italic text.</p>
-<p class="font-normal">Text without font style</p>
+<p class="fw-bold">Bold text.</p>
+<p class="fw-bolder">Bolder weight text (relative to the parent element).</p>
+<p class="fw-normal">Normal weight text.</p>
+<p class="fw-light">Light weight text.</p>
+<p class="fw-lighter">Lighter weight text (relative to the parent element).</p>
+<p class="f-italic">Italic text.</p>
+<p class="f-normal">Text without font style</p>
 {{< /example >}}
 
 ## Line height

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -65,7 +65,7 @@ Note how `.text-capitalize` only changes the first letter of each word, leaving 
 
 ## Font size
 
-Quickly change the `font-size` of text. While our heading classes (e.g., `.h1`–`.h6`) apply `font-size`, `font-weight`, and `line-height`, these utilities _only_ apply `font-size`.
+Quickly change the `font-size` of text. While our heading classes (e.g., `.h1`–`.h6`) apply `font-size`, `font-weight`, and `line-height`, these utilities _only_ apply `font-size`. Sizing for these utilities matches HTML's heading elements, so as the number increases, their size decreases.
 
 {{< example >}}
 <p class="fs-1">.fs-1 text</p>

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -91,7 +91,7 @@ Quickly change the `font-weight` or `font-style` of text with these utilities. `
 <p class="fw-light">Light weight text.</p>
 <p class="fw-lighter">Lighter weight text (relative to the parent element).</p>
 <p class="fst-italic">Italic text.</p>
-<p class="fst-normal">Text without font style</p>
+<p class="fst-normal">Text with normal font style</p>
 {{< /example >}}
 
 ## Line height


### PR DESCRIPTION
- Adds new font-sizes Sass map
- Generates six new classes for setting only font-size
- Updates docs to mention this, including a scss-docs reference

It occurs to me this might need some `rfs` magic, but I'm unsure how to add that right now to the utilities file. Also, should these be responsive so folks can do `.fs-md-3 .fs-lg-4`? I'm thinking not given obvious file bloat.

Also makes me think `.font-weight-*` utilities should be shortened to `.fw-*`. `.font-style` is obviously trickier... could remap to `.text-*` or `.font-*`?

Fixes #25832.

https://deploy-preview-30571--twbs-bootstrap.netlify.app/docs/5.0/utilities/text/#font-size