### PR TITLE
Release Drafter tweaks

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_MAJOR_VERSION'
-tag-template: 'v$NEXT_MAJOR_VERSION'
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
 prerelease: true
 exclude-labels:
   - 'skip-changelog'


### PR DESCRIPTION
- [x] Don't jump to next major version
- [ ] Look into the v4-dev and main issues (why does publishing a v4.x release reset for `main` branch) - Upstream issue, a fix doesn't seem to exist yet
- [ ] Anything else?
- [ ] Exclude dependencies? It adds a lot of noise
- [ ] Sorting doesn't seem to be by PR number?
- [ ] Add Examples section