### PR TITLE
Use `:focus-visible` polyfill

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "51 kB"
+      "maxSize": "53.2 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "23 kB"
+      "maxSize": "23.1 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "28 kB"
+      "maxSize": "30.2 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
-      "maxSize": "19 kB"
+      "maxSize": "19.3 kB"
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "29 kB"
+      "maxSize": "30.8 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.5 kB"
+      "maxSize": "16.6 kB"
     }
   ],
   "ci": {

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -16,7 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
-import '../node_modules/focus-visible/dist/focus-visible.js'
+import 'focus-visible'
 
 export {
   Alert,

--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -16,6 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import '../node_modules/focus-visible/dist/focus-visible.js'
 
 export {
   Alert,

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -16,7 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
-import '../node_modules/focus-visible/dist/focus-visible.js'
+import 'focus-visible'
 
 export default {
   Alert,

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -16,6 +16,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import '../node_modules/focus-visible/dist/focus-visible.js'
 
 export default {
   Alert,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,6 +4731,12 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "focus-visible": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.1.0.tgz",
+      "integrity": "sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-unicorn": "^20.0.0",
     "find-unused-sass-variables": "^2.0.0",
+    "focus-visible": "^5.1.0",
     "glob": "^7.1.6",
     "hammer-simulator": "0.0.1",
     "hugo-bin": "^0.59.0",

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -64,6 +64,13 @@ body {
   outline: 0 !important;
 }
 
+// Using the :focus-visible polyfill to hide outline defensively
+// See https://github.com/WICG/focus-visible
+.js-focus-visible :focus:not([data-focus-visible-added]),
+.js-focus-visible .focus:not([data-focus-visible-added]) {
+  outline: 0 !important;
+}
+
 
 // Content grouping
 //


### PR DESCRIPTION
This is a very rough first try to include and use [WICG's `:focus-visible` polyfill](https://github.com/WICG/focus-visible) in Bootstrap. Let me add some background.

## What

[`:focus-visible` belong to CSS Selectors level 4 specification](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo). As per the spec:

> The `:focus-visible` pseudo-class applies while an element matches the `:focus` pseudo-class and the user agent determines via heuristics that the focus should be made evident on the element.

Thus it's a very helpful selector to massively enhance accessibility. I suggest you read ["`:focus-visible` and backwards compatibility"](https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/) by @patrickhlauke for more explanation and even more background.

## Why

First of all: it's an easy way to safely drop the (sometimes) ugly default `outline`s when activating things using a mouse. This PR, as-is, fixes #27163 and may help with #29875.

For years, Bootstrap has been using `box-shadow` for focus states, which can lead to some confusion since there's also a `$enable-shadows` variable that may cause some focus style to not render appropriately. See #26802 for an example.

But what's more promising here is that it'd allow us to **make focus styles stronger** and more obvious.

It would allow us to increase contrasts on `:focus`, which had been requested a few times (#23329 and #29422).

And I'm quite sure there's probably a few cases with our components where focus could be better. :)

## How

There, I need some help from @twbs/js-review :D

I added the dependency, but this definetly require some JS love to be included in the best possible way. For now, I roughly imported the file form the `node_modules`—which can't obviously stay this way.

On the CSS side:
1. I added a global reset for default `outline`s: you can preview this in our docs navbar for example, which got the default `outline` until now.
2. This is using [the `[data-focus-visible-added]` attribute instead of the `.focus-visible` class since it's environment-proof](https://github.com/WICG/focus-visible/issues/179).
3. And we'll be able to enhance focus everywhere, but that's another story :) FYI in Boosted we chose to use `2px` wide solid `outline`s, and a `transition` on `outline-offset` (which may vary, depending on the component). You can use keyboard to navigate through [Boosted website](https://boosted.orange.com/) to preview this.

## Sidenote

@patrickhlauke mentionned in his post in 2018 the potential use of `@supports`—but it couldn't test for selector support at that time. Well, [it can now](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports#selector) and [the support for, say, `@supports selector(:focus-visible)`](https://caniuse.com/#feat=mdn-css_at-rules_supports_selector) is pretty much the same than [support for `:focus-visible`](https://caniuse.com/#search=focus-visible).

So a future-proof, JS-free way to go might be using `@supports`—but it'd be much, much more verbose on the CSS side.