### PR TITLE
Extract Carousel's swipe functionality to a separate Class

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -54,7 +54,7 @@
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16 kB"
+      "maxSize": "16.25 kB"
     }
   ],
   "ci": {

--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -1,0 +1,122 @@
+import EventHandler from '../dom/event-handler'
+import { execute, typeCheckConfig } from './index'
+
+const EVENT_KEY = '.bs.swipe'
+const EVENT_TOUCHSTART = `touchstart${EVENT_KEY}`
+const EVENT_TOUCHMOVE = `touchmove${EVENT_KEY}`
+const EVENT_TOUCHEND = `touchend${EVENT_KEY}`
+const EVENT_POINTERDOWN = `pointerdown${EVENT_KEY}`
+const EVENT_POINTERUP = `pointerup${EVENT_KEY}`
+const POINTER_TYPE_TOUCH = 'touch'
+const POINTER_TYPE_PEN = 'pen'
+const CLASS_NAME_POINTER_EVENT = 'pointer-event'
+const SWIPE_THRESHOLD = 40
+
+const Default = {
+  leftCallback: null,
+  rightCallback: null,
+  endCallback: null
+}
+const DefaultType = {
+  leftCallback: '(function|null)',
+  rightCallback: '(function|null)',
+  endCallback: '(function|null)'
+}
+
+const NAME = 'swipe'
+
+class Swipe {
+  constructor(element, config) {
+    this._element = element
+
+    if (!element || !Swipe.isSupported()) {
+      return
+    }
+
+    this._config = this._getConfig(config)
+    this._xDown = 0
+    this._supportPointerEvents = Boolean(window.PointerEvent)
+    this._initEvents()
+  }
+
+  dispose() {
+    EventHandler.off(this._element, EVENT_KEY)
+  }
+
+  _start(event) {
+    if (!this._supportPointerEvents) {
+      this._xDown = event.touches[0].clientX
+
+      return
+    }
+
+    if (this._eventIsNotSwipe(event)) {
+      this._xDown = event.clientX
+    }
+  }
+
+  _end(event) {
+    if (this._eventIsNotSwipe(event)) {
+      this._xDown = event.clientX - this._xDown
+    }
+
+    this._handleSwipe()
+    execute(this._config.endCallback)
+  }
+
+  _move(event) {
+    this._xDown = event.touches && event.touches.length > 1 ?
+      0 :
+      event.touches[0].clientX - this._xDown
+  }
+
+  _handleSwipe() {
+    const absDeltaX = Math.abs(this._xDown)
+
+    if (absDeltaX <= SWIPE_THRESHOLD) {
+      return
+    }
+
+    const direction = absDeltaX / this._xDown
+
+    this._xDown = 0
+
+    if (!direction) {
+      return
+    }
+
+    execute(direction > 0 ? this._config.rightCallback : this._config.leftCallback)
+  }
+
+  _initEvents() {
+    if (this._supportPointerEvents) {
+      EventHandler.on(this._element, EVENT_POINTERDOWN, event => this._start(event))
+      EventHandler.on(this._element, EVENT_POINTERUP, event => this._end(event))
+
+      this._element.classList.add(CLASS_NAME_POINTER_EVENT)
+    } else {
+      EventHandler.on(this._element, EVENT_TOUCHSTART, event => this._start(event))
+      EventHandler.on(this._element, EVENT_TOUCHMOVE, event => this._move(event))
+      EventHandler.on(this._element, EVENT_TOUCHEND, event => this._end(event))
+    }
+  }
+
+  _getConfig(config) {
+    config = {
+      ...Default,
+      ...(typeof config === 'object' ? config : {})
+    }
+    typeCheckConfig(NAME, config, DefaultType)
+    return config
+  }
+
+  _eventIsNotSwipe(event) {
+    return this._supportPointerEvents && (event.pointerType === POINTER_TYPE_PEN || event.pointerType === POINTER_TYPE_TOUCH)
+  }
+
+  static isSupported() {
+    return 'ontouchstart' in document.documentElement || navigator.maxTouchPoints > 0
+  }
+}
+
+export default Swipe

--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -34,7 +34,7 @@ class Swipe {
     }
 
     this._config = this._getConfig(config)
-    this._xDown = 0
+    this._startX = 0
     this._supportPointerEvents = Boolean(window.PointerEvent)
     this._initEvents()
   }
@@ -45,19 +45,19 @@ class Swipe {
 
   _start(event) {
     if (!this._supportPointerEvents) {
-      this._xDown = event.touches[0].clientX
+      this._startX = event.touches[0].clientX
 
       return
     }
 
-    if (this._eventIsNotSwipe(event)) {
-      this._xDown = event.clientX
+    if (this._eventIsPointerPenTouch(event)) {
+      this._startX = event.clientX
     }
   }
 
   _end(event) {
-    if (this._eventIsNotSwipe(event)) {
-      this._xDown = event.clientX - this._xDown
+    if (this._eventIsPointerPenTouch(event)) {
+      this._startX = event.clientX - this._startX
     }
 
     this._handleSwipe()
@@ -65,21 +65,21 @@ class Swipe {
   }
 
   _move(event) {
-    this._xDown = event.touches && event.touches.length > 1 ?
+    this._startX = event.touches && event.touches.length > 1 ?
       0 :
-      event.touches[0].clientX - this._xDown
+      event.touches[0].clientX - this._startX
   }
 
   _handleSwipe() {
-    const absDeltaX = Math.abs(this._xDown)
+    const absDeltaX = Math.abs(this._startX)
 
     if (absDeltaX <= SWIPE_THRESHOLD) {
       return
     }
 
-    const direction = absDeltaX / this._xDown
+    const direction = absDeltaX / this._startX
 
-    this._xDown = 0
+    this._startX = 0
 
     if (!direction) {
       return
@@ -110,7 +110,7 @@ class Swipe {
     return config
   }
 
-  _eventIsNotSwipe(event) {
+  _eventIsPointerPenTouch(event) {
     return this._supportPointerEvents && (event.pointerType === POINTER_TYPE_PEN || event.pointerType === POINTER_TYPE_TOUCH)
   }
 

--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -34,7 +34,7 @@ class Swipe {
     }
 
     this._config = this._getConfig(config)
-    this._startX = 0
+    this._deltaX = 0
     this._supportPointerEvents = Boolean(window.PointerEvent)
     this._initEvents()
   }
@@ -45,19 +45,19 @@ class Swipe {
 
   _start(event) {
     if (!this._supportPointerEvents) {
-      this._startX = event.touches[0].clientX
+      this._deltaX = event.touches[0].clientX
 
       return
     }
 
     if (this._eventIsPointerPenTouch(event)) {
-      this._startX = event.clientX
+      this._deltaX = event.clientX
     }
   }
 
   _end(event) {
     if (this._eventIsPointerPenTouch(event)) {
-      this._startX = event.clientX - this._startX
+      this._deltaX = event.clientX - this._deltaX
     }
 
     this._handleSwipe()
@@ -65,21 +65,21 @@ class Swipe {
   }
 
   _move(event) {
-    this._startX = event.touches && event.touches.length > 1 ?
+    this._deltaX = event.touches && event.touches.length > 1 ?
       0 :
-      event.touches[0].clientX - this._startX
+      event.touches[0].clientX - this._deltaX
   }
 
   _handleSwipe() {
-    const absDeltaX = Math.abs(this._startX)
+    const absDeltaX = Math.abs(this._deltaX)
 
     if (absDeltaX <= SWIPE_THRESHOLD) {
       return
     }
 
-    const direction = absDeltaX / this._startX
+    const direction = absDeltaX / this._deltaX
 
-    this._startX = 0
+    this._deltaX = 0
 
     if (!direction) {
       return

--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -11,19 +11,19 @@ const POINTER_TYPE_TOUCH = 'touch'
 const POINTER_TYPE_PEN = 'pen'
 const CLASS_NAME_POINTER_EVENT = 'pointer-event'
 const SWIPE_THRESHOLD = 40
+const NAME = 'swipe'
 
 const Default = {
   leftCallback: null,
   rightCallback: null,
   endCallback: null
 }
+
 const DefaultType = {
   leftCallback: '(function|null)',
   rightCallback: '(function|null)',
   endCallback: '(function|null)'
 }
-
-const NAME = 'swipe'
 
 class Swipe {
   constructor(element, config) {

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -568,7 +568,7 @@ describe('Carousel', () => {
       }, () => {
         restorePointerEvents()
         delete document.documentElement.ontouchstart
-        expect(carousel._swipeHelper._startX).toEqual(0)
+        expect(carousel._swipeHelper._deltaX).toEqual(0)
         done()
       })
     })

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -568,7 +568,7 @@ describe('Carousel', () => {
       }, () => {
         restorePointerEvents()
         delete document.documentElement.ontouchstart
-        expect(carousel._swipeHelper._xDown).toEqual(0)
+        expect(carousel._swipeHelper._startX).toEqual(0)
         done()
       })
     })

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -2,6 +2,7 @@ import Carousel from '../../src/carousel'
 import EventHandler from '../../src/dom/event-handler'
 import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture'
 import { isRTL, noop } from '../../src/util/index'
+import Swipe from '../../src/util/swipe'
 
 describe('Carousel', () => {
   const { Simulator, PointerEvent } = window
@@ -301,23 +302,24 @@ describe('Carousel', () => {
       })
 
       expect(carousel._addTouchEventListeners).not.toHaveBeenCalled()
+      expect(carousel._swipeHelper).toBeNull()
     })
 
     it('should not add touch event listeners if touch supported = false', () => {
       fixtureEl.innerHTML = '<div></div>'
 
       const carouselEl = fixtureEl.querySelector('div')
+      spyOn(Swipe, 'isSupported').and.returnValue(false)
 
       const carousel = new Carousel(carouselEl)
-
-      EventHandler.off(carouselEl, '.bs-carousel')
-      carousel._touchSupported = false
+      EventHandler.off(carouselEl, Carousel.EVENT_KEY)
 
       spyOn(carousel, '_addTouchEventListeners')
 
       carousel._addEventListeners()
 
       expect(carousel._addTouchEventListeners).not.toHaveBeenCalled()
+      expect(carousel._swipeHelper).toBeNull()
     })
 
     it('should add touch event listeners by default', () => {
@@ -566,7 +568,7 @@ describe('Carousel', () => {
       }, () => {
         restorePointerEvents()
         delete document.documentElement.ontouchstart
-        expect(carousel.touchDeltaX).toEqual(0)
+        expect(carousel._swipeHelper._xDown).toEqual(0)
         done()
       })
     })
@@ -1237,19 +1239,20 @@ describe('Carousel', () => {
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       const addEventSpy = spyOn(carouselEl, 'addEventListener').and.callThrough()
-      const removeEventSpy = spyOn(carouselEl, 'removeEventListener').and.callThrough()
+      const removeEventSpy = spyOn(EventHandler, 'off').and.callThrough()
 
       // Headless browser does not support touch events, so need to fake it
       // to test that touch events are add/removed properly.
       document.documentElement.ontouchstart = noop
 
       const carousel = new Carousel(carouselEl)
+      const swipeHelperSpy = spyOn(carousel._swipeHelper, 'dispose').and.callThrough()
 
       const expectedArgs = [
         ['keydown', jasmine.any(Function), jasmine.any(Boolean)],
         ['mouseover', jasmine.any(Function), jasmine.any(Boolean)],
         ['mouseout', jasmine.any(Function), jasmine.any(Boolean)],
-        ...(carousel._pointerEvent ?
+        ...(carousel._swipeHelper._supportPointerEvents ?
           [
             ['pointerdown', jasmine.any(Function), jasmine.any(Boolean)],
             ['pointerup', jasmine.any(Function), jasmine.any(Boolean)]
@@ -1265,7 +1268,8 @@ describe('Carousel', () => {
 
       carousel.dispose()
 
-      expect(removeEventSpy.calls.allArgs()).toEqual(expectedArgs)
+      expect(removeEventSpy).toHaveBeenCalledWith(carouselEl, Carousel.EVENT_KEY)
+      expect(swipeHelperSpy).toHaveBeenCalled()
 
       delete document.documentElement.ontouchstart
     })

--- a/js/tests/unit/util/swipe.spec.js
+++ b/js/tests/unit/util/swipe.spec.js
@@ -1,0 +1,262 @@
+import { clearFixture, getFixture } from '../../helpers/fixture'
+import EventHandler from '../../../src/dom/event-handler'
+import Swipe from '../../../src/util/swipe'
+
+describe('Swipe', () => {
+  const { Simulator, PointerEvent } = window
+  const originWinPointerEvent = PointerEvent
+  const supportPointerEvent = Boolean(PointerEvent)
+
+  let fixtureEl
+  let swipeEl
+  const clearPointerEvents = () => {
+    window.PointerEvent = null
+  }
+
+  const restorePointerEvents = () => {
+    window.PointerEvent = originWinPointerEvent
+  }
+
+  // Headless browser does not support touch events, so need to fake it
+  // to test that touch events are add properly.
+  const defineDocumentElementOntouchstart = () => {
+    document.documentElement.ontouchstart = () => {}
+  }
+
+  const deleteDocumentElementOntouchstart = () => {
+    delete document.documentElement.ontouchstart
+  }
+
+  const mockSwipeGesture = (element, options = {}, type = 'touch') => {
+    Simulator.setType(type)
+    const _options = { deltaX: 0, deltaY: 0, ...options }
+
+    Simulator.gestures.swipe(element, _options)
+  }
+
+  beforeEach(() => {
+    fixtureEl = getFixture()
+    const cssStyle = [
+      '<style>',
+      '   #fixture .pointer-event {',
+      '     touch-action: pan-y;',
+      '  }',
+      '   #fixture div {',
+      '     width: 300px;',
+      '     height: 300px;',
+      '  }',
+      '</style>'
+    ].join('')
+
+    fixtureEl.innerHTML = '<div id="swipeEl"></div>' + cssStyle
+    swipeEl = fixtureEl.querySelector('div')
+  })
+
+  afterEach(() => {
+    clearFixture()
+    deleteDocumentElementOntouchstart()
+  })
+
+  describe('constructor', () => {
+    it('should add touch event listeners by default', () => {
+      defineDocumentElementOntouchstart()
+
+      spyOn(Swipe.prototype, '_initEvents').and.callThrough()
+      const swipe = new Swipe(swipeEl)
+      expect(swipe._initEvents).toHaveBeenCalled()
+    })
+
+    it('should not add touch event listeners if touch is not supported', () => {
+      spyOn(Swipe, 'isSupported').and.returnValue(false)
+
+      spyOn(Swipe.prototype, '_initEvents').and.callThrough()
+      const swipe = new Swipe(swipeEl)
+
+      expect(swipe._initEvents).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Config', () => {
+    it('Test leftCallback', done => {
+      const spyRight = jasmine.createSpy('spy')
+      clearPointerEvents()
+      defineDocumentElementOntouchstart()
+      // eslint-disable-next-line no-unused-vars
+      const swipe = new Swipe(swipeEl, {
+        leftCallback: () => {
+          expect(spyRight).not.toHaveBeenCalled()
+          restorePointerEvents()
+          done()
+        },
+        rightCallback: spyRight
+      })
+
+      mockSwipeGesture(swipeEl, {
+        pos: [300, 10],
+        deltaX: -300
+      })
+    })
+
+    it('Test rightCallback', done => {
+      const spyLeft = jasmine.createSpy('spy')
+      clearPointerEvents()
+      defineDocumentElementOntouchstart()
+      // eslint-disable-next-line no-unused-vars
+      const swipe = new Swipe(swipeEl, {
+        rightCallback: () => {
+          expect(spyLeft).not.toHaveBeenCalled()
+          restorePointerEvents()
+          done()
+        },
+        leftCallback: spyLeft
+      })
+
+      mockSwipeGesture(swipeEl, {
+        pos: [10, 10],
+        deltaX: 300
+      })
+    })
+
+    it('Test endCallback', done => {
+      clearPointerEvents()
+      defineDocumentElementOntouchstart()
+      let isFirstTime = true
+
+      const callback = () => {
+        if (isFirstTime) {
+          isFirstTime = false
+          return
+        }
+
+        expect().nothing()
+        restorePointerEvents()
+        done()
+      }
+
+      // eslint-disable-next-line no-unused-vars
+      const swipe = new Swipe(swipeEl, {
+        endCallback: callback
+      })
+      mockSwipeGesture(swipeEl, {
+        pos: [10, 10],
+        deltaX: 300
+      })
+
+      mockSwipeGesture(swipeEl, {
+        pos: [300, 10],
+        deltaX: -300
+      })
+    })
+  })
+
+  describe('Functionality on PointerEvents', () => {
+    it('should allow swipeRight and call "rightCallback" with pointer events', done => {
+      if (!supportPointerEvent) {
+        expect().nothing()
+        done()
+        return
+      }
+
+      const style = '#fixture .pointer-event { touch-action: none !important; }'
+      fixtureEl.innerHTML += style
+
+      defineDocumentElementOntouchstart()
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, {
+        rightCallback: () => {
+          deleteDocumentElementOntouchstart()
+          expect().nothing()
+          done()
+        }
+      })
+
+      mockSwipeGesture(swipeEl, { deltaX: 300 }, 'pointer')
+    })
+
+    it('should allow swipeLeft and call "leftCallback" with pointer events', done => {
+      if (!supportPointerEvent) {
+        expect().nothing()
+        done()
+        return
+      }
+
+      const style = '#fixture .pointer-event { touch-action: none !important; }'
+      fixtureEl.innerHTML += style
+
+      defineDocumentElementOntouchstart()
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, {
+        leftCallback: () => {
+          expect().nothing()
+          deleteDocumentElementOntouchstart()
+          done()
+        }
+      })
+
+      mockSwipeGesture(swipeEl, {
+        pos: [300, 10],
+        deltaX: -300
+      }, 'pointer')
+    })
+  })
+
+  describe('Dispose', () => {
+    it('should call EventHandler.off', () => {
+      defineDocumentElementOntouchstart()
+      spyOn(EventHandler, 'off').and.callThrough()
+      const swipe = new Swipe(swipeEl)
+
+      swipe.dispose()
+      expect(EventHandler.off).toHaveBeenCalledWith(swipeEl, '.bs.swipe')
+    })
+
+    it('should destroy', () => {
+      const addEventSpy = spyOn(fixtureEl, 'addEventListener').and.callThrough()
+      const removeEventSpy = spyOn(fixtureEl, 'removeEventListener').and.callThrough()
+      defineDocumentElementOntouchstart()
+
+      const swipe = new Swipe(fixtureEl)
+
+      const expectedArgs =
+        swipe._supportPointerEvents ?
+          [
+            ['pointerdown', jasmine.any(Function), jasmine.any(Boolean)],
+            ['pointerup', jasmine.any(Function), jasmine.any(Boolean)]
+          ] :
+          [
+            ['touchstart', jasmine.any(Function), jasmine.any(Boolean)],
+            ['touchmove', jasmine.any(Function), jasmine.any(Boolean)],
+            ['touchend', jasmine.any(Function), jasmine.any(Boolean)]
+          ]
+
+      expect(addEventSpy.calls.allArgs()).toEqual(expectedArgs)
+
+      swipe.dispose()
+
+      expect(removeEventSpy.calls.allArgs()).toEqual(expectedArgs)
+
+      delete document.documentElement.ontouchstart
+    })
+  })
+
+  describe('"isSupported" static', () => {
+    it('should return "true" if "touchstart" exists in document element)', () => {
+      Object.defineProperty(window.navigator, 'maxTouchPoints', () => 0)
+      defineDocumentElementOntouchstart()
+
+      expect(Swipe.isSupported()).toBeTrue()
+    })
+
+    it('should return "false" if "touchstart" not exists in document element and "navigator.maxTouchPoints" are  zero (0)', () => {
+      Object.defineProperty(window.navigator, 'maxTouchPoints', () => 0)
+      deleteDocumentElementOntouchstart()
+
+      if ('ontouchstart' in document.documentElement) {
+        expect().nothing()
+        return
+      }
+
+      expect(Swipe.isSupported()).toBeFalse()
+    })
+  })
+})

--- a/js/tests/unit/util/swipe.spec.js
+++ b/js/tests/unit/util/swipe.spec.js
@@ -1,6 +1,7 @@
 import { clearFixture, getFixture } from '../../helpers/fixture'
 import EventHandler from '../../../src/dom/event-handler'
 import Swipe from '../../../src/util/swipe'
+import { noop } from '../../../src/util'
 
 describe('Swipe', () => {
   const { Simulator, PointerEvent } = window
@@ -20,7 +21,7 @@ describe('Swipe', () => {
   // Headless browser does not support touch events, so need to fake it
   // to test that touch events are add properly.
   const defineDocumentElementOntouchstart = () => {
-    document.documentElement.ontouchstart = () => {}
+    document.documentElement.ontouchstart = noop
   }
 
   const deleteDocumentElementOntouchstart = () => {
@@ -81,8 +82,8 @@ describe('Swipe', () => {
       const spyRight = jasmine.createSpy('spy')
       clearPointerEvents()
       defineDocumentElementOntouchstart()
-      // eslint-disable-next-line no-unused-vars
-      const swipe = new Swipe(swipeEl, {
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, {
         leftCallback: () => {
           expect(spyRight).not.toHaveBeenCalled()
           restorePointerEvents()
@@ -101,8 +102,8 @@ describe('Swipe', () => {
       const spyLeft = jasmine.createSpy('spy')
       clearPointerEvents()
       defineDocumentElementOntouchstart()
-      // eslint-disable-next-line no-unused-vars
-      const swipe = new Swipe(swipeEl, {
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, {
         rightCallback: () => {
           expect(spyLeft).not.toHaveBeenCalled()
           restorePointerEvents()
@@ -133,8 +134,8 @@ describe('Swipe', () => {
         done()
       }
 
-      // eslint-disable-next-line no-unused-vars
-      const swipe = new Swipe(swipeEl, {
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, {
         endCallback: callback
       })
       mockSwipeGesture(swipeEl, {

--- a/js/tests/unit/util/swipe.spec.js
+++ b/js/tests/unit/util/swipe.spec.js
@@ -18,8 +18,8 @@ describe('Swipe', () => {
     window.PointerEvent = originWinPointerEvent
   }
 
-  // Headless browser does not support touch events, so need to fake it
-  // to test that touch events are add properly.
+  // The headless browser does not support touch events, so we need to fake it
+  // in order to test that touch events are added properly
   const defineDocumentElementOntouchstart = () => {
     document.documentElement.ontouchstart = noop
   }


### PR DESCRIPTION
Separate 'Swipe' functionality from Carousel component, in favor of:
*  clean up 
*  possible a future usages like modal/offcanvas swipe to close
*  easier support of swipe horizontal support for vertical carousel

[preview](https://deploy-preview-32999--twbs-bootstrap.netlify.app/docs/5.1/components/carousel/)