### PR TITLE
4.6: Remove dependency on Sizzle’s :visible pseudo selector.

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -130,10 +130,11 @@ class Carousel {
 
   nextWhenVisible() {
     const $element = $(this._element)
+    const htmlElement = $element.get(0)
     // Don't call next when the page isn't visible
     // or the carousel or its parent isn't visible
     if (!document.hidden &&
-      ($element.is(':visible') && $element.css('visibility') !== 'hidden')) {
+      (htmlElement.offsetWidth || htmlElement.offsetHeight || htmlElement.getClientRects().length) && $element.css('visibility') !== 'hidden') {
       this.next()
     }
   }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -479,7 +479,7 @@ class Dropdown {
     }
 
     const items = [].slice.call(parent.querySelectorAll(SELECTOR_VISIBLE_ITEMS))
-      .filter(item => $(item).is(':visible'))
+      .filter(item => item.offsetWidth || item.offsetHeight || item.getClientRects().length)
 
     if (items.length === 0) {
       return

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -604,7 +604,8 @@ $(document).on(EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
     }
 
     $target.one(EVENT_HIDDEN, () => {
-      if ($(this).is(':visible')) {
+      const elem = $(this).get(0)
+      if (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length) {
         this.focus()
       }
     })


### PR DESCRIPTION
Its implementation is in jquery/src/css/hiddenVisibleSelectors.js .

Rationale: this enables the usage of Bootstrap with a slimmer than the “slim” jQuery distribution, utilizing the Native Selector
instead of the Sizzle selector.  In my case (for the modules I use) I build jQuery with:

> npm grunt custom:slim,-sizzle,-dimensions,-offset,-deprecated,-wrap,-core/ready,-exports/amd,-deferred --filename=jquery.s.js && npm grunt remove_map_comment --filename=jquery.s.js

N.B. I do not understand jQuery and I have not run any automatic tests.