### PR TITLE
Docs: Fix vertical align link

### DIFF
--- a/site/content/docs/5.0/utilities/vertical-align.md
+++ b/site/content/docs/5.0/utilities/vertical-align.md
@@ -9,7 +9,7 @@ Change the alignment of elements with the [`vertical-alignment`](https://develop
 
 Choose from `.align-baseline`, `.align-top`, `.align-middle`, `.align-bottom`, `.align-text-bottom`, and `.align-text-top` as needed.
 
-To vertically center non-inline content (like `<div>`s and more), use our [flex box utilities]({{< docsref "/utilities/flex#auto-margins" >}}).
+To vertically center non-inline content (like `<div>`s and more), use our [flex box utilities]({{< docsref "/utilities/flex#align-items" >}}).
 
 With inline elements:
 


### PR DESCRIPTION
Link currently points to flex "auto margins" section, but I think "align items" is more appropriate given the vertical alignment context.