### PR TITLE
cheatsheet: Drop redundant `(current)` text

### DIFF
--- a/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet-rtl/index.html
@@ -1304,7 +1304,7 @@ direction: rtl
           <ul class="pagination pagination-sm">
             <li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item active" aria-current="page">
-              <a class="page-link" href="#">2 <span class="visually-hidden">(تيار)</span></a>
+              <a class="page-link" href="#">2</a>
             </li>
             <li class="page-item"><a class="page-link" href="#">3</a></li>
           </ul>
@@ -1339,7 +1339,7 @@ direction: rtl
             </li>
             <li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item active" aria-current="page">
-              <a class="page-link" href="#">2 <span class="visually-hidden">(تيار)</span></a>
+              <a class="page-link" href="#">2</a>
             </li>
             <li class="page-item"><a class="page-link" href="#">3</a></li>
             <li class="page-item">

--- a/site/content/docs/5.0/examples/cheatsheet/index.html
+++ b/site/content/docs/5.0/examples/cheatsheet/index.html
@@ -1303,7 +1303,7 @@ body_class: "bg-light"
           <ul class="pagination pagination-sm">
             <li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item active" aria-current="page">
-              <a class="page-link" href="#">2 <span class="visually-hidden">(current)</span></a>
+              <a class="page-link" href="#">2</a>
             </li>
             <li class="page-item"><a class="page-link" href="#">3</a></li>
           </ul>
@@ -1338,7 +1338,7 @@ body_class: "bg-light"
             </li>
             <li class="page-item"><a class="page-link" href="#">1</a></li>
             <li class="page-item active" aria-current="page">
-              <a class="page-link" href="#">2 <span class="visually-hidden">(current)</span></a>
+              <a class="page-link" href="#">2</a>
             </li>
             <li class="page-item"><a class="page-link" href="#">3</a></li>
             <li class="page-item">


### PR DESCRIPTION
USeless since we're using `aria-current` (see #31891).