### PR TITLE
Update _custom-forms.scss

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -37,7 +37,7 @@
   &:focus ~ .custom-control-label::before {
     // the mixin is not used here to make sure there is feedback
     @if $enable-shadows {
-      box-shadow: $input-box-shadow, $input-focus-box-shadow;
+      box-shadow: $input-box-shadow, $custom-control-indicator-focus-box-shadow;
     } @else {
       box-shadow: $custom-control-indicator-focus-box-shadow;
     }


### PR DESCRIPTION
Typo in box-shadow attribute, global variable used instead of local.

Found this because i cannot set checkbox shadow to `none` on `focus` state.
Checkbox shadow dissapear only when i turn off all shadow, but it's not true way to solve it.