### PR TITLE
search.js: use the current v5.getbootstrap.com URL

### DIFF
--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -42,7 +42,7 @@
     transformData: function (hits) {
       return hits.map(function (hit) {
         var currentUrl = getOrigin()
-        var liveUrl = 'https://getbootstrap.com/'
+        var liveUrl = 'https://v5.getbootstrap.com/'
 
         hit.url = currentUrl.lastIndexOf(liveUrl, 0) === 0 ?
           // On production, return the result as is


### PR DESCRIPTION
Should be reverted when we move the docs to the main domain; added it in #31057

Fixes the Netlify main search results which wrongfully pointed to v5.getbootstrap.com instead of the preview deployment.