### PR TITLE
Ensure decent contrast in color-related utilities

### DIFF
--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -53,7 +53,7 @@
           // Ensures decent contrast where possible
           @if "background-color" == $property and "transparent" != inspect($value) {
             color: color-contrast($value);
-          } @else if "color" == $property and "inherit" != inspect($value) and $accessible-orange != $value {
+          } @else if "color" == $property and "inherit" != inspect($value) {
             background-color: color-contrast($value);
           }
         }

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -50,6 +50,12 @@
       .#{$property-class + $infix + $property-class-modifier} {
         @each $property in $properties {
           #{$property}: $value if($enable-important-utilities, !important, null);
+          // Ensures decent contrast where possible
+          @if "background-color" == $property and "transparent" != inspect($value) {
+            color: color-contrast($value);
+          } @else if "color" == $property and "inherit" != inspect($value) and $accessible-orange != $value {
+            background-color: color-contrast($value);
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #34016 

Drafting this because it's valuable for Bootstrap's overall accessibility, just a I did with `:focus-visible` polyfill. Would regret not trying :)

Inspired by [Boosted](https://www.github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/tree/v5-dev/scss%2Fmixins%2F_utilities.scss), I still think this is highly valuable by getting decent contrasts for free using our utilities — and no more requiring eg. `.text-dark` alongside `.bg-info`. 

Things to consider:

- Might be considered a BC, even if nothing will break: colors and background will change and while it's certainly for the best, it'll obviously get back to us as issues and discussions (RTL is recent, isn't it?).
- Always ignoring `!important` to ease overrides, in order to still use `.text-*` and `.bg-*` together.
- Could lead to side-effect when eg. a component part uses a color and a `.bg-*`: since utilities are added last in our build, `.bg-*` according color would override the component part's one if its selector is a class (or equivalent specificity).

I didn't met such cases while working with Boosted for years so I'm pretty confident, however Bootstrap is a bit more popular and used :D


## To do

If this PR gets positive feedback, before merging we'll need to:

- [ ] drop a few `.text-*` or `.bg-*` throughout our docs (and examples)
- [ ] updates utilities documentation
- [ ] mention this in the migration guide, somehow: it'll ease the migration from `badge badge-info` from v4 to `badge bg-info` instead of `badge bg-info text-dark`—and we'll probably find other cases.
