### PR TITLE
Fix for sliding checkmark

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -20,6 +20,7 @@
   margin-top: ($line-height-base - $form-check-input-width) / 2; // line-height minus check height
   vertical-align: top;
   background-color: $form-check-input-bg;
+  background-position: $form-check-input-checked-bg-position;
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;


### PR DESCRIPTION
If the $form-check-input-width variable is changed and therefore the size of the checkbox or the radio button is different, the transition for the background-position will make the checkmark or the radio circle to slide a bit while appearing on-checked.
This change will fix the position to the center to prevent the undesirable sliding effect.