### PR TITLE
Update .rounded utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -461,13 +461,13 @@ $utilities: map-merge(
     "rounded": (
       property: border-radius,
       class: rounded,
-      values: (
-        null: $border-radius,
-        sm: $border-radius-sm,
-        lg: $border-radius-lg,
-        circle: 50%,
-        pill: $rounded-pill,
-        0: 0,
+      values: map-merge(
+        $rounded-sizes,
+        (
+          null: $border-radius,
+          "circle": 50%,
+          "pill": $rounded-pill,
+        )
       )
     ),
     "rounded-top": (

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -339,6 +339,7 @@ $border-radius:               .25rem !default;
 $border-radius-sm:            .2rem !default;
 $border-radius-lg:            .3rem !default;
 
+$rounded-sizes:               map-remove($spacers, 4, 5) !default;
 $rounded-pill:                50rem !default;
 
 $box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;

--- a/site/content/docs/5.0/utilities/borders.md
+++ b/site/content/docs/5.0/utilities/borders.md
@@ -45,7 +45,7 @@ Change the border color using utilities built on our theme colors.
 
 ## Border-radius
 
-Add `.rounded` classes to an element to round the corners via `border-radius`. Rounded utilities include a subset of sizes from our `$spacing` Sass map, as well as options for circle and pill shapes and a default `.rounded` that uses our `$border-radius` variable.
+Add `.rounded` classes to an element to round the corners via `border-radius`. Rounded utilities include a subset of sizes from our `$spacing` Sass map, as well as options for circle and pill shapes and a default `.rounded` class that uses our `$border-radius` variable.
 
 {{< example class="bd-example-rounded-utils" >}}
 {{< placeholder width="80" height="80" class="rounded-0" title="Rounded image" >}}

--- a/site/content/docs/5.0/utilities/borders.md
+++ b/site/content/docs/5.0/utilities/borders.md
@@ -45,25 +45,25 @@ Change the border color using utilities built on our theme colors.
 
 ## Border-radius
 
-Add classes to an element to easily round its corners.
+Add `.rounded` classes to an element to round the corners via `border-radius`. Rounded utilities include a subset of sizes from our `$spacing` Sass map, as well as options for circle and pill shapes and a default `.rounded` that uses our `$border-radius` variable.
 
 {{< example class="bd-example-rounded-utils" >}}
-{{< placeholder width="75" height="75" class="rounded" title="Example rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-top" title="Example top rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-right" title="Example right rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-bottom" title="Example bottom rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-left" title="Example left rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-circle" title="Completely round image" >}}
-{{< placeholder width="150" height="75" class="rounded-pill" title="Rounded pill image" >}}
-{{< placeholder width="75" height="75" class="rounded-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="80" height="80" class="rounded-0" title="Rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-1" title="Rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-2" title="Rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-3" title="Rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded" title="Example rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-circle" title="Completely round image" >}}
+{{< placeholder width="160" height="80" class="rounded-pill" title="Rounded pill image" >}}
 {{< /example >}}
 
+### Rounded sides
 
-## Sizes
-
-Use `.rounded-lg` or `.rounded-sm` for larger or smaller border-radius.
+You can also round just one side of an element. Please note that you cannot set `.rounded-{0|1|2|3}` on one side at this time, only our default `$border-radius`.
 
 {{< example class="bd-example-rounded-utils" >}}
-{{< placeholder width="75" height="75" class="rounded-sm" title="Example small rounded image" >}}
-{{< placeholder width="75" height="75" class="rounded-lg" title="Example large rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-top" title="Example top rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-right" title="Example right rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-bottom" title="Example bottom rounded image" >}}
+{{< placeholder width="80" height="80" class="rounded-left" title="Example left rounded image" >}}
 {{< /example >}}


### PR DESCRIPTION
- Adds .rounded-1, .rounded-2, and .rounded-3
- Drops .rounded-sm and .rounded-lg because they conflict with breakpoint nomenclature
- Rearrange rounded docs

Closes #30048, fixes #29989, closes #30778.

---

My hope with this PR is to balance keeping the primary `.rounded` class while reducing confusion around class names and adding additional control. To that end, I'm thinking of keeping `.rounded` even though it's the same as `.rounded-1` as of right now. This then drops `.rounded-sm` and `.rounded-lg` for something else.

That last change feels maybe problematic though since our large and small inputs and buttons use those variables.

Which of the referenced PRs are the best approaches? I feel like I could go any direction...

/cc @twbs/css-review 