### PR TITLE
Add view on GitHub links for easier content editing from the docs

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -15,7 +15,10 @@
       </div>
 
       <div class="bd-intro pt-md-3 pl-lg-4">
-        <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
+        <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
+          <a class="btn btn-link btn-sm mb-2 text-muted text-decoration-none bg-light" href="https://github.com/twbs/bootstrap/tree/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
+          <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
+        </div>
         <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
         {{ partial "ads" . }}
       </div>

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -16,7 +16,7 @@
 
       <div class="bd-intro pt-md-3 pl-lg-4">
         <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
-          <a class="btn btn-link btn-sm mb-2 text-muted text-decoration-none bg-light" href="https://github.com/twbs/bootstrap/tree/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
+          <a class="btn btn-link btn-sm mb-2 text-muted text-decoration-none bg-light" href="{{ .Site.Params.repo }}/tree/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
           <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
         </div>
         <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>

--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -16,7 +16,7 @@
 
       <div class="bd-intro pt-md-3 pl-lg-4">
         <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
-          <a class="btn btn-link btn-sm mb-2 text-muted text-decoration-none bg-light" href="{{ .Site.Params.repo }}/tree/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
+          <a class="btn btn-sm btn-bd-light mb-2 mb-md-0" href="{{ .Site.Params.repo }}/tree/main/site/content/{{ .Page.File.Path }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">View on GitHub</a>
           <h1 class="bd-title" id="content">{{ .Title | markdownify }}</h1>
         </div>
         <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>


### PR DESCRIPTION
Fixes #31293 (which should've been an issue).

Thoughts on backporting to v4?

Preview: https://deploy-preview-31339--twbs-bootstrap.netlify.app/docs/5.0/getting-started/introduction/