### PR TITLE
Position Utilities Docs: Fix the marker SVG color to match the button

### DIFF
--- a/site/content/docs/5.0/utilities/position.md
+++ b/site/content/docs/5.0/utilities/position.md
@@ -78,7 +78,7 @@ Here are some real life examples of these classes:
 </button>
 
 <button type="button" class="btn btn-dark position-relative">
-  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 left-50 translate-middle mt-1 bi bi-caret-down-fill" fill="#343a40" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
+  Marker <svg width="1em" height="1em" viewBox="0 0 16 16" class="position-absolute top-100 left-50 translate-middle mt-1 bi bi-caret-down-fill" fill="#212529" xmlns="http://www.w3.org/2000/svg"><path d="M7.247 11.14L2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/></svg>
 </button>
 
 <button type="button" class="btn btn-primary position-relative">


### PR DESCRIPTION
The bottom marker icon is a different color to the button color.

![image](https://user-images.githubusercontent.com/1212885/99393597-ea358380-2920-11eb-9195-d80ee603ba48.png)

This looked like a mistake, so this PR updates the color to match the `btn-dark` color - but if it was intentional to show how this is positioned of course feel free to decline the PR. :-)