### PR TITLE
BrowserStack: test both on iPhone 7 and iPhone X

### DIFF
--- a/js/tests/browsers.js
+++ b/js/tests/browsers.js
@@ -37,11 +37,18 @@ const browsers = {
     browser: 'Firefox',
     browser_version: 'latest'
   },
-  iphoneX: {
+  iphone7: {
     base: 'BrowserStack',
     os: 'ios',
-    os_version: '11.0',
-    device: 'iPhone X',
+    os_version: '10.0',
+    device: 'iPhone 7',
+    real_mobile: true
+  },
+  iphone11: {
+    base: 'BrowserStack',
+    os: 'ios',
+    os_version: '13.0',
+    device: 'iPhone 11',
     real_mobile: true
   },
   pixel2: {


### PR DESCRIPTION
iOS 10.0 is our currently minimum iOS version, so it makes sense to test this.