### PR TITLE
docs(forms): change inline custom radio name

### DIFF
--- a/site/docs/4.5/components/forms.md
+++ b/site/docs/4.5/components/forms.md
@@ -1276,11 +1276,11 @@ $('.your-checkbox').prop('indeterminate', true)
 
 {% capture example %}
 <div class="custom-control custom-radio custom-control-inline">
-  <input type="radio" id="customRadioInline1" name="customRadioInline1" class="custom-control-input">
+  <input type="radio" id="customRadioInline1" name="customRadioInline" class="custom-control-input">
   <label class="custom-control-label" for="customRadioInline1">Toggle this custom radio</label>
 </div>
 <div class="custom-control custom-radio custom-control-inline">
-  <input type="radio" id="customRadioInline2" name="customRadioInline1" class="custom-control-input">
+  <input type="radio" id="customRadioInline2" name="customRadioInline" class="custom-control-input">
   <label class="custom-control-label" for="customRadioInline2">Or toggle this other custom radio</label>
 </div>
 {% endcapture %}


### PR DESCRIPTION
Using the name "customRadioInline1" is confusing because it is also used by `id`/`for` for the first custom radio.

As we can see in the previous example of the documentation (https://getbootstrap.com/docs/4.5/components/forms/#radios), we have `customRadio` and not `customRadio1`.

Note: the documentation in v5 is correct, it uses "inlineRadioOptions":
```
<div class="form-check form-check-inline">
  <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1">
  <label class="form-check-label" for="inlineRadio1">1</label>
</div>
<div class="form-check form-check-inline">
  <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2">
  <label class="form-check-label" for="inlineRadio2">2</label>
</div>
<div class="form-check form-check-inline">
  <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio3" value="option3" disabled>
  <label class="form-check-label" for="inlineRadio3">3 (disabled)</label>
</div>
```