### PR TITLE
Fix backdrop "Cannot read property 'removeChild' of null" when removed from body

### DIFF
--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -116,7 +116,11 @@ class Backdrop {
 
     EventHandler.off(this._element, EVENT_MOUSEDOWN)
 
-    this._getElement().parentNode.removeChild(this._element)
+    const { parentNode } = this._getElement()
+    if (parentNode) {
+      parentNode.removeChild(this._element)
+    }
+
     this._isAppended = false
   }
 

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -129,6 +129,25 @@ describe('Backdrop', () => {
     })
   })
 
+  it('should not error if the backdrop no longer has a parent', done => {
+    const instance = new Backdrop({
+      isVisible: true,
+      isAnimated: true
+    })
+    const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
+
+    instance.show(() => {
+      instance.hide(() => {
+        expect(getElements().length).toEqual(0)
+
+        // replace the fixture, which was just wiped out
+        fixtureEl = getFixture()
+        done()
+      })
+      document.body.innerHTML = 'changed'
+    })
+  })
+
   describe('click callback', () => {
     it('it should execute callback on click', done => {
       const spy = jasmine.createSpy('spy')


### PR DESCRIPTION
Hi!

This fixes #33946 

Here is a reproducer: https://weaverryan.github.io/bootstrap-modal-close-reproducer/
Code: https://github.com/weaverryan/bootstrap-modal-close-reproducer/blob/main/index.html#L34-L46

1) Click "Launch demo modal"
2) Click "Save changes" in the modal.

Then in the console you'll see:

> TypeError: Cannot read property 'removeChild' of null
> (backdrop.js:119)

This occurs if you `hide()` a backdrop, but then the HTML of the backdrop is removed from the body while its animation is finishing. From the reproducer:


```js
bootstrap.Modal.getInstance(document.querySelector('#exampleModal')).hide();
document.body.innerHTML = 'Page content changed';
```

When would this happen? It happens, for example, if you're using [Turbo](https://github.com/hotwired/turbo). For example, if you close a modal, then immediately "visit" another page, in reality, that just swaps the `body.innerHTML` for the page, which causes backdrop to error when it can't find its parent (after the animation). 

Please let me know if you need any more clarification or tweaks to the PR :).

Thanks!