### PR TITLE
Add smooth scroll utility 

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -497,6 +497,13 @@ $utilities: map-merge(
         visible: visible,
         invisible: hidden,
       )
+    ),
+    "smooth":(
+      property: scroll-behavior,
+      class: null,
+      values:(
+        smooth: smooth
+      )
     )
   ),
   $utilities

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -498,6 +498,7 @@ $utilities: map-merge(
         invisible: hidden,
       )
     ),
+    //Smooth scroll utility 
     "smooth":(
       property: scroll-behavior,
       class: null,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -498,11 +498,11 @@ $utilities: map-merge(
         invisible: hidden,
       )
     ),
-    //Smooth scroll utility 
-    "smooth":(
+    //Smooth scroll utility
+    "smooth": (
       property: scroll-behavior,
       class: null,
-      values:(
+      values: (
         smooth: smooth
       )
     )


### PR DESCRIPTION
Closes #31357 

Apply the smooth scroll utilities by simply adding the `.smooth` class.
I've defined a `"smooth"` value in `map-merge` located in the `scss/_utilities.scss` file.

The corresponding additions to the documentation have yet to be made though.