### PR TITLE
Floating labels improvements

### DIFF
--- a/site/content/docs/5.0/examples/floating-labels/floating-labels.css
+++ b/site/content/docs/5.0/examples/floating-labels/floating-labels.css
@@ -23,13 +23,13 @@ body {
   margin-bottom: 1rem;
 }
 
-.form-label-group > input,
-.form-label-group > label {
+.form-label-group input,
+.form-label-group label {
   height: 3.125rem;
   padding: .75rem;
 }
 
-.form-label-group > label {
+.form-label-group label {
   position: absolute;
   top: 0;
   left: 0;
@@ -47,11 +47,11 @@ body {
   color: transparent;
 }
 
-.form-label-group input::-ms-input-placeholder {
+.form-label-group input::-moz-placeholder {
   color: transparent;
 }
 
-.form-label-group input::-moz-placeholder {
+.form-label-group input::-ms-input-placeholder {
   color: transparent;
 }
 

--- a/site/content/docs/5.0/examples/floating-labels/floating-labels.css
+++ b/site/content/docs/5.0/examples/floating-labels/floating-labels.css
@@ -86,9 +86,15 @@ body {
 /* Fallback for Edge
 -------------------------------------------------- */
 @supports (-ms-ime-align: auto) {
-  .form-label-group > label {
-    display: none;
+  .form-label-group {
+    display: flex;
+    flex-direction: column-reverse;
   }
+
+  .form-label-group label {
+    position: static;
+  }
+
   .form-label-group input::-ms-input-placeholder {
     color: #777;
   }


### PR DESCRIPTION
Next to #30965 — for v5 concerns.

1. Edge fallback can be accessible by not making labels `display: none` and simply switching to flex reversed layout…
2. Refactored things a bit since we have plenty of vendor prefixes in this file, whilst none of our supported browser require it.

Preview: https://deploy-preview-30966--twbs-bootstrap.netlify.app/docs/5.0/examples/floating-labels/


