### PR TITLE
Turn off scroll anchoring for accordions

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -220,6 +220,8 @@
 //
 
 .accordion {
+  overflow-anchor: none;
+
   > .card {
     overflow: hidden;
 


### PR DESCRIPTION
New default behavior for scroll anchoring (rolled out in Chrome 84?) leads to unsightly/odd accordion interactions - see #31341
This rule suppresses this new behavior and reverts back to the old way.

See https://drafts.csswg.org/css-scroll-anchoring/

Closes #31341 