### PR TITLE
Update look and feel of examples and copy buttons

### DIFF
--- a/site/assets/scss/_clipboard-js.scss
+++ b/site/assets/scss/_clipboard-js.scss
@@ -18,20 +18,21 @@
 
 .btn-clipboard {
   position: absolute;
-  top: .65rem;
-  right: .65rem;
+  top: .35rem;
+  right: .5rem;
   z-index: 10;
   display: block;
   padding: .25rem .5rem;
-  @include font-size(.65em);
-  color: $primary;
-  background-color: $white;
-  border: 1px solid;
+  @include font-size(.75em);
+  color: $gray-700;
+  user-select: none;
+  background-color: transparent;
+  border: 0;
   @include border-radius();
 
   &:hover,
   &:focus {
-    color: $white;
-    background-color: $primary;
+    color: $gray-900;
+    background-color: $gray-200;
   }
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -83,6 +83,8 @@
     @include border-top-radius(.25rem);
 
     + .bd-clipboard + .highlight {
+      border-top: 0;
+      @include border-top-radius(0);
       @include border-bottom-radius(.25rem);
     }
   }
@@ -287,18 +289,20 @@
 //
 
 .highlight {
-  padding: 1rem;
+  position: relative;
+  padding: 3.5rem 1rem 0;
   margin-bottom: 1rem;
+  overflow: auto;
   background-color: $gray-100;
+  border: 1px solid $gray-300;
 
   @include media-breakpoint-up(sm) {
-    padding: 1rem 1.5rem;
+    @include border-radius(.25rem);
   }
 
   pre {
-    padding: 0;
-    margin-top: .65rem;
-    margin-bottom: .65rem;
+    padding: 0 0 1rem;
+    margin-bottom: .5rem;
     white-space: pre;
     background-color: transparent;
     border: 0;
@@ -319,4 +323,27 @@
     margin-right: 0;
     margin-left: 0;
   }
+}
+
+.bd-example-multiple-langs + .bd-clipboard + .highlight {
+  margin-bottom: 0;
+  border-bottom: 0;
+  @include border-bottom-radius(0);
+}
+.highlight + .bd-clipboard + .highlight {
+  @include border-top-radius(0);
+}
+
+[data-lang]::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  padding: .5rem 1rem;
+  @include font-size(.875rem);
+  color: $gray-700;
+  text-transform: uppercase;
+  content: attr(data-lang);
+  user-select: none;
+  border-bottom: 1px solid $gray-300;
 }


### PR DESCRIPTION
<img width="845" alt="Screen Shot 2021-03-18 at 10 08 16 PM" src="https://user-images.githubusercontent.com/98681/111734556-99cf2380-8837-11eb-91d2-f89d932837be.png">

Restores some of the look and feel from previous versions :). More specifically:

- Adds border around the code snippets
- Removes the blue coloring around Copy buttons
- Adds the language at the top of each code snippet
- Includes some messy code for attaching multiple code snippets to an example (see above screenshot)—would love help cleaning this up somehow. Maybe I just wrap it all in some custom HTML? Something else?

/cc @XhmikosR 