### PR TITLE
data: reword storage key in DOM

### DIFF
--- a/js/src/dom/data.js
+++ b/js/src/dom/data.js
@@ -16,22 +16,22 @@ const mapData = (() => {
   let id = 1
   return {
     set(element, key, data) {
-      if (typeof element.key === 'undefined') {
-        element.key = {
+      if (typeof element.bsKey === 'undefined') {
+        element.bsKey = {
           key,
           id
         }
         id++
       }
 
-      storeData[element.key.id] = data
+      storeData[element.bsKey.id] = data
     },
     get(element, key) {
-      if (!element || typeof element.key === 'undefined') {
+      if (!element || typeof element.bsKey === 'undefined') {
         return null
       }
 
-      const keyProperties = element.key
+      const keyProperties = element.bsKey
       if (keyProperties.key === key) {
         return storeData[keyProperties.id]
       }
@@ -39,14 +39,14 @@ const mapData = (() => {
       return null
     },
     delete(element, key) {
-      if (typeof element.key === 'undefined') {
+      if (typeof element.bsKey === 'undefined') {
         return
       }
 
-      const keyProperties = element.key
+      const keyProperties = element.bsKey
       if (keyProperties.key === key) {
         delete storeData[keyProperties.id]
-        delete element.key
+        delete element.bsKey
       }
     }
   }

--- a/js/tests/unit/dom/data.spec.js
+++ b/js/tests/unit/dom/data.spec.js
@@ -15,7 +15,7 @@ describe('Data', () => {
   })
 
   describe('setData', () => {
-    it('should set data in an element by adding a key attribute', () => {
+    it('should set data in an element by adding a bsKey attribute', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const div = fixtureEl.querySelector('div')
@@ -24,7 +24,7 @@ describe('Data', () => {
       }
 
       Data.setData(div, 'test', data)
-      expect(div.key).toBeDefined()
+      expect(div.bsKey).toBeDefined()
     })
 
     it('should change data if something is already stored', () => {
@@ -40,7 +40,7 @@ describe('Data', () => {
       data.test = 'bsData2'
       Data.setData(div, 'test', data)
 
-      expect(div.key).toBeDefined()
+      expect(div.bsKey).toBeDefined()
     })
   })
 
@@ -104,11 +104,11 @@ describe('Data', () => {
 
       Data.setData(div, 'test', data)
 
-      expect(div.key).toBeDefined()
+      expect(div.bsKey).toBeDefined()
 
       Data.removeData(div, 'test2')
 
-      expect(div.key).toBeDefined()
+      expect(div.bsKey).toBeDefined()
     })
 
     it('should remove data if something is stored', () => {
@@ -121,11 +121,11 @@ describe('Data', () => {
 
       Data.setData(div, 'test', data)
 
-      expect(div.key).toBeDefined()
+      expect(div.bsKey).toBeDefined()
 
       Data.removeData(div, 'test')
 
-      expect(div.key).toBeUndefined()
+      expect(div.bsKey).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
I was migrating one of my project to BS 5 and React use `key` as attribute a lot, so there was a conflict with us.
Which is why I renamed `key` --> `bsKey`