### PR TITLE
V4 Examples/Floating-labels: fix bad behavior with autofill

### DIFF
--- a/site/docs/4.5/examples/floating-labels/floating-labels.css
+++ b/site/docs/4.5/examples/floating-labels/floating-labels.css
@@ -103,6 +103,13 @@ body {
   color: #777;
 }
 
+.form-label-group input:-webkit-autofill ~ label {
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+  font-size: 12px;
+  color: #777;
+}
+
 /* Fallback for Edge
 -------------------------------------------------- */
 @supports (-ms-ime-align: auto) {


### PR DESCRIPTION
If the browser has already credentials on the autocomplete, the layout of <input> will breaks.

![image](https://user-images.githubusercontent.com/4308648/96789112-8de35080-13c2-11eb-89dd-7fef4f796bdc.png)


closes #31948
