### PR TITLE
Getting started / Downloads : improve CDN wording

### DIFF
--- a/site/docs/4.5/getting-started/download.md
+++ b/site/docs/4.5/getting-started/download.md
@@ -43,7 +43,7 @@ Skip the download with [BootstrapCDN](https://www.bootstrapcdn.com/) to deliver 
 <script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
 {% endhighlight %}
 
-If you're using our compiled JavaScript, don't forget to include CDN versions of jQuery and Popper.js before it.
+If you're using our compiled JavaScript, don't forget to include jQuery and Popper.js, via a CDN preferably, before our JS.
 
 {% highlight html %}
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
Improve wording for Popper.js and jQuery inclusion—based on `master`'s wording.

Fixes #30873