### PR TITLE
Remove Browser support link/note from Floating Labels Example

### DIFF
--- a/site/content/docs/5.0/examples/floating-labels/index.html
+++ b/site/content/docs/5.0/examples/floating-labels/index.html
@@ -10,7 +10,7 @@ include_js: false
   <div class="text-center mb-4">
     <img class="mb-4" src="/docs/{{< param docs_version >}}/assets/brand/bootstrap-solid.svg" alt="" width="72" height="72">
     <h1 class="h3 mb-3 font-weight-normal">Floating labels</h1>
-    <p>Build form controls with floating labels via the <code>:placeholder-shown</code> pseudo-element. <a href="https://caniuse.com/#feat=css-placeholder-shown">Works in latest Chrome, Safari, and Firefox.</a></p>
+    <p>Build form controls with floating labels via the <code>:placeholder-shown</code> pseudo-element.</p>
   </div>
 
   <div class="form-label-group">


### PR DESCRIPTION
Now that Placeholder shown is widely supported and this example works with all browsers which Bootstrap 5 target, this link can safely be removed.
REF: https://caniuse.com/#feat=css-placeholder-shown