### PR TITLE
Update links to bug and feature request issue templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   <a href="https://v5.getbootstrap.com/docs/5.0/"><strong>Explore Bootstrap docs »</strong></a>
   <br>
   <br>
-  <a href="https://github.com/twbs/bootstrap/issues/new?template=bug.md">Report bug</a>
+  <a href="https://github.com/twbs/bootstrap/issues/new?template=bug_report.md">Report bug</a>
   ·
-  <a href="https://github.com/twbs/bootstrap/issues/new?template=feature.md&labels=feature">Request feature</a>
+  <a href="https://github.com/twbs/bootstrap/issues/new?template=feature_request.md">Request feature</a>
   ·
   <a href="https://themes.getbootstrap.com/">Themes</a>
   ·


### PR DESCRIPTION
Updated the `feature_request.md` template separately accidentally to add the `feature` label automatically. Thinking we maybe add a `bug` label and add that to the `bug_report.md` template, too?