### PR TITLE
Fix browser support versions in migration doc

### DIFF
--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -19,10 +19,9 @@ toc: true
 - Dropped Internet Explorer 10 and 11
 - Dropped Microsoft Edge < 16 (Legacy Edge)
 - Dropped Firefox < 60
-- Dropped Safari < 10
-- Dropped iOS Safari < 10
+- Dropped Safari < 12
+- Dropped iOS Safari < 12
 - Dropped Chrome < 60
-- Dropped Android < 6
 
 <hr class="my-5">
 


### PR DESCRIPTION
Noticed browser support versions in migration doc didn't match browserslist file