### PR TITLE
Support configuring "root element" for modal

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -86,7 +86,7 @@ class Modal extends BaseComponent {
     this._isShown = false
     this._ignoreBackdropClick = false
     this._isTransitioning = false
-    this._scrollBar = new ScrollBarHelper()
+    this._scrollBar = new ScrollBarHelper(this._config.rootElement)
   }
 
   // Getters

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -60,7 +60,6 @@ const EVENT_MOUSEUP_DISMISS = `mouseup.dismiss${EVENT_KEY}`
 const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-const CLASS_NAME_MODAL_CUSTOM_ROOT = 'modal-custom-root'
 const CLASS_NAME_OPEN = 'modal-open'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
@@ -247,9 +246,6 @@ class Modal extends BaseComponent {
     }
 
     this._element.classList.add(CLASS_NAME_SHOW)
-    if (this._hasCustomRoot()) {
-      this._element.classList.add(CLASS_NAME_MODAL_CUSTOM_ROOT)
-    }
 
     if (this._config.focus) {
       this._enforceFocus()
@@ -308,11 +304,6 @@ class Modal extends BaseComponent {
     this._element.setAttribute('aria-hidden', true)
     this._element.removeAttribute('aria-modal')
     this._element.removeAttribute('role')
-
-    if (this._hasCustomRoot()) {
-      this._element.classList.remove(CLASS_NAME_MODAL_CUSTOM_ROOT)
-    }
-
     this._isTransitioning = false
     this._backdrop.hide(() => {
       this._config.rootElement.classList.remove(CLASS_NAME_OPEN)
@@ -345,10 +336,6 @@ class Modal extends BaseComponent {
 
   _isAnimated() {
     return this._element.classList.contains(CLASS_NAME_FADE)
-  }
-
-  _hasCustomRoot() {
-    return this._config.rootElement !== document.body
   }
 
   _triggerBackdropTransition() {

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -44,7 +44,7 @@ const DefaultType = {
   backdrop: '(boolean|string)',
   keyboard: 'boolean',
   focus: 'boolean',
-  rootElement: '(element|string)'
+  rootElement: 'element'
 }
 
 const EVENT_HIDE = `hide${EVENT_KEY}`

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -35,13 +35,15 @@ const ESCAPE_KEY = 'Escape'
 const Default = {
   backdrop: true,
   keyboard: true,
-  focus: true
+  focus: true,
+  rootElement: 'body'
 }
 
 const DefaultType = {
   backdrop: '(boolean|string)',
   keyboard: 'boolean',
-  focus: 'boolean'
+  focus: 'boolean',
+  rootElement: '(element|string)'
 }
 
 const EVENT_HIDE = `hide${EVENT_KEY}`
@@ -57,7 +59,7 @@ const EVENT_MOUSEUP_DISMISS = `mouseup.dismiss${EVENT_KEY}`
 const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-const CLASS_NAME_OPEN = 'modal-open'
+const CLASS_NAME_MODAL_CUSTOM_ROOT = 'modal-custom-root'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_STATIC = 'modal-static'
@@ -80,6 +82,7 @@ class Modal extends BaseComponent {
     this._config = this._getConfig(config)
     this._dialog = SelectorEngine.findOne(SELECTOR_DIALOG, this._element)
     this._backdrop = this._initializeBackDrop()
+    this._isCustomRoot = Boolean(config && config.rootElement)
     this._isShown = false
     this._ignoreBackdropClick = false
     this._isTransitioning = false
@@ -122,11 +125,7 @@ class Modal extends BaseComponent {
     }
 
     this._scrollBar.hide()
-
-    document.body.classList.add(CLASS_NAME_OPEN)
-
     this._adjustDialog()
-
     this._setEscapeEvent()
     this._setResizeEvent()
 
@@ -202,7 +201,8 @@ class Modal extends BaseComponent {
   _initializeBackDrop() {
     return new Backdrop({
       isVisible: Boolean(this._config.backdrop), // 'static' option will be translated to true, and booleans will keep their value
-      isAnimated: this._isAnimated()
+      isAnimated: this._isAnimated(),
+      rootElement: this._config.rootElement
     })
   }
 
@@ -240,6 +240,9 @@ class Modal extends BaseComponent {
     }
 
     this._element.classList.add(CLASS_NAME_SHOW)
+    if (this._isCustomRoot) {
+      this._element.classList.add(CLASS_NAME_MODAL_CUSTOM_ROOT)
+    }
 
     if (this._config.focus) {
       this._enforceFocus()
@@ -298,9 +301,14 @@ class Modal extends BaseComponent {
     this._element.setAttribute('aria-hidden', true)
     this._element.removeAttribute('aria-modal')
     this._element.removeAttribute('role')
+
+    if (this._isCustomRoot) {
+      this._element.classList.remove(CLASS_NAME_MODAL_CUSTOM_ROOT)
+    }
+
     this._isTransitioning = false
+
     this._backdrop.hide(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
       this._resetAdjustments()
       this._scrollBar.reset()
       EventHandler.trigger(this._element, EVENT_HIDDEN)

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -24,7 +24,6 @@ const DefaultType = {
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'
-const CLASS_NAME_BACKDROP_CUSTOM_ROOT = 'modal-backdrop-custom-root'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 
@@ -75,9 +74,7 @@ class Backdrop {
   _getElement() {
     if (!this._element) {
       const backdrop = document.createElement('div')
-      backdrop.className = this._hasCustomRoot() ?
-        `${this._config.className} ${CLASS_NAME_BACKDROP_CUSTOM_ROOT}` :
-        this._config.className
+      backdrop.className = this._config.className
       if (this._config.isAnimated) {
         backdrop.classList.add(CLASS_NAME_FADE)
       }
@@ -112,10 +109,6 @@ class Backdrop {
     })
 
     this._isAppended = true
-  }
-
-  _hasCustomRoot() {
-    return this._config.rootElement !== document.body
   }
 
   dispose() {

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -20,7 +20,7 @@ const DefaultType = {
   className: 'string',
   isVisible: 'boolean',
   isAnimated: 'boolean',
-  rootElement: '(element|string)',
+  rootElement: 'element',
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -24,6 +24,7 @@ const DefaultType = {
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'
+const CLASS_NAME_BACKDROP_CUSTOM_ROOT = 'modal-backdrop-custom-root'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 
@@ -32,6 +33,7 @@ const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 class Backdrop {
   constructor(config) {
     this._config = this._getConfig(config)
+    this._isCustomRoot = Boolean(config && config.rootElement)
     this._isAppended = false
     this._element = null
   }
@@ -74,7 +76,9 @@ class Backdrop {
   _getElement() {
     if (!this._element) {
       const backdrop = document.createElement('div')
-      backdrop.className = this._config.className
+      backdrop.className = this._isCustomRoot ?
+        `${this._config.className} ${CLASS_NAME_BACKDROP_CUSTOM_ROOT}` :
+        this._config.className
       if (this._config.isAnimated) {
         backdrop.classList.add(CLASS_NAME_FADE)
       }

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -33,7 +33,6 @@ const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 class Backdrop {
   constructor(config) {
     this._config = this._getConfig(config)
-    this._isCustomRoot = Boolean(config && config.rootElement)
     this._isAppended = false
     this._element = null
   }
@@ -76,7 +75,7 @@ class Backdrop {
   _getElement() {
     if (!this._element) {
       const backdrop = document.createElement('div')
-      backdrop.className = this._isCustomRoot ?
+      backdrop.className = this._hasCustomRoot() ?
         `${this._config.className} ${CLASS_NAME_BACKDROP_CUSTOM_ROOT}` :
         this._config.className
       if (this._config.isAnimated) {
@@ -113,6 +112,10 @@ class Backdrop {
     })
 
     this._isAppended = true
+  }
+
+  _hasCustomRoot() {
+    return this._config.rootElement !== document.body
   }
 
   dispose() {

--- a/js/src/util/scrollbar.js
+++ b/js/src/util/scrollbar.js
@@ -13,14 +13,20 @@ const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-to
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
 
 class ScrollBarHelper {
-  constructor(rootElement) {
-    this._element = rootElement || document.body
+  constructor(element = document.body) {
+    this._isBody = [document.body, document.documentElement].includes(element)
+
+    this._element = this._isBody ? document.body : element
   }
 
   getWidth() {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
-    const documentWidth = document.documentElement.clientWidth
-    return Math.abs(window.innerWidth - documentWidth)
+    if (this._isBody) {
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
+      const documentWidth = document.documentElement.clientWidth
+      return Math.abs(window.innerWidth - documentWidth)
+    }
+
+    return Math.abs(this._element.offsetWidth - this._element.clientWidth)
   }
 
   hide() {
@@ -87,10 +93,6 @@ class ScrollBarHelper {
     } else {
       SelectorEngine.find(selector, this._element).forEach(callBack)
     }
-  }
-
-  isOverflowing() {
-    return this.getWidth() > 0
   }
 }
 

--- a/js/src/util/scrollbar.js
+++ b/js/src/util/scrollbar.js
@@ -13,8 +13,8 @@ const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-to
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
 
 class ScrollBarHelper {
-  constructor() {
-    this._element = document.body
+  constructor(rootElement) {
+    this._element = rootElement || document.body
   }
 
   getWidth() {

--- a/js/tests/integration/bundle.js
+++ b/js/tests/integration/bundle.js
@@ -1,4 +1,4 @@
-import { Tooltip } from '../../../dist/js/bootstrap.esm.js'
+import { Tooltip } from './../../../dist/js/bootstrap.esm.js'
 
 window.addEventListener('load', () => {
   [].concat(...document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -717,8 +717,9 @@ describe('Modal', () => {
   describe('config rootElement', () => {
     it('should append backdrop to root element', done => {
       fixtureEl.innerHTML = [
-        '<div id="modal-root"></div>',
-        '<div class="modal"><div class="modal-dialog"></div></div>'
+        '<div id="modal-root">',
+        '   <div class="modal"><div class="modal-dialog"></div></div>',
+        '</div>'
       ].join('')
 
       const modalEl = fixtureEl.querySelector('.modal')
@@ -726,6 +727,7 @@ describe('Modal', () => {
       const modal = new Modal(modalEl, { rootElement })
 
       modalEl.addEventListener('shown.bs.modal', () => {
+        expect(fixtureEl.querySelector('.modal-open')).toEqual(rootElement)
         expect(rootElement.querySelector('.modal-backdrop')).not.toBeNull()
         done()
       })

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -714,6 +714,26 @@ describe('Modal', () => {
     })
   })
 
+  describe('config rootElement', () => {
+    it('should append backdrop to root element', done => {
+      fixtureEl.innerHTML = [
+        '<div id="modal-root"></div>',
+        '<div class="modal"><div class="modal-dialog"></div></div>'
+      ].join('')
+
+      const modalEl = fixtureEl.querySelector('.modal')
+      const rootElement = fixtureEl.querySelector('#modal-root')
+      const modal = new Modal(modalEl, { rootElement })
+
+      modalEl.addEventListener('shown.bs.modal', () => {
+        expect(rootElement.querySelector('.modal-backdrop')).not.toBeNull()
+        done()
+      })
+
+      modal.show()
+    })
+  })
+
   describe('handleUpdate', () => {
     it('should call adjust dialog', () => {
       fixtureEl.innerHTML = '<div id="exampleModal" class="modal"><div class="modal-dialog"></div></div>'

--- a/js/tests/unit/util/scrollbar.spec.js
+++ b/js/tests/unit/util/scrollbar.spec.js
@@ -75,6 +75,21 @@ describe('ScrollBar', () => {
 
       expect(result).toEqual(false)
     })
+
+    it('allows rootElement to be set', () => {
+      fixtureEl.innerHTML = [
+        '<div id="another-root" style="height: 100vh; width: 100%"><div style="height: 110vh; width: 100%"></div></div>'
+      ].join('')
+      const anotherRootElement = document.querySelector('#another-root')
+      anotherRootElement.style.overflowY = 'scroll'
+      const result = new ScrollBarHelper(anotherRootElement).isOverflowing()
+
+      if (isScrollBarHidden()) {
+        expect(result).toEqual(false)
+      } else {
+        expect(result).toEqual(true)
+      }
+    })
   })
 
   describe('getWidth', () => {

--- a/js/tests/unit/util/scrollbar.spec.js
+++ b/js/tests/unit/util/scrollbar.spec.js
@@ -48,76 +48,64 @@ describe('ScrollBar', () => {
     clearBodyAndDocument()
   })
 
-  describe('isBodyOverflowing', () => {
-    it('should return true if body is overflowing', () => {
-      document.documentElement.style.overflowY = 'scroll'
-      document.body.style.overflowY = 'scroll'
-      fixtureEl.innerHTML = [
-        '<div style="height: 110vh; width: 100%"></div>'
-      ].join('')
-      const result = new ScrollBarHelper().isOverflowing()
-
-      if (isScrollBarHidden()) {
-        expect(result).toEqual(false)
-      } else {
-        expect(result).toEqual(true)
-      }
-    })
-
-    it('should return false if body is not overflowing', () => {
-      doc.style.overflowY = 'hidden'
-      document.body.style.overflowY = 'hidden'
-      fixtureEl.innerHTML = [
-        '<div style="height: 110vh; width: 100%"></div>'
-      ].join('')
-      const scrollBar = new ScrollBarHelper()
-      const result = scrollBar.isOverflowing()
-
-      expect(result).toEqual(false)
-    })
-
-    it('allows rootElement to be set', () => {
-      fixtureEl.innerHTML = [
-        '<div id="another-root" style="height: 100vh; width: 100%"><div style="height: 110vh; width: 100%"></div></div>'
-      ].join('')
-      const anotherRootElement = document.querySelector('#another-root')
-      anotherRootElement.style.overflowY = 'scroll'
-      const result = new ScrollBarHelper(anotherRootElement).isOverflowing()
-
-      if (isScrollBarHidden()) {
-        expect(result).toEqual(false)
-      } else {
-        expect(result).toEqual(true)
-      }
-    })
-  })
-
   describe('getWidth', () => {
-    it('should return an integer greater than zero, if body is overflowing', () => {
-      doc.style.overflowY = 'scroll'
-      document.body.style.overflowY = 'scroll'
-      fixtureEl.innerHTML = [
-        '<div style="height: 110vh; width: 100%"></div>'
-      ].join('')
-      const result = new ScrollBarHelper().getWidth()
+    describe('Body', () => {
+      it('should return an integer greater than zero, if body is overflowing', () => {
+        doc.style.overflowY = 'scroll'
+        document.body.style.overflowY = 'scroll'
+        fixtureEl.innerHTML = [
+          '<div style="height: 110vh; width: 100%"></div>'
+        ].join('')
+        const result = new ScrollBarHelper().getWidth()
 
-      if (isScrollBarHidden()) {
-        expect(result).toBe(0)
-      } else {
-        expect(result).toBeGreaterThan(1)
-      }
+        if (isScrollBarHidden()) {
+          expect(result).toBe(0)
+        } else {
+          expect(result).toBeGreaterThan(1)
+        }
+      })
+
+      it('should return 0 if body is not overflowing', () => {
+        document.documentElement.style.overflowY = 'hidden'
+        document.body.style.overflowY = 'hidden'
+        fixtureEl.innerHTML = [
+          '<div style="height: 110vh; width: 100%"></div>'
+        ].join('')
+
+        const result = new ScrollBarHelper().getWidth()
+
+        expect(result).toEqual(0)
+      })
     })
 
-    it('should return 0 if body is not overflowing', () => {
-      document.documentElement.style.overflowY = 'hidden'
-      document.body.style.overflowY = 'hidden'
-      fixtureEl.innerHTML = [
-        '<div style="height: 110vh; width: 100%"></div>'
-      ].join('')
+    describe('Element', () => {
+      it('should return an integer greater than zero, if wrapper element is overflowing', () => {
+        fixtureEl.innerHTML = [
+          '<div class="wrapper" style="height: 100px; width: 100%; overflow: scroll">' +
+          '   <div style="height: 120px; width: 100%"></div>' +
+          '</div>'
+        ].join('')
+        const wrapper = fixtureEl.querySelector('.wrapper')
+        const result = new ScrollBarHelper(wrapper).getWidth()
 
-      const result = new ScrollBarHelper().getWidth()
+        if (isScrollBarHidden()) {
+          expect(result).toBe(0)
+        } else {
+          expect(result).toBeGreaterThan(1)
+        }
+      })
 
-      expect(result).toEqual(0)
+      it('should return 0 if wrapper element is not overflowing', () => {
+        fixtureEl.innerHTML = [
+          '<div class="wrapper" style="height: 100px; width: 100%">' +
+          '   <div style="height: 20px; width: 100%"></div>' +
+          '</div>'
+        ].join('')
+        const wrapper = fixtureEl.querySelector('.wrapper')
+        const result = new ScrollBarHelper(wrapper).getWidth()
+
+        expect(result).toEqual(0)
+      })
     })
   })
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,3 +1,4 @@
+// .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and stuff

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -88,11 +88,14 @@
   @include overlay-backdrop($zindex-modal-backdrop, $modal-backdrop-bg, $modal-backdrop-opacity);
 }
 
-.modal-custom-root,
-.modal-backdrop-custom-root {
-  position: absolute;
-  width: 100%;
-  height: 100%;
+// custom root specified
+.modal-open:not(body) {
+  .modal,
+  .modal-backdrop {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 // Modal header

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,4 +1,3 @@
-// .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and stuff
@@ -86,6 +85,13 @@
 // Modal background
 .modal-backdrop {
   @include overlay-backdrop($zindex-modal-backdrop, $modal-backdrop-bg, $modal-backdrop-opacity);
+}
+
+.modal-custom-root,
+.modal-backdrop-custom-root {
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }
 
 // Modal header

--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -117,6 +117,16 @@
     })
   }
 
+  var rootElementExample = document.getElementById('modal-root-example')
+  if (rootElementExample) {
+    var rootElementModal = new bootstrap.Modal(rootElementExample, {
+      rootElement: document.getElementById('another-element')
+    })
+    document.getElementById('modal-root-example-btn').addEventListener('click', function () {
+      rootElementModal.show()
+    })
+  }
+
   // Activate animated progress bar
   var btnToggleAnimatedProgress = document.getElementById('btnToggleAnimatedProgress')
   if (btnToggleAnimatedProgress) {

--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -117,16 +117,6 @@
     })
   }
 
-  var rootElementExample = document.getElementById('modal-root-example')
-  if (rootElementExample) {
-    var rootElementModal = new bootstrap.Modal(rootElementExample, {
-      rootElement: document.getElementById('another-element')
-    })
-    document.getElementById('modal-root-example-btn').addEventListener('click', function () {
-      rootElementModal.show()
-    })
-  }
-
   // Activate animated progress bar
   var btnToggleAnimatedProgress = document.getElementById('btnToggleAnimatedProgress')
   if (btnToggleAnimatedProgress) {

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -564,6 +564,38 @@ Be sure to add `aria-labelledby="..."`, referencing the modal title, to `.modal`
 
 Embedding YouTube videos in modals requires additional JavaScript not in Bootstrap to automatically stop playback and more. [See this helpful Stack Overflow post](https://stackoverflow.com/questions/18622508/bootstrap-3-and-youtube-in-modal) for more information.
 
+### Configuring root element
+
+Currently this is only supported when using modals with JavaScript
+
+```js
+var modal = bootstrap.Modal(document.getElementById('modal'), {
+  rootElement: document.getElementById('another-element')
+});
+```
+{{< example >}}
+<!-- modal will appear within this element and not document.body -->
+<div id="another-element" class="position-relative border" style="height: 300px;">
+
+  <!-- modal -->
+  <div id="modal-root-example" class="modal fade" tabindex="-1" aria-labelledby="modal-root-example-title" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title h4" id="modal-root-example-title">Modal in a container</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          ...
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<button id="modal-root-example-btn" type="button" class="btn btn-primary mt-3" data-bs-target="#modal-root-example">
+  Show modal in another element
+</button>
+{{< /example >}}
 ## Optional sizes
 
 Modals have three optional sizes, available via modifier classes to be placed on a `.modal-dialog`. These sizes kick in at certain breakpoints to avoid horizontal scrollbars on narrower viewports.
@@ -876,6 +908,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>boolean</td>
       <td><code>true</code></td>
       <td>Puts the focus on the modal when initialized.</td>
+    </tr>
+    <tr>
+      <td><code>rootElement</code></td>
+      <td>string or element</td>
+      <td><code>document.body</code></td>
+      <td>Configure the container that the modal resides in.</td>
     </tr>
   </tbody>
 </table>

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -566,7 +566,13 @@ Embedding YouTube videos in modals requires additional JavaScript not in Bootstr
 
 ### Configuring root element
 
-Currently this is only supported when using modals with JavaScript
+Specify `data-bs-root-element` attribute
+```html
+<div id="another-element" class="position-relative">
+<div class="modal ..." data-bs-root-element="#another-element" tabindex="-1" aria-hidden="true">
+```
+
+Or pass it in the config via JavaScript
 
 ```js
 var modal = bootstrap.Modal(document.getElementById('modal'), {
@@ -578,7 +584,7 @@ var modal = bootstrap.Modal(document.getElementById('modal'), {
 <div id="another-element" class="position-relative border" style="height: 300px;">
 
   <!-- modal -->
-  <div id="modal-root-example" class="modal fade" tabindex="-1" aria-labelledby="modal-root-example-title" aria-hidden="true">
+  <div id="modal-root-example" class="modal fade" tabindex="-1" aria-labelledby="modal-root-example-title" aria-hidden="true" data-bs-root-element="#another-element">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -592,7 +598,7 @@ var modal = bootstrap.Modal(document.getElementById('modal'), {
     </div>
   </div>
 </div>
-<button id="modal-root-example-btn" type="button" class="btn btn-primary mt-3" data-bs-target="#modal-root-example">
+<button type="button" class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#modal-root-example">
   Show modal in another element
 </button>
 {{< /example >}}


### PR DESCRIPTION
Hi guys,

New contributor here, please let me know if I have missed anything

This PR attempts to resolve https://github.com/twbs/bootstrap/issues/31509 adding support to allow configuring the "root element" for the modal component. This PR only implements configuring this when initialising the modal via Javascript. I haven't dug deep into how this can be done via providing html attributes. 

Please let me know if this is the right approach


Thanks!

[preview](https://deploy-preview-33018--twbs-bootstrap.netlify.app/docs/5.0/components/modal/#configuring-root-element)


closes #34309