### PR TITLE
docs: Remove unneeded `.form-group` class

### DIFF
--- a/site/content/docs/5.0/components/toasts.md
+++ b/site/content/docs/5.0/components/toasts.md
@@ -137,7 +137,7 @@ Place toasts with custom CSS as you need them. The top right is often used for n
 
 {{< example >}}
 <form>
-  <div class="form-group mb-3">
+  <div class="mb-3">
     <label for="selectToastPlacement">Toast placement</label>
     <select class="form-select mt-2" id="selectToastPlacement">
       <option value="" selected>Select a position...</option>


### PR DESCRIPTION
`.form-group` was dropped, so it's not needed in the example