### PR TITLE
Fixed: Undefined mixin 'deprecate' when importing 'bootstrap-grid-scss'

### DIFF
--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -16,12 +16,10 @@ html {
   box-sizing: inherit;
 }
 
-// Deprecate
-@import "mixins/deprecate";
-
 @import "functions";
 @import "variables";
 
+@import "mixins/deprecate";
 @import "mixins/breakpoints";
 @import "mixins/grid-framework";
 @import "mixins/grid";

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -16,6 +16,9 @@ html {
   box-sizing: inherit;
 }
 
+// Deprecate
+@import "mixins/deprecate";
+
 @import "functions";
 @import "variables";
 


### PR DESCRIPTION
Following @mdo 's fix #31438 that adds a **deprecate** notice, I've noticed that this also breaks the compilation when solely importing `bootstrap-grid.scss`.