### PR TITLE
SVG placeholders accessibility

### DIFF
--- a/site/layouts/shortcodes/placeholder.html
+++ b/site/layouts/shortcodes/placeholder.html
@@ -23,7 +23,7 @@
 {{- $show_title := not (eq $title "false") -}}
 {{- $show_text := not (eq $text "false") -}}
 
-<svg class="bd-placeholder-img{{ with $class }} {{ . }}{{ end }}" width="{{ $width }}" height="{{ $height }}" xmlns="http://www.w3.org/2000/svg"{{ if (or $show_title $show_text) }} aria-label="{{ if $show_title }}{{ $title }}{{ if $show_text }}: {{ end }}{{ end }}{{ if ($show_text) }}{{ $text }}{{ end }}"{{ end }} preserveAspectRatio="xMidYMid slice" role="img" focusable="false">
+<svg class="bd-placeholder-img{{ with $class }} {{ . }}{{ end }}" width="{{ $width }}" height="{{ $height }}" xmlns="http://www.w3.org/2000/svg"{{ if (or $show_title $show_text) }} role="img" aria-label="{{ if $show_title }}{{ $title }}{{ if $show_text }}: {{ end }}{{ end }}{{ if ($show_text) }}{{ $text }}{{ end }}"{{ else }} aria-hidden="true"{{ end }} preserveAspectRatio="xMidYMid slice" focusable="false">
   {{- if $show_title -}}<title>{{ $title }}</title>{{- end -}}
   <rect width="100%" height="100%" fill="{{ $background }}"/>
   {{- if $show_text -}}<text x="50%" y="50%" fill="{{ $color }}" dy=".3em">{{ $text }}</text>{{- end -}}


### PR DESCRIPTION
Our shortcode currently generates SVGs with `role="img"` without any alternate text when no `title` nor `text` is used–which is flagged by aXe (and [my very own  a11y.css](https://ffoodd.github.io/a11y.css/errors.html#no-aria-label)) as an error.

This PR ensure to set `role="img"` only if we have either `text` or `title`, and `aria-hidden="true"` otherwise.