### PR TITLE
Restore word-break: break-word on .text-break

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -440,7 +440,7 @@ $utilities: map-merge(
       values: italic normal
     ),
     "word-wrap": (
-      property: word-wrap,
+      property: word-wrap word-break,
       class: text,
       values: (break: break-word)
     ),

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -45,7 +45,7 @@ Prevent text from wrapping with a `.text-nowrap` class.
 
 ## Word break
 
-Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-wrap: break-word`. We use `word-wrap` instead of the more common `overflow-wrap` for wider browser support.
+Prevent long strings of text from breaking your components' layout by using `.text-break` to set `word-wrap: break-word` and `word-break: break-word`. We use `word-wrap` instead of the more common `overflow-wrap` for wider browser support, and add the deprecated `word-break: break-word` to avoid issues with flex containers.
 
 {{< example >}}
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>


### PR DESCRIPTION
Restores `word-break: break-word` on `.text-break` to fix text breaking on flex containers.

Fixes #30803.

---

**Original issue and PRs:**

- v4 backport: #30074
- v5 PR: #29325
- Original issue: #28304

**Demo:** https://codepen.io/emdeoh/pen/dyYjwoO?editors=1100