### PR TITLE
Few updates for v5.0.0-beta1 NuGet support

### DIFF
--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -3,22 +3,19 @@
   <metadata>
     <id>bootstrap</id>
     <!-- pulled from package.json -->
-    <version>4</version>
+    <version>5</version>
     <title>Bootstrap CSS</title>
     <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
     <description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>https://blog.getbootstrap.com/</releaseNotes>
-    <summary>Bootstrap framework in CSS. Includes JavaScript</summary>
+    <summary>Bootstrap framework in CSS. Includes JavaScript but requires PopperJS which must be installed independently</summary>
     <language>en-us</language>
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <icon>bootstrap.png</icon>
     <license type="file">LICENSE.txt</license>
     <copyright>Copyright 2017-2020</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-      <dependency id="@popperjs/core" version="[2.5.4,3)" />
-    </dependencies>
     <tags>css mobile-first responsive front-end framework web</tags>
     <contentFiles>
       <files include="**/*" buildAction="Content" />

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -9,7 +9,7 @@
     <owners>bootstrap</owners>
     <description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>https://blog.getbootstrap.com/</releaseNotes>
-    <summary>Bootstrap framework in CSS. Includes JavaScript but requires PopperJS which must be installed independently</summary>
+    <summary>Bootstrap framework in CSS. Includes JavaScript</summary>
     <language>en-us</language>
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <icon>bootstrap.png</icon>

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -9,7 +9,7 @@
     <owners>bootstrap</owners>
     <description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>https://blog.getbootstrap.com/</releaseNotes>
-    <summary>Bootstrap framework in Sass. Includes JavaScript but requires PopperJS which must be installed independently</summary>
+    <summary>Bootstrap framework in Sass. Includes JavaScript</summary>
     <language>en-us</language>
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <icon>bootstrap.png</icon>

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -3,22 +3,19 @@
   <metadata>
     <id>bootstrap.sass</id>
     <!-- pulled from package.json -->
-    <version>4</version>
+    <version>5</version>
     <title>Bootstrap Sass</title>
     <authors>The Bootstrap Authors, Twitter Inc.</authors>
     <owners>bootstrap</owners>
     <description>The most popular front-end framework for developing responsive, mobile first projects on the web.</description>
     <releaseNotes>https://blog.getbootstrap.com/</releaseNotes>
-    <summary>Bootstrap framework in Sass. Includes JavaScript</summary>
+    <summary>Bootstrap framework in Sass. Includes JavaScript but requires PopperJS which must be installed independently</summary>
     <language>en-us</language>
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <icon>bootstrap.png</icon>
     <license type="file">LICENSE.txt</license>
     <copyright>Copyright 2017-2020</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-      <dependency id="@popperjs/core" version="[2.5.4,3)" />
-    </dependencies>
     <tags>css sass mobile-first responsive front-end framework web</tags>
     <contentFiles>
       <files include="**/*" buildAction="Content" />

--- a/site/content/docs/5.0/getting-started/download.md
+++ b/site/content/docs/5.0/getting-started/download.md
@@ -104,8 +104,7 @@ composer require twbs/bootstrap:{{< param current_version >}}
 
 ### NuGet
 
-If you develop in .NET, you can also install and manage Bootstrap's [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/). 
-As of 5.0.0-beta1, [PopperJS](https://popper.js.org/) needs to be [installed](https://popper.js.org/docs/v2/tutorial/#setting-up) independently as it is no longer published as a NuGet package:
+If you develop in .NET, you can also install and manage Bootstrap's [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/):
 
 ```powershell
 Install-Package bootstrap

--- a/site/content/docs/5.0/getting-started/download.md
+++ b/site/content/docs/5.0/getting-started/download.md
@@ -104,7 +104,8 @@ composer require twbs/bootstrap:{{< param current_version >}}
 
 ### NuGet
 
-If you develop in .NET, you can also install and manage Bootstrap's [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/):
+If you develop in .NET, you can also install and manage Bootstrap's [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/). 
+As of 5.0.0-beta1, [PopperJS](https://popper.js.org/) needs to be [installed](https://popper.js.org/docs/v2/tutorial/#setting-up) independently as it is no longer published as a NuGet package:
 
 ```powershell
 Install-Package bootstrap


### PR DESCRIPTION
PopperJS 2.0 isn't on NuGet so dropped as a dependency and added a note to install independently