### PR TITLE
Consistently use outline:0 rather than outline:none

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -22,7 +22,7 @@
   }
 
   &:focus {
-    outline: none;
+    outline: 0;
     box-shadow: $btn-close-focus-shadow;
     opacity: $btn-close-focus-opacity;
   }

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -12,7 +12,7 @@
   appearance: none;
 
   &:focus {
-    outline: none;
+    outline: 0;
 
     // Pseudo-elements must be split across multiple rulesets to have an effect.
     // No box-shadow() mixin for focus accessibility.


### PR DESCRIPTION
just for code consistency, no actual effect on styling per se