### PR TITLE
Lighten disabled dropdown text to $gray-500

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -943,7 +943,7 @@ $dropdown-link-hover-bg:            $gray-200 !default;
 $dropdown-link-active-color:        $component-active-color !default;
 $dropdown-link-active-bg:           $component-active-bg !default;
 
-$dropdown-link-disabled-color:      $gray-600 !default;
+$dropdown-link-disabled-color:      $gray-500 !default;
 
 $dropdown-item-padding-y:           $spacer / 4 !default;
 $dropdown-item-padding-x:           $spacer !default;


### PR DESCRIPTION
Fixes #32474.

Unclear if we backport. /cc @twbs/css-review 