### PR TITLE
v5: Utilities CSS cleanup, new border and bg utils, renames rounded to radius

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -4,20 +4,13 @@ $utilities: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $utilities: map-merge(
   (
-    "align": (
-      property: vertical-align,
-      class: align,
-      values: baseline top middle bottom text-bottom text-top
+    // Positioning
+    "position": (
+      property: position,
+      values: static relative absolute fixed sticky
     ),
-    "float": (
-      responsive: true,
-      property: float,
-      values: left right none
-    ),
-    "overflow": (
-      property: overflow,
-      values: auto hidden,
-    ),
+
+    // Display
     "display": (
       responsive: true,
       print: true,
@@ -25,113 +18,7 @@ $utilities: map-merge(
       class: d,
       values: none inline inline-block block table table-row table-cell flex inline-flex
     ),
-    "shadow": (
-      property: box-shadow,
-      class: shadow,
-      values: (
-        null: $box-shadow,
-        sm: $box-shadow-sm,
-        lg: $box-shadow-lg,
-        none: none,
-      )
-    ),
-    "position": (
-      property: position,
-      values: static relative absolute fixed sticky
-    ),
-    "border": (
-      property: border,
-      values: (
-        null: $border-width solid $border-color,
-        0: 0,
-      )
-    ),
-    "border-top": (
-      property: border-top,
-      values: (
-        null: $border-width solid $border-color,
-        0: 0,
-      )
-    ),
-    "border-right": (
-      property: border-right,
-      values: (
-        null: $border-width solid $border-color,
-        0: 0,
-      )
-    ),
-    "border-bottom": (
-      property: border-bottom,
-      values: (
-        null: $border-width solid $border-color,
-        0: 0,
-      )
-    ),
-    "border-left": (
-      property: border-left,
-      values: (
-        null: $border-width solid $border-color,
-        0: 0,
-      )
-    ),
-    "border-color": (
-      property: border-color,
-      class: border,
-      values: map-merge($theme-colors, ("white": $white))
-    ),
-    // Sizing utilities
-    "width": (
-      property: width,
-      class: w,
-      values: (
-        25: 25%,
-        50: 50%,
-        75: 75%,
-        100: 100%,
-        auto: auto
-      )
-    ),
-    "max-width": (
-      property: max-width,
-      class: mw,
-      values: (100: 100%)
-    ),
-    "viewport-width": (
-      property: width,
-      class: vw,
-      values: (100: 100vw)
-    ),
-    "min-viewport-width": (
-      property: min-width,
-      class: min-vw,
-      values: (100: 100vw)
-    ),
-    "height": (
-      property: height,
-      class: h,
-      values: (
-        25: 25%,
-        50: 50%,
-        75: 75%,
-        100: 100%,
-        auto: auto
-      )
-    ),
-    "max-height": (
-      property: max-height,
-      class: mh,
-      values: (100: 100%)
-    ),
-    "viewport-height": (
-      property: height,
-      class: vh,
-      values: (100: 100vh)
-    ),
-    "min-viewport-height": (
-      property: min-height,
-      class: min-vh,
-      values: (100: 100vh)
-    ),
+
     // Flex utilities
     "flex": (
       responsive: true,
@@ -228,7 +115,111 @@ $utilities: map-merge(
         last: 6,
       ),
     ),
-    // Margin utilities
+
+    // Dimentions and display-related
+    "float": (
+      responsive: true,
+      property: float,
+      values: left right none
+    ),
+    "width": (
+      property: width,
+      class: w,
+      values: (
+        25: 25%,
+        50: 50%,
+        75: 75%,
+        100: 100%,
+        auto: auto
+      )
+    ),
+    "max-width": (
+      property: max-width,
+      class: mw,
+      values: (100: 100%)
+    ),
+    "viewport-width": (
+      property: width,
+      class: vw,
+      values: (100: 100vw)
+    ),
+    "min-viewport-width": (
+      property: min-width,
+      class: min-vw,
+      values: (100: 100vw)
+    ),
+    "height": (
+      property: height,
+      class: h,
+      values: (
+        25: 25%,
+        50: 50%,
+        75: 75%,
+        100: 100%,
+        auto: auto
+      )
+    ),
+    "max-height": (
+      property: max-height,
+      class: mh,
+      values: (100: 100%)
+    ),
+    "viewport-height": (
+      property: height,
+      class: vh,
+      values: (100: 100vh)
+    ),
+    "min-viewport-height": (
+      property: min-height,
+      class: min-vh,
+      values: (100: 100vh)
+    ),
+
+    // Padding
+    "padding": (
+      responsive: true,
+      property: padding,
+      class: p,
+      values: $spacers
+    ),
+    "padding-x": (
+      responsive: true,
+      property: padding-right padding-left,
+      class: px,
+      values: $spacers
+    ),
+    "padding-y": (
+      responsive: true,
+      property: padding-top padding-bottom,
+      class: py,
+      values: $spacers
+    ),
+    "padding-top": (
+      responsive: true,
+      property: padding-top,
+      class: pt,
+      values: $spacers
+    ),
+    "padding-right": (
+      responsive: true,
+      property: padding-right,
+      class: pr,
+      values: $spacers
+    ),
+    "padding-bottom": (
+      responsive: true,
+      property: padding-bottom,
+      class: pb,
+      values: $spacers
+    ),
+    "padding-left": (
+      responsive: true,
+      property: padding-left,
+      class: pl,
+      values: $spacers
+    ),
+
+    // Margin
     "margin": (
       responsive: true,
       property: margin,
@@ -314,50 +305,24 @@ $utilities: map-merge(
       class: ml,
       values: $negative-spacers
     ),
-    // Padding utilities
-    "padding": (
-      responsive: true,
-      property: padding,
-      class: p,
-      values: $spacers
+
+    // Overflow
+    "overflow": (
+      property: overflow,
+      values: auto hidden,
     ),
-    "padding-x": (
-      responsive: true,
-      property: padding-right padding-left,
-      class: px,
-      values: $spacers
+
+    // Fonts
+    "font-family": (
+      property: font-family,
+      class: font,
+      values: (monospace: var(--bs-font-monospace))
     ),
-    "padding-y": (
-      responsive: true,
-      property: padding-top padding-bottom,
-      class: py,
-      values: $spacers
+    "font-style": (
+      property: font-style,
+      class: font,
+      values: italic normal
     ),
-    "padding-top": (
-      responsive: true,
-      property: padding-top,
-      class: pt,
-      values: $spacers
-    ),
-    "padding-right": (
-      responsive: true,
-      property: padding-right,
-      class: pr,
-      values: $spacers
-    ),
-    "padding-bottom": (
-      responsive: true,
-      property: padding-bottom,
-      class: pb,
-      values: $spacers
-    ),
-    "padding-left": (
-      responsive: true,
-      property: padding-left,
-      class: pl,
-      values: $spacers
-    ),
-    // Text
     "font-weight": (
       property: font-weight,
       values: (
@@ -368,17 +333,18 @@ $utilities: map-merge(
         bolder: $font-weight-bolder
       )
     ),
-    "text-transform": (
-      property: text-transform,
-      class: text,
-      values: lowercase uppercase capitalize
+    "line-height": (
+      property: line-height,
+      class: lh,
+      values: (
+        1: 1,
+        sm: $line-height-sm,
+        base: $line-height-base,
+        lg: $line-height-lg,
+      )
     ),
-    "text-align": (
-      responsive: true,
-      property: text-align,
-      class: text,
-      values: left right center
-    ),
+
+    // Color
     "color": (
       property: color,
       class: text,
@@ -394,16 +360,54 @@ $utilities: map-merge(
         )
       )
     ),
-    "line-height": (
-      property: line-height,
-      class: lh,
+
+    // Text
+    "text-align": (
+      responsive: true,
+      property: text-align,
+      class: text,
+      values: left right center
+    ),
+    "text-decoration": (
+      property: text-decoration,
+      values: none underline line-through
+    ),
+    "text-transform": (
+      property: text-transform,
+      class: text,
+      values: lowercase uppercase capitalize
+    ),
+    "word-wrap": (
+      property: word-wrap,
+      class: text,
+      values: (break: break-word)
+    ),
+    "white-space": (
+      property: white-space,
+      class: text,
       values: (
-        1: 1,
-        sm: $line-height-sm,
-        base: $line-height-base,
-        lg: $line-height-lg,
+        wrap: normal,
+        nowrap: nowrap,
       )
     ),
+    "align": (
+      property: vertical-align,
+      class: align,
+      values: baseline top middle bottom text-bottom text-top
+    ),
+
+    // Behaviors
+    "user-select": (
+      property: user-select,
+      values: all auto none
+    ),
+    "pointer-events": (
+      property: pointer-events,
+      class: pe,
+      values: none auto,
+    ),
+
+    // Background
     "background-color": (
       property: background-color,
       class: bg,
@@ -416,42 +420,50 @@ $utilities: map-merge(
         )
       )
     ),
-    "white-space": (
-      property: white-space,
-      class: text,
+
+    // Border
+    "border": (
+      property: border,
       values: (
-        wrap: normal,
-        nowrap: nowrap,
+        null: $border-width solid $border-color,
+        0: 0,
       )
     ),
-    "text-decoration": (
-      property: text-decoration,
-      values: none underline line-through
+    "border-top": (
+      property: border-top,
+      values: (
+        null: $border-width solid $border-color,
+        0: 0,
+      )
     ),
-    "font-style": (
-      property: font-style,
-      class: font,
-      values: italic normal
+    "border-right": (
+      property: border-right,
+      values: (
+        null: $border-width solid $border-color,
+        0: 0,
+      )
     ),
-    "word-wrap": (
-      property: word-wrap,
-      class: text,
-      values: (break: break-word)
+    "border-bottom": (
+      property: border-bottom,
+      values: (
+        null: $border-width solid $border-color,
+        0: 0,
+      )
     ),
-    "font-family": (
-      property: font-family,
-      class: font,
-      values: (monospace: var(--bs-font-monospace))
+    "border-left": (
+      property: border-left,
+      values: (
+        null: $border-width solid $border-color,
+        0: 0,
+      )
     ),
-    "user-select": (
-      property: user-select,
-      values: all auto none
+    "border-color": (
+      property: border-color,
+      class: border,
+      values: map-merge($theme-colors, ("white": $white))
     ),
-    "pointer-events": (
-      property: pointer-events,
-      class: pe,
-      values: none auto,
-    ),
+
+    // Border-radius
     "rounded": (
       property: border-radius,
       class: rounded,
@@ -483,6 +495,18 @@ $utilities: map-merge(
       property: border-bottom-left-radius border-top-left-radius,
       class: rounded-left,
       values: (null: $border-radius)
+    ),
+
+    // Effects
+    "shadow": (
+      property: box-shadow,
+      class: shadow,
+      values: (
+        null: $box-shadow,
+        sm: $box-shadow-sm,
+        lg: $box-shadow-lg,
+        none: none,
+      )
     ),
     "visibility": (
       property: visibility,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -405,6 +405,8 @@ $utilities: map-merge(
         (
           "body": $body-bg,
           "white": $white,
+          "gray": $gray-400,
+          "black": black,
           "transparent": transparent
         )
       )
@@ -448,7 +450,15 @@ $utilities: map-merge(
     "border-color": (
       property: border-color,
       class: border,
-      values: map-merge($theme-colors, ("white": $white))
+      values: map-merge(
+        $theme-colors,
+        (
+          "white": $white,
+          "gray-500": $gray-500,
+          "gray-700": $gray-700,
+          "black": $black
+        )
+      )
     ),
     // Border-radius
     "radius": (

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -9,7 +9,6 @@ $utilities: map-merge(
       property: position,
       values: static relative absolute fixed sticky
     ),
-
     // Display
     "display": (
       responsive: true,
@@ -18,7 +17,6 @@ $utilities: map-merge(
       class: d,
       values: none inline inline-block block table table-row table-cell flex inline-flex
     ),
-
     // Flex utilities
     "flex": (
       responsive: true,
@@ -115,7 +113,6 @@ $utilities: map-merge(
         last: 6,
       ),
     ),
-
     // Dimentions and display-related
     "float": (
       responsive: true,
@@ -174,7 +171,6 @@ $utilities: map-merge(
       class: min-vh,
       values: (100: 100vh)
     ),
-
     // Padding
     "padding": (
       responsive: true,
@@ -218,7 +214,6 @@ $utilities: map-merge(
       class: pl,
       values: $spacers
     ),
-
     // Margin
     "margin": (
       responsive: true,
@@ -305,13 +300,11 @@ $utilities: map-merge(
       class: ml,
       values: $negative-spacers
     ),
-
     // Overflow
     "overflow": (
       property: overflow,
       values: auto hidden,
     ),
-
     // Fonts
     "font-family": (
       property: font-family,
@@ -343,7 +336,6 @@ $utilities: map-merge(
         lg: $line-height-lg,
       )
     ),
-
     // Color
     "color": (
       property: color,
@@ -360,7 +352,6 @@ $utilities: map-merge(
         )
       )
     ),
-
     // Text
     "text-align": (
       responsive: true,
@@ -395,7 +386,6 @@ $utilities: map-merge(
       class: align,
       values: baseline top middle bottom text-bottom text-top
     ),
-
     // Behaviors
     "user-select": (
       property: user-select,
@@ -406,7 +396,6 @@ $utilities: map-merge(
       class: pe,
       values: none auto,
     ),
-
     // Background
     "background-color": (
       property: background-color,
@@ -420,7 +409,6 @@ $utilities: map-merge(
         )
       )
     ),
-
     // Border
     "border": (
       property: border,
@@ -462,41 +450,40 @@ $utilities: map-merge(
       class: border,
       values: map-merge($theme-colors, ("white": $white))
     ),
-
     // Border-radius
-    "rounded": (
+    "radius": (
       property: border-radius,
-      class: rounded,
+      class: radius,
       values: (
-        null: $border-radius,
-        sm: $border-radius-sm,
-        lg: $border-radius-lg,
+        // null: $border-radius,
+        0: 0,
+        1: $border-radius-sm,
+        2: $border-radius,
+        3: $border-radius-lg,
         circle: 50%,
         pill: $rounded-pill,
-        0: 0,
       )
     ),
-    "rounded-top": (
+    "radius-t": (
       property: border-top-left-radius border-top-right-radius,
-      class: rounded-top,
+      class: radius-t,
       values: (null: $border-radius)
     ),
-    "rounded-right": (
+    "radius-r": (
       property: border-top-right-radius border-bottom-right-radius,
-      class: rounded-right,
+      class: radius-r,
       values: (null: $border-radius)
     ),
-    "rounded-bottom": (
+    "radius-b": (
       property: border-bottom-right-radius border-bottom-left-radius,
-      class: rounded-bottom,
+      class: radius-b,
       values: (null: $border-radius)
     ),
-    "rounded-left": (
+    "radius-l": (
       property: border-bottom-left-radius border-top-left-radius,
-      class: rounded-left,
+      class: radius-l,
       values: (null: $border-radius)
     ),
-
     // Effects
     "shadow": (
       property: box-shadow,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -474,24 +474,24 @@ $utilities: map-merge(
         pill: $rounded-pill,
       )
     ),
-    "radius-t": (
+    "radius-top": (
       property: border-top-left-radius border-top-right-radius,
-      class: radius-t,
+      class: radius-top,
       values: (null: $border-radius)
     ),
-    "radius-r": (
+    "radius-right": (
       property: border-top-right-radius border-bottom-right-radius,
-      class: radius-r,
+      class: radius-right,
       values: (null: $border-radius)
     ),
-    "radius-b": (
+    "radius-bottom": (
       property: border-bottom-right-radius border-bottom-left-radius,
-      class: radius-b,
+      class: radius-bottom,
       values: (null: $border-radius)
     ),
-    "radius-l": (
+    "radius-left": (
       property: border-bottom-left-radius border-top-left-radius,
-      class: radius-l,
+      class: radius-left,
       values: (null: $border-radius)
     ),
     // Effects

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -213,8 +213,8 @@
   }
 }
 
-.bd-example-rounded-utils {
-  [class*="rounded"] {
+.bd-example-radius-utils {
+  [class*="radius"] {
     margin: .25rem;
   }
 }

--- a/site/content/docs/4.3/components/badge.md
+++ b/site/content/docs/4.3/components/badge.md
@@ -55,11 +55,11 @@ Use our background utility classes to quickly change the appearance of a badge. 
 
 ## Pill badges
 
-Use the `.rounded-pill` utility class to make badges more rounded with a larger `border-radius`.
+Use the `.radius-pill` utility class to make badges more rounded with a larger `border-radius`.
 
 {{< example >}}
 {{< badge.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<span class="badge rounded-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
+<span class="badge radius-pill bg-{{ .name }}{{ if or (eq .name "light") (eq .name "warning") }} text-dark{{ end }}">{{ .name | title }}</span>{{- end -}}
 {{< /badge.inline >}}
 {{< /example >}}

--- a/site/content/docs/4.3/components/list-group.md
+++ b/site/content/docs/4.3/components/list-group.md
@@ -152,15 +152,15 @@ Add badges to any list group item to show unread counts, activity, and more with
 <ul class="list-group">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Cras justo odio
-    <span class="badge bg-primary rounded-pill">14</span>
+    <span class="badge bg-primary radius-pill">14</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Dapibus ac facilisis in
-    <span class="badge bg-primary rounded-pill">2</span>
+    <span class="badge bg-primary radius-pill">2</span>
   </li>
   <li class="list-group-item d-flex justify-content-between align-items-center">
     Morbi leo risus
-    <span class="badge bg-primary rounded-pill">1</span>
+    <span class="badge bg-primary radius-pill">1</span>
   </li>
 </ul>
 {{< /example >}}

--- a/site/content/docs/4.3/examples/carousel/index.html
+++ b/site/content/docs/4.3/examples/carousel/index.html
@@ -93,19 +93,19 @@ extra_css:
     <!-- Three columns of text below the carousel -->
     <div class="row">
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="radius-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="radius-circle" >}}
         <h2>Heading</h2>
         <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
       </div><!-- /.col-lg-4 -->
       <div class="col-lg-4">
-        {{< placeholder width="140" height="140" background="#777" color="#777" class="rounded-circle" >}}
+        {{< placeholder width="140" height="140" background="#777" color="#777" class="radius-circle" >}}
         <h2>Heading</h2>
         <p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
         <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>

--- a/site/content/docs/4.3/examples/checkout/index.html
+++ b/site/content/docs/4.3/examples/checkout/index.html
@@ -19,7 +19,7 @@ body_class: "bg-light"
     <div class="col-md-5 col-lg-4 order-md-last">
       <h4 class="d-flex justify-content-between align-items-center mb-3">
         <span class="text-muted">Your cart</span>
-        <span class="badge bg-secondary rounded-pill">3</span>
+        <span class="badge bg-secondary radius-pill">3</span>
       </h4>
       <ul class="list-group mb-3">
         <li class="list-group-item d-flex justify-content-between lh-sm">

--- a/site/content/docs/4.3/examples/offcanvas/index.html
+++ b/site/content/docs/4.3/examples/offcanvas/index.html
@@ -51,7 +51,7 @@ body_class: "bg-light"
     <a class="nav-link active" aria-current="page" href="#">Dashboard</a>
     <a class="nav-link" href="#">
       Friends
-      <span class="badge bg-light text-dark rounded-pill align-text-bottom">27</span>
+      <span class="badge bg-light text-dark radius-pill align-text-bottom">27</span>
     </a>
     <a class="nav-link" href="#">Explore</a>
     <a class="nav-link" href="#">Suggestions</a>

--- a/site/content/docs/4.3/migration.md
+++ b/site/content/docs/4.3/migration.md
@@ -140,7 +140,7 @@ Changes to Reboot, typography, tables, and more.
 Badges were overhauled to better differentiate themselves from buttons and to better utilize utility classes.
 
 - **Todo:** Removed and replaced `.badge` modifier classes with background utility classes (e.g., use `.bg-primary` instead of `.badge-primary`)
-- **Todo:** Removed `.badge-pill` for the `.rounded-pill` utility class
+- **Todo:** Removed `.badge-pill` for the `.radius-pill` utility class
 - **Todo:** Removed badge's hover and focus styles for `a.badge` and `button.badge`.
 
 ### Cards
@@ -178,6 +178,8 @@ Badges were overhauled to better differentiate themselves from buttons and to be
 - Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is `.order-5` instead of `.order-12`. [See #28874](https://github.com/twbs/bootstrap/pull/28874).
 - New `line-height` utilities: `.lh-1`, `.lh-sm`, `.lh-base` and `.lh-lg`. See [here]({{< docsref "/utilities/text#line-height" >}}).
 - Added `.bg-body` for quickly setting the `<body>`'s background to additional elements.
+- Renamed the `.rounded` utility class to `.radius`. See [here]({{< docsref "/utilities/borders#border-radius" >}}).
+- Removed `.rounded-sm` and `.rounded-lg`, replaced them with new border-radius utilities (`.radius-0`, `.radius-1`, `.radius-2`, `.radius-3`) See [here]({{< docsref "/utilities/borders#sizes" >}}).
 - **Todo:** Drop `.text-hide` as it's an antiquated method for hiding text that shouldn't be used anymore
 - **Todo:** Split utilities into property-value utility classes and helpers
 - Negative margin utilities are disabled by default. You can re-enable them by setting `$enable-negative-margins: true`, but keep in mind this can increase the file size quite a lot.

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -47,23 +47,23 @@ Change the border color using utilities built on our theme colors.
 
 Add classes to an element to easily round its corners.
 
-{{< example class="bd-example-rounded-utils" >}}
-{{< placeholder width="75" height="75" class="rounded" title="Example rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-top" title="Example top rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-right" title="Example right rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-bottom" title="Example bottom rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-left" title="Example left rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-circle" title="Completely round image" >}}
-{{< placeholder width="150" height="75" class="rounded-pill" title="Rounded pill image" >}}
-{{< placeholder width="75" height="75" class="rounded-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< example class="bd-example-radius-utils" >}}
+{{< placeholder width="75" height="75" class="radius" title="Example rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-t" title="Example top rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-r" title="Example right rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-b" title="Example bottom rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-l" title="Example left rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-circle" title="Completely round image" >}}
+{{< placeholder width="150" height="75" class="radius-pill" title="Rounded pill image" >}}
+{{< placeholder width="75" height="75" class="radius-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
 {{< /example >}}
 
+### Sizes
 
-## Sizes
-
-Use `.rounded-lg` or `.rounded-sm` for larger or smaller border-radius.
+Similar to our spacing scales, there's a scale option for our `border-radius`: `0`, `1`, `2`, and `3`.
 
 {{< example class="bd-example-rounded-utils" >}}
-{{< placeholder width="75" height="75" class="rounded-sm" title="Example small rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-lg" title="Example large rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-1" title="Example small rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-2" title="Example rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-3" title="Example large rounded image" >}}
 {{< /example >}}

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -32,7 +32,7 @@ Use border utilities to add or remove an element's borders. Choose from all bord
 
 ## Border color
 
-Change the border color using utilities built on our theme colors.
+Change the border color using utilities built on our theme colors. We've also included a subset of our gray colors to provide more flexibility.
 
 {{< example class="bd-example-border-utils" >}}
 {{< border.inline >}}
@@ -41,6 +41,18 @@ Change the border color using utilities built on our theme colors.
 {{- end -}}
 {{< /border.inline >}}
 <span class="border border-white"></span>
+<span class="border border-gray-500"></span>
+<span class="border border-gray-700"></span>
+<span class="border border-black"></span>
+{{< /example >}}
+
+The gray `border-color` utilities differ slightly than our `background-color` utilities so that there's some slight contrast between the two.
+
+{{< example >}}
+<div class="p-3 mb-1 bg-light border"></div>
+<div class="p-3 mb-1 bg-gray border border-gray-500"></div>
+<div class="p-3 mb-1 bg-secondary border border-gray-700"></div>
+<div class="p-3 mb-1 bg-dark border border-black"></div>
 {{< /example >}}
 
 ## Border-radius

--- a/site/content/docs/4.3/utilities/borders.md
+++ b/site/content/docs/4.3/utilities/borders.md
@@ -61,10 +61,10 @@ Add classes to an element to easily round its corners.
 
 {{< example class="bd-example-radius-utils" >}}
 {{< placeholder width="75" height="75" class="radius" title="Example rounded image" >}}
-{{< placeholder width="75" height="75" class="radius-t" title="Example top rounded image" >}}
-{{< placeholder width="75" height="75" class="radius-r" title="Example right rounded image" >}}
-{{< placeholder width="75" height="75" class="radius-b" title="Example bottom rounded image" >}}
-{{< placeholder width="75" height="75" class="radius-l" title="Example left rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-top" title="Example top rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-right" title="Example right rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-bottom" title="Example bottom rounded image" >}}
+{{< placeholder width="75" height="75" class="radius-left" title="Example left rounded image" >}}
 {{< placeholder width="75" height="75" class="radius-circle" title="Completely round image" >}}
 {{< placeholder width="150" height="75" class="radius-pill" title="Rounded pill image" >}}
 {{< placeholder width="75" height="75" class="radius-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}

--- a/site/content/docs/4.3/utilities/colors.md
+++ b/site/content/docs/4.3/utilities/colors.md
@@ -33,7 +33,9 @@ Similar to the contextual text color classes, easily set the background of an el
 <div class="p-3 mb-2 bg-{{ .name }} {{ if or (eq .name "light") (eq .name "warning") }}text-dark{{ else }}text-white{{ end }}">.bg-{{ .name }}</div>
 {{- end -}}
 {{< /colors.inline >}}
+<div class="p-3 mb-2 bg-gray text-dark">.bg-gray</div>
 <div class="p-3 mb-2 bg-white text-dark">.bg-white</div>
+<div class="p-3 mb-2 bg-black text-white">.bg-black</div>
 <div class="p-3 mb-2 bg-transparent text-dark">.bg-transparent</div>
 {{< /example >}}
 


### PR DESCRIPTION
- Rearranges utilities CSS to better reflect our property order
- Renames `rounded` utils to `radius`, closes #30048 and closes #29989.
- Adds new `border-gray-500` and `border-gray-700` class
- Adds new `bg-gray` class
- Adds some docs to the border utils page to show how I intend these new utils to be combined