### PR TITLE
Update default value for gutter in container mixins

### DIFF
--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -1,9 +1,10 @@
 // Container mixins
 
-@mixin make-container($gutter: $container-padding-x) {
+@mixin make-container($gutter: $grid-gutter-width) {
+  --#{$variable-prefix}gutter-x: #{$gutter};
   width: 100%;
-  padding-right: var(--#{$variable-prefix}gutter-x, #{$gutter});
-  padding-left: var(--#{$variable-prefix}gutter-x, #{$gutter});
+  padding-right: var(--#{$variable-prefix}gutter-x);
+  padding-left: var(--#{$variable-prefix}gutter-x);
   margin-right: auto;
   margin-left: auto;
 }

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -3,8 +3,8 @@
 @mixin make-container($gutter: $grid-gutter-width) {
   --#{$variable-prefix}gutter-x: #{$gutter};
   width: 100%;
-  padding-right: var(--#{$variable-prefix}gutter-x);
-  padding-left: var(--#{$variable-prefix}gutter-x);
+  padding-right: calc(var(--#{$variable-prefix}gutter-x)/2);
+  padding-left: calc(var(--#{$variable-prefix}gutter-x)/2);
   margin-right: auto;
   margin-left: auto;
 }


### PR DESCRIPTION
This PR fixes #32658 

There was an issue with when I have set custom gutter as it was only taking default value (0.75rem) in the container as the var was missing.
Fixed by replacing default value for parameter on make-container mixin as well as added declaration for variable as it was missing.
Row was fully working however the container wasn't.

Solution by @jeremyvii  (#33199) has not taken custom gutter but only the default gutter variable.


