### PR TITLE
_variables.scss: add missing newline before new section

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -821,6 +821,7 @@ $pagination-disabled-border-color:  $gray-300 !default;
 $pagination-border-radius-sm:       $border-radius-sm !default;
 $pagination-border-radius-lg:       $border-radius-lg !default;
 
+
 // Jumbotron
 
 $jumbotron-padding:                 2rem !default;


### PR DESCRIPTION
There should be two line breaks before a new section.