### PR TITLE
Make jquery and popper.js optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,14 @@
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.16.0"
   },
+  "peerDependenciesMeta": {
+    "jquery": {
+      "optional": true
+    },
+    "popper.js": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
I know this is a discussion that has been had many many times before, but I have never seen this specific solution proposed.
The `peerDependenciesMeta` property of `package.json` is little known, and is not documented, but has been released in `npm@6.11`:

https://github.com/npm/cli/releases/tag/v6.11.0
https://npm.community/t/release-6-11-0/9572

It allows to mark certain `peerDependencies` as optional, opting for a middle-ground between `optionalDependencies` and `peerDependencies`. People who use `bootstrap` with `react` will benefit from this change by not having an incorrect warning about missing dependencies, and people who use `bootstrap` as is will continue to use it without any changes.