### PR TITLE
browsers-devices.md: make heading an `h3`

### DIFF
--- a/site/docs/4.5/getting-started/browsers-devices.md
+++ b/site/docs/4.5/getting-started/browsers-devices.md
@@ -165,7 +165,7 @@ As of Safari v8.0, use of the fixed-width `.container` class can cause Safari to
 
 Out of the box, Android 4.1 (and even some newer releases apparently) ship with the Browser app as the default web browser of choice (as opposed to Chrome). Unfortunately, the Browser app has lots of bugs and inconsistencies with CSS in general.
 
-#### Select menu
+### Select menu
 
 On `<select>` elements, the Android stock browser will not display the side controls if there is a `border-radius` and/or `border` applied. (See [this StackOverflow question](https://stackoverflow.com/questions/14744437/html-select-box-not-showing-drop-down-arrow-on-android-version-4-0-when-set-with) for details.) Use the snippet of code below to remove the offending CSS and render the `<select>` as an unstyled element on the Android stock browser. The user agent sniffing avoids interference with Chrome, Safari, and Mozilla browsers.
 


### PR DESCRIPTION
Noticed it in #32077 due to the ToC being indented.