### PR TITLE
Remove useless `.text-left` in Layout / Overview

### DIFF
--- a/site/content/docs/4.5/layout/overview.md
+++ b/site/content/docs/4.5/layout/overview.md
@@ -21,7 +21,7 @@ The table below illustrates how each container's `max-width` compares to the ori
 
 See them in action and compare them in our [Grid example]({{< docsref "/examples/grid#containers" >}}).
 
-<table class="table text-left">
+<table class="table">
   <thead>
     <tr>
       <th></th>


### PR DESCRIPTION
Preview: https://deploy-preview-32363--twbs-bootstrap.netlify.app/docs/4.5/layout/overview/