### PR TITLE
Add a rounded-pill-<side> utility.

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -490,6 +490,27 @@ $utilities: map-merge(
       class: rounded-left,
       values: (null: $border-radius)
     ),
+    // Rounded pill side
+    "rounded-pill-top": (
+      property: border-top-left-radius border-top-right-radius,
+      class: rounded-pill-top,
+      values: (null: $rounded-pill)
+    ),
+    "rounded-pill-right": (
+      property: border-top-right-radius border-bottom-right-radius,
+      class: rounded-pill-right,
+      values: (null: $rounded-pill)
+    ),
+    "rounded-pill-bottom": (
+      property: border-bottom-right-radius border-bottom-left-radius,
+      class: rounded-pill-bottom,
+      values: (null: $rounded-pill)
+    ),
+    "rounded-pill-left": (
+      property: border-bottom-left-radius border-top-left-radius,
+      class: rounded-pill-left,
+      values: (null: $rounded-pill)
+    ),
     "visibility": (
       property: visibility,
       class: null,

--- a/site/content/docs/5.0/utilities/borders.md
+++ b/site/content/docs/5.0/utilities/borders.md
@@ -55,6 +55,10 @@ Add classes to an element to easily round its corners.
 {{< placeholder width="75" height="75" class="rounded-left" title="Example left rounded image" >}}
 {{< placeholder width="75" height="75" class="rounded-circle" title="Completely round image" >}}
 {{< placeholder width="150" height="75" class="rounded-pill" title="Rounded pill image" >}}
+{{< placeholder width="150" height="75" class="rounded-pill-top" title="Rounded pill top image" >}}
+{{< placeholder width="150" height="75" class="rounded-pill-right" title="Rounded pill right image" >}}
+{{< placeholder width="150" height="75" class="rounded-pill-bottom" title="Rounded pill bottom image" >}}
+{{< placeholder width="150" height="75" class="rounded-pill-left" title="Rounded pill left image" >}}
 {{< placeholder width="75" height="75" class="rounded-0" title="Example non-rounded image (overrides rounding applied elsewhere)" >}}
 {{< /example >}}
 


### PR DESCRIPTION
 Add a rounded-pill-<side> utility. 
 
- Having a class to make just one side rounded pill, will help improve the design options.

 .rounded-pill-top
 .rounded-pill-right
 .rounded-pill-bottom
 .rounded-pill-left
