### PR TITLE
Update version.md to include v5

### DIFF
--- a/site/content/docs/versions.md
+++ b/site/content/docs/versions.md
@@ -1,6 +1,6 @@
 ---
 title: Versions
-description: An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v4.
+description: An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v5.
 ---
 
 {{< list-versions.inline >}}


### PR DESCRIPTION
Version.md on v5.getbootstrap.com is only referring to v1 > v4 when it should be referring to v1 > v5.

**Preview**: https://deploy-preview-31272--twbs-bootstrap.netlify.app/docs/versions/