### PR TITLE
Remove duplicated 'follow Bootstrap on Twitter' link in Getting Started

### DIFF
--- a/site/content/docs/5.0/getting-started/introduction.md
+++ b/site/content/docs/5.0/getting-started/introduction.md
@@ -152,7 +152,6 @@ For improved cross-browser rendering, we use [Reboot]({{< docsref "/content/rebo
 
 Stay up to date on the development of Bootstrap and reach out to the community with these helpful resources.
 
-- Follow [@getbootstrap on Twitter](https://twitter.com/{{< param twitter >}}).
 - Read and subscribe to [The Official Bootstrap Blog]({{< param blog >}}).
 - Join [the official Slack room]({{< param slack >}}).
 - Chat with fellow Bootstrappers in IRC. On the `irc.freenode.net` server, in the `##bootstrap` channel.


### PR DESCRIPTION
https://getbootstrap.com/docs/5.0/getting-started/introduction/#community

This looked like it was unintentional to list it twice. Feel free to edit the PR if you'd rather keep the first bullet-point and remove the very last line instead. 👍