### PR TITLE
Offcanvas.js: If scroll is allowed, should allow focus on other elements

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -112,6 +112,7 @@ class Offcanvas extends BaseComponent {
 
     if (!this._config.scroll) {
       scrollBarHide()
+      this._enforceFocusOnElement(this._element)
     }
 
     this._element.removeAttribute('aria-hidden')
@@ -121,7 +122,6 @@ class Offcanvas extends BaseComponent {
 
     const completeCallBack = () => {
       EventHandler.trigger(this._element, EVENT_SHOWN, { relatedTarget })
-      this._enforceFocusOnElement(this._element)
     }
 
     const transitionDuration = getTransitionDurationFromElement(this._element)

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -220,6 +220,24 @@ describe('Offcanvas', () => {
 
       offCanvas.show()
     })
+
+    it('should not enforce focus if focus scroll is allowed', done => {
+      fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+      const offCanvasEl = fixtureEl.querySelector('.offcanvas')
+      const offCanvas = new Offcanvas(offCanvasEl, {
+        scroll: true
+      })
+
+      spyOn(offCanvas, '_enforceFocusOnElement')
+
+      offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+        expect(offCanvas._enforceFocusOnElement).not.toHaveBeenCalled()
+        done()
+      })
+
+      offCanvas.show()
+    })
   })
 
   describe('toggle', () => {
@@ -327,6 +345,22 @@ describe('Offcanvas', () => {
       const instance = Offcanvas.getInstance(offCanvasEl)
       expect(instance).not.toBeNull()
       expect(Offcanvas.prototype.show).toHaveBeenCalled()
+    })
+
+    it('should enforce focus', done => {
+      fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+      const offCanvasEl = fixtureEl.querySelector('.offcanvas')
+      const offCanvas = new Offcanvas(offCanvasEl)
+
+      spyOn(offCanvas, '_enforceFocusOnElement')
+
+      offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+        expect(offCanvas._enforceFocusOnElement).toHaveBeenCalled()
+        done()
+      })
+
+      offCanvas.show()
     })
   })
 


### PR DESCRIPTION
This change does allow to focus on other elements while an offcanvas that allows body scroll, is open

Preview: https://deploy-preview-33677--twbs-bootstrap.netlify.app/docs/5.0/components/offcanvas/#backdrop

