### PR TITLE
Docs: screen reader helper/visibility utility tweaks

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -2,6 +2,6 @@
 @import "helpers/colored-links";
 @import "helpers/embed";
 @import "helpers/position";
-@import "helpers/screenreaders";
+@import "helpers/visually-hidden";
 @import "helpers/stretched-link";
 @import "helpers/text-truncation";

--- a/scss/helpers/_visually-hidden.scss
+++ b/scss/helpers/_visually-hidden.scss
@@ -1,5 +1,5 @@
 //
-// Screenreaders
+// Visually hidden
 //
 
 .visually-hidden,

--- a/site/content/docs/5.0/forms/layout.md
+++ b/site/content/docs/5.0/forms/layout.md
@@ -297,7 +297,7 @@ You can then remix that once again with size-specific column classes.
 
 Use the `.col-auto` class to create horizontal layouts. By adding [gutter modifier classes]({{< docsref "/layout/gutters" >}}), we'll have gutters in horizontal and vertical directions. The `.align-items-center` aligns the form elements to the middle, making the `.form-checkbox` align properly.
 
-Be sure to always include a `<label>` with each form control, even if you need to hide it from non-screenreader visitors with `.visually-hidden`.
+Be sure to always include a `<label>` with each form control, even if you need to visually hide it with `.visually-hidden` (which still keeps it available to assistive technologies such as screen readers).
 
 {{< example >}}
 <form class="row row-cols-md-auto g-3 align-items-center">

--- a/site/content/docs/5.0/helpers/visually-hidden.md
+++ b/site/content/docs/5.0/helpers/visually-hidden.md
@@ -1,0 +1,25 @@
+---
+layout: docs
+title: Visually hidden
+description: Use these helpers to visually hide elements but keep them accessible to assistive technologies.
+group: helpers
+---
+
+Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.sr-only`. Use `.sr-only-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
+
+{{< example >}}
+<h2 class="sr-only">Title for screen readers</h2>
+<a class="sr-only-focusable" href="#content">Skip to main content</a>
+{{< /example >}}
+
+{{< highlight scss >}}
+// Usage as a mixin
+
+.sr-only-title {
+  @include sr-only;
+}
+
+.skip-navigation {
+  @include sr-only-focusable;
+}
+{{< /highlight >}}

--- a/site/content/docs/5.0/helpers/visually-hidden.md
+++ b/site/content/docs/5.0/helpers/visually-hidden.md
@@ -6,21 +6,21 @@ group: helpers
 aliases: "/docs/5.0/helpers/screen-readers/"
 ---
 
-Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.sr-only`. Use `.sr-only-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
+Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.visually-hidden`. Use `.visually-hidden-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
 
 {{< example >}}
-<h2 class="sr-only">Title for screen readers</h2>
-<a class="sr-only-focusable" href="#content">Skip to main content</a>
+<h2 class="visually-hidden">Title for screen readers</h2>
+<a class="visually-hidden-focusable" href="#content">Skip to main content</a>
 {{< /example >}}
 
 {{< highlight scss >}}
 // Usage as a mixin
 
-.sr-only-title {
-  @include sr-only;
+.visually-hidden-title {
+  @include visually-hidden;
 }
 
 .skip-navigation {
-  @include sr-only-focusable;
+  @include visually-hidden-focusable;
 }
 {{< /highlight >}}

--- a/site/content/docs/5.0/helpers/visually-hidden.md
+++ b/site/content/docs/5.0/helpers/visually-hidden.md
@@ -3,6 +3,7 @@ layout: docs
 title: Visually hidden
 description: Use these helpers to visually hide elements but keep them accessible to assistive technologies.
 group: helpers
+aliases: "/docs/5.0/helpers/screen-readers/"
 ---
 
 Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.sr-only`. Use `.sr-only-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.

--- a/site/content/docs/5.0/utilities/visibility.md
+++ b/site/content/docs/5.0/utilities/visibility.md
@@ -5,7 +5,11 @@ description: Control the visibility, without modifying the display, of elements 
 group: utilities
 ---
 
-Set the `visibility` of elements with our visibility utilities. These utility classes do not modify the `display` value at all and do not affect layout – `.invisible` elements still take up space in the page. Content will be hidden both visually and for assistive technology/screen reader users.
+Set the `visibility` of elements with our visibility utilities. These utility classes do not modify the `display` value at all and do not affect layout – `.invisible` elements still take up space in the page.
+
+{{< callout warning >}}
+Elements with the `.invisible` class will be hidden *both* visually and for assistive technology/screen reader users.
+{{< /callout >}}
 
 Apply `.visible` or `.invisible` as needed.
 

--- a/site/content/docs/5.0/utilities/visibility.md
+++ b/site/content/docs/5.0/utilities/visibility.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Visibility
-description: Control the visibility, without modifying the display, of elements with visibility utilities.
+description: Control the visibility of elements, without modifying their display, with visibility utilities.
 group: utilities
 ---
 

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -81,7 +81,7 @@
     - title: Colored links
     - title: Embed
     - title: Position
-    - title: Screen readers
+    - title: Visually hidden
     - title: Stretched link
     - title: Text truncation
 


### PR DESCRIPTION
- rename "Screen readers" helper to "Visually hidden" (in future, may consider actually renaming the classes as well? `.visually-hidden` / `.visually-hidden-focusable` or similar?)
- reword description for visibility utility, emphasise/call out the fact that `.invisible` hides stuff from AT