### PR TITLE
Refactor: move disposing properties into the base class

### DIFF
--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -36,7 +36,10 @@ class BaseComponent {
   dispose() {
     Data.remove(this._element, this.constructor.DATA_KEY)
     EventHandler.off(this._element, `.${this.constructor.DATA_KEY}`)
-    this._element = null
+
+    Object.getOwnPropertyNames(this).forEach(propertyName => {
+      this[propertyName] = null
+    })
   }
 
   _queueCallback(callback, element, isAnimated = true) {

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -213,18 +213,6 @@ class Carousel extends BaseComponent {
     this._slide(order, this._items[index])
   }
 
-  dispose() {
-    this._items = null
-    this._config = null
-    this._interval = null
-    this._isPaused = null
-    this._isSliding = null
-    this._activeElement = null
-    this._indicatorsElement = null
-
-    super.dispose()
-  }
-
   // Private
 
   _getConfig(config) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -253,14 +253,6 @@ class Collapse extends BaseComponent {
     this._isTransitioning = isTransitioning
   }
 
-  dispose() {
-    super.dispose()
-    this._config = null
-    this._parent = null
-    this._triggerArray = null
-    this._isTransitioning = null
-  }
-
   // Private
 
   _getConfig(config) {

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -217,11 +217,8 @@ class Dropdown extends BaseComponent {
   }
 
   dispose() {
-    this._menu = null
-
     if (this._popper) {
       this._popper.destroy()
-      this._popper = null
     }
 
     super.dispose()

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -183,6 +183,7 @@ class Modal extends BaseComponent {
     [window, this._dialog]
       .forEach(htmlElement => EventHandler.off(htmlElement, EVENT_KEY))
 
+    this._backdrop.dispose()
     super.dispose()
 
     /**
@@ -191,14 +192,6 @@ class Modal extends BaseComponent {
      * It will remove `EVENT_CLICK_DATA_API` event that should remain
      */
     EventHandler.off(document, EVENT_FOCUSIN)
-
-    this._config = null
-    this._dialog = null
-    this._backdrop.dispose()
-    this._backdrop = null
-    this._isShown = null
-    this._ignoreBackdropClick = null
-    this._isTransitioning = null
   }
 
   handleUpdate() {

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -162,9 +162,6 @@ class Offcanvas extends BaseComponent {
     this._backdrop.dispose()
     super.dispose()
     EventHandler.off(document, EVENT_FOCUSIN)
-
-    this._config = null
-    this._backdrop = null
   }
 
   // Private

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -137,16 +137,8 @@ class ScrollSpy extends BaseComponent {
   }
 
   dispose() {
-    super.dispose()
     EventHandler.off(this._scrollElement, EVENT_KEY)
-
-    this._scrollElement = null
-    this._config = null
-    this._selector = null
-    this._offsets = null
-    this._targets = null
-    this._activeTarget = null
-    this._scrollHeight = null
+    super.dispose()
   }
 
   // Private

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -142,7 +142,6 @@ class Toast extends BaseComponent {
     }
 
     super.dispose()
-    this._config = null
   }
 
   // Private

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -219,17 +219,10 @@ class Tooltip extends BaseComponent {
       this.tip.parentNode.removeChild(this.tip)
     }
 
-    this._isEnabled = null
-    this._timeout = null
-    this._hoverState = null
-    this._activeTrigger = null
     if (this._popper) {
       this._popper.destroy()
     }
 
-    this._popper = null
-    this.config = null
-    this.tip = null
     super.dispose()
   }
 


### PR DESCRIPTION
**This Pr :**
**Moves** some more functionality to `base-component`, transferring some **responsibility of disposal,** **to parent** class
Each component, dusting disposal, sets its protected properties to `null`. So the same can be done in one place for all children components 