### PR TITLE
Migration: mention the removal of `.rounded-sm/lg` utilities

### DIFF
--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -12,7 +12,7 @@ toc: true
 ### Sass
 
 #### Utilities
-
+- Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
 - Renamed `--aspect-ratio` to `--bs-aspect-ratio` to be consistent with other custom properties.
 - Extended the `.visually-hidden-focusable` helper to also work on containers, using `:focus-within`.
 - `bootstrap-utilities.css` now also includes our helpers. Helpers don't need to be imported in custom builds anymore.

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -12,6 +12,7 @@ toc: true
 ### Sass
 
 #### Utilities
+
 - Renamed `--aspect-ratio` to `--bs-aspect-ratio` to be consistent with other custom properties.
 - Extended the `.visually-hidden-focusable` helper to also work on containers, using `:focus-within`.
 - `bootstrap-utilities.css` now also includes our helpers. Helpers don't need to be imported in custom builds anymore.

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -126,7 +126,7 @@ Breakpoints specific variants are consequently renamed too (eg. `.text-md-start`
   - Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 - Added `.d-grid` to display utilities
 - Added new `gap` utilities (`.gap`) for CSS Grid layouts
- - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687)
+- Removed `.rounded-sm` and `rounded-lg`, and introduced `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687).
 
 ## v5.0.0-alpha2
 

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -12,7 +12,6 @@ toc: true
 ### Sass
 
 #### Utilities
-- Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
 - Renamed `--aspect-ratio` to `--bs-aspect-ratio` to be consistent with other custom properties.
 - Extended the `.visually-hidden-focusable` helper to also work on containers, using `:focus-within`.
 - `bootstrap-utilities.css` now also includes our helpers. Helpers don't need to be imported in custom builds anymore.
@@ -123,6 +122,7 @@ Breakpoints specific variants are consequently renamed too (eg. `.text-md-start`
 
 - **Text utilities:**
   - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
+  - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
   - Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
   - Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 - Added `.d-grid` to display utilities

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -122,11 +122,11 @@ Breakpoints specific variants are consequently renamed too (eg. `.text-md-start`
 
 - **Text utilities:**
   - Added `.fs-*` utilities for `font-size` utilities (with RFS enabled). These use the same scale as HTML's default headings (1-6, large to small), and can be modified via Sass map.
-  - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
   - Renamed `.font-weight-*` utilities as `.fw-*` for brevity and consistency.
   - Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 - Added `.d-grid` to display utilities
 - Added new `gap` utilities (`.gap`) for CSS Grid layouts
+ - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
 
 ## v5.0.0-alpha2
 

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -126,7 +126,7 @@ Breakpoints specific variants are consequently renamed too (eg. `.text-md-start`
   - Renamed `.font-style-*` utilities as `.fst-*` for brevity and consistency.
 - Added `.d-grid` to display utilities
 - Added new `gap` utilities (`.gap`) for CSS Grid layouts
- - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`.
+ - Removed `.rounded-sm` and `rounded-lg` and introduced `.rounded-0` to `.rounded-3`. [See #31687](https://github.com/twbs/bootstrap/pull/31687)
 
 ## v5.0.0-alpha2
 


### PR DESCRIPTION
Issue - [Docs] v5 migration guide doesn't mention removal of .rounded-sm/lg

Added information about the removal of `.rounded-sm` and `.rounded-lg`.
And addition of `.rounded-0` to `.rounded-3`.


![Screenshot (227)](https://user-images.githubusercontent.com/54969439/104232563-89d14700-5476-11eb-8c75-011b5a7b15f4.png)

Fixes #32734