### PR TITLE
v4 Backport #31826

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -34,6 +34,7 @@
     position: absolute;
     top: 0;
     right: 0;
+    z-index: 2;
     padding: $alert-padding-y $alert-padding-x;
     color: inherit;
   }


### PR DESCRIPTION
Fix for alert-dismissible close button not clickable with stretched-link