### PR TITLE
Remove redundant visually hidden "(current)" from pagination controls

### DIFF
--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -19,7 +19,7 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav">
             <li class="nav-item active">
-              <a class="nav-link" href="#">Home <span class="visually-hidden">(current)</span></a>
+              <a class="nav-link" href="#" aria-current="page">Home</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#">Link</a>

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -19,7 +19,7 @@
         <a class="navbar-brand" href="#">This shouldn't jump!</a>
         <ul class="navbar-nav">
           <li class="nav-item active">
-            <a class="nav-link" href="#">Home <span class="visually-hidden">(current)</span></a>
+            <a class="nav-link" href="#" aria-current="page">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/components/pagination.md
+++ b/site/content/docs/5.0/components/pagination.md
@@ -62,7 +62,7 @@ While the `.disabled` class uses `pointer-events: none` to _try_ to disable the 
     </li>
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item active" aria-current="page">
-      <a class="page-link" href="#">2 <span class="visually-hidden">(current)</span></a>
+      <a class="page-link" href="#">2</a>
     </li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item">
@@ -82,10 +82,7 @@ You can optionally swap out active or disabled anchors for `<span>`, or omit the
     </li>
     <li class="page-item"><a class="page-link" href="#">1</a></li>
     <li class="page-item active" aria-current="page">
-      <span class="page-link">
-        2
-        <span class="visually-hidden">(current)</span>
-      </span>
+      <span class="page-link">2</span>
     </li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item">
@@ -103,10 +100,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <nav aria-label="...">
   <ul class="pagination pagination-lg">
     <li class="page-item active" aria-current="page">
-      <span class="page-link">
-        1
-        <span class="visually-hidden">(current)</span>
-      </span>
+      <span class="page-link">1</span>
     </li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
@@ -118,10 +112,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <nav aria-label="...">
   <ul class="pagination pagination-sm">
     <li class="page-item active" aria-current="page">
-      <span class="page-link">
-        1
-        <span class="visually-hidden">(current)</span>
-      </span>
+      <span class="page-link">1</span>
     </li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>


### PR DESCRIPTION
additionally, fixes up the markup in two of the visual tests

Closes #31891 