### PR TITLE
v4: Update docs callout for responsive SVG images

### DIFF
--- a/site/docs/4.5/content/images.md
+++ b/site/docs/4.5/content/images.md
@@ -19,9 +19,9 @@ Images in Bootstrap are made responsive with `.img-fluid`. `max-width: 100%;` an
 {% endhighlight %}
 
 {% capture callout %}
-##### SVG images and IE 10
+##### SVG images and Internet Explorer
 
-In Internet Explorer 10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. This fix improperly sizes other image formats, so Bootstrap doesn't apply it automatically.
+In Internet Explorer 10 and 11, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100%;` or `.w-100` where necessary. This fix improperly sizes other image formats, so Bootstrap doesn't apply it automatically.
 {% endcapture %}
 {% include callout.html content=callout type="warning" %}
 


### PR DESCRIPTION
Turns out this applies to IE11 as well as IE10, so this clarifies the docs callout.

Closes #25242.