### PR TITLE
Fix bad backdrop-filter rendering on Safari

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -1,4 +1,5 @@
 .toast {
+  position: relative;
   max-width: $toast-max-width;
   overflow: hidden; // cheap rounded corners on nested items
   @include font-size($toast-font-size);
@@ -6,8 +7,6 @@
   background-color: $toast-background-color;
   background-clip: padding-box;
   border: $toast-border-width solid $toast-border-color;
-  box-shadow: $toast-box-shadow;
-  backdrop-filter: blur(10px);
   opacity: 0;
   @include border-radius($toast-border-radius);
 
@@ -26,6 +25,24 @@
 
   &.hide {
     display: none;
+  }
+
+  &::before,
+  &::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: -1;
+    content: "";
+  }
+
+  &::before {
+    backdrop-filter: blur(10px);
+  }
+  &::after {
+    box-shadow: $toast-box-shadow;
   }
 }
 


### PR DESCRIPTION
This PR is a proposed fix for the bug https://github.com/twbs/bootstrap/issues/30844

In order to have the same behavior on the different browsers we could imagine positioning the backdrop-filter and box-shadow effect on pseudo-elements. 

Before : 

<img width="1096" alt="Capture d’écran 2020-06-24 à 16 23 12" src="https://user-images.githubusercontent.com/66947157/85574450-15000200-b637-11ea-8582-81bb4426641f.png">

After : 
<img width="870" alt="Capture d’écran 2020-06-24 à 16 23 28" src="https://user-images.githubusercontent.com/66947157/85574519-2517e180-b637-11ea-9fb8-db492ec15540.png">
