### PR TITLE
Use more accurate value for viewport width.

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -450,7 +450,7 @@ class Modal extends BaseComponent {
 
   _checkScrollbar() {
     const rect = document.body.getBoundingClientRect()
-    this._isBodyOverflowing = Math.round(rect.left + rect.right) < window.innerWidth
+    this._isBodyOverflowing = Math.round(rect.left + rect.right) < Math.round(window.visualViewport.width)
     this._scrollbarWidth = this._getScrollbarWidth()
   }
 


### PR DESCRIPTION
As described in https://github.com/twbs/bootstrap/issues/32779, extra right padding is being added due to `window.innerWidth` not returning the right value. Using `Math.round(window.visualViewport.width)` instead provides the expected value.

Resolves #32779