### PR TITLE
Update `.btn-close-white` docs to `filter` (not `backdrop-filter`)

### DIFF
--- a/site/content/docs/5.0/components/close-button.md
+++ b/site/content/docs/5.0/components/close-button.md
@@ -24,7 +24,7 @@ Disabled close buttons change their `opacity`. We've also applied `pointer-event
 
 ## White variant
 
-Change the default `.btn-close` to be white with the `.btn-close-white` class. This class uses the `backdrop-filter` property to invert the `background-image`.
+Change the default `.btn-close` to be white with the `.btn-close-white` class. This class uses the `filter` property to invert the `background-image`.
 
 {{< example class="bg-dark" >}}
 <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -65,7 +65,7 @@ toc: true
 - Renamed `.close` to `.btn-close` for a less generic name.
 - Close buttons now use a `background-image` (embedded SVG) instead of a `&times;` in the HTML, allowing for easier customization without the need to touch your markup.
 - Added new variables to better control the customization.
-- Added new `.btn-close-white` variant that uses `backdrop-filter: invert(1)` to enable higher contrast dismiss icons against darker backgrounds.
+- Added new `.btn-close-white` variant that uses `filter: invert(1)` to enable higher contrast dismiss icons against darker backgrounds.
 
 #### Collapse
 


### PR DESCRIPTION
This PR fixes a small error in the v5 (alpha 2) docs. The `btn-close-white` class actually uses `filter` (not `backdrop-filter`)