### PR TITLE
Add stale Action for old issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,6 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open two years with no activity. Remove the stale label or leave a comment to keep it open, or this will be closed in 7 days.'
+        stale-issue-message: 'This issue is stale because it has been open for two years with no activity. Remove the stale label or leave a comment to keep it open, or this will be automaticaly closed in 14 days.'
         days-before-stale: 730
-        days-before-close: 7
+        days-before-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open two years with no activity. Remove the stale label or leave a comment to keep it open, or this will be closed in 7 days.'
+        days-before-stale: 730
+        days-before-close: 7


### PR DESCRIPTION
It seems a tad silly to keep old issues around that no one has touched in years. Opening this up for debate to keep things leaner here, but I'd like to see about closing issues more than two years old that have seen no new activity.

Should we go longer? Is one week's notice enough before fully closing?

/cc @twbs/team 