### PR TITLE
Add Hugo Pipes logic for local and vendored scripts.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -40,10 +40,12 @@ module:
       target:           static/apple-touch-icon.png
     - source:           site/static/docs/5.0/assets/img/favicons/favicon.ico
       target:           static/favicon.ico
-    # docsearch is referenced in a `script` tag so we just mount it in the static folder
+    
+    # the following are processed via Hugo pipes so we need them in the assets folder
+    ## the following will be printed with Hugo pipes
     - source:           node_modules/docsearch.js/dist/cdn/docsearch.min.js
-      target:           static/docs/5.0/assets/js/vendor/docsearch.min.js
-    # the following are concatenated via Hugo pipes with docs.js so we need them in the assets folder
+      target:           assets/js/vendor/docsearch.min.js
+    ## The following vendor files will be bundled together on top of local js files as /docs.js
     - source:           node_modules/anchor-js/anchor.min.js
       target:           assets/js/vendor/anchor.min.js
     - source:           node_modules/bs-custom-file-input/dist/bs-custom-file-input.min.js

--- a/site/layouts/partials/func/get-js-assets.html
+++ b/site/layouts/partials/func/get-js-assets.html
@@ -18,7 +18,7 @@
 {{ $jsAssets := slice }}
 
 {{/* Storing the reused mount warning message */}}
-{{ $missing_file_warning := "%s not found. Check your mounts settings." }}
+{{ $missing_file_warning := "%s not found. Check your mounts settings and/or run `npm i`." }}
 {{ $doc_version := site.Params.docs_version }}
 {{/* Doc Search */}}
 {{ if eq .Page.Layout "docs" -}}
@@ -31,7 +31,7 @@
   */}}
     {{ $jsAssets = $jsAssets | append . }}
   {{ else }}
-    {{ warnf $missing_file_warning "docsearch.min.js" }}
+    {{ errorf $missing_file_warning "docsearch.min.js" }}
   {{ end }}
 {{- end }}
 
@@ -44,12 +44,12 @@
   1. Check for missing mounts and throw an error
   2. Control order if need be
   3. Exclude docsearch (though there would be other ways) */}}
-{{ $vendor_filenames := slice "clipboard.min.js" "anchor.min.js" "bs-custom-file-input.min.js" }}
+{{ $vendor_filenames := slice "clipboard.min.js" "anchor.min.js" }}
 {{ range $filename := $vendor_filenames }}
   {{ with resources.GetMatch (print "js/vendor/" .) }}
     {{ $vendor_assets = $vendor_assets | append . }}
   {{ else }}
-    {{ warnf $missing_file_warning $filename }}
+    {{ errorf $missing_file_warning $filename }}
   {{ end }}
 {{ end }}
 {{ with $vendor_assets }}

--- a/site/layouts/partials/func/get-js-assets.html
+++ b/site/layouts/partials/func/get-js-assets.html
@@ -1,0 +1,74 @@
+{{/*
+  get-js-assets
+  Returns a list of processed Hugo Assets to be used in templates
+
+  @author @regisphilibert
+
+  @context Page (.)
+
+  @access public
+
+  @example - Go Template
+  {{- range partialCached "func/get-js-assets" . $variant -}}
+    <script src="{{ .RelPermalink }}"></script>
+  {{- end -}}
+*/}}
+
+{{/* We'll return a slice so templates can safely use `range` */}}
+{{ $jsAssets := slice }}
+
+{{/* Storing the reused mount warning message */}}
+{{ $missing_file_warning := "%s not found. Check your mounts settings." }}
+{{ $doc_version := site.Params.docs_version }}
+{{/* Doc Search */}}
+{{ if eq .Page.Layout "docs" -}}
+  {{ with resources.GetMatch "js/vendor/docsearch.min.js" }}
+  {{/* As this is a WIP, we don't customize the asset URL,
+    but we will after Hugo .74 and resources.Put (https://github.com/gohugoio/hugo/issues/7406):
+  {{ with resources.GetMatch "js/vendor/docsearch.min.js" }}
+    {{ $docsearch := . | resources.Put (printf /docs/%s/assets/js/vendor/docsearch.min.js" $doc_version) }}
+    {{ $jsAssets = $jsAssets | append $docsearch }}
+  */}}
+    {{ $jsAssets = $jsAssets | append . }}
+  {{ else }}
+    {{ warnf $missing_file_warning "docsearch.min.js" }}
+  {{ end }}
+{{- end }}
+
+{{/* --- Bundle */}}
+{{ $bundle := slice }}
+
+{{/* ----- Mounted from vendors */}}
+{{- $vendor_assets := slice -}}
+{{/* As we need to list the desired mounted files to:
+  1. Check for missing mounts and throw an error
+  2. Control order if need be
+  3. Exclude docsearch (though there would be other ways) */}}
+{{ $vendor_filenames := slice "clipboard.min.js" "anchor.min.js" "bs-custom-file-input.min.js" }}
+{{ range $filename := $vendor_filenames }}
+  {{ with resources.GetMatch (print "js/vendor/" .) }}
+    {{ $vendor_assets = $vendor_assets | append . }}
+  {{ else }}
+    {{ warnf $missing_file_warning $filename }}
+  {{ end }}
+{{ end }}
+{{ with $vendor_assets }}
+  {{ $bundle = $bundle | append . }}
+{{ end }}
+
+{{/* ----- Local assets */}}
+{{ with resources.Match "js/*.js" }}
+  {{ $bundle = $bundle | append . }}
+{{ end }}
+
+{{/* Above code should have populated $bundle slice */}}
+{{ with $bundle }}
+  {{ $targetBundlePath := printf "/docs/%s/assets/js/docs.js" $doc_version }}
+  {{ $bundle_asset := $bundle | resources.Concat $targetBundlePath }}
+  {{ if eq hugo.Environment "production" }}
+    {{ $bundle_asset = $bundle_asset | resources.Minify }}
+  {{ end }}
+  {{ $jsAssets = $jsAssets | append $bundle_asset }}
+{{ end }}
+
+{{ return $jsAssets }}

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -4,17 +4,7 @@
   <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.js"></script>
 {{- end }}
 
-{{ if eq .Page.Layout "docs" -}}
-<script src="/docs/{{ .Site.Params.docs_version }}/assets/js/vendor/docsearch.min.js"></script>
-{{- end }}
-
-{{- $vendor := resources.Match "js/vendor/*.js" -}}
-{{- $js := resources.Match "js/*.js" -}}
-{{- $targetDocsJSPath := printf "/docs/%s/assets/js/docs.js" .Site.Params.docs_version -}}
-{{- $docsJs := append $js $vendor | resources.Concat $targetDocsJSPath -}}
-
-{{- if eq hugo.Environment "production" -}}
-  {{- $docsJs = $docsJs | resources.Minify -}}
-{{- end }}
-
-<script src="{{ $docsJs.Permalink | relURL }}"></script>
+{{- $variant := cond (eq .Page.Layout "docs") "docs" "default" -}}
+{{- range partialCached "func/get-js-assets" . $variant -}}
+  <script src="{{ .RelPermalink }}"></script>
+{{- end -}}


### PR DESCRIPTION
@XhmikosR 

I stored the Hugo pipe logic in a returning partial so we can:
1. not concern ourselves with whitespace and line breaks when working logics
2. use partialCached on the logic
3. compontentize.

Also: 
- When missing mounts, I'm using warnings instead of errors, but I think you wanted errors so the build is stopped. In this case we can replace `warnf` by `errorf` through the code.
- For now the `docsearch.min.js` file is not published at the desired permalink (including version) but will after Hugo .74 introduces the new `resources.Put` method (see comment)
- I'm not 100% sure the order in which files should be bundled is correct, but I don't have any errors in console.
- I used my own [conventions](https://regisphilibert.com/blog/2019/12/hugo-partial-series-part-2-functions-with-returning-partials/#some-conventions) for file naming and commenting, feel free to adjust to the team's own.
- I left alone the asset loaded from CDN (`bootstrap.bundle.min.js`), but once you are ready to let Hugo handle it we'll just have to include in the GetJSAssets partial.

Preview: <https://deploy-preview-29283--twbs-bootstrap.netlify.app/>
