### PR TITLE
Fix doc typo and Bootstrap Icons link

### DIFF
--- a/site/content/docs/5.0/components/alerts.md
+++ b/site/content/docs/5.0/components/alerts.md
@@ -51,7 +51,7 @@ Alerts can also contain additional HTML elements like headings, paragraphs and d
 
 ### Icons
 
-Similarly, you can use [flexbox utilities]({{< docsref "/utilities/flex" >}}) and [Bootstrap Icons]({{ .Site.Params.icons }}) to create alerts with icons. Depending on your icons and content, you may want to add more utilities or custom styles.
+Similarly, you can use [flexbox utilities]({{< docsref "/utilities/flex" >}}) and [Bootstrap Icons]({{< param icons >}}) to create alerts with icons. Depending on your icons and content, you may want to add more utilities or custom styles.
 
 {{< example >}}
 <div class="alert alert-primary d-flex align-items-center" role="alert">

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -18,7 +18,7 @@ toc: true
 
 ### Forms
 
-- Validation icons are no longer applied to `<select>`s with `muliptle`.
+- Validation icons are no longer applied to `<select>`s with `multiple`.
 
 ### JavaScript
 


### PR DESCRIPTION
Fixes a couple issues in docs:
- typo in migration guide
- bad link in alerts page