### PR TITLE
Firefox error

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -5278,7 +5278,8 @@ a.thumbnail.active {
 .media,
 .media-body {
   overflow: hidden;
-  zoom: 1;
+  transform: scale(1);
+  transform-origin: 0 0;
 }
 .media-body {
   width: 10000px;


### PR DESCRIPTION
Change zoom: 1 to transform: scale(1); transform-origin: 0 0; because in firefox have error message in console "This page uses the non standard property “zoom”. Consider using calc() in the relevant property values, or using “transform” along with “transform-origin: 0 0”."