### PR TITLE
v5: Adjust docs sidebar and navbar

### DIFF
--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -2,10 +2,6 @@
   padding: 3rem 0;
   background: linear-gradient(165deg, lighten($bd-purple-light, 16%) 50%, $white 50%);
 
-  @include media-breakpoint-up(sm) {
-    padding: 5rem 0;
-  }
-
   h1 {
     @include font-size(4rem);
     line-height: 1;

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -1,22 +1,21 @@
 .bd-navbar {
-  padding: .625rem 0;
+  padding: .75rem 0;
   background-color: $bd-purple-bright;
 
-  @include media-breakpoint-down(lg) {
-    .navbar-nav-scroll {
-      width: 100%;
+  .navbar-toggler {
+    padding: 0;
+    border: 0;
 
-      .navbar-nav {
-        margin: -.5rem 0;
-        overflow-x: auto;
-        white-space: nowrap;
-        -webkit-overflow-scrolling: touch;
-      }
+    .bi {
+      width: 2rem;
+      fill: currentColor;
     }
   }
 
   .navbar-nav {
     .nav-link {
+      padding-right: $spacer / 4;
+      padding-left: $spacer / 4;
       color: rgba($white, .85);
 
       &:hover,

--- a/site/assets/scss/_sidebar.scss
+++ b/site/assets/scss/_sidebar.scss
@@ -1,6 +1,6 @@
 .bd-sidebar {
   @include media-breakpoint-down(md) {
-    margin: 0 -1.5rem 1rem;
+    margin: 0 -.75rem 1rem;
   }
 }
 
@@ -23,7 +23,7 @@
 
   > ul {
     @include media-breakpoint-down(md) {
-      padding: 1.5rem;
+      padding: 1.5rem .75rem;
       background-color: $gray-100;
       border-bottom: 1px solid $gray-200;
     }

--- a/site/assets/scss/_sidebar.scss
+++ b/site/assets/scss/_sidebar.scss
@@ -1,4 +1,11 @@
+.bd-sidebar {
+  @include media-breakpoint-down(md) {
+    margin: 0 -1.5rem 1rem;
+  }
+}
+
 .bd-links {
+  overflow: auto;
   font-weight: 600;
 
   @include media-breakpoint-up(md) {
@@ -12,6 +19,14 @@
     padding-left: .25rem;
     margin-left: -.25rem;
     overflow-y: auto;
+  }
+
+  > ul {
+    @include media-breakpoint-down(md) {
+      padding: 1.5rem;
+      background-color: $gray-100;
+      border-bottom: 1px solid $gray-200;
+    }
   }
 
   a {

--- a/site/assets/scss/_subnav.scss
+++ b/site/assets/scss/_subnav.scss
@@ -30,3 +30,23 @@
     box-shadow: 0 0 0 3px rgba($bd-purple-bright, .25);
   }
 }
+
+.bd-sidebar-toggle {
+  color: $text-muted;
+
+  &:hover,
+  &:focus {
+    color: $link-color;
+  }
+
+  .bi {
+    fill: currentColor;
+  }
+
+  .bi-collapse { display: none; }
+
+  &:not(.collapsed) {
+    .bi-expand { display: none; }
+    .bi-collapse { display: inline-block; }
+  }
+}

--- a/site/assets/scss/_subnav.scss
+++ b/site/assets/scss/_subnav.scss
@@ -25,10 +25,6 @@
 }
 
 .bd-search {
-  @include media-breakpoint-down(md) {
-    width: 100%;
-  }
-
   .form-control:focus {
     border-color: $bd-purple-bright;
     box-shadow: 0 0 0 3px rgba($bd-purple-bright, .25);

--- a/site/assets/scss/_subnav.scss
+++ b/site/assets/scss/_subnav.scss
@@ -36,7 +36,11 @@
 
   &:hover,
   &:focus {
-    color: $link-color;
+    color: $bd-purple-bright;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 3px rgba($bd-purple-bright, .25);
   }
 
   .bi {

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -9,13 +9,13 @@
     {{ partial "docs-navbar" . }}
     {{ partial "docs-subnav" . }}
 
-    <div class="container-xxl my-4 bd-layout">
+    <div class="container-xxl my-md-4 bd-layout">
       <aside class="bd-sidebar">
         {{ partial "docs-sidebar" . }}
       </aside>
 
       <main class="bd-main order-1">
-        <div class="bd-intro pt-md-3 pl-lg-4">
+        <div class="bd-intro pl-lg-4">
           <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
             <a class="btn btn-sm btn-bd-light mb-2 mb-md-0" href="{{ .Site.Params.repo }}/blob/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
             <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
@@ -24,11 +24,11 @@
           {{ partial "ads" . }}
         </div>
 
-      {{ if (eq .Page.Params.toc true) }}
-        <div class="bd-toc mt-4 mb-5 my-md-0 pl-xl-3 mb-lg-5 text-muted">
-          <strong class="d-block h6 my-2 pb-2 border-bottom">On this page</strong>
-          {{ .TableOfContents }}
-        </div>
+        {{ if (eq .Page.Params.toc true) }}
+          <div class="bd-toc mt-4 mb-5 my-md-0 pl-xl-3 mb-lg-5 text-muted">
+            <strong class="d-block h6 my-2 pb-2 border-bottom">On this page</strong>
+            {{ .TableOfContents }}
+          </div>
         {{ end }}
 
         <div class="bd-content pl-lg-4">

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -24,8 +24,8 @@
           {{ partial "ads" . }}
         </div>
 
-        {{ if (eq .Page.Params.toc true) }}
-        <div class="bd-toc pl-xl-3 text-muted mb-lg-5">
+      {{ if (eq .Page.Params.toc true) }}
+        <div class="bd-toc mt-4 mb-5 my-md-0 pl-xl-3 mb-lg-5 text-muted">
           <strong class="d-block h6 my-2 pb-2 border-bottom">On this page</strong>
           {{ .TableOfContents }}
         </div>

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -1,58 +1,67 @@
-<header class="navbar navbar-expand navbar-dark bd-navbar">
+<header class="navbar navbar-expand-md navbar-dark bd-navbar">
   <nav class="container-xxl flex-wrap flex-md-nowrap" aria-label="Main navigation">
     <a class="navbar-brand p-0 mr-2" href="/" aria-label="Bootstrap">
-      {{ partial "icons/bootstrap-white-fill.svg" (dict "class" "d-block" "width" "40" "height" "32") }}
+      {{ partial "icons/bootstrap-white-fill.svg" (dict "class" "d-block my-1" "width" "2.5rem" "height" "2rem") }}
     </a>
 
-    <div class="navbar-nav-scroll order-3 order-md-0 d-flex justify-content-center justify-content-md-start mt-1 mt-md-0">
-      <ul class="navbar-nav bd-navbar-nav flex-row py-2 py-md-0">
-        <li class="nav-item">
-          <a class="nav-link{{ if .IsHome }} active" aria-current="page{{ end }}" href="/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Bootstrap');">Home</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#bdNavbar" aria-controls="bdNavbar" aria-expanded="false" aria-label="Toggle navigation">
+      <svg class="bi" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" d="M2.5 11.5A.5.5 0 0 1 3 11h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 3h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+      </svg>
+    </button>
+
+    <div class="collapse navbar-collapse" id="bdNavbar">
+      <ul class="navbar-nav flex-row flex-wrap bd-navbar-nav pt-2 py-md-0">
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2{{ if .IsHome }} active" aria-current="page{{ end }}" href="/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Bootstrap');">Home</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link{{ if eq .Page.Layout "docs" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/getting-started/introduction/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Docs');">Docs</a>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2{{ if eq .Page.Layout "docs" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/getting-started/introduction/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Docs');">Docs</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link{{ if eq .Page.Title "Examples" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Examples');">Examples</a>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2{{ if eq .Page.Title "Examples" }} active" aria-current="true{{ end }}" href="/docs/{{ .Site.Params.docs_version }}/examples/" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Examples');">Examples</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ .Site.Params.icons }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Icons');" target="_blank" rel="noopener">Icons</a>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.icons }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Icons');" target="_blank" rel="noopener">Icons</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ .Site.Params.themes }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Themes');" target="_blank" rel="noopener">Themes</a>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.themes }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Themes');" target="_blank" rel="noopener">Themes</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ .Site.Params.expo }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Expo');" target="_blank" rel="noopener">Expo</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ .Site.Params.blog }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Blog');" target="_blank" rel="noopener">Blog</a>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.blog }}" onclick="ga('send', 'event', 'Navbar', 'Community links', 'Blog');" target="_blank" rel="noopener">Blog</a>
         </li>
       </ul>
+
+      <hr class="d-md-none text-white-50">
+
+      <ul class="navbar-nav flex-row flex-wrap ml-md-auto">
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.github_org }}" target="_blank" rel="noopener">
+            {{ partial "icons/github.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
+            <small class="d-md-none ml-2">GitHub</small>
+          </a>
+        </li>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="https://twitter.com/{{ .Site.Params.twitter }}" target="_blank" rel="noopener">
+            {{ partial "icons/twitter.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
+            <small class="d-md-none ml-2">Twitter</small>
+          </a>
+        </li>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.slack }}" target="_blank" rel="noopener">
+            {{ partial "icons/slack.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
+            <small class="d-md-none ml-2">Slack</small>
+          </a>
+        </li>
+        <li class="nav-item col-6 col-md-auto">
+          <a class="nav-link p-2" href="{{ .Site.Params.opencollective }}" target="_blank" rel="noopener">
+            {{ partial "icons/opencollective.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
+            <small class="d-md-none ml-2">Open Collective</small>
+          </a>
+        </li>
+      </ul>
+
+      <a class="btn btn-bd-download d-lg-inline-block my-2 my-md-0 ml-md-3" href="/docs/{{ .Site.Params.docs_version }}/getting-started/download/">Download</a>
     </div>
-
-    <ul class="navbar-nav ml-sm-auto">
-      <li class="nav-item">
-        <a class="nav-link px-1 mx-1 py-2" href="{{ .Site.Params.github_org }}" target="_blank" rel="noopener" aria-label="GitHub">
-          {{ partial "icons/github.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link px-1 mx-1 py-2" href="https://twitter.com/{{ .Site.Params.twitter }}" target="_blank" rel="noopener" aria-label="Twitter">
-          {{ partial "icons/twitter.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link px-1 mx-1 py-2" href="{{ .Site.Params.slack }}" target="_blank" rel="noopener" aria-label="Slack">
-          {{ partial "icons/slack.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link px-1 mx-1 py-2" href="{{ .Site.Params.opencollective }}" target="_blank" rel="noopener" aria-label="Open Collective">
-          {{ partial "icons/opencollective.svg" (dict "class" "navbar-nav-svg d-inline-block align-text-top" "width" "36" "height" "36") }}
-        </a>
-      </li>
-    </ul>
-
-    <a class="btn btn-bd-download d-none d-lg-inline-block mb-3 mb-md-0 ml-md-3" href="/docs/{{ .Site.Params.docs_version }}/getting-started/download/">Download</a>
   </nav>
 </header>

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -2,7 +2,7 @@
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 
-  <ul class="list-unstyled mb-0 pt-1 pb-3">
+  <ul class="list-unstyled mb-0 py-3 pt-md-1">
   {{- range $group := .Site.Data.sidebar -}}
     {{- $link := $group.title -}}
     {{- $link_slug := $link | urlize -}}

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -7,8 +7,8 @@
     {{ partial "docs-versions" . }}
 
     <button class="btn bd-sidebar-toggle d-md-none py-0 px-1 ml-3 order-3 collapsed" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
-      {{ partial "icons/expand.svg" (dict "class" "bi bi-expand" "width" "" "height" "1.5rem") }}
-      {{ partial "icons/collapse.svg" (dict "class" "bi bi-collapse" "width" "" "height" "1.5rem") }}
+      {{ partial "icons/expand.svg" (dict "class" "bi bi-expand" "width" "1.5rem" "height" "1.5rem") }}
+      {{ partial "icons/collapse.svg" (dict "class" "bi bi-collapse" "width" "1.5rem" "height" "1.5rem") }}
     </button>
   </div>
 </nav>

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -6,8 +6,9 @@
 
     {{ partial "docs-versions" . }}
 
-    <button class="btn bd-search-docs-toggle d-md-none p-0 ml-3 order-3" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
-     {{ partial "icons/list.svg" (dict "class" "bi" "width" "" "height" "2rem") }}
-   </button>
+    <button class="btn bd-sidebar-toggle d-md-none py-0 px-1 ml-3 order-3 collapsed" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
+      {{ partial "icons/expand.svg" (dict "class" "bi bi-expand" "width" "" "height" "1.5rem") }}
+      {{ partial "icons/collapse.svg" (dict "class" "bi bi-collapse" "width" "" "height" "1.5rem") }}
+    </button>
   </div>
 </nav>

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -7,7 +7,7 @@
     {{ partial "docs-versions" . }}
 
     <button class="btn bd-search-docs-toggle d-md-none p-0 ml-3 order-3 ml-auto" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
-     {{ partial "icons/menu.svg" (dict "width" "30" "height" "30") }}
+     {{ partial "icons/list.svg" (dict "class" "bi" "width" "" "height" "2rem") }}
    </button>
   </div>
 </nav>

--- a/site/layouts/partials/docs-subnav.html
+++ b/site/layouts/partials/docs-subnav.html
@@ -1,12 +1,12 @@
-<nav class="bd-subnavbar pt-2 pb-3 pb-md-2" aria-label="Secondary navigation">
-  <div class="container-xxl d-flex align-items-md-center flex-wrap">
-    <form class="bd-search position-relative mb-2 mb-md-0 mr-auto">
+<nav class="bd-subnavbar py-2" aria-label="Secondary navigation">
+  <div class="container-xxl d-flex align-items-md-center">
+    <form class="bd-search position-relative mr-auto">
       <input type="search" class="form-control" id="search-input" placeholder="Search docs..." aria-label="Search docs for..." autocomplete="off" data-docs-version="{{ .Site.Params.docs_version }}">
     </form>
 
     {{ partial "docs-versions" . }}
 
-    <button class="btn bd-search-docs-toggle d-md-none p-0 ml-3 order-3 ml-auto" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
+    <button class="btn bd-search-docs-toggle d-md-none p-0 ml-3 order-3" type="button" data-toggle="collapse" data-target="#bd-docs-nav" aria-controls="bd-docs-nav" aria-expanded="false" aria-label="Toggle docs navigation">
      {{ partial "icons/list.svg" (dict "class" "bi" "width" "" "height" "2rem") }}
    </button>
   </div>

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -1,8 +1,8 @@
-<div class="dropdown">
+<div class="dropdown ml-3">
   <button class="btn btn-bd-light dropdown-toggle" id="bd-versions" data-toggle="dropdown" aria-expanded="false" data-display="static">
-    Bootstrap v{{ .Site.Params.docs_version }}
+    <span class="d-none d-lg-inline">Bootstrap</span> v{{ .Site.Params.docs_version }}
   </button>
-  <ul class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions">
+  <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="bd-versions">
     <li><a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest (5.0.x)</a></li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.5/">v4.5.0</a></li>

--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -1,4 +1,4 @@
-<div class="bd-masthead mb-3 mb-md-5" id="content">
+<div class="bd-masthead mb-3" id="content">
   <div class="container px-4 px-md-3">
     <div class="row align-items-lg-center">
       <div class="col-8 mx-auto col-md-4 order-md-2 col-lg-5">

--- a/site/layouts/partials/icons/collapse.svg
+++ b/site/layouts/partials/icons/collapse.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"{{ with .width }} width="{{ . }}"{{ end }}{{ with .height }} height="{{ . }}"{{ end }}{{ with .class }} class="{{ . }}"{{ end }} viewBox="0 0 16 16">
+  <title>{{ with .title }}{{ . }}{{ else }}Collapse{{ end }}</title>
+  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8zm7-8a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0zm-.5 11.707l-1.146 1.147a.5.5 0 0 1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 0 0 1-1 0v-3.793z"/>
+</svg>

--- a/site/layouts/partials/icons/expand.svg
+++ b/site/layouts/partials/icons/expand.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"{{ with .width }} width="{{ . }}"{{ end }}{{ with .height }} height="{{ . }}"{{ end }}{{ with .class }} class="{{ . }}"{{ end }} viewBox="0 0 16 16">
+  <title>{{ with .title }}{{ . }}{{ else }}Expand{{ end }}</title>
+  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8zM7.646.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 1.707V5.5a.5.5 0 0 1-1 0V1.707L6.354 2.854a.5.5 0 1 1-.708-.708l2-2zM8 10a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 14.293V10.5A.5.5 0 0 1 8 10z"/>
+</svg>

--- a/site/layouts/partials/icons/list.svg
+++ b/site/layouts/partials/icons/list.svg
@@ -1,0 +1,3 @@
+<svg{{ with .width }} width="{{ . }}"{{ end }}{{ with .height }} height="{{ . }}"{{ end }}{{ with .class }} class="{{ . }}"{{ end }} viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M2.5 11.5A.5.5 0 0 1 3 11h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 3h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+</svg>


### PR DESCRIPTION
Some tweaks to ideally improve navigating across our documentation on narrow devices. This PR removes the navbar scroll that I had implemented and replaces it with our classic collapsing navbar, but with a slight twist. I've added column classes to stack the nav across two columns on mobile devices so that the opened nav isn't too tall.

Still need to adjust the menu toggles (missing some styles, tap targets could be larger, etc), but hoping to get some initial feedback from the team on overall direction. Also wondering if I should do more to condense the subnav (search, version picker, and sidebar toggle) on mobile views.

Any thoughts, feedback, or examples of other patterns would be appreciated!

/cc @twbs/css-review 

Preview: https://deploy-preview-31119--twbs-bootstrap.netlify.app/