### PR TITLE
Move "active" class from `.nav-item` to `.nav-link`

### DIFF
--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -68,7 +68,7 @@ describe('ScrollSpy', () => {
       fixtureEl.innerHTML = [
         '<nav id="navigation" class="navbar">',
         '  <ul class="navbar-nav">',
-        '    <li class="nav-item active"><a class="nav-link" id="one-link" href="#">One</a></li>',
+        '    <li class="nav-item"><a class="nav-link active" id="one-link" href="#">One</a></li>',
         '    <li class="nav-item"><a class="nav-link" id="two-link" href="#two">Two</a></li>',
         '    <li class="nav-item"><a class="nav-link" id="three-link" href="#three">Three</a></li>',
         '  </ul>',
@@ -177,7 +177,7 @@ describe('ScrollSpy', () => {
         '<div id="header" style="height: 500px;"></div>',
         '<nav id="navigation" class="navbar">',
         ' <ul class="navbar-nav">',
-        '   <li class="nav-item active"><a class="nav-link" id="one-link" href="#one">One</a></li>',
+        '   <li class="nav-item"><a class="nav-link active" id="one-link" href="#one">One</a></li>',
         '   <li class="nav-item"><a class="nav-link" id="two-link" href="#two">Two</a></li>',
         '   <li class="nav-item"><a class="nav-link" id="three-link" href="#three">Three</a></li>',
         ' </ul>',

--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -18,8 +18,8 @@
 
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav">
-            <li class="nav-item active">
-              <a class="nav-link" href="#" aria-current="page">Home</a>
+            <li class="nav-item">
+              <a class="nav-link active" href="#" aria-current="page">Home</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#">Link</a>

--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -18,8 +18,8 @@
       <div class="collapse navbar-expand-md" id="navbarResponsive">
         <a class="navbar-brand" href="#">This shouldn't jump!</a>
         <ul class="navbar-nav">
-          <li class="nav-item active">
-            <a class="nav-link" href="#" aria-current="page">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" href="#" aria-current="page">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/navbar-bottom/index.html
+++ b/site/content/docs/5.0/examples/navbar-bottom/index.html
@@ -18,8 +18,8 @@ title: Bottom navbar example
     </button>
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/navbar-fixed/index.html
+++ b/site/content/docs/5.0/examples/navbar-fixed/index.html
@@ -13,8 +13,8 @@ extra_css:
     </button>
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav me-auto mb-2 mb-md-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/navbar-static/index.html
+++ b/site/content/docs/5.0/examples/navbar-static/index.html
@@ -13,8 +13,8 @@ extra_css:
     </button>
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav me-auto mb-2 mb-md-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/navbars/index.html
+++ b/site/content/docs/5.0/examples/navbars/index.html
@@ -15,8 +15,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample01">
         <ul class="navbar-nav me-auto mb-2">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -49,8 +49,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample02">
         <ul class="navbar-nav me-auto">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -72,8 +72,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample03">
         <ul class="navbar-nav me-auto mb-2 mb-sm-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -106,8 +106,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample04">
         <ul class="navbar-nav me-auto mb-2 mb-md-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -140,8 +140,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample05">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -174,8 +174,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample06">
         <ul class="navbar-nav me-auto mb-2 mb-xl-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -208,8 +208,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExampleXxl">
         <ul class="navbar-nav me-auto mb-2 mb-xl-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -242,8 +242,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample07">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -276,8 +276,8 @@ extra_css:
 
       <div class="collapse navbar-collapse" id="navbarsExample07XL">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -313,8 +313,8 @@ extra_css:
 
       <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample08">
         <ul class="navbar-nav">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Centered nav only</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Centered nav only</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>
@@ -345,8 +345,8 @@ extra_css:
 
         <div class="collapse navbar-collapse" id="navbarsExample09">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item active">
-              <a class="nav-link" aria-current="page" href="#">Home</a>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="#">Home</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#">Link</a>
@@ -378,8 +378,8 @@ extra_css:
 
         <div class="collapse navbar-collapse justify-content-md-center" id="navbarsExample10">
           <ul class="navbar-nav">
-            <li class="nav-item active">
-              <a class="nav-link" aria-current="page" href="#">Centered nav only</a>
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="#">Centered nav only</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/offcanvas/index.html
+++ b/site/content/docs/5.0/examples/offcanvas/index.html
@@ -17,8 +17,8 @@ body_class: "bg-light"
 
     <div class="navbar-collapse offcanvas-collapse" id="navbarsExampleDefault">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Dashboard</a>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Dashboard</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Notifications</a>

--- a/site/content/docs/5.0/examples/starter-template/index.html
+++ b/site/content/docs/5.0/examples/starter-template/index.html
@@ -14,8 +14,8 @@ extra_css:
 
     <div class="collapse navbar-collapse" id="navbarsExampleDefault">
       <ul class="navbar-nav me-auto mb-2 mb-md-0">
-        <li class="nav-item active">
-          <a class="nav-link" aria-current="page" href="#">Home</a>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#">Link</a>

--- a/site/content/docs/5.0/examples/sticky-footer-navbar/index.html
+++ b/site/content/docs/5.0/examples/sticky-footer-navbar/index.html
@@ -17,8 +17,8 @@ body_class: "d-flex flex-column h-100"
       </button>
       <div class="collapse navbar-collapse" id="navbarCollapse">
         <ul class="navbar-nav me-auto mb-2 mb-md-0">
-          <li class="nav-item active">
-            <a class="nav-link" aria-current="page" href="#">Home</a>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Link</a>


### PR DESCRIPTION
The "active" CSS class must be on "nav-link" element, see `_navbar.scss`:

```css
    .nav-link.active {
      color: $navbar-dark-active-color;
    }
```

Commit 62a0358f79af95c03da47f39206f076b8591e54e (PR #32647) has fixed the issue on a single file, but forgot the others.

cc @XhmikosR