### PR TITLE
Remove `Manipulator.toggleClass`

### DIFF
--- a/js/src/dom/manipulator.js
+++ b/js/src/dom/manipulator.js
@@ -72,18 +72,6 @@ const Manipulator = {
       top: element.offsetTop,
       left: element.offsetLeft
     }
-  },
-
-  toggleClass(element, className) {
-    if (!element) {
-      return
-    }
-
-    if (element.classList.contains(className)) {
-      element.classList.remove(className)
-    } else {
-      element.classList.add(className)
-    }
   }
 }
 

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -197,8 +197,8 @@ class Dropdown {
     this._element.focus()
     this._element.setAttribute('aria-expanded', true)
 
-    Manipulator.toggleClass(this._menu, CLASS_NAME_SHOW)
-    Manipulator.toggleClass(this._element, CLASS_NAME_SHOW)
+    this._menu.classList.toggle(CLASS_NAME_SHOW)
+    this._element.classList.toggle(CLASS_NAME_SHOW)
     EventHandler.trigger(parent, EVENT_SHOWN, relatedTarget)
   }
 
@@ -222,8 +222,8 @@ class Dropdown {
       this._popper.destroy()
     }
 
-    Manipulator.toggleClass(this._menu, CLASS_NAME_SHOW)
-    Manipulator.toggleClass(this._element, CLASS_NAME_SHOW)
+    this._menu.classList.toggle(CLASS_NAME_SHOW)
+    this._element.classList.toggle(CLASS_NAME_SHOW)
     EventHandler.trigger(parent, EVENT_HIDDEN, relatedTarget)
   }
 

--- a/js/tests/unit/dom/manipulator.spec.js
+++ b/js/tests/unit/dom/manipulator.spec.js
@@ -129,30 +129,4 @@ describe('Manipulator', () => {
       expect(position.left).toEqual(jasmine.any(Number))
     })
   })
-
-  describe('toggleClass', () => {
-    it('should not error out if element is null or undefined', () => {
-      Manipulator.toggleClass(null, 'test')
-      Manipulator.toggleClass(undefined, 'test')
-      expect().nothing()
-    })
-
-    it('should add class if it is missing', () => {
-      fixtureEl.innerHTML = '<div></div>'
-
-      const div = fixtureEl.querySelector('div')
-
-      Manipulator.toggleClass(div, 'test')
-      expect(div.classList.contains('test')).toEqual(true)
-    })
-
-    it('should remove class if it is set', () => {
-      fixtureEl.innerHTML = '<div class="test"></div>'
-
-      const div = fixtureEl.querySelector('div')
-
-      Manipulator.toggleClass(div, 'test')
-      expect(div.classList.contains('test')).toEqual(false)
-    })
-  })
 })


### PR DESCRIPTION
It's only used in one place so it makes more sense to remove it for the time being.