### PR TITLE
Drop h4 color customization in callouts

### DIFF
--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -28,12 +28,14 @@
 }
 
 // Variations
-@mixin bs-callout-variant($color) {
-  border-left-color: $color;
-
-  h4 { color: $color; }
+.bd-callout-info {
+  border-left-color: $bd-info;
 }
 
-.bd-callout-info { @include bs-callout-variant($bd-info); }
-.bd-callout-warning { @include bs-callout-variant($bd-warning); }
-.bd-callout-danger { @include bs-callout-variant($bd-danger); }
+.bd-callout-warning {
+  border-left-color: $bd-warning;
+}
+
+.bd-callout-danger {
+  border-left-color: $bd-danger;
+}


### PR DESCRIPTION
Our docs colors are very, very light and used in our callouts for `h4`, with a white background—resulting in contrasts under 2:1!

Since only `h4` are customized and we also use `h3` or `h5` in callouts (which stay black) I'd be in favor of simply drop this color for headings to ensure readability.