### PR TITLE
Add important to toast display: none

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -15,7 +15,7 @@
   }
 
   &.hide {
-    display: none;
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
Toast divs with another style (such as `d-flex`) that declares a different `display` property may not hide correctly as this `display: none` may not have priority.