### PR TITLE
Add input focus blur variable

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -570,7 +570,8 @@ $input-btn-line-height:       $line-height-base !default;
 $input-btn-focus-width:         .25rem !default;
 $input-btn-focus-color-opacity: .25 !default;
 $input-btn-focus-color:         rgba($component-active-bg, $input-btn-focus-color-opacity) !default;
-$input-btn-focus-box-shadow:    0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
+$input-btn-focus-blur:          0 !default;
+$input-btn-focus-box-shadow:    0 0 $input-btn-focus-blur $input-btn-focus-width $input-btn-focus-color !default;
 
 $input-btn-padding-y-sm:      .25rem !default;
 $input-btn-padding-x-sm:      .5rem !default;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -19,7 +19,7 @@
   $icon,
   $tooltip-color: color-contrast($color),
   $tooltip-bg-color: rgba($color, $form-feedback-tooltip-opacity),
-  $focus-box-shadow: 0 0 0 $input-focus-width rgba($color, $input-btn-focus-color-opacity)
+  $focus-box-shadow: 0 0 $input-btn-focus-blur $input-focus-width rgba($color, $input-btn-focus-color-opacity)
 ) {
   .#{$state}-feedback {
     display: none;


### PR DESCRIPTION
I have added an additional variable to allow users to customise the value of the `blur` property for `box-shadows`. Previously, input shadows set their own blur value, which made it difficult to overwrite due to the usage of mixins to generate a lot of the validation styles; [Issue #31940](https://github.com/twbs/bootstrap/issues/31940).

This PR offers a new `$input-btn-focus-blur` variable, which defaults to a value of `0`, and is then used to populate the blur for all input related `box-shadow` variables.