### PR TITLE
fix: make EventHandler better handle mouseenter/mouseleave events

### DIFF
--- a/js/src/dom/event-handler.js
+++ b/js/src/dom/event-handler.js
@@ -22,6 +22,7 @@ const customEvents = {
   mouseenter: 'mouseover',
   mouseleave: 'mouseout'
 }
+const customEventsRegex = /^(mouseenter|mouseleave)/i
 const nativeEvents = new Set([
   'click',
   'dblclick',
@@ -165,8 +166,8 @@ function addHandler(element, originalTypeEvent, handler, delegationFn, oneOff) {
   }
 
   // in case of mouseenter or mouseleave wrap the handler within a function that checks for its DOM position
-  // this prevents the handler getting triggered the same way as mouseover or mouseout does
-  if (/^mouse(enter|leave)/i.test(originalTypeEvent)) {
+  // this prevents the handler from being dispatched the same way as mouseover or mouseout does
+  if (customEventsRegex.test(originalTypeEvent)) {
     const wrapFn = fn => {
       return function (event) {
         if (!event.relatedTarget || (event.relatedTarget !== event.delegateTarget && event.relatedTarget.contains(event.delegateTarget))) {


### PR DESCRIPTION
This PR makes the `EventHandler` handle `mouseenter` and `mouseleave` more like their native counterparts.

### Background
Currently the `EventHandler` is implemented to simply map `mouseenter` to `mouseover` and `mouseleave` to `mouseout` events - see this comment https://github.com/twbs/bootstrap/issues/31646#issuecomment-761166484

The problem is that `mouseenter` and `mouseleave` behave different to some extent but this wasn't respected yet. As such there are situations e.g. within the tooltip plugin where one does expect nested elements not to trigger the bound event handlers.

With the PR https://github.com/twbs/bootstrap/pull/33289 by @RyanBerliner this is addressed although in my opinion (and I assume Ryan agrees to some degree) some general fix to the `EventHandler` module would be more appropriate.

### TBD
With this implementation the `targets` are not rewritten. In some situations e.g. when the window loses focus and some nested element is hovered when it receives back focus, the targets differ between `mouseenter` and `mouseover`.

Also like asked here https://github.com/twbs/bootstrap/discussions/33220 - are there any reasons as to why `mouseover/mouseout` was used in the first place?