### PR TITLE
@rollup/plugin-replace: specify `preventAssignment: true`

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -28,7 +28,13 @@ if (BUNDLE) {
   // Remove last entry in external array to bundle Popper
   external.pop()
   delete globals['@popperjs/core']
-  plugins.push(replace({ 'process.env.NODE_ENV': '"production"' }), nodeResolve())
+  plugins.push(
+    replace({
+      'process.env.NODE_ENV': '"production"',
+      preventAssignment: true
+    }),
+    nodeResolve()
+  )
 }
 
 const rollupConfig = {

--- a/js/tests/integration/rollup.bundle.js
+++ b/js/tests/integration/rollup.bundle.js
@@ -12,7 +12,8 @@ module.exports = {
   },
   plugins: [
     replace({
-      'process.env.NODE_ENV': '"production"'
+      'process.env.NODE_ENV': '"production"',
+      preventAssignment: true
     }),
     nodeResolve(),
     babel({

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -77,7 +77,8 @@ const conf = {
   rollupPreprocessor: {
     plugins: [
       replace({
-        'process.env.NODE_ENV': '"dev"'
+        'process.env.NODE_ENV': '"dev"',
+        preventAssignment: true
       }),
       istanbul({
         exclude: [


### PR DESCRIPTION
This is to fix a warning since the option will be set to true in the next major version of the plugin

Fixes #33193.