### PR TITLE
Refactor/fade show

### DIFF
--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -2,6 +2,7 @@
   @include transition($transition-fade);
 
   &:not(.show) {
+    visibility: hidden;
     opacity: 0;
   }
 }


### PR DESCRIPTION
Minor tweak to `.fade:not(.show)` to enhance voiceover ability to capture changes as well as remove pointer events from hidden items.

Inspiration taken from https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/

You can see an example working here (i've made some other tweaks to the modal i'd like to test out before raising a PR)
https://safari-voiceover-modal.netlify.app/examples/single-modal 