### PR TITLE
Fix backdrops' rootElement is `null` when bootstrap is loaded in the `<head>` section.

### DIFF
--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -11,14 +11,14 @@ import { emulateTransitionEnd, execute, getTransitionDurationFromElement, reflow
 const Default = {
   isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
   isAnimated: false,
-  rootElement: document.body, // give the choice to place backdrop under different elements
+  rootElement: () => document.body, // give the choice to place backdrop under different elements
   clickCallback: null
 }
 
 const DefaultType = {
   isVisible: 'boolean',
   isAnimated: 'boolean',
-  rootElement: 'element',
+  rootElement: '(function|element)',
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'
@@ -98,10 +98,16 @@ class Backdrop {
       return
     }
 
-    this._config.rootElement.appendChild(this._getElement())
+    let { rootElement, clickCallback } = this._config
+
+    if (typeof rootElement === 'function') {
+      rootElement = rootElement()
+    }
+
+    rootElement.appendChild(this._getElement())
 
     EventHandler.on(this._getElement(), EVENT_MOUSEDOWN, () => {
-      execute(this._config.clickCallback)
+      execute(clickCallback)
     })
 
     this._isAppended = true

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -102,6 +102,24 @@ describe('Backdrop', () => {
         done()
       })
     })
+
+    it('should allow rootElement to be defined as a function', done => {
+      fixtureEl.innerHTML = [
+        '<div id="wrapper">',
+        '</div>'
+      ].join('')
+
+      const wrapper = fixtureEl.querySelector('#wrapper')
+      const instance = new Backdrop({
+        isVisible: true,
+        rootElement: () => wrapper
+      })
+      const getElement = () => document.querySelector(CLASS_BACKDROP)
+      instance.show(() => {
+        expect(getElement().parentElement).toEqual(wrapper)
+        done()
+      })
+    })
   })
 
   describe('hide', () => {


### PR DESCRIPTION
fixes #33840

This approach utilizes a function to return the default `rootElement` at run time rather then defining it when the code is evaluated. It allows a function or element to be used for the `rootElement` in the config, so that no further changes are required.