### PR TITLE
Responsively align last line of text using utils

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -376,7 +376,7 @@ $utilities: map-merge(
     ),
     "text-align": (
       responsive: true,
-      property: text-align,
+      property: text-align text-align-last,
       class: text,
       values: left right center
     ),


### PR DESCRIPTION
For themes that modify the alignment of the last line of text, the responsive utils do not update the alignment of the last line of text. This keeps the responsiveness consistent with the rest of the text block.