### PR TITLE
Change 'library' to 'framework', as elsewhere

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ module:
       target:           static/favicon.ico
 
 params:
-  description:          "The most popular HTML, CSS, and JS library in the world."
+  description:          "The most popular HTML, CSS, and JS framework in the world."
   authors:              "Mark Otto, Jacob Thornton, and Bootstrap contributors"
   social_image_path:    /docs/5.0/assets/brand/bootstrap-social.png
   social_logo_path:     /docs/5.0/assets/brand/bootstrap-social-logo.png


### PR DESCRIPTION
The "description" text appears in promotions of the project, e.g. in Google searches. Every other description I could find described Bootstrap as a "framework". 

This itty-bitty change makes Bootstrap's public face match its "framework" reality.