### PR TITLE
v4: Clarify JS bundle docs

### DIFF
--- a/site/docs/4.5/getting-started/introduction.md
+++ b/site/docs/4.5/getting-started/introduction.md
@@ -32,7 +32,7 @@ Place **one of the following `<script>`s** near the end of your pages, right bef
 
 #### Bundle
 
-Include everything you need in one script with our bundle. Our `bootstrap.bundle.js` and `bootstrap.bundle.min.js` include [Popper](https://popper.js.org/), but not [jQuery](https://jquery.com/). For more information about what's included in Bootstrap, please see our [contents]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/contents/#precompiled-bootstrap) section.
+Include every Bootstrap JavaScript plugin with one of our two bundles. Both `bootstrap.bundle.js` and `bootstrap.bundle.min.js` include [Popper](https://popper.js.org/) for our tooltips and popovers, but not [jQuery](https://jquery.com/). Include jQuery first, then a Bootstrap JavaScript bundle. For more information about what's included in Bootstrap, please see our [contents]({{ site.baseurl }}/docs/{{ site.docs_version }}/getting-started/contents/#precompiled-bootstrap) section.
 
 {% highlight html %}
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
@@ -41,7 +41,7 @@ Include everything you need in one script with our bundle. Our `bootstrap.bundle
 
 #### Separate
 
-If you decide to go with the separate scripts solution, Popper.js must come first, and then our JavaScript plugins.
+If you decide to go with the separate scripts solution, Popper.js must come first (if you're using tooltips or popovers), and then our JavaScript plugins.
 
 {% highlight html %}
 <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
@@ -51,7 +51,7 @@ If you decide to go with the separate scripts solution, Popper.js must come firs
 
 #### Components
 
-Curious which components explicitly require jQuery, our JS, and Popper.js? Click the show components link below. If you're unsure about the page structure, keep reading for an example page template.
+Curious which components explicitly require jQuery, our JavaScript, and Popper.js? Click the show components link below. If you're unsure about the page structure, keep reading for an example page template.
 
 <details>
 <summary class="text-primary mb-3">Show components requiring JavaScript</summary>


### PR DESCRIPTION
v4 version of #32105.

Clarifies number of scripts and how they all come together. Not a straight port of that v5 PR though, since the content is slightly different given lack of jQuery in v5.