### PR TITLE
Regular readonly input

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -25,7 +25,7 @@
   &[type="file"] {
     overflow: hidden; // prevent pseudo element button overlap
 
-    &:not(:disabled):not(:read-only) {
+    &:not(:disabled) {
       cursor: pointer;
     }
   }
@@ -88,7 +88,7 @@
     @include transition($btn-transition);
   }
 
-  &:hover:not(:disabled):not(:read-only)::file-selector-button {
+  &:hover:not(:disabled)::file-selector-button {
     background-color: $form-file-button-hover-bg;
   }
 
@@ -107,7 +107,7 @@
     @include transition($btn-transition);
   }
 
-  &:hover:not(:disabled):not(:read-only)::-webkit-file-upload-button {
+  &:hover:not(:disabled)::-webkit-file-upload-button {
     background-color: $form-file-button-hover-bg;
   }
 }
@@ -203,7 +203,7 @@ textarea {
   height: auto; // Override fixed browser height
   padding: $input-padding-y;
 
-  &:not(:disabled):not(:read-only) {
+  &:not(:disabled) {
     cursor: pointer;
   }
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -59,13 +59,12 @@
     opacity: 1;
   }
 
-  // Disabled and read-only inputs
+  // Disabled inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
   // disabled if the fieldset is disabled. Due to implementation difficulty, we
   // don't honor that edge case; we style them as disabled anyway.
-  &:disabled,
-  &:read-only {
+  &:disabled {
     background-color: $input-disabled-bg;
     border-color: $input-disabled-border-color;
     // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655.

--- a/site/content/docs/5.0/forms/form-control.md
+++ b/site/content/docs/5.0/forms/form-control.md
@@ -40,7 +40,7 @@ Add the `disabled` boolean attribute on an input to give it a grayed out appeara
 
 ## Readonly
 
-Add the `readonly` boolean attribute on an input to prevent modification of the input's value. Read-only inputs appear lighter (just like disabled inputs), but retain the standard cursor.
+Add the `readonly` boolean attribute on an input to prevent modification of the input's value.
 
 {{< example >}}
 <input class="form-control" type="text" placeholder="Readonly input here..." aria-label="readonly input example" readonly>


### PR DESCRIPTION
Closes #33925

- First commit: "Inputs of type="file" and type="color" don't support readonly attribute"

[HTML5 spec](https://html.spec.whatwg.org/multipage/input.html#concept-input-apply):

![image](https://user-images.githubusercontent.com/643434/117733263-916ce680-b1f1-11eb-9bb1-d6465cfc815a.png)

Browsers ignore the readonly attribute for input type="file" and input type="color". It's not good to style them as disabled inputs since they are not.

- Second commit: "Don't style read-only input like all browsers and most UI frameworks"

Actually closes #33925