### PR TITLE
Add `word-wrap` and `word-break` to Reboot

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -8,7 +8,6 @@
   flex-direction: column;
   min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
   height: $card-height;
-  word-wrap: break-word;
   background-color: $card-bg;
   background-clip: border-box;
   border: $card-border-width solid $card-border-color;

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -9,8 +9,6 @@
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
   @include font-size($popover-font-size);
-  // Allow breaking very long words so they don't overflow the popover's bounds
-  word-wrap: break-word;
   background-color: $popover-bg;
   background-clip: padding-box;
   border: $popover-border-width solid $popover-border-color;

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -55,8 +55,8 @@ body {
   line-height: $line-height-base;
   color: $body-color;
   text-align: $body-text-align;
-  word-wrap: break-word; // 2
   word-break: break-word; // 2
+  word-wrap: break-word; // 2
   background-color: $body-bg; // 3
   -webkit-text-size-adjust: 100%; // 4
   -webkit-tap-highlight-color: rgba($black, 0); // 5

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -39,13 +39,13 @@
 // Body
 //
 // 1. Remove the margin in all browsers.
-// 2. As a best practice, apply a default `background-color`.
-// 3. Prevent adjustments of font size after orientation changes in iOS.
-// 4. Change the default tap highlight to be completely transparent in iOS.
-// 5. Prevent long strings of text from breaking your components' layout.
+// 2. Prevent long strings of text from breaking your components' layout.
 //    We use `word-wrap` instead of the more common `overflow-wrap` for wider
 //    browser support, and add the deprecated `word-break: break-word` to
 //    avoid issues with flex containers.
+// 3. As a best practice, apply a default `background-color`.
+// 4. Prevent adjustments of font size after orientation changes in iOS.
+// 5. Change the default tap highlight to be completely transparent in iOS.
 
 body {
   margin: 0; // 1
@@ -55,12 +55,13 @@ body {
   line-height: $line-height-base;
   color: $body-color;
   text-align: $body-text-align;
-  background-color: $body-bg; // 2
-  -webkit-text-size-adjust: 100%; // 3
-  -webkit-tap-highlight-color: rgba($black, 0); // 4
-  word-wrap: break-word; // 5
-  word-break: break-word; // 5
+  word-wrap: break-word; // 2
+  word-break: break-word; // 2
+  background-color: $body-bg; // 3
+  -webkit-text-size-adjust: 100%; // 4
+  -webkit-tap-highlight-color: rgba($black, 0); // 5
 }
+
 
 // Content grouping
 //

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -42,6 +42,10 @@
 // 2. As a best practice, apply a default `background-color`.
 // 3. Prevent adjustments of font size after orientation changes in iOS.
 // 4. Change the default tap highlight to be completely transparent in iOS.
+// 5. Prevent long strings of text from breaking your components' layout.
+//    We use `word-wrap` instead of the more common `overflow-wrap` for wider
+//    browser support, and add the deprecated `word-break: break-word` to
+//    avoid issues with flex containers.
 
 body {
   margin: 0; // 1
@@ -54,8 +58,9 @@ body {
   background-color: $body-bg; // 2
   -webkit-text-size-adjust: 100%; // 3
   -webkit-tap-highlight-color: rgba($black, 0); // 4
+  word-wrap: break-word; // 5
+  word-break: break-word; // 5
 }
-
 
 // Content grouping
 //

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -47,5 +47,4 @@
 
 .toast-body {
   padding: $toast-padding-x; // apply to both vertical and horizontal
-  word-wrap: break-word;
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -8,8 +8,6 @@
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
   @include font-size($tooltip-font-size);
-  // Allow breaking very long words so they don't overflow the tooltip's bounds
-  word-wrap: break-word;
   opacity: 0;
 
   &.show { opacity: $tooltip-opacity; }

--- a/site/content/docs/5.0/content/reboot.md
+++ b/site/content/docs/5.0/content/reboot.md
@@ -26,6 +26,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
   - No base `font-size` is declared on the `<html>`, but `16px` is assumed (the browser default). `font-size: 1rem` is applied on the `<body>` for easy responsive type-scaling via media queries while respecting user preferences and ensuring a more accessible approach. This browser default can be overridden by modifying the `$font-size-root` variable.
 - The `<body>` also sets a global `font-family`, `font-weight`, `line-height`, and `color`. This is inherited later by some form elements to prevent font inconsistencies.
 - For safety, the `<body>` has a declared `background-color`, defaulting to `#fff`.
+- The `word-wrap` and `word-break` are set to `break-word` to prevent long strings of text from breaking your components' layout. We use `word-wrap` instead of the more common `overflow-wrap` for wider browser support, and add the deprecated `word-break: break-word` to avoid issues with flex containers.
 
 ## Native font stack
 


### PR DESCRIPTION
Why would you want the default browser behavior of a long word overflowing the container?

What’s already done:

- Applied `.text-break` to `body` in Reboot (see https://getbootstrap.com/docs/5.0/utilities/text/#word-break)
- Removed instances of `word-wrap` from components, which now became redundant.

What’s left to do:

- Remove `.text-break`?
- Provide an utility with the converse, which sets `word-break` and `word-wrap` back to `normal`?

Follow up to: https://github.com/twbs/bootstrap/issues/20323