### PR TITLE
Fixed "Thidd" typo in ScollSpy component example

### DIFF
--- a/site/content/docs/5.0/components/scrollspy.md
+++ b/site/content/docs/5.0/components/scrollspy.md
@@ -52,7 +52,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
     <h4 id="scrollspyHeading2">Second heading</h4>
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
-    <h4 id="scrollspyHeading3">Thidd heading</h4>
+    <h4 id="scrollspyHeading3">Third heading</h4>
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
     <h4 id="scrollspyHeading4">Fourth heading</h4>
     <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
@@ -87,7 +87,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
   <p>...</p>
   <h4 id="scrollspyHeading2">Second heading</h4>
   <p>...</p>
-  <h4 id="scrollspyHeading3">Thidd heading</h4>
+  <h4 id="scrollspyHeading3">Third heading</h4>
   <p>...</p>
   <h4 id="scrollspyHeading4">Fourth heading</h4>
   <p>...</p>


### PR DESCRIPTION
While going through the ScrollSpy examples in the Bootstrap v5.0 documentation (https://getbootstrap.com/docs/5.0/components/scrollspy/), I noticed a spelling mistake in the example with the word "Third" - it was misspelled "Thidd" in some parts of the example.

It's a very minor issue but I thought I'd create a pull request and fix it. Thanks!