### PR TITLE
Fix sidebar jump

### DIFF
--- a/site/assets/scss/_sidebar.scss
+++ b/site/assets/scss/_sidebar.scss
@@ -50,11 +50,6 @@
         }
       }
     }
-
-    // Adjust font size and font weights in submenu
-    + ul {
-      @include font-size(.875rem);
-    }
   }
 
   .active {

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -21,14 +21,16 @@
       </a>
 
       {{- if $group.pages }}
-      <ul class="list-unstyled font-weight-normal mb-2 collapse{{ if $is_active_group }} show{{ end }}" id="{{ $group_slug }}-collapse">
-        {{- range $doc := $group.pages -}}
-          {{- $doc_slug := $doc.title | urlize -}}
-          {{- $is_active := and $is_active_group (eq $page_slug $doc_slug) -}}
-          {{- $href := printf "/docs/%s/%s/%s/" $.Site.Params.docs_version $group_slug $doc_slug }}
-          <li><a href="{{ $href }}" class="d-inline-flex align-items-center rounded{{ if $is_active }} active{{ end }}"{{ if $is_active }} aria-current="page"{{ end }}>{{ $doc.title }}</a></li>
-        {{- end }}
-      </ul>
+      <div class="collapse{{ if $is_active_group }} show{{ end }}" id="{{ $group_slug }}-collapse">
+        <ul class="list-unstyled font-weight-normal pb-1">
+          {{- range $doc := $group.pages -}}
+            {{- $doc_slug := $doc.title | urlize -}}
+            {{- $is_active := and $is_active_group (eq $page_slug $doc_slug) -}}
+            {{- $href := printf "/docs/%s/%s/%s/" $.Site.Params.docs_version $group_slug $doc_slug }}
+            <li><a href="{{ $href }}" class="d-inline-flex align-items-center rounded{{ if $is_active }} active{{ end }}"{{ if $is_active }} aria-current="page"{{ end }}>{{ $doc.title }}</a></li>
+          {{- end }}
+        </ul>
+      </div>
       {{- end }}
     </li>
   {{- end }}

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -2,7 +2,7 @@
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 
-  <ul class="list-unstyled mb-0 pt-1">
+  <ul class="list-unstyled mb-0 pt-1 pb-3">
   {{- range $group := .Site.Data.sidebar -}}
     {{- $link := $group.title -}}
     {{- $link_slug := $link | urlize -}}

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -22,7 +22,7 @@
 
       {{- if $group.pages }}
       <div class="collapse{{ if $is_active_group }} show{{ end }}" id="{{ $group_slug }}-collapse">
-        <ul class="list-unstyled font-weight-normal pb-1">
+        <ul class="list-unstyled font-weight-normal pb-1 small">
           {{- range $doc := $group.pages -}}
             {{- $doc_slug := $doc.title | urlize -}}
             {{- $is_active := and $is_active_group (eq $page_slug $doc_slug) -}}

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -2,7 +2,7 @@
   {{- $url := split .Permalink "/" -}}
   {{- $page_slug := index $url (sub (len $url) 2) -}}
 
-  <ul class="list-unstyled mb-0">
+  <ul class="list-unstyled mb-0 pt-1">
   {{- range $group := .Site.Data.sidebar -}}
     {{- $link := $group.title -}}
     {{- $link_slug := $link | urlize -}}
@@ -15,7 +15,7 @@
     {{- $group_slug := $group.title | urlize -}}
     {{- $is_active_group := eq $.Page.Params.group $group_slug }}
 
-    <li class="my-1{{ if $is_active_group }} active{{ end }}">
+    <li class="mb-1{{ if $is_active_group }} active{{ end }}">
       <a class="d-inline-flex align-items-center rounded{{ if not $is_active_group }} collapsed{{ end }}" data-toggle="collapse" href="#{{ $group_slug }}-collapse" role="button" aria-expanded="{{ $is_active_group }}"{{ if $is_active_group }} aria-current="true"{{ end }}>
         {{ $group.title }}
       </a>


### PR DESCRIPTION
Nested the submenu in a div without margin and added a padding class on the ul. Also added the `small` class to remove some css.

Toggle "Extend" menu to see the effect:
Before: https://twbs-bootstrap.netlify.app/docs/5.0/extend/approach/
After: https://deploy-preview-31232--twbs-bootstrap.netlify.app/docs/5.0/extend/approach/