### PR TITLE
carousel: switch to `if/else`

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -340,16 +340,12 @@ class Carousel extends BaseComponent {
       return
     }
 
-    switch (event.key) {
-      case ARROW_LEFT_KEY:
-        event.preventDefault()
-        this.prev()
-        break
-      case ARROW_RIGHT_KEY:
-        event.preventDefault()
-        this.next()
-        break
-      default:
+    if (event.key === ARROW_LEFT_KEY) {
+      event.preventDefault()
+      this.prev()
+    } else if (event.key === ARROW_RIGHT_KEY) {
+      event.preventDefault()
+      this.next()
     }
   }
 


### PR DESCRIPTION
There are only two conditions, so `if/else` is shorter and has the same effect.