### PR TITLE
v4 — zero `min-width` on .col has too much side-effect

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -34,7 +34,6 @@
       .col#{$infix} {
         flex-basis: 0;
         flex-grow: 1;
-        min-width: 0; // See https://github.com/twbs/bootstrap/issues/25410
         max-width: 100%;
       }
 


### PR DESCRIPTION
`v4-dev` backport of #30979, fixes #30852