### PR TITLE
Add note that `user-select-all` is not supported on IE or Edge Legacy

### DIFF
--- a/site/docs/4.5/utilities/interactions.md
+++ b/site/docs/4.5/utilities/interactions.md
@@ -16,4 +16,6 @@ Change how the content is selected when the user interacts with it.
 {% endcapture %}
 {% include example.html content=example %}
 
+**Note: `user-select-all` is not supported on Internet Explorer or Edge Legacy.**
+
 Customize the available classes by changing the `$user-selects` Sass list in `_variables.scss`.


### PR DESCRIPTION
Fixes: #32092 

I kept the style/formatting of the compatibility issue **bold**, so it matches what is used elsewhere for IE issues, e.g.:
https://getbootstrap.com/docs/4.5/utilities/flex/#auto-margins
https://getbootstrap.com/docs/4.5/utilities/position/#sticky-top

I haven't been able to test this change locally by building the docs (don't have Jekyll 4.x installed right now)... but as this is simple change hopefully it should be ok.

Preview: https://deploy-preview-32120--twbs-bootstrap.netlify.app/docs/4.5/utilities/interactions/