### PR TITLE
Prevent skip links from overlapping header

### DIFF
--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -1,13 +1,20 @@
+// stylelint-disable declaration-no-important
+
 .skippy {
-  position: fixed;
-  top: .5rem;
-  left: .5rem;
-  z-index: $zindex-fixed;
-  padding: .5rem;
-  color: $white;
   background-color: $bd-purple;
 
-  &:hover {
+  a {
     color: $white;
+  }
+
+  &:focus-within a {
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+    padding: $spacer / 2 !important;
+    margin: $spacer / 4 !important;
+    overflow: visible !important;
+    clip: auto !important;
+    white-space: normal !important;
   }
 }

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,5 +1,9 @@
-<a class="skippy visually-hidden-focusable" href="#content">Skip to main content</a>
+<div class="skippy overflow-hidden">
+  <div class="container-xl">
+    <a class="visually-hidden-focusable d-inline-flex p-2 m-1" href="#content">Skip to main content</a>
 
-{{ if (eq .Page.Layout "docs") }}
-  <a class="skippy visually-hidden-focusable d-none d-md-block" href="#bd-docs-nav">Skip to docs navigation</a>
-{{- end }}
+    {{ if (eq .Page.Layout "docs") }}
+      <a class="visually-hidden-focusable d-none d-md-inline-flex p-2 m-1" href="#bd-docs-nav">Skip to docs navigation</a>
+    {{- end }}
+  </div>
+</div>


### PR DESCRIPTION
Here it is, after #30073 discussions: I got back the kind of banner that appeared previously, only aligning skip-links to the left.

As a bonus (feel free to discuss it, of course), I enhanced progressively the whole thing by making all skip links appear together when `:focus` is within the container.

And to stay consistent with #30866 I used utilities, seems legit in that case.

Preview: <https://deploy-preview-30897--twbs-bootstrap.netlify.app/>

Fixes #30491