### PR TITLE
Reduce color-scheme complexity

### DIFF
--- a/scss/mixins/_color-scheme.scss
+++ b/scss/mixins/_color-scheme.scss
@@ -1,17 +1,7 @@
 // scss-docs-start mixin-color-scheme
 @mixin color-scheme($name) {
-  @if $name == dark {
-    @media (prefers-color-scheme: dark) {
-      @content;
-    }
-  } @else if $name == light {
-    @media (prefers-color-scheme: light) {
-      @content;
-    }
-  } @else {
-    @media (prefers-color-scheme: #{$name}) {
-      @content;
-    }
+  @media (prefers-color-scheme: #{$name}) {
+    @content;
   }
 }
 // scss-docs-end mixin-color-scheme


### PR DESCRIPTION
Since light and dark are used in media-query the same way any named argument is, there's no point using conditions to output them. Am I missing something?

Sorry I missed that somehow, didn't see the PR sooner.