### PR TITLE
Dropdown — Apply positioning only when Popper is not used

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -16,7 +16,6 @@
 // The dropdown menu
 .dropdown-menu {
   position: absolute;
-  top: 100%;
   z-index: $zindex-dropdown;
   display: none; // none by default, but block on "open" of the menu
   min-width: $dropdown-min-width;
@@ -33,6 +32,7 @@
   @include box-shadow($dropdown-box-shadow);
 
   &[data-bs-popper] {
+    top: 100%;
     left: 0;
     margin-top: $dropdown-spacer;
   }
@@ -83,15 +83,12 @@
 }
 
 .dropend {
-  .dropdown-menu {
+  .dropdown-menu[data-bs-popper] {
     top: 0;
     right: auto;
     left: 100%;
-
-    &[data-bs-popper] {
-      margin-top: 0;
-      margin-left: $dropdown-spacer;
-    }
+    margin-top: 0;
+    margin-left: $dropdown-spacer;
   }
 
   .dropdown-toggle {
@@ -103,15 +100,12 @@
 }
 
 .dropstart {
-  .dropdown-menu {
+  .dropdown-menu[data-bs-popper] {
     top: 0;
     right: 100%;
     left: auto;
-
-    &[data-bs-popper] {
-      margin-top: 0;
-      margin-right: $dropdown-spacer;
-    }
+    margin-top: 0;
+    margin-right: $dropdown-spacer;
   }
 
   .dropdown-toggle {


### PR DESCRIPTION
Apply positioning styles on the dropdown menus only when they are not using Popper. Since initial positioning styles may interfere with Popper (Previously these styles caused issues).

Ref:
- #33120
- https://popper.js.org/docs/v2/faq/#why-is-my-popper-in-the-wrong-location-or-not-visible-at-all

Preview:- https://deploy-preview-33482--twbs-bootstrap.netlify.app/docs/5.0/components/dropdowns/