### PR TITLE
fix failure to hide tooltip if already destroyed

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -340,7 +340,9 @@ class Tooltip {
       this._cleanTipClass()
       this.element.removeAttribute('aria-describedby')
       EventHandler.trigger(this.element, this.constructor.Event.HIDDEN)
-      this._popper.destroy()
+      if (this._popper !== null) {
+        this._popper.destroy()
+      }
     }
 
     const hideEvent = EventHandler.trigger(this.element, this.constructor.Event.HIDE)


### PR DESCRIPTION
This one is a super simple bugfix, let me know if there's anything else I need to do (rebuild / move to different branch / etc).

Cheers!