### PR TITLE
Add Extend > Snippets docs page

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -276,13 +276,13 @@
   .position-relative {
     height: 200px;
     background-color: #f5f5f5;
-  }
 
-  .position-absolute {
-    width: 2em;
-    height: 2em;
-    background-color: $dark;
-    @include border-radius();
+    [class^="position-"] {
+      width: 2em;
+      height: 2em;
+      background-color: $dark;
+      @include border-radius();
+    }
   }
 }
 

--- a/site/assets/scss/_snippets.scss
+++ b/site/assets/scss/_snippets.scss
@@ -1,3 +1,13 @@
+// Light badges
+@each $color, $value in $theme-colors {
+  $badge-light-bg: shift-color($value, -80%);
+  .badge-light-#{$color} {
+    background-color: $badge-light-bg;
+  }
+}
+
+
+// Light buttons
 @each $color, $value in $theme-colors {
   $btn-light-bg: shift-color($value, -80%);
   $btn-light-border: shift-color($value, -80%);

--- a/site/assets/scss/_snippets.scss
+++ b/site/assets/scss/_snippets.scss
@@ -1,0 +1,7 @@
+@each $color, $value in $theme-colors {
+  $btn-light-bg: shift-color($value, -80%);
+  $btn-light-border: shift-color($value, -80%);
+  .btn-light-#{$color} {
+    @include button-variant($btn-light-bg, $btn-light-border, shift-color($value, 50%));
+  }
+}

--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -53,6 +53,7 @@ $enable-cssgrid: true; // stylelint-disable-line scss/dollar-variable-default
 @import "colors";
 @import "clipboard-js";
 @import "placeholder-img";
+@import "snippets";
 
 // Load docs dependencies
 @import "syntax";

--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -27,6 +27,8 @@
 @import "../../../scss/functions";
 @import "../../../scss/variables";
 @import "../../../scss/mixins";
+@import "../../../scss/maps";
+@import "../../../scss/utilities";
 
 // fusv-disable
 $enable-grid-classes: false; // stylelint-disable-line scss/dollar-variable-default
@@ -59,3 +61,18 @@ $enable-cssgrid: true; // stylelint-disable-line scss/dollar-variable-default
 @import "syntax";
 @import "anchor";
 @import "algolia";
+
+// stylelint-disable scss/dollar-variable-default
+$utilities: map-merge(
+  $utilities,
+  (
+    "position": map-merge(
+      map-get($utilities, "position"),
+      (
+        responsive: true
+      ),
+    ),
+  )
+);
+
+@import "../../../scss/utilities/api";

--- a/site/content/docs/5.1/extend/snippets.md
+++ b/site/content/docs/5.1/extend/snippets.md
@@ -3,6 +3,7 @@ layout: docs
 title: Snippets
 description: Extend Bootstrap with some common snippets of source code not included in the main project.
 group: extend
+toc: true
 ---
 
 ## Components
@@ -47,5 +48,74 @@ group: extend
 
 ## Utilities
 
-- Opacity
-- Expanded widths/heights
+### Responsive position
+
+```scss
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/maps";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+@import "bootstrap/scss/utilities/api";
+
+$utilities: map-merge(
+  $utilities,
+  (
+    "position": map-merge(
+      map-get($utilities, "position"),
+      (
+        responsive: true
+      ),
+    ),
+  )
+);
+```
+
+### Responsive width
+
+```scss
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/maps";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+@import "bootstrap/scss/utilities/api";
+
+$utilities: map-merge(
+  $utilities,
+  (
+    "width": map-merge(
+      map-get($utilities, "width"),
+      (
+        responsive: true
+      ),
+    ),
+  )
+);
+```
+
+### Additional height
+
+```scss
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/maps";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+@import "bootstrap/scss/utilities/api";
+
+$utilities: map-merge(
+  $utilities,
+  (
+    "height": map-merge(
+      map-get($utilities, "height"),
+      (
+        values: map-merge(
+          map-get(map-get($utilities, "height"), "values"),
+          (10: 10%),
+        ),
+      ),
+    ),
+  )
+);
+```

--- a/site/content/docs/5.1/extend/snippets.md
+++ b/site/content/docs/5.1/extend/snippets.md
@@ -1,0 +1,33 @@
+---
+layout: docs
+title: Snippets
+description: Extend Bootstrap with some common snippets of source code not included in the main project.
+group: extend
+---
+
+## Components
+
+### Light buttons
+
+{{< example >}}
+{{< buttons.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<button type="button" class="btn btn-light-{{ .name }}">{{ .name | title }}</button>
+{{- end -}}
+{{< /buttons.inline >}}
+{{< /example >}}
+
+```scss
+@each $color, $value in $theme-colors {
+  $btn-light-bg: shift-color($value, -80%);
+  $btn-light-border: shift-color($value, -80%);
+  .btn-light-#{$color} {
+    @include button-variant($btn-light-bg, $btn-light-border, shift-color($value, 50%));
+  }
+}
+```
+
+## Utilities
+
+- Opacity
+- Expanded widths/heights

--- a/site/content/docs/5.1/extend/snippets.md
+++ b/site/content/docs/5.1/extend/snippets.md
@@ -7,6 +7,24 @@ group: extend
 
 ## Components
 
+### Light badges
+
+{{< example >}}
+{{< badge.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<span class="badge badge-light-{{ .name }} text-dark">{{ .name | title }}</span>{{- end -}}
+{{< /badge.inline >}}
+{{< /example >}}
+
+```scss
+@each $color, $value in $theme-colors {
+  $badge-light-bg: shift-color($value, -80%);
+  .badge-light-#{$color} {
+    background-color: $badge-light-bg;
+  }
+}
+```
+
 ### Light buttons
 
 {{< example >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -118,6 +118,7 @@
 - title: Extend
   pages:
     - title: Approach
+    - title: Snippets
     - title: Icons
 
 - title: About


### PR DESCRIPTION
Exploring a new docs Extend page for capturing snippets of things folks would probably like to see in the core but aren't popular enough or important enough to make it into the main project.

---

### Components

- [x] #33285: Light buttons

### Utilities

- [x] Extended and responsive width/height
- [ ] Responsive borders
- [x] Responsive position

Preview: https://deploy-preview-33627--twbs-bootstrap.netlify.app/docs/5.1/extend/snippets/
