### PR TITLE
docs: Fix syntax highlighting language

### DIFF
--- a/site/docs/4.5/content/reboot.md
+++ b/site/docs/4.5/content/reboot.md
@@ -31,7 +31,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 
 The default web fonts (Helvetica Neue, Helvetica, and Arial) have been dropped in Bootstrap 4 and replaced with a "native font stack" for optimum text rendering on every device and OS. Read more about [native font stacks in this *Smashing Magazine* article](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/).
 
-{% highlight sass %}
+{% highlight scss %}
 $font-family-sans-serif:
   // Safari for macOS and iOS (San Francisco)
   -apple-system,

--- a/site/docs/4.5/layout/grid.md
+++ b/site/docs/4.5/layout/grid.md
@@ -547,7 +547,7 @@ Here's the source code for creating these styles. Note that column overrides are
 
 **Need an edge-to-edge design?** Drop the parent `.container` or `.container-fluid`.
 
-{% highlight sass %}
+{% highlight scss %}
 .no-gutters {
   margin-right: 0;
   margin-left: 0;


### PR DESCRIPTION
Split from #32077

Preview: <https://deploy-preview-32195--twbs-bootstrap.netlify.app/docs/4.5/content/reboot/#native-font-stack>