### PR TITLE
Support .focus on form-control

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -31,7 +31,7 @@
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.
-  &:focus {
+  &:focus, &.focus {
     color: $input-focus-color;
     background-color: $input-focus-bg;
     border-color: $input-focus-border-color;


### PR DESCRIPTION
This allows pseudo focus for custom wrappers, e.g. around https://tiptap.dev/title.