### PR TITLE
Adding text ellipsis as utility

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -444,6 +444,11 @@ $utilities: map-merge(
       class: text,
       values: (break: break-word)
     ),
+    "text-ellipsis": (
+      property: text-overflow,
+      class: text,
+      values: ellipsis
+    ),
     "font-family": (
       property: font-family,
       class: font,

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -51,6 +51,15 @@ Prevent long strings of text from breaking your components' layout by using `.te
 <p class="text-break">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
 {{< /example >}}
 
+## Text Ellipsis
+
+Prevent long strings to overflow layout by using `.text-ellipsis` to set `text-overflow: ellpisis`. Use it with  `.overflow-hidden`.
+
+{{< example >}}
+<p class="text-ellipsis overflow-hidden">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+{{< /example >}}
+
+
 ## Text transform
 
 Transform text in components with text capitalization classes.

--- a/site/content/docs/5.0/utilities/text.md
+++ b/site/content/docs/5.0/utilities/text.md
@@ -59,7 +59,6 @@ Prevent long strings to overflow layout by using `.text-ellipsis` to set `text-o
 <p class="text-ellipsis overflow-hidden">mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
 {{< /example >}}
 
-
 ## Text transform
 
 Transform text in components with text capitalization classes.


### PR DESCRIPTION

This PR adds ```text-overflow: ellpisis``` as a util.

Demo:
![image](https://user-images.githubusercontent.com/536918/87940561-67f29b00-cab7-11ea-9999-a32d59a774b7.png)
