### PR TITLE
Ability to add listeners directly to objects like Modals/Collapse/etc

### DIFF
--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -30,6 +30,18 @@ class BaseComponent {
     this._element = null
   }
 
+  on(event, handler) {
+    this._element.addEventListener(`${event}.${this.constructor.DATA_KEY}`, handler)
+
+    return this
+  }
+
+  off(event, handler) {
+    this._element.removeEventListener(`${event}.${this.constructor.DATA_KEY}`, handler)
+
+    return this
+  }
+
   /** Static */
 
   static getInstance(element) {

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -1119,4 +1119,60 @@ describe('Modal', () => {
       expect(Modal.getInstance(div)).toEqual(null)
     })
   })
+
+  describe('on', () => {
+    it('should register an event handler', done => {
+      fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
+
+      const modalEl = fixtureEl.querySelector('.modal')
+
+      const onShow = e => {
+        expect(e).toBeDefined()
+      }
+
+      const onShown = () => {
+        expect(modalEl.getAttribute('aria-modal')).toEqual('true')
+        expect(modalEl.getAttribute('role')).toEqual('dialog')
+        expect(modalEl.getAttribute('aria-hidden')).toEqual(null)
+        expect(modalEl.style.display).toEqual('block')
+        expect(document.querySelector('.modal-backdrop')).toBeDefined()
+        done()
+      }
+
+      new Modal(modalEl)
+        .on('show', onShow)
+        .on('shown', onShown)
+        .show()
+    })
+  })
+
+  describe('off', () => {
+    it('should remove a registered event handler', () => {
+      fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
+
+      const modalEl = fixtureEl.querySelector('.modal')
+      const modal = new Modal(modalEl)
+      let counter = 0
+
+      const incrementCounter = () => {
+        counter += 1
+      }
+
+      modal.on('shown', incrementCounter)
+           .on('hidden', incrementCounter)
+
+      modal.show()
+      modal.hide()
+
+      expect(counter).toEqual(2)
+
+      modal.off('shown', incrementCounter)
+           .off('hidden', incrementCounter)
+
+      modal.show()
+      modal.hide()
+
+      expect(counter).toEqual(2)
+    })
+  })
 })


### PR DESCRIPTION
Hi everyone,

I count on your guidance/help for my first PR :wink: 

As i mentioned in my suggestion (#31266), this PR will allow us to add event listeners directly from an instantiated object with a new `on()` method.

I've also added a new methd `off()` to remove a registered event listener. 

### TODO:

* [ ] Alert
* [ ] Button
* [ ] Carousel
* [ ] Collapse
* [ ] Dropdown
* [ ] Popover
* [x] Modal
* [ ] Scrollspy
* [ ] Tab
* [ ] Toast
* [ ] Tooltip

I'll start with `Modal` class just to be sure that i'm on the right path.

There is a class called `EventHandler`, do i need to use it to add/remove event listeners?

Closes: #31266