### PR TITLE
Match container gutters with row gutters

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -325,7 +325,7 @@ $gutters: $spacers !default;
 
 // Container padding
 
-$container-padding-x: 1rem !default;
+$container-padding-x: $grid-gutter-width !default;
 
 
 // Components

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -4,8 +4,8 @@
   --bs-gutter-x: #{$gutter};
 
   width: 100%;
-  padding-right: var(--bs-gutter-x);
-  padding-left: var(--bs-gutter-x);
+  padding-right: calc(var(--bs-gutter-x) / 2); // stylelint-disable-line function-blacklist
+  padding-left: calc(var(--bs-gutter-x) / 2); // stylelint-disable-line function-blacklist
   margin-right: auto;
   margin-left: auto;
 }

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -1,9 +1,11 @@
 // Container mixins
 
-@mixin make-container($padding-x: $container-padding-x) {
+@mixin make-container($gutter: $container-padding-x) {
+  --bs-gutter-x: #{$gutter};
+
   width: 100%;
-  padding-right: $padding-x;
-  padding-left: $padding-x;
+  padding-right: var(--bs-gutter-x);
+  padding-left: var(--bs-gutter-x);
   margin-right: auto;
   margin-left: auto;
 }


### PR DESCRIPTION
Grid container, row, and column padding/margin should always match. I missed this in my reviews and testing, unless there's uh something else I missed. 😅

- Replaces make-container mixin's padding-x param with gutter to match naming
- Changes value of container padding variable to match grid gutter width variable
- Uses local CSS variable for container padding

Fixes #31642

/cc @MartijnCuppens directly since the original PR at #29146 changed this