### PR TITLE
Added separator for button groups

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -108,6 +108,21 @@
   }
 }
 
+// Reposition the caret
+.btn .caret {
+  margin-left: 0;
+}
+// Carets in other button sizes
+.btn-lg .caret {
+  border-width: $caret-width $caret-width 0;
+  border-bottom-width: 0;
+}
+// Upside down carets for .dropup
+.dropup .btn-lg .caret {
+  border-width: 0 $caret-width $caret-width;
+}
+
+
 
 //
 // Vertical button groups


### PR DESCRIPTION
Worked on a small fix for #31832, reverting some code from branch v3-dev to ensure borders in button groups.