### PR TITLE
Fixed wrong method name _getInstance

### DIFF
--- a/site/content/docs/5.0/components/offcanvas.md
+++ b/site/content/docs/5.0/components/offcanvas.md
@@ -240,7 +240,7 @@ var bsOffcanvas = new bootstrap.Offcanvas(myOffcanvas)
 | `toggle` | Toggles an offcanvas element to shown or hidden. **Returns to the caller before the offcanvas element has actually been shown or hidden** (i.e. before the `shown.bs.offcanvas` or `hidden.bs.offcanvas` event occurs). |
 | `show` | Shows an offcanvas element. **Returns to the caller before the offcanvas element has actually been shown** (i.e. before the `shown.bs.offcanvas` event occurs).|
 | `hide` | Hides an offcanvas element. **Returns to the caller before the offcanvas element has actually been hidden** (i.e. before the `hidden.bs.offcanvas` event occurs).|
-| `_getInstance` | *Static* method which allows you to get the offcanvas instance associated with a DOM element |
+| `getInstance` | *Static* method which allows you to get the offcanvas instance associated with a DOM element |
 {{< /bs-table >}}
 
 ### Events


### PR DESCRIPTION
There is no _getInstance method, but there is a getInstance method