### PR TITLE
browsers-devices: add `chomp`

### DIFF
--- a/site/content/docs/5.0/getting-started/browsers-devices.md
+++ b/site/content/docs/5.0/getting-started/browsers-devices.md
@@ -16,7 +16,7 @@ You can find our supported range of browsers and their versions [in our `.browse
 
 ```text
 {{< rf.inline >}}
-{{- readFile ".browserslistrc" | htmlEscape -}}
+{{- readFile ".browserslistrc" | chomp | htmlEscape -}}
 {{< /rf.inline >}}
 ```
 


### PR DESCRIPTION
This is to remove any trailing newlines in the `.browserslistrc` shortcode

Refs #32104 

/CC @coliff 

Preview: https://deploy-preview-32116--twbs-bootstrap.netlify.app/docs/5.0/getting-started/browsers-devices/#supported-browsers
Main: https://twbs-bootstrap.netlify.app/docs/5.0/getting-started/browsers-devices/#supported-browsers