### PR TITLE
Improve build/zip-examples.js

### DIFF
--- a/build/zip-examples.js
+++ b/build/zip-examples.js
@@ -27,15 +27,12 @@ sh.cd(path.join(__dirname, '..'))
 
 // remove any previously created folder with the same name
 sh.rm('-rf', folderName)
+// create any folders so that `cp` works
 sh.mkdir('-p', folderName)
 sh.mkdir('-p', `${folderName}/assets/brand/`)
 
-// copy the examples and dist folders; for the examples we use `*`
-// so that its content are copied to the root dist dir
-sh.cp('-Rf', [
-  `_gh_pages/docs/${versionShort}/examples/*`,
-  `_gh_pages/docs/${versionShort}/dist/`
-], folderName)
+sh.cp('-Rf', `_gh_pages/docs/${versionShort}/examples/*`, folderName)
+sh.cp('-Rf', `_gh_pages/docs/${versionShort}/dist/`, `${folderName}/assets/`)
 // also copy the two brand images we use in the examples
 sh.cp('-f', [
   `_gh_pages/docs/${versionShort}/assets/brand/bootstrap-outline.svg`,
@@ -48,6 +45,7 @@ sh.find(`${folderName}/**/*.html`).forEach(file => {
   const fileContents = sh.cat(file)
     .toString()
     .replace(new RegExp(`"/docs/${versionShort}/`, 'g'), '"../')
+    .replace(/"..\/dist\//g, '"../assets/dist/')
     .replace(/(<link href="\.\.\/.*) integrity=".*>/g, '$1>')
     .replace(/(<script src="\.\.\/.*) integrity=".*>/g, '$1></script>')
     .replace(/( +)<!-- favicons(.|\n)+<style>/i, '    <style>')

--- a/build/zip-examples.js
+++ b/build/zip-examples.js
@@ -19,7 +19,7 @@ const folderName = `bootstrap-${version}-examples`
 sh.config.fatal = true
 
 if (!sh.test('-d', '_gh_pages')) {
-  throw new Error('The _gh_pages folder does not exist, did you forget building the docs?')
+  throw new Error('The "_gh_pages" folder does not exist, did you forget building the docs?')
 }
 
 // switch to the root dir
@@ -28,6 +28,7 @@ sh.cd(path.join(__dirname, '..'))
 // remove any previously created folder with the same name
 sh.rm('-rf', folderName)
 sh.mkdir('-p', folderName)
+sh.mkdir('-p', `${folderName}/assets/brand/`)
 
 // copy the examples and dist folders; for the examples we use `*`
 // so that its content are copied to the root dist dir
@@ -35,13 +36,22 @@ sh.cp('-Rf', [
   `_gh_pages/docs/${versionShort}/examples/*`,
   `_gh_pages/docs/${versionShort}/dist/`
 ], folderName)
+// also copy the two brand images we use in the examples
+sh.cp('-f', [
+  `_gh_pages/docs/${versionShort}/assets/brand/bootstrap-outline.svg`,
+  `_gh_pages/docs/${versionShort}/assets/brand/bootstrap-solid.svg`
+], `${folderName}/assets/brand/`)
 sh.rm(`${folderName}/index.html`)
 
-// sed-fu
+// get all examples' HTML files
 sh.find(`${folderName}/**/*.html`).forEach(file => {
-  sh.sed('-i', new RegExp(`"/docs/${versionShort}/`, 'g'), '"../', file)
-  sh.sed('-i', /(<link href="\.\.\/.*) integrity=".*>/g, '$1>', file)
-  sh.sed('-i', /(<script src="\.\.\/.*) integrity=".*>/g, '$1></script>', file)
+  const fileContents = sh.cat(file)
+    .toString()
+    .replace(new RegExp(`"/docs/${versionShort}/`, 'g'), '"../')
+    .replace(/(<link href="\.\.\/.*) integrity=".*>/g, '$1>')
+    .replace(/(<script src="\.\.\/.*) integrity=".*>/g, '$1></script>')
+    .replace(/( +)<!-- favicons(.|\n)+<style>/i, '    <style>')
+  new sh.ShellString(fileContents).to(file)
 })
 
 // create the zip file


### PR DESCRIPTION
* remove favicons meta tags
* copy the two brand images we use in the examples

`sh.sed` has the same limitations as the `sed` tool, hence this solution. Not perfect but does the job.

https://github.com/shelljs/shelljs#sedoptions-search_regex-replacement-file--file-

>Also, like unix sed, ShellJS sed runs replacements on each line from the input file (split by '\n') separately, so search_regexes that span more than one line (or include '\n') will not match anything and nothing will be replaced.