### PR TITLE
Fixed offset in scrollspy component

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -106,7 +106,7 @@ class ScrollSpy extends BaseComponent {
 
     const offsetBase = offsetMethod === METHOD_POSITION ?
       this._getScrollTop() :
-      0
+      window.pageYOffset
 
     this._offsets = []
     this._targets = []


### PR DESCRIPTION
When `getBoundingClientRect` method is used and when page is refreshed to a scroll position that is not at the top but below it, clicking a nav button will result in scrolling to wrong position. I was able to fix this giving offset of `window.pageYOffset`
