### PR TITLE
Streamline application.js exampleModal code

### DIFF
--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -66,14 +66,16 @@
   var exampleModal = document.getElementById('exampleModal')
   if (exampleModal) {
     exampleModal.addEventListener('show.bs.modal', function (event) {
-      var button = event.relatedTarget // Button that triggered the modal
-      var recipient = button.getAttribute('data-whatever') // Extract info from data-* attributes
+      // Button that triggered the modal
+      var button = event.relatedTarget
+      // Extract info from data-* attributes
+      var recipient = button.getAttribute('data-whatever')
 
       // Update the modal's content.
       var modalTitle = exampleModal.querySelector('.modal-title')
       var modalBodyInput = exampleModal.querySelector('.modal-body input')
 
-      modalTitle.innerHTML = 'New message to ' + recipient
+      modalTitle.textContent = 'New message to ' + recipient
       modalBodyInput.value = recipient
     })
   }

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -547,8 +547,11 @@ exampleModal.addEventListener('show.bs.modal', function (event) {
   // and then do the updating in a callback.
   //
   // Update the modal's content.
-  exampleModal.querySelector('.modal-title').textContent = 'New message to ' + recipient
-  exampleModal.querySelector('.modal-body input').value = recipient
+  var modalTitle = exampleModal.querySelector('.modal-title')
+  var modalBodyInput = exampleModal.querySelector('.modal-body input')
+
+  modalTitle.textContent = 'New message to ' + recipient
+  modalBodyInput.value = recipient
 })
 {{< /highlight >}}
 


### PR DESCRIPTION
* use `textContent` since we only need to add text
* move comments

We should probably reduce duplication later and instead read from an external file and use the snippet only in the page that's needed. I will add this in my TODO for later.

Preview: <https://deploy-preview-30819--twbs-bootstrap.netlify.app/docs/5.0/components/modal/#varying-modal-content>