### PR TITLE
Expand `visually-hidden-focusable` so it can be used on a container, …

### DIFF
--- a/scss/helpers/_visually-hidden.scss
+++ b/scss/helpers/_visually-hidden.scss
@@ -3,6 +3,6 @@
 //
 
 .visually-hidden,
-.visually-hidden-focusable:not(:focus) {
+.visually-hidden-focusable:not(:focus):not(:focus-within) {
   @include visually-hidden();
 }

--- a/scss/mixins/_visually-hidden.scss
+++ b/scss/mixins/_visually-hidden.scss
@@ -17,12 +17,13 @@
   border: 0 !important;
 }
 
-// Use to only display content when it's focused.
+// Use to only display content when it's focused, or one of its child elements is focused
+// (i.e. when focus is within the element/container that the class was applied to)
 //
 // Useful for "Skip to main content" links; see https://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
 
 @mixin visually-hidden-focusable() {
-  &:not(:focus) {
+  &:not(:focus):not(:focus-within) {
     @include visually-hidden();
   }
 }

--- a/site/assets/scss/_skippy.scss
+++ b/site/assets/scss/_skippy.scss
@@ -1,20 +1,7 @@
-// stylelint-disable declaration-no-important
-
 .skippy {
   background-color: $bd-purple;
 
   a {
     color: $white;
-  }
-
-  &:focus-within a {
-    position: static !important;
-    width: auto !important;
-    height: auto !important;
-    padding: $spacer / 2 !important;
-    margin: $spacer / 4 !important;
-    overflow: visible !important;
-    clip: auto !important;
-    white-space: normal !important;
   }
 }

--- a/site/content/docs/5.0/helpers/visually-hidden.md
+++ b/site/content/docs/5.0/helpers/visually-hidden.md
@@ -6,12 +6,15 @@ group: helpers
 aliases: "/docs/5.0/helpers/screen-readers/"
 ---
 
-Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.visually-hidden`. Use `.visually-hidden-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
+Visually hide an element while still allowing it to be exposed to assistive technologies (such as screen readers) with `.visually-hidden`. Use `.visually-hidden-focusable` to visually hide an element by default, but to display it when it's focused (e.g. by a keyboard-only user). `.visually-hidden-focusable` can also be applied to a container–thanks to `:focus-within`, the container will be displayed when any child element of the container receives focus.
 
 {{< example >}}
 <h2 class="visually-hidden">Title for screen readers</h2>
 <a class="visually-hidden-focusable" href="#content">Skip to main content</a>
+<div class="visually-hidden-focusable">A container with a <a href="#">focusable element</a>.</div>
 {{< /example >}}
+
+Both `visually-hidden` and `visually-hidden-focusable` can also be used as mixins.
 
 ```scss
 // Usage as a mixin

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -9,6 +9,10 @@ toc: true
 
 ## v5.0.0-beta2
 
+### Sass
+
+- Extended the `.visually-hidden-focusable` helper to also work on containers, using `:focus-within`.
+
 ### JavaScript
 
 - The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of popper elements.
@@ -57,7 +61,6 @@ Breakpoints specific variants are consequently renamed too (eg. `.text-md-start`
 - Renamed `$form-switch-padding-left` to `$form-switch-padding-start`.
 - Renamed `$form-check-inline-margin-right` to `$form-check-inline-margin-end`.
 - Renamed `$form-select-feedback-icon-padding-right` to `$form-select-feedback-icon-padding-end`.
-
 
 ### JavaScript
 

--- a/site/layouts/partials/skippy.html
+++ b/site/layouts/partials/skippy.html
@@ -1,8 +1,8 @@
-<div class="skippy overflow-hidden">
+<div class="skippy visually-hidden-focusable overflow-hidden">
   <div class="container-xl">
-    <a class="visually-hidden-focusable d-inline-flex p-2 m-1" href="#content">Skip to main content</a>
+    <a class="d-inline-flex p-2 m-1" href="#content">Skip to main content</a>
     {{ if (eq .Page.Layout "docs") -}}
-    <a class="visually-hidden-focusable d-none d-md-inline-flex p-2 m-1" href="#bd-docs-nav">Skip to docs navigation</a>
+    <a class="d-none d-md-inline-flex p-2 m-1" href="#bd-docs-nav">Skip to docs navigation</a>
     {{- end }}
   </div>
 </div>


### PR DESCRIPTION
…so the container becomes visible when focus is inside it / on one of its child elements.

Closes https://github.com/twbs/bootstrap/issues/32370

https://deploy-preview-32440--twbs-bootstrap.netlify.app/docs/5.0/helpers/visually-hidden/