### PR TITLE
CI: remove no longer needed steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: node --version
-      - run: npm --version
       - run: java -version
 
       - name: Set up npm cache


### PR DESCRIPTION
The latest `actions/setup-node` prints this info by default