### PR TITLE
Updated jquery to the minimum version necessary for Meteor 1.9+ 

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,17 +1,15 @@
 // package metadata file for Meteor.js
 
 Package.describe({
-  name: 'twbs:bootstrap', // https://atmospherejs.com/twbs/bootstrap
-  summary: 'The most popular front-end framework for developing responsive, mobile first projects on the web.',
-  version: '4.5.2',
-  git: 'https://github.com/twbs/bootstrap.git'
+  name: "twbs:bootstrap", // https://atmospherejs.com/twbs/bootstrap
+  summary:
+    "The most popular front-end framework for developing responsive, mobile first projects on the web.",
+  version: "4.5.2",
+  git: "https://github.com/twbs/bootstrap.git",
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('METEOR@1.0');
-  api.use('jquery', 'client');
-  api.addFiles([
-    'dist/css/bootstrap.css',
-    'dist/js/bootstrap.js'
-  ], 'client');
+  api.versionsFrom("METEOR@1.9");
+  api.use("jquery@3.0.0", "client");
+  api.addFiles(["dist/css/bootstrap.css", "dist/js/bootstrap.js"], "client");
 });


### PR DESCRIPTION
Hi @XhmikosR, finally getting back to this five months after the fact (as referenced in our thread on PR #30914 ). 

I have updated jquery to the minimum dependency of [3.0.0](https://atmospherejs.com/meteor/jquery), which is required by Meteor versions 1.9 and above. This seems to be the crux of the compatibility issues with the `twbs:bootstrap` package on [Atmosphere](https://atmospherejs.com/twbs/bootstrap). 

Resolves issue #30843

(PS - I'm not sure if the .editorconfig file you have on this branch did it's job - I do have editorconfig installed in my IDE so it should find the file, but the formatting appears to have changed from single to double quotes.) 