### PR TITLE
Buttons should grow in nav-fill & nav-justified

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -117,6 +117,13 @@
   }
 }
 
+.nav-fill,
+.nav-justified {
+  .nav-item .nav-link {
+    width: 100%; // Make sure button will grow
+  }
+}
+
 
 // Tabbable tabs
 //


### PR DESCRIPTION
Fixes  #33196

Wrapping in `.nav-item` is required since using `.nav-pill` with `button`s as direct children works fine and wouldn't anymore if those `button`s got `width: 100%`.

---

Initial test case: https://codepen.io/Kramb/pen/VwmyYLq?editors=1100
This PR one: https://codepen.io/ffoodd/pen/wvoydpe?editors=1000