### PR TITLE
Fix collapse with focused input

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -242,7 +242,14 @@ class Collapse extends BaseComponent {
 
     this.setTransitioning(true)
 
-    const complete = () => {
+    const complete = event => {
+      // if event is dispatched by a nested element reschedule the event handler
+      if (event.target !== this._element) {
+        EventHandler.one(this._element, 'transitionend', complete)
+        emulateTransitionEnd(this._element, transitionDuration)
+        return
+      }
+
       this.setTransitioning(false)
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE)

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -371,6 +371,47 @@ describe('Collapse', () => {
 
       collapse.hide()
     })
+
+    it('should ignore transitionend events from nested elements', done => {
+      fixtureEl.innerHTML = [
+        '<div class="collapse show">',
+        '  <input type="text" class="form-control" />',
+        '</div>'
+      ].join('')
+
+      const collapseEl = fixtureEl.querySelector('div')
+      const inputEl = fixtureEl.querySelector('input')
+
+      spyOn(window, 'getComputedStyle').and.returnValue({
+        transitionDuration: '0.1s',
+        transitionDelay: '0s'
+      })
+
+      const eventSpy = jasmine.createSpy('transitionend dispatched')
+      const hiddenSpy = jasmine.createSpy('collapse is hidden')
+
+      const collapse = new Collapse(collapseEl, {
+        toggle: false
+      })
+
+      collapseEl.addEventListener('transitionend', eventSpy)
+      collapseEl.addEventListener('hidden.bs.collapse', hiddenSpy)
+
+      collapse.hide()
+      inputEl.dispatchEvent(new TransitionEvent('transitionend', {
+        bubbles: true
+      }))
+
+      setTimeout(() => {
+        expect(eventSpy).toHaveBeenCalled()
+        expect(hiddenSpy).not.toHaveBeenCalled()
+      }, 50)
+
+      setTimeout(() => {
+        expect(hiddenSpy).toHaveBeenCalled()
+        done()
+      }, 150)
+    })
   })
 
   describe('dispose', () => {


### PR DESCRIPTION
Closes https://github.com/twbs/bootstrap/issues/33682

## Background

Our inputs are using transitions for the focus effect. If a nested input got focus right before clicking the collapse button, the input triggers a transitionend event that causes the transition of the collapse module to end prematurely.