### PR TITLE
Improve change-version script

### DIFF
--- a/build/change-version.js
+++ b/build/change-version.js
@@ -9,11 +9,21 @@
 
 'use strict'
 
-const fs = require('fs')
+const fs = require('fs').promises
 const path = require('path')
-const sh = require('shelljs')
+const globby = require('globby')
 
-sh.config.fatal = true
+const VERBOSE = process.argv.includes('--verbose')
+const DRY_RUN = process.argv.includes('--dry') || process.argv.includes('--dry-run')
+
+// These are the filetypes we only care about replacing the version
+const GLOB = [
+  '**/*.{css,html,js,json,md,scss,txt,yml}'
+]
+const GLOBBY_OPTIONS = {
+  cwd: path.join(__dirname, '..'),
+  gitignore: true
+}
 
 // Blame TC39... https://github.com/benjamingr/RegExp.escape/issues/37
 function regExpQuote(string) {
@@ -24,89 +34,48 @@ function regExpQuoteReplacement(string) {
   return string.replace(/\$/g, '$$')
 }
 
-const DRY_RUN = false
+async function replaceRecursively(file, oldVersion, newVersion) {
+  const originalString = await fs.readFile(file, 'utf8')
+  const newString = originalString.replace(
+    new RegExp(regExpQuote(oldVersion), 'g'), regExpQuoteReplacement(newVersion)
+  )
 
-function walkAsync(directory, excludedDirectories, fileCallback, errback) {
-  if (excludedDirectories.has(path.parse(directory).base)) {
+  // No need to move any further if the strings are identical
+  if (originalString === newString) {
     return
   }
 
-  fs.readdir(directory, (err, names) => {
-    if (err) {
-      errback(err)
-      return
-    }
+  if (VERBOSE) {
+    console.log(`FILE: ${file}`)
+  }
 
-    names.forEach(name => {
-      const filepath = path.join(directory, name)
-      fs.lstat(filepath, (err, stats) => {
-        if (err) {
-          process.nextTick(errback, err)
-          return
-        }
+  if (DRY_RUN) {
+    return
+  }
 
-        if (stats.isDirectory()) {
-          process.nextTick(walkAsync, filepath, excludedDirectories, fileCallback, errback)
-        } else if (stats.isFile()) {
-          process.nextTick(fileCallback, filepath)
-        }
-      })
-    })
-  })
+  await fs.writeFile(file, newString, 'utf8')
 }
 
-function replaceRecursively(directory, excludedDirectories, allowedExtensions, original, replacement) {
-  original = new RegExp(regExpQuote(original), 'g')
-  replacement = regExpQuoteReplacement(replacement)
-  const updateFile = DRY_RUN ?
-    filepath => {
-      if (allowedExtensions.has(path.parse(filepath).ext)) {
-        console.log(`FILE: ${filepath}`)
-      } else {
-        console.log(`EXCLUDED:${filepath}`)
-      }
-    } :
-    filepath => {
-      if (allowedExtensions.has(path.parse(filepath).ext)) {
-        sh.sed('-i', original, replacement, filepath)
-      }
-    }
+async function main(args) {
+  const [oldVersion, newVersion] = args
 
-  walkAsync(directory, excludedDirectories, updateFile, err => {
-    console.error('ERROR while traversing directory!:')
-    console.error(err)
-    process.exit(1)
-  })
-}
-
-function main(args) {
-  if (args.length !== 2) {
-    console.error('USAGE: change-version old_version new_version')
+  if (!oldVersion || !newVersion) {
+    console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
     console.error('Got arguments:', args)
     process.exit(1)
   }
 
-  const oldVersion = args[0]
-  const newVersion = args[1]
-  const EXCLUDED_DIRS = new Set([
-    '.git',
-    '_site',
-    'node_modules',
-    'resources'
-  ])
-  const INCLUDED_EXTENSIONS = new Set([
-    // This extension allowlist is how we avoid modifying binary files
-    '',
-    '.css',
-    '.html',
-    '.js',
-    '.json',
-    '.md',
-    '.scss',
-    '.txt',
-    '.yml'
-  ])
-  replaceRecursively('.', EXCLUDED_DIRS, INCLUDED_EXTENSIONS, oldVersion, newVersion)
+  // Strip any leading `v` from arguments because otherwise we will end up with duplicate `v`s
+  [oldVersion, newVersion].map(arg => arg.startsWith('v') ? arg.slice(1) : arg)
+
+  try {
+    const files = await globby(GLOB, GLOBBY_OPTIONS)
+
+    await Promise.all(files.map(file => replaceRecursively(file, oldVersion, newVersion)))
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
 }
 
 main(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "eslint-plugin-unicorn": "^28.0.2",
     "find-unused-sass-variables": "^3.1.0",
     "glob": "^7.1.6",
+    "globby": "^11.0.2",
     "hammer-simulator": "0.0.1",
     "hugo-bin": "^0.69.0",
     "ip": "^1.1.5",


### PR DESCRIPTION
I have this patch around for some time now.

Using globby is a little slower than on main, but we get to simplify the script a lot.

So, apart from adding a couple of command line options, and not writing the files back to disk if they are changed, this changes the logic of the script: we only replace the version in the files we have in the glob and not all file types.

I could split the patches but I thought it might make sense to make all the changes in the same PR.

Please check the individual commits in case I missed something.

If merged, I will backport it to v4-dev.