### PR TITLE
Update Translations page's Chinese Language website link for bootstrap 5

### DIFF
--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -1,12 +1,12 @@
+- name: Chinese
+  code: zh
+  description: Bootstrap 5 · 全球最流行的 HTML、CSS 和 JS 工具库。
+  url: https://code.z01.com/bootstrap/
+
 - name: 中文(繁體)
   code: zh-tw
   description: Bootstrap 4 繁體中文手冊
   url: https://bootstrap.hexschool.com/
-
-- name: Chinese
-  code: zh
-  description: Bootstrap 4 · 全球最流行的 HTML、CSS 和 JS 工具库。
-  url: https://code.z01.com/v4/
 
 - name: Brazilian Portuguese
   code: pt-BR

--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -1,6 +1,6 @@
 - name: Chinese
   code: zh
-  description: Bootstrap 5 · 全球最流行的 HTML、CSS 和 JS 工具库。
+  description: Bootstrap 5 · 全球最流行的HTML、CSS和JS前端web框架。
   url: https://code.z01.com/bootstrap/
 
 - name: 中文(繁體)


### PR DESCRIPTION
We are the maintenance team of the bootstrap Chinese Language website,Glad to see Boostrap 5 published beta1.
This is A exciting news！

Now， We apply to Update Translations page's Chinese Language website link,
Here is the new information：
Title: Bootstrap 5 · 全球最流行的HTML、CSS和JS前端web框架
Url: http://code.z01.com/bootstrap

At the same time, we will continue to optimize Chinese translation, so that our products can be known and adopted by more users, and contribute to the development of the Internet!

Thinks!

-- by Zoomla! CMS Team(boostrap Chinese Language website maintainer)