### PR TITLE
example.html: remove extra whitespace

### DIFF
--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -21,6 +21,6 @@
 
 {{- if eq $show_markup true -}}
   {{- $content := replaceRE `<svg class="bd\-placeholder\-img(?:\-lg)?(?: *?bd\-placeholder\-img\-lg)? ?(.*?)".*?<\/svg>\n` `<img src="..." class="$1" alt="...">` $input -}}
-  {{- $content = replaceRE `(class=" *?")` "" $content -}}
+  {{- $content = replaceRE ` (class=" *?")` "" $content -}}
   {{- highlight (trim $content "\n") $lang "" -}}
 {{- end -}}


### PR DESCRIPTION
If we don't pass `class` to the `placeholder` shortcode, this resulted in two spaces before the `alt` attribute:

```html
{{< example >}}
{{< placeholder width="64" height="64" >}}
{{< /example >}}
```

```html
<img src="..."  alt="...">
```

Need to check if this causes any issues.

Preview: <https://deploy-preview-32143--twbs-bootstrap.netlify.app/>