### PR TITLE
Change click eventListener timing on elements outside offcanvas

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -8,7 +8,6 @@
 import {
   defineJQueryPlugin,
   getElementFromSelector,
-  getSelectorFromElement,
   getTransitionDurationFromElement,
   isDisabled,
   isVisible,
@@ -124,6 +123,7 @@ class Offcanvas extends BaseComponent {
 
     const completeCallBack = () => {
       this._element.classList.remove(CLASS_NAME_TOGGLING)
+      this._listenClicksOutsideElement()
       EventHandler.trigger(this._element, EVENT_SHOWN, { relatedTarget })
       this._enforceFocusOnElement(this._element)
     }
@@ -201,11 +201,15 @@ class Offcanvas extends BaseComponent {
         this.hide()
       }
     })
+  }
 
-    EventHandler.on(document, EVENT_CLICK_DATA_API, event => {
-      const target = SelectorEngine.findOne(getSelectorFromElement(event.target))
-      if (!this._element.contains(event.target) && target !== this._element) {
+  _listenClicksOutsideElement() {
+    // add click handler to close open offcanvas
+    EventHandler.one(document, EVENT_CLICK_DATA_API, event => {
+      if (!this._element.contains(event.target) && event.target !== this._element) {
         this.hide()
+      } else {
+        this._listenClicksOutsideElement()
       }
     })
   }

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -269,6 +269,33 @@ describe('Offcanvas', () => {
       offCanvas.show()
     })
 
+    it('should open an offcanvas if an image is inside toggle and hide it if click on an outside element', done => {
+      fixtureEl.innerHTML = [
+        '<div id="wrapper">' +
+        '  <button data-bs-toggle="offcanvas" data-bs-target="#offcanvas" >' +
+        '    <img src=""/>' +
+        '  </button>',
+        '  <div id="offcanvas" class="offcanvas"></div>' +
+        '</div>'
+      ].join('')
+
+      const offCanvasEl = fixtureEl.querySelector('#offcanvas')
+      const img = fixtureEl.querySelector('img')
+      const wrapper = fixtureEl.querySelector('#wrapper')
+
+      offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+        expect(offCanvasEl.classList.contains('show')).toEqual(true)
+        wrapper.click()
+      })
+
+      offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
+        expect(offCanvasEl.classList.contains('show')).toEqual(false)
+        done()
+      })
+
+      img.click()
+    })
+
     it('on window load, should make visible an offcanvas element, if its markup contains class "show"', done => {
       fixtureEl.innerHTML = '<div class="offcanvas show"></div>'
 


### PR DESCRIPTION
On initialization the offcanvas registers click listeners. 
Although it was good for simple buttons, if a button contains another element and user clicks on this, the click seems that through delegation, is triggering two times, so the offcanvas instantly toggles itself

Closes #33457


 could be fixed by  #33545