### PR TITLE
Remove unneeded twitter:title and twitter:description from docs

### DIFF
--- a/site/layouts/partials/social.html
+++ b/site/layouts/partials/social.html
@@ -2,8 +2,6 @@
 <meta name="twitter:card" content="{{ if .IsHome }}summary_large_image{{ else }}summary{{ end }}">
 <meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
 <meta name="twitter:creator" content="@{{ .Site.Params.twitter }}">
-<meta name="twitter:title" content="{{ .Title | markdownify }}">
-<meta name="twitter:description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
 <meta name="twitter:image" content="{{ if .IsHome }}{{ .Site.Params.social_logo_path | absURL }}{{ else }}{{ .Site.Params.social_image_path | absURL }}{{ end }}">
 
 {{ "<!-- Facebook -->" | safeHTML }}


### PR DESCRIPTION
These only need to be defined if they are different to the Opengraph title/descriptions. As they are identical they aren't needed.
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#twitter-cards-and-open-graph
Removing them slightly reduces HTML file size / improves page load time.
I didn't remove/touch the twitter:image tag as it looks like that behaves differently to the og:image one.