### PR TITLE
Remove `TRANSITION_END` from utils

### DIFF
--- a/js/src/alert.js
+++ b/js/src/alert.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement
@@ -83,7 +82,7 @@ class Alert extends BaseComponent {
 
     const transitionDuration = getTransitionDurationFromElement(element)
 
-    EventHandler.one(element, TRANSITION_END, () => this._destroyElement(element))
+    EventHandler.one(element, 'transitionend', () => this._destroyElement(element))
     emulateTransitionEnd(element, transitionDuration)
   }
 

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -484,7 +483,7 @@ class Carousel extends BaseComponent {
 
       const transitionDuration = getTransitionDurationFromElement(activeElement)
 
-      EventHandler.one(activeElement, TRANSITION_END, () => {
+      EventHandler.one(activeElement, 'transitionend', () => {
         nextElement.classList.remove(directionalClassName, orderClassName)
         nextElement.classList.add(CLASS_NAME_ACTIVE)
 

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getSelectorFromElement,
   getElementFromSelector,
@@ -59,6 +58,8 @@ const HEIGHT = 'height'
 
 const SELECTOR_ACTIVES = '.show, .collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="collapse"]'
+
+const TRANSITION_END = 'transitionend'
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -59,8 +59,6 @@ const HEIGHT = 'height'
 const SELECTOR_ACTIVES = '.show, .collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="collapse"]'
 
-const TRANSITION_END = 'transitionend'
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -204,7 +202,7 @@ class Collapse extends BaseComponent {
     const scrollSize = `scroll${capitalizedDimension}`
     const transitionDuration = getTransitionDurationFromElement(this._element)
 
-    EventHandler.one(this._element, TRANSITION_END, complete)
+    EventHandler.one(this._element, 'transitionend', complete)
 
     emulateTransitionEnd(this._element, transitionDuration)
     this._element.style[dimension] = `${this._element[scrollSize]}px`
@@ -254,7 +252,7 @@ class Collapse extends BaseComponent {
     this._element.style[dimension] = ''
     const transitionDuration = getTransitionDurationFromElement(this._element)
 
-    EventHandler.one(this._element, TRANSITION_END, complete)
+    EventHandler.one(this._element, 'transitionend', complete)
     emulateTransitionEnd(this._element, transitionDuration)
   }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -72,8 +72,6 @@ const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="modal"]'
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
 
-const TRANSITION_END = 'transitionend'
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -185,7 +183,7 @@ class Modal extends BaseComponent {
     if (transition) {
       const transitionDuration = getTransitionDurationFromElement(this._element)
 
-      EventHandler.one(this._element, TRANSITION_END, event => this._hideModal(event))
+      EventHandler.one(this._element, 'transitionend', event => this._hideModal(event))
       emulateTransitionEnd(this._element, transitionDuration)
     } else {
       this._hideModal()
@@ -273,7 +271,7 @@ class Modal extends BaseComponent {
     if (transition) {
       const transitionDuration = getTransitionDurationFromElement(this._dialog)
 
-      EventHandler.one(this._dialog, TRANSITION_END, transitionComplete)
+      EventHandler.one(this._dialog, 'transitionend', transitionComplete)
       emulateTransitionEnd(this._dialog, transitionDuration)
     } else {
       transitionComplete()
@@ -378,7 +376,7 @@ class Modal extends BaseComponent {
 
       const backdropTransitionDuration = getTransitionDurationFromElement(this._backdrop)
 
-      EventHandler.one(this._backdrop, TRANSITION_END, callback)
+      EventHandler.one(this._backdrop, 'transitionend', callback)
       emulateTransitionEnd(this._backdrop, backdropTransitionDuration)
     } else if (!this._isShown && this._backdrop) {
       this._backdrop.classList.remove(CLASS_NAME_SHOW)
@@ -390,7 +388,7 @@ class Modal extends BaseComponent {
 
       if (this._element.classList.contains(CLASS_NAME_FADE)) {
         const backdropTransitionDuration = getTransitionDurationFromElement(this._backdrop)
-        EventHandler.one(this._backdrop, TRANSITION_END, callbackRemove)
+        EventHandler.one(this._backdrop, 'transitionend', callbackRemove)
         emulateTransitionEnd(this._backdrop, backdropTransitionDuration)
       } else {
         callbackRemove()
@@ -414,11 +412,11 @@ class Modal extends BaseComponent {
 
     this._element.classList.add(CLASS_NAME_STATIC)
     const modalTransitionDuration = getTransitionDurationFromElement(this._dialog)
-    EventHandler.off(this._element, TRANSITION_END)
-    EventHandler.one(this._element, TRANSITION_END, () => {
+    EventHandler.off(this._element, 'transitionend')
+    EventHandler.one(this._element, 'transitionend', () => {
       this._element.classList.remove(CLASS_NAME_STATIC)
       if (!isModalOverflowing) {
-        EventHandler.one(this._element, TRANSITION_END, () => {
+        EventHandler.one(this._element, 'transitionend', () => {
           this._element.style.overflowY = ''
         })
         emulateTransitionEnd(this._element, modalTransitionDuration)

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -72,6 +71,8 @@ const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="modal"]'
 const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="modal"]'
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
+
+const TRANSITION_END = 'transitionend'
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -132,7 +131,7 @@ class Tab extends BaseComponent {
       const transitionDuration = getTransitionDurationFromElement(active)
       active.classList.remove(CLASS_NAME_SHOW)
 
-      EventHandler.one(active, TRANSITION_END, complete)
+      EventHandler.one(active, 'transitionend', complete)
       emulateTransitionEnd(active, transitionDuration)
     } else {
       complete()

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -7,7 +7,6 @@
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   getTransitionDurationFromElement,
   reflow,
@@ -52,6 +51,8 @@ const Default = {
 }
 
 const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="toast"]'
+
+const TRANSITION_END = 'transitionend'
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -52,8 +52,6 @@ const Default = {
 
 const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="toast"]'
 
-const TRANSITION_END = 'transitionend'
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -117,7 +115,7 @@ class Toast extends BaseComponent {
     if (this._config.animation) {
       const transitionDuration = getTransitionDurationFromElement(this._element)
 
-      EventHandler.one(this._element, TRANSITION_END, complete)
+      EventHandler.one(this._element, 'transitionend', complete)
       emulateTransitionEnd(this._element, transitionDuration)
     } else {
       complete()
@@ -144,7 +142,7 @@ class Toast extends BaseComponent {
     if (this._config.animation) {
       const transitionDuration = getTransitionDurationFromElement(this._element)
 
-      EventHandler.one(this._element, TRANSITION_END, complete)
+      EventHandler.one(this._element, 'transitionend', complete)
       emulateTransitionEnd(this._element, transitionDuration)
     } else {
       complete()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -117,8 +117,6 @@ const TRIGGER_FOCUS = 'focus'
 const TRIGGER_CLICK = 'click'
 const TRIGGER_MANUAL = 'manual'
 
-const TRANSITION_END = 'transitionend'
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -318,7 +316,7 @@ class Tooltip extends BaseComponent {
 
       if (this.tip.classList.contains(CLASS_NAME_FADE)) {
         const transitionDuration = getTransitionDurationFromElement(this.tip)
-        EventHandler.one(this.tip, TRANSITION_END, complete)
+        EventHandler.one(this.tip, 'transitionend', complete)
         emulateTransitionEnd(this.tip, transitionDuration)
       } else {
         complete()
@@ -368,7 +366,7 @@ class Tooltip extends BaseComponent {
     if (this.tip.classList.contains(CLASS_NAME_FADE)) {
       const transitionDuration = getTransitionDurationFromElement(tip)
 
-      EventHandler.one(tip, TRANSITION_END, complete)
+      EventHandler.one(tip, 'transitionend', complete)
       emulateTransitionEnd(tip, transitionDuration)
     } else {
       complete()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -9,7 +9,6 @@ import * as Popper from '@popperjs/core'
 
 import {
   defineJQueryPlugin,
-  TRANSITION_END,
   emulateTransitionEnd,
   findShadowRoot,
   getTransitionDurationFromElement,
@@ -117,6 +116,8 @@ const TRIGGER_HOVER = 'hover'
 const TRIGGER_FOCUS = 'focus'
 const TRIGGER_CLICK = 'click'
 const TRIGGER_MANUAL = 'manual'
+
+const TRANSITION_END = 'transitionend'
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -205,7 +205,6 @@ const defineJQueryPlugin = (name, plugin) => {
 }
 
 export {
-  TRANSITION_END,
   getUID,
   getSelectorFromElement,
   getElementFromSelector,


### PR DESCRIPTION
This was useful in v4-dev and back when we supported older browsers.

TODO:

- [x] Drop the variable completely from plugins?