### PR TITLE
tests: fix sanitizer test.

### DIFF
--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -20,7 +20,7 @@ describe('Sanitizer', () => {
 
       const result = sanitizeHtml(template, DefaultAllowlist, null)
 
-      expect(result).not.toContain('script')
+      expect(result).not.toContain('href="javascript:alert(7)')
     })
 
     it('should allow aria attributes and safe attributes', () => {


### PR DESCRIPTION
The test template does not include a `script` tag so the test always returned true.

I need to check if the same issue is present in v4-dev. **EDIT**: it's present in v4-dev too, I'll backport it in #32035 after this one lands.

Requires #32043 