### PR TITLE
Btn : Add different border color for btn-primary #31832

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -10,6 +10,9 @@
   > .btn {
     position: relative;
     flex: 1 1 auto;
+    &.btn-primary{
+      border-color: #0257d5;
+    }
   }
 
   // Bring the hover, focused, and "active" buttons to the front to overlay


### PR DESCRIPTION
Regrading #31832
Issue was there because we are using same color for button background and button border.
Updated the color of border to make it different.

Please See: Used the same color we use for hover in btn-primary.

If approved, will do the same for all buttons.

Made changes as required. @XhmikosR 