### PR TITLE
Remove the `show` config option from the modal plugin

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -37,15 +37,13 @@ const ESCAPE_KEY = 'Escape'
 const Default = {
   backdrop: true,
   keyboard: true,
-  focus: true,
-  show: true
+  focus: true
 }
 
 const DefaultType = {
   backdrop: '(boolean|string)',
   keyboard: 'boolean',
-  focus: 'boolean',
-  show: 'boolean'
+  focus: 'boolean'
 }
 
 const EVENT_HIDE = `hide${EVENT_KEY}`
@@ -558,8 +556,6 @@ class Modal {
         }
 
         data[config](relatedTarget)
-      } else if (_config.show) {
-        data.show(relatedTarget)
       }
     })
   }

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -877,12 +877,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td><code>true</code></td>
       <td>Puts the focus on the modal when initialized.</td>
     </tr>
-    <tr>
-      <td><code>show</code></td>
-      <td>boolean</td>
-      <td><code>true</code></td>
-      <td>Shows the modal when initialized.</td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Drop the support of show property from the modal plugin.
When creating the new modal instance in v5, the `show` property does not work anymore, so instead of fixing the behavior just removing it permanently to keep the consistency between all the plugins. (All other plugins require the `show()` method to be called on the instances to be shown)

Ref: https://github.com/twbs/bootstrap/issues/31452#issuecomment-734392044
Closes: #31452
