### PR TITLE
v4: `.card-img-overlay corners

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -127,6 +127,7 @@
   bottom: 0;
   left: 0;
   padding: $card-img-overlay-padding;
+  @include border-radius($card-inner-border-radius);
 }
 
 .card-img,


### PR DESCRIPTION
Allows use of background-color and more. Fixes #29033 for v4.