### PR TITLE
Add callouts about using light colors ideally on a dark background

### DIFF
--- a/site/content/docs/5.0/components/buttons.md
+++ b/site/content/docs/5.0/components/buttons.md
@@ -54,6 +54,10 @@ In need of a button, but not the hefty background colors they bring? Replace the
 {{< /buttons.inline >}}
 {{< /example >}}
 
+{{< callout info >}}
+Some of the button styles use a relatively light foreground color, and should only be used on a dark background in order to have sufficient contrast.
+{{< /callout >}}
+
 ## Sizes
 
 Fancy larger or smaller buttons? Add `.btn-lg` or `.btn-sm` for additional sizes.

--- a/site/content/docs/5.0/helpers/colored-links.md
+++ b/site/content/docs/5.0/helpers/colored-links.md
@@ -15,3 +15,7 @@ You can use the `.link-*` classes to colorize links. Unlike the [`.text-*` class
 {{- end -}}
 {{< /colored-links.inline >}}
 {{< /example >}}
+
+{{< callout info >}}
+Some of the link styles use a relatively light foreground color, and should only be used on a dark background in order to have sufficient contrast.
+{{< /callout >}}


### PR DESCRIPTION
would be even better to show those buttons on a dark background, but i assume that'd require a lot more logic behind the scenes (to only show the outline buttons that are contrasty enough against white on a white background, and the others on a dark background)