### PR TITLE
Hide validation icons from multiple selects

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -88,17 +88,12 @@
       border-color: $color;
 
       @if $enable-validation-icons {
-        padding-right: $form-select-feedback-icon-padding-end;
-        background-image: escape-svg($form-select-indicator), escape-svg($icon);
-        background-position: $form-select-bg-position, $form-select-feedback-icon-position;
-        background-size: $form-select-bg-size, $form-select-feedback-icon-size;
-
-        &[multiple],
-        &[size]:not([size="1"]) {
-          padding-right: $input-height-inner;
-          background-image: escape-svg($icon);
-          background-position: top $input-height-inner-quarter right $input-height-inner-quarter;
-          background-size: $form-select-feedback-icon-size;
+        &:not([multiple]):not([size]),
+        &:not([multiple])[size="1"] {
+          padding-right: $form-select-feedback-icon-padding-end;
+          background-image: escape-svg($form-select-indicator), escape-svg($icon);
+          background-position: $form-select-bg-position, $form-select-feedback-icon-position;
+          background-size: $form-select-bg-size, $form-select-feedback-icon-size;
         }
       }
 


### PR DESCRIPTION
Implementation provided in #33411 does not take into account that some
Operating Systems may display a vertical scrollbar in the multiple
select field

This implementation will hide the validation icons from multiple select
fields, just like Bootstrap 4 does.

Fix: #33591

### Demo fiddles
BS4: https://jsfiddle.net/tagliala/y1t4cuqg/show
BS5: https://jsfiddle.net/tagliala/s45v1hLy/show

### Before (Win 10 / Chrome 89)

#### Main
![image](https://user-images.githubusercontent.com/556268/114199738-dd0f4480-9954-11eb-9eba-ab92f14b13d8.png)

#### 5.0.0.beta3
![image](https://user-images.githubusercontent.com/556268/114199895-fdd79a00-9954-11eb-9ae2-b6deacc1c3e0.png)


### After (Win 10 / Chrome 89)

![image](https://user-images.githubusercontent.com/556268/114199430-96214f00-9954-11eb-9b17-b50c6ce54f9e.png)

### Bootstrap 4 vs Bootstrap 5

![image](https://user-images.githubusercontent.com/556268/114304712-fe973a00-9ad4-11eb-9af7-413190ed437f.png)


