### PR TITLE
v4: Add z-index to .custom-check to fix custom checks in CSS columns

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -9,6 +9,7 @@
 
 .custom-control {
   position: relative;
+  z-index: 1;
   display: block;
   min-height: $font-size-base * $line-height-base;
   padding-left: $custom-control-gutter + $custom-control-indicator-size;


### PR DESCRIPTION
For some reason, custom checks in CSS columns need a new stacking order to maintain visibility. This PR adds `z-index: 1` to trigger that new stacking order. Since v5's forms are being redone entirely, and we're dropping IE10/11 there, I think this is totally fine to ship with v4 only. Will need to check v5's forms it in Edge though.

Fixes #29607.