### PR TITLE
docs: Add `system-ui` to the native font stack documentation

### DIFF
--- a/site/content/docs/5.0/content/reboot.md
+++ b/site/content/docs/5.0/content/reboot.md
@@ -33,6 +33,8 @@ Bootstrap utilizes a "native font stack" or "system font stack" for optimum text
 
 ```scss
 $font-family-sans-serif:
+  // Cross-platform generic font family (default user interface font)
+  system-ui,
   // Safari for macOS and iOS (San Francisco)
   -apple-system,
   // Chrome < 56 for macOS (San Francisco)

--- a/site/content/docs/5.0/getting-started/rtl.md
+++ b/site/content/docs/5.0/getting-started/rtl.md
@@ -116,6 +116,8 @@ For example, to switch from `Helvetica Neue Webfont` for LTR to `Helvetica Neue 
 ```scss
 $font-family-sans-serif:
   Helvetica Neue #{"/* rtl:insert:Arabic */"},
+  // Cross-platform generic font family (default user interface font)
+  system-ui,
   // Safari for macOS and iOS (San Francisco)
   -apple-system,
   // Chrome < 56 for macOS (San Francisco)


### PR DESCRIPTION
`system-ui` was added to the v5 native font stack in #30561 but the docs were not updated. For the comment I used the description of the [system-ui font family in the W3 draft](https://www.w3.org/TR/css-fonts-4/#valdef-font-family-system-ui):

> This generic font family lets text render with the default user interface font on the platform on which the UA is running.

Please let me know if you think there is a better way to write it.