### PR TITLE
Spinner alignment changes

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -12,7 +12,7 @@
   display: inline-block;
   width: $spinner-width;
   height: $spinner-height;
-  vertical-align: text-bottom;
+  vertical-align: $spinner-vertical-align;
   border: $spinner-border-width solid currentColor;
   border-right-color: transparent;
   // stylelint-disable-next-line property-disallowed-list
@@ -46,7 +46,7 @@
   display: inline-block;
   width: $spinner-width;
   height: $spinner-height;
-  vertical-align: text-bottom;
+  vertical-align: $spinner-vertical-align;
   background-color: currentColor;
   // stylelint-disable-next-line property-disallowed-list
   border-radius: 50%;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1406,6 +1406,7 @@ $carousel-dark-control-icon-filter:  invert(1) grayscale(100) !default;
 // scss-docs-start spinner-variables
 $spinner-width:           2rem !default;
 $spinner-height:          $spinner-width !default;
+$spinner-vertical-align:  -.125em !default;
 $spinner-border-width:    .25em !default;
 $spinner-animation-speed: .75s !default;
 


### PR DESCRIPTION
Fixes #33524. Uses the same `vertical-align` value from the Bootstrap Icons project, as even the normal spinners appear to be sitting a little too low still.