### PR TITLE
Give more priority to `.d-none`

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -23,7 +23,7 @@ $utilities: map-merge(
       print: true,
       property: display,
       class: d,
-      values: none inline inline-block block table table-row table-cell flex inline-flex
+      values: inline inline-block block table table-row table-cell flex inline-flex none
     ),
     "shadow": (
       property: box-shadow,


### PR DESCRIPTION
So we don't have to remove already assigned d-* class to hide the element.

Fixes #31426