### PR TITLE
Add a comment for escape-svg function

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -74,6 +74,9 @@
 }
 
 // See https://codepen.io/kevinweber/pen/dXWoRw
+//
+// Requires the use of quotes around data URIs.
+
 @function escape-svg($string) {
   @if str-index($string, "data:image/svg+xml") {
     @each $char, $encoded in $escaped-characters {

--- a/site/content/docs/5.0/customize/sass.md
+++ b/site/content/docs/5.0/customize/sass.md
@@ -207,7 +207,7 @@ You can also specify a base color with our color map functions:
 
 ### Escape SVG
 
-We use the `escape-svg` function to escape the `<`, `>` and `#` characters for SVG background images.
+We use the `escape-svg` function to escape the `<`, `>` and `#` characters for SVG background images. When using the `escape-svg` function, data URIs must be quoted.
 
 ### Add and Subtract functions
 


### PR DESCRIPTION
 Closes #30835 by leaving a comment in the source that the escape-svg() function must have quotes around data URIs.