### PR TITLE
`<pre>`: Disable auto-hiding scrollbar in legacy Edge

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -290,6 +290,8 @@ samp {
 // 1. Remove browser default top margin
 // 2. Reset browser default of `1em` to use `rem`s
 // 3. Don't allow content to break outside
+// 4. Disable auto-hiding scrollbar in legacy Edge to avoid overlap,
+//    making it impossible to interact with the content
 
 pre {
   display: block;
@@ -298,6 +300,7 @@ pre {
   overflow: auto; // 3
   @include font-size($code-font-size);
   color: $pre-color;
+  -ms-overflow-style: scrollbar; // 4
 
   // Account for some code outputs that place code tags in pre tags
   code {


### PR DESCRIPTION
Disable auto-hiding scrollbar in legacy Edge to avoid overlap, making it impossible to interact with the content.
![image](https://user-images.githubusercontent.com/11559216/80609217-20b8b900-8a38-11ea-8677-adc6feb0baa2.png)

Ref. https://github.com/twbs/bootstrap/commit/f3fc973dd93d1bb69183404d9985157284a3be7f#diff-7f9eec82312835f6155c8de839bf0e49