### PR TITLE
Docs on enforcing HTTPS and avoiding mixed content

### DIFF
--- a/site/content/docs/5.0/customize/optimize.md
+++ b/site/content/docs/5.0/customize/optimize.md
@@ -74,6 +74,8 @@ Whenever possible, be sure to compress all the code you serve to your visitors. 
 
 _Help wanted with this section, please consider opening a PR. Thanks!_
 
-## Always use https
+## Always use HTTPS
 
-_Help wanted with this section, please consider opening a PR. Thanks!_
+Your website should only be available over HTTPS connections in production. HTTPS improves the security, privacy, and availability of all sites, and [there is no such thing as non-sensitive web traffic](https://https.cio.gov/everything/). The steps to configure your website to be served exclusively over HTTPS vary widely depending on your architecture and web hosting provider, and thus are beyond the scope of these docs.
+
+Sites served over HTTPS should also access all stylesheets, scripts, and other assets over HTTPS connections. Otherwise, you'll be sending users [mixed active content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content), leading to potential vulnerabilities where a site can be compromised by altering a dependency. This can lead to security issues and in-browser warnings displayed to users. Whether you're getting Bootstrap from a CDN or serving it yourself, ensure that you only access it over HTTPS connections.


### PR DESCRIPTION
The live documentation requested that someone fill in the section on "Always use https"

This PR includes a short reference on why to use HTTPS for all sites.

It also includes a more relevant warning about mixed active content.

Both paragraphs link to authoritative, neutral third-party sources.