### PR TITLE
CI: switch to the coverallsapp/github-action tag

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run js-test
 
       - name: Run Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v1.1.2
         if: matrix.node == 14
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Unfortunately, they don't offer a `v1` tag