### PR TITLE
Docs: fix homepage npm install version

### DIFF
--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -12,7 +12,7 @@
       <a class="btn btn-lg btn-outline-primary mb-3" href="/docs/{{ .Site.Params.docs_version }}/getting-started/download/">Read installation docs</a>
     </div>
     <div class="col-md-7 pl-md-5">
-      {{ highlight "npm install bootstrap" "sh" "" }}
+      {{ highlight "npm install bootstrap@next" "sh" "" }}
       {{ highlight (printf ("gem install bootstrap -v %s") .Site.Params.current_ruby_version) "sh" "" }}
     </div>
   </section>


### PR DESCRIPTION
The `npm install bootstrap` should be `npm install bootstrap@next` on the homepage . People (such as me) will mistakenly think that v5 is already the latest version, especially when I see the following sentence is `
gem install bootstrap -v 5.0.0.alpha3`...