### PR TITLE
Expands 'rounded' classes

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -489,13 +489,15 @@ $utilities: map-merge(
     "rounded": (
       property: border-radius,
       class: rounded,
-      values: (
-        null: $border-radius,
-        sm: $border-radius-sm,
-        lg: $border-radius-lg,
-        circle: 50%,
-        pill: $rounded-pill,
-        0: 0,
+      values: map-merge(
+        $spacers,
+        (
+          null: $border-radius,
+          sm: $border-radius-sm,
+          lg: $border-radius-lg,
+          circle: 50%,
+          pill: $rounded-pill,
+        )
       )
     ),
     "rounded-top": (
@@ -516,6 +518,26 @@ $utilities: map-merge(
     "rounded-left": (
       property: border-bottom-left-radius border-top-left-radius,
       class: rounded-left,
+      values: (null: $border-radius)
+    ),
+    "rounded-top-left": (
+      property: border-top-left-radius,
+      class: rounded-top-left,
+      values: (null: $border-radius)
+    ),
+    "rounded-top-right": (
+      property: border-top-right-radius,
+      class: rounded-top-right,
+      values: (null: $border-radius)
+    ),
+    "rounded-bottom-left": (
+      property: border-bottom-left-radius,
+      class: rounded-bottom-left,
+      values: (null: $border-radius)
+    ),
+    "rounded-bottom-right": (
+      property: border-bottom-right-radius,
+      class: rounded-bottom-right,
       values: (null: $border-radius)
     ),
     "visibility": (


### PR DESCRIPTION
This PR adds first 2 features proposed in issue #31784 .

The following changes were made in scss/_utilities.scss -

1. Classes` rounded-top-left`, `rounded-top-right`, `rounded-bottom-left`, `rounded-bottom-right` were added to implement rounding of 1 corner only.
2. `$spacers` was added in `values` of `rounded` class to implement size increments for rounding more akin to the margin/padding sizes (0-5).