### PR TITLE
Support multiple tab targets

### DIFF
--- a/js/src/dom/event-handler.js
+++ b/js/src/dom/event-handler.js
@@ -227,6 +227,19 @@ const EventHandler = {
     addHandler(element, event, handler, delegationFn, true)
   },
 
+  oneForMany(elements, event, handler, delegationFn) {
+    let handled = 0
+
+    elements.forEach(element => {
+      addHandler(element, event, () => {
+        handled++
+        if (handled === elements.length) {
+          handler()
+        }
+      }, delegationFn, true)
+    })
+  },
+
   off(element, originalTypeEvent, handler, delegationFn) {
     if (typeof originalTypeEvent !== 'string' || !element) {
       return

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -8,7 +8,7 @@
 import {
   defineJQueryPlugin,
   emulateTransitionEnd,
-  getElementFromSelector,
+  getAllElementsFromSelector,
   getTransitionDurationFromElement,
   reflow
 } from './util/index'
@@ -72,7 +72,7 @@ class Tab extends BaseComponent {
     }
 
     let previous
-    const target = getElementFromSelector(this._element)
+    const targets = getAllElementsFromSelector(this._element)
     const listElement = this._element.closest(SELECTOR_NAV_LIST_GROUP)
 
     if (listElement) {
@@ -95,7 +95,7 @@ class Tab extends BaseComponent {
       return
     }
 
-    this._activate(this._element, listElement)
+    this._activate([this._element], listElement)
 
     const complete = () => {
       EventHandler.trigger(previous, EVENT_HIDDEN, {
@@ -106,8 +106,8 @@ class Tab extends BaseComponent {
       })
     }
 
-    if (target) {
-      this._activate(target, target.parentNode, complete)
+    if (targets && targets.length > 0) {
+      this._activate(targets, targets[0].parentNode, complete)
     } else {
       complete()
     }
@@ -115,63 +115,72 @@ class Tab extends BaseComponent {
 
   // Private
 
-  _activate(element, container, callback) {
+  _activate(elements, container, callback) {
     const activeElements = container && (container.nodeName === 'UL' || container.nodeName === 'OL') ?
       SelectorEngine.find(SELECTOR_ACTIVE_UL, container) :
       SelectorEngine.children(container, SELECTOR_ACTIVE)
 
-    const active = activeElements[0]
-    const isTransitioning = callback && (active && active.classList.contains(CLASS_NAME_FADE))
+    const hasActive = Boolean(activeElements) && activeElements.length > 0
+    const isTransitioning = Boolean(callback) && activeElements.some(active => {
+      return (active && active.classList.contains(CLASS_NAME_FADE))
+    })
 
-    const complete = () => this._transitionComplete(element, active, callback)
+    const complete = () => this._transitionComplete(elements, activeElements, callback)
 
-    if (active && isTransitioning) {
-      const transitionDuration = getTransitionDurationFromElement(active)
-      active.classList.remove(CLASS_NAME_SHOW)
+    if (hasActive && isTransitioning) {
+      EventHandler.oneForMany(activeElements, 'transitionend', complete)
 
-      EventHandler.one(active, 'transitionend', complete)
-      emulateTransitionEnd(active, transitionDuration)
+      activeElements.forEach(active => {
+        const transitionDuration = getTransitionDurationFromElement(active)
+        active.classList.remove(CLASS_NAME_SHOW)
+
+        emulateTransitionEnd(active, transitionDuration)
+      })
     } else {
       complete()
     }
   }
 
-  _transitionComplete(element, active, callback) {
-    if (active) {
-      active.classList.remove(CLASS_NAME_ACTIVE)
+  _transitionComplete(elements, activeElements, callback) {
+    if (activeElements) {
+      activeElements.forEach(active => {
+        active.classList.remove(CLASS_NAME_ACTIVE)
 
-      const dropdownChild = SelectorEngine.findOne(SELECTOR_DROPDOWN_ACTIVE_CHILD, active.parentNode)
+        const dropdownChild = SelectorEngine.findOne(SELECTOR_DROPDOWN_ACTIVE_CHILD, active.parentNode)
 
-      if (dropdownChild) {
-        dropdownChild.classList.remove(CLASS_NAME_ACTIVE)
+        if (dropdownChild) {
+          dropdownChild.classList.remove(CLASS_NAME_ACTIVE)
+        }
+
+        if (active.getAttribute('role') === 'tab') {
+          active.setAttribute('aria-selected', false)
+        }
+      })
+    }
+
+    elements.forEach(element => {
+      element.classList.add(CLASS_NAME_ACTIVE)
+      if (element.getAttribute('role') === 'tab') {
+        element.setAttribute('aria-selected', true)
       }
 
-      if (active.getAttribute('role') === 'tab') {
-        active.setAttribute('aria-selected', false)
-      }
-    }
+      reflow(element)
 
-    element.classList.add(CLASS_NAME_ACTIVE)
-    if (element.getAttribute('role') === 'tab') {
-      element.setAttribute('aria-selected', true)
-    }
-
-    reflow(element)
-
-    if (element.classList.contains(CLASS_NAME_FADE)) {
-      element.classList.add(CLASS_NAME_SHOW)
-    }
-
-    if (element.parentNode && element.parentNode.classList.contains(CLASS_NAME_DROPDOWN_MENU)) {
-      const dropdownElement = element.closest(SELECTOR_DROPDOWN)
-
-      if (dropdownElement) {
-        SelectorEngine.find(SELECTOR_DROPDOWN_TOGGLE)
-          .forEach(dropdown => dropdown.classList.add(CLASS_NAME_ACTIVE))
+      if (element.classList.contains(CLASS_NAME_FADE)) {
+        element.classList.add(CLASS_NAME_SHOW)
       }
 
-      element.setAttribute('aria-expanded', true)
-    }
+      if (element.parentNode && element.parentNode.classList.contains(CLASS_NAME_DROPDOWN_MENU)) {
+        const dropdownElement = element.closest(SELECTOR_DROPDOWN)
+
+        if (dropdownElement) {
+          SelectorEngine.find(SELECTOR_DROPDOWN_TOGGLE)
+            .forEach(dropdown => dropdown.classList.add(CLASS_NAME_ACTIVE))
+        }
+
+        element.setAttribute('aria-expanded', true)
+      }
+    })
 
     if (callback) {
       callback()

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -60,6 +60,12 @@ const getElementFromSelector = element => {
   return selector ? document.querySelector(selector) : null
 }
 
+const getAllElementsFromSelector = element => {
+  const selector = getSelector(element)
+
+  return selector ? document.querySelectorAll(selector) : null
+}
+
 const getTransitionDurationFromElement = element => {
   if (!element) {
     return 0
@@ -208,6 +214,7 @@ export {
   getUID,
   getSelectorFromElement,
   getElementFromSelector,
+  getAllElementsFromSelector,
   getTransitionDurationFromElement,
   triggerTransitionEnd,
   isElement,

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -326,6 +326,37 @@ describe('Tab', () => {
 
       btnCloseEl.click()
     })
+
+    it('should activate multiple content targets', done => {
+      fixtureEl.innerHTML = `
+        <ul class="nav nav-tabs" role="tablist">
+          <li class="nav-item" role="presentation">
+            <a href="#home" data-bs-toggle="tab" role="tab" class="nav-link active">Home</a>
+          </li>
+          <li class="nav-item" role="presentation">
+            <a id="triggerProfile" href="#profile" data-bs-target="#profile,#profile2"
+               data-bs-toggle="tab" role="tab" class="nav-link"
+            >Profile</a>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div class="tab-pane fade show active" id="home" role="tabpanel"></div>
+          <div class="tab-pane fade" id="profile" role="tabpanel"></div>
+          <div class="tab-pane fade" id="profile2" role="tabpanel"></div>
+        </div>
+      `
+
+      const profileTriggerEl = fixtureEl.querySelector('#triggerProfile')
+      const tab = new Tab(profileTriggerEl)
+
+      profileTriggerEl.addEventListener('shown.bs.tab', () => {
+        expect(fixtureEl.querySelector('#profile').classList.contains('active')).toEqual(true)
+        expect(fixtureEl.querySelector('#profile2').classList.contains('active')).toEqual(true)
+        done()
+      })
+
+      tab.show()
+    })
   })
 
   describe('dispose', () => {

--- a/site/content/docs/5.0/components/navs-tabs.md
+++ b/site/content/docs/5.0/components/navs-tabs.md
@@ -553,6 +553,30 @@ To make tabs fade in, add `.fade` to each `.tab-pane`. The first tab pane must a
 </div>
 ```
 
+### Multiple content targets
+
+You can show multiple content panes with one tab by using the `data-bs-target` attribute with a multi element selector.
+
+{{< callout warning >}}
+While this is possible it is currently **not** supported by the [<abbr title="Web Accessibility Initiative">WAI</abbr> <abbr title="Accessible Rich Internet Applications">ARIA</abbr> Authoring Practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel).
+{{< /callout >}}
+
+```html
+<ul class="nav nav-tabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a href="#home" data-bs-toggle="tab" role="tab" class="nav-link active">Home</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a data-bs-target="#profile,#profile2" data-bs-toggle="tab" role="tab" class="nav-link">Profile</a>
+  </li>
+</ul>
+<div class="tab-content">
+  <div class="tab-pane fade show active" id="home" role="tabpanel">...</div>
+  <div class="tab-pane fade" id="profile" role="tabpanel">...</div>
+  <div class="tab-pane fade" id="profile2" role="tabpanel">...</div>
+</div>
+```
+
 ### Methods
 
 {{< callout danger >}}


### PR DESCRIPTION
Fixes #19964 

This implements support for multiple tab content targets by one tab.

I had to change quite a bit to make transitions work correctly. Please let me know if my solution is clean enough.

Also added documentation but English is not my native language so it might not be optimal.

Preview: https://deploy-preview-32690--twbs-bootstrap.netlify.app/docs/5.0/components/navs-tabs/#multiple-content-targets