### PR TITLE
docs(examples): typo in offcanvas example in .bg-body

### DIFF
--- a/site/content/docs/5.0/examples/offcanvas/index.html
+++ b/site/content/docs/5.0/examples/offcanvas/index.html
@@ -46,7 +46,7 @@ body_class: "bg-light"
   </div>
 </nav>
 
-<div class="nav-scroller bg--body shadow-sm">
+<div class="nav-scroller bg-body shadow-sm">
   <nav class="nav nav-underline" aria-label="Secondary navigation">
     <a class="nav-link active" aria-current="page" href="#">Dashboard</a>
     <a class="nav-link" href="#">


### PR DESCRIPTION
Caught by pa11y-ci on Boosted (because of insufficient contrasts) :heart: