### PR TITLE
WIP: More CSS vars

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "24.25 kB"
+      "maxSize": "25 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "22.25 kB"
+      "maxSize": "22.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -165,6 +165,11 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 @function shift-color($color, $weight) {
   @return if($weight > 0, shade-color($color, $weight), tint-color($color, -$weight));
 }
+
+// Convert hex values to RGB
+@function hex-to-rgb($color) {
+  @return #{red($color)}, #{green($color)}, #{blue($color)};
+}
 // scss-docs-end color-functions
 
 // Return valid calc

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -26,7 +26,7 @@
 // null by default, thus nothing is generated.
 
 :root {
-  font-size: $font-size-root;
+  font-size: var(--root-font-size);
 
   @if $enable-smooth-scroll {
     @media (prefers-reduced-motion: no-preference) {
@@ -45,13 +45,13 @@
 
 body {
   margin: 0; // 1
-  font-family: $font-family-base;
-  @include font-size($font-size-base);
+  font-family: var(--bs-body-font);
+  @include font-size(var(--bs-body-font-size));
   font-weight: $font-weight-base;
   line-height: $line-height-base;
-  color: $body-color;
+  color: var(--bs-body-color);
   text-align: $body-text-align;
-  background-color: $body-bg; // 2
+  background-color: var(--bs-body-bg); // 2
   -webkit-text-size-adjust: 100%; // 3
   -webkit-tap-highlight-color: rgba($black, 0); // 4
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -30,12 +30,13 @@
   --#{$variable-prefix}grid-gutter-width: #{$grid-gutter-width};
 
   // Spacing
-  // TODO: Ideally we'd size these values based on the CSS var instead of the Sass map, so they'd be live updating, but TBD on feasibility
+  // Ideally we'd size these values based on the CSS var instead of the Sass map, so they'd be live updating, but TBD on feasibility
   --#{$variable-prefix}spacer: #{$spacer};
   @each $size, $value in $spacers {
     --#{$variable-prefix}spacer-#{$size}: #{$value};
   }
 
+  // Breakpoints
   @each $breakpoint, $width in $grid-breakpoints {
     @if $width > 0 {
       --#{$variable-prefix}breakpoint-#{$breakpoint}: #{$width};

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -4,6 +4,10 @@
     --#{$variable-prefix}#{$color}: #{$value};
   }
 
+  @each $color, $value in $grays {
+    --#{$variable-prefix}gray-#{$color}: #{$value};
+  }
+
   @each $color, $value in $theme-colors {
     --#{$variable-prefix}#{$color}: #{$value};
   }
@@ -13,4 +17,22 @@
   --#{$variable-prefix}font-sans-serif: #{inspect($font-family-sans-serif)};
   --#{$variable-prefix}font-monospace: #{inspect($font-family-monospace)};
   --#{$variable-prefix}gradient: #{$gradient};
+
+  // Root and body
+  --#{$variable-prefix}root-font-size: #{$font-size-root};
+  --#{$variable-prefix}body-font: #{$font-family-base};
+  --#{$variable-prefix}body-font-size: #{$font-size-base};
+  --#{$variable-prefix}body-color: #{$body-color};
+  --#{$variable-prefix}body-bg: #{$body-bg};
+
+  // Layout
+  --#{$variable-prefix}grid-columns: #{$grid-columns};
+  --#{$variable-prefix}grid-gutter-width: #{$grid-gutter-width};
+
+  // Spacing
+  // TODO: Ideally we'd size these values based on the CSS var instead of the Sass map, so they'd be live updating, but TBD on feasibility
+  --#{$variable-prefix}spacer: #{$spacer};
+  @each $size, $value in $spacers {
+    --#{$variable-prefix}spacer-#{$size}: #{$value};
+  }
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -2,14 +2,18 @@
   // Custom variable values only support SassScript inside `#{}`.
   @each $color, $value in $colors {
     --#{$variable-prefix}#{$color}: #{$value};
+    --#{$variable-prefix}#{$color}-rgb: #{hex-to-rgb($value)};
   }
 
   @each $color, $value in $grays {
     --#{$variable-prefix}gray-#{$color}: #{$value};
+    --#{$variable-prefix}gray-#{$color}-rgb: #{hex-to-rgb($value)};
   }
 
   @each $color, $value in $theme-colors {
+    // --#{$variable-prefix}#{$color}: rgba(#{hex-to-rgb($value)}, var(--#{$variable-prefix}color-opacity, 1));
     --#{$variable-prefix}#{$color}: #{$value};
+    --#{$variable-prefix}#{$color}-rgb: #{hex-to-rgb($value)};
   }
 
   // Use `inspect` for lists so that quoted items keep the quotes.

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -35,4 +35,10 @@
   @each $size, $value in $spacers {
     --#{$variable-prefix}spacer-#{$size}: #{$value};
   }
+
+  @each $breakpoint, $width in $grid-breakpoints {
+    @if $width > 0 {
+      --#{$variable-prefix}breakpoint-#{$breakpoint}: #{$width};
+    }
+  }
 }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,7 +2,7 @@
 //
 // Generate semantic grid columns with these mixins.
 
-@mixin make-row($gutter: $grid-gutter-width) {
+@mixin make-row($gutter: var(--bs-grid-gutter-width)) {
   --#{$variable-prefix}gutter-x: #{$gutter};
   --#{$variable-prefix}gutter-y: 0;
   display: flex;

--- a/site/content/docs/5.0/customize/css-variables.md
+++ b/site/content/docs/5.0/customize/css-variables.md
@@ -14,7 +14,7 @@ Bootstrap includes a slew of [CSS custom properties (variables)](https://develop
 
 Here are the variables we include (note that the `:root` is required) that can be accessed anywhere Bootstrap's CSS is loaded. They're located in our `_root.scss` file and included in our compiled dist files.
 
-```scss
+```css
 {{< root.inline >}}
 {{- $css := readFile "dist/css/bootstrap.css" -}}
 {{- $match := findRE ":root {([^}]*)}" $css 1 -}}
@@ -40,6 +40,10 @@ We're also using CSS variables across our grids—primarily for gutters—with m
 
 CSS variables offer similar flexibility to Sass's variables, but without the need for compilation before being served to the browser. For example, here we're resetting our page's font and link styles with CSS variables.
 
+### Basics
+
+Use a CSS variable where you would typically place a normal value, like fonts and colors.
+
 ```css
 body {
   font: 1rem/1.5 var(--bs-font-sans-serif);
@@ -48,6 +52,56 @@ a {
   color: var(--bs-blue);
 }
 ```
+
+### RGB colors
+
+While our colors are defined as hex values, we also include RGB values as additional CSS variables ending in `-rgb`. For example, we have `--bs-blue` and `--bs-blue-rgb`. This allows you to create more dynamic utilities and customizations. Using the regular CSS variables, you can create a custom `.text-blue` utility.
+
+<div class="bd-example">
+  <style>
+  .text-blue {
+    color: var(--bs-blue);
+  }
+  </style>
+  <span class="text-blue">Custom blue text</span>
+</div>
+
+```css
+.text-blue {
+  color: var(--bs-blue);
+}
+```
+
+But you can also create your own utilities that interact with one another, like using the `-rgb` variables and custom opacities to create translucent text. Let's expand on the above example:
+
+<div class="bd-example bd-example-multiple-langs">
+  <style>
+  .text-blue2 { color: rgba(var(--bs-blue-rgb), var(--bs-color-opacity, 1)); }
+  .text-opacity-100 { --bs-color-opacity: 1; }
+  .text-opacity-75 { --bs-color-opacity: .75; }
+  .text-opacity-50 { --bs-color-opacity: .5; }
+  .text-opacity-25 { --bs-color-opacity: .25; }
+  </style>
+  <div class="text-blue2 text-opacity-100">Custom blue text at 100% opacity</div>
+  <div class="text-blue2 text-opacity-75">Custom blue text at 75% opacity</div>
+  <div class="text-blue2 text-opacity-50">Custom blue text at 50% opacity</div>
+  <div class="text-blue2 text-opacity-25">Custom blue text at 25% opacity</div>
+</div>
+
+```css
+.text-blue { color: rgba(var(--bs-blue-rgb), var(--bs-color-opacity, 1)); }
+
+.text-opacity-100 { --bs-color-opacity: 1; }
+.text-opacity-75 { --bs-color-opacity: .75; }
+.text-opacity-50 { --bs-color-opacity: .5; }
+.text-opacity-25 { --bs-color-opacity: .25; }
+```
+
+```html
+<div class="text-blue text-opacity-50">Custom blue text at 50% opacity</div>
+```
+
+This allows you to create some powerful customizations with little overhead.
 
 ## Grid breakpoints
 

--- a/site/content/docs/5.0/customize/css-variables.md
+++ b/site/content/docs/5.0/customize/css-variables.md
@@ -6,7 +6,7 @@ group: customize
 toc: true
 ---
 
-Bootstrap includes around two dozen [CSS custom properties (variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) in its compiled CSS, with dozens more on the way for improved customization on a per-component basis. These provide easy access to commonly used values like our theme colors, breakpoints, and primary font stacks when working in your browser's inspector, a code sandbox, or general prototyping.
+Bootstrap includes a slew of [CSS custom properties (variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) in its compiled CSS for improved on-the-fly customization. These provide easy access to commonly used values like our theme colors, breakpoints, and primary font stacks when working in your browser's inspector, a code sandbox, or general prototyping. All without recompiling source Sass files.
 
 **All our custom properties are prefixed with `bs-`** to avoid conflicts with third party CSS.
 
@@ -14,7 +14,7 @@ Bootstrap includes around two dozen [CSS custom properties (variables)](https://
 
 Here are the variables we include (note that the `:root` is required) that can be accessed anywhere Bootstrap's CSS is loaded. They're located in our `_root.scss` file and included in our compiled dist files.
 
-```css
+```scss
 {{< root.inline >}}
 {{- $css := readFile "dist/css/bootstrap.css" -}}
 {{- $match := findRE ":root {([^}]*)}" $css 1 -}}
@@ -48,3 +48,7 @@ a {
   color: var(--bs-blue);
 }
 ```
+
+## Grid breakpoints
+
+While we include our grid breakpoints as variables (except for `xs`), but be aware that CSS variables do not work in media queries. This is by design in the CSS spec for variables, but may change in coming years with support for `env()` variables. Check out [this Stack Overflow answer](https://stackoverflow.com/a/47212942) for some helpful links.


### PR DESCRIPTION
This PR adds additional CSS custom properties to our `:root` in the hopes of improving ease of customization and extensibility.

## Approach

In some situations, I'm just adding CSS vars for the sake of adding them. The more we expose here, the more folks can do with Bootstrap. Of course there's a filesize issue to consider, but we'll manage that by keeping things pretty tight for now. Beyond that, I'm creating CSS vars for some situations and replacing their Sass variables with interpolated CSS vars (e.g., instead of `$body-bg` it's `var(--bs-body-bg)` which has a computed value of `$body-bg`).

## What's new

- Added all `$grays`
- Added `$spacers` (ideally we could make the CSS var versions powered by `--bs-spacer`, but unsure how to do that)
- Added grid column count and gutter width, and replaced their Sass values in our mixins
- Added body values (font, color, background-color) and replaced their Sass values in Reboot

Still more to think about and fine-tune here.

## All CSS variables

```css
--bs-blue: #0d6efd;
--bs-indigo: #6610f2;
--bs-purple: #6f42c1;
--bs-pink: #d63384;
--bs-red: #dc3545;
--bs-orange: #fd7e14;
--bs-yellow: #ffc107;
--bs-green: #198754;
--bs-teal: #20c997;
--bs-cyan: #0dcaf0;
--bs-white: #fff;
--bs-gray: #6c757d;
--bs-gray-dark: #343a40;
--bs-100: #f8f9fa;
--bs-200: #e9ecef;
--bs-300: #dee2e6;
--bs-400: #ced4da;
--bs-500: #adb5bd;
--bs-600: #6c757d;
--bs-700: #495057;
--bs-800: #343a40;
--bs-900: #212529;
--bs-primary: #0d6efd;
--bs-secondary: #6c757d;
--bs-success: #198754;
--bs-info: #0dcaf0;
--bs-warning: #ffc107;
--bs-danger: #dc3545;
--bs-light: #f8f9fa;
--bs-dark: #212529;
--bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
--bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
--bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
--bs-body-font: var(--bs-font-sans-serif);
--bs-body-font-size: 1rem;
--bs-body-color: #212529;
--bs-body-bg: #fff;
--bs-grid-columns: 12;
--bs-grid-gutter-width: 1.5rem;
--bs-spacer: 1rem;
--bs-spacer-0: 0;
--bs-spacer-1: 0.25rem;
--bs-spacer-2: 0.5rem;
--bs-spacer-3: 1rem;
--bs-spacer-4: 1.5rem;
--bs-spacer-5: 3rem;
```