### PR TITLE
v4: Add an actual `data-touch="false"` example in the carousel docs

### DIFF
--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -270,7 +270,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>interval</td>
       <td>number</td>
       <td>5000</td>
-      <td>The amount of time to delay between automatically cycling an item. If false, carousel will not automatically cycle.</td>
+      <td>The amount of time to delay between automatically cycling an item. If <code>false</code>, carousel will not automatically cycle.</td>
     </tr>
     <tr>
       <td>keyboard</td>
@@ -281,15 +281,15 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     <tr>
       <td>pause</td>
       <td>string | boolean</td>
-      <td>"hover"</td>
-      <td><p>If set to <code>"hover"</code>, pauses the cycling of the carousel on <code>mouseenter</code> and resumes the cycling of the carousel on <code>mouseleave</code>. If set to <code>false</code>, hovering over the carousel won't pause it.</p>
-      <p>On touch-enabled devices, when set to <code>"hover"</code>, cycling will pause on <code>touchend</code> (once the user finished interacting with the carousel) for two intervals, before automatically resuming. Note that this is in addition to the above mouse behavior.</p></td>
+      <td>'hover'</td>
+      <td><p>If set to <code>'hover'</code>, pauses the cycling of the carousel on <code>mouseenter</code> and resumes the cycling of the carousel on <code>mouseleave</code>. If set to <code>false</code>, hovering over the carousel won't pause it.</p>
+      <p>On touch-enabled devices, when set to <code>'hover'</code>, cycling will pause on <code>touchend</code> (once the user finished interacting with the carousel) for two intervals, before automatically resuming. Note that this is in addition to the above mouse behavior.</p></td>
     </tr>
     <tr>
       <td>ride</td>
       <td>string</td>
       <td>false</td>
-      <td>Autoplays the carousel after the user manually cycles the first item. If set to <code>carousel</code>, autoplays the carousel on load.</td>
+      <td>Autoplays the carousel after the user manually cycles the first item. If set to <code>'carousel'</code>, autoplays the carousel on load.</td>
     </tr>
     <tr>
       <td>wrap</td>

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -210,10 +210,10 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 ### Suppressing touch swiping
 
-By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride` attribute nor the `.slide` class, meaning that it won't autoplay.
+By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride`, meaning that it won't autoplay.
 
 {{< example >}}
-<div id="carouselExampleControlsNoTouching" class="carousel" data-touch="false">
+<div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false">
   <div class="carousel-inner">
     <div class="carousel-item active">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}
@@ -286,10 +286,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <p>On touch-enabled devices, when set to <code>"hover"</code>, cycling will pause on <code>touchend</code> (once the user finished interacting with the carousel) for two intervals, before automatically resuming. Note that this is in addition to the above mouse behavior.</p></td>
     </tr>
     <tr>
-      <td>slide</td>
+      <td>ride</td>
       <td>string</td>
       <td>false</td>
-      <td>Autoplays the carousel after the user manually cycles the first item. If <code>data-ride="carousel"</code> is present, autoplays the carousel on load.</td>
+      <td>Autoplays the carousel after the user manually cycles the first item. If set to <code>carousel</code>, autoplays the carousel on load.</td>
     </tr>
     <tr>
       <td>wrap</td>

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -210,10 +210,10 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 ### Suppressing touch swiping
 
-By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride` attribute, meaning that it won't autoplay.
+By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride` attribute nor the `.slide` class, meaning that it won't autoplay.
 
 {{< example >}}
-<div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false">
+<div id="carouselExampleControlsNoTouching" class="carousel" data-touch="false">
   <div class="carousel-inner">
     <div class="carousel-item active">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}
@@ -286,10 +286,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <p>On touch-enabled devices, when set to <code>"hover"</code>, cycling will pause on <code>touchend</code> (once the user finished interacting with the carousel) for two intervals, before automatically resuming. Note that this is in addition to the above mouse behavior.</p></td>
     </tr>
     <tr>
-      <td>ride</td>
+      <td>slide</td>
       <td>string</td>
       <td>false</td>
-      <td>Autoplays the carousel after the user manually cycles the first item. If "carousel", autoplays the carousel on load.</td>
+      <td>Autoplays the carousel after the user manually cycles the first item. If <code>data-ride="carousel"</code> is present, autoplays the carousel on load.</td>
     </tr>
     <tr>
       <td>wrap</td>

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -210,7 +210,7 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 ### Disable touch swiping
 
-By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride`, and has `data-interval="false"`, meaning that it won't autoplay.
+Carousels support swiping left/right on touchscreen devices to move between slides. This can be disabled using the `data-touch` attribute. The example below also does not include the `data-ride` attribute and has `data-interval="false"` so it doesn't autoplay.
 
 {{< example >}}
 <div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false" data-interval="false">

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -208,7 +208,7 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 </div>
 {{< /example >}}
 
-### Suppressing touch swiping
+### Disable touch swiping
 
 By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride`, and has `data-interval="false"`, meaning that it won't autoplay.
 

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -210,10 +210,10 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 ### Suppressing touch swiping
 
-By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute.
+By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride` attribute, meaning that it won't autoplay.
 
 {{< example >}}
-<div id="carouselExampleControlsNoTouching" class="carousel slide" data-ride="carousel" data-touch="false">
+<div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false">
   <div class="carousel-inner">
     <div class="carousel-item active">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -208,6 +208,34 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 </div>
 {{< /example >}}
 
+### Suppressing touch swiping
+
+By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute.
+
+{{< example >}}
+<div id="carouselExampleControlsNoTouching" class="carousel slide" data-ride="carousel" data-touch="false">
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#444" background="#666" text="Second slide" >}}
+    </div>
+    <div class="carousel-item">
+      {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#333" background="#555" text="Third slide" >}}
+    </div>
+  </div>
+  <a class="carousel-control-prev" href="#carouselExampleControlsNoTouching" role="button" data-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="sr-only">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#carouselExampleControlsNoTouching" role="button" data-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="sr-only">Next</span>
+  </a>
+</div>
+{{< /example >}}
+
 ## Usage
 
 ### Via data attributes

--- a/site/content/docs/4.5/components/carousel.md
+++ b/site/content/docs/4.5/components/carousel.md
@@ -210,10 +210,10 @@ Add `data-interval=""` to a `.carousel-item` to change the amount of time to del
 
 ### Suppressing touch swiping
 
-By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride`, meaning that it won't autoplay.
+By default, carousels support swiping left/right on touchscreen devices to move between slides. This can be explicitly suppressed using the `data-touch` attribute. The example below also does not include the `data-ride`, and has `data-interval="false"`, meaning that it won't autoplay.
 
 {{< example >}}
-<div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false">
+<div id="carouselExampleControlsNoTouching" class="carousel slide" data-touch="false" data-interval="false">
   <div class="carousel-inner">
     <div class="carousel-item active">
       {{< placeholder width="800" height="400" class="bd-placeholder-img-lg d-block w-100" color="#555" background="#777" text="First slide" >}}


### PR DESCRIPTION
Backport of https://github.com/twbs/bootstrap/pull/32638