### PR TITLE
Modals no longer use `.modal-open` to affect the `<body>` scroll

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -4,16 +4,6 @@
 // .modal-content   - actual modal w/ bg and corners and stuff
 
 
-.modal-open {
-  // Kill the scroll on the body
-  overflow: hidden;
-
-  .modal {
-    overflow-x: hidden;
-    overflow-y: auto;
-  }
-}
-
 // Container that the modal scrolls within
 .modal {
   position: fixed;
@@ -23,7 +13,8 @@
   display: none;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;


### PR DESCRIPTION
`.modal-open.modal` css rules, overrides default `.modal` rules, concerning  `overflow` property

![image](https://user-images.githubusercontent.com/22406063/113521927-631e3a80-95a5-11eb-8fb0-961a246278ff.png)

[preview](https://deploy-preview-33551--twbs-bootstrap.netlify.app/)
