### PR TITLE
Move codeql.yml workflow to top level and specify javascript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      with:
+        languages: javascript
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below).


### PR DESCRIPTION
Follow up to https://github.com/twbs/bootstrap/pull/30676. That PR created the GitHub Action workflow for CodeQL in the wrong place (🤦) - this moves it so it will actually run.