### PR TITLE
Issue#27163 close icon focus style

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -12,6 +12,14 @@
     text-decoration: none;
   }
 
+  &:not(:disabled):not(.disabled) {
+    width: max-content;
+    height: max-content;
+    @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-border-radius);
+    @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix($color, $border, 15%), .5));
+    box-shadow: $btn-focus-box-shadow;
+  }
+
   &:hover,
   &:focus {
     opacity: .75;

--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -13,10 +13,8 @@
   }
 
   &:not(:disabled):not(.disabled) {
-    width: max-content;
-    height: max-content;
-    @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-border-radius);
-    @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix($color, $border, 15%), .5));
+    width: $btn-padding-x;
+    height: $btn-padding-y;
     box-shadow: $btn-focus-box-shadow;
   }
 


### PR DESCRIPTION
### Restyle close icon's focus style
- Added dedicated width and height to focused close icon to give it box like outline
- Set distinct shadow which is applied if icon is focused