### PR TITLE
Reset Popper position in RTL

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -35,7 +35,7 @@
 
   // Reset positioning when positioned with Popper
   &[style] {
-    right: auto !important; // stylelint-disable-line declaration-no-important
+    right: auto#{"/* rtl:ignore */"} !important; // stylelint-disable-line declaration-no-important
   }
 }
 


### PR DESCRIPTION
The [RTL cheatsheet's dropdowns](https://getbootstrap.com/docs/5.0/examples/cheatsheet-rtl/#dropdowns) aren't positionned correctly because of RTLCSS transforming `right: auto` to `left:auto` (which conflicts with Popper positionning, I guess).

Somehow missed that while merging both PRs, but would like some review here to ensure I don't miss the point. 
Ping @MartijnCuppens @Johann-S

Preview: https://deploy-preview-32415--twbs-bootstrap.netlify.app//docs/5.0/examples/cheatsheet-rtl/#dropdowns