### PR TITLE
Remove default linear gradient

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -4,7 +4,6 @@
 
 .table {
   --#{$variable-prefix}table-bg: #{$table-bg};
-  --#{$variable-prefix}table-accent-bg: transparent;
   --#{$variable-prefix}table-striped-color: #{$table-striped-color};
   --#{$variable-prefix}table-striped-bg: #{$table-striped-bg};
   --#{$variable-prefix}table-active-color: #{$table-active-color};


### PR DESCRIPTION
Remove the default invisible gradient causing the performance issue in https://github.com/twbs/bootstrap/issues/32266. By removing the custom property, the linear gradient will become invalid, thus not appear by default.

There can still be a performance issue with striped tables though.

