### PR TITLE
Don't change the value for `altBoundary` option

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -502,7 +502,6 @@ class Tooltip extends BaseComponent {
         {
           name: 'flip',
           options: {
-            altBoundary: true,
             fallbackPlacements: this.config.fallbackPlacements
           }
         },


### PR DESCRIPTION
Closes #33463 and
Closes #33579

Since the bootstrap is not changing the default value of the `elementContext` option, changing the value of the `altBoundary` option is not needed for any modifier in real. By default, the value for `elementContext` is `'popper'` which means the boundary context will be checked for the popper element by default. Setting the `altBoundary` to true in the flip modifier will change this behavior and then boundary context will be checked for reference element (means button element).

Doing so will require setting the value for the `boundary` option manually. That is not needed in real (at least for the tooltips when these are appended to the body).

See the discussion here: https://github.com/twbs/bootstrap/issues/33463#issuecomment-822352640

/CC @XhmikosR to add this in the next release if seems good.