### PR TITLE
Fix typo in migration.md

### DIFF
--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -170,7 +170,7 @@ toc: true
 
 ### Accordion
 
-- Added [new accordion component]({{< docsref "/components/accordion" >}}!
+- Added [new accordion component]({{< docsref "/components/accordion" >}})!
 
 ### Alerts
 


### PR DESCRIPTION
First of all, thank you for creating and maintaining a great framework.

Today I read the v5 migration guide and found a typo in the doc. Thus I'd like to fix it.

<img width="1318" alt="Screen Shot 2021-05-06 at 5 42 03 PM" src="https://user-images.githubusercontent.com/291028/117269042-e5469b00-ae92-11eb-988d-fd7518291608.png">
(An ending square bracket is missing)