### PR TITLE
Simplify list-group borders in cards

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -33,6 +33,13 @@
       @include border-bottom-radius($card-inner-border-radius);
     }
   }
+
+  // Due to specificity of the above selector (`.card > .list-group`), we must
+  // use a child selector here to prevent double borders.
+  > .card-header + .list-group,
+  > .list-group + .card-footer {
+    border-top: 0;
+  }
 }
 
 .card-body {
@@ -79,12 +86,6 @@
 
   &:first-child {
     @include border-radius($card-inner-border-radius $card-inner-border-radius 0 0);
-  }
-
-  + .list-group {
-    .list-group-item:first-child {
-      border-top: 0;
-    }
   }
 }
 

--- a/site/content/docs/5.0/components/card.md
+++ b/site/content/docs/5.0/components/card.md
@@ -101,6 +101,19 @@ Create lists of content in a card with a flush list group.
 </div>
 {{< /example >}}
 
+{{< example >}}
+<div class="card" style="width: 18rem;">
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Cras justo odio</li>
+    <li class="list-group-item">Dapibus ac facilisis in</li>
+    <li class="list-group-item">Vestibulum at eros</li>
+  </ul>
+  <div class="card-footer">
+    Card footer
+  </div>
+</div>
+{{< /example >}}
+
 ### Kitchen sink
 
 Mix and match multiple content types to create the card you need, or throw everything in there. Shown below are image styles, blocks, text styles, and a list group—all wrapped in a fixed-width card.


### PR DESCRIPTION
Consolidates some CSS and beefs up the selector to account for inherited border styles. Fixes #30793, a regression from v4.4.1 that shipped in #30497.