### PR TITLE
Docs: reduce subnavbar z-index

### DIFF
--- a/site/assets/scss/_subnav.scss
+++ b/site/assets/scss/_subnav.scss
@@ -1,7 +1,7 @@
 .bd-subnavbar {
   // The position and z-index are needed for the dropdown to stay on top of the content
   position: relative;
-  z-index: $zindex-sticky;
+  z-index: 10;
   background-color: rgba($white, .95);
   box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .05), inset 0 -1px 0 rgba(0, 0, 0, .15);
 


### PR DESCRIPTION
The super-high (`1080`) sticky z-index is unnecessary and interferes with modal dialogs and the planned off-canvas side modal https://github.com/twbs/bootstrap/pull/29017

Example of the current behaviour, using the off-canvas preview as an example:

![offcanvas-subnav](https://user-images.githubusercontent.com/895831/105045487-deb92280-5a5f-11eb-9b4f-d890722e08fa.png)
