### PR TITLE
Drop `BlinkMacSystemFont` in docs

### DIFF
--- a/site/content/docs/5.0/content/reboot.md
+++ b/site/content/docs/5.0/content/reboot.md
@@ -37,8 +37,6 @@ $font-family-sans-serif:
   system-ui,
   // Safari for macOS and iOS (San Francisco)
   -apple-system,
-  // Chrome < 56 for macOS (San Francisco)
-  BlinkMacSystemFont,
   // Windows
   "Segoe UI",
   // Android


### PR DESCRIPTION
Closes #33977

Not supporting Chrome < 56 anymore, dropped in #30561.