### PR TITLE
Update Babel config

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,12 +4,9 @@ module.exports = {
       '@babel/preset-env',
       {
         loose: true,
-        modules: false,
-        exclude: ['transform-typeof-symbol']
+        bugfixes: true,
+        modules: false
       }
     ]
-  ],
-  plugins: [
-    '@babel/plugin-proposal-object-rest-spread'
   ]
 };

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
   "devDependencies": {
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.10.3",
     "@babel/preset-env": "^7.10.3",
     "@rollup/plugin-babel": "^5.0.4",
     "@rollup/plugin-commonjs": "^13.0.0",


### PR DESCRIPTION
* remove plugin-proposal-object-rest-spread
* add bugfixes
* `exclude: ['transform-typeof-symbol']` did nothing with our config

Closes #31007 