### PR TITLE
fix: clicking an item in navbar dropdown should not collapse the dropdown in firefox

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -412,7 +412,7 @@ class Dropdown extends BaseComponent {
         return
       }
 
-      if (/input|select|textarea|form/i.test(event.target.tagName)) {
+      if (/input|select|option|textarea|form/i.test(event.target.tagName)) {
         return
       }
     }


### PR DESCRIPTION
fixes #33592

## Background
When clicking on an option of a select element the `event.target` in Firefox matches the option element itself unlike the select element like in other browsers.