### PR TITLE
added to() method in carousel component in documentation

### DIFF
--- a/site/content/docs/5.0/components/carousel.md
+++ b/site/content/docs/5.0/components/carousel.md
@@ -364,6 +364,10 @@ var carousel = new bootstrap.Carousel(myCarousel, {
     </tr>
     <tr>
       <td><code>nextWhenVisible</code></td>
+      <td>Don't Cycles the carousel to a next frame when it's not visible.<strong></td>
+    </tr>
+    <tr>
+      <td><code>to</code></td>
       <td>Cycles the carousel to a particular frame (0 based, similar to an array). <strong>Returns to the caller before the target item has been shown</strong> (e.g., before the <code>slid.bs.carousel</code> event occurs).</td>
     </tr>
     <tr>


### PR DESCRIPTION
Confusion on the "nextWhenVisible()" method on Carousel Component #31788 tried to fix this issue 
Changed "nextWhenVisible()" method description in documentation and also added to() method in the documentation

![Screenshot (143)](https://user-images.githubusercontent.com/54969439/94739209-3f77fe80-038e-11eb-99af-bbfebeb03f28.png)
