### PR TITLE
Fix sibling card links in RTL

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -69,7 +69,7 @@
   }
 
   + .card-link {
-    margin-left: $card-spacer-x #{"/* rtl:ignore */"};
+    margin-left: $card-spacer-x;
   }
 }
 


### PR DESCRIPTION
Fixes a bug mentioned in [#32330](https://github.com/twbs/bootstrap/issues/32330#issuecomment-782001326).

---

Preview: https://deploy-preview-33154--twbs-bootstrap.netlify.app/docs/5.0/examples/cheatsheet-rtl/#card