### PR TITLE
util: change `isRTL` to a function

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -97,8 +97,6 @@ const SELECTOR_DATA_RIDE = '[data-bs-ride="carousel"]'
 const POINTER_TYPE_TOUCH = 'touch'
 const POINTER_TYPE_PEN = 'pen'
 
-const IS_RTL = isRTL()
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -255,7 +253,7 @@ class Carousel extends BaseComponent {
 
     // swipe left
     if (direction > 0) {
-      if (IS_RTL) {
+      if (isRTL()) {
         this.next()
       } else {
         this.prev()
@@ -264,7 +262,7 @@ class Carousel extends BaseComponent {
 
     // swipe right
     if (direction < 0) {
-      if (IS_RTL) {
+      if (isRTL()) {
         this.prev()
       } else {
         this.next()
@@ -352,14 +350,14 @@ class Carousel extends BaseComponent {
 
     if (event.key === ARROW_LEFT_KEY) {
       event.preventDefault()
-      if (IS_RTL) {
+      if (isRTL()) {
         this.next()
       } else {
         this.prev()
       }
     } else if (event.key === ARROW_RIGHT_KEY) {
       event.preventDefault()
-      if (IS_RTL) {
+      if (isRTL()) {
         this.prev()
       } else {
         this.next()

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -253,7 +253,7 @@ class Carousel extends BaseComponent {
 
     // swipe left
     if (direction > 0) {
-      if (isRTL) {
+      if (isRTL()) {
         this.next()
       } else {
         this.prev()
@@ -262,7 +262,7 @@ class Carousel extends BaseComponent {
 
     // swipe right
     if (direction < 0) {
-      if (isRTL) {
+      if (isRTL()) {
         this.prev()
       } else {
         this.next()
@@ -350,14 +350,14 @@ class Carousel extends BaseComponent {
 
     if (event.key === ARROW_LEFT_KEY) {
       event.preventDefault()
-      if (isRTL) {
+      if (isRTL()) {
         this.next()
       } else {
         this.prev()
       }
     } else if (event.key === ARROW_RIGHT_KEY) {
       event.preventDefault()
-      if (isRTL) {
+      if (isRTL()) {
         this.prev()
       } else {
         this.next()

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -97,6 +97,8 @@ const SELECTOR_DATA_RIDE = '[data-bs-ride="carousel"]'
 const POINTER_TYPE_TOUCH = 'touch'
 const POINTER_TYPE_PEN = 'pen'
 
+const IS_RTL = isRTL()
+
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -253,7 +255,7 @@ class Carousel extends BaseComponent {
 
     // swipe left
     if (direction > 0) {
-      if (isRTL()) {
+      if (IS_RTL) {
         this.next()
       } else {
         this.prev()
@@ -262,7 +264,7 @@ class Carousel extends BaseComponent {
 
     // swipe right
     if (direction < 0) {
-      if (isRTL()) {
+      if (IS_RTL) {
         this.prev()
       } else {
         this.next()
@@ -350,14 +352,14 @@ class Carousel extends BaseComponent {
 
     if (event.key === ARROW_LEFT_KEY) {
       event.preventDefault()
-      if (isRTL()) {
+      if (IS_RTL) {
         this.next()
       } else {
         this.prev()
       }
     } else if (event.key === ARROW_RIGHT_KEY) {
       event.preventDefault()
-      if (isRTL()) {
+      if (IS_RTL) {
         this.prev()
       } else {
         this.next()

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -64,12 +64,12 @@ const SELECTOR_MENU = '.dropdown-menu'
 const SELECTOR_NAVBAR_NAV = '.navbar-nav'
 const SELECTOR_VISIBLE_ITEMS = '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
 
-const PLACEMENT_TOP = isRTL ? 'top-end' : 'top-start'
-const PLACEMENT_TOPEND = isRTL ? 'top-start' : 'top-end'
-const PLACEMENT_BOTTOM = isRTL ? 'bottom-end' : 'bottom-start'
-const PLACEMENT_BOTTOMEND = isRTL ? 'bottom-start' : 'bottom-end'
-const PLACEMENT_RIGHT = isRTL ? 'left-start' : 'right-start'
-const PLACEMENT_LEFT = isRTL ? 'right-start' : 'left-start'
+const PLACEMENT_TOP = isRTL() ? 'top-end' : 'top-start'
+const PLACEMENT_TOPEND = isRTL() ? 'top-start' : 'top-end'
+const PLACEMENT_BOTTOM = isRTL() ? 'bottom-end' : 'bottom-start'
+const PLACEMENT_BOTTOMEND = isRTL() ? 'bottom-start' : 'bottom-end'
+const PLACEMENT_RIGHT = isRTL() ? 'left-start' : 'right-start'
+const PLACEMENT_LEFT = isRTL() ? 'right-start' : 'left-start'
 
 const Default = {
   offset: [0, 2],

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -64,14 +64,12 @@ const SELECTOR_MENU = '.dropdown-menu'
 const SELECTOR_NAVBAR_NAV = '.navbar-nav'
 const SELECTOR_VISIBLE_ITEMS = '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
 
-const IS_RTL = isRTL()
-
-const PLACEMENT_TOP = IS_RTL ? 'top-end' : 'top-start'
-const PLACEMENT_TOPEND = IS_RTL ? 'top-start' : 'top-end'
-const PLACEMENT_BOTTOM = IS_RTL ? 'bottom-end' : 'bottom-start'
-const PLACEMENT_BOTTOMEND = IS_RTL ? 'bottom-start' : 'bottom-end'
-const PLACEMENT_RIGHT = IS_RTL ? 'left-start' : 'right-start'
-const PLACEMENT_LEFT = IS_RTL ? 'right-start' : 'left-start'
+const PLACEMENT_TOP = isRTL() ? 'top-end' : 'top-start'
+const PLACEMENT_TOPEND = isRTL() ? 'top-start' : 'top-end'
+const PLACEMENT_BOTTOM = isRTL() ? 'bottom-end' : 'bottom-start'
+const PLACEMENT_BOTTOMEND = isRTL() ? 'bottom-start' : 'bottom-end'
+const PLACEMENT_RIGHT = isRTL() ? 'left-start' : 'right-start'
+const PLACEMENT_LEFT = isRTL() ? 'right-start' : 'left-start'
 
 const Default = {
   offset: [0, 2],

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -64,12 +64,14 @@ const SELECTOR_MENU = '.dropdown-menu'
 const SELECTOR_NAVBAR_NAV = '.navbar-nav'
 const SELECTOR_VISIBLE_ITEMS = '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
 
-const PLACEMENT_TOP = isRTL() ? 'top-end' : 'top-start'
-const PLACEMENT_TOPEND = isRTL() ? 'top-start' : 'top-end'
-const PLACEMENT_BOTTOM = isRTL() ? 'bottom-end' : 'bottom-start'
-const PLACEMENT_BOTTOMEND = isRTL() ? 'bottom-start' : 'bottom-end'
-const PLACEMENT_RIGHT = isRTL() ? 'left-start' : 'right-start'
-const PLACEMENT_LEFT = isRTL() ? 'right-start' : 'left-start'
+const IS_RTL = isRTL()
+
+const PLACEMENT_TOP = IS_RTL ? 'top-end' : 'top-start'
+const PLACEMENT_TOPEND = IS_RTL ? 'top-start' : 'top-end'
+const PLACEMENT_BOTTOM = IS_RTL ? 'bottom-end' : 'bottom-start'
+const PLACEMENT_BOTTOMEND = IS_RTL ? 'bottom-start' : 'bottom-end'
+const PLACEMENT_RIGHT = IS_RTL ? 'left-start' : 'right-start'
+const PLACEMENT_LEFT = IS_RTL ? 'right-start' : 'left-start'
 
 const Default = {
   offset: [0, 2],

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -72,6 +72,8 @@ const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="modal"]'
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
 
+const IS_RTL = isRTL()
+
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -433,11 +435,11 @@ class Modal extends BaseComponent {
   _adjustDialog() {
     const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
 
-    if ((!this._isBodyOverflowing && isModalOverflowing && !isRTL()) || (this._isBodyOverflowing && !isModalOverflowing && isRTL())) {
+    if ((!this._isBodyOverflowing && isModalOverflowing && !IS_RTL) || (this._isBodyOverflowing && !isModalOverflowing && IS_RTL)) {
       this._element.style.paddingLeft = `${this._scrollbarWidth}px`
     }
 
-    if ((this._isBodyOverflowing && !isModalOverflowing && !isRTL()) || (!this._isBodyOverflowing && isModalOverflowing && isRTL())) {
+    if ((this._isBodyOverflowing && !isModalOverflowing && !IS_RTL) || (!this._isBodyOverflowing && isModalOverflowing && IS_RTL)) {
       this._element.style.paddingRight = `${this._scrollbarWidth}px`
     }
   }

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -72,8 +72,6 @@ const SELECTOR_DATA_DISMISS = '[data-bs-dismiss="modal"]'
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
 
-const IS_RTL = isRTL()
-
 /**
  * ------------------------------------------------------------------------
  * Class Definition
@@ -435,11 +433,11 @@ class Modal extends BaseComponent {
   _adjustDialog() {
     const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
 
-    if ((!this._isBodyOverflowing && isModalOverflowing && !IS_RTL) || (this._isBodyOverflowing && !isModalOverflowing && IS_RTL)) {
+    if ((!this._isBodyOverflowing && isModalOverflowing && !isRTL()) || (this._isBodyOverflowing && !isModalOverflowing && isRTL())) {
       this._element.style.paddingLeft = `${this._scrollbarWidth}px`
     }
 
-    if ((this._isBodyOverflowing && !isModalOverflowing && !IS_RTL) || (!this._isBodyOverflowing && isModalOverflowing && IS_RTL)) {
+    if ((this._isBodyOverflowing && !isModalOverflowing && !isRTL()) || (!this._isBodyOverflowing && isModalOverflowing && isRTL())) {
       this._element.style.paddingRight = `${this._scrollbarWidth}px`
     }
   }

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -431,14 +431,13 @@ class Modal extends BaseComponent {
   // ----------------------------------------------------------------------
 
   _adjustDialog() {
-    const isModalOverflowing =
-      this._element.scrollHeight > document.documentElement.clientHeight
+    const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
 
-    if ((!this._isBodyOverflowing && isModalOverflowing && !isRTL) || (this._isBodyOverflowing && !isModalOverflowing && isRTL)) {
+    if ((!this._isBodyOverflowing && isModalOverflowing && !isRTL()) || (this._isBodyOverflowing && !isModalOverflowing && isRTL())) {
       this._element.style.paddingLeft = `${this._scrollbarWidth}px`
     }
 
-    if ((this._isBodyOverflowing && !isModalOverflowing && !isRTL) || (!this._isBodyOverflowing && isModalOverflowing && isRTL)) {
+    if ((this._isBodyOverflowing && !isModalOverflowing && !isRTL()) || (!this._isBodyOverflowing && isModalOverflowing && isRTL())) {
       this._element.style.paddingRight = `${this._scrollbarWidth}px`
     }
   }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -40,6 +40,7 @@ const EVENT_KEY = `.${DATA_KEY}`
 const CLASS_PREFIX = 'bs-tooltip'
 const BSCLS_PREFIX_REGEX = new RegExp(`(^|\\s)${CLASS_PREFIX}\\S+`, 'g')
 const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
+const IS_RTL = isRTL()
 
 const DefaultType = {
   animation: 'boolean',
@@ -64,9 +65,9 @@ const DefaultType = {
 const AttachmentMap = {
   AUTO: 'auto',
   TOP: 'top',
-  RIGHT: isRTL() ? 'left' : 'right',
+  RIGHT: IS_RTL ? 'left' : 'right',
   BOTTOM: 'bottom',
-  LEFT: isRTL() ? 'right' : 'left'
+  LEFT: IS_RTL ? 'right' : 'left'
 }
 
 const Default = {

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -64,9 +64,9 @@ const DefaultType = {
 const AttachmentMap = {
   AUTO: 'auto',
   TOP: 'top',
-  RIGHT: isRTL ? 'left' : 'right',
+  RIGHT: isRTL() ? 'left' : 'right',
   BOTTOM: 'bottom',
-  LEFT: isRTL ? 'right' : 'left'
+  LEFT: isRTL() ? 'right' : 'left'
 }
 
 const Default = {
@@ -563,8 +563,7 @@ class Tooltip extends BaseComponent {
 
     triggers.forEach(trigger => {
       if (trigger === 'click') {
-        EventHandler.on(this._element, this.constructor.Event.CLICK, this.config.selector, event => this.toggle(event)
-        )
+        EventHandler.on(this._element, this.constructor.Event.CLICK, this.config.selector, event => this.toggle(event))
       } else if (trigger !== TRIGGER_MANUAL) {
         const eventIn = trigger === TRIGGER_HOVER ?
           this.constructor.Event.MOUSEENTER :

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -40,7 +40,6 @@ const EVENT_KEY = `.${DATA_KEY}`
 const CLASS_PREFIX = 'bs-tooltip'
 const BSCLS_PREFIX_REGEX = new RegExp(`(^|\\s)${CLASS_PREFIX}\\S+`, 'g')
 const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
-const IS_RTL = isRTL()
 
 const DefaultType = {
   animation: 'boolean',
@@ -65,9 +64,9 @@ const DefaultType = {
 const AttachmentMap = {
   AUTO: 'auto',
   TOP: 'top',
-  RIGHT: IS_RTL ? 'left' : 'right',
+  RIGHT: isRTL() ? 'left' : 'right',
   BOTTOM: 'bottom',
-  LEFT: IS_RTL ? 'right' : 'left'
+  LEFT: isRTL() ? 'right' : 'left'
 }
 
 const Default = {

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -198,7 +198,7 @@ const onDOMContentLoaded = callback => {
   }
 }
 
-const isRTL = document.documentElement.dir === 'rtl'
+const isRTL = () => document.documentElement.dir === 'rtl'
 
 const defineJQueryPlugin = (name, plugin) => {
   onDOMContentLoaded(() => {


### PR DESCRIPTION
This allows the bundler to tree-shake the function.

I wonder if we should cache the function call in the plugins we use `isRTL()`?