### PR TITLE
Fix validation feedback icon in select multiple

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -92,6 +92,14 @@
         background-image: escape-svg($form-select-indicator), escape-svg($icon);
         background-position: $form-select-bg-position, $form-select-feedback-icon-position;
         background-size: $form-select-bg-size, $form-select-feedback-icon-size;
+
+        &[multiple],
+        &[size]:not([size="1"]) {
+          padding-right: $input-height-inner;
+          background-image: escape-svg($icon);
+          background-position: top $input-height-inner-quarter right $input-height-inner-quarter;
+          background-size: $form-select-feedback-icon-size;
+        }
       }
 
       &:focus {


### PR DESCRIPTION
Hi! 👋🏼👋🏼👋🏼

It has been a long time I do not contribute to Bootstrap. I've searched for "select validation feedback" but I didn't find open issues or other PRs, so apologies if it is a duplicate or if the behavior is intended

Validation feedback for `<select multiple>` should look like
`<textarea>`.

The previous implementation was placing the validation icon in the
middle of the select field together with the single select arrow, that
is not supposed to be part of this kind of inputs.

### How to replicate

1. Go to https://getbootstrap.com/docs/5.0/forms/select/#sizing
2. Add `is-invalid` or `is-valid` class to one of the `<select multiple>` or `<select size="n>1">` inputs

### What did you get

![image](https://user-images.githubusercontent.com/556268/111841786-cbf78880-88fe-11eb-996d-fd65e2c3fd6d.png)


### What did you expect (this PR)

![image](https://user-images.githubusercontent.com/556268/111842035-2d1f5c00-88ff-11eb-8e62-2f83e2c3230f.png)
