### PR TITLE
Support floating labels on `.form-control-plaintext`

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -2,6 +2,7 @@
   position: relative;
 
   > .form-control,
+  > .form-control-plaintext,
   > .form-select {
     height: $form-floating-height;
     line-height: $form-floating-line-height;
@@ -19,8 +20,8 @@
     @include transition($form-floating-transition);
   }
 
-  // stylelint-disable no-duplicate-selectors
-  > .form-control {
+  > .form-control,
+  > .form-control-plaintext {
     padding: $form-floating-padding-y $form-floating-padding-x;
 
     &::placeholder {
@@ -46,6 +47,7 @@
 
   > .form-control:focus,
   > .form-control:not(:placeholder-shown),
+  > .form-control-plaintext,
   > .form-select {
     ~ label {
       opacity: $form-floating-label-opacity;
@@ -59,5 +61,10 @@
       transform: $form-floating-label-transform;
     }
   }
-  // stylelint-enable no-duplicate-selectors
+
+  > .form-control-plaintext {
+    ~ label {
+      border-width: $input-border-width 0; // Required to properly position label text - as explained above
+    }
+  }
 }

--- a/site/content/docs/5.1/forms/floating-labels.md
+++ b/site/content/docs/5.1/forms/floating-labels.md
@@ -75,6 +75,22 @@ Other than `.form-control`, floating labels are only available on `.form-select`
 </div>
 {{< /example >}}
 
+## Readonly plain text
+
+You can also use floating labels with the `.form-control-plaintext` class to remove the default form field styling and preserve the correct margin and padding.
+
+{{< example >}}
+<div class="form-floating mb-3">
+  <input type="email" readonly class="form-control-plaintext" id="floatingEmptyPlaintextInput" placeholder="name@example.com">
+  <label for="floatingEmptyPlaintextInput">Empty input</label>
+</div>
+<div class="form-floating mb-3">
+  <input type="email" readonly class="form-control-plaintext" id="floatingPlaintextInput" placeholder="name@example.com" value="name@example.com">
+  <label for="floatingPlaintextInput">Input with value</label>
+</div>
+{{< /example >}}
+
+
 ## Layout
 
 When working with the Bootstrap grid system, be sure to place form elements within column classes.

--- a/site/content/docs/5.1/forms/floating-labels.md
+++ b/site/content/docs/5.1/forms/floating-labels.md
@@ -90,7 +90,6 @@ You can also use floating labels with the `.form-control-plaintext` class to rem
 </div>
 {{< /example >}}
 
-
 ## Layout
 
 When working with the Bootstrap grid system, be sure to place form elements within column classes.

--- a/site/content/docs/5.1/forms/floating-labels.md
+++ b/site/content/docs/5.1/forms/floating-labels.md
@@ -75,9 +75,9 @@ Other than `.form-control`, floating labels are only available on `.form-select`
 </div>
 {{< /example >}}
 
-## Readonly plain text
+## Readonly plaintext
 
-You can also use floating labels with the `.form-control-plaintext` class to remove the default form field styling and preserve the correct margin and padding.
+Floating labels also support `.form-control-plaintext`, which can be helpful for toggling from an editable `<input>` to a plaintext value without affecting the page layout.
 
 {{< example >}}
 <div class="form-floating mb-3">


### PR DESCRIPTION
I've made a tiny fix that will allow usage of floating labels with `.form-control-plaintext` elements.

Before:
![screenshot-20210119_153457](https://user-images.githubusercontent.com/3293161/105049233-ba177780-5a6c-11eb-88c9-824e6b645fcf.png)

After:
![screenshot-20210119_153601](https://user-images.githubusercontent.com/3293161/105049255-c1d71c00-5a6c-11eb-91bb-668b070675fd.png)

I'm not sure that this requires a dedicated section in the documentation, but as part of PoC, I've made one, so it's included. Feel free to wipe it out.

Preview: https://deploy-preview-32840--twbs-bootstrap.netlify.app/docs/5.0/forms/floating-labels/#readonly-plain-text