### PR TITLE
Utility API, RFS option: Only generate responsive classes when needed

### DIFF
--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -26,7 +26,7 @@
       @each $key, $utility in $utilities {
         // The utility can be disabled with `false`, thus check if the utility is a map first
         // Only proceed if responsive media queries are enabled or if it's the base media query
-        @if type-of($utility) == "map" and map-get($utility, rfs) {
+        @if type-of($utility) == "map" and map-get($utility, rfs) and (map-get($utility, responsive) or $infix == "") {
           @include generate-utility($utility, $infix, true);
         }
       }


### PR DESCRIPTION
I bumped into these classes which shouldn't be generated when `responsive` isn't set `true`:
https://github.com/twbs/bootstrap/blob/b1290ff189f03fae12a74ece09b25069d6f97f1a/dist/css/bootstrap.css#L10631-L10673