### PR TITLE
docs: mention "Liberation Sans"

### DIFF
--- a/site/docs/4.5/content/reboot.md
+++ b/site/docs/4.5/content/reboot.md
@@ -45,6 +45,7 @@ $font-family-sans-serif:
   "Helvetica Neue", Arial,
   // Linux
   "Noto Sans",
+  "Liberation Sans",
   // Sans serif fallback
   sans-serif,
   // Emoji fonts

--- a/site/docs/4.5/getting-started/theming.md
+++ b/site/docs/4.5/getting-started/theming.md
@@ -447,7 +447,7 @@ Here are the variables we include (note that the `:root` is required). They're l
   --breakpoint-md: 768px;
   --breakpoint-lg: 992px;
   --breakpoint-xl: 1200px;
-  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 {% endhighlight %}


### PR DESCRIPTION
Missing after the #31657 backport