### PR TITLE
Add Action: Label PRs

### DIFF
--- a/.github/label-pr.yml
+++ b/.github/label-pr.yml
@@ -1,0 +1,8 @@
+- regExp: ".*\\.md+$"
+  labels: ["docs"]
+- regExp: ".*\\.scss+$"
+  labels: ["css"]
+- regExp: ".*\\.js+$"
+  labels: ["js"]
+- regExp: "^(package\\.json|build\\.gradle)$"
+  labels: ["dependencies"]

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,18 @@
+name: Label PRs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      # We need to checkout the repository to access the configured file (.github/label-pr.yml)
+      - uses: actions/checkout@v2
+      - name: PR label by Files
+        uses: Decathlon/pull-request-labeler-action@v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds an Action to automatically label PRs based on what files they modify. I could go either way on this, because we'd likely also want to automatically add `v5` and projects perhaps. Thoughts?