### PR TITLE
Focus state input group

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -25,16 +25,7 @@
 
   // Customize the `:focus` state to imitate native WebKit styles.
   &:focus {
-    color: $input-focus-color;
-    background-color: $input-focus-bg;
-    border-color: $input-focus-border-color;
-    outline: 0;
-    @if $enable-shadows {
-      @include box-shadow($input-box-shadow, $input-focus-box-shadow);
-    } @else {
-      // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: $input-focus-box-shadow;
-    }
+    @include form-control-focus();
   }
 
   // Placeholder

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -8,6 +8,19 @@
   flex-wrap: wrap; // For form validation feedback
   align-items: stretch;
   width: 100%;
+  @include border-radius($input-border-radius, 0);
+
+  &:focus-within {
+    @include form-control-focus();
+
+    > .form-control:focus {
+      color: $input-color;
+      background-color: $input-bg;
+      border-color: $input-border-color;
+      outline: 0;
+      box-shadow: none;
+    }
+  }
 
   > .form-control,
   > .form-select,

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -131,3 +131,16 @@
     }
   }
 }
+
+@mixin form-control-focus() {
+  color: $input-focus-color;
+  background-color: $input-focus-bg;
+  border: $input-border-width $input-focus-border-color solid;
+  outline: 0;
+  @if $enable-shadows {
+    @include box-shadow($input-box-shadow, $input-focus-box-shadow);
+  } @else {
+    // Avoid using mixin so we can pass custom focus shadow properly
+    box-shadow: $input-focus-box-shadow;
+  }
+}


### PR DESCRIPTION
IMO on an input-group, the focus state should cover the entire group

Before
<img width="772" alt="Screenshot 2020-08-14 at 19 57 19" src="https://user-images.githubusercontent.com/5782495/90279263-2c09e600-de69-11ea-847c-52d5b42153f9.png">

After
<img width="781" alt="Screenshot 2020-08-14 at 19 55 56" src="https://user-images.githubusercontent.com/5782495/90279271-2f9d6d00-de69-11ea-9aa1-b6a9341cfd88.png">


