### PR TITLE
Create custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>404 Not Found</title>
+        <style>
+            body {
+                font-family: Arial, Helvetica, sans-serif;
+                text-align: center;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>404 Not Found</h1>
+    </body>
+</html>


### PR DESCRIPTION
The current 404 page is the default GitHub Pages one. I prefer one which does not use the GitHub branding, and this is a simple one.