### PR TITLE
spacing problem between dropdowns on dropdown docs

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -121,7 +121,8 @@
 
   // Buttons
   > .btn,
-  > .btn-group {
+  > .btn-group,
+  > .btn-toolbar > .btn-group {
     margin: .25rem .125rem;
   }
   > .btn-toolbar + .btn-toolbar {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -122,7 +122,8 @@
   // Buttons
   > .btn,
   > .btn-group,
-  > .btn-toolbar > .btn-group {
+  > .btn-toolbar > .btn-group,
+  > .btn-toolbar > .input-group {
     margin: .25rem .125rem;
   }
   > .btn-toolbar + .btn-toolbar {

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -260,7 +260,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
         <li><a class="dropdown-item" href="#">Separated link</a></li>
       </ul>
     </div><!-- /btn-group -->
-    <div class="btn-group ml-2">
+    <div class="btn-group ml-sm-2">
       <button type="button" class="btn btn-lg btn-secondary">Large split button</button>
       <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -260,7 +260,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
         <li><a class="dropdown-item" href="#">Separated link</a></li>
       </ul>
     </div><!-- /btn-group -->
-    <div class="btn-group ml-sm-2">
+    <div class="btn-group">
       <button type="button" class="btn btn-lg btn-secondary">Large split button</button>
       <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>
@@ -287,7 +287,7 @@ Button dropdowns work with buttons of all sizes, including default and split dro
         <li><a class="dropdown-item" href="#">Separated link</a></li>
       </ul>
     </div><!-- /btn-group -->
-    <div class="btn-group ml-2">
+    <div class="btn-group">
       <button type="button" class="btn btn-sm btn-secondary">Small split button</button>
       <button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
         <span class="visually-hidden">Toggle Dropdown</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9622730/95094718-2a6fe680-0765-11eb-9745-9f6f6395dfd2.png)

I've found that a spacing problem between dropdowns on docs. This problem is caused by left margin even though line breaks. To fix problem, I removed left margin between dropdowns on xs size and applied the margin on over sm size.

You can check the issue on [Sizing](https://v5.getbootstrap.com/docs/5.0/components/dropdowns/#sizing) section of dropdown page. Check it on xs size screen. And this issue is happened to v4 as well as v5.

Preview: https://deploy-preview-31841--twbs-bootstrap.netlify.app/docs/5.0/components/dropdowns/#sizing
