### PR TITLE
v5: Versions cleanup

### DIFF
--- a/site/content/docs/versions.md
+++ b/site/content/docs/versions.md
@@ -1,6 +1,6 @@
 ---
 title: Versions
-description: An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v4.
+description: An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v5.
 ---
 
 {{< list-versions.inline >}}

--- a/site/content/docs/versions.md
+++ b/site/content/docs/versions.md
@@ -5,7 +5,7 @@ description: An appendix of hosted documentation for nearly every release of Boo
 
 {{< list-versions.inline >}}
 <div class="row">
-  {{- range $release := (index $.Site.Data "docs-versions") }}
+  {{- range $release := sort (index $.Site.Data "docs-versions") "group" "desc" }}
   <div class="col-md mb-4">
     <h2>{{ $release.group }}</h2>
     <p>{{ $release.description }}</p>

--- a/site/content/docs/versions.md
+++ b/site/content/docs/versions.md
@@ -6,7 +6,7 @@ description: An appendix of hosted documentation for nearly every release of Boo
 {{< list-versions.inline >}}
 <div class="row">
   {{- range $release := (index $.Site.Data "docs-versions") }}
-  <div class="col-md">
+  <div class="col-md mb-4">
     <h2>{{ $release.group }}</h2>
     <p>{{ $release.description }}</p>
     {{- $versions := sort $release.versions "v" "desc" -}}


### PR DESCRIPTION
I'd like to be able to sort this page in the reverse order, showing v5 first. I still struggle with Hugo's syntax and couldn't first out if I needed to use `sort` here or `reverse`, or where to even place it. I give up on it.

Otherwise, this cleans up some spacing and pulls in the chnage from #31272.