### PR TITLE
Popover & Tooltip: Allow `dispose`/`hide` methods usage through `jQueryIntreface`

### DIFF
--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -149,10 +149,6 @@ class Popover extends Tooltip {
       let data = Data.get(this, DATA_KEY)
       const _config = typeof config === 'object' ? config : null
 
-      if (!data && /dispose|hide/.test(config)) {
-        return
-      }
-
       if (!data) {
         data = new Popover(this, _config)
         Data.set(this, DATA_KEY, data)

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -725,10 +725,6 @@ class Tooltip extends BaseComponent {
       let data = Data.get(this, DATA_KEY)
       const _config = typeof config === 'object' && config
 
-      if (!data && /dispose|hide/.test(config)) {
-        return
-      }
-
       if (!data) {
         data = new Tooltip(this, _config)
       }

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -266,21 +266,6 @@ describe('Popover', () => {
 
       expect(popover.show).toHaveBeenCalled()
     })
-
-    it('should do nothing if dipose is called when a popover do not exist', () => {
-      fixtureEl.innerHTML = '<a href="#" title="Popover" data-bs-content="https://twitter.com/getbootstrap">BS twitter</a>'
-
-      const popoverEl = fixtureEl.querySelector('a')
-
-      jQueryMock.fn.popover = Popover.jQueryInterface
-      jQueryMock.elements = [popoverEl]
-
-      spyOn(Popover.prototype, 'dispose')
-
-      jQueryMock.fn.popover.call(jQueryMock, 'dispose')
-
-      expect(Popover.prototype.dispose).not.toHaveBeenCalled()
-    })
   })
 
   describe('getInstance', () => {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1351,21 +1351,6 @@ describe('Tooltip', () => {
       expect(tooltip.show).toHaveBeenCalled()
     })
 
-    it('should do nothing when we call dispose or hide if there is no tooltip created', () => {
-      fixtureEl.innerHTML = '<div></div>'
-
-      const div = fixtureEl.querySelector('div')
-
-      spyOn(Tooltip.prototype, 'dispose')
-
-      jQueryMock.fn.tooltip = Tooltip.jQueryInterface
-      jQueryMock.elements = [div]
-
-      jQueryMock.fn.tooltip.call(jQueryMock, 'dispose')
-
-      expect(Tooltip.prototype.dispose).not.toHaveBeenCalled()
-    })
-
     it('should throw error on undefined method', () => {
       fixtureEl.innerHTML = '<div></div>'
 


### PR DESCRIPTION
All the other components, forward called methods through jQueryInterface.

Popover and Tooltip is good to have the same behavior, as it is on the developer hand to decide how to use them, regardless of js/jQuery usage 