### PR TITLE
fix tooltips disappearing after trying to interact during their fade out animation

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -283,6 +283,10 @@ class Tooltip extends BaseComponent {
 
     EventHandler.trigger(this._element, this.constructor.Event.INSERTED)
 
+    if (this._popper) {
+      this._popper.destroy()
+    }
+
     this._popper = Popper.createPopper(this._element, tip, this._getPopperConfig(attachment))
 
     tip.classList.add(CLASS_NAME_SHOW)
@@ -650,7 +654,7 @@ class Tooltip extends BaseComponent {
     if (event) {
       context._activeTrigger[
         event.type === 'focusout' ? TRIGGER_FOCUS : TRIGGER_HOVER
-      ] = false
+      ] = context._element.contains(event.relatedTarget)
     }
 
     if (context._isWithActiveTrigger()) {

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -279,9 +279,8 @@ class Tooltip extends BaseComponent {
 
     if (!this._element.ownerDocument.documentElement.contains(this.tip)) {
       container.appendChild(tip)
+      EventHandler.trigger(this._element, this.constructor.Event.INSERTED)
     }
-
-    EventHandler.trigger(this._element, this.constructor.Event.INSERTED)
 
     if (this._popper) {
       this._popper.update()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -284,10 +284,10 @@ class Tooltip extends BaseComponent {
     EventHandler.trigger(this._element, this.constructor.Event.INSERTED)
 
     if (this._popper) {
-      this._popper.destroy()
+      this._popper.update()
+    } else {
+      this._popper = Popper.createPopper(this._element, tip, this._getPopperConfig(attachment))
     }
-
-    this._popper = Popper.createPopper(this._element, tip, this._getPopperConfig(attachment))
 
     tip.classList.add(CLASS_NAME_SHOW)
 

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -329,6 +329,10 @@ class Tooltip extends BaseComponent {
 
     const tip = this.getTipElement()
     const complete = () => {
+      if (this._isWithActiveTrigger()) {
+        return
+      }
+
       if (this._hoverState !== HOVER_STATE_SHOW && tip.parentNode) {
         tip.parentNode.removeChild(tip)
       }

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -708,8 +708,9 @@ describe('Tooltip', () => {
       tooltipEl.dispatchEvent(createEvent('mouseover'))
     })
 
-    it('should not hide tooltip if leave event occurs and enter event occurs during hide transition', done => {
-      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">'
+    it('should properly maintain tooltip state if leave event occurs and enter event occurs during hide transition', done => {
+      // Style this tooltip to give it plenty of room for popper to do what it wants
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip" data-bs-placement="top" style="position:fixed;left:50%;top:50%;">Trigger</a>'
 
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl)
@@ -721,6 +722,7 @@ describe('Tooltip', () => {
 
       setTimeout(() => {
         expect(tooltip._popper).not.toBeNull()
+        expect(tooltip.getTipElement().getAttribute('data-popper-placement')).toBe('top')
         tooltipEl.dispatchEvent(createEvent('mouseout'))
 
         setTimeout(() => {
@@ -730,6 +732,7 @@ describe('Tooltip', () => {
 
         setTimeout(() => {
           expect(tooltip._popper).not.toBeNull()
+          expect(tooltip.getTipElement().getAttribute('data-popper-placement')).toBe('top')
           done()
         }, 200)
       }, 0)

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -708,6 +708,35 @@ describe('Tooltip', () => {
       tooltipEl.dispatchEvent(createEvent('mouseover'))
     })
 
+    it('should not hide tooltip if leave event occurs and enter event occurs during hide transition', done => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+
+      spyOn(window, 'getComputedStyle').and.returnValue({
+        transitionDuration: '0.15s',
+        transitionDelay: '0s'
+      })
+
+      setTimeout(() => {
+        expect(tooltip._popper).not.toBeNull()
+        tooltipEl.dispatchEvent(createEvent('mouseout'))
+
+        setTimeout(() => {
+          expect(tooltip.getTipElement().classList.contains('show')).toEqual(false)
+          tooltipEl.dispatchEvent(createEvent('mouseover'))
+        }, 100)
+
+        setTimeout(() => {
+          expect(tooltip._popper).not.toBeNull()
+          done()
+        }, 200)
+      }, 0)
+
+      tooltipEl.dispatchEvent(createEvent('mouseover'))
+    })
+
     it('should show a tooltip with custom class provided in data attributes', done => {
       fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip" data-bs-custom-class="custom-class">'
 

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -708,6 +708,37 @@ describe('Tooltip', () => {
       tooltipEl.dispatchEvent(createEvent('mouseover'))
     })
 
+    it('should not hide tooltip if leave event occurs and interaction remains inside trigger', done => {
+      fixtureEl.innerHTML = [
+        '<a href="#" rel="tooltip" title="Another tooltip">',
+        '<b>Trigger</b>',
+        'the tooltip',
+        '</a>'
+      ]
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+      const triggerChild = tooltipEl.querySelector('b')
+
+      spyOn(tooltip, 'hide').and.callThrough()
+
+      tooltipEl.addEventListener('mouseover', () => {
+        const moveMouseToChildEvent = createEvent('mouseout')
+        Object.defineProperty(moveMouseToChildEvent, 'relatedTarget', {
+          value: triggerChild
+        })
+
+        tooltipEl.dispatchEvent(moveMouseToChildEvent)
+      })
+
+      tooltipEl.addEventListener('mouseout', () => {
+        expect(tooltip.hide).not.toHaveBeenCalled()
+        done()
+      })
+
+      tooltipEl.dispatchEvent(createEvent('mouseover'))
+    })
+
     it('should properly maintain tooltip state if leave event occurs and enter event occurs during hide transition', done => {
       // Style this tooltip to give it plenty of room for popper to do what it wants
       fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip" data-bs-placement="top" style="position:fixed;left:50%;top:50%;">Trigger</a>'
@@ -738,6 +769,37 @@ describe('Tooltip', () => {
       }, 0)
 
       tooltipEl.dispatchEvent(createEvent('mouseover'))
+    })
+
+    it('should only trigger inserted event if a new tooltip element was created', done => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip">'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl)
+
+      spyOn(window, 'getComputedStyle').and.returnValue({
+        transitionDuration: '0.15s',
+        transitionDelay: '0s'
+      })
+
+      const insertedFunc = jasmine.createSpy()
+      tooltipEl.addEventListener('inserted.bs.tooltip', insertedFunc)
+
+      setTimeout(() => {
+        expect(insertedFunc).toHaveBeenCalledTimes(1)
+        tooltip.hide()
+
+        setTimeout(() => {
+          tooltip.show()
+        }, 100)
+
+        setTimeout(() => {
+          expect(insertedFunc).toHaveBeenCalledTimes(1)
+          done()
+        }, 200)
+      }, 0)
+
+      tooltip.show()
     })
 
     it('should show a tooltip with custom class provided in data attributes', done => {


### PR DESCRIPTION
Resolves #32372, resolves #31646

This points out that components that transition may have a blind spot in testing. Since transition duration & delay is computed using [getTransitionDurationFromElement(element)](https://github.com/twbs/bootstrap/blob/main/js/src/util/index.js#L76), which gets transitions from css, its always going to be returning 0 in the unit tests unless otherwise mocked or styled inline. That means that any components that use this transition method will have tests that mostly ignore them... which may not actually matter (likely true), but at least in this case it does matter.

Ideal in testing you'd mock the actual `getTransitionDurationFromElement(element)` imo, and just return the duration, however I was having some trouble getting jasmine spys to properly do this. I went for the next best thing in this case, which is mocking computed styles to get a non-zero return from that function. Happy to change it if anyones got ideas.

Preview: https://deploy-preview-33289--twbs-bootstrap.netlify.app/docs/5.0/components/tooltips/