### PR TITLE
Docs: fix typo

### DIFF
--- a/site/content/docs/5.0/layout/gutters.md
+++ b/site/content/docs/5.0/layout/gutters.md
@@ -10,7 +10,7 @@ toc: true
 
 - **Gutters are the gaps between column content, created by horizontal `padding`.** We set `padding-right` and `padding-left` on each column, and use negative `margin` to offset that at the start and end of each row to align content.
 
-- **Gutters start are `1.5rem` (`24px`) wide.** This allows us to match our grid to the [padding and margin spacers]({{< docsref "/utilities/spacing" >}}) scale.
+- **Gutters start at `1.5rem` (`24px`) wide.** This allows us to match our grid to the [padding and margin spacers]({{< docsref "/utilities/spacing" >}}) scale.
 
 - **Gutters can be responsively adjusted.** Use breakpoint-specific gutter classes to modify horizontal gutters, vertical gutters, and all gutters.
 

--- a/site/content/docs/5.0/layout/gutters.md
+++ b/site/content/docs/5.0/layout/gutters.md
@@ -10,7 +10,7 @@ toc: true
 
 - **Gutters are the gaps between column content, created by horizontal `padding`.** We set `padding-right` and `padding-left` on each column, and use negative `margin` to offset that at the start and end of each row to align content.
 
-- **Gutters start are `1.5rem` (`20px`) wide.** This allows us to match our grid to the [padding and margin spacers]({{< docsref "/utilities/spacing" >}}) scale.
+- **Gutters start are `1.5rem` (`24px`) wide.** This allows us to match our grid to the [padding and margin spacers]({{< docsref "/utilities/spacing" >}}) scale.
 
 - **Gutters can be responsively adjusted.** Use breakpoint-specific gutter classes to modify horizontal gutters, vertical gutters, and all gutters.
 


### PR DESCRIPTION
Fixes a typo so it displays the correct px's.

Closes: #31104 