### PR TITLE
make breakpoints specifications consistent with layout/grid.md

### DIFF
--- a/site/content/docs/5.0/layout/breakpoints.md
+++ b/site/content/docs/5.0/layout/breakpoints.md
@@ -31,7 +31,7 @@ Bootstrap includes six default breakpoints, sometimes referred to as _grid tiers
     <tr>
       <td>X-Small</td>
       <td><em>None</em></td>
-      <td>0–576px</td>
+      <td>&lt;576px</td>
     </tr>
     <tr>
       <td>Small</td>


### PR DESCRIPTION
0-576px could also be misinterpreted as "up to 576px included"