### PR TITLE
fix typo in "migration" page in docs

### DIFF
--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -220,7 +220,7 @@ toc: true
 
 - Replaced chevron icons for carousel controls with new SVGs from [Bootstrap Icons]({{< param "icons" >}}).
 
-### Close buttton
+### Close button
 
 - <span class="badge bg-danger">Breaking</span> Renamed `.close` to `.btn-close` for a less generic name.
 


### PR DESCRIPTION
Fixes a small typo in the "migration" page in the docs, from "Buttton" to "Button"