### PR TITLE
tests: tweak Jasmine usage

### DIFF
--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -297,31 +297,31 @@ describe('EventHandler', () => {
       EventHandler.trigger(subelement, 'click')
 
       // first listeners called
-      expect(i === 2).toEqual(true)
+      expect(i).toEqual(2)
 
       EventHandler.off(element, 'click', 'span', handler)
       EventHandler.trigger(subelement, 'click')
 
       // removed listener not called
-      expect(i === 2).toEqual(true)
+      expect(i).toEqual(2)
 
       EventHandler.trigger(anchor, 'click')
 
       // not removed listener called
-      expect(i === 3).toEqual(true)
+      expect(i).toEqual(3)
 
       EventHandler.on(element, 'click', 'span', handler)
       EventHandler.trigger(anchor, 'click')
       EventHandler.trigger(subelement, 'click')
 
       // listener re-registered
-      expect(i === 5).toEqual(true)
+      expect(i).toEqual(5)
 
       EventHandler.off(element, 'click', 'span')
       EventHandler.trigger(subelement, 'click')
 
       // listener removed again
-      expect(i === 5).toEqual(true)
+      expect(i).toEqual(5)
     })
   })
 })

--- a/js/tests/unit/dom/manipulator.spec.js
+++ b/js/tests/unit/dom/manipulator.spec.js
@@ -56,7 +56,7 @@ describe('Manipulator', () => {
 
   describe('getDataAttributes', () => {
     it('should return empty object for null', () => {
-      expect(Manipulator.getDataAttributes(null), {})
+      expect(Manipulator.getDataAttributes(null)).toEqual({})
       expect().nothing()
     })
 

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1320,8 +1320,8 @@ describe('Dropdown', () => {
         triggerDropdown.dispatchEvent(keydown)
 
         expect(document.activeElement.classList.contains('d-none')).toEqual(false, '.d-none not focused')
-        expect(document.activeElement.style.display === 'none').toEqual(false, '"display: none" not focused')
-        expect(document.activeElement.style.visibility === 'hidden').toEqual(false, '"visibility: hidden" not focused')
+        expect(document.activeElement.style.display).not.toBe('none', '"display: none" not focused')
+        expect(document.activeElement.style.visibility).not.toBe('hidden', '"visibility: hidden" not focused')
 
         done()
       })

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -637,7 +637,7 @@ describe('Modal', () => {
       modalEl.addEventListener('shown.bs.modal', () => {
         modalEl.click()
         setTimeout(() => {
-          expect(modalEl.clientHeight === modalEl.scrollHeight).toEqual(true)
+          expect(modalEl.clientHeight).toEqual(modalEl.scrollHeight)
           done()
         }, 20)
       })


### PR DESCRIPTION
Notes:

1. I think I'd prefer if we could make the rules throw an error instead of a warning, but I can't find an easy way to do it so we'd need to specify all the rules we want and set them as errors
2. `jasmine/expect-single-argument` has false warnings with `expect().nothing()`
3. `jasmine/prefer-toHaveBeenCalledWith` would be nice to have AFAICT, but it would need more code changes so I disabled it for now

After #32043 this branch should have zero warnings.