### PR TITLE
Update checks and radios in input groups

### DIFF
--- a/site/content/docs/5.0/forms/input-group.md
+++ b/site/content/docs/5.0/forms/input-group.md
@@ -81,19 +81,19 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 
 ## Checkboxes and radios
 
-Place any checkbox or radio option within an input group's addon instead of text.
+Place any checkbox or radio option within an input group's addon instead of text. We recommend adding `.mt-0` to the `.form-check-input` when there's no visible text next to the input.
 
 {{< example >}}
 <div class="input-group mb-3">
   <div class="input-group-text">
-    <input class="form-check-input" type="checkbox" value="" aria-label="Checkbox for following text input">
+    <input class="form-check-input mt-0" type="checkbox" value="" aria-label="Checkbox for following text input">
   </div>
   <input type="text" class="form-control" aria-label="Text input with checkbox">
 </div>
 
 <div class="input-group">
   <div class="input-group-text">
-    <input class="form-check-input" type="radio" value="" aria-label="Radio button for following text input">
+    <input class="form-check-input mt-0" type="radio" value="" aria-label="Radio button for following text input">
   </div>
   <input type="text" class="form-control" aria-label="Text input with radio button">
 </div>


### PR DESCRIPTION
I think I'd rather go this route than zeroing out the margin via component CSS. Doing it in the CSS would require specific control over the HTML (e.g., with a selector like `.input-group-addon > .form-check-input`) which would be less flexible to custom markup. It'd also cause issues when there's visible text next to the input as it would now be misaligned there.

Fixes #32857.