### PR TITLE
.browserslistrc: remove Android and make Safari/iOS 12 the minimum

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -9,7 +9,6 @@ Firefox >= 60
 # should be removed in the future when its usage drops or when it's moved to dead browsers
 not Edge < 79
 Firefox ESR
-iOS >= 10
-Safari >= 10
-Android >= 6
+iOS >= 12
+Safari >= 12
 not Explorer <= 11

--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,27 +34,27 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43 kB"
+      "maxSize": "41 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "22.75 kB"
+      "maxSize": "22 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "28.5 kB"
+      "maxSize": "27 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
-      "maxSize": "19 kB"
+      "maxSize": "18 kB"
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "29 kB"
+      "maxSize": "27 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "16.5 kB"
+      "maxSize": "15.75 kB"
     }
   ],
   "ci": {

--- a/js/tests/browsers.js
+++ b/js/tests/browsers.js
@@ -40,7 +40,7 @@ const browsers = {
   iphone7: {
     base: 'BrowserStack',
     os: 'ios',
-    os_version: '10.0',
+    os_version: '12.0',
     device: 'iPhone 7',
     real_mobile: true
   },


### PR DESCRIPTION
This will result in more modern JS dist files, and saves us a good amount of bytes. This was the plan in #30986, but I gave up after the Safari 10 failures back then.

Apart from terser which we use, I tested the latest uglify-js and seems to work fine too.

Closes #31153. 

/CC @alpadev @RyanBerliner @GeoSot @Johann-S @rohit2sharma95 @mdo

Preview: https://deploy-preview-33399--twbs-bootstrap.netlify.app/

TODO:

- [x] Adapt bundlewatch limits