### PR TITLE
Don't add empty content holder when there is no content available

### DIFF
--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -30,7 +30,7 @@ const Default = {
   content: '',
   template: '<div class="popover" role="tooltip">' +
               '<div class="popover-arrow"></div>' +
-                '<h3 class="popover-header"></h3>' +
+              '<h3 class="popover-header"></h3>' +
               '<div class="popover-body"></div>' +
             '</div>'
 }

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -30,7 +30,7 @@ const Default = {
   content: '',
   template: '<div class="popover" role="tooltip">' +
               '<div class="popover-arrow"></div>' +
-                '<h3 class="popover-header"></h3>' +
+              '<h3 class="popover-header"></h3>' +
               '<div class="popover-body"></div>' +
             '</div>'
 }
@@ -88,6 +88,24 @@ class Popover extends Tooltip {
 
   isWithContent() {
     return this.getTitle() || this._getContent()
+  }
+
+  getTipElement() {
+    if (this.tip) {
+      return this.tip
+    }
+
+    this.tip = super.getTipElement()
+
+    if (!this.getTitle()) {
+      this.tip.removeChild(SelectorEngine.findOne(SELECTOR_TITLE, this.tip))
+    }
+
+    if (!this._getContent()) {
+      this.tip.removeChild(SelectorEngine.findOne(SELECTOR_CONTENT, this.tip))
+    }
+
+    return this.tip
   }
 
   setContent() {

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -30,7 +30,7 @@ const Default = {
   content: '',
   template: '<div class="popover" role="tooltip">' +
               '<div class="popover-arrow"></div>' +
-              '<h3 class="popover-header"></h3>' +
+                '<h3 class="popover-header"></h3>' +
               '<div class="popover-body"></div>' +
             '</div>'
 }

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -117,6 +117,46 @@ describe('Popover', () => {
       popover.show()
     })
 
+    it('should show a popover with just content without having header', done => {
+      fixtureEl.innerHTML = '<a href="#">Nice link</a>'
+
+      const popoverEl = fixtureEl.querySelector('a')
+      const popover = new Popover(popoverEl, {
+        content: 'Some beautiful content :)'
+      })
+
+      popoverEl.addEventListener('shown.bs.popover', () => {
+        const popoverDisplayed = document.querySelector('.popover')
+
+        expect(popoverDisplayed).not.toBeNull()
+        expect(popoverDisplayed.querySelector('.popover-header')).toBeNull()
+        expect(popoverDisplayed.querySelector('.popover-body').textContent).toEqual('Some beautiful content :)')
+        done()
+      })
+
+      popover.show()
+    })
+
+    it('should show a popover with just title without having body', done => {
+      fixtureEl.innerHTML = '<a href="#">Nice link</a>'
+
+      const popoverEl = fixtureEl.querySelector('a')
+      const popover = new Popover(popoverEl, {
+        title: 'Title, which does not require content'
+      })
+
+      popoverEl.addEventListener('shown.bs.popover', () => {
+        const popoverDisplayed = document.querySelector('.popover')
+
+        expect(popoverDisplayed).not.toBeNull()
+        expect(popoverDisplayed.querySelector('.popover-body')).toBeNull()
+        expect(popoverDisplayed.querySelector('.popover-header').textContent).toEqual('Title, which does not require content')
+        done()
+      })
+
+      popover.show()
+    })
+
     it('should show a popover with provided custom class', done => {
       fixtureEl.innerHTML = '<a href="#" title="Popover" data-bs-content="https://twitter.com/getbootstrap" data-bs-custom-class="custom-class">BS twitter</a>'
 


### PR DESCRIPTION
Fixes #29127
Alternative to #29570

A popover should not have an empty header or body when the content is not available on the main element or in the configuration.