### PR TITLE
Allow card list-items to inherit background-color

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -34,6 +34,12 @@
     }
   }
 
+  // If a background-color is set on the card element, allow the
+  // list-group-item to inherit the card background-color.
+  .list-group-item {
+    background-color: inherit;
+  }
+
   // Due to specificity of the above selector (`.card > .list-group`), we must
   // use a child selector here to prevent double borders.
   > .card-header + .list-group,


### PR DESCRIPTION
Fix bug where list-group-items rendered in a card element
with a background-color do not inherit the card background
and are not visible.

Fixes #33084