### PR TITLE
Use `safeHTMLAttr` in the `integrity` attributes.

### DIFF
--- a/site/layouts/_default/examples.html
+++ b/site/layouts/_default/examples.html
@@ -44,13 +44,13 @@
 
     {{ if ne .Page.Params.include_js false -}}
       {{- if eq hugo.Environment "production" -}}
-        <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.min.js" integrity="{{ .Site.Params.cdn.js_bundle_hash }}" crossorigin="anonymous"></script>
+        <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.min.js" {{ printf "integrity=%q" .Site.Params.cdn.js_bundle_hash | safeHTMLAttr }} crossorigin="anonymous"></script>
       {{- else -}}
         <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.js"></script>
       {{- end }}
 
       {{ range .Page.Params.extra_js -}}
-        <script{{ with .async }} async{{ end }} src="{{ .src }}"{{ with .integrity }} integrity="{{ . }}" crossorigin="anonymous"{{ end }}></script>
+        <script{{ with .async }} async{{ end }} src="{{ .src }}"{{ with .integrity }} {{ printf "integrity=%q" . | safeHTMLAttr }} crossorigin="anonymous"{{ end }}></script>
       {{- end -}}
     {{- end }}
   </body>

--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -26,11 +26,11 @@
   <a class="btn btn-lg btn-outline-primary mb-4" href="/docs/{{ .Site.Params.docs_version }}/getting-started/introduction/">Explore the docs</a>
   <div class="text-left mx-md-5 px-md-5">
     <h5>CSS only</h5>
-    {{ highlight (printf (`<link rel="stylesheet" href="%s" integrity="%s" crossorigin="anonymous">`) .Site.Params.cdn.css .Site.Params.cdn.css_hash) "html" "" }}
+    {{ highlight (printf (`<link rel="stylesheet" href="%s" integrity=%q crossorigin="anonymous">`) .Site.Params.cdn.css (.Site.Params.cdn.css_hash | safeHTMLAttr)) "html" "" }}
     <h5>JS and Popper.js</h5>
-    {{ highlight (printf (`<script src="%s" integrity="%s" crossorigin="anonymous"></script>
-<script src="%s" integrity="%s" crossorigin="anonymous"></script>
-`) .Site.Params.cdn.popper .Site.Params.cdn.popper_hash .Site.Params.cdn.js .Site.Params.cdn.js_hash) "html" "" }}
+    {{ highlight (printf (`<script src="%s" integrity=%q crossorigin="anonymous"></script>
+<script src="%s" integrity=%q crossorigin="anonymous"></script>
+`) .Site.Params.cdn.popper (.Site.Params.cdn.popper_hash | safeHTMLAttr) .Site.Params.cdn.js (.Site.Params.cdn.js_hash | safeHTMLAttr)) "html" "" }}
   </div>
 </div>
 

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -1,5 +1,5 @@
 {{ if eq hugo.Environment "production" -}}
-  <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.min.js" integrity="{{ .Site.Params.cdn.js_bundle_hash }}" crossorigin="anonymous"></script>
+  <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.min.js" {{ printf "integrity=%q" .Site.Params.cdn.js_bundle_hash | safeHTMLAttr }} crossorigin="anonymous"></script>
 {{ else -}}
   <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.js"></script>
 {{- end }}

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,6 +1,6 @@
 {{- "<!-- Bootstrap core CSS -->" | safeHTML }}
 {{ if eq hugo.Environment "production" -}}
-<link href="/docs/{{ .Site.Params.docs_version }}/dist/css/bootstrap.min.css" rel="stylesheet" integrity="{{ .Site.Params.cdn.css_hash }}" crossorigin="anonymous">
+<link href="/docs/{{ .Site.Params.docs_version }}/dist/css/bootstrap.min.css" rel="stylesheet" {{ printf "integrity=%q" .Site.Params.cdn.css_hash | safeHTMLAttr }} crossorigin="anonymous">
 {{- else -}}
 <link href="/docs/{{ .Site.Params.docs_version }}/dist/css/bootstrap.css" rel="stylesheet">
 {{- end }}

--- a/site/layouts/shortcodes/param.html
+++ b/site/layouts/shortcodes/param.html
@@ -1,0 +1,12 @@
+{{- /*
+  Work around wrong escapes in integrity attributes.
+*/ -}}
+
+{{- $name := .Get 0 -}}
+{{- with $name -}}
+{{- $value := $.Page.Param . -}}
+{{- if in $name "_hash" -}}
+  {{- $value = $value | safeHTML -}}
+{{- end -}}
+{{- with $value }}{{ . }}{{ else }}{{ errorf "Param %q not found: %s" $name $.Position }}{{ end -}}
+{{- else }}{{ errorf "Missing param key: %s" $.Position }}{{ end -}}


### PR DESCRIPTION
I just noticed this after testing Microsoft Edge (old Edge) and I was getting this error although the CSS did load:

```
SEC7136: [Integrity] The origin 'https://twbs-bootstrap.netlify.app' failed an integrity check for a style resource at 'https://twbs-bootstrap.netlify.app/docs/4.3/dist/css/bootstrap.min.css'.
```

It seems Hugo escapes those. Now the problem is these two:

1. The masthead-followup.html becomes more and more unreadable IMO. But at least it does work properly.
2. There are 2 cases we print integrity hashes in Markdown with shortcodes where I don't know how to fix the issue:
  * https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/download.md
  * https://github.com/twbs/bootstrap/blob/master/site/content/docs/4.3/getting-started/introduction.md

@regisphilibert: maybe you have any suggestions how to fix this? 🙂

Preview: <https://deploy-preview-30680--twbs-bootstrap.netlify.app/>
