### PR TITLE
Fix offcanvas example, using a custom trigger selector

### DIFF
--- a/site/content/docs/5.0/examples/offcanvas-navbar/index.html
+++ b/site/content/docs/5.0/examples/offcanvas-navbar/index.html
@@ -12,7 +12,7 @@ aliases: "/docs/5.0/examples/offcanvas/"
 <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark" aria-label="Main navigation">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Offcanvas navbar</a>
-    <button class="navbar-toggler p-0 border-0" type="button" data-bs-toggle="offcanvas" aria-label="Toggle navigation">
+    <button class="navbar-toggler p-0 border-0" type="button" id="navbarSideCollapse" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/site/content/docs/5.0/examples/offcanvas-navbar/offcanvas.js
+++ b/site/content/docs/5.0/examples/offcanvas-navbar/offcanvas.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict'
 
-  document.querySelector('[data-bs-toggle="offcanvas"]').addEventListener('click', function () {
+  document.querySelector('#navbarSideCollapse').addEventListener('click', function () {
     document.querySelector('.offcanvas-collapse').classList.toggle('open')
   })
 })()


### PR DESCRIPTION
Fixes #33792

Offcanvas example, is based on an old custom implementation, but uses the data-bs-toggle="offcanvas" that triggers the offcanvas component without a given target.
