### PR TITLE
avoid preventing input event onclick

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -153,10 +153,9 @@ $(document)
         return
       }
 
-      if (initialButton.tagName === 'LABEL' && inputBtn && inputBtn.type === 'checkbox') {
-        event.preventDefault() // work around event sent to label and input
+      if (initialButton.tagName !== 'LABEL' || inputBtn && inputBtn.type !== 'checkbox') {
+        Button._jQueryInterface.call($(button), 'toggle')
       }
-      Button._jQueryInterface.call($(button), 'toggle')
     }
   })
   .on(EVENT_FOCUS_BLUR_DATA_API, SELECTOR_DATA_TOGGLE_CARROT, (event) => {

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -222,7 +222,7 @@ $(function () {
     assert.ok(!$btn2.find('input')[0].checked, 'btn2 is not checked')
   })
 
-  QUnit.test('should fire click event on input and label', function (assert) {
+  QUnit.test('should fire click event on input', function (assert) {
     assert.expect(1)
     var done = assert.async()
     var groupHTML = '<div class="btn-group" data-toggle="buttons">' +
@@ -234,6 +234,26 @@ $(function () {
 
     var $btn = $group.children().eq(0)
     $group.find('input').on('click', function (e) {
+      e.preventDefault()
+      assert.ok(true, 'click event fired')
+      done()
+    })
+
+    $btn[0].click()
+  })
+
+  QUnit.test('should fire click event on label', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var groupHTML = '<div class="btn-group" data-toggle="buttons">' +
+      '<label class="btn btn-primary active">' +
+      '<input type="checkbox" id="option1"> Option 1' +
+      '</label>' +
+      '</div>'
+    var $group = $(groupHTML).appendTo('#qunit-fixture')
+
+    var $btn = $group.children().eq(0)
+    $group.find('label').on('click', function (e) {
       e.preventDefault()
       assert.ok(true, 'click event fired')
       done()

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -222,6 +222,26 @@ $(function () {
     assert.ok(!$btn2.find('input')[0].checked, 'btn2 is not checked')
   })
 
+  QUnit.test('should fire click event on input and label', function (assert) {
+    assert.expect(1)
+    var done = assert.async()
+    var groupHTML = '<div class="btn-group" data-toggle="buttons">' +
+      '<label class="btn btn-primary active">' +
+      '<input type="checkbox" id="option1"> Option 1' +
+      '</label>' +
+      '</div>'
+    var $group = $(groupHTML).appendTo('#qunit-fixture')
+
+    var $btn = $group.children().eq(0)
+    $group.find('input').on('click', function (e) {
+      e.preventDefault()
+      assert.ok(true, 'click event fired')
+      done()
+    })
+
+    $btn[0].click()
+  })
+
   QUnit.test('should not add aria-pressed on labels for radio/checkbox inputs in a data-toggle="buttons" group', function (assert) {
     assert.expect(2)
     var groupHTML = '<div class="btn-group" data-toggle="buttons">' +


### PR DESCRIPTION
instead of stopping event if onclick is triggered on input, call toggle method only if its not on checkbox inside a label

fix https://github.com/twbs/bootstrap/issues/30849 following regression introduced by https://github.com/twbs/bootstrap/pull/30388