### PR TITLE
Don't redefine `$list-group-color` in loop

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -163,12 +163,12 @@
 // Organizationally, this must come after the `:hover` states.
 
 @each $state, $value in $theme-colors {
-  $list-group-background: shift-color($value, $list-group-item-bg-scale);
-  $list-group-color: shift-color($value, $list-group-item-color-scale);
-  @if (contrast-ratio($list-group-background, $list-group-color) < $min-contrast-ratio) {
-    $list-group-color: mix($value, color-contrast($list-group-background), abs($list-group-item-color-scale));
+  $list-group-variant-bg: shift-color($value, $list-group-item-bg-scale);
+  $list-group-variant-color: shift-color($value, $list-group-item-color-scale);
+  @if (contrast-ratio($list-group-variant-bg, $list-group-variant-color) < $min-contrast-ratio) {
+    $list-group-variant-color: mix($value, color-contrast($list-group-variant-bg), abs($list-group-item-color-scale));
   }
 
-  @include list-group-item-variant($state, $list-group-background, $list-group-color);
+  @include list-group-item-variant($state, $list-group-variant-bg, $list-group-variant-color);
 }
 // scss-docs-end list-group-modifiers


### PR DESCRIPTION
The loop in `scss/_list_group.scss` uses `$list-group-color` as though it was a local variable, but is in fact overwriting the setting from `_variables.scss`. This means that using the value of `$list-group-color` in other stylesheets included in the scss build will get the wrong color value (I'd expect it to be `#212529`, but it is in fact `#141619`).