### PR TITLE
Fix carousel RTL and refactor code, fix rtl swipe issues

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "22.6 kB"
+      "maxSize": "22.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
@@ -54,7 +54,7 @@
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.3 kB"
+      "maxSize": "16.5 kB"
     }
   ],
   "ci": {

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "22.5 kB"
+      "maxSize": "22.6 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
@@ -54,7 +54,7 @@
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.25 kB"
+      "maxSize": "16.3 kB"
     }
   ],
   "ci": {

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -387,7 +387,12 @@ class Carousel extends BaseComponent {
 
   _setActiveIndicatorElement(element) {
     if (this._indicatorsElement) {
-      const indicators = SelectorEngine.find(SELECTOR_ACTIVE, this._indicatorsElement)
+      const activeIndicator = SelectorEngine.findOne(SELECTOR_ACTIVE, this._indicatorsElement)
+
+      activeIndicator.classList.remove(CLASS_NAME_ACTIVE)
+      activeIndicator.removeAttribute('aria-current')
+
+      const indicators = SelectorEngine.find(SELECTOR_INDICATOR, this._indicatorsElement)
 
       for (let i = 0; i < indicators.length; i++) {
         if (Number.parseInt(indicators[i].getAttribute('data-bs-slide-to'), 10) === this._getItemIndex(element)) {
@@ -416,8 +421,8 @@ class Carousel extends BaseComponent {
     }
   }
 
-  _slide(direction, element) {
-    const order = this._directionToOrder(direction)
+  _slide(directionOrOrder, element) {
+    const order = this._directionToOrder(directionOrOrder)
     const activeElement = SelectorEngine.findOne(SELECTOR_ACTIVE_ITEM, this._element)
     const activeElementIndex = this._getItemIndex(activeElement)
     const nextElement = element || this._getItemByOrder(order, activeElement)
@@ -428,7 +433,7 @@ class Carousel extends BaseComponent {
     const isNext = order === ORDER_NEXT
     const directionalClassName = isNext ? CLASS_NAME_START : CLASS_NAME_END
     const orderClassName = isNext ? CLASS_NAME_NEXT : CLASS_NAME_PREV
-    const eventDirectionName = isNext ? DIRECTION_LEFT : DIRECTION_RIGHT
+    const eventDirectionName = this._orderToDirection(order)
 
     if (nextElement && nextElement.classList.contains(CLASS_NAME_ACTIVE)) {
       this._isSliding = false
@@ -506,15 +511,23 @@ class Carousel extends BaseComponent {
       return direction
     }
 
-    if (!this._isRtl()) {
-      return direction === DIRECTION_RIGHT ? ORDER_NEXT : ORDER_PREV
+    if (isRTL()) {
+      return direction === DIRECTION_RIGHT ? ORDER_PREV : ORDER_NEXT
     }
 
-    return direction === DIRECTION_RIGHT ? ORDER_PREV : ORDER_NEXT
+    return direction === DIRECTION_RIGHT ? ORDER_NEXT : ORDER_PREV
   }
 
-  _isRtl() {
-    return isRTL
+  _orderToDirection(order) {
+    if (![ORDER_NEXT, ORDER_PREV].includes(order)) {
+      return order
+    }
+
+    if (isRTL()) {
+      return order === ORDER_NEXT ? DIRECTION_LEFT : DIRECTION_RIGHT
+    }
+
+    return order === ORDER_NEXT ? DIRECTION_RIGHT : DIRECTION_LEFT
   }
 
   // Static

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -358,8 +358,7 @@ class Carousel extends BaseComponent {
     const isPrev = order === ORDER_PREV
     const activeIndex = this._getItemIndex(activeElement)
     const lastItemIndex = this._items.length - 1
-    const isGoingToWrap = (isPrev && activeIndex === 0) ||
-      (isNext && activeIndex === lastItemIndex)
+    const isGoingToWrap = (isPrev && activeIndex === 0) || (isNext && activeIndex === lastItemIndex)
 
     if (isGoingToWrap && !this._config.wrap) {
       return activeElement

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1095,15 +1095,12 @@ describe('Carousel', () => {
 
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
-
       const spy = spyOn(carousel, '_directionToOrder').and.callThrough()
 
       carousel._slide('left')
-
       expect(spy).toHaveBeenCalledWith('left')
 
       carousel._slide('right')
-
       expect(spy).toHaveBeenCalledWith('right')
     })
   })

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -347,10 +347,10 @@ describe('Carousel', () => {
 
       spyOn(carousel, '_slide').and.callThrough()
 
-      carouselEl.addEventListener('slid.bs.carousel', ev => {
+      carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
         expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(ev.direction).toEqual('right')
+        expect(event.direction).toEqual('right')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -392,10 +392,10 @@ describe('Carousel', () => {
 
       spyOn(carousel, '_slide').and.callThrough()
 
-      carouselEl.addEventListener('slid.bs.carousel', ev => {
+      carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
         expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(ev.direction).toEqual('left')
+        expect(event.direction).toEqual('left')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -432,10 +432,10 @@ describe('Carousel', () => {
 
       spyOn(carousel, '_slide').and.callThrough()
 
-      carouselEl.addEventListener('slid.bs.carousel', ev => {
+      carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
         expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(ev.direction).toEqual('right')
+        expect(event.direction).toEqual('right')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()
@@ -471,10 +471,10 @@ describe('Carousel', () => {
 
       spyOn(carousel, '_slide').and.callThrough()
 
-      carouselEl.addEventListener('slid.bs.carousel', ev => {
+      carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
         expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(ev.direction).toEqual('left')
+        expect(event.direction).toEqual('left')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1073,6 +1073,9 @@ describe('Carousel', () => {
       expect(carousel._directionToOrder('prev')).toEqual('prev')
       expect(carousel._directionToOrder('right')).toEqual('next')
       expect(carousel._directionToOrder('next')).toEqual('next')
+
+      expect(carousel._orderToDirection('next')).toEqual('right')
+      expect(carousel._orderToDirection('prev')).toEqual('left')
     })
 
     it('rtl left has to return "next" order', () => {
@@ -1087,6 +1090,9 @@ describe('Carousel', () => {
       expect(carousel._directionToOrder('prev')).toEqual('prev')
       expect(carousel._directionToOrder('right')).toEqual('prev')
       expect(carousel._directionToOrder('next')).toEqual('next')
+
+      expect(carousel._orderToDirection('next')).toEqual('left')
+      expect(carousel._orderToDirection('prev')).toEqual('right')
       document.documentElement.dir = 'ltl'
     })
 
@@ -1096,12 +1102,15 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
       const spy = spyOn(carousel, '_directionToOrder').and.callThrough()
+      const spy2 = spyOn(carousel, '_orderToDirection').and.callThrough()
 
       carousel._slide('left')
       expect(spy).toHaveBeenCalledWith('left')
+      expect(spy2).toHaveBeenCalledWith('prev')
 
       carousel._slide('right')
       expect(spy).toHaveBeenCalledWith('right')
+      expect(spy2).toHaveBeenCalledWith('next')
     })
   })
 

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1063,7 +1063,7 @@ describe('Carousel', () => {
     })
   })
   describe('rtl function', () => {
-    it('right has to return "next" order ', () => {
+    it('"_directionToOrder" and "_orderToDirection" must return the right results', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const carouselEl = fixtureEl.querySelector('div')
@@ -1078,7 +1078,7 @@ describe('Carousel', () => {
       expect(carousel._orderToDirection('prev')).toEqual('left')
     })
 
-    it('rtl left has to return "next" order', () => {
+    it('"_directionToOrder" and "_orderToDirection" must return the right results when rtl=true', () => {
       document.documentElement.dir = 'rtl'
       fixtureEl.innerHTML = '<div></div>'
 
@@ -1096,7 +1096,7 @@ describe('Carousel', () => {
       document.documentElement.dir = 'ltl'
     })
 
-    it('rtl "_slide" has to call _directionToOrder', () => {
+    it('"_slide" has to call _directionToOrder and "_orderToDirection"', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const carouselEl = fixtureEl.querySelector('div')
@@ -1111,6 +1111,26 @@ describe('Carousel', () => {
       carousel._slide('right')
       expect(spy).toHaveBeenCalledWith('right')
       expect(spy2).toHaveBeenCalledWith('next')
+    })
+
+    it('"_slide" has to call "_directionToOrder" and "_orderToDirection" when rtl=true', () => {
+      document.documentElement.dir = 'rtl'
+      fixtureEl.innerHTML = '<div></div>'
+
+      const carouselEl = fixtureEl.querySelector('div')
+      const carousel = new Carousel(carouselEl, {})
+      const spy = spyOn(carousel, '_directionToOrder').and.callThrough()
+      const spy2 = spyOn(carousel, '_orderToDirection').and.callThrough()
+
+      carousel._slide('left')
+      expect(spy).toHaveBeenCalledWith('left')
+      expect(spy2).toHaveBeenCalledWith('next')
+
+      carousel._slide('right')
+      expect(spy).toHaveBeenCalledWith('right')
+      expect(spy2).toHaveBeenCalledWith('prev')
+
+      document.documentElement.dir = 'ltl'
     })
   })
 


### PR DESCRIPTION
It fixes rtl next/previous functionality,
it separates directions from order, and transfers all the rtl and direction responsibility on the `_slide` method

Preview: https://deploy-preview-32913--twbs-bootstrap.netlify.app/docs/5.0/components/carousel/