### PR TITLE
Remove explicit heights on form elements

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -737,7 +737,6 @@ $form-select-padding-y:             $input-padding-y !default;
 $form-select-padding-x:             $input-padding-x !default;
 $form-select-font-family:           $input-font-family !default;
 $form-select-font-size:             $input-font-size !default;
-$form-select-height:                $input-height !default;
 $form-select-indicator-padding:     1rem !default; // Extra padding to account for the presence of the background-image based indicator
 $form-select-font-weight:           $input-font-weight !default;
 $form-select-line-height:           $input-line-height !default;
@@ -767,12 +766,10 @@ $form-select-focus-box-shadow:    0 0 0 $form-select-focus-width $input-btn-focu
 $form-select-padding-y-sm:        $input-padding-y-sm !default;
 $form-select-padding-x-sm:        $input-padding-x-sm !default;
 $form-select-font-size-sm:        $input-font-size-sm !default;
-$form-select-height-sm:           $input-height-sm !default;
 
 $form-select-padding-y-lg:        $input-padding-y-lg !default;
 $form-select-padding-x-lg:        $input-padding-x-lg !default;
 $form-select-font-size-lg:        $input-font-size-lg !default;
-$form-select-height-lg:           $input-height-lg !default;
 
 $form-range-track-width:          100% !default;
 $form-range-track-height:         .5rem !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -5,7 +5,6 @@
 .form-control {
   display: block;
   width: 100%;
-  min-height: $input-height;
   padding: $input-padding-y $input-padding-x;
   font-family: $input-font-family;
   @include font-size($input-font-size);
@@ -43,6 +42,13 @@
       // Avoid using mixin so we can pass custom focus shadow properly
       box-shadow: $input-focus-box-shadow;
     }
+  }
+
+  // Add some height to date inputs on IOS
+  // https://github.com/twbs/bootstrap/issues/23307
+  &::-webkit-date-and-time-value {
+    // Multiply line-height by 1em if it has no unit
+    height: if(unit($input-line-height) == "", $input-line-height * 1em, $input-line-height);
   }
 
   // Placeholder
@@ -179,6 +185,24 @@
     margin-inline-end: $input-padding-x-lg;
   }
 }
+
+// Make sure textareas don't shrink too much when resized
+// https://github.com/twbs/bootstrap/pull/29124
+// stylelint-disable selector-no-qualifying-type
+textarea {
+  &.form-control {
+    min-height: $input-height;
+  }
+
+  &.form-control-sm {
+    min-height: $input-height-sm;
+  }
+
+  &.form-control-lg {
+    min-height: $input-height-lg;
+  }
+}
+// stylelint-enable selector-no-qualifying-type
 
 .form-control-color {
   max-width: 3rem;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -44,8 +44,9 @@
     }
   }
 
-  // Add some height to date inputs on IOS
+  // Add some height to date inputs on iOS
   // https://github.com/twbs/bootstrap/issues/23307
+  // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
   &::-webkit-date-and-time-value {
     // Multiply line-height by 1em if it has no unit
     height: if(unit($input-line-height) == "", $input-line-height * 1em, $input-line-height);

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -6,7 +6,6 @@
 .form-select {
   display: block;
   width: 100%;
-  min-height: $form-select-height;
   padding: $form-select-padding-y ($form-select-padding-x + $form-select-indicator-padding) $form-select-padding-y $form-select-padding-x;
   font-family: $form-select-font-family;
   @include font-size($form-select-font-size);
@@ -47,7 +46,6 @@
 
   &[multiple],
   &[size]:not([size="1"]) {
-    height: auto;
     padding-right: $form-select-padding-x;
     background-image: none;
   }
@@ -66,7 +64,6 @@
 }
 
 .form-select-sm {
-  height: $form-select-height-sm;
   padding-top: $form-select-padding-y-sm;
   padding-bottom: $form-select-padding-y-sm;
   padding-left: $form-select-padding-x-sm;
@@ -74,7 +71,6 @@
 }
 
 .form-select-lg {
-  height: $form-select-height-lg;
   padding-top: $form-select-padding-y-lg;
   padding-bottom: $form-select-padding-y-lg;
   padding-left: $form-select-padding-x-lg;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -63,14 +63,6 @@
 // Remix the default form control sizing classes into new ones for easier
 // manipulation.
 
-.input-group-lg > .form-control {
-  min-height: $input-height-lg;
-}
-
-.input-group-lg > .form-select {
-  height: $input-height-lg;
-}
-
 .input-group-lg > .form-control,
 .input-group-lg > .form-select,
 .input-group-lg > .input-group-text,
@@ -78,14 +70,6 @@
   padding: $input-padding-y-lg $input-padding-x-lg;
   @include font-size($input-font-size-lg);
   @include border-radius($input-border-radius-lg);
-}
-
-.input-group-sm > .form-control {
-  min-height: $input-height-sm;
-}
-
-.input-group-sm > .form-select {
-  height: $input-height-sm;
 }
 
 .input-group-sm > .form-control,


### PR DESCRIPTION
Input heights were initially added in https://github.com/twbs/bootstrap/pull/26820 to fix https://github.com/twbs/bootstrap/issues/18842. Select heights were added to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1560824.

But:
- The additional height in https://github.com/twbs/bootstrap/pull/26820 was caused by pseudo elements, something I fixed in https://github.com/twbs/bootstrap/pull/30269.
- In the meantime the select issue in FF is changed when you explicitly set the line height (https://bugzilla.mozilla.org/show_bug.cgi?id=1560824#c14), making setting the height redundant

However, removing the explicit height would reintroduce https://github.com/twbs/bootstrap/issues/23307. Luckily, date inputs have a `::-webkit-datetime-edit` of which we can set the height in `em` 🎉

This means, we can safely remove those (min-)heights that seem to cause some issues like https://github.com/twbs/bootstrap/pull/26820#issuecomment-565485267 or https://github.com/twbs/bootstrap/pull/31955#issuecomment-716101054 (this fixes issues when zoomed in/out)

I've kept a min-height for textareas, to keep support for https://github.com/twbs/bootstrap/pull/29124

I didn't apply this change to `.form-file`, since this will introduce conflicts with https://github.com/twbs/bootstrap/pull/31955, therefor I'll keep this in draft.