### PR TITLE
Change breadcrumb-item display to block

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -10,7 +10,7 @@
 }
 
 .breadcrumb-item {
-  display: flex;
+  display: block; // inline-block adds white space from some HTML formatting, flex has some side effects
 
   // The separator between breadcrumbs (by default, a forward-slash: "/")
   + .breadcrumb-item {


### PR DESCRIPTION
Fixes #29689 again, which was fixed in #29745 by @719media, but this introduced #31546. Undoing that last PR by setting this to `block` instead of `inline-block` (original value) or `flex` (current value).

Demo: https://codepen.io/emdeoh/pen/XWdPPxG