### PR TITLE
Remove redundant `modal-open` class from modal.js

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -59,7 +59,6 @@ const EVENT_MOUSEUP_DISMISS = `mouseup.dismiss${EVENT_KEY}`
 const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
-const CLASS_NAME_OPEN = 'modal-open'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_STATIC = 'modal-static'
@@ -123,8 +122,6 @@ class Modal extends BaseComponent {
     this._isShown = true
 
     scrollBarHide()
-
-    document.body.classList.add(CLASS_NAME_OPEN)
 
     this._adjustDialog()
 
@@ -322,7 +319,6 @@ class Modal extends BaseComponent {
     this._element.removeAttribute('role')
     this._isTransitioning = false
     this._backdrop.hide(() => {
-      document.body.classList.remove(CLASS_NAME_OPEN)
       this._resetAdjustments()
       scrollBarReset()
       EventHandler.trigger(this._element, EVENT_HIDDEN)

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -25,6 +25,7 @@ const NAME = 'backdrop'
 const CLASS_NAME_BACKDROP = 'modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
+const CLASS_NAME_OPEN = 'modal-open'
 
 const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 
@@ -50,6 +51,7 @@ class Backdrop {
     this._getElement().classList.add(CLASS_NAME_SHOW)
 
     this._emulateAnimation(() => {
+      this._config.rootElement.classList.add(CLASS_NAME_OPEN)
       execute(callback)
     })
   }
@@ -63,6 +65,7 @@ class Backdrop {
     this._getElement().classList.remove(CLASS_NAME_SHOW)
 
     this._emulateAnimation(() => {
+      this._config.rootElement.classList.remove(CLASS_NAME_OPEN)
       this.dispose()
       execute(callback)
     })

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,13 +1,6 @@
-// .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg and corners and stuff
-
-
-.modal-open {
-  // Kill the scroll on the body
-  overflow: hidden;
-}
 
 // Container that the modal scrolls within
 .modal {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -7,11 +7,6 @@
 .modal-open {
   // Kill the scroll on the body
   overflow: hidden;
-
-  .modal {
-    overflow-x: hidden;
-    overflow-y: auto;
-  }
 }
 
 // Container that the modal scrolls within
@@ -23,7 +18,8 @@
   display: none;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -827,7 +827,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
 
 ## Usage
 
-The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
+The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It overrides the `<body>` default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
 
 ### Via data attributes
 

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -827,7 +827,7 @@ Another override is the option to pop up a modal that covers the user viewport, 
 
 ## Usage
 
-The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It overrides the `<body>` default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
+The modal plugin toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
 
 ### Via data attributes
 


### PR DESCRIPTION
As `scrollbar.js` handles `body` overflowY, it is useless to use an extra class for the same reason

Based on this PR #33551