### PR TITLE
Add classes to remove rounding from single side

### DIFF
--- a/dist/css/bootstrap-utilities.css
+++ b/dist/css/bootstrap-utilities.css
@@ -1097,6 +1097,26 @@
   border-top-left-radius: 0.25rem !important;
 }
 
+.rounded-top-0 {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.rounded-right-0 {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.rounded-bottom-0 {
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.rounded-left-0 {
+  border-bottom-left-radius: 0 !important;
+  border-top-left-radius: 0 !important;
+}
+
 .visible {
   visibility: visible !important;
 }

--- a/site/content/docs/5.0/utilities/borders.md
+++ b/site/content/docs/5.0/utilities/borders.md
@@ -56,6 +56,10 @@ Add classes to an element to easily round its corners.
 {{< placeholder width="75" height="75" class="rounded-circle" title="Completely round image" >}}
 {{< placeholder width="150" height="75" class="rounded-pill" title="Rounded pill image" >}}
 {{< placeholder width="75" height="75" class="rounded-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="rounded-top-0" title="Example top non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="rounded-right-0" title="Example right non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="rounded-bottom-0" title="Example bottom non-rounded image (overrides rounding applied elsewhere)" >}}
+{{< placeholder width="75" height="75" class="rounded-left-0" title="Example left non-rounded image (overrides rounding applied elsewhere)" >}}
 {{< /example >}}
 
 


### PR DESCRIPTION
This PR adds styles that remove the rounding from a single side of an element that may already be round. They are similar to rounded-0 and are the corollary to their rounded-SIDE siblings.