### PR TITLE
File input: inherit padding to avoid duplicating it for sizes

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -75,7 +75,7 @@
   // File input buttons theming
   // stylelint-disable-next-line selector-pseudo-element-no-unknown
   &::file-selector-button {
-    padding: $input-padding-y $input-padding-x;
+    padding: inherit;
     margin: (-$input-padding-y) (-$input-padding-x);
     margin-inline-end: $input-padding-x;
     -moz-margin-end: subtract($input-padding-x, 5px); // stylelint-disable-line property-no-vendor-prefix
@@ -96,7 +96,7 @@
   }
 
   &::-webkit-file-upload-button {
-    padding: $input-padding-y $input-padding-x;
+    padding: inherit;
     margin: (-$input-padding-y) (-$input-padding-x);
     margin-inline-end: $input-padding-x;
     color: $form-file-button-color;
@@ -153,14 +153,12 @@
 
   // stylelint-disable-next-line selector-pseudo-element-no-unknown
   &::file-selector-button {
-    padding: $input-padding-y-sm $input-padding-x-sm;
     margin: (-$input-padding-y-sm) (-$input-padding-x-sm);
     margin-inline-end: $input-padding-x-sm;
     -moz-margin-end: subtract($input-padding-x-sm, 5px); // stylelint-disable-line property-no-vendor-prefix
   }
 
   &::-webkit-file-upload-button {
-    padding: $input-padding-y-sm $input-padding-x-sm;
     margin: (-$input-padding-y-sm) (-$input-padding-x-sm);
     margin-inline-end: $input-padding-x-sm;
   }
@@ -174,14 +172,12 @@
 
   // stylelint-disable-next-line selector-pseudo-element-no-unknown
   &::file-selector-button {
-    padding: $input-padding-y-lg $input-padding-x-lg;
     margin: (-$input-padding-y-lg) (-$input-padding-x-lg);
     margin-inline-end: $input-padding-x-lg;
     -moz-margin-end: subtract($input-padding-x-lg, 5px); // stylelint-disable-line property-no-vendor-prefix
   }
 
   &::-webkit-file-upload-button {
-    padding: $input-padding-y-lg $input-padding-x-lg;
     margin: (-$input-padding-y-lg) (-$input-padding-x-lg);
     margin-inline-end: $input-padding-x-lg;
   }


### PR DESCRIPTION
While backporting it to Boosted, I noticed we duplicate `padding` for `::file-selector-button` but it would benefit from `inherit`ing it from its parent input since we wouldn't have to duplicate it for sizes variant.