### PR TITLE
v5: Export DOM utils

### DIFF
--- a/js/index.esm.js
+++ b/js/index.esm.js
@@ -17,6 +17,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import * as domUtils from './src/dom/index'
 
 export {
   Alert,
@@ -30,5 +31,6 @@ export {
   ScrollSpy,
   Tab,
   Toast,
-  Tooltip
+  Tooltip,
+  domUtils
 }

--- a/js/index.umd.js
+++ b/js/index.umd.js
@@ -17,6 +17,7 @@ import ScrollSpy from './src/scrollspy'
 import Tab from './src/tab'
 import Toast from './src/toast'
 import Tooltip from './src/tooltip'
+import * as domUtils from './src/dom/index'
 
 export default {
   Alert,
@@ -30,5 +31,6 @@ export default {
   ScrollSpy,
   Tab,
   Toast,
-  Tooltip
+  Tooltip,
+  domUtils
 }

--- a/js/src/dom/index.js
+++ b/js/src/dom/index.js
@@ -1,0 +1,11 @@
+import Data from './data'
+import EventHandler from './event-handler'
+import Manipulator from './manipulator'
+import SelectorEngine from './selector-engine'
+
+export {
+  Data,
+  EventHandler,
+  Manipulator,
+  SelectorEngine
+}


### PR DESCRIPTION
Follow up of #32941

This commit exports exports all the DOM utils into a `domUtils` property, to be able to use them in thrid party JS plugins.

**Motivation :**
The plan is to allow third party plugins to integrates as best as possible into Bootstrap system. Previously this was done through jQuery. But now Bootstrap is basically starting from scratch and locking itself.

- Without `Data`, third party plugins cannot interact with core and other plugins because the map storing instances is private.  
- Without `EventHandler`, third party plugins will never be able to have a similar event system, neither seamlessly integrate with jQuery when present. **This is IMHO critical** because it will lead to a scatter of patterns, namings, param handling, etc.  
- `SelectorEngine` and `Manipulator` are bonuses, they are not necessary.

**Usage :**
Since 2014 I develop [Bootstrap Confirmation](https://github.com/mistic100/Bootstrap-Confirmation) and always tried to stick to Bootstrap patterns, sometimes refusing changes because it would be incompatible with Popover behavior.  I wouldn't like to offer a degraded v5 migration.

**What next :**
I think Bootstrap would benefits a documentation, or a least an introduction, to plugins creations, perhaps on the [Extend page](https://getbootstrap.com/docs/5.0/extend).  
Unfortunately I don't know enough internals to propose somthing.