### PR TITLE
Update parcel.md

### DIFF
--- a/site/content/docs/5.0/getting-started/parcel.md
+++ b/site/content/docs/5.0/getting-started/parcel.md
@@ -14,7 +14,7 @@ Install [Parcel Bundler](https://en.parceljs.org/getting_started.html).
 
 [Install bootstrap]({{< docsref "/getting-started/download#npm" >}}) as a Node.js module using npm.
 
-Bootstrap depends on [Popper](https://popper.js.org/), which is specified in the `peerDependencies` property. This means that you will have to make sure to add both of them to your `package.json` using `npm install popper.js`.
+Bootstrap depends on [Popper](https://popper.js.org/), which is specified in the `peerDependencies` property. This means that you will have to make sure to add both of them to your `package.json` using `npm install @popperjs/core`.
 
 When all will be completed, your project will be structured like this:
 


### PR DESCRIPTION
Popper.js old version has been deprecated. 
New version of Popper.js package is named @popperjs/core