### PR TITLE
.browserslistrc: remove the Edge workaround.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,9 +5,6 @@ last 2 major versions
 not dead
 Chrome >= 60
 Firefox >= 60
-# needed since Legacy Edge still has usage; 79 was the first Chromium Edge version
-# should be removed in the future when its usage drops or when it's moved to dead browsers
-not Edge < 79
 Firefox ESR
 iOS >= 10
 Safari >= 10


### PR DESCRIPTION
It seems that Legacy Edge has been moved to dead, so this is no loner needed.