### PR TITLE
modal tests: Add a 20ms timeout

### DIFF
--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -986,7 +986,7 @@ $(function () {
       setTimeout(function () {
         assert.ok($modal.hasClass('modal-static'), 'has modal-static class')
         done()
-      }, 0)
+      }, 20)
     })
       .bootstrapModal({
         backdrop: 'static'

--- a/js/tests/unit/modal.js
+++ b/js/tests/unit/modal.js
@@ -1008,7 +1008,7 @@ $(function () {
       setTimeout(function () {
         assert.notOk($modal.hasClass('modal-static'), 'should not have modal-static class')
         done()
-      }, 0)
+      }, 20)
     })
       .bootstrapModal({
         backdrop: 'static'


### PR DESCRIPTION
We seem to be getting some intermittent test failures there. Trying to see if this fixes the issue.