### PR TITLE
Fix floating label touch input left border

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -10,7 +10,7 @@
   > label {
     position: absolute;
     top: 0;
-    left: 0;
+    left: auto;
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     pointer-events: none;


### PR DESCRIPTION
Fix: Floating label touch input left border when Bootstrap grid `col-*` class use with `form-floating` class.

Fixes #32615