### PR TITLE
Add chat

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -11,7 +11,7 @@
   </div>
 </footer>
 <!-- Begin chat by Gitter -->
-<button class="chat-button btn btn-secondary" style="position:fixed;bottom:15px;right:15px">Open Chat</button>
+<button class="chat-button btn btn-secondary" type="button" style="position:fixed;bottom:15px;right:15px;z-index:999">Open Chat</button>
 <script>
   ((window.gitter = {}).chat = {}).options = {
     room: 'twbs/bootstrap',

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -11,7 +11,7 @@
   </div>
 </footer>
 <!-- Begin chat by Gitter -->
-<button class="chat-button btn btn-secondary" type="button" style="position:fixed;bottom:15px;right:15px;z-index:999">Open Chat</button>
+<button class="chat-button btn btn-secondary" type="button">Open Chat</button>
 <script>
   ((window.gitter = {}).chat = {}).options = {
     room: 'twbs/bootstrap',

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -10,3 +10,13 @@
     <p class="mb-0">Currently v{{ .Site.Params.current_version }}. Code licensed <a href="{{ .Site.Params.repo }}/blob/main/LICENSE" target="_blank" rel="license noopener">MIT</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license noopener">CC BY 3.0</a>.</p>
   </div>
 </footer>
+<!-- Begin chat by Gitter -->
+<button class="chat-button btn btn-secondary" style="position:fixed;bottom:15px;right:15px">Open Chat</button>
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+    room: 'twbs/bootstrap',
+    activationElement: '.chat-button'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+<!-- End chat by Gitter -->

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -18,3 +18,9 @@
 
 <link rel="stylesheet" href="{{ $style.Permalink | relURL }}">
 {{- end }}
+
+<style>
+  .gitter-chat-embed {
+    z-index: 9999;
+  }
+</style>

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -20,6 +20,12 @@
 {{- end }}
 
 <style>
+  .chat-button {
+    position: fixed;
+    bottom: 15px;
+    right: 15px;
+    z-index: 999;
+  }
   .gitter-chat-embed {
     z-index: 9999;
   }


### PR DESCRIPTION
I think that adding a chat feature to the docs pages would be a good idea. This pull request adds [Gitter](https://gitter.im/twbs/bootstrap) to such pages, allowing this to happen.

I think that this would be a good idea because GitHub issues are mainly for feature requests or bug reports, not really for general talk.