### PR TITLE
Fix "directoinal" typo in v5 migration docs

### DIFF
--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -305,7 +305,7 @@ toc: true
 
 ## Utilities
 
-- <span class="badge bg-danger">Breaking</span> Renamed several utilities to use logical property names instead of directoinal names with the addition of RTL support:
+- <span class="badge bg-danger">Breaking</span> Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
   - Renamed `.left-*` and `.right-*` to `.start-*` and `.end-*`.
   - Renamed `.float-left` and `.float-right` to `.float-start` and `.float-end`.
   - Renamed `.border-left` and `.border-right` to `.border-start` and `.border-end`.


### PR DESCRIPTION
Typo under [docs/5.0/migration#utilities](https://getbootstrap.com/docs/5.0/migration/#utilities):

![Screenshot from 2021-05-10 14-55-29](https://user-images.githubusercontent.com/2503508/117717017-e2ec8580-b19f-11eb-8a0e-75ccccf99ad7.png)
