### PR TITLE
Alert : Added z-index for close button

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -34,7 +34,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 2;
+    z-index: $stretched-link-z-index + 1;
     padding: $alert-padding-y * 1.25 $alert-padding-x;
   }
 }

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -34,6 +34,7 @@
     position: absolute;
     top: 0;
     right: 0;
+    z-index: 2;
     padding: $alert-padding-y * 1.25 $alert-padding-x;
   }
 }


### PR DESCRIPTION
Fix for alert-dismissible close button not clickable with stretched-link: Fixes #29985
Added z-index to close button.