### PR TITLE
Fix default value for `$enable-deprecation-messages`

### DIFF
--- a/site/content/docs/5.0/customize/options.md
+++ b/site/content/docs/5.0/customize/options.md
@@ -24,6 +24,6 @@ You can find and customize these variables for key global options in Bootstrap's
 | `$enable-rfs`                  | `true` (default) or `false`        | Globally enables [RFS]({{< docsref "/getting-started/rfs" >}}). |
 | `$enable-validation-icons`     | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
 | `$enable-negative-margins`     | `true` or `false` (default)        | Enables the generation of [negative margin utilities]({{< docsref "/utilities/spacing#negative-margin" >}}). |
-| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `true` to show warnings when using any of the deprecated mixins and functions that are planned to be removed in `v5`. |
+| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in `v6`. |
 | `$enable-important-utilities`  | `true` (default) or `false`        | Enables the `!important` suffix in utility classes. |
 {{< /bs-table >}}

--- a/site/content/docs/5.0/customize/options.md
+++ b/site/content/docs/5.0/customize/options.md
@@ -24,6 +24,6 @@ You can find and customize these variables for key global options in Bootstrap's
 | `$enable-rfs`                  | `true` (default) or `false`        | Globally enables [RFS]({{< docsref "/getting-started/rfs" >}}). |
 | `$enable-validation-icons`     | `true` (default) or `false`        | Enables `background-image` icons within textual inputs and some custom forms for validation states. |
 | `$enable-negative-margins`     | `true` or `false` (default)        | Enables the generation of [negative margin utilities]({{< docsref "/utilities/spacing#negative-margin" >}}). |
-| `$enable-deprecation-messages` | `true` or `false` (default)        | Set to `true` to show warnings when using any of the deprecated mixins and functions that are planned to be removed in `v5`. |
+| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `true` to show warnings when using any of the deprecated mixins and functions that are planned to be removed in `v5`. |
 | `$enable-important-utilities`  | `true` (default) or `false`        | Enables the `!important` suffix in utility classes. |
 {{< /bs-table >}}


### PR DESCRIPTION
As seen in the https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss, the `$enable-deprecation-messages` variable (line 220) is set to `true` by default.

Direct permalink to the line 220 @ _GitHub_:
https://github.com/twbs/bootstrap/blob/e79c8f3489527d7f5eef2bb3cf14856f26c49871/scss/_variables.scss#L220