### PR TITLE
Stub out idea for improving details and summary elements in Reboot

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -596,6 +596,12 @@ iframe {
 summary {
   display: list-item; // 1
   cursor: pointer;
+  @include border-radius();
+
+  &:focus {
+    outline: 0;
+    box-shadow: $btn-focus-box-shadow;
+  }
 }
 
 

--- a/site/content/docs/5.0/content/reboot.md
+++ b/site/content/docs/5.0/content/reboot.md
@@ -166,6 +166,17 @@ Use `<pre>`s for multiple lines of code. Once again, be sure to escape any angle
 </code></pre>
 {{< /example >}}
 
+## Details
+
+The `<details>` disclosure element has been updated to feature a more consistent cross-browser focus state.
+
+{{< example >}}
+<details>
+  <summary>Show details</summary>
+  This is an example of the details element.
+</details>
+{{< /example >}}
+
 ## Variables
 
 For indicating variables use the `<var>` tag.


### PR DESCRIPTION
WIP still, but wanted to capture feedback before going too far. Should we style this more (display, padding, alignment, etc)? Skip it entirely? Wondering how much would be overboard.

<img width="848" alt="Screen Shot 2020-09-14 at 3 29 00 PM" src="https://user-images.githubusercontent.com/98681/93144582-2ccbad00-f69f-11ea-8ea7-9d4e772aa55e.png">
