### PR TITLE
Bundlewatch: stop ignoring dependabot branches

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -2,8 +2,6 @@ name: Bundlewatch
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
   pull_request:
 
 env:


### PR DESCRIPTION
Otherwise we need to go into the workflow to see the results.