### PR TITLE
Simplify .form-check style

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -672,8 +672,8 @@ $input-transition:                      border-color .15s ease-in-out, box-shado
 
 
 $form-check-input-width:                  1em !default;
+$form-check-input-margin-right:           .2rem !default;
 $form-check-min-height:                   $font-size-base * $line-height-base !default;
-$form-check-padding-left:                 $form-check-input-width + .5em !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-label-color:                  null !default;
 $form-check-label-cursor:                 null !default;

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -5,19 +5,14 @@
 .form-check {
   display: block;
   min-height: $form-check-min-height;
-  padding-left: $form-check-padding-left;
   margin-bottom: $form-check-margin-bottom;
-
-  .form-check-input {
-    float: left;
-    margin-left: $form-check-padding-left * -1;
-  }
 }
 
 .form-check-input {
   width: $form-check-input-width;
   height: $form-check-input-width;
   margin-top: ($line-height-base - $form-check-input-width) / 2; // line-height minus check height
+  margin-right: $form-check-input-margin-right;
   vertical-align: top;
   background-color: $form-check-input-bg;
   background-repeat: no-repeat;

--- a/site/content/docs/5.0/components/list-group.md
+++ b/site/content/docs/5.0/components/list-group.md
@@ -205,23 +205,23 @@ Place Bootstrap's checkboxes and radios within list group items and customize as
 {{< example >}}
 <ul class="list-group">
   <li class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" value="" aria-label="...">
     Cras justo odio
   </li>
   <li class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" value="" aria-label="...">
     Dapibus ac facilisis in
   </li>
   <li class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" value="" aria-label="...">
     Morbi leo risus
   </li>
   <li class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" value="" aria-label="...">
     Porta ac consectetur ac
   </li>
   <li class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" value="" aria-label="...">
     Vestibulum at eros
   </li>
 </ul>
@@ -232,23 +232,23 @@ And if you want `<label>`s as the `.list-group-item` for large hit areas, you ca
 {{< example >}}
 <div class="list-group">
   <label class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="">
+    <input class="form-check-input" type="checkbox" value="">
     Cras justo odio
   </label>
   <label class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="">
+    <input class="form-check-input" type="checkbox" value="">
     Dapibus ac facilisis in
   </label>
   <label class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="">
+    <input class="form-check-input" type="checkbox" value="">
     Morbi leo risus
   </label>
   <label class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="">
+    <input class="form-check-input" type="checkbox" value="">
     Porta ac consectetur ac
   </label>
   <label class="list-group-item">
-    <input class="form-check-input mr-1" type="checkbox" value="">
+    <input class="form-check-input" type="checkbox" value="">
     Vestibulum at eros
   </label>
 </div>


### PR DESCRIPTION
This allows `.form-check-input` to be used with fewer classes when not wrapped in `.form-check`, and it prevents the space between input and label from scaling uncomfortably big at larger font sizes.

**Before**

![simplify-form-check-style-before](https://user-images.githubusercontent.com/771968/94999377-8f1d1c80-057e-11eb-92b6-c9132756e05d.png)

**After**

![simplify-form-check-style-after](https://user-images.githubusercontent.com/771968/94999378-947a6700-057e-11eb-9757-7e50759e4cbc.png)

---

I admit I am unsure of the purpose of the `float: left`.  I evaluated this change with all of the "Checks and radios" examples in the docs, and they all looked correct.  Is there a use case I am missing, or is its presence historical?
