### PR TITLE
footer: fix `rel=noopener` attribute

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -8,7 +8,7 @@
         </a>
         <ul class="list-unstyled small text-muted">
           <li class="mb-2">Designed and built with all the love in the world by the <a href="/docs/{{ .Site.Params.docs_version }}/about/team/">Bootstrap team</a> with the help of <a href="{{ .Site.Params.repo }}/graphs/contributors">our contributors</a>.</li>
-          <li class="mb-2">Code licensed <a href="{{ .Site.Params.repo }}/blob/main/LICENSE" target="_blank" rel="license">MIT</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license">CC BY 3.0</a>.</li>
+          <li class="mb-2">Code licensed <a href="{{ .Site.Params.repo }}/blob/main/LICENSE" target="_blank" rel="license noopener">MIT</a>, docs <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="license noopener">CC BY 3.0</a>.</li>
           <li class="mb-2">Currently v{{ .Site.Params.current_version }}.</li>
         </ul>
       </div>
@@ -34,22 +34,22 @@
       <div class="col-6 col-lg-2 mb-3">
         <h5>Projects</h5>
         <ul class="list-unstyled">
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap" rel="noopener">Bootstrap 5</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/tree/v4-dev" rel="noopener">Bootstrap 4</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/icons" rel="noopener">Icons</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/rfs" rel="noopener">RFS</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap-npm-starter" rel="noopener">npm starter</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap">Bootstrap 5</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/tree/v4-dev">Bootstrap 4</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/icons">Icons</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/rfs">RFS</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap-npm-starter">npm starter</a></li>
         </ul>
       </div>
       <div class="col-6 col-lg-2 mb-3">
         <h5>Community</h5>
         <ul class="list-unstyled">
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/issues" rel="noopener">Issues</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/discussions" rel="noopener">Discussions</a></li>
-          <li class="mb-2"><a href="https://github.com/sponsors/twbs" rel="noopener">Corporate sponsors</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.opencollective }}" rel="noopener">Open Collective</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.slack }}" rel="noopener">Slack</a></li>
-          <li class="mb-2"><a href="https://stackoverflow.com/questions/tagged/bootstrap-5" rel="noopener">Stack Overflow</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/issues">Issues</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/discussions">Discussions</a></li>
+          <li class="mb-2"><a href="https://github.com/sponsors/twbs">Corporate sponsors</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.opencollective }}">Open Collective</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.slack }}">Slack</a></li>
+          <li class="mb-2"><a href="https://stackoverflow.com/questions/tagged/bootstrap-5">Stack Overflow</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
There's no need to use `rel=noopener` without `target=_blank`, but otherwise, it should be used since it's a potential security issue.