### PR TITLE
Use collapse plugin for the "Show components requiring JavaScript" dropdown

### DIFF
--- a/site/layouts/partials/getting-started/components-requiring-javascript.html
+++ b/site/layouts/partials/getting-started/components-requiring-javascript.html
@@ -1,5 +1,9 @@
-<details>
-  <summary class="text-primary mb-3">Show components requiring JavaScript</summary>
+<p>
+  <a class="btn btn-link" data-toggle="collapse" href="#javascriptComponents" role="button" aria-expanded="false" aria-controls="javascriptComponents">
+    Show components requiring JavaScript
+  </a>
+</p>
+<div class="collapse" id="javascriptComponents">
   <ul>
     <li>Alerts for dismissing</li>
     <li>Buttons for toggling states and checkbox/radio functionality</li>
@@ -11,4 +15,4 @@
     <li>Tooltips and popovers for displaying and positioning (also requires <a href="https://popper.js.org/">Popper.js</a>)</li>
     <li>Scrollspy for scroll behavior and navigation updates</li>
   </ul>
-</details>
+</div>


### PR DESCRIPTION
The "Show components requiring JavaScript" dropdown menu currently uses `<details>` and `<summary>`. It can easily be converted to the collapse plugin to be consistent with the sidebar.