### PR TITLE
Fix backdrop `rootElement` not initialized in Modal

### DIFF
--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -89,6 +89,8 @@ class Backdrop {
       ...Default,
       ...(typeof config === 'object' ? config : {})
     }
+
+    config.rootElement = config.rootElement || document.body
     typeCheckConfig(NAME, config, DefaultType)
     return config
   }

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -5,6 +5,8 @@ import { clearFixture, getFixture } from '../../helpers/fixture'
 const CLASS_BACKDROP = '.modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
+const CLASS_NAME_PARENT = 'modal-parent'
+const CLASS_PARENT = '.modal-parent'
 
 describe('Backdrop', () => {
   let fixtureEl
@@ -15,8 +17,12 @@ describe('Backdrop', () => {
 
   afterEach(() => {
     clearFixture()
-    const list = document.querySelectorAll(CLASS_BACKDROP)
+    const parent = document.querySelectorAll(CLASS_PARENT)
+    parent.forEach(el => {
+      document.body.removeChild(el)
+    })
 
+    const list = document.querySelectorAll(CLASS_BACKDROP)
     list.forEach(el => {
       document.body.removeChild(el)
     })
@@ -234,6 +240,37 @@ describe('Backdrop', () => {
       instance.show()
       instance.hide(() => {
         expect(spy).not.toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+
+  describe('initialization callbacks', () => {
+    it('Should default parent element to "document.body" when config value is null', done => {
+      const instance = new Backdrop({
+        isVisible: true,
+        rootElement: null
+      })
+      const getElement = () => document.querySelector(CLASS_BACKDROP)
+      instance.show(() => {
+        expect(getElement().parentElement).toEqual(document.body)
+        done()
+      })
+    })
+
+    it('Should use the custom parent element given in the config', done => {
+      const parent = document.createElement('div')
+      parent.className = CLASS_NAME_PARENT
+      document.body.appendChild(parent)
+
+      const instance = new Backdrop({
+        isVisible: true,
+        rootElement: parent
+      })
+
+      const getElement = () => document.querySelector(CLASS_BACKDROP)
+      instance.show(() => {
+        expect(getElement().parentElement).toEqual(parent)
         done()
       })
     })

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -5,8 +5,6 @@ import { clearFixture, getFixture } from '../../helpers/fixture'
 const CLASS_BACKDROP = '.modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
-const CLASS_NAME_PARENT = 'modal-parent'
-const CLASS_PARENT = '.modal-parent'
 
 describe('Backdrop', () => {
   let fixtureEl
@@ -17,12 +15,8 @@ describe('Backdrop', () => {
 
   afterEach(() => {
     clearFixture()
-    const parent = document.querySelectorAll(CLASS_PARENT)
-    parent.forEach(el => {
-      document.body.removeChild(el)
-    })
-
     const list = document.querySelectorAll(CLASS_BACKDROP)
+
     list.forEach(el => {
       document.body.removeChild(el)
     })
@@ -76,35 +70,6 @@ describe('Backdrop', () => {
         getElements().forEach(el => {
           expect(el.classList.contains(CLASS_NAME_FADE)).toEqual(true)
         })
-        done()
-      })
-    })
-
-    it('Should be appended on "document.body" by default', done => {
-      const instance = new Backdrop({
-        isVisible: true
-      })
-      const getElement = () => document.querySelector(CLASS_BACKDROP)
-      instance.show(() => {
-        expect(getElement().parentElement).toEqual(document.body)
-        done()
-      })
-    })
-
-    it('Should appended on any element given by the proper config', done => {
-      fixtureEl.innerHTML = [
-        '<div id="wrapper">',
-        '</div>'
-      ].join('')
-
-      const wrapper = fixtureEl.querySelector('#wrapper')
-      const instance = new Backdrop({
-        isVisible: true,
-        rootElement: wrapper
-      })
-      const getElement = () => document.querySelector(CLASS_BACKDROP)
-      instance.show(() => {
-        expect(getElement().parentElement).toEqual(wrapper)
         done()
       })
     })
@@ -245,7 +210,18 @@ describe('Backdrop', () => {
     })
   })
 
-  describe('initialization callbacks', () => {
+  describe('rootElement initialization', () => {
+    it('Should be appended on "document.body" by default', done => {
+      const instance = new Backdrop({
+        isVisible: true
+      })
+      const getElement = () => document.querySelector(CLASS_BACKDROP)
+      instance.show(() => {
+        expect(getElement().parentElement).toEqual(document.body)
+        done()
+      })
+    })
+
     it('Should default parent element to "document.body" when config value is null', done => {
       const instance = new Backdrop({
         isVisible: true,
@@ -258,19 +234,20 @@ describe('Backdrop', () => {
       })
     })
 
-    it('Should use the custom parent element given in the config', done => {
-      const parent = document.createElement('div')
-      parent.className = CLASS_NAME_PARENT
-      document.body.appendChild(parent)
+    it('Should appended on any element given by the proper config', done => {
+      fixtureEl.innerHTML = [
+        '<div id="wrapper">',
+        '</div>'
+      ].join('')
 
+      const wrapper = fixtureEl.querySelector('#wrapper')
       const instance = new Backdrop({
         isVisible: true,
-        rootElement: parent
+        rootElement: wrapper
       })
-
       const getElement = () => document.querySelector(CLASS_BACKDROP)
       instance.show(() => {
-        expect(getElement().parentElement).toEqual(parent)
+        expect(getElement().parentElement).toEqual(wrapper)
         done()
       })
     })


### PR DESCRIPTION
Fixes #33840

The backdrop rootElement is not initialized when the javascript file loaded in the document head as the document.body is not yet initialized and Default variable in backdrop.js is loaded before it.