### PR TITLE
Remove period in list item link for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Our default branch is for development of our upcoming Bootstrap 5 release. Head 
 
 Several quick start options are available:
 
-- [Download the latest release.](https://github.com/twbs/bootstrap/archive/v5.0.0.zip)
+- [Download the latest release](https://github.com/twbs/bootstrap/archive/v5.0.0.zip)
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com/): `npm install bootstrap@next`
 - Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@next`


### PR DESCRIPTION
To remain consistent with the other list items in the `Several quick start options are available` section, I removed the period in the first list item link.