### PR TITLE
Handle Chromium to run Karma

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -33,11 +33,15 @@ const detectBrowsers = {
       return debug ? ['Chrome'] : ['ChromeHeadless']
     }
 
+    if (env.CI === true || availableBrowser.includes('Chromium')) {
+      return debug ? ['Chromium'] : ['ChromiumHeadless']
+    }
+
     if (availableBrowser.includes('Firefox')) {
       return debug ? ['Firefox'] : ['FirefoxHeadless']
     }
 
-    throw new Error('Please install Firefox or Chrome')
+    throw new Error('Please install Firefox, Chrome or Chromium')
   }
 }
 

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -41,7 +41,7 @@ const detectBrowsers = {
       return debug ? ['Firefox'] : ['FirefoxHeadless']
     }
 
-    throw new Error('Please install Firefox, Chrome or Chromium')
+    throw new Error('Please install Chrome, Chromium or Firefox')
   }
 }
 


### PR DESCRIPTION
I do not have Chrome nor stable Firefox and am always using this locally to run tests.

Could also add Firefox Nightly or ESR but I guess Chromium is a first, better choice.