### PR TITLE
docs: use `event` instead of `e`

### DIFF
--- a/site/content/docs/5.0/components/list-group.md
+++ b/site/content/docs/5.0/components/list-group.md
@@ -342,8 +342,8 @@ var triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
 triggerTabList.forEach(function (triggerEl) {
   var tabTrigger = new bootstrap.Tab(triggerEl)
 
-  triggerEl.addEventListener('click', function (e) {
-    e.preventDefault()
+  triggerEl.addEventListener('click', function (event) {
+    event.preventDefault()
     tabTrigger.show()
   })
 })
@@ -465,8 +465,8 @@ If no tab was already active, the `hide.bs.tab` and `hidden.bs.tab` events will 
 
 ```js
 var tabEl = document.querySelector('a[data-bs-toggle="list"]')
-tabEl.addEventListener('shown.bs.tab', function (e) {
-  e.target // newly activated tab
-  e.relatedTarget // previous active tab
+tabEl.addEventListener('shown.bs.tab', function (event) {
+  event.target // newly activated tab
+  event.relatedTarget // previous active tab
 })
 ```

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -988,7 +988,7 @@ Bootstrap's modal class exposes a few events for hooking into modal functionalit
 
 ```js
 var myModalEl = document.getElementById('myModal')
-myModalEl.addEventListener('hidden.bs.modal', function (e) {
+myModalEl.addEventListener('hidden.bs.modal', function (event) {
   // do something...
 })
 ```

--- a/site/content/docs/5.0/components/navs-tabs.md
+++ b/site/content/docs/5.0/components/navs-tabs.md
@@ -523,8 +523,8 @@ var triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
 triggerTabList.forEach(function (triggerEl) {
   var tabTrigger = new bootstrap.Tab(triggerEl)
 
-  triggerEl.addEventListener('click', function (e) {
-    e.preventDefault()
+  triggerEl.addEventListener('click', function (event) {
+    event.preventDefault()
     tabTrigger.show()
   })
 })
@@ -658,8 +658,8 @@ If no tab was already active, then the `hide.bs.tab` and `hidden.bs.tab` events 
 
 ```js
 var tabEl = document.querySelector('a[data-bs-toggle="tab"]')
-tabEl.addEventListener('shown.bs.tab', function (e) {
-  e.target // newly activated tab
-  e.relatedTarget // previous active tab
+tabEl.addEventListener('shown.bs.tab', function (event) {
+  event.target // newly activated tab
+  event.relatedTarget // previous active tab
 })
 ```

--- a/site/content/docs/5.0/getting-started/javascript.md
+++ b/site/content/docs/5.0/getting-started/javascript.md
@@ -61,9 +61,9 @@ All infinitive events provide [`preventDefault()`](https://developer.mozilla.org
 ```js
 var myModal = document.getElementById('myModal')
 
-myModal.addEventListener('show.bs.modal', function (e) {
+myModal.addEventListener('show.bs.modal', function (event) {
   if (!data) {
-    return e.preventDefault() // stops modal from being shown
+    return event.preventDefault() // stops modal from being shown
   }
 })
 ```
@@ -102,7 +102,7 @@ In order to execute an action once the transition is complete, you can listen to
 ```js
 var myCollapseEl = document.getElementById('#myCollapse')
 
-myCollapseEl.addEventListener('shown.bs.collapse', function (e) {
+myCollapseEl.addEventListener('shown.bs.collapse', function (event) {
   // Action to execute once the collapsible area is expanded
 })
 ```
@@ -113,7 +113,7 @@ In addition a method call on a **transitioning component will be ignored**.
 var myCarouselEl = document.getElementById('myCarousel')
 var carousel = bootstrap.Carousel.getInstance(myCarouselEl) // Retrieve a Carousel instance
 
-myCarouselEl.addEventListener('slid.bs.carousel', function (e) {
+myCarouselEl.addEventListener('slid.bs.carousel', function (event) {
   carousel.to('2') // Will slide to the slide 2 as soon as the transition to slide 1 is finished
 })
 


### PR DESCRIPTION
It's better for clarity.