### PR TITLE
being ssr friendly when accessing dom objects

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "22.75 kB"
+      "maxSize": "22.95 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
@@ -50,11 +50,11 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "29 kB"
+      "maxSize": "29.1 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.5 kB"
+      "maxSize": "16.6 kB"
     }
   ],
   "ci": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,13 @@
 {
   "root": true,
+  "plugins": ["ssr-friendly"],
   "extends": [
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:unicorn/recommended",
     "xo/esnext",
-    "xo/browser"
+    "xo/browser",
+    "plugin:ssr-friendly/recommended"
   ],
   "rules": {
     "capitalized-comments": "off",
@@ -53,6 +55,8 @@
     "unicorn/prefer-dom-node-remove": "off",
     "unicorn/prefer-query-selector": "off",
     "unicorn/prefer-spread": "off",
-    "unicorn/prevent-abbreviations": "off"
+    "unicorn/prevent-abbreviations": "off",
+    "ssr-friendly/no-dom-globals-in-react-cc-render": "off",
+    "ssr-friendly/no-dom-globals-in-react-fc": "off"
   }
 }

--- a/js/src/alert.js
+++ b/js/src/alert.js
@@ -8,6 +8,7 @@
 import {
   defineJQueryPlugin,
   emulateTransitionEnd,
+  getDocument,
   getElementFromSelector,
   getTransitionDurationFromElement
 } from './util/index'
@@ -127,7 +128,7 @@ class Alert extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DISMISS, Alert.handleDismiss(new Alert()))
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DISMISS, Alert.handleDismiss(new Alert()))
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -18,7 +18,7 @@ const VERSION = '5.0.0-beta2'
 
 class BaseComponent {
   constructor(element) {
-    element = typeof element === 'string' ? document.querySelector(element) : element
+    element = typeof element === 'string' ? getDocument().querySelector(element) : element
 
     if (!element) {
       return

--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -6,6 +6,7 @@
  */
 
 import Data from './dom/data'
+import { getDocument, getWindow } from './util/index'
 
 /**
  * ------------------------------------------------------------------------
@@ -24,6 +25,8 @@ class BaseComponent {
     }
 
     this._element = element
+    this._window = getWindow()
+    this._document = getDocument()
     Data.set(this._element, this.constructor.DATA_KEY, this)
   }
 

--- a/js/src/button.js
+++ b/js/src/button.js
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { defineJQueryPlugin } from './util/index'
+import { defineJQueryPlugin, getDocument } from './util/index'
 import Data from './dom/data'
 import EventHandler from './dom/event-handler'
 import BaseComponent from './base-component'
@@ -70,7 +70,7 @@ class Button extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
   event.preventDefault()
 
   const button = event.target.closest(SELECTOR_DATA_TOGGLE)

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -8,8 +8,10 @@
 import {
   defineJQueryPlugin,
   emulateTransitionEnd,
+  getDocument,
   getElementFromSelector,
   getTransitionDurationFromElement,
+  getWindow,
   isRTL,
   isVisible,
   reflow,
@@ -117,8 +119,8 @@ class Carousel extends BaseComponent {
 
     this._config = this._getConfig(config)
     this._indicatorsElement = SelectorEngine.findOne(SELECTOR_INDICATORS, this._element)
-    this._touchSupported = 'ontouchstart' in document.documentElement || navigator.maxTouchPoints > 0
-    this._pointerEvent = Boolean(window.PointerEvent)
+    this._touchSupported = 'ontouchstart' in this._document.documentElement || this._window.navigator.maxTouchPoints > 0
+    this._pointerEvent = Boolean(this._window.PointerEvent)
 
     this._addEventListeners()
   }
@@ -144,7 +146,7 @@ class Carousel extends BaseComponent {
   nextWhenVisible() {
     // Don't call next when the page isn't visible
     // or the carousel or its parent isn't visible
-    if (!document.hidden && isVisible(this._element)) {
+    if (!this._document.hidden && isVisible(this._element)) {
       this.next()
     }
   }
@@ -183,7 +185,7 @@ class Carousel extends BaseComponent {
       this._updateInterval()
 
       this._interval = setInterval(
-        (document.visibilityState ? this.nextWhenVisible : this.next).bind(this),
+        (this._document.visibilityState ? this.nextWhenVisible : this.next).bind(this),
         this._config.interval
       )
     }
@@ -604,9 +606,9 @@ class Carousel extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_SLIDE, Carousel.dataApiClickHandler)
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_SLIDE, Carousel.dataApiClickHandler)
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+EventHandler.on(getWindow(), EVENT_LOAD_DATA_API, () => {
   const carousels = SelectorEngine.find(SELECTOR_DATA_RIDE)
 
   for (let i = 0, len = carousels.length; i < len; i++) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -8,6 +8,7 @@
 import {
   defineJQueryPlugin,
   emulateTransitionEnd,
+  getDocument,
   getSelectorFromElement,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -369,7 +370,7 @@ class Collapse extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   // preventDefault only for <a> elements (which change the URL) not inside the collapsible element
   if (event.target.tagName === 'A' || (event.delegateTarget && event.delegateTarget.tagName === 'A')) {
     event.preventDefault()

--- a/js/src/dom/event-handler.js
+++ b/js/src/dom/event-handler.js
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { getjQuery } from '../util/index'
+import { getDocument, getjQuery } from '../util/index'
 
 /**
  * ------------------------------------------------------------------------
@@ -292,7 +292,7 @@ const EventHandler = {
     }
 
     if (isNative) {
-      evt = document.createEvent('HTMLEvents')
+      evt = getDocument().createEvent('HTMLEvents')
       evt.initEvent(typeEvent, bubbles, true)
     } else {
       evt = new CustomEvent(event, {

--- a/js/src/dom/manipulator.js
+++ b/js/src/dom/manipulator.js
@@ -5,6 +5,8 @@
  * --------------------------------------------------------------------------
  */
 
+import { getDocument } from '../util/index'
+
 function normalizeData(val) {
   if (val === 'true') {
     return true
@@ -62,6 +64,7 @@ const Manipulator = {
 
   offset(element) {
     const rect = element.getBoundingClientRect()
+    const document = getDocument()
 
     return {
       top: rect.top + document.body.scrollTop,

--- a/js/src/dom/manipulator.js
+++ b/js/src/dom/manipulator.js
@@ -64,11 +64,11 @@ const Manipulator = {
 
   offset(element) {
     const rect = element.getBoundingClientRect()
-    const document = getDocument()
+    const documentRef = getDocument()
 
     return {
-      top: rect.top + document.body.scrollTop,
-      left: rect.left + document.body.scrollLeft
+      top: rect.top + documentRef.body.scrollTop,
+      left: rect.left + documentRef.body.scrollLeft
     }
   },
 

--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -5,6 +5,8 @@
  * --------------------------------------------------------------------------
  */
 
+import { getDocument } from '../util/index'
+
 /**
  * ------------------------------------------------------------------------
  * Constants
@@ -14,11 +16,11 @@
 const NODE_TEXT = 3
 
 const SelectorEngine = {
-  find(selector, element = document.documentElement) {
+  find(selector, element = getDocument().documentElement) {
     return [].concat(...Element.prototype.querySelectorAll.call(element, selector))
   },
 
-  findOne(selector, element = document.documentElement) {
+  findOne(selector, element = getDocument().documentElement) {
     return Element.prototype.querySelector.call(element, selector)
   },
 

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -9,6 +9,7 @@ import * as Popper from '@popperjs/core'
 
 import {
   defineJQueryPlugin,
+  getDocument,
   getElementFromSelector,
   isElement,
   isVisible,
@@ -190,9 +191,9 @@ class Dropdown extends BaseComponent {
     // empty mouseover listeners to the body's immediate children;
     // only needed because of broken event delegation on iOS
     // https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
-    if ('ontouchstart' in document.documentElement &&
+    if ('ontouchstart' in this._document.documentElement &&
       !parent.closest(SELECTOR_NAVBAR_NAV)) {
-      [].concat(...document.body.children)
+      [].concat(...this._document.body.children)
         .forEach(elem => EventHandler.on(elem, 'mouseover', null, noop()))
     }
 
@@ -414,10 +415,12 @@ class Dropdown extends BaseComponent {
         continue
       }
 
+      const documentRef = getDocument()
+
       // If this is a touch-enabled device we remove the extra
       // empty mouseover listeners we added for iOS support
-      if ('ontouchstart' in document.documentElement) {
-        [].concat(...document.body.children)
+      if ('ontouchstart' in documentRef.documentElement) {
+        [].concat(...documentRef.body.children)
           .forEach(elem => EventHandler.off(elem, 'mouseover', null, noop()))
       }
 
@@ -513,16 +516,18 @@ class Dropdown extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_KEYDOWN_DATA_API, SELECTOR_DATA_TOGGLE, Dropdown.dataApiKeydownHandler)
-EventHandler.on(document, EVENT_KEYDOWN_DATA_API, SELECTOR_MENU, Dropdown.dataApiKeydownHandler)
-EventHandler.on(document, EVENT_CLICK_DATA_API, Dropdown.clearMenus)
-EventHandler.on(document, EVENT_KEYUP_DATA_API, Dropdown.clearMenus)
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+const documentRef = getDocument()
+
+EventHandler.on(documentRef, EVENT_KEYDOWN_DATA_API, SELECTOR_DATA_TOGGLE, Dropdown.dataApiKeydownHandler)
+EventHandler.on(documentRef, EVENT_KEYDOWN_DATA_API, SELECTOR_MENU, Dropdown.dataApiKeydownHandler)
+EventHandler.on(documentRef, EVENT_CLICK_DATA_API, Dropdown.clearMenus)
+EventHandler.on(documentRef, EVENT_KEYUP_DATA_API, Dropdown.clearMenus)
+EventHandler.on(documentRef, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   event.preventDefault()
   event.stopPropagation()
   Dropdown.dropdownInterface(this, 'toggle')
 })
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_FORM_CHILD, e => e.stopPropagation())
+EventHandler.on(documentRef, EVENT_CLICK_DATA_API, SELECTOR_FORM_CHILD, e => e.stopPropagation())
 
 /**
  * ------------------------------------------------------------------------

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -468,7 +468,7 @@ class Modal extends BaseComponent {
   _setElementAttributes(selector, styleProp, callback) {
     SelectorEngine.find(selector)
       .forEach(element => {
-        if (element !== document.body && window.innerWidth > element.clientWidth + this._scrollbarWidth) {
+        if (element !== this._document.body && this._window.innerWidth > element.clientWidth + this._scrollbarWidth) {
           return
         }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -7,6 +7,7 @@
 
 import {
   defineJQueryPlugin,
+  getDocument,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -234,7 +235,7 @@ class Modal extends BaseComponent {
 
     if (!this._element.parentNode || this._element.parentNode.nodeType !== Node.ELEMENT_NODE) {
       // Don't move modal's DOM position
-      document.body.appendChild(this._element)
+      this._document.body.appendChild(this._element)
     }
 
     this._element.style.display = 'block'
@@ -319,7 +320,7 @@ class Modal extends BaseComponent {
     this._element.removeAttribute('role')
     this._isTransitioning = false
     this._showBackdrop(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
+      this._document.body.classList.remove(CLASS_NAME_OPEN)
       this._resetAdjustments()
       this._resetScrollbar()
       EventHandler.trigger(this._element, EVENT_HIDDEN)
@@ -334,14 +335,14 @@ class Modal extends BaseComponent {
   _showBackdrop(callback) {
     const isAnimated = this._isAnimated()
     if (this._isShown && this._config.backdrop) {
-      this._backdrop = document.createElement('div')
+      this._backdrop = this._document.createElement('div')
       this._backdrop.className = CLASS_NAME_BACKDROP
 
       if (isAnimated) {
         this._backdrop.classList.add(CLASS_NAME_FADE)
       }
 
-      document.body.appendChild(this._backdrop)
+      this._document.body.appendChild(this._backdrop)
 
       EventHandler.on(this._element, EVENT_CLICK_DISMISS, event => {
         if (this._ignoreBackdropClick) {
@@ -405,7 +406,7 @@ class Modal extends BaseComponent {
       return
     }
 
-    const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
+    const isModalOverflowing = this._element.scrollHeight > this._document.documentElement.clientHeight
 
     if (!isModalOverflowing) {
       this._element.style.overflowY = 'hidden'
@@ -432,7 +433,7 @@ class Modal extends BaseComponent {
   // ----------------------------------------------------------------------
 
   _adjustDialog() {
-    const isModalOverflowing = this._element.scrollHeight > document.documentElement.clientHeight
+    const isModalOverflowing = this._element.scrollHeight > this._document.documentElement.clientHeight
 
     if ((!this._isBodyOverflowing && isModalOverflowing && !isRTL()) || (this._isBodyOverflowing && !isModalOverflowing && isRTL())) {
       this._element.style.paddingLeft = `${this._scrollbarWidth}px`
@@ -449,8 +450,8 @@ class Modal extends BaseComponent {
   }
 
   _checkScrollbar() {
-    const rect = document.body.getBoundingClientRect()
-    this._isBodyOverflowing = Math.round(rect.left + rect.right) < window.innerWidth
+    const rect = this._document.body.getBoundingClientRect()
+    this._isBodyOverflowing = Math.round(rect.left + rect.right) < this._window.innerWidth
     this._scrollbarWidth = this._getScrollbarWidth()
   }
 
@@ -461,7 +462,7 @@ class Modal extends BaseComponent {
       this._setElementAttributes('body', 'paddingRight', calculatedValue => calculatedValue + this._scrollbarWidth)
     }
 
-    document.body.classList.add(CLASS_NAME_OPEN)
+    this._document.body.classList.add(CLASS_NAME_OPEN)
   }
 
   _setElementAttributes(selector, styleProp, callback) {
@@ -472,7 +473,7 @@ class Modal extends BaseComponent {
         }
 
         const actualValue = element.style[styleProp]
-        const calculatedValue = window.getComputedStyle(element)[styleProp]
+        const calculatedValue = this._window.getComputedStyle(element)[styleProp]
         Manipulator.setDataAttribute(element, styleProp, actualValue)
         element.style[styleProp] = callback(Number.parseFloat(calculatedValue)) + 'px'
       })
@@ -487,7 +488,7 @@ class Modal extends BaseComponent {
   _resetElementAttributes(selector, styleProp) {
     SelectorEngine.find(selector).forEach(element => {
       const value = Manipulator.getDataAttribute(element, styleProp)
-      if (typeof value === 'undefined' && element === document.body) {
+      if (typeof value === 'undefined' && element === this._document.body) {
         element.style[styleProp] = ''
       } else {
         Manipulator.removeDataAttribute(element, styleProp)
@@ -497,11 +498,11 @@ class Modal extends BaseComponent {
   }
 
   _getScrollbarWidth() { // thx d.walsh
-    const scrollDiv = document.createElement('div')
+    const scrollDiv = this._document.createElement('div')
     scrollDiv.className = CLASS_NAME_SCROLLBAR_MEASURER
-    document.body.appendChild(scrollDiv)
+    this._document.body.appendChild(scrollDiv)
     const scrollbarWidth = scrollDiv.getBoundingClientRect().width - scrollDiv.clientWidth
-    document.body.removeChild(scrollDiv)
+    this._document.body.removeChild(scrollDiv)
     return scrollbarWidth
   }
 
@@ -537,7 +538,7 @@ class Modal extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   const target = getElementFromSelector(this)
 
   if (this.tagName === 'A' || this.tagName === 'AREA') {

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -7,6 +7,7 @@
 
 import {
   defineJQueryPlugin,
+  getDocument,
   getElementFromSelector,
   getSelectorFromElement,
   getTransitionDurationFromElement,
@@ -107,7 +108,7 @@ class Offcanvas extends BaseComponent {
     this._element.style.visibility = 'visible'
 
     if (this._config.backdrop) {
-      document.body.classList.add(CLASS_NAME_BACKDROP_BODY)
+      this._document.body.classList.add(CLASS_NAME_BACKDROP_BODY)
     }
 
     if (!this._config.scroll) {
@@ -153,7 +154,7 @@ class Offcanvas extends BaseComponent {
       this._element.style.visibility = 'hidden'
 
       if (this._config.backdrop) {
-        document.body.classList.remove(CLASS_NAME_BACKDROP_BODY)
+        this._document.body.classList.remove(CLASS_NAME_BACKDROP_BODY)
       }
 
       if (!this._config.scroll) {
@@ -233,7 +234,7 @@ class Offcanvas extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   const target = getElementFromSelector(this)
 
   if (['A', 'AREA'].includes(this.tagName)) {

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -9,6 +9,7 @@ import {
   defineJQueryPlugin,
   getSelectorFromElement,
   getUID,
+  getWindow,
   isElement,
   typeCheckConfig
 } from './util/index'
@@ -68,7 +69,7 @@ const METHOD_POSITION = 'position'
 class ScrollSpy extends BaseComponent {
   constructor(element, config) {
     super(element)
-    this._scrollElement = this._element.tagName === 'BODY' ? window : this._element
+    this._scrollElement = this._element.tagName === 'BODY' ? this._window : this._element
     this._config = this._getConfig(config)
     this._selector = `${this._config.target} ${SELECTOR_NAV_LINKS}, ${this._config.target} ${SELECTOR_LIST_ITEMS}, ${this._config.target} .${CLASS_NAME_DROPDOWN_ITEM}`
     this._offsets = []
@@ -181,14 +182,14 @@ class ScrollSpy extends BaseComponent {
 
   _getScrollHeight() {
     return this._scrollElement.scrollHeight || Math.max(
-      document.body.scrollHeight,
-      document.documentElement.scrollHeight
+      this._document.body.scrollHeight,
+      this._document.documentElement.scrollHeight
     )
   }
 
   _getOffsetHeight() {
     return this._scrollElement === window ?
-      window.innerHeight :
+      this._window.innerHeight :
       this._scrollElement.getBoundingClientRect().height
   }
 
@@ -302,7 +303,7 @@ class ScrollSpy extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
+EventHandler.on(getWindow(), EVENT_LOAD_DATA_API, () => {
   SelectorEngine.find(SELECTOR_DATA_SPY)
     .forEach(spy => new ScrollSpy(spy, Manipulator.getDataAttributes(spy)))
 })

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -8,6 +8,7 @@
 import {
   defineJQueryPlugin,
   emulateTransitionEnd,
+  getDocument,
   getElementFromSelector,
   getTransitionDurationFromElement,
   isDisabled,
@@ -201,7 +202,7 @@ class Tab extends BaseComponent {
  * ------------------------------------------------------------------------
  */
 
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+EventHandler.on(getDocument(), EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   event.preventDefault()
 
   const data = Data.get(this, DATA_KEY) || new Tab(this)

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -299,8 +299,8 @@ class Tooltip extends BaseComponent {
     // empty mouseover listeners to the body's immediate children;
     // only needed because of broken event delegation on iOS
     // https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
-    if ('ontouchstart' in document.documentElement) {
-      [].concat(...document.body.children).forEach(element => {
+    if ('ontouchstart' in this._document.documentElement) {
+      [].concat(...this._document.body.children).forEach(element => {
         EventHandler.on(element, 'mouseover', noop())
       })
     }
@@ -359,8 +359,8 @@ class Tooltip extends BaseComponent {
 
     // If this is a touch-enabled device we remove the extra
     // empty mouseover listeners we added for iOS support
-    if ('ontouchstart' in document.documentElement) {
-      [].concat(...document.body.children)
+    if ('ontouchstart' in this._document.documentElement) {
+      [].concat(...this._document.body.children)
         .forEach(element => EventHandler.off(element, 'mouseover', noop))
     }
 
@@ -397,7 +397,7 @@ class Tooltip extends BaseComponent {
       return this.tip
     }
 
-    const element = document.createElement('div')
+    const element = this._document.createElement('div')
     element.innerHTML = this.config.template
 
     this.tip = element.children[0]
@@ -551,7 +551,7 @@ class Tooltip extends BaseComponent {
 
   _getContainer() {
     if (this.config.container === false) {
-      return document.body
+      return this._document.body
     }
 
     if (isElement(this.config.container)) {

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -27,7 +27,7 @@ const toType = obj => {
 const getUID = prefix => {
   do {
     prefix += Math.floor(Math.random() * MAX_UID)
-  } while (document.getElementById(prefix))
+  } while (getDocument().getElementById(prefix))
 
   return prefix
 }
@@ -61,7 +61,7 @@ const getSelectorFromElement = element => {
   const selector = getSelector(element)
 
   if (selector) {
-    return document.querySelector(selector) ? selector : null
+    return getDocument().querySelector(selector) ? selector : null
   }
 
   return null
@@ -70,7 +70,7 @@ const getSelectorFromElement = element => {
 const getElementFromSelector = element => {
   const selector = getSelector(element)
 
-  return selector ? document.querySelector(selector) : null
+  return selector ? getDocument().querySelector(selector) : null
 }
 
 const getTransitionDurationFromElement = element => {
@@ -79,7 +79,7 @@ const getTransitionDurationFromElement = element => {
   }
 
   // Get transition-duration of the element
-  let { transitionDuration, transitionDelay } = window.getComputedStyle(element)
+  let { transitionDuration, transitionDelay } = getWindow().getComputedStyle(element)
 
   const floatTransitionDuration = Number.parseFloat(transitionDuration)
   const floatTransitionDelay = Number.parseFloat(transitionDelay)
@@ -170,7 +170,7 @@ const isDisabled = element => {
 }
 
 const findShadowRoot = element => {
-  if (!document.documentElement.attachShadow) {
+  if (!getDocument().documentElement.attachShadow) {
     return null
   }
 
@@ -199,7 +199,7 @@ const reflow = element => element.offsetHeight
 const getjQuery = () => {
   const { jQuery } = window
 
-  if (jQuery && !document.body.hasAttribute('data-bs-no-jquery')) {
+  if (jQuery && !getDocument().body.hasAttribute('data-bs-no-jquery')) {
     return jQuery
   }
 
@@ -207,14 +207,14 @@ const getjQuery = () => {
 }
 
 const onDOMContentLoaded = callback => {
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', callback)
+  if (getDocument().readyState === 'loading') {
+    getDocument().addEventListener('DOMContentLoaded', callback)
   } else {
     callback()
   }
 }
 
-const isRTL = () => document.documentElement.dir === 'rtl'
+const isRTL = () => getDocument().documentElement.dir === 'rtl'
 
 const defineJQueryPlugin = (name, plugin) => {
   onDOMContentLoaded(() => {
@@ -230,6 +230,22 @@ const defineJQueryPlugin = (name, plugin) => {
       }
     }
   })
+}
+
+const getWindow = () => {
+  if (typeof window !== 'undefined') {
+    return window
+  }
+
+  return {}
+}
+
+const getDocument = () => {
+  if (typeof document !== 'undefined') {
+    return document
+  }
+
+  return {}
 }
 
 export {
@@ -249,5 +265,7 @@ export {
   getjQuery,
   onDOMContentLoaded,
   isRTL,
-  defineJQueryPlugin
+  defineJQueryPlugin,
+  getWindow,
+  getDocument
 }

--- a/js/src/util/sanitizer.js
+++ b/js/src/util/sanitizer.js
@@ -5,6 +5,8 @@
  * --------------------------------------------------------------------------
  */
 
+import { getWindow } from './index'
+
 const uriAttrs = new Set([
   'background',
   'cite',
@@ -98,7 +100,8 @@ export function sanitizeHtml(unsafeHtml, allowList, sanitizeFn) {
     return sanitizeFn(unsafeHtml)
   }
 
-  const domParser = new window.DOMParser()
+  const windowRef = getWindow()
+  const domParser = new windowRef.DOMParser()
   const createdDocument = domParser.parseFromString(unsafeHtml, 'text/html')
   const allowlistKeys = Object.keys(allowList)
   const elements = [].concat(...createdDocument.body.querySelectorAll('*'))

--- a/js/src/util/scrollbar.js
+++ b/js/src/util/scrollbar.js
@@ -7,18 +7,21 @@
 
 import SelectorEngine from '../dom/selector-engine'
 import Manipulator from '../dom/manipulator'
+import { getDocument, getWindow } from './index'
 
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
+const windowRef = getWindow()
+const documentRef = getDocument()
 
 const getWidth = () => {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
-  const documentWidth = document.documentElement.clientWidth
-  return Math.abs(window.innerWidth - documentWidth)
+  const documentWidth = documentRef.documentElement.clientWidth
+  return Math.abs(getWindow().innerWidth - documentWidth)
 }
 
 const hide = (width = getWidth()) => {
-  document.body.style.overflow = 'hidden'
+  documentRef.body.style.overflow = 'hidden'
   _setElementAttributes(SELECTOR_FIXED_CONTENT, 'paddingRight', calculatedValue => calculatedValue + width)
   _setElementAttributes(SELECTOR_STICKY_CONTENT, 'marginRight', calculatedValue => calculatedValue - width)
   _setElementAttributes('body', 'paddingRight', calculatedValue => calculatedValue + width)
@@ -28,19 +31,19 @@ const _setElementAttributes = (selector, styleProp, callback) => {
   const scrollbarWidth = getWidth()
   SelectorEngine.find(selector)
     .forEach(element => {
-      if (element !== document.body && window.innerWidth > element.clientWidth + scrollbarWidth) {
+      if (element !== documentRef.body && windowRef.innerWidth > element.clientWidth + scrollbarWidth) {
         return
       }
 
       const actualValue = element.style[styleProp]
-      const calculatedValue = window.getComputedStyle(element)[styleProp]
+      const calculatedValue = windowRef.getComputedStyle(element)[styleProp]
       Manipulator.setDataAttribute(element, styleProp, actualValue)
       element.style[styleProp] = callback(Number.parseFloat(calculatedValue)) + 'px'
     })
 }
 
 const reset = () => {
-  document.body.style.overflow = 'auto'
+  documentRef.body.style.overflow = 'auto'
   _resetElementAttributes(SELECTOR_FIXED_CONTENT, 'paddingRight')
   _resetElementAttributes(SELECTOR_STICKY_CONTENT, 'marginRight')
   _resetElementAttributes('body', 'paddingRight')
@@ -49,7 +52,7 @@ const reset = () => {
 const _resetElementAttributes = (selector, styleProp) => {
   SelectorEngine.find(selector).forEach(element => {
     const value = Manipulator.getDataAttribute(element, styleProp)
-    if (typeof value === 'undefined' && element === document.body) {
+    if (typeof value === 'undefined' && element === documentRef.body) {
       element.style.removeProperty(styleProp)
     } else {
       Manipulator.removeDataAttribute(element, styleProp)

--- a/js/tests/integration/bundle-modularity.js
+++ b/js/tests/integration/bundle-modularity.js
@@ -1,6 +1,7 @@
 import Tooltip from '../../dist/tooltip'
 import '../../dist/carousel'
 
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
 window.addEventListener('load', () => {
   [].concat(...document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     .map(tooltipNode => new Tooltip(tooltipNode))

--- a/js/tests/integration/bundle.js
+++ b/js/tests/integration/bundle.js
@@ -1,5 +1,6 @@
 import { Tooltip } from '../../../dist/js/bootstrap.esm.js'
 
+// eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
 window.addEventListener('load', () => {
   [].concat(...document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     .map(tooltipNode => new Tooltip(tooltipNode))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3898,6 +3898,32 @@
         }
       }
     },
+    "eslint-plugin-ssr-friendly": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ssr-friendly/-/eslint-plugin-ssr-friendly-1.0.5.tgz",
+      "integrity": "sha512-F1vKfzhOnrIXhcx91Y3r1x8vjJAoCex25PUgYErOe6q95T4KuCTz6+LgGQ4TTvhBdCfNqu1U0krAHe3UNuEOqg==",
+      "dev": true,
+      "requires": {
+        "globals": "^13.2.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.6.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+          "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-unicorn": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-28.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint": "^7.22.0",
     "eslint-config-xo": "^0.35.0",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-ssr-friendly": "^1.0.5",
     "eslint-plugin-unicorn": "^28.0.2",
     "find-unused-sass-variables": "^3.1.0",
     "glob": "^7.1.6",


### PR DESCRIPTION
Hi :)

A small PR to allow Bootstrap to be SSR friendly.

I had this idea in mind for quite a long time and it'll avoid developers some headache on how to handle errors like `document is undefined` or `windows is undefined` if they use SSR frameworks (for example Gatsby or Next.js)

I added an ESLint plugin to enforce that in all of our source code: https://www.npmjs.com/package/eslint-plugin-ssr-friendly

If you think it's not a relevant do not hesitate to close my PR 👍 