### PR TITLE
Update getSelectorFromElement to handle invalid selectors

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -48,7 +48,11 @@ const getSelectorFromElement = element => {
   const selector = getSelector(element)
 
   if (selector) {
-    return document.querySelector(selector) ? selector : null
+    try {
+      return document.querySelector(selector) ? selector : null
+    } catch (_) {
+      return null
+    }
   }
 
   return null

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -72,6 +72,14 @@ describe('Util', () => {
 
       expect(Util.getSelectorFromElement(testEl)).toBeNull()
     })
+
+    it('should return null if selector is a URL', () => {
+      fixtureEl.innerHTML = '<a id="test" href="/users/1"></a>'
+
+      const testEl = fixtureEl.querySelector('#test')
+
+      expect(Util.getSelectorFromElement(testEl)).toBeNull()
+    })
   })
 
   describe('getElementFromSelector', () => {


### PR DESCRIPTION
Bootstrap v5 introduced a regression wherein an unhandled `DOMException` would be thrown if initialising a dropdown element on an anchor tag with a standard URL in the `href` tag.

This is a realistic scenario when the UI shows dropdown on hover but still allows the user to click the link.

This PR adds error handling for this scenario and a spec to cover the change, essentially reimplementing how this is handled in v4:

https://github.com/twbs/bootstrap/blob/4f44a2afd0acbf8a2d199c6fffe619b91dee1c99/js/src/util.js#L88-L92