### PR TITLE
fix typo in docs

### DIFF
--- a/site/content/docs/4.6/content/typography.md
+++ b/site/content/docs/4.6/content/typography.md
@@ -201,7 +201,7 @@ Use text utilities as needed to change the alignment of your blockquote.
 
 {{< example >}}
 <blockquote class="blockquote text-center">
-  <p class="mb-0">>A well-known quote, contained in a blockquote element.</p>
+  <p class="mb-0">A well-known quote, contained in a blockquote element.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
 </blockquote>
 {{< /example >}}


### PR DESCRIPTION
Fixed typo in docs where an HTML element had an extra closing `>` that was printed as real text.

This error is located here -> https://getbootstrap.com/docs/4.6/content/typography/#alignment