### PR TITLE
Simplify `make-container()`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -337,7 +337,7 @@ $gutters: $spacers !default;
 
 // Container padding
 
-$container-padding-x: $grid-gutter-width !default;
+$container-padding-x: $grid-gutter-width / 2 !default;
 
 
 // Components

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -1,11 +1,9 @@
 // Container mixins
 
 @mixin make-container($gutter: $container-padding-x) {
-  --bs-gutter-x: calc(#{$gutter} / 2); // stylelint-disable-line function-blacklist
-
   width: 100%;
-  padding-right: var(--bs-gutter-x);
-  padding-left: var(--bs-gutter-x);
+  padding-right: var(--bs-gutter-x, #{$gutter});
+  padding-left: var(--bs-gutter-x, #{$gutter});
   margin-right: auto;
   margin-left: auto;
 }

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -1,11 +1,11 @@
 // Container mixins
 
 @mixin make-container($gutter: $container-padding-x) {
-  --bs-gutter-x: #{$gutter};
+  --bs-gutter-x: calc(#{$gutter} / 2); // stylelint-disable-line function-blacklist
 
   width: 100%;
-  padding-right: calc(var(--bs-gutter-x) / 2); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--bs-gutter-x) / 2); // stylelint-disable-line function-disallowed-list
+  padding-right: var(--bs-gutter-x);
+  padding-left: var(--bs-gutter-x);
   margin-right: auto;
   margin-left: auto;
 }


### PR DESCRIPTION
By dividing in the custom property directly:
1. code is shorter,
2. a single `stylelint-disable` rule
3. easier override for `padding`s since we only have to change the custom property—without having to think about multiplying what we want by 2.

Any thoughts?