### PR TITLE
Fix crash when pressing ArrowUp the first time

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -479,7 +479,7 @@ class Dropdown {
       return
     }
 
-    let index = items.indexOf(event.target) || 0
+    let index = items.indexOf(event.target)
 
     if (event.which === ARROW_UP_KEYCODE && index > 0) { // Up
       index--
@@ -488,6 +488,9 @@ class Dropdown {
     if (event.which === ARROW_DOWN_KEYCODE && index < items.length - 1) { // Down
       index++
     }
+
+    // index is -1 if the first keydown is an ArrowUp
+    index = index === -1 ? 0 : index
 
     items[index].focus()
   }

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1367,6 +1367,34 @@ describe('Dropdown', () => {
       triggerDropdown.click()
     })
 
+    it('should focus on the first element when using ArrowUp for the first time', done => {
+      fixtureEl.innerHTML = [
+        '<div class="dropdown">',
+        '  <button class="btn dropdown-toggle" data-toggle="dropdown">Dropdown</button>',
+        '  <div class="dropdown-menu">',
+        '    <a id="item1" class="dropdown-item" href="#">A link</a>',
+        '    <a id="item2" class="dropdown-item" href="#">Another link</a>',
+        '  </div>',
+        '</div>'
+      ].join('')
+
+      const triggerDropdown = fixtureEl.querySelector('[data-toggle="dropdown"]')
+      const dropdown = fixtureEl.querySelector('.dropdown')
+      const item1 = fixtureEl.querySelector('#item1')
+
+      dropdown.addEventListener('shown.bs.dropdown', () => {
+        const keydown = createEvent('keydown')
+        keydown.key = 'ArrowUp'
+
+        document.activeElement.dispatchEvent(keydown)
+        expect(document.activeElement).toEqual(item1, 'item1 is focused')
+
+        done()
+      })
+
+      triggerDropdown.click()
+    })
+
     it('should not close the dropdown if the user clicks on a text field', done => {
       fixtureEl.innerHTML = [
         '<div class="dropdown">',


### PR DESCRIPTION
Edit: already done in #30597

Fix crash in dropdown: "Uncaught TypeError: Cannot read property 'focus' of undefined"

When opening the dropdown and pressing ArrowUp for the first time.
Crash already present here: https://twbs-bootstrap.netlify.com/docs/4.3/components/dropdowns/

https://github.com/twbs/bootstrap/blob/f0abe26b98ade4d6a2d0b234758a94ea33b85388/js/src/dropdown.js#L482

`items.indexOf(event.target) || 0` gives `-1 || 0` which returns... `-1`... See explanations ["Why are JavaScript negative numbers not always true or false?"](https://stackoverflow.com/q/3619797)