### PR TITLE
feat(grid): simplify gutters usage

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -330,14 +330,14 @@ $container-max-widths: (
 // Set the number of columns and specify the width of the gutters.
 
 $grid-columns:                12 !default;
-$grid-gutter-width:           1.5rem !default;
+$grid-gutter-width:           .75rem !default;
 $grid-row-columns:            6 !default;
 
 $gutters: $spacers !default;
 
 // Container padding
 
-$container-padding-x: $grid-gutter-width / 2 !default;
+$container-padding-x: $grid-gutter-width !default;
 
 
 // Components
@@ -1010,7 +1010,7 @@ $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          $spacer !default;
 
-$card-group-margin:                 $grid-gutter-width / 2 !default;
+$card-group-margin:                 $grid-gutter-width !default;
 
 // Accordion
 $accordion-padding-y:                     1rem !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -330,14 +330,15 @@ $container-max-widths: (
 // Set the number of columns and specify the width of the gutters.
 
 $grid-columns:                12 !default;
-$grid-gutter-width:           .75rem !default;
+$grid-gutter-width:           1.5rem !default;
+$grid-gutter-half:            $grid-gutter-width / 2 !default;
 $grid-row-columns:            6 !default;
 
 $gutters: $spacers !default;
 
 // Container padding
 
-$container-padding-x: $grid-gutter-width !default;
+$container-padding-x: $grid-gutter-half !default;
 
 
 // Components
@@ -1010,7 +1011,7 @@ $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          $spacer !default;
 
-$card-group-margin:                 $grid-gutter-width !default;
+$card-group-margin:                 $grid-gutter-half !default;
 
 // Accordion
 $accordion-padding-y:                     1rem !default;

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -8,8 +8,8 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: calc(var(--#{$variable-prefix}gutter-y) * -1); // stylelint-disable-line function-disallowed-list
-  margin-right: calc(var(--#{$variable-prefix}gutter-x) / -2); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(var(--#{$variable-prefix}gutter-x) / -2); // stylelint-disable-line function-disallowed-list
+  margin-right: calc(var(--#{$variable-prefix}gutter-x) * -1); // stylelint-disable-line function-disallowed-list
+  margin-left: calc(var(--#{$variable-prefix}gutter-x) * -1); // stylelint-disable-line function-disallowed-list
 }
 
 @mixin make-col-ready($gutter: $grid-gutter-width) {
@@ -21,8 +21,8 @@
   flex-shrink: 0;
   width: 100%;
   max-width: 100%; // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
-  padding-right: calc(var(--#{$variable-prefix}gutter-x) / 2); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$variable-prefix}gutter-x) / 2); // stylelint-disable-line function-disallowed-list
+  padding-right: var(--#{$variable-prefix}gutter-x);
+  padding-left: var(--#{$variable-prefix}gutter-x);
   margin-top: var(--#{$variable-prefix}gutter-y);
 }
 

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,7 +2,7 @@
 //
 // Generate semantic grid columns with these mixins.
 
-@mixin make-row($gutter: $grid-gutter-width) {
+@mixin make-row($gutter: $grid-gutter-half) {
   --#{$variable-prefix}gutter-x: #{$gutter};
   --#{$variable-prefix}gutter-y: 0;
   display: flex;
@@ -12,7 +12,7 @@
   margin-left: calc(var(--#{$variable-prefix}gutter-x) * -1); // stylelint-disable-line function-disallowed-list
 }
 
-@mixin make-col-ready($gutter: $grid-gutter-width) {
+@mixin make-col-ready($gutter: $grid-gutter-half) {
   // Add box sizing if only the grid is loaded
   box-sizing: if(variable-exists(include-column-box-sizing) and $include-column-box-sizing, border-box, null);
   // Prevent columns from becoming too narrow when at smaller grid tiers by
@@ -58,7 +58,7 @@
 // Used only by Bootstrap to generate the correct number of grid classes given
 // any value of `$grid-columns`.
 
-@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
+@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-half, $breakpoints: $grid-breakpoints) {
   @each $breakpoint in map-keys($breakpoints) {
     $infix: breakpoint-infix($breakpoint, $breakpoints);
 

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -107,7 +107,7 @@
       @each $key, $value in $gutters {
         .g#{$infix}-#{$key},
         .gx#{$infix}-#{$key} {
-          --#{$variable-prefix}gutter-x: #{$value};
+          --#{$variable-prefix}gutter-x: #{($value / 2)};
         }
 
         .g#{$infix}-#{$key},

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -70,7 +70,7 @@
 .bd-example {
   position: relative;
   padding: 1rem;
-  margin: 1rem (-$grid-gutter-width / 2) 0;
+  margin: 1rem -#{$grid-gutter-width} 0;
   border: solid $gray-300;
   border-width: 1px 0 0;
   @include clearfix();
@@ -300,8 +300,8 @@
 }
 
 .bd-content .highlight {
-  margin-right: (-$grid-gutter-width / 2);
-  margin-left: (-$grid-gutter-width / 2);
+  margin-right: -#{$grid-gutter-width};
+  margin-left: -#{$grid-gutter-width};
 
   @include media-breakpoint-up(sm) {
     margin-right: 0;

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -70,7 +70,7 @@
 .bd-example {
   position: relative;
   padding: 1rem;
-  margin: 1rem -#{$grid-gutter-width} 0;
+  margin: 1rem -#{$grid-gutter-half} 0;
   border: solid $gray-300;
   border-width: 1px 0 0;
   @include clearfix();
@@ -300,8 +300,8 @@
 }
 
 .bd-content .highlight {
-  margin-right: -#{$grid-gutter-width};
-  margin-left: -#{$grid-gutter-width};
+  margin-right: -#{$grid-gutter-half};
+  margin-left: -#{$grid-gutter-half};
 
   @include media-breakpoint-up(sm) {
     margin-right: 0;

--- a/site/assets/scss/_layout.scss
+++ b/site/assets/scss/_layout.scss
@@ -1,7 +1,7 @@
 .bd-layout {
   @include media-breakpoint-up(md) {
     display: grid;
-    gap: $grid-gutter-width * 2;
+    gap: $grid-gutter-width;
     grid-template-areas: "sidebar main";
     grid-template-columns: 1fr 3fr;
   }

--- a/site/assets/scss/_layout.scss
+++ b/site/assets/scss/_layout.scss
@@ -1,7 +1,7 @@
 .bd-layout {
   @include media-breakpoint-up(md) {
     display: grid;
-    gap: $grid-gutter-width;
+    gap: $grid-gutter-width * 2;
     grid-template-areas: "sidebar main";
     grid-template-columns: 1fr 3fr;
   }


### PR DESCRIPTION
Right after #31735, I think the same kind of simplification on every gutter usage could help a lot. It simplifies quite a lot of occurrencies, for a single more complex (in our `.gx-*` utilities, needs to `/ 2`).

## To-do

- [ ] documentation?
- [ ] check what needs to be added to the migration guide

---

- Preview: https://deploy-preview-32207--twbs-bootstrap.netlify.app/docs/5.0/examples/grid/
- Main: https://getbootstrap.com/docs/5.0/examples/grid/