### PR TITLE
Fix wrong carousel transformation, direction to order

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -255,7 +255,7 @@ class Carousel extends BaseComponent {
       return
     }
 
-    this._slide(direction > 0 ? DIRECTION_LEFT : DIRECTION_RIGHT)
+    this._slide(direction > 0 ? DIRECTION_RIGHT : DIRECTION_LEFT)
   }
 
   _addEventListeners() {
@@ -336,10 +336,10 @@ class Carousel extends BaseComponent {
 
     if (event.key === ARROW_LEFT_KEY) {
       event.preventDefault()
-      this._slide(DIRECTION_LEFT)
+      this._slide(DIRECTION_RIGHT)
     } else if (event.key === ARROW_RIGHT_KEY) {
       event.preventDefault()
-      this._slide(DIRECTION_RIGHT)
+      this._slide(DIRECTION_LEFT)
     }
   }
 
@@ -509,10 +509,10 @@ class Carousel extends BaseComponent {
     }
 
     if (isRTL()) {
-      return direction === DIRECTION_RIGHT ? ORDER_PREV : ORDER_NEXT
+      return direction === DIRECTION_LEFT ? ORDER_PREV : ORDER_NEXT
     }
 
-    return direction === DIRECTION_RIGHT ? ORDER_NEXT : ORDER_PREV
+    return direction === DIRECTION_LEFT ? ORDER_NEXT : ORDER_PREV
   }
 
   _orderToDirection(order) {
@@ -521,10 +521,10 @@ class Carousel extends BaseComponent {
     }
 
     if (isRTL()) {
-      return order === ORDER_NEXT ? DIRECTION_LEFT : DIRECTION_RIGHT
+      return order === ORDER_PREV ? DIRECTION_LEFT : DIRECTION_RIGHT
     }
 
-    return order === ORDER_NEXT ? DIRECTION_RIGHT : DIRECTION_LEFT
+    return order === ORDER_PREV ? DIRECTION_RIGHT : DIRECTION_LEFT
   }
 
   // Static

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -255,7 +255,7 @@ class Carousel extends BaseComponent {
       return
     }
 
-    this._slide(direction > 0 ? DIRECTION_RIGHT : DIRECTION_LEFT)
+    this._slide(direction > 0 ? DIRECTION_LEFT : DIRECTION_RIGHT)
   }
 
   _addEventListeners() {

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -349,8 +349,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
-        expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(event.direction).toEqual('right')
+        expect(carousel._slide).toHaveBeenCalledWith('left')
+        expect(event.direction).toEqual('left')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -394,8 +394,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
-        expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(event.direction).toEqual('left')
+        expect(carousel._slide).toHaveBeenCalledWith('right')
+        expect(event.direction).toEqual('right')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -434,8 +434,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
-        expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(event.direction).toEqual('right')
+        expect(carousel._slide).toHaveBeenCalledWith('left')
+        expect(event.direction).toEqual('left')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()
@@ -473,8 +473,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
-        expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(event.direction).toEqual('left')
+        expect(carousel._slide).toHaveBeenCalledWith('right')
+        expect(event.direction).toEqual('right')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -349,8 +349,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
-        expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(event.direction).toEqual('left')
+        expect(carousel._slide).toHaveBeenCalledWith('right')
+        expect(event.direction).toEqual('right')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -394,8 +394,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
-        expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(event.direction).toEqual('right')
+        expect(carousel._slide).toHaveBeenCalledWith('left')
+        expect(event.direction).toEqual('left')
         document.head.removeChild(stylesCarousel)
         delete document.documentElement.ontouchstart
         done()
@@ -434,8 +434,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(true)
-        expect(carousel._slide).toHaveBeenCalledWith('left')
-        expect(event.direction).toEqual('left')
+        expect(carousel._slide).toHaveBeenCalledWith('right')
+        expect(event.direction).toEqual('right')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()
@@ -473,8 +473,8 @@ describe('Carousel', () => {
 
       carouselEl.addEventListener('slid.bs.carousel', event => {
         expect(item.classList.contains('active')).toEqual(false)
-        expect(carousel._slide).toHaveBeenCalledWith('right')
-        expect(event.direction).toEqual('right')
+        expect(carousel._slide).toHaveBeenCalledWith('left')
+        expect(event.direction).toEqual('left')
         delete document.documentElement.ontouchstart
         restorePointerEvents()
         done()
@@ -601,7 +601,7 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl, {})
 
       const onSlide = e => {
-        expect(e.direction).toEqual('right')
+        expect(e.direction).toEqual('left')
         expect(e.relatedTarget.classList.contains('carousel-item')).toEqual(true)
         expect(e.from).toEqual(0)
         expect(e.to).toEqual(1)
@@ -613,7 +613,7 @@ describe('Carousel', () => {
       }
 
       const onSlide2 = e => {
-        expect(e.direction).toEqual('left')
+        expect(e.direction).toEqual('right')
         done()
       }
 
@@ -636,7 +636,7 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl, {})
 
       const onSlid = e => {
-        expect(e.direction).toEqual('right')
+        expect(e.direction).toEqual('left')
         expect(e.relatedTarget.classList.contains('carousel-item')).toEqual(true)
         expect(e.from).toEqual(0)
         expect(e.to).toEqual(1)
@@ -648,7 +648,7 @@ describe('Carousel', () => {
       }
 
       const onSlid2 = e => {
-        expect(e.direction).toEqual('left')
+        expect(e.direction).toEqual('right')
         done()
       }
 
@@ -1069,13 +1069,13 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
 
-      expect(carousel._directionToOrder('left')).toEqual('prev')
+      expect(carousel._directionToOrder('left')).toEqual('next')
       expect(carousel._directionToOrder('prev')).toEqual('prev')
-      expect(carousel._directionToOrder('right')).toEqual('next')
+      expect(carousel._directionToOrder('right')).toEqual('prev')
       expect(carousel._directionToOrder('next')).toEqual('next')
 
-      expect(carousel._orderToDirection('next')).toEqual('right')
-      expect(carousel._orderToDirection('prev')).toEqual('left')
+      expect(carousel._orderToDirection('next')).toEqual('left')
+      expect(carousel._orderToDirection('prev')).toEqual('right')
     })
 
     it('"_directionToOrder" and "_orderToDirection" must return the right results when rtl=true', () => {
@@ -1086,13 +1086,13 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl, {})
       expect(util.isRTL()).toEqual(true, 'rtl has to be true')
 
-      expect(carousel._directionToOrder('left')).toEqual('next')
+      expect(carousel._directionToOrder('left')).toEqual('prev')
       expect(carousel._directionToOrder('prev')).toEqual('prev')
-      expect(carousel._directionToOrder('right')).toEqual('prev')
+      expect(carousel._directionToOrder('right')).toEqual('next')
       expect(carousel._directionToOrder('next')).toEqual('next')
 
-      expect(carousel._orderToDirection('next')).toEqual('left')
-      expect(carousel._orderToDirection('prev')).toEqual('right')
+      expect(carousel._orderToDirection('next')).toEqual('right')
+      expect(carousel._orderToDirection('prev')).toEqual('left')
       document.documentElement.dir = 'ltl'
     })
 
@@ -1106,11 +1106,11 @@ describe('Carousel', () => {
 
       carousel._slide('left')
       expect(spy).toHaveBeenCalledWith('left')
-      expect(spy2).toHaveBeenCalledWith('prev')
+      expect(spy2).toHaveBeenCalledWith('next')
 
       carousel._slide('right')
       expect(spy).toHaveBeenCalledWith('right')
-      expect(spy2).toHaveBeenCalledWith('next')
+      expect(spy2).toHaveBeenCalledWith('prev')
     })
 
     it('"_slide" has to call "_directionToOrder" and "_orderToDirection" when rtl=true', () => {
@@ -1124,11 +1124,11 @@ describe('Carousel', () => {
 
       carousel._slide('left')
       expect(spy).toHaveBeenCalledWith('left')
-      expect(spy2).toHaveBeenCalledWith('next')
+      expect(spy2).toHaveBeenCalledWith('prev')
 
       carousel._slide('right')
       expect(spy).toHaveBeenCalledWith('right')
-      expect(spy2).toHaveBeenCalledWith('prev')
+      expect(spy2).toHaveBeenCalledWith('next')
 
       document.documentElement.dir = 'ltl'
     })

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -317,7 +317,7 @@ describe('Carousel', () => {
       expect(carousel._addTouchEventListeners).toHaveBeenCalled()
     })
 
-    it('should allow swiperight and call _slide with pointer events', done => {
+    it('should allow swiperight and call _slide (prev) with pointer events', done => {
       if (!supportPointerEvent) {
         expect().nothing()
         done()
@@ -362,7 +362,7 @@ describe('Carousel', () => {
       })
     })
 
-    it('should allow swipeleft and call previous with pointer events', done => {
+    it('should allow swipeleft and call next with pointer events', done => {
       if (!supportPointerEvent) {
         expect().nothing()
         done()
@@ -408,7 +408,7 @@ describe('Carousel', () => {
       })
     })
 
-    it('should allow swiperight and call _slide with touch events', done => {
+    it('should allow swiperight and call _slide (prev) with touch events', done => {
       Simulator.setType('touch')
       clearPointerEvents()
       document.documentElement.ontouchstart = () => {}
@@ -447,7 +447,7 @@ describe('Carousel', () => {
       })
     })
 
-    it('should allow swipeleft and call _slide with touch events', done => {
+    it('should allow swipeleft and call _slide (next) with touch events', done => {
       Simulator.setType('touch')
       clearPointerEvents()
       document.documentElement.ontouchstart = () => {}


### PR DESCRIPTION
Fixes wrong [swipe to direction translation](https://github.com/twbs/bootstrap/commit/b9f30903a5a916904c873bd078240b3df743e093#commitcomment-48786795)

[preview](https://deploy-preview-33499--twbs-bootstrap.netlify.app/docs/5.0/components/carousel/)