### PR TITLE
Add font-display property to glyphicon's font-face

### DIFF
--- a/less/glyphicons.less
+++ b/less/glyphicons.less
@@ -18,6 +18,7 @@
        url("@{icon-font-path}@{icon-font-name}.woff") format("woff"),
        url("@{icon-font-path}@{icon-font-name}.ttf") format("truetype"),
        url("@{icon-font-path}@{icon-font-name}.svg#@{icon-font-svg-id}") format("svg");
+  font-display: block;
 }
 
 // Catchall baseclass


### PR DESCRIPTION
This change will remove this Google Lighthouse's warning for the glyphicon font :

`Ensure text remains visible during webfont load`

- [their page on the subject](https://web.dev/font-display/)
- [the file where this check is done](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/font-display.js#L10)

Any value (except `auto`) for the `font-display` would work I guess, but `block` seamed the proper choice since we don't want the browser trying to display glyphicons with another system font until the real font gets loaded !

- [font-display documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)

Thanks for your time !