### PR TITLE
Misc v4 backports

### DIFF
--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -13,6 +13,7 @@
   display: block;
   min-height: $font-size-base * $line-height-base;
   padding-left: $custom-control-gutter + $custom-control-indicator-size;
+  color-adjust: exact; // Keep themed appearance for print
 }
 
 .custom-control-inline {

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -278,10 +278,14 @@ caption {
   caption-side: bottom;
 }
 
+// 1. Removes font-weight bold by inheriting
+// 2. Matches default `<td>` alignment by inheriting `text-align`.
+// 3. Fix alignment for Safari
+
 th {
-  // Matches default `<td>` alignment by inheriting from the `<body>`, or the
-  // closest parent with a set `text-align`.
-  text-align: inherit;
+  font-weight: $table-th-font-weight; // 1
+  text-align: inherit; // 2
+  text-align: -webkit-match-parent; // 3
 }
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -363,6 +363,7 @@ $table-border-color:          $border-color !default;
 
 $table-head-bg:               $gray-200 !default;
 $table-head-color:            $gray-700 !default;
+$table-th-font-weight:        null !default;
 
 $table-dark-color:            $white !default;
 $table-dark-bg:               $gray-800 !default;

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -63,8 +63,8 @@
 .text-decoration-none { text-decoration: none !important; }
 
 .text-break {
-  word-break: break-word !important; // IE & < Edge 18
-  overflow-wrap: break-word !important;
+  word-break: break-word !important; // Deprecated, but avoids issues with flex containers
+  word-wrap: break-word !important; // Used instead of `overflow-wrap` for IE & Edge Legacy
 }
 
 // Reset

--- a/site/docs/versions.html
+++ b/site/docs/versions.html
@@ -5,8 +5,9 @@ description: An appendix of hosted documentation for nearly every release of Boo
 ---
 
 <div class="row">
-{% for release in site.data.docs-versions %}
-  <div class="col-md">
+{% assign releases = site.data.docs-versions | reverse %}
+{% for release in releases %}
+  <div class="col-md-6 col-lg-4 col-xl mb-4">
     <h2>{{ release.group }}</h2>
     <p>{{ release.description }}</p>
     {% assign versions = release.versions | reverse %}


### PR DESCRIPTION
- #30781: Reboot's th updates
- #29714: Keep custom check, radio, and switch theme when printing
- #31754: Improve versions page rendering (also reversed the order while I was here)
- #30932: `.text-break` changes to drop `overflow-wrap` and use `word-wrap` once again (closes #31727)