### PR TITLE
.gitignore: remove Ruby/Jekyll entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,7 @@
 # Ignore docs files
 /_gh_pages/
-# This is the old Jekyll docs dist folder;
-# keeping it here so that when we switch branches it doesn't show up
-/site/docs/**/dist/
-# Jekyll's cache folder; keeping it for the same reason as above
-/site/.jekyll-cache/
 # Hugo resources folder
 /resources/
-
-# Ignore ruby/bundler files;
-# keeping them here so that when we switch branches they don't show up
-/.bundle/
-/vendor/
-/.ruby-version
 
 # Numerous always-ignore extensions
 *.diff


### PR DESCRIPTION
Our currently supported branches, v4-dev and main, use Hugo.