### PR TITLE
v5: Update color on custom switch focus state

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -681,7 +681,7 @@ $form-switch-padding-left:        $form-switch-width + .5em !default;
 $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius:       $form-switch-width !default;
 
-$form-switch-focus-color:         hsla(211, 100%, 75%, 1) !default;
+$form-switch-focus-color:         $input-focus-border-color !default;
 $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
 
 $form-switch-checked-color:       $component-active-color !default;


### PR DESCRIPTION
Replaces a custom `hsla()` value (dunno what I was thinking when I added this) with a reassigned existing variable. This variable goes up the stack and attaches to the `$component-active-bg` variable, derived from our `$primary` color out of the box.

The variable of choice was `$input-focus-border-color`, which is applied to the border of our switches anyway, so now the inside of the switch matches the border. This is a slightly darker color, too, which is an improvement IMO.

Fixes #30646.