### PR TITLE
Add eslint-plugin-qunit and tighten JS tests

### DIFF
--- a/js/tests/unit/.eslintrc.json
+++ b/js/tests/unit/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "../../../.eslintrc.json"
+    "../../../.eslintrc.json",
+    "plugin:qunit/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 5,

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -29,7 +29,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $alert = $el.bootstrapAlert()
-    assert.ok($alert instanceof $, 'returns jquery collection')
+    assert.true($alert instanceof $, 'returns jquery collection')
     assert.strictEqual($alert[0], $el[0], 'collection contains element')
   })
 
@@ -44,7 +44,7 @@ $(function () {
 
     $alert.find('.close').trigger('click')
 
-    assert.strictEqual($alert.hasClass('show'), false, 'remove .show class on .close click')
+    assert.false($alert.hasClass('show'), 'remove .show class on .close click')
   })
 
   QUnit.test('should remove element when clicking .close', function (assert) {
@@ -104,18 +104,18 @@ $(function () {
     var $el = $('<div/>')
     var $alert = $el.bootstrapAlert()
 
-    assert.ok(typeof $alert.data('bs.alert') !== 'undefined')
+    assert.notStrictEqual(typeof $alert.data('bs.alert'), 'undefined')
 
     $alert.data('bs.alert').dispose()
 
-    assert.ok(typeof $alert.data('bs.button') === 'undefined')
+    assert.strictEqual(typeof $alert.data('bs.button'), 'undefined')
   })
 
   QUnit.test('should return alert version', function (assert) {
     assert.expect(1)
 
     if (typeof Alert !== 'undefined') {
-      assert.ok(typeof Alert.VERSION === 'string')
+      assert.strictEqual(typeof Alert.VERSION, 'string')
     } else {
       assert.notOk()
     }

--- a/js/tests/unit/alert.js
+++ b/js/tests/unit/alert.js
@@ -1,6 +1,8 @@
 $(function () {
   'use strict'
 
+  window.Alert = typeof bootstrap !== 'undefined' ? bootstrap.Alert : Alert
+
   QUnit.module('alert plugin')
 
   QUnit.test('should be defined on jquery object', function (assert) {
@@ -114,10 +116,6 @@ $(function () {
   QUnit.test('should return alert version', function (assert) {
     assert.expect(1)
 
-    if (typeof Alert !== 'undefined') {
-      assert.strictEqual(typeof Alert.VERSION, 'string')
-    } else {
-      assert.notOk()
-    }
+    assert.strictEqual(typeof Alert.VERSION, 'string')
   })
 })

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -29,16 +29,16 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $button = $el.bootstrapButton()
-    assert.ok($button instanceof $, 'returns jquery collection')
+    assert.true($button instanceof $, 'returns jquery collection')
     assert.strictEqual($button[0], $el[0], 'collection contains element')
   })
 
   QUnit.test('should toggle active', function (assert) {
     assert.expect(2)
     var $btn = $('<button class="btn" data-toggle="button">mdo</button>')
-    assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
+    assert.false($btn.hasClass('active'), 'btn does not have active class')
     $btn.bootstrapButton('toggle')
-    assert.ok($btn.hasClass('active'), 'btn has class active')
+    assert.true($btn.hasClass('active'), 'btn has class active')
   })
 
   QUnit.test('should toggle active when btn children are clicked', function (assert) {
@@ -48,9 +48,9 @@ $(function () {
     $btn
       .append($inner)
       .appendTo('#qunit-fixture')
-    assert.ok(!$btn.hasClass('active'), 'btn does not have active class')
+    assert.false($btn.hasClass('active'), 'btn does not have active class')
     $inner.trigger('click')
-    assert.ok($btn.hasClass('active'), 'btn has class active')
+    assert.true($btn.hasClass('active'), 'btn has class active')
   })
 
   QUnit.test('should toggle aria-pressed', function (assert) {
@@ -107,7 +107,7 @@ $(function () {
     $btn.appendTo('#qunit-fixture')
     $(window).trigger($.Event('load'))
     setTimeout(function () {
-      assert.ok($btn.hasClass('active'), 'button with aria-pressed="true" has been given class active')
+      assert.true($btn.hasClass('active'), 'button with aria-pressed="true" has been given class active')
       done()
     }, 5)
   })
@@ -125,7 +125,7 @@ $(function () {
 
     $(window).trigger($.Event('load'))
     setTimeout(function () {
-      assert.ok($btn.hasClass('active'), 'checked checkbox button has been given class active')
+      assert.true($btn.hasClass('active'), 'checked checkbox button has been given class active')
       done()
     }, 5)
   })
@@ -137,7 +137,7 @@ $(function () {
     $btn.appendTo('#qunit-fixture')
     $(window).trigger($.Event('load'))
     setTimeout(function () {
-      assert.ok(!$btn.hasClass('active'), 'button without aria-pressed="true" has had active class removed')
+      assert.false($btn.hasClass('active'), 'button without aria-pressed="true" has had active class removed')
       done()
     }, 5)
   })
@@ -155,7 +155,7 @@ $(function () {
 
     $(window).trigger($.Event('load'))
     setTimeout(function () {
-      assert.ok(!$btn.hasClass('active'), 'unchecked checkbox button has had active class removed')
+      assert.false($btn.hasClass('active'), 'unchecked checkbox button has had active class removed')
       done()
     }, 5)
   })
@@ -199,7 +199,7 @@ $(function () {
     })
 
     setTimeout(function () {
-      assert.ok(countChangeEvent === 1, 'onchange event fired only once')
+      assert.strictEqual(countChangeEvent, 1, 'onchange event fired only once')
       done()
     }, 5)
 
@@ -224,28 +224,28 @@ $(function () {
     var $btn1 = $group.children().eq(0)
     var $btn2 = $group.children().eq(1)
 
-    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
-    assert.ok($btn1.find('input').prop('checked'), 'btn1 is checked')
-    assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
-    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
+    assert.true($btn1.hasClass('active'), 'btn1 has active class')
+    assert.true($btn1.find('input').prop('checked'), 'btn1 is checked')
+    assert.false($btn2.hasClass('active'), 'btn2 does not have active class')
+    assert.false($btn2.find('input').prop('checked'), 'btn2 is not checked')
     $btn2.find('input').trigger('click')
-    assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
-    assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is not checked')
-    assert.ok($btn2.hasClass('active'), 'btn2 has active class')
-    assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
+    assert.false($btn1.hasClass('active'), 'btn1 does not have active class')
+    assert.false($btn1.find('input').prop('checked'), 'btn1 is not checked')
+    assert.true($btn2.hasClass('active'), 'btn2 has active class')
+    assert.true($btn2.find('input').prop('checked'), 'btn2 is checked')
 
     $btn2.find('input').trigger('click') // Clicking an already checked radio should not un-check it
-    assert.ok(!$btn1.hasClass('active'), 'btn1 does not have active class')
-    assert.ok(!$btn1.find('input').prop('checked'), 'btn1 is not checked')
-    assert.ok($btn2.hasClass('active'), 'btn2 has active class')
-    assert.ok($btn2.find('input').prop('checked'), 'btn2 is checked')
+    assert.false($btn1.hasClass('active'), 'btn1 does not have active class')
+    assert.false($btn1.find('input').prop('checked'), 'btn1 is not checked')
+    assert.true($btn2.hasClass('active'), 'btn2 has active class')
+    assert.true($btn2.find('input').prop('checked'), 'btn2 is checked')
     $btn1.bootstrapButton('toggle')
-    assert.ok($btn1.hasClass('active'), 'btn1 has active class')
-    assert.ok($btn1.find('input').prop('checked'), 'btn1 prop is checked')
-    assert.ok($btn1.find('input')[0].checked, 'btn1 is checked with jquery')
-    assert.ok(!$btn2.hasClass('active'), 'btn2 does not have active class')
-    assert.ok(!$btn2.find('input').prop('checked'), 'btn2 is not checked')
-    assert.ok(!$btn2.find('input')[0].checked, 'btn2 is not checked')
+    assert.true($btn1.hasClass('active'), 'btn1 has active class')
+    assert.true($btn1.find('input').prop('checked'), 'btn1 prop is checked')
+    assert.true($btn1.find('input')[0].checked, 'btn1 is checked with jquery')
+    assert.false($btn2.hasClass('active'), 'btn2 does not have active class')
+    assert.false($btn2.find('input').prop('checked'), 'btn2 is not checked')
+    assert.false($btn2.find('input')[0].checked, 'btn2 is not checked')
   })
 
   QUnit.test('should fire click event on input', function (assert) {
@@ -300,10 +300,10 @@ $(function () {
     var $btn2 = $group.children().eq(1)
 
     $btn1.find('input').trigger('click')
-    assert.ok($btn1.is(':not([aria-pressed])'), 'label for nested checkbox input has not been given an aria-pressed attribute')
+    assert.true($btn1.is(':not([aria-pressed])'), 'label for nested checkbox input has not been given an aria-pressed attribute')
 
     $btn2.find('input').trigger('click')
-    assert.ok($btn2.is(':not([aria-pressed])'), 'label for nested radio input has not been given an aria-pressed attribute')
+    assert.true($btn2.is(':not([aria-pressed])'), 'label for nested radio input has not been given an aria-pressed attribute')
   })
 
   QUnit.test('should handle disabled attribute on non-button elements', function (assert) {
@@ -318,11 +318,11 @@ $(function () {
     var $btn = $group.children().eq(0)
     var $input = $btn.children().eq(0)
 
-    assert.ok($btn.is(':not(.active)'), 'button is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox is initially not checked')
+    assert.true($btn.is(':not(.active)'), 'button is initially not active')
+    assert.false($input.prop('checked'), 'checkbox is initially not checked')
     $btn[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok($btn.is(':not(.active)'), 'button did not become active')
-    assert.ok(!$input.prop('checked'), 'checkbox did not get checked')
+    assert.true($btn.is(':not(.active)'), 'button did not become active')
+    assert.false($input.prop('checked'), 'checkbox did not get checked')
   })
 
   QUnit.test('should not set active class if inner hidden checkbox is disabled but author forgot to set disabled class on outer button', function (assert) {
@@ -337,11 +337,11 @@ $(function () {
     var $btn = $group.children().eq(0)
     var $input = $btn.children().eq(0)
 
-    assert.ok($btn.is(':not(.active)'), 'button is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox is initially not checked')
+    assert.true($btn.is(':not(.active)'), 'button is initially not active')
+    assert.false($input.prop('checked'), 'checkbox is initially not checked')
     $btn[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok($btn.is(':not(.active)'), 'button did not become active')
-    assert.ok(!$input.prop('checked'), 'checkbox did not get checked')
+    assert.true($btn.is(':not(.active)'), 'button did not become active')
+    assert.false($input.prop('checked'), 'checkbox did not get checked')
   })
 
   QUnit.test('should correctly set checked state on input and active class on label when using <label><input></label> structure', function (assert) {
@@ -356,11 +356,11 @@ $(function () {
     var $label = $group.children().eq(0)
     var $input = $label.children().eq(0)
 
-    assert.ok($label.is(':not(.active)'), 'label is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox is initially not checked')
+    assert.true($label.is(':not(.active)'), 'label is initially not active')
+    assert.false($input.prop('checked'), 'checkbox is initially not checked')
     $label[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok($label.is('.active'), 'label is active after click')
-    assert.ok($input.prop('checked'), 'checkbox is checked after click')
+    assert.true($label.is('.active'), 'label is active after click')
+    assert.true($input.prop('checked'), 'checkbox is checked after click')
   })
 
   QUnit.test('should correctly set checked state on input and active class on the faked button when using <div><input></div> structure', function (assert) {
@@ -375,11 +375,11 @@ $(function () {
     var $btn = $group.children().eq(0)
     var $input = $btn.children().eq(0)
 
-    assert.ok($btn.is(':not(.active)'), '<div> is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox is initially not checked')
+    assert.true($btn.is(':not(.active)'), '<div> is initially not active')
+    assert.false($input.prop('checked'), 'checkbox is initially not checked')
     $btn[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok($btn.is('.active'), '<div> is active after click')
-    assert.ok($input.prop('checked'), 'checkbox is checked after click')
+    assert.true($btn.is('.active'), '<div> is active after click')
+    assert.true($input.prop('checked'), 'checkbox is checked after click')
   })
 
   QUnit.test('should correctly set checked state on input and active class on the label when using button toggle', function (assert) {
@@ -394,13 +394,13 @@ $(function () {
     var $btn = $group.children().eq(0)
     var $input = $btn.children().eq(0)
 
-    assert.ok($btn.is(':not(.active)'), '<label> is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox property is initially not checked')
-    assert.ok(!$input[0].checked, 'checkbox is not checked by jquery after click')
+    assert.true($btn.is(':not(.active)'), '<label> is initially not active')
+    assert.false($input.prop('checked'), 'checkbox property is initially not checked')
+    assert.false($input[0].checked, 'checkbox is not checked by jquery after click')
     $btn.bootstrapButton('toggle')
-    assert.ok($btn.is('.active'), '<label> is active after click')
-    assert.ok($input.prop('checked'), 'checkbox property is checked after click')
-    assert.ok($input[0].checked, 'checkbox is checked by jquery after click')
+    assert.true($btn.is('.active'), '<label> is active after click')
+    assert.true($input.prop('checked'), 'checkbox property is checked after click')
+    assert.true($input[0].checked, 'checkbox is checked by jquery after click')
   })
 
   QUnit.test('should not do anything if the click was just sent to the outer container with data-toggle', function (assert) {
@@ -415,11 +415,11 @@ $(function () {
     var $label = $group.children().eq(0)
     var $input = $label.children().eq(0)
 
-    assert.ok($label.is(':not(.active)'), 'label is initially not active')
-    assert.ok(!$input.prop('checked'), 'checkbox is initially not checked')
+    assert.true($label.is(':not(.active)'), 'label is initially not active')
+    assert.false($input.prop('checked'), 'checkbox is initially not checked')
     $group[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok($label.is(':not(.active)'), 'label is not active after click')
-    assert.ok(!$input.prop('checked'), 'checkbox is not checked after click')
+    assert.true($label.is(':not(.active)'), 'label is not active after click')
+    assert.false($input.prop('checked'), 'checkbox is not checked after click')
   })
 
   QUnit.test('should not try and set checked property on an input of type="hidden"', function (assert) {
@@ -434,9 +434,9 @@ $(function () {
     var $label = $group.children().eq(0)
     var $input = $label.children().eq(0)
 
-    assert.ok(!$input.prop('checked'), 'hidden input initially has no checked property')
+    assert.false($input.prop('checked'), 'hidden input initially has no checked property')
     $label[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok(!$input.prop('checked'), 'hidden input does not have a checked property')
+    assert.false($input.prop('checked'), 'hidden input does not have a checked property')
   })
 
   QUnit.test('should not try and set checked property on an input that is not a radio button or checkbox', function (assert) {
@@ -451,9 +451,9 @@ $(function () {
     var $label = $group.children().eq(0)
     var $input = $label.children().eq(0)
 
-    assert.ok(!$input.prop('checked'), 'text input initially has no checked property')
+    assert.false($input.prop('checked'), 'text input initially has no checked property')
     $label[0].click() // fire a real click on the DOM node itself, not a click() on the jQuery object that just aliases to trigger('click')
-    assert.ok(!$input.prop('checked'), 'text input does not have a checked property')
+    assert.false($input.prop('checked'), 'text input does not have a checked property')
   })
 
   QUnit.test('dispose should remove data and the element', function (assert) {
@@ -462,18 +462,18 @@ $(function () {
     var $el = $('<div/>')
     var $button = $el.bootstrapButton()
 
-    assert.ok(typeof $button.data('bs.button') !== 'undefined')
+    assert.notStrictEqual(typeof $button.data('bs.button'), 'undefined')
 
     $button.data('bs.button').dispose()
 
-    assert.ok(typeof $button.data('bs.button') === 'undefined')
+    assert.strictEqual(typeof $button.data('bs.button'), 'undefined')
   })
 
   QUnit.test('should return button version', function (assert) {
     assert.expect(1)
 
     if (typeof Button !== 'undefined') {
-      assert.ok(typeof Button.VERSION === 'string')
+      assert.strictEqual(typeof Button.VERSION, 'string')
     } else {
       assert.notOk()
     }

--- a/js/tests/unit/button.js
+++ b/js/tests/unit/button.js
@@ -1,6 +1,8 @@
 $(function () {
   'use strict'
 
+  window.Button = typeof bootstrap !== 'undefined' ? bootstrap.Button : Button
+
   QUnit.module('button plugin')
 
   QUnit.test('should be defined on jquery object', function (assert) {
@@ -472,10 +474,6 @@ $(function () {
   QUnit.test('should return button version', function (assert) {
     assert.expect(1)
 
-    if (typeof Button !== 'undefined') {
-      assert.strictEqual(typeof Button.VERSION, 'string')
-    } else {
-      assert.notOk()
-    }
+    assert.strictEqual(typeof Button.VERSION, 'string')
   })
 })

--- a/js/tests/unit/carousel.js
+++ b/js/tests/unit/carousel.js
@@ -56,7 +56,7 @@ $(function () {
 
     var defaultConfig = Carousel.Default
 
-    assert.strictEqual(defaultConfig.touch, true)
+    assert.true(defaultConfig.touch)
   })
 
   QUnit.test('should throw explicit error on undefined method', function (assert) {
@@ -74,7 +74,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $carousel = $el.bootstrapCarousel()
-    assert.ok($carousel instanceof $, 'returns jquery collection')
+    assert.true($carousel instanceof $, 'returns jquery collection')
     assert.strictEqual($carousel[0], $el[0], 'collection contains element')
   })
 
@@ -93,7 +93,7 @@ $(function () {
       message = error.message
     }
 
-    assert.ok(message === expectedMessage, 'correct error message')
+    assert.strictEqual(message, expectedMessage, 'correct error message')
 
     config = {
       keyboard: document.createElement('div')
@@ -106,7 +106,7 @@ $(function () {
       message = error.message
     }
 
-    assert.ok(message === expectedMessage, 'correct error message')
+    assert.strictEqual(message, expectedMessage, 'correct error message')
   })
 
   QUnit.test('should not fire slid when slide is prevented', function (assert) {
@@ -153,17 +153,17 @@ $(function () {
       .one('slide.bs.carousel', function (e) {
         e.preventDefault()
         setTimeout(function () {
-          assert.ok($carousel.find('.carousel-item:nth-child(1)').is('.active'), 'first item still active')
-          assert.ok($carousel.find('.carousel-indicators li:nth-child(1)').is('.active'), 'first indicator still active')
+          assert.true($carousel.find('.carousel-item:nth-child(1)').is('.active'), 'first item still active')
+          assert.true($carousel.find('.carousel-indicators li:nth-child(1)').is('.active'), 'first indicator still active')
           $carousel.bootstrapCarousel('next')
         }, 0)
       })
       .one('slid.bs.carousel', function () {
         setTimeout(function () {
-          assert.ok(!$carousel.find('.carousel-item:nth-child(1)').is('.active'), 'first item still active')
-          assert.ok(!$carousel.find('.carousel-indicators li:nth-child(1)').is('.active'), 'first indicator still active')
-          assert.ok($carousel.find('.carousel-item:nth-child(2)').is('.active'), 'second item active')
-          assert.ok($carousel.find('.carousel-indicators li:nth-child(2)').is('.active'), 'second indicator active')
+          assert.false($carousel.find('.carousel-item:nth-child(1)').is('.active'), 'first item still active')
+          assert.false($carousel.find('.carousel-indicators li:nth-child(1)').is('.active'), 'first indicator still active')
+          assert.true($carousel.find('.carousel-item:nth-child(2)').is('.active'), 'second item active')
+          assert.true($carousel.find('.carousel-indicators li:nth-child(2)').is('.active'), 'second indicator active')
           done()
         }, 0)
       })
@@ -211,12 +211,12 @@ $(function () {
 
     $carousel
       .one('slide.bs.carousel', function (e) {
-        assert.ok(e.direction, 'direction present on next')
+        assert.notStrictEqual(e.direction, 'undefined', 'direction present on next')
         assert.strictEqual(e.direction, 'left', 'direction is left on next')
 
         $carousel
           .one('slide.bs.carousel', function (e) {
-            assert.ok(e.direction, 'direction present on prev')
+            assert.notStrictEqual(e.direction, 'undefined', 'direction present on prev')
             assert.strictEqual(e.direction, 'right', 'direction is right on prev')
             done()
           })
@@ -266,12 +266,12 @@ $(function () {
 
     $carousel
       .one('slid.bs.carousel', function (e) {
-        assert.ok(e.direction, 'direction present on next')
+        assert.notStrictEqual(e.direction, 'undefined', 'direction present on next')
         assert.strictEqual(e.direction, 'left', 'direction is left on next')
 
         $carousel
           .one('slid.bs.carousel', function (e) {
-            assert.ok(e.direction, 'direction present on prev')
+            assert.notStrictEqual(e.direction, 'undefined', 'direction present on prev')
             assert.strictEqual(e.direction, 'right', 'direction is right on prev')
             done()
           })
@@ -320,8 +320,8 @@ $(function () {
 
     $(template)
       .on('slide.bs.carousel', function (e) {
-        assert.ok(e.relatedTarget, 'relatedTarget present')
-        assert.ok($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
+        assert.notStrictEqual(e.relatedTarget, 'undefined', 'relatedTarget present')
+        assert.true($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
         done()
       })
       .bootstrapCarousel('next')
@@ -367,8 +367,8 @@ $(function () {
 
     $(template)
       .on('slid.bs.carousel', function (e) {
-        assert.ok(e.relatedTarget, 'relatedTarget present')
-        assert.ok($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
+        assert.notStrictEqual(e.relatedTarget, 'undefined', 'relatedTarget present')
+        assert.true($(e.relatedTarget).hasClass('carousel-item'), 'relatedTarget has class "item"')
         done()
       })
       .bootstrapCarousel('next')
@@ -404,14 +404,14 @@ $(function () {
     var done = assert.async()
     $(template)
       .on('slid.bs.carousel', function (e) {
-        assert.ok(typeof e.from !== 'undefined', 'from present')
-        assert.ok(typeof e.to !== 'undefined', 'to present')
+        assert.notStrictEqual(typeof e.from, 'undefined', 'from present')
+        assert.notStrictEqual(typeof e.to, 'undefined', 'to present')
         $(this).off()
         done()
       })
       .on('slide.bs.carousel', function (e) {
-        assert.ok(typeof e.from !== 'undefined', 'from present')
-        assert.ok(typeof e.to !== 'undefined', 'to present')
+        assert.notStrictEqual(typeof e.from, 'undefined', 'from present')
+        assert.notStrictEqual(typeof e.to, 'undefined', 'to present')
         $(this).off('slide.bs.carousel')
       })
       .bootstrapCarousel('next')
@@ -475,7 +475,7 @@ $(function () {
     $carousel.attr('data-interval', false)
     $carousel.appendTo('body')
     $carousel.bootstrapCarousel(1)
-    assert.strictEqual($carousel.data('bs.carousel')._config.interval, false, 'data attribute has higher priority than default options')
+    assert.false($carousel.data('bs.carousel')._config.interval, 'data attribute has higher priority than default options')
     $carousel.remove()
   })
 
@@ -670,13 +670,13 @@ $(function () {
     })
 
     $template.one('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+      assert.false(event.isDefaultPrevented())
     })
 
     $template.trigger(eventArrowDown)
 
     $template.one('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+      assert.false(event.isDefaultPrevented())
       done()
     })
 
@@ -950,12 +950,12 @@ $(function () {
       which: 65
     }) // 65 for "a"
     $inputText.on('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+      assert.false(event.isDefaultPrevented())
     })
     $inputText.trigger(eventKeyDown)
 
     $textArea.on('keydown', function (event) {
-      assert.strictEqual(event.isDefaultPrevented(), false)
+      assert.false(event.isDefaultPrevented())
       done()
     })
     $textArea.trigger(eventKeyDown)
@@ -985,14 +985,14 @@ $(function () {
 
     var $firstItem = $('#firstItem')
     setTimeout(function () {
-      assert.ok($firstItem.hasClass('active'))
+      assert.true($firstItem.hasClass('active'))
       $html
         .bootstrapCarousel('dispose')
         .attr('style', 'visibility: hidden;')
         .bootstrapCarousel()
 
       setTimeout(function () {
-        assert.ok($firstItem.hasClass('active'))
+        assert.true($firstItem.hasClass('active'))
         done()
       }, 80)
     }, 80)
@@ -1025,13 +1025,13 @@ $(function () {
     var $firstItem = $('#firstItem')
 
     setTimeout(function () {
-      assert.ok($firstItem.hasClass('active'))
+      assert.true($firstItem.hasClass('active'))
       $carousel.bootstrapCarousel('dispose')
       $parent.attr('style', 'visibility: hidden;')
       $carousel.bootstrapCarousel()
 
       setTimeout(function () {
-        assert.ok($firstItem.hasClass('active'))
+        assert.true($firstItem.hasClass('active'))
         done()
       }, 80)
     }, 80)
@@ -1069,8 +1069,8 @@ $(function () {
 
     $carousel.one('slid.bs.carousel', function () {
       assert.ok(true, 'slid event fired')
-      assert.ok($item.hasClass('active'))
-      assert.ok(spy.called)
+      assert.true($item.hasClass('active'))
+      assert.true(spy.called)
       $styles.remove()
       delete document.documentElement.ontouchstart
       done()
@@ -1111,8 +1111,8 @@ $(function () {
 
     $carousel.one('slid.bs.carousel', function () {
       assert.ok(true, 'slid event fired')
-      assert.ok($item.hasClass('active'))
-      assert.ok(spy.called)
+      assert.true($item.hasClass('active'))
+      assert.true(spy.called)
       delete document.documentElement.ontouchstart
       restorePointerEvents()
       done()
@@ -1158,8 +1158,8 @@ $(function () {
 
     $carousel.one('slid.bs.carousel', function () {
       assert.ok(true, 'slid event fired')
-      assert.ok(!$item.hasClass('active'))
-      assert.ok(spy.called)
+      assert.false($item.hasClass('active'))
+      assert.true(spy.called)
       assert.strictEqual(carousel.touchDeltaX, 0)
       $styles.remove()
       delete document.documentElement.ontouchstart
@@ -1202,8 +1202,8 @@ $(function () {
 
     $carousel.one('slid.bs.carousel', function () {
       assert.ok(true, 'slid event fired')
-      assert.ok(!$item.hasClass('active'))
-      assert.ok(spy.called)
+      assert.false($item.hasClass('active'))
+      assert.true(spy.called)
       assert.strictEqual(carousel.touchDeltaX, 0)
       restorePointerEvents()
       delete document.documentElement.ontouchstart
@@ -1258,7 +1258,7 @@ $(function () {
 
     carousel.next()
 
-    assert.strictEqual(spy.called, false)
+    assert.false(spy.called)
   })
 
   QUnit.test('should call next when the page is visible', function (assert) {
@@ -1282,7 +1282,7 @@ $(function () {
 
     carousel.nextWhenVisible()
 
-    assert.strictEqual(spy.called, true)
+    assert.true(spy.called)
     sandbox.restore()
   })
 
@@ -1296,7 +1296,7 @@ $(function () {
     $carousel.appendTo('#qunit-fixture')
     $carousel.bootstrapCarousel()
 
-    assert.strictEqual(spy.called, false)
+    assert.false(spy.called)
     spy.restore()
   })
 
@@ -1310,7 +1310,7 @@ $(function () {
     $carousel.appendTo('#qunit-fixture')
     $carousel.bootstrapCarousel()
 
-    assert.strictEqual(spy.called, true)
+    assert.true(spy.called)
     spy.restore()
   })
 
@@ -1327,7 +1327,7 @@ $(function () {
     $(window).trigger($.Event('load'))
 
     setTimeout(function () {
-      assert.strictEqual(spy.called, true)
+      assert.true(spy.called)
       spy.restore()
       done()
     }, 5)
@@ -1342,7 +1342,7 @@ $(function () {
     $carousel.appendTo('#qunit-fixture')
     $carousel.bootstrapCarousel()
 
-    assert.strictEqual(spy.called, false)
+    assert.false(spy.called)
     spy.restore()
   })
 })

--- a/js/tests/unit/collapse.js
+++ b/js/tests/unit/collapse.js
@@ -40,7 +40,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $collapse = $el.bootstrapCollapse()
-    assert.ok($collapse instanceof $, 'returns jquery collection')
+    assert.true($collapse instanceof $, 'returns jquery collection')
     assert.strictEqual($collapse[0], $el[0], 'collection contains element')
   })
 
@@ -50,8 +50,8 @@ $(function () {
     var $el = $('<div class="collapse"/>')
 
     $el.one('shown.bs.collapse', function () {
-      assert.ok($el.hasClass('show'), 'has class "show"')
-      assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
+      assert.true($el.hasClass('show'), 'has class "show"')
+      assert.false(/height/i.test($el.attr('style')), 'has height reset')
       done()
     }).bootstrapCollapse('show')
   })
@@ -63,12 +63,12 @@ $(function () {
     var $el = $('<div class="collapse multi"/>').appendTo('#qunit-fixture')
     var $el2 = $('<div class="collapse multi"/>').appendTo('#qunit-fixture')
     $el.one('shown.bs.collapse', function () {
-      assert.ok($el.hasClass('show'), 'has class "show"')
-      assert.ok(!/height/i.test($el.attr('style')), 'has height reset')
+      assert.true($el.hasClass('show'), 'has class "show"')
+      assert.false(/height/i.test($el.attr('style')), 'has height reset')
     })
     $el2.one('shown.bs.collapse', function () {
-      assert.ok($el2.hasClass('show'), 'has class "show"')
-      assert.ok(!/height/i.test($el2.attr('style')), 'has height reset')
+      assert.true($el2.hasClass('show'), 'has class "show"')
+      assert.false(/height/i.test($el2.attr('style')), 'has height reset')
       done()
     })
     $target.trigger('click')
@@ -93,8 +93,8 @@ $(function () {
     var $el1 = $('#collapse1')
     var $el2 = $('#collapse2')
     $el1.one('shown.bs.collapse', function () {
-      assert.ok($el1.hasClass('show'))
-      assert.ok($el2.hasClass('show'))
+      assert.true($el1.hasClass('show'))
+      assert.true($el2.hasClass('show'))
       done()
     }).bootstrapCollapse('show')
   })
@@ -103,7 +103,7 @@ $(function () {
     assert.expect(1)
     var $el = $('<div class="collapse"/>').bootstrapCollapse('hide')
 
-    assert.ok(!$el.hasClass('show'), 'does not have class "show"')
+    assert.false($el.hasClass('show'), 'does not have class "show"')
   })
 
   QUnit.test('should not fire shown when show is prevented', function (assert) {
@@ -161,7 +161,7 @@ $(function () {
     $('<div id="test1"/>')
       .appendTo('#qunit-fixture')
       .on('shown.bs.collapse', function () {
-        assert.ok(!$target.hasClass('collapsed'), 'target does not have collapsed class')
+        assert.false($target.hasClass('collapsed'), 'target does not have collapsed class')
         done()
       })
 
@@ -177,7 +177,7 @@ $(function () {
     $('<div id="test1" class="show"/>')
       .appendTo('#qunit-fixture')
       .on('hidden.bs.collapse', function () {
-        assert.ok($target.hasClass('collapsed'), 'target has collapsed class')
+        assert.true($target.hasClass('collapsed'), 'target has collapsed class')
         done()
       })
 
@@ -194,8 +194,8 @@ $(function () {
     $('<div id="test1"/>')
       .appendTo('#qunit-fixture')
       .on('shown.bs.collapse', function () {
-        assert.ok(!$target.hasClass('collapsed'), 'target trigger does not have collapsed class')
-        assert.ok(!$alt.hasClass('collapsed'), 'alt trigger does not have collapsed class')
+        assert.false($target.hasClass('collapsed'), 'target trigger does not have collapsed class')
+        assert.false($alt.hasClass('collapsed'), 'alt trigger does not have collapsed class')
         done()
       })
 
@@ -212,14 +212,15 @@ $(function () {
     $('<div id="test1" class="show"/>')
       .appendTo('#qunit-fixture')
       .on('hidden.bs.collapse', function () {
-        assert.ok($target.hasClass('collapsed'), 'target has collapsed class')
-        assert.ok($alt.hasClass('collapsed'), 'alt trigger has collapsed class')
+        assert.true($target.hasClass('collapsed'), 'target has collapsed class')
+        assert.true($alt.hasClass('collapsed'), 'alt trigger has collapsed class')
         done()
       })
 
     $target.trigger('click')
   })
 
+  // eslint-disable-next-line qunit/resolve-async
   QUnit.test('should not close a collapse when initialized with "show" option if already shown', function (assert) {
     assert.expect(0)
     var done = assert.async()
@@ -235,6 +236,7 @@ $(function () {
     setTimeout(done, 0)
   })
 
+  // eslint-disable-next-line qunit/resolve-async
   QUnit.test('should open a collapse when initialized with "show" option if not already shown', function (assert) {
     assert.expect(1)
     var done = assert.async()
@@ -250,6 +252,7 @@ $(function () {
     setTimeout(done, 0)
   })
 
+  // eslint-disable-next-line qunit/resolve-async
   QUnit.test('should not show a collapse when initialized with "hide" option if already hidden', function (assert) {
     assert.expect(0)
     var done = assert.async()
@@ -264,6 +267,7 @@ $(function () {
     setTimeout(done, 0)
   })
 
+  // eslint-disable-next-line qunit/resolve-async
   QUnit.test('should hide a collapse when initialized with "hide" option if not already hidden', function (assert) {
     assert.expect(1)
     var done = assert.async()
@@ -302,9 +306,9 @@ $(function () {
     $('<div id="body3" data-parent="#accordion"/>')
       .appendTo($groups.eq(2))
       .on('shown.bs.collapse', function () {
-        assert.ok($target1.hasClass('collapsed'), 'inactive target 1 does have class "collapsed"')
-        assert.ok($target2.hasClass('collapsed'), 'inactive target 2 does have class "collapsed"')
-        assert.ok(!$target3.hasClass('collapsed'), 'active target 3 does not have class "collapsed"')
+        assert.true($target1.hasClass('collapsed'), 'inactive target 1 does have class "collapsed"')
+        assert.true($target2.hasClass('collapsed'), 'inactive target 2 does have class "collapsed"')
+        assert.false($target3.hasClass('collapsed'), 'active target 3 does not have class "collapsed"')
 
         done()
       })
@@ -336,9 +340,9 @@ $(function () {
     $('<div id="body3" data-parent=".accordion"/>')
       .appendTo($groups.eq(2))
       .on('shown.bs.collapse', function () {
-        assert.ok($target1.hasClass('collapsed'), 'inactive target 1 does have class "collapsed"')
-        assert.ok($target2.hasClass('collapsed'), 'inactive target 2 does have class "collapsed"')
-        assert.ok(!$target3.hasClass('collapsed'), 'active target 3 does not have class "collapsed"')
+        assert.true($target1.hasClass('collapsed'), 'inactive target 1 does have class "collapsed"')
+        assert.true($target2.hasClass('collapsed'), 'inactive target 2 does have class "collapsed"')
+        assert.false($target3.hasClass('collapsed'), 'active target 3 does not have class "collapsed"')
 
         done()
       })
@@ -479,7 +483,7 @@ $(function () {
     $target1.trigger('click')
 
     setTimeout(function () {
-      assert.ok(!showFired, 'show event did not fire')
+      assert.false(showFired, 'show event did not fire')
       done()
     }, 1)
   })
@@ -493,7 +497,7 @@ $(function () {
     $('<div id="test1" class="show"/>')
       .appendTo('#qunit-fixture')
       .on('hidden.bs.collapse', function () {
-        assert.ok($target.hasClass('collapsed'))
+        assert.true($target.hasClass('collapsed'))
         done()
       })
       .bootstrapCollapse('hide')
@@ -508,7 +512,7 @@ $(function () {
     $('<div id="test1"/>')
       .appendTo('#qunit-fixture')
       .on('shown.bs.collapse', function () {
-        assert.ok(!$target.hasClass('collapsed'))
+        assert.false($target.hasClass('collapsed'))
         done()
       })
       .bootstrapCollapse('show')
@@ -534,11 +538,11 @@ $(function () {
     var $collapseOne = $('#collapseOne')
     var $collapseTwo = $('#collapseTwo')
     $collapseOne.on('shown.bs.collapse', function () {
-      assert.ok($collapseOne.hasClass('show'), '#collapseOne is shown')
-      assert.ok(!$collapseTwo.hasClass('show'), '#collapseTwo is not shown')
+      assert.true($collapseOne.hasClass('show'), '#collapseOne is shown')
+      assert.false($collapseTwo.hasClass('show'), '#collapseTwo is not shown')
       $collapseTwo.on('shown.bs.collapse', function () {
-        assert.ok(!$collapseOne.hasClass('show'), '#collapseOne is not shown')
-        assert.ok($collapseTwo.hasClass('show'), '#collapseTwo is shown')
+        assert.false($collapseOne.hasClass('show'), '#collapseOne is not shown')
+        assert.true($collapseTwo.hasClass('show'), '#collapseTwo is shown')
         done()
       })
       $triggerTwo.trigger($.Event('click'))
@@ -572,11 +576,11 @@ $(function () {
     var $collapseOne = $('#collapseOne')
     var $collapseTwo = $('#collapseTwo')
     $collapseOne.on('shown.bs.collapse', function () {
-      assert.ok($collapseOne.hasClass('show'), '#collapseOne is shown')
-      assert.ok(!$collapseTwo.hasClass('show'), '#collapseTwo is not shown')
+      assert.true($collapseOne.hasClass('show'), '#collapseOne is shown')
+      assert.false($collapseTwo.hasClass('show'), '#collapseTwo is not shown')
       $collapseTwo.on('shown.bs.collapse', function () {
-        assert.ok(!$collapseOne.hasClass('show'), '#collapseOne is not shown')
-        assert.ok($collapseTwo.hasClass('show'), '#collapseTwo is shown')
+        assert.false($collapseOne.hasClass('show'), '#collapseOne is not shown')
+        assert.true($collapseTwo.hasClass('show'), '#collapseTwo is shown')
         done()
       })
       $triggerTwo.trigger($.Event('click'))
@@ -609,18 +613,18 @@ $(function () {
     }
 
     function firstTest() {
-      assert.ok($collapseOneOne.hasClass('show'), '#collapseOneOne is shown')
-      assert.ok($collapseOneTwo.hasClass('show'), '#collapseOneTwo is shown')
-      assert.ok(!$collapseTwoOne.hasClass('show'), '#collapseTwoOne is not shown')
-      assert.ok(!$collapseTwoTwo.hasClass('show'), '#collapseTwoTwo is not shown')
+      assert.true($collapseOneOne.hasClass('show'), '#collapseOneOne is shown')
+      assert.true($collapseOneTwo.hasClass('show'), '#collapseOneTwo is shown')
+      assert.false($collapseTwoOne.hasClass('show'), '#collapseTwoOne is not shown')
+      assert.false($collapseTwoTwo.hasClass('show'), '#collapseTwoTwo is not shown')
       $triggerTwo.trigger($.Event('click'))
     }
 
     function secondTest() {
-      assert.ok(!$collapseOneOne.hasClass('show'), '#collapseOneOne is not shown')
-      assert.ok(!$collapseOneTwo.hasClass('show'), '#collapseOneTwo is not shown')
-      assert.ok($collapseTwoOne.hasClass('show'), '#collapseTwoOne is shown')
-      assert.ok($collapseTwoTwo.hasClass('show'), '#collapseTwoTwo is shown')
+      assert.false($collapseOneOne.hasClass('show'), '#collapseOneOne is not shown')
+      assert.false($collapseOneTwo.hasClass('show'), '#collapseOneTwo is not shown')
+      assert.true($collapseTwoOne.hasClass('show'), '#collapseTwoOne is shown')
+      assert.true($collapseTwoTwo.hasClass('show'), '#collapseTwoTwo is shown')
       done()
     }
 
@@ -688,17 +692,17 @@ $(function () {
     var $nestedCollapseOne = $('#nestedCollapseOne')
 
     $collapseOne.one('shown.bs.collapse', function () {
-      assert.ok($collapseOne.hasClass('show'), '#collapseOne is shown')
-      assert.ok(!$collapseTwo.hasClass('show'), '#collapseTwo is not shown')
-      assert.ok(!$('#nestedCollapseOne').hasClass('show'), '#nestedCollapseOne is not shown')
+      assert.true($collapseOne.hasClass('show'), '#collapseOne is shown')
+      assert.false($collapseTwo.hasClass('show'), '#collapseTwo is not shown')
+      assert.false($('#nestedCollapseOne').hasClass('show'), '#nestedCollapseOne is not shown')
       $nestedCollapseOne.one('shown.bs.collapse', function () {
-        assert.ok($collapseOne.hasClass('show'), '#collapseOne is shown')
-        assert.ok(!$collapseTwo.hasClass('show'), '#collapseTwo is not shown')
-        assert.ok($nestedCollapseOne.hasClass('show'), '#nestedCollapseOne is shown')
+        assert.true($collapseOne.hasClass('show'), '#collapseOne is shown')
+        assert.false($collapseTwo.hasClass('show'), '#collapseTwo is not shown')
+        assert.true($nestedCollapseOne.hasClass('show'), '#nestedCollapseOne is shown')
         $collapseTwo.one('shown.bs.collapse', function () {
-          assert.ok(!$collapseOne.hasClass('show'), '#collapseOne is not shown')
-          assert.ok($collapseTwo.hasClass('show'), '#collapseTwo is shown')
-          assert.ok($nestedCollapseOne.hasClass('show'), '#nestedCollapseOne is shown')
+          assert.false($collapseOne.hasClass('show'), '#collapseOne is not shown')
+          assert.true($collapseTwo.hasClass('show'), '#collapseTwo is shown')
+          assert.true($nestedCollapseOne.hasClass('show'), '#nestedCollapseOne is shown')
           done()
         })
         $triggerTwo.trigger($.Event('click'))
@@ -716,9 +720,9 @@ $(function () {
     $('<div id="collapsediv1"/>')
       .appendTo('#qunit-fixture')
       .on('shown.bs.collapse', function () {
-        assert.ok($(this).hasClass('show'))
-        assert.ok($target.attr('aria-expanded') === 'true')
-        assert.ok($target.prop('checked'))
+        assert.true($(this).hasClass('show'))
+        assert.strictEqual($target.attr('aria-expanded'), 'true')
+        assert.true($target.prop('checked'))
         done()
       })
 
@@ -737,17 +741,17 @@ $(function () {
     var $target2 = $('<div id="test2" class="multi"/>').appendTo('#qunit-fixture')
 
     $target2.one('shown.bs.collapse', function () {
-      assert.ok(!$trigger1.hasClass('collapsed'), 'trigger1 does not have collapsed class')
-      assert.ok(!$trigger2.hasClass('collapsed'), 'trigger2 does not have collapsed class')
-      assert.ok(!$trigger3.hasClass('collapsed'), 'trigger3 does not have collapsed class')
+      assert.false($trigger1.hasClass('collapsed'), 'trigger1 does not have collapsed class')
+      assert.false($trigger2.hasClass('collapsed'), 'trigger2 does not have collapsed class')
+      assert.false($trigger3.hasClass('collapsed'), 'trigger3 does not have collapsed class')
       $target2.one('hidden.bs.collapse', function () {
-        assert.ok(!$trigger1.hasClass('collapsed'), 'trigger1 does not have collapsed class')
-        assert.ok($trigger2.hasClass('collapsed'), 'trigger2 has collapsed class')
-        assert.ok(!$trigger3.hasClass('collapsed'), 'trigger3 does not have collapsed class')
+        assert.false($trigger1.hasClass('collapsed'), 'trigger1 does not have collapsed class')
+        assert.true($trigger2.hasClass('collapsed'), 'trigger2 has collapsed class')
+        assert.false($trigger3.hasClass('collapsed'), 'trigger3 does not have collapsed class')
         $target1.one('hidden.bs.collapse', function () {
-          assert.ok($trigger1.hasClass('collapsed'), 'trigger1 has collapsed class')
-          assert.ok($trigger2.hasClass('collapsed'), 'trigger2 has collapsed class')
-          assert.ok($trigger3.hasClass('collapsed'), 'trigger3 has collapsed class')
+          assert.true($trigger1.hasClass('collapsed'), 'trigger1 has collapsed class')
+          assert.true($trigger2.hasClass('collapsed'), 'trigger2 has collapsed class')
+          assert.true($trigger3.hasClass('collapsed'), 'trigger3 has collapsed class')
           done()
         })
         $trigger1.trigger('click')
@@ -802,11 +806,11 @@ $(function () {
     $(htmlCollapse)
       .appendTo('#qunit-fixture')
       .on('shown.bs.collapse', function () {
-        assert.ok($target.prop('checked'), '$trigger is checked')
+        assert.true($target.prop('checked'), '$trigger is checked')
         var $testCheckbox = $('#testCheckbox')
         $testCheckbox.trigger($.Event('click'))
         setTimeout(function () {
-          assert.ok($testCheckbox.prop('checked'), '$testCheckbox is checked too')
+          assert.true($testCheckbox.prop('checked'), '$testCheckbox is checked too')
           done()
         }, 5)
       })
@@ -882,8 +886,8 @@ $(function () {
     })
 
     $collapse2.on('shown.bs.collapse', function () {
-      assert.ok($collapse2.hasClass('show'))
-      assert.ok(!$('#collapse1').hasClass('show'))
+      assert.true($collapse2.hasClass('show'))
+      assert.false($('#collapse1').hasClass('show'))
       done()
     })
 

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -1227,7 +1227,7 @@ $(function () {
   })
 
   QUnit.test('should show dropdown', function (assert) {
-    assert.expect(2)
+    assert.expect(3)
 
     var dropdownHTML =
       '<div class="dropdown">' +
@@ -1248,6 +1248,7 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('show.bs.dropdown', function () {
+        assert.strictEqual(dropdown._popper, null)
         assert.ok(true, 'show was fired')
       })
       .on('shown.bs.dropdown', function () {
@@ -1333,39 +1334,6 @@ $(function () {
     var dropdown = $dropdown.data('bs.dropdown')
     dropdown.hide()
     assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is still hidden')
-  })
-
-  QUnit.test('should show dropdown', function (assert) {
-    assert.expect(3)
-
-    var dropdownHTML =
-      '<div class="dropdown">' +
-      '  <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown</a>' +
-      '  <div class="dropdown-menu">' +
-      '    <a class="dropdown-item" href="#">Another link</a>' +
-      '  </div>' +
-      '</div>'
-
-    var $dropdown = $(dropdownHTML)
-      .appendTo('#qunit-fixture')
-      .find('[data-toggle="dropdown"]')
-      .bootstrapDropdown()
-
-    var dropdown = $dropdown.data('bs.dropdown')
-    var done = assert.async()
-
-    $dropdown
-      .parent('.dropdown')
-      .on('show.bs.dropdown', function () {
-        assert.strictEqual(dropdown._popper, null)
-        assert.ok(true, 'show was fired')
-      })
-      .on('shown.bs.dropdown', function () {
-        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
-        done()
-      })
-
-    dropdown.show()
   })
 
   QUnit.test('should prevent default event on show method call', function (assert) {

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -40,7 +40,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $dropdown = $el.bootstrapDropdown()
-    assert.ok($dropdown instanceof $, 'returns jquery collection')
+    assert.true($dropdown instanceof $, 'returns jquery collection')
     assert.strictEqual($dropdown[0], $el[0], 'collection contains element')
   })
 
@@ -61,7 +61,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.on('click', function () {
-      assert.ok(!$dropdown.parent('.dropdown').hasClass('show'))
+      assert.false($dropdown.parent('.dropdown').hasClass('show'))
       done()
     })
     $dropdown.trigger($.Event('click'))
@@ -88,7 +88,7 @@ $(function () {
     $button.trigger('focus').trigger($.Event('keydown', {
       which: 27
     }))
-    assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown after escape pressed')
+    assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown after escape pressed')
     done()
   })
 
@@ -108,7 +108,7 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('position-static'), '"position-static" class not added')
+        assert.false($dropdown.parent('.dropdown').hasClass('position-static'), '"position-static" class not added')
         done()
       })
     $dropdown.trigger('click')
@@ -130,7 +130,7 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('position-static'), '"position-static" class added')
+        assert.true($dropdown.parent('.dropdown').hasClass('position-static'), '"position-static" class added')
         done()
       })
     $dropdown.trigger('click')
@@ -211,7 +211,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.on('click', function () {
-      assert.ok(!$dropdown.parent('.dropdown').hasClass('show'))
+      assert.false($dropdown.parent('.dropdown').hasClass('show'))
       done()
     })
     $dropdown.trigger($.Event('click'))
@@ -235,7 +235,7 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
         done()
       })
     $dropdown.trigger('click')
@@ -263,10 +263,10 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
         $(document.body).trigger('click')
       }).on('hidden.bs.dropdown', function () {
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), '"show" class removed')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), '"show" class removed')
         done()
       })
     $dropdown.trigger('click')
@@ -293,12 +293,12 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), '"show" class added on click')
         var e = $.Event('keyup')
         e.which = 9 // Tab
         $(document.body).trigger(e)
       }).on('hidden.bs.dropdown', function () {
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), '"show" class removed')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), '"show" class removed')
         done()
       })
     $dropdown.trigger('click')
@@ -520,10 +520,10 @@ $(function () {
 
     $dropdown.parent('.dropdown')
       .on('hide.bs.dropdown', function (e) {
-        assert.ok(e.clickEvent)
+        assert.notStrictEqual(e.clickEvent, 'undefined')
       })
       .on('hidden.bs.dropdown', function (e) {
-        assert.ok(e.clickEvent)
+        assert.notStrictEqual(e.clickEvent, 'undefined')
       })
       .on('shown.bs.dropdown', function () {
         assert.ok(true, 'shown was fired')
@@ -553,10 +553,10 @@ $(function () {
 
     $dropdown.parent('.dropdown')
       .on('hide.bs.dropdown', function (e) {
-        assert.notOk(e.clickEvent)
+        assert.strictEqual(typeof e.clickEvent, 'undefined')
       })
       .on('hidden.bs.dropdown', function (e) {
-        assert.notOk(e.clickEvent)
+        assert.strictEqual(typeof e.clickEvent, 'undefined')
       })
       .on('shown.bs.dropdown', function () {
         assert.ok(true, 'shown was fired')
@@ -601,12 +601,12 @@ $(function () {
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 38
         }))
-        assert.ok($(document.activeElement).is($input), 'input still focused')
+        assert.true($(document.activeElement).is($input), 'input still focused')
 
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 38
         }))
-        assert.ok($(document.activeElement).is($textarea), 'textarea still focused')
+        assert.true($(document.activeElement).is($textarea), 'textarea still focused')
 
         done()
       })
@@ -642,8 +642,8 @@ $(function () {
         $dropdown.trigger($.Event('keydown', {
           which: 40
         }))
-        assert.ok(!$(document.activeElement).is('.disabled'), '.disabled is not focused')
-        assert.ok(!$(document.activeElement).is(':disabled'), ':disabled is not focused')
+        assert.false($(document.activeElement).is('.disabled'), '.disabled is not focused')
+        assert.false($(document.activeElement).is(':disabled'), ':disabled is not focused')
         done()
       })
     $dropdown.trigger('click')
@@ -673,17 +673,17 @@ $(function () {
         $dropdown.trigger($.Event('keydown', {
           which: 40
         }))
-        assert.ok($(document.activeElement).is($('#item1')), 'item1 is focused')
+        assert.true($(document.activeElement).is($('#item1')), 'item1 is focused')
 
         $(document.activeElement).trigger($.Event('keydown', {
           which: 40
         }))
-        assert.ok($(document.activeElement).is($('#item2')), 'item2 is focused')
+        assert.true($(document.activeElement).is($('#item2')), 'item2 is focused')
 
         $(document.activeElement).trigger($.Event('keydown', {
           which: 38
         }))
-        assert.ok($(document.activeElement).is($('#item1')), 'item1 is focused')
+        assert.true($(document.activeElement).is($('#item1')), 'item1 is focused')
         done()
       })
     $dropdown.trigger('click')
@@ -705,14 +705,14 @@ $(function () {
 
     var $textfield = $('#textField')
     $textfield.on('click', function () {
-      assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+      assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
       done()
     })
 
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
         $textfield.trigger($.Event('click'))
       })
     $dropdown.trigger('click')
@@ -734,14 +734,14 @@ $(function () {
 
     var $textarea = $('#textArea')
     $textarea.on('click', function () {
-      assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+      assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
       done()
     })
 
     $dropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
         $textarea.trigger($.Event('click'))
       })
     $dropdown.trigger('click')
@@ -770,7 +770,7 @@ $(function () {
     $triggerDropdown
       .parent('.dropdown')
       .on('shown.bs.dropdown', function () {
-        assert.ok(typeof $dropdownMenu.attr('style') === 'undefined', 'No inline style applied by Popper')
+        assert.strictEqual(typeof $dropdownMenu.attr('style'), 'undefined', 'No inline style applied by Popper')
         done()
       })
     $triggerDropdown.trigger($.Event('click'))
@@ -800,15 +800,15 @@ $(function () {
       .on('shown.bs.dropdown', function () {
         // Forcibly focus first item
         $item[0].focus()
-        assert.ok($(document.activeElement)[0] === $item[0], 'menu item initial focus set')
+        assert.strictEqual($(document.activeElement)[0], $item[0], 'menu item initial focus set')
 
         // Key escape
         $item.trigger('focus').trigger($.Event('keydown', {
           which: 27
         }))
 
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu was closed after escape')
-        assert.ok($(document.activeElement)[0] === $toggle[0], 'toggle has focus again once menu was closed after escape')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu was closed after escape')
+        assert.strictEqual($(document.activeElement)[0], $toggle[0], 'toggle has focus again once menu was closed after escape')
         done()
       })
 
@@ -847,37 +847,37 @@ $(function () {
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 32
         }))
-        assert.ok($(document.activeElement)[0] === $input[0], 'input still focused')
+        assert.strictEqual($(document.activeElement)[0], $input[0], 'input still focused')
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 32
         }))
-        assert.ok($(document.activeElement)[0] === $textarea[0], 'textarea still focused')
+        assert.strictEqual($(document.activeElement)[0], $textarea[0], 'textarea still focused')
 
         // Key up
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 38
         }))
-        assert.ok($(document.activeElement)[0] === $input[0], 'input still focused')
+        assert.strictEqual($(document.activeElement)[0], $input[0], 'input still focused')
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 38
         }))
-        assert.ok($(document.activeElement)[0] === $textarea[0], 'textarea still focused')
+        assert.strictEqual($(document.activeElement)[0], $textarea[0], 'textarea still focused')
 
         // Key down
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 40
         }))
-        assert.ok($(document.activeElement)[0] === $input[0], 'input still focused')
+        assert.strictEqual($(document.activeElement)[0], $input[0], 'input still focused')
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 40
         }))
-        assert.ok($(document.activeElement)[0] === $textarea[0], 'textarea still focused')
+        assert.strictEqual($(document.activeElement)[0], $textarea[0], 'textarea still focused')
 
         // Key escape
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 27
         }))
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
         done()
       })
 
@@ -917,14 +917,14 @@ $(function () {
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 32
         }))
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
-        assert.ok($(document.activeElement).is($input), 'input is still focused')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($(document.activeElement).is($input), 'input is still focused')
 
         // Key escape
         $input.trigger('focus').trigger($.Event('keydown', {
           which: 27
         }))
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
 
         $dropdown
           .parent('.dropdown')
@@ -933,7 +933,7 @@ $(function () {
             $input.trigger('focus').trigger($.Event('keydown', {
               which: 40
             }))
-            assert.ok(document.activeElement === $('#item1')[0], 'item1 is focused')
+            assert.strictEqual(document.activeElement, $('#item1')[0], 'item1 is focused')
 
             $dropdown
               .parent('.dropdown')
@@ -942,7 +942,7 @@ $(function () {
                 $input.trigger('focus').trigger($.Event('keydown', {
                   which: 38
                 }))
-                assert.ok(document.activeElement === $('#item1')[0], 'item1 is focused')
+                assert.strictEqual(document.activeElement, $('#item1')[0], 'item1 is focused')
                 done()
               }).bootstrapDropdown('toggle')
             $input.trigger('click')
@@ -985,14 +985,14 @@ $(function () {
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 32
         }))
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
-        assert.ok($(document.activeElement).is($textarea), 'textarea is still focused')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($(document.activeElement).is($textarea), 'textarea is still focused')
 
         // Key escape
         $textarea.trigger('focus').trigger($.Event('keydown', {
           which: 27
         }))
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is not shown')
 
         $dropdown
           .parent('.dropdown')
@@ -1001,7 +1001,7 @@ $(function () {
             $textarea.trigger('focus').trigger($.Event('keydown', {
               which: 40
             }))
-            assert.ok(document.activeElement === $('#item1')[0], 'item1 is focused')
+            assert.strictEqual(document.activeElement, $('#item1')[0], 'item1 is focused')
 
             $dropdown
               .parent('.dropdown')
@@ -1010,7 +1010,7 @@ $(function () {
                 $textarea.trigger('focus').trigger($.Event('keydown', {
                   which: 38
                 }))
-                assert.ok(document.activeElement === $('#item1')[0], 'item1 is focused')
+                assert.strictEqual(document.activeElement, $('#item1')[0], 'item1 is focused')
                 done()
               }).bootstrapDropdown('toggle')
             $textarea.trigger('click')
@@ -1048,7 +1048,7 @@ $(function () {
       which: 27
     }))
 
-    assert.ok($body.hasClass('event-handled'), 'ESC key event was propagated')
+    assert.true($body.hasClass('event-handled'), 'ESC key event was propagated')
     done()
   })
 
@@ -1080,7 +1080,7 @@ $(function () {
       which: 27
     }))
 
-    assert.ok($body.hasClass('event-handled'), 'ESC key event was propagated')
+    assert.true($body.hasClass('event-handled'), 'ESC key event was propagated')
     done()
   })
 
@@ -1132,14 +1132,14 @@ $(function () {
 
     var dropdown = $dropdown.data('bs.dropdown')
     dropdown.toggle()
-    assert.ok(dropdown._popper)
+    assert.notStrictEqual(dropdown._popper, null)
 
     var spyPopper = sinon.spy(dropdown._popper, 'scheduleUpdate')
     var spyDetectNavbar = sinon.spy(dropdown, '_detectNavbar')
     dropdown.update()
 
-    assert.ok(spyPopper.called)
-    assert.ok(spyDetectNavbar.called)
+    assert.true(spyPopper.called)
+    assert.true(spyDetectNavbar.called)
   })
 
   QUnit.test('should just detect navbar on update', function (assert) {
@@ -1163,8 +1163,8 @@ $(function () {
 
     dropdown.update()
 
-    assert.notOk(dropdown._popper)
-    assert.ok(spyDetectNavbar.called)
+    assert.strictEqual(dropdown._popper, null)
+    assert.true(spyDetectNavbar.called)
   })
 
   QUnit.test('should dispose dropdown with Popper', function (assert) {
@@ -1186,16 +1186,16 @@ $(function () {
     var dropdown = $dropdown.data('bs.dropdown')
     dropdown.toggle()
 
-    assert.ok(dropdown._popper)
-    assert.ok(dropdown._menu !== null)
-    assert.ok(dropdown._element !== null)
+    assert.notStrictEqual(dropdown._popper, null)
+    assert.notStrictEqual(dropdown._menu, null)
+    assert.notStrictEqual(dropdown._element, null)
     var spyDestroy = sinon.spy(dropdown._popper, 'destroy')
 
     dropdown.dispose()
 
-    assert.ok(spyDestroy.called)
-    assert.ok(dropdown._menu === null)
-    assert.ok(dropdown._element === null)
+    assert.true(spyDestroy.called)
+    assert.strictEqual(dropdown._menu, null)
+    assert.strictEqual(dropdown._element, null)
   })
 
   QUnit.test('should dispose dropdown', function (assert) {
@@ -1216,14 +1216,14 @@ $(function () {
 
     var dropdown = $dropdown.data('bs.dropdown')
 
-    assert.notOk(dropdown._popper)
-    assert.ok(dropdown._menu !== null)
-    assert.ok(dropdown._element !== null)
+    assert.strictEqual(dropdown._popper, null)
+    assert.notStrictEqual(dropdown._menu, null)
+    assert.notStrictEqual(dropdown._element, null)
 
     dropdown.dispose()
 
-    assert.ok(dropdown._menu === null)
-    assert.ok(dropdown._element === null)
+    assert.strictEqual(dropdown._menu, null)
+    assert.strictEqual(dropdown._element, null)
   })
 
   QUnit.test('should show dropdown', function (assert) {
@@ -1251,7 +1251,7 @@ $(function () {
         assert.ok(true, 'show was fired')
       })
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
         done()
       })
 
@@ -1284,7 +1284,7 @@ $(function () {
         assert.ok(true, 'hide was fired')
       })
       .on('hidden.bs.dropdown', function () {
-        assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is hidden')
+        assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is hidden')
         done()
       })
 
@@ -1311,7 +1311,7 @@ $(function () {
     $dropdown.trigger('click')
     dropdown.show()
 
-    assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is still shown')
+    assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is still shown')
   })
 
   QUnit.test('should not show dropdown', function (assert) {
@@ -1332,7 +1332,7 @@ $(function () {
 
     var dropdown = $dropdown.data('bs.dropdown')
     dropdown.hide()
-    assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is still hidden')
+    assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is still hidden')
   })
 
   QUnit.test('should show dropdown', function (assert) {
@@ -1357,11 +1357,11 @@ $(function () {
     $dropdown
       .parent('.dropdown')
       .on('show.bs.dropdown', function () {
-        assert.ok(dropdown._popper === null)
+        assert.strictEqual(dropdown._popper, null)
         assert.ok(true, 'show was fired')
       })
       .on('shown.bs.dropdown', function () {
-        assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+        assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
         done()
       })
 
@@ -1395,7 +1395,7 @@ $(function () {
       })
 
     dropdown.show()
-    assert.ok(!$dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is hidden')
+    assert.false($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is hidden')
   })
 
   QUnit.test('should prevent default event on hide method call', function (assert) {
@@ -1426,7 +1426,7 @@ $(function () {
       })
 
     dropdown.hide()
-    assert.ok($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
+    assert.true($dropdown.parent('.dropdown').hasClass('show'), 'dropdown menu is shown')
   })
 
   QUnit.test('should not open dropdown via show method if target is disabled via attribute', function (assert) {
@@ -1441,7 +1441,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.show()
-    assert.ok(!$dropdown.parent('.dropdown').hasClass('show'))
+    assert.false($dropdown.parent('.dropdown').hasClass('show'))
   })
 
   QUnit.test('should not open dropdown via show method if target is disabled via class', function (assert) {
@@ -1457,7 +1457,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.show()
-    assert.ok(!$dropdown.parent('.dropdown').hasClass('show'))
+    assert.false($dropdown.parent('.dropdown').hasClass('show'))
   })
 
   QUnit.test('should not hide dropdown via hide method if target is disabled via attribute', function (assert) {
@@ -1472,7 +1472,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.hide()
-    assert.ok($dropdown.parent('.dropdown').hasClass('show'))
+    assert.true($dropdown.parent('.dropdown').hasClass('show'))
   })
 
   QUnit.test('should not hide dropdown via hide method if target is disabled via class', function (assert) {
@@ -1488,7 +1488,7 @@ $(function () {
     $(dropdownHTML).appendTo('#qunit-fixture')
     var $dropdown = $('#qunit-fixture').find('[data-toggle="dropdown"]').bootstrapDropdown()
     $dropdown.hide()
-    assert.ok($dropdown.parent('.dropdown').hasClass('show'))
+    assert.true($dropdown.parent('.dropdown').hasClass('show'))
   })
 
   QUnit.test('should create offset modifier correctly when offset option is a function', function (assert) {
@@ -1516,8 +1516,8 @@ $(function () {
     var dropdown = $dropdown.data('bs.dropdown')
     var offset = dropdown._getOffset()
 
-    assert.ok(typeof offset.offset === 'undefined')
-    assert.ok(typeof offset.fn === 'function')
+    assert.strictEqual(typeof offset.offset, 'undefined')
+    assert.strictEqual(typeof offset.fn, 'function')
   })
 
   QUnit.test('should create offset modifier correctly when offset option is not a function', function (assert) {
@@ -1543,7 +1543,7 @@ $(function () {
     var offset = dropdown._getOffset()
 
     assert.strictEqual(offset.offset, myOffset)
-    assert.ok(typeof offset.fn === 'undefined')
+    assert.strictEqual(typeof offset.fn, 'undefined')
   })
 
   QUnit.test('should allow to pass config to Popper with `popperConfig`', function (assert) {
@@ -1602,14 +1602,14 @@ $(function () {
     var spyPopper
 
     $firstDropdownEl.one('shown.bs.dropdown', function () {
-      assert.strictEqual($firstDropdownEl.hasClass('show'), true)
+      assert.true($firstDropdownEl.hasClass('show'))
       spyPopper = sinon.spy(dropdown1._popper, 'destroy')
       dropdown2.toggle()
     })
 
     $secondDropdownEl.one('shown.bs.dropdown', function () {
-      assert.strictEqual($secondDropdownEl.hasClass('show'), true)
-      assert.ok(spyPopper.called)
+      assert.true($secondDropdownEl.hasClass('show'))
+      assert.true(spyPopper.called)
       done()
     })
 
@@ -1643,7 +1643,7 @@ $(function () {
     })
 
     $dropdownEl.one('hidden.bs.dropdown', function () {
-      assert.ok(spyPopper.called)
+      assert.true(spyPopper.called)
       done()
     })
 
@@ -1682,9 +1682,9 @@ $(function () {
         which: 40
       }))
 
-      assert.strictEqual($(document.activeElement).hasClass('d-none'), false, '.d-none not focused')
-      assert.strictEqual($(document.activeElement).css('display') === 'none', false, '"display: none" not focused')
-      assert.strictEqual(document.activeElement.style.visibility === 'hidden', false, '"visibility: hidden" not focused')
+      assert.false($(document.activeElement).hasClass('d-none'), '.d-none not focused')
+      assert.notStrictEqual($(document.activeElement).css('display'), 'none', '"display: none" not focused')
+      assert.notStrictEqual(document.activeElement.style.visibility, 'hidden', '"visibility: hidden" not focused')
       done()
     })
 

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -53,7 +53,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div id="modal-test"/>')
     var $modal = $el.bootstrapModal()
-    assert.ok($modal instanceof $, 'returns jquery collection')
+    assert.true($modal instanceof $, 'returns jquery collection')
     assert.strictEqual($modal[0], $el[0], 'collection contains element')
   })
 
@@ -121,8 +121,8 @@ $(function () {
         }
       })
       .on('shown.bs.modal', function () {
-        assert.ok(prevented, 'show prevented')
-        assert.ok($el.hasClass('fade'))
+        assert.true(prevented, 'show prevented')
+        assert.true($el.hasClass('fade'))
         done()
       })
       .bootstrapModal('show')
@@ -134,12 +134,12 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
         $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         done()
       })
       .bootstrapModal('show')
@@ -151,12 +151,12 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
         $(this).bootstrapModal('toggle')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         done()
       })
       .bootstrapModal('toggle')
@@ -168,12 +168,12 @@ $(function () {
 
     $('<div id="modal-test"><span class="close" data-dismiss="modal"/></div>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
         $(this).find('.close').trigger('click')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         done()
       })
       .bootstrapModal('toggle')
@@ -185,11 +185,11 @@ $(function () {
 
     $('<div id="modal-test" data-backdrop="false"/>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         done()
       })
       .bootstrapModal('show')
@@ -203,11 +203,11 @@ $(function () {
       .on('shown.bs.modal', function () {
         assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
         $('.contents').trigger('click')
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         $('#modal-test').trigger('click')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         done()
       })
       .bootstrapModal('show')
@@ -220,7 +220,7 @@ $(function () {
     $('<div id="modal-test" data-backdrop="false"><div class="contents"/></div>')
       .on('shown.bs.modal', function () {
         $('#modal-test').trigger('click')
-        assert.ok($('#modal-test').is(':visible'), 'modal not hidden')
+        assert.true($('#modal-test').is(':visible'), 'modal not hidden')
         done()
       })
       .bootstrapModal('show')
@@ -233,14 +233,14 @@ $(function () {
     var $div = $('<div id="modal-test"/>')
     $div
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').length, 'modal inserted into dom')
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         $div.trigger($.Event('keydown', {
           which: 27
         }))
 
         setTimeout(function () {
-          assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+          assert.false($('#modal-test').is(':visible'), 'modal hidden')
           $div.remove()
           done()
         }, 0)
@@ -255,14 +255,14 @@ $(function () {
     var $div = $('<div id="modal-test"/>')
     $div
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').length, 'modal inserted into dom')
-        assert.ok($('#modal-test').is(':visible'), 'modal visible')
+        assert.notStrictEqual($('#modal-test').length, 0, 'modal inserted into dom')
+        assert.true($('#modal-test').is(':visible'), 'modal visible')
         $div.trigger($.Event('keyup', {
           which: 27
         }))
 
         setTimeout(function () {
-          assert.ok($div.is(':visible'), 'modal still visible')
+          assert.true($div.is(':visible'), 'modal still visible')
           $div.remove()
           done()
         }, 0)
@@ -295,11 +295,11 @@ $(function () {
 
     $('<div id="modal-test" aria-hidden="true"/>')
       .on('shown.bs.modal', function () {
-        assert.notOk($('#modal-test').is('[aria-hidden]'), 'aria-hidden attribute removed')
+        assert.false($('#modal-test').is('[aria-hidden]'), 'aria-hidden attribute removed')
         $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
-        assert.ok($('#modal-test').is('[aria-hidden]'), 'aria-hidden attribute added')
+        assert.true($('#modal-test').is('[aria-hidden]'), 'aria-hidden attribute added')
         assert.strictEqual($('#modal-test').attr('aria-hidden'), 'true', 'correct aria-hidden="true" added')
         done()
       })
@@ -312,12 +312,12 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is('[aria-modal]'), 'aria-modal attribute added')
+        assert.true($('#modal-test').is('[aria-modal]'), 'aria-modal attribute added')
         assert.strictEqual($('#modal-test').attr('aria-modal'), 'true', 'correct aria-modal="true" added')
         $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
-        assert.notOk($('#modal-test').is('[aria-modal]'), 'aria-modal attribute removed')
+        assert.false($('#modal-test').is('[aria-modal]'), 'aria-modal attribute removed')
         done()
       })
       .bootstrapModal('show')
@@ -329,12 +329,12 @@ $(function () {
 
     $('<div id="modal-test"/>')
       .on('shown.bs.modal', function () {
-        assert.ok($('#modal-test').is('[role]'), 'role attribute added')
+        assert.true($('#modal-test').is('[role]'), 'role attribute added')
         assert.strictEqual($('#modal-test').attr('role'), 'dialog', 'correct role="dialog" added')
         $(this).bootstrapModal('hide')
       })
       .on('hidden.bs.modal', function () {
-        assert.notOk($('#modal-test').is('[role]'), 'role attribute removed')
+        assert.false($('#modal-test').is('[role]'), 'role attribute removed')
         done()
       })
       .bootstrapModal('show')
@@ -350,13 +350,13 @@ $(function () {
       })
       .one('hidden.bs.modal', function () {
         // After one open-close cycle
-        assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+        assert.false($('#modal-test').is(':visible'), 'modal hidden')
         $(this)
           .one('shown.bs.modal', function () {
             $('#close').trigger('click')
           })
           .one('hidden.bs.modal', function () {
-            assert.ok(!$('#modal-test').is(':visible'), 'modal hidden')
+            assert.false($('#modal-test').is(':visible'), 'modal hidden')
             done()
           })
           .bootstrapModal('show')
@@ -373,7 +373,7 @@ $(function () {
     $('<div id="modal-test"><div class="contents"><div id="close" data-dismiss="modal"/></div></div>')
       .on('hidden.bs.modal', function () {
         setTimeout(function () {
-          assert.ok($(document.activeElement).is($toggleBtn), 'toggling element is once again focused')
+          assert.true($(document.activeElement).is($toggleBtn), 'toggling element is once again focused')
           done()
         }, 0)
       })
@@ -401,7 +401,7 @@ $(function () {
       })
       .on('hidden.bs.modal', function () {
         setTimeout(function () {
-          assert.ok($(document.activeElement).is($otherBtn), 'focus returned to toggling element')
+          assert.true($(document.activeElement).is($otherBtn), 'focus returned to toggling element')
           done()
         }, 0)
       })
@@ -648,10 +648,10 @@ $(function () {
 
     $('#test')
       .on('click.bs.modal.data-api', function (event) {
-        assert.notOk(event.isDefaultPrevented(), 'navigating to href will happen')
+        assert.false(event.isDefaultPrevented(), 'navigating to href will happen')
 
         setTimeout(function () {
-          assert.ok(event.isDefaultPrevented(), 'model shown instead of navigating to href')
+          assert.true(event.isDefaultPrevented(), 'model shown instead of navigating to href')
           done()
         }, 1)
       })
@@ -672,6 +672,7 @@ $(function () {
     }, 0)
   })
 
+  // eslint-disable-next-line qunit/resolve-async
   QUnit.test('should not execute js from target', function (assert) {
     assert.expect(0)
     var done = assert.async()
@@ -742,7 +743,7 @@ $(function () {
     var spy = sinon.spy(Util, 'getTransitionDurationFromElement')
 
     $modal.on('shown.bs.modal', function () {
-      assert.ok(spy.returned(expectedTransitionDuration))
+      assert.true(spy.returned(expectedTransitionDuration))
       $style.remove()
       spy.restore()
       done()
@@ -777,11 +778,11 @@ $(function () {
           }
         })
 
-      assert.ok(typeof $(this).data('bs.modal') === 'undefined', 'modal data object was disposed')
+      assert.strictEqual(typeof $(this).data('bs.modal'), 'undefined', 'modal data object was disposed')
 
-      assert.ok(spy.callCount === 4, '`jQuery.off` was called')
+      assert.strictEqual(spy.callCount, 4, '`jQuery.off` was called')
 
-      assert.ok(modalDataApiEvent.length === 1, '`Event.CLICK_DATA_API` on `document` was not removed')
+      assert.strictEqual(modalDataApiEvent.length, 1, '`Event.CLICK_DATA_API` on `document` was not removed')
 
       $.fn.off.restore()
       done()
@@ -849,7 +850,7 @@ $(function () {
     var spyDocOn = sinon.spy($(document), 'on')
 
     $modal.one('shown.bs.modal', function () {
-      assert.ok(spy.called, '_enforceFocus called')
+      assert.true(spy.called, '_enforceFocus called')
       assert.ok(spyDocOff.withArgs('focusin.bs.modal'))
       assert.ok(spyDocOn.withArgs('focusin.bs.modal'))
 
@@ -859,7 +860,7 @@ $(function () {
       })
 
       $(document).one('focusin', function () {
-        assert.ok(spyFocus.called)
+        assert.true(spyFocus.called)
         done()
       })
 
@@ -869,7 +870,7 @@ $(function () {
   })
 
   QUnit.test('should scroll to top of the modal body if the modal has .modal-dialog-scrollable class', function (assert) {
-    assert.expect(2)
+    assert.expect(3)
     var done = assert.async()
 
     var $modal = $([
@@ -886,7 +887,8 @@ $(function () {
 
     var $modalBody = $('.modal-body')
     $modalBody.scrollTop(100)
-    assert.ok($modalBody.scrollTop() > 95 && $modalBody.scrollTop() <= 100)
+    assert.true($modalBody.scrollTop() > 95)
+    assert.true($modalBody.scrollTop() <= 100)
 
     $modal.on('shown.bs.modal', function () {
       assert.strictEqual($modalBody.scrollTop(), 0, 'modal body scrollTop should be 0 when opened')
@@ -925,12 +927,12 @@ $(function () {
       setTimeout(function () {
         var modal = $modal.data('bs.modal')
 
-        assert.strictEqual(modal._isShown, true)
+        assert.true(modal._isShown)
         done()
       }, 10)
     })
       .on('hidden.bs.modal', function () {
-        assert.strictEqual(true, false, 'should not hide the modal')
+        assert.true(false, 'should not hide the modal')
       })
       .bootstrapModal({
         backdrop: 'static'
@@ -950,7 +952,7 @@ $(function () {
       setTimeout(function () {
         var modal = $modal.data('bs.modal')
 
-        assert.strictEqual(modal._isShown, false)
+        assert.false(modal._isShown)
         done()
       }, 10)
     })
@@ -973,12 +975,12 @@ $(function () {
       setTimeout(function () {
         var modal = $modal.data('bs.modal')
 
-        assert.strictEqual(modal._isShown, true)
+        assert.true(modal._isShown)
         done()
       }, 10)
     })
       .on('hidden.bs.modal', function () {
-        assert.strictEqual(false, true, 'should not hide the modal')
+        assert.false(true, 'should not hide the modal')
       })
       .bootstrapModal({
         keyboard: false
@@ -1010,7 +1012,7 @@ $(function () {
     $modal.on('shown.bs.modal', function () {
       $modal.trigger('click')
       setTimeout(function () {
-        assert.ok($modal.hasClass('modal-static'), 'has modal-static class')
+        assert.true($modal.hasClass('modal-static'), 'has modal-static class')
         done()
       }, 0)
     })
@@ -1032,7 +1034,7 @@ $(function () {
     $modal.on('shown.bs.modal', function () {
       $modal.trigger('click')
       setTimeout(function () {
-        assert.notOk($modal.hasClass('modal-static'), 'should not have modal-static class')
+        assert.false($modal.hasClass('modal-static'), 'should not have modal-static class')
         done()
       }, 0)
     })

--- a/js/tests/unit/popover.js
+++ b/js/tests/unit/popover.js
@@ -41,7 +41,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $popover = $el.bootstrapPopover()
-    assert.ok($popover instanceof $, 'returns jquery collection')
+    assert.true($popover instanceof $, 'returns jquery collection')
     assert.strictEqual($popover[0], $el[0], 'collection contains element')
   })
 
@@ -67,8 +67,8 @@ $(function () {
     $('<a href="#" title="mdo" data-content="https://twitter.com/mdo" data-custom-class="a b">@mdo</a>')
       .appendTo('#qunit-fixture')
       .on('shown.bs.popover', function () {
-        assert.strictEqual($('.popover').hasClass('popover fade bs-popover-right show'), true, 'has default classes')
-        assert.strictEqual($('.popover').hasClass('a b'), true, 'has custom classes')
+        assert.true($('.popover').hasClass('popover fade bs-popover-right show'), 'has default classes')
+        assert.true($('.popover').hasClass('a b'), 'has custom classes')
         done()
       })
       .bootstrapPopover('show')
@@ -157,9 +157,9 @@ $(function () {
 
     assert.notStrictEqual($('.popover').length, 0, 'popover inserted')
     assert.strictEqual($('.popover .popover-header').text(), '@glebm <3 writing tests', 'title inserted')
-    assert.ok(!$.contains($('.popover').get(0), title), 'title node copied, not moved')
+    assert.false($.contains($('.popover').get(0), title), 'title node copied, not moved')
     assert.strictEqual($('.popover .popover-body').html(), '¯\\_(ツ)_/¯', 'content inserted')
-    assert.ok(!$.contains($('.popover').get(0), content), 'content node copied, not moved')
+    assert.false($.contains($('.popover').get(0), content), 'content node copied, not moved')
   })
 
   QUnit.test('should not duplicate HTML object', function (assert) {
@@ -254,7 +254,7 @@ $(function () {
       })
       .one('shown.bs.popover', function () {
         assert.notStrictEqual($('.popover').length, 0, 'popover was inserted')
-        assert.ok($('.popover').hasClass('foobar'), 'custom class is present')
+        assert.true($('.popover').hasClass('foobar'), 'custom class is present')
         $popover.bootstrapPopover('hide')
       })
       .one('hidden.bs.popover', function () {
@@ -265,7 +265,7 @@ $(function () {
   })
 
   QUnit.test('should destroy popover', function (assert) {
-    assert.expect(7)
+    assert.expect(9)
     var $popover = $('<div/>')
       .bootstrapPopover({
         trigger: 'hover'
@@ -273,16 +273,18 @@ $(function () {
       .on('click.foo', $.noop)
 
     assert.ok($popover.data('bs.popover'), 'popover has data')
-    assert.ok($._data($popover[0], 'events').mouseover && $._data($popover[0], 'events').mouseout, 'popover has hover event')
+    assert.ok($._data($popover[0], 'events').mouseover, 'popover has mouseover event')
+    assert.ok($._data($popover[0], 'events').mouseout, 'popover has mouseout event')
     assert.strictEqual($._data($popover[0], 'events').click[0].namespace, 'foo', 'popover has extra click.foo event')
 
     $popover.bootstrapPopover('show')
     $popover.bootstrapPopover('dispose')
 
-    assert.ok(!$popover.hasClass('show'), 'popover is hidden')
-    assert.ok(!$popover.data('popover'), 'popover does not have data')
+    assert.false($popover.hasClass('show'), 'popover is hidden')
+    assert.strictEqual(typeof $popover.data('popover'), 'undefined', 'popover does not have data')
     assert.strictEqual($._data($popover[0], 'events').click[0].namespace, 'foo', 'popover still has click.foo')
-    assert.ok(!$._data($popover[0], 'events').mouseover && !$._data($popover[0], 'events').mouseout, 'popover does not have any events')
+    assert.strictEqual(typeof $._data($popover[0], 'events').mouseover, 'undefined', 'popover does not have mouseover event')
+    assert.strictEqual(typeof $._data($popover[0], 'events').mouseout, 'undefined', 'popover does not have mouseout event')
   })
 
   QUnit.test('should render popover element using delegated selector', function (assert) {
@@ -335,7 +337,7 @@ $(function () {
             $div
               .one('shown.bs.popover', function () {
                 $('.content-with-handler .btn').trigger('click')
-                assert.ok(handlerCalled, 'content\'s event handler still present')
+                assert.true(handlerCalled, 'content\'s event handler still present')
                 $div.bootstrapPopover('dispose')
                 done()
               })
@@ -448,14 +450,14 @@ $(function () {
         content: 'with disable/enable'
       })
       .on('shown.bs.popover', function () {
-        assert.strictEqual($('.popover').hasClass('show'), true)
+        assert.true($('.popover').hasClass('show'))
         done()
       })
 
     $popover.bootstrapPopover('disable')
     $popover.trigger($.Event('click'))
     setTimeout(function () {
-      assert.strictEqual($('.popover').length === 0, true)
+      assert.strictEqual($('.popover').length, 0)
       $popover.bootstrapPopover('enable')
       $popover.trigger($.Event('click'))
     }, 200)

--- a/js/tests/unit/scrollspy.js
+++ b/js/tests/unit/scrollspy.js
@@ -40,7 +40,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>').appendTo('#qunit-fixture')
     var $scrollspy = $el.bootstrapScrollspy()
-    assert.ok($scrollspy instanceof $, 'returns jquery collection')
+    assert.true($scrollspy instanceof $, 'returns jquery collection')
     assert.strictEqual($scrollspy[0], $el[0], 'collection contains element')
   })
 
@@ -84,7 +84,7 @@ $(function () {
       })
 
     $scrollspy.one('scroll', function () {
-      assert.ok($section.hasClass('active'), '"active" class still on root node')
+      assert.true($section.hasClass('active'), '"active" class still on root node')
       done()
     })
 
@@ -131,7 +131,7 @@ $(function () {
       })
 
     $scrollspy.one('scroll', function () {
-      assert.ok($section.hasClass('active'), '"active" class still on root node')
+      assert.true($section.hasClass('active'), '"active" class still on root node')
       done()
     })
 
@@ -179,7 +179,7 @@ $(function () {
       })
 
     $scrollspy.one('scroll', function () {
-      assert.ok($section.hasClass('active'), '"active" class still on root node')
+      assert.true($section.hasClass('active'), '"active" class still on root node')
       done()
     })
 
@@ -226,10 +226,10 @@ $(function () {
         target: $('.container')
       })
 
-    assert.ok($('.container').attr('id').length > 0, '`target` has an ID attribute')
+    assert.notStrictEqual($('.container').attr('id').length, 0, '`target` has an ID attribute')
 
     $scrollspy.one('scroll', function () {
-      assert.ok($section.hasClass('active'), '"active" class still on root node')
+      assert.true($section.hasClass('active'), '"active" class still on root node')
       done()
     })
 
@@ -264,9 +264,9 @@ $(function () {
     })
 
     $scrollspy.one('scroll', function () {
-      assert.ok(!$section.find('#one-link').hasClass('active'), '"active" class removed from first section')
-      assert.ok($section.find('#two-link').hasClass('active'), '"active" class on middle section')
-      assert.ok(!$section.find('#three-link').hasClass('active'), '"active" class not on last section')
+      assert.false($section.find('#one-link').hasClass('active'), '"active" class removed from first section')
+      assert.true($section.find('#two-link').hasClass('active'), '"active" class on middle section')
+      assert.false($section.find('#three-link').hasClass('active'), '"active" class not on last section')
       done()
     })
 
@@ -303,7 +303,7 @@ $(function () {
       var paddingTop = 5
       var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top) + paddingTop
       $content.one('scroll', function () {
-        assert.ok($(element).hasClass('active'), 'target:' + target + ', element' + element)
+        assert.true($(element).hasClass('active'), 'target:' + target + ', element' + element)
         deferred.resolve()
       })
       $content.scrollTop(scrollHeight)
@@ -349,7 +349,7 @@ $(function () {
       var paddingTop = 5
       var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top) + paddingTop
       $content.one('scroll', function () {
-        assert.ok($(element).hasClass('active'), 'target:' + target + ', element' + element)
+        assert.true($(element).hasClass('active'), 'target:' + target + ', element' + element)
         deferred.resolve()
       })
       $content.scrollTop(scrollHeight)
@@ -395,7 +395,7 @@ $(function () {
       var paddingTop = 5
       var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top) + paddingTop
       $content.one('scroll', function () {
-        assert.ok($(element).hasClass('active'), 'target:' + target + ', element' + element)
+        assert.true($(element).hasClass('active'), 'target:' + target + ', element' + element)
         deferred.resolve()
       })
       $content.scrollTop(scrollHeight)
@@ -446,8 +446,8 @@ $(function () {
       }
 
       $content.one('scroll', function () {
-        assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
-        assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
+        assert.true($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
+        assert.true($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
         testActiveElements()
       })
 
@@ -491,8 +491,8 @@ $(function () {
       }
 
       $content.one('scroll', function () {
-        assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
-        assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
+        assert.true($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
+        assert.true($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
         testActiveElements()
       })
 
@@ -536,8 +536,8 @@ $(function () {
       }
 
       $content.one('scroll', function () {
-        assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
-        assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
+        assert.true($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
+        assert.true($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
         testActiveElements()
       })
 
@@ -581,8 +581,8 @@ $(function () {
       }
 
       $content.one('scroll', function () {
-        assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
-        assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
+        assert.true($('#a-1').hasClass('active'), 'nav item for outer element has "active" class')
+        assert.true($('#a-2').hasClass('active'), 'nav item for inner element has "active" class')
         testActiveElements()
       })
 
@@ -622,7 +622,7 @@ $(function () {
       })
       .one('scroll', function () {
         assert.strictEqual($('.active').length, 1, '"active" class on only one element present')
-        assert.strictEqual($('.active').is('#two-link'), true, '"active" class on second section')
+        assert.true($('.active').is('#two-link'), '"active" class on second section')
         $scrollspy
           .one('scroll', function () {
             assert.strictEqual($('.active').length, 0, 'selection cleared')
@@ -665,11 +665,11 @@ $(function () {
       })
       .one('scroll', function () {
         assert.strictEqual($('.active').length, 1, '"active" class on only one element present')
-        assert.strictEqual($('.active').is('#two-link'), true, '"active" class on second section')
+        assert.true($('.active').is('#two-link'), '"active" class on second section')
         $scrollspy
           .one('scroll', function () {
             assert.strictEqual($('.active').length, 1, '"active" class on only one element present')
-            assert.strictEqual($('.active').is('#one-link'), true, '"active" class on first section')
+            assert.true($('.active').is('#one-link'), '"active" class on first section')
             done()
           })
           .scrollTop(negativeHeight)
@@ -712,7 +712,7 @@ $(function () {
       var paddingTop = 5
       var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top) + paddingTop
       $content.one('scroll', function () {
-        assert.ok($(element).hasClass('active'), 'target:' + target + ', element: ' + element)
+        assert.true($(element).hasClass('active'), 'target:' + target + ', element: ' + element)
         deferred.resolve()
       })
       $content.scrollTop(scrollHeight)
@@ -775,8 +775,8 @@ $(function () {
       var $target = $('#div-' + type + 'm-2')
       var scrollspy = $content.data('bs.scrollspy')
 
-      assert.ok(scrollspy._offsets[1] === $target.offset().top, 'offset method with ' + type + ' option')
-      assert.ok(scrollspy._offsets[1] !== $target.position().top, 'position method with ' + type + ' option')
+      assert.strictEqual(scrollspy._offsets[1], $target.offset().top, 'offset method with ' + type + ' option')
+      assert.notStrictEqual(scrollspy._offsets[1], $target.position().top, 'position method with ' + type + ' option')
       $navbar.remove()
       $content.remove()
     }
@@ -822,8 +822,8 @@ $(function () {
       var $target = $('#div-' + type + 'm-2')
       var scrollspy = $content.data('bs.scrollspy')
 
-      assert.ok(scrollspy._offsets[1] !== $target.offset().top, 'offset method with ' + type + ' option')
-      assert.ok(scrollspy._offsets[1] === $target.position().top, 'position method with ' + type + ' option')
+      assert.notStrictEqual(scrollspy._offsets[1], $target.offset().top, 'offset method with ' + type + ' option')
+      assert.strictEqual(scrollspy._offsets[1], $target.position().top, 'position method with ' + type + ' option')
       $navbar.remove()
       $content.remove()
     }

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -40,7 +40,7 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $tab = $el.bootstrapTab()
-    assert.ok($tab instanceof $, 'returns jquery collection')
+    assert.true($tab instanceof $, 'returns jquery collection')
     assert.strictEqual($tab[0], $el[0], 'collection contains element')
   })
 
@@ -321,8 +321,8 @@ $(function () {
     var $tabs = $(tabsHTML).appendTo('#qunit-fixture')
 
     $tabs.find('li:last-child a').trigger('click')
-    assert.notOk($tabs.find('li:first-child a').hasClass('active'))
-    assert.ok($tabs.find('li:last-child a').hasClass('active'))
+    assert.false($tabs.find('li:first-child a').hasClass('active'))
+    assert.true($tabs.find('li:last-child a').hasClass('active'))
   })
 
   QUnit.test('selected tab should deactivate previous selected link in dropdown', function (assert) {
@@ -340,9 +340,9 @@ $(function () {
     var $tabs = $(tabsHTML).appendTo('#qunit-fixture')
 
     $tabs.find('li:first-child a').trigger('click')
-    assert.ok($tabs.find('li:first-child a').hasClass('active'))
-    assert.notOk($tabs.find('li:last-child a').hasClass('active'))
-    assert.notOk($tabs.find('li:last-child .dropdown-menu a:first-child').hasClass('active'))
+    assert.true($tabs.find('li:first-child a').hasClass('active'))
+    assert.false($tabs.find('li:last-child a').hasClass('active'))
+    assert.false($tabs.find('li:last-child .dropdown-menu a:first-child').hasClass('active'))
   })
 
   QUnit.test('should support li > .dropdown-item', function (assert) {
@@ -363,8 +363,8 @@ $(function () {
     var $tabs = $(tabsHTML).appendTo('#qunit-fixture')
 
     $tabs.find('.dropdown-item').trigger('click')
-    assert.ok($tabs.find('.dropdown-item').hasClass('active'))
-    assert.notOk($tabs.find('.nav-link:not(.dropdown-toggle)').hasClass('active'))
+    assert.true($tabs.find('.dropdown-item').hasClass('active'))
+    assert.false($tabs.find('.nav-link:not(.dropdown-toggle)').hasClass('active'))
   })
 
   QUnit.test('Nested tabs', function (assert) {
@@ -394,12 +394,12 @@ $(function () {
     $(tabsHTML).appendTo('#qunit-fixture')
 
     $('#tabNested2').on('shown.bs.tab', function () {
-      assert.ok($('#x-tab1').hasClass('active'))
+      assert.true($('#x-tab1').hasClass('active'))
       done()
     })
 
     $('#tab1').on('shown.bs.tab', function () {
-      assert.ok($('#x-tab1').hasClass('active'))
+      assert.true($('#x-tab1').hasClass('active'))
       $('#tabNested2').trigger($.Event('click'))
     })
       .trigger($.Event('click'))
@@ -420,15 +420,15 @@ $(function () {
     $(tabsHTML).appendTo('#qunit-fixture')
     $('#tab-profile')
       .on('shown.bs.tab', function () {
-        assert.ok($('#profile').hasClass('fade'))
-        assert.ok($('#profile').hasClass('show'))
+        assert.true($('#profile').hasClass('fade'))
+        assert.true($('#profile').hasClass('show'))
 
         $('#tab-home')
           .on('shown.bs.tab', function () {
-            assert.ok($('#profile').hasClass('fade'))
-            assert.notOk($('#profile').hasClass('show'))
-            assert.ok($('#home').hasClass('fade'))
-            assert.ok($('#home').hasClass('show'))
+            assert.true($('#profile').hasClass('fade'))
+            assert.false($('#profile').hasClass('show'))
+            assert.true($('#home').hasClass('fade'))
+            assert.true($('#home').hasClass('show'))
 
             done()
           })

--- a/js/tests/unit/tab.js
+++ b/js/tests/unit/tab.js
@@ -60,7 +60,7 @@ $(function () {
     assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home')
   })
 
-  QUnit.test('should activate element by tab id', function (assert) {
+  QUnit.test('should activate element by tab id (.nav-pills)', function (assert) {
     assert.expect(2)
     var pillsHTML = '<ul class="nav nav-pills">' +
         '<li><a href="#home">Home</a></li>' +

--- a/js/tests/unit/toast.js
+++ b/js/tests/unit/toast.js
@@ -1,9 +1,7 @@
 $(function () {
   'use strict'
 
-  if (typeof bootstrap !== 'undefined') {
-    window.Toast = bootstrap.Toast
-  }
+  window.Toast = typeof bootstrap !== 'undefined' ? bootstrap.Toast : Toast
 
   QUnit.module('toast plugin')
 

--- a/js/tests/unit/toast.js
+++ b/js/tests/unit/toast.js
@@ -51,7 +51,7 @@ $(function () {
 
     var $el = $('<div/>')
     var $toast = $el.bootstrapToast()
-    assert.ok($toast instanceof $, 'returns jquery collection')
+    assert.true($toast instanceof $, 'returns jquery collection')
     assert.strictEqual($toast[0], $el[0], 'collection contains element')
   })
 
@@ -71,7 +71,7 @@ $(function () {
       .appendTo($('#qunit-fixture'))
 
     $toast.on('hidden.bs.toast', function () {
-      assert.strictEqual($toast.hasClass('show'), false)
+      assert.false($toast.hasClass('show'))
       done()
     })
       .bootstrapToast('show')
@@ -93,7 +93,7 @@ $(function () {
       .appendTo($('#qunit-fixture'))
 
     $toast.on('shown.bs.toast', function () {
-      assert.strictEqual($toast.hasClass('fade'), false)
+      assert.false($toast.hasClass('fade'))
       done()
     })
       .bootstrapToast('show')
@@ -119,7 +119,7 @@ $(function () {
         $toast.bootstrapToast('hide')
       })
       .on('hidden.bs.toast', function () {
-        assert.strictEqual($toast.hasClass('show'), false)
+        assert.false($toast.hasClass('show'))
         done()
       })
       .bootstrapToast('show')
@@ -136,7 +136,7 @@ $(function () {
 
     $toast.bootstrapToast('hide')
 
-    assert.strictEqual(spy.called, true)
+    assert.true(spy.called)
   })
 
   QUnit.test('should allow to destroy toast', function (assert) {
@@ -146,11 +146,11 @@ $(function () {
       .bootstrapToast()
       .appendTo($('#qunit-fixture'))
 
-    assert.ok(typeof $toast.data('bs.toast') !== 'undefined')
+    assert.notStrictEqual(typeof $toast.data('bs.toast'), 'undefined')
 
     $toast.bootstrapToast('dispose')
 
-    assert.ok(typeof $toast.data('bs.toast') === 'undefined')
+    assert.strictEqual(typeof $toast.data('bs.toast'), 'undefined')
   })
 
   QUnit.test('should allow to destroy toast and hide it before that', function (assert) {
@@ -170,13 +170,13 @@ $(function () {
 
     $toast.one('shown.bs.toast', function () {
       setTimeout(function () {
-        assert.ok($toast.hasClass('show'))
-        assert.ok(typeof $toast.data('bs.toast') !== 'undefined')
+        assert.true($toast.hasClass('show'))
+        assert.notStrictEqual(typeof $toast.data('bs.toast'), 'undefined')
 
         $toast.bootstrapToast('dispose')
 
-        assert.ok(typeof $toast.data('bs.toast') === 'undefined')
-        assert.ok($toast.hasClass('show') === false)
+        assert.strictEqual(typeof $toast.data('bs.toast'), 'undefined')
+        assert.false($toast.hasClass('show'))
 
         done()
       }, 1)
@@ -202,7 +202,7 @@ $(function () {
       .appendTo($('#qunit-fixture'))
 
     $toast.on('shown.bs.toast', function () {
-      assert.strictEqual($toast.hasClass('show'), true)
+      assert.true($toast.hasClass('show'))
       done()
     })
       .bootstrapToast('show')
@@ -225,12 +225,12 @@ $(function () {
 
     $toast
       .on('shown.bs.toast', function () {
-        assert.strictEqual($toast.hasClass('show'), true)
+        assert.true($toast.hasClass('show'))
         var button = $toast.find('.close')
         button.trigger('click')
       })
       .on('hidden.bs.toast', function () {
-        assert.strictEqual($toast.hasClass('show'), false)
+        assert.false($toast.hasClass('show'))
         done()
       })
       .bootstrapToast('show')
@@ -274,7 +274,7 @@ $(function () {
     var shownCalled = false
     function assertDone() {
       setTimeout(function () {
-        assert.strictEqual(shownCalled, false)
+        assert.false(shownCalled)
         done()
       }, 20)
     }
@@ -311,8 +311,8 @@ $(function () {
     setTimeout(function () {
       toast._config.autohide = false
       $toast.on('shown.bs.toast', function () {
-        assert.ok(spyClearTimeout.called)
-        assert.ok(toast._timeout === null)
+        assert.true(spyClearTimeout.called)
+        assert.strictEqual(toast._timeout, null)
         done()
       })
       $toast.bootstrapToast('show')
@@ -339,7 +339,7 @@ $(function () {
     var hiddenCalled = false
     function assertDone() {
       setTimeout(function () {
-        assert.strictEqual(hiddenCalled, false)
+        assert.false(hiddenCalled)
         done()
       }, 20)
     }

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -41,13 +41,13 @@ $(function () {
     assert.expect(2)
     var $el = $('<div/>')
     var $tooltip = $el.bootstrapTooltip()
-    assert.ok($tooltip instanceof $, 'returns jquery collection')
+    assert.true($tooltip instanceof $, 'returns jquery collection')
     assert.strictEqual($tooltip[0], $el[0], 'collection contains element')
   })
 
   QUnit.test('should expose default settings', function (assert) {
     assert.expect(1)
-    assert.ok($.fn.bootstrapTooltip.Constructor.Default, 'defaults is defined')
+    assert.ok($.fn.bootstrapTooltip.Constructor.Default, 'defaults are defined')
   })
 
   QUnit.test('should empty title attribute', function (assert) {
@@ -73,7 +73,7 @@ $(function () {
 
     assert.strictEqual($('#' + id).length, 1, 'has a unique id')
     assert.strictEqual($('.tooltip').attr('aria-describedby'), $trigger.attr('id'), 'tooltip id and aria-describedby on trigger match')
-    assert.ok($trigger[0].hasAttribute('aria-describedby'), 'trigger has aria-describedby')
+    assert.true($trigger[0].hasAttribute('aria-describedby'), 'trigger has aria-describedby')
   })
 
   QUnit.test('should remove aria-describedby from trigger on hide', function (assert) {
@@ -85,11 +85,11 @@ $(function () {
 
     $trigger
       .one('shown.bs.tooltip', function () {
-        assert.ok($trigger[0].hasAttribute('aria-describedby'), 'trigger has aria-describedby')
+        assert.true($trigger[0].hasAttribute('aria-describedby'), 'trigger has aria-describedby')
         $trigger.bootstrapTooltip('hide')
       })
       .one('hidden.bs.tooltip', function () {
-        assert.ok(!$trigger[0].hasAttribute('aria-describedby'), 'trigger does not have aria-describedby')
+        assert.false($trigger[0].hasAttribute('aria-describedby'), 'trigger does not have aria-describedby')
         done()
       })
       .bootstrapTooltip('show')
@@ -118,8 +118,7 @@ $(function () {
 
     $tooltip
       .one('shown.bs.tooltip', function () {
-        assert.ok($('.tooltip')
-          .is('.fade.bs-tooltip-bottom.show'), 'has correct classes applied')
+        assert.true($('.tooltip').is('.fade.bs-tooltip-bottom.show'), 'has correct classes applied')
 
         $tooltip.bootstrapTooltip('hide')
       })
@@ -165,7 +164,7 @@ $(function () {
       .one('shown.bs.tooltip', function () {
         assert.notStrictEqual($('.tooltip').length, 0, 'tooltip inserted')
         assert.strictEqual($('.tooltip').text(), '<3 writing tests', 'title inserted')
-        assert.ok(!$.contains($('.tooltip').get(0), title), 'title node copied, not moved')
+        assert.false($.contains($('.tooltip').get(0), title), 'title node copied, not moved')
         done()
       })
       .bootstrapTooltip('show')
@@ -203,7 +202,7 @@ $(function () {
 
     $tooltip
       .one('shown.bs.tooltip', function () {
-        assert.ok($('.tooltip').hasClass('some-class'), 'custom class is present')
+        assert.true($('.tooltip').hasClass('some-class'), 'custom class is present')
         $tooltip.bootstrapTooltip('hide')
       })
       .one('hidden.bs.tooltip', function () {
@@ -333,22 +332,24 @@ $(function () {
   })
 
   QUnit.test('should destroy tooltip', function (assert) {
-    assert.expect(7)
+    assert.expect(9)
     var $tooltip = $('<div/>')
       .bootstrapTooltip()
       .on('click.foo', function () {})
 
     assert.ok($tooltip.data('bs.tooltip'), 'tooltip has data')
-    assert.ok($._data($tooltip[0], 'events').mouseover && $._data($tooltip[0], 'events').mouseout, 'tooltip has hover events')
+    assert.ok($._data($tooltip[0], 'events').mouseover, 'tooltip has mouseover event')
+    assert.ok($._data($tooltip[0], 'events').mouseout, 'tooltip has mouseout event')
     assert.strictEqual($._data($tooltip[0], 'events').click[0].namespace, 'foo', 'tooltip has extra click.foo event')
 
     $tooltip.bootstrapTooltip('show')
     $tooltip.bootstrapTooltip('dispose')
 
-    assert.ok(!$tooltip.hasClass('show'), 'tooltip is hidden')
-    assert.ok(!$._data($tooltip[0], 'bs.tooltip'), 'tooltip does not have data')
+    assert.false($tooltip.hasClass('show'), 'tooltip is hidden')
+    assert.strictEqual(typeof $._data($tooltip[0], 'bs.tooltip'), 'undefined', 'tooltip does not have data')
     assert.strictEqual($._data($tooltip[0], 'events').click[0].namespace, 'foo', 'tooltip still has click.foo')
-    assert.ok(!$._data($tooltip[0], 'events').mouseover && !$._data($tooltip[0], 'events').mouseout, 'tooltip does not have hover events')
+    assert.strictEqual(typeof $._data($tooltip[0], 'events').mouseover, 'undefined', 'tooltip does not have mouseover event')
+    assert.strictEqual(typeof $._data($tooltip[0], 'events').mouseout, 'undefined', 'tooltip does not have mouseout event')
   })
 
   // QUnit.test('should show tooltip with delegate selector on click', function (assert) {
@@ -361,7 +362,7 @@ $(function () {
   //     })
 
   //   $div.find('a').trigger('click')
-  //   assert.ok($('.tooltip').is('.fade.in'), 'tooltip is faded in')
+  //   assert.true($('.tooltip').is('.fade.in'), 'tooltip is faded in')
 
   //   $div.find('a').trigger('click')
   //   assert.strictEqual($div.data('bs.tooltip').tip.parentNode, null, 'tooltip removed')
@@ -376,7 +377,7 @@ $(function () {
       })
       .bootstrapTooltip('toggle')
 
-    assert.ok($('.tooltip').is('.fade.show'), 'tooltip is faded active')
+    assert.true($('.tooltip').is('.fade.show'), 'tooltip is faded active')
   })
 
   QUnit.test('should hide previously shown tooltip when toggle is called on tooltip', function (assert) {
@@ -478,8 +479,8 @@ $(function () {
       })
       .on('inserted.bs.tooltip', function () {
         var $tooltip = $($(this).data('bs.tooltip').tip)
-        assert.ok($tooltip.hasClass('bs-tooltip-right'))
-        assert.ok(typeof $tooltip.attr('style') === 'undefined')
+        assert.true($tooltip.hasClass('bs-tooltip-right'))
+        assert.strictEqual(typeof $tooltip.attr('style'), 'undefined')
         $styles.remove()
         done()
       })
@@ -565,7 +566,7 @@ $(function () {
       passed = false
     }
 
-    assert.ok(passed, '.tooltip(\'show\') should not throw an error if element no longer is in dom')
+    assert.true(passed, '.tooltip(\'show\') should not throw an error if element no longer is in dom')
   })
 
   QUnit.test('should show tooltip if leave event hasn\'t occurred before delay expires', function (assert) {
@@ -579,11 +580,11 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '100ms: tooltip is not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '100ms: tooltip is not faded active')
     }, 100)
 
     setTimeout(function () {
-      assert.ok($('.tooltip').is('.fade.show'), '200ms: tooltip is faded active')
+      assert.true($('.tooltip').is('.fade.show'), '200ms: tooltip is faded active')
       done()
     }, 200)
 
@@ -601,12 +602,12 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
       $tooltip.trigger('mouseout')
     }, 100)
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '200ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '200ms: tooltip not faded active')
       done()
     }, 200)
 
@@ -627,16 +628,16 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok($('.tooltip').is('.fade.show'), '1ms: tooltip faded active')
+      assert.true($('.tooltip').is('.fade.show'), '1ms: tooltip faded active')
       $tooltip.trigger('mouseout')
 
       setTimeout(function () {
-        assert.ok($('.tooltip').is('.fade.show'), '100ms: tooltip still faded active')
+        assert.true($('.tooltip').is('.fade.show'), '100ms: tooltip still faded active')
         $tooltip.trigger('mouseenter')
       }, 100)
 
       setTimeout(function () {
-        assert.ok($('.tooltip').is('.fade.show'), '200ms: tooltip still faded active')
+        assert.true($('.tooltip').is('.fade.show'), '200ms: tooltip still faded active')
         done()
       }, 200)
     }, 0)
@@ -655,12 +656,12 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
       $tooltip.trigger('mouseout')
     }, 100)
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '200ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '200ms: tooltip not faded active')
       done()
     }, 200)
 
@@ -681,12 +682,12 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
       $tooltip.trigger('mouseout')
     }, 100)
 
     setTimeout(function () {
-      assert.ok(!$('.tooltip').is('.fade.show'), '250ms: tooltip not faded active')
+      assert.false($('.tooltip').is('.fade.show'), '250ms: tooltip not faded active')
       done()
     }, 250)
 
@@ -707,16 +708,16 @@ $(function () {
       })
 
     setTimeout(function () {
-      assert.ok($($tooltip.data('bs.tooltip').tip).is('.fade.show'), '1ms: tooltip faded active')
+      assert.true($($tooltip.data('bs.tooltip').tip).is('.fade.show'), '1ms: tooltip faded active')
 
       $tooltip.trigger('mouseout')
 
       setTimeout(function () {
-        assert.ok($($tooltip.data('bs.tooltip').tip).is('.fade.show'), '100ms: tooltip still faded active')
+        assert.true($($tooltip.data('bs.tooltip').tip).is('.fade.show'), '100ms: tooltip still faded active')
       }, 100)
 
       setTimeout(function () {
-        assert.ok(!$($tooltip.data('bs.tooltip').tip).is('.show'), '200ms: tooltip removed')
+        assert.false($($tooltip.data('bs.tooltip').tip).is('.show'), '200ms: tooltip removed')
         done()
       }, 200)
     }, 0)
@@ -785,10 +786,10 @@ $(function () {
     $('#tt-outer').trigger('mouseleave')
     assert.strictEqual(currentUid, $('#tt-content').text())
 
-    assert.ok(obj._hoverState === 'out', 'the tooltip hoverState should be set to "out"')
+    assert.strictEqual(obj._hoverState, 'out', 'the tooltip hoverState should be set to "out"')
 
     $('#tt-outer').trigger('mouseenter')
-    assert.ok(obj._hoverState === 'show', 'the tooltip hoverState should be set to "show"')
+    assert.strictEqual(obj._hoverState, 'show', 'the tooltip hoverState should be set to "show"')
 
     assert.strictEqual(currentUid, $('#tt-content').text())
   })
@@ -838,7 +839,7 @@ $(function () {
       ['mouseenter', 'focusin', 'click', 'click', 'mouseleave', 'focusout']
     ]
 
-    assert.ok(!showingTooltip())
+    assert.false(showingTooltip())
 
     $.each(tests, function (idx, triggers) {
       for (var i = 0, len = triggers.length; i < len; i++) {
@@ -865,13 +866,13 @@ $(function () {
     }
 
     $el.trigger('click')
-    assert.ok(showingTooltip(), 'tooltip is faded in')
+    assert.true(showingTooltip(), 'tooltip is faded in')
 
     $el.bootstrapTooltip('hide')
-    assert.ok(!showingTooltip(), 'tooltip was faded out')
+    assert.false(showingTooltip(), 'tooltip was faded out')
 
     $el.trigger('click')
-    assert.ok(showingTooltip(), 'tooltip is faded in again')
+    assert.true(showingTooltip(), 'tooltip is faded in again')
   })
 
   QUnit.test('should hide tooltip when their containing modal is closed', function (assert) {
@@ -954,8 +955,8 @@ $(function () {
       .on('hidden.bs.tooltip', function () {
         var tooltip = $el.data('bs.tooltip')
         var $tooltip = $(tooltip.getTipElement())
-        assert.ok($tooltip.hasClass('tooltip'))
-        assert.ok($tooltip.hasClass('fade'))
+        assert.true($tooltip.hasClass('tooltip'))
+        assert.true($tooltip.hasClass('fade'))
         done()
       })
 
@@ -985,14 +986,14 @@ $(function () {
       .appendTo('#qunit-fixture')
       .bootstrapTooltip()
       .on('shown.bs.tooltip', function () {
-        assert.strictEqual($('.tooltip').hasClass('show'), true)
+        assert.true($('.tooltip').hasClass('show'))
         done()
       })
 
     $trigger.bootstrapTooltip('disable')
     $trigger.trigger($.Event('click'))
     setTimeout(function () {
-      assert.strictEqual($('.tooltip').length === 0, true)
+      assert.strictEqual($('.tooltip').length, 0)
       $trigger.bootstrapTooltip('enable')
       $trigger.trigger($.Event('click'))
     }, 200)
@@ -1011,7 +1012,7 @@ $(function () {
 
     var spyPopper = sinon.spy(tooltip._popper, 'scheduleUpdate')
     tooltip.update()
-    assert.ok(spyPopper.called)
+    assert.true(spyPopper.called)
   })
 
   QUnit.test('should not call Popper to update', function (assert) {
@@ -1024,7 +1025,7 @@ $(function () {
     var tooltip = $tooltip.data('bs.tooltip')
     tooltip.update()
 
-    assert.ok(tooltip._popper === null)
+    assert.strictEqual(tooltip._popper, null)
   })
 
   QUnit.test('should use Popper to get the tip on placement change', function (assert) {
@@ -1047,7 +1048,7 @@ $(function () {
       placement: 'auto'
     })
 
-    assert.ok(tooltip.tip === $tipTest[0])
+    assert.strictEqual(tooltip.tip, $tipTest[0])
   })
 
   QUnit.test('should toggle enabled', function (assert) {
@@ -1059,15 +1060,15 @@ $(function () {
 
     var tooltip = $tooltip.data('bs.tooltip')
 
-    assert.strictEqual(tooltip._isEnabled, true)
+    assert.true(tooltip._isEnabled)
 
     tooltip.toggleEnabled()
 
-    assert.strictEqual(tooltip._isEnabled, false)
+    assert.false(tooltip._isEnabled)
 
     tooltip.toggleEnabled()
 
-    assert.strictEqual(tooltip._isEnabled, true)
+    assert.true(tooltip._isEnabled)
   })
 
   QUnit.test('should create offset modifier correctly when offset option is a function', function (assert) {
@@ -1086,8 +1087,8 @@ $(function () {
     var tooltip = $trigger.data('bs.tooltip')
     var offset = tooltip._getOffset()
 
-    assert.ok(typeof offset.offset === 'undefined')
-    assert.ok(typeof offset.fn === 'function')
+    assert.strictEqual(typeof offset.offset, 'undefined')
+    assert.strictEqual(typeof offset.fn, 'function')
   })
 
   QUnit.test('should create offset modifier correctly when offset option is not a function', function (assert) {
@@ -1104,7 +1105,7 @@ $(function () {
     var offset = tooltip._getOffset()
 
     assert.strictEqual(offset.offset, myOffset)
-    assert.ok(typeof offset.fn === 'undefined')
+    assert.strictEqual(typeof offset.fn, 'undefined')
   })
 
   QUnit.test('should disable sanitizer', function (assert) {
@@ -1117,7 +1118,7 @@ $(function () {
       })
 
     var tooltip = $trigger.data('bs.tooltip')
-    assert.strictEqual(tooltip.config.sanitize, false)
+    assert.false(tooltip.config.sanitize)
   })
 
   QUnit.test('should sanitize template by removing disallowed tags', function (assert) {
@@ -1191,7 +1192,7 @@ $(function () {
     var tooltip = $trigger.data('bs.tooltip')
 
     assert.strictEqual(tooltip.config.template.indexOf('<a'), -1)
-    assert.ok(tooltip.config.template.indexOf('span') !== -1)
+    assert.notStrictEqual(tooltip.config.template.indexOf('span'), -1)
   })
 
   QUnit.test('should allow passing a custom function for sanitization', function (assert) {
@@ -1210,7 +1211,7 @@ $(function () {
 
     var tooltip = $trigger.data('bs.tooltip')
 
-    assert.ok(tooltip.config.template.indexOf('span') !== -1)
+    assert.notStrictEqual(tooltip.config.template.indexOf('span'), -1)
   })
 
   QUnit.test('should allow passing aria attributes', function (assert) {
@@ -1226,7 +1227,7 @@ $(function () {
 
     var tooltip = $trigger.data('bs.tooltip')
 
-    assert.ok(tooltip.config.template.indexOf('aria-pressed') !== -1)
+    assert.notStrictEqual(tooltip.config.template.indexOf('aria-pressed'), -1)
   })
 
   QUnit.test('should not sanitize element content', function (assert) {
@@ -1264,7 +1265,7 @@ $(function () {
 
     var tooltip = $trigger.data('bs.tooltip')
 
-    assert.strictEqual(tooltip.config.sanitize, true)
+    assert.true(tooltip.config.sanitize)
   })
 
   QUnit.test('should allow to pass config to Popper with `popperConfig`', function (assert) {
@@ -1294,8 +1295,8 @@ $(function () {
 
     var tooltip = $('.tooltip')
 
-    assert.strictEqual(tooltip.hasClass('a b'), true)
-    assert.strictEqual(tooltip.hasClass('tooltip fade bs-tooltip-top show'), true)
+    assert.true(tooltip.hasClass('a b'))
+    assert.true(tooltip.hasClass('tooltip fade bs-tooltip-top show'))
   })
 
   QUnit.test('additional classes can be applied via config string', function (assert) {
@@ -1310,8 +1311,8 @@ $(function () {
 
     var tooltip = $('.tooltip')
 
-    assert.strictEqual(tooltip.hasClass('a b'), true)
-    assert.strictEqual(tooltip.hasClass('tooltip fade bs-tooltip-top show'), true)
+    assert.true(tooltip.hasClass('a b'))
+    assert.true(tooltip.hasClass('tooltip fade bs-tooltip-top show'))
   })
 
   QUnit.test('additional classes can be applied via function', function (assert) {
@@ -1330,8 +1331,8 @@ $(function () {
 
     var tooltip = $('.tooltip')
 
-    assert.strictEqual(tooltip.hasClass('a b'), true)
-    assert.strictEqual(tooltip.hasClass('tooltip fade bs-tooltip-top show'), true)
+    assert.true(tooltip.hasClass('a b'))
+    assert.true(tooltip.hasClass('tooltip fade bs-tooltip-top show'))
   })
 
   QUnit.test('HTML content can be passed through sanitation multiple times', function (assert) {

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -629,29 +629,6 @@ $(function () {
     $tooltip.trigger('mouseenter')
   })
 
-  QUnit.test('should not show tooltip if leave event occurs before delay expires', function (assert) {
-    assert.expect(2)
-    var done = assert.async()
-
-    var $tooltip = $('<a href="#" rel="tooltip" title="Another tooltip"/>')
-      .appendTo('#qunit-fixture')
-      .bootstrapTooltip({
-        delay: 150
-      })
-
-    setTimeout(function () {
-      assert.false($('.tooltip').is('.fade.show'), '100ms: tooltip not faded active')
-      $tooltip.trigger('mouseout')
-    }, 100)
-
-    setTimeout(function () {
-      assert.false($('.tooltip').is('.fade.show'), '200ms: tooltip not faded active')
-      done()
-    }, 200)
-
-    $tooltip.trigger('mouseenter')
-  })
-
   QUnit.test('should not show tooltip if leave event occurs before delay expires, even if hide delay is 0', function (assert) {
     assert.expect(2)
     var done = assert.async()

--- a/js/tests/unit/tooltip.js
+++ b/js/tests/unit/tooltip.js
@@ -352,22 +352,6 @@ $(function () {
     assert.strictEqual(typeof $._data($tooltip[0], 'events').mouseout, 'undefined', 'tooltip does not have mouseout event')
   })
 
-  // QUnit.test('should show tooltip with delegate selector on click', function (assert) {
-  //   assert.expect(2)
-  //   var $div = $('<div><a href="#" rel="tooltip" title="Another tooltip"/></div>')
-  //     .appendTo('#qunit-fixture')
-  //     .bootstrapTooltip({
-  //       selector: 'a[rel="tooltip"]',
-  //       trigger: 'click'
-  //     })
-
-  //   $div.find('a').trigger('click')
-  //   assert.true($('.tooltip').is('.fade.in'), 'tooltip is faded in')
-
-  //   $div.find('a').trigger('click')
-  //   assert.strictEqual($div.data('bs.tooltip').tip.parentNode, null, 'tooltip removed')
-  // })
-
   QUnit.test('should show tooltip when toggle is called', function (assert) {
     assert.expect(1)
     $('<a href="#" rel="tooltip" title="tooltip on toggle"/>')

--- a/js/tests/unit/util.js
+++ b/js/tests/unit/util.js
@@ -67,7 +67,7 @@ $(function () {
 
     Util.typeCheckConfig(namePlugin, config, defaultType)
 
-    assert.strictEqual(true, true)
+    assert.true(true)
   })
 
   QUnit.test('Util.isElement should check if we passed an element or not', function (assert) {
@@ -76,7 +76,7 @@ $(function () {
 
     assert.strictEqual(Util.isElement($div), 1)
     assert.strictEqual(Util.isElement($div[0]), 1)
-    assert.strictEqual(typeof Util.isElement({}) === 'undefined', true)
+    assert.strictEqual(typeof Util.isElement({}), 'undefined')
   })
 
   QUnit.test('Util.getTransitionDurationFromElement should accept transition durations in milliseconds', function (assert) {
@@ -129,18 +129,18 @@ $(function () {
     var id = Util.getUID('test')
     var id2 = Util.getUID('test')
 
-    assert.ok(id !== id2, id + ' !== ' + id2)
+    assert.notStrictEqual(id, id2, id + ' !== ' + id2)
 
     id = Util.getUID('test')
     $('<div id="' + id + '"></div>').appendTo($('#qunit-fixture'))
 
     id2 = Util.getUID('test')
-    assert.ok(id !== id2, id + ' !== ' + id2)
+    assert.notStrictEqual(id, id2, id + ' !== ' + id2)
   })
 
   QUnit.test('Util.supportsTransitionEnd should return true', function (assert) {
     assert.expect(1)
-    assert.ok(Util.supportsTransitionEnd())
+    assert.true(Util.supportsTransitionEnd())
   })
 
   QUnit.test('Util.findShadowRoot should find the shadow DOM root', function (assert) {
@@ -166,7 +166,7 @@ $(function () {
 
     var $div = $('<div id="test"></div>').appendTo($('#qunit-fixture'))
     if (!document.documentElement.attachShadow) {
-      assert.strictEqual(null, Util.findShadowRoot($div[0]))
+      assert.strictEqual(Util.findShadowRoot($div[0]), null)
     } else {
       var sandbox = sinon.createSandbox()
 
@@ -175,7 +175,7 @@ $(function () {
         return $div
       })
 
-      assert.strictEqual(null, Util.findShadowRoot($div[0]))
+      assert.strictEqual(Util.findShadowRoot($div[0]), null)
       sandbox.restore()
     }
   })

--- a/js/tests/unit/util.js
+++ b/js/tests/unit/util.js
@@ -3,6 +3,8 @@ $(function () {
 
   window.Util = typeof bootstrap !== 'undefined' ? bootstrap.Util : Util
 
+  var supportsAttachShadow = document.documentElement.attachShadow
+
   QUnit.module('util', {
     afterEach: function () {
       $('#qunit-fixture').html('')
@@ -143,13 +145,8 @@ $(function () {
     assert.true(Util.supportsTransitionEnd())
   })
 
-  QUnit.test('Util.findShadowRoot should find the shadow DOM root', function (assert) {
-    // Only for newer browsers
-    if (!document.documentElement.attachShadow) {
-      assert.expect(0)
-      return
-    }
-
+  // Only for newer browsers
+  QUnit[supportsAttachShadow ? 'test' : 'skip']('Util.findShadowRoot should find the shadow DOM root', function (assert) {
     assert.expect(2)
     var $div = $('<div id="test"></div>').appendTo($('#qunit-fixture'))
     var shadowRoot = $div[0].attachShadow({
@@ -161,23 +158,11 @@ $(function () {
     assert.strictEqual(shadowRoot, Util.findShadowRoot(shadowRoot.firstChild))
   })
 
-  QUnit.test('Util.findShadowRoot should return null when attachShadow is not available', function (assert) {
+  QUnit[supportsAttachShadow ? 'skip' : 'test']('Util.findShadowRoot should return null when attachShadow is not available', function (assert) {
     assert.expect(1)
-
     var $div = $('<div id="test"></div>').appendTo($('#qunit-fixture'))
-    if (!document.documentElement.attachShadow) {
-      assert.strictEqual(Util.findShadowRoot($div[0]), null)
-    } else {
-      var sandbox = sinon.createSandbox()
 
-      sandbox.replace(document.documentElement, 'attachShadow', function () {
-        // to avoid empty function
-        return $div
-      })
-
-      assert.strictEqual(Util.findShadowRoot($div[0]), null)
-      sandbox.restore()
-    }
+    assert.strictEqual(Util.findShadowRoot($div[0]), null)
   })
 
   QUnit.test('Util.jQueryDetection should detect jQuery', function (assert) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4171,6 +4171,27 @@
         }
       }
     },
+    "eslint-plugin-qunit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
+      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-unicorn": {
       "version": "36.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-36.0.0.tgz",
@@ -9582,6 +9603,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "eslint": "^7.32.0",
     "eslint-config-xo": "^0.38.0",
     "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-qunit": "^6.2.0",
     "eslint-plugin-unicorn": "^36.0.0",
     "find-unused-sass-variables": "^3.1.0",
     "glob": "^7.1.7",


### PR DESCRIPTION
TODO:

- [x] Address the remaining lint errors
- [ ] `assert.expect(0)`??
- [ ] Search for `assert.ok` and `assert.notOk` and convert any tests that can be converted
- [ ] Change `VERSION` checks to check for `length !== 0` too ?
