### PR TITLE
Update manifest.json

### DIFF
--- a/site/static/docs/5.0/assets/img/favicons/manifest.json
+++ b/site/static/docs/5.0/assets/img/favicons/manifest.json
@@ -3,12 +3,12 @@
   "short_name": "Bootstrap",
   "icons": [
     {
-      "src": "/docs/5.0/assets/img/favicons/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/docs/5.0/assets/img/favicons/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
Switch to relative URLs so that we don't need to change the path with every major/minor release

If we merge this, we might as well backport it.

Info: <https://developer.mozilla.org/en-US/docs/Web/Manifest/icons>

>src: The path to the image file. If `src` is a relative URL, the base URL will be the URL of the manifest.
