### PR TITLE
Restore and deprecate make-container-max-widths mixin

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -25,6 +25,7 @@
       max-width: $container-max-width;
     }
   }
+  @include deprecate("The `make-container-max-widths` mixin", "v4.5.2", "v5", $ignore-warning);
 }
 
 @mixin make-col-ready($gutter: $grid-gutter-width) {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -25,7 +25,7 @@
       max-width: $container-max-width;
     }
   }
-  @include deprecate("The `make-container-max-widths` mixin", "v4.5.2", "v5", $ignore-warning);
+  @include deprecate("The `make-container-max-widths` mixin", "v4.5.2", "v5");
 }
 
 @mixin make-col-ready($gutter: $grid-gutter-width) {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -18,6 +18,15 @@
   margin-left: -$gutter / 2;
 }
 
+// For each breakpoint, define the maximum width of the container in a media query
+@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
+  @each $breakpoint, $container-max-width in $max-widths {
+    @include media-breakpoint-up($breakpoint, $breakpoints) {
+      max-width: $container-max-width;
+    }
+  }
+}
+
 @mixin make-col-ready($gutter: $grid-gutter-width) {
   position: relative;
   // Prevent columns from becoming too narrow when at smaller grid tiers by


### PR DESCRIPTION
We removed this to de-dupe our grid containers in our compiled CSS (see #30969) and I wasn't thinking when reviewing that it'd be a breaking change. We're sticking with not using the mixin, but adding the mixin back for others to use.

We may need to add a deprecation notice to it as well.

Fixes #31436, fixes #31440 