### PR TITLE
Generate color and background-color utils with CSS variables

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "24.25 kB"
+      "maxSize": "24.5 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "22.25 kB"
+      "maxSize": "22.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -2,6 +2,10 @@
 //
 // Utility mixins and functions for evaluating source code across our variables, maps, and mixins.
 
+@function to-rgb($value) {
+  @return red($value), green($value), blue($value);
+}
+
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
 @mixin _assert-ascending($map, $map-name) {

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -6,6 +6,36 @@
   @return red($value), green($value), blue($value);
 }
 
+// stylelint-disable scss/dollar-variable-pattern
+@function map-loop($map, $func, $args...) {
+  $_map: ();
+
+  @each $key, $value in $map {
+    // allow to pass the $key and $value of the map as an function argument
+    $_args: ();
+    @each $arg in $args {
+      $_args: append($_args, if($arg == "$key", $key, if($arg == "$value", $value, $arg)));
+    }
+
+    $_map: map-merge($_map, ($key: call(get-function($func), $_args...)));
+  }
+
+  @return $_map;
+}
+// stylelint-enable scss/dollar-variable-pattern
+
+@function varify($list) {
+  $result: null;
+  @each $entry in $list {
+    $result: append($result, var(--#{$variable-prefix}#{$entry}), space);
+  }
+  @return $result;
+}
+
+@function rgba-css-var($identifier, $target) {
+  @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity, 1));
+}
+
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
 @mixin _assert-ascending($map, $map-name) {

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -8,6 +8,17 @@
     --#{$variable-prefix}#{$color}: #{$value};
   }
 
+  @each $color, $value in $theme-colors-rgb {
+    --#{$variable-prefix}#{$color}-rgb: #{$value};
+  }
+
+  // Root and body
+  --#{$variable-prefix}root-font-size: #{$font-size-root};
+  --#{$variable-prefix}body-font: #{$font-family-base};
+  --#{$variable-prefix}body-font-size: #{$font-size-base};
+  --#{$variable-prefix}body-color: #{$body-color};
+  --#{$variable-prefix}body-bg: #{$body-bg};
+
   // Use `inspect` for lists so that quoted items keep the quotes.
   // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
   --#{$variable-prefix}font-sans-serif: #{inspect($font-family-sans-serif)};

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -517,7 +517,8 @@ $utilities: map-merge(
       values: (
         25: .25,
         50: .5,
-        75: .75
+        75: .75,
+        100: 1
       )
     ),
     // scss-docs-end utils-color
@@ -539,7 +540,8 @@ $utilities: map-merge(
         10: .1,
         25: .25,
         50: .5,
-        75: .75
+        75: .75,
+        100: 1
       )
     ),
     // scss-docs-end utils-bg-color

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -502,15 +502,22 @@ $utilities: map-merge(
       property: color,
       class: text,
       values: map-merge(
-        $theme-colors,
+        $utilities-text-colors,
         (
-          "white": $white,
-          "body": $body-color,
           "muted": $text-muted,
           "black-50": rgba($black, .5),
           "white-50": rgba($white, .5),
           "reset": inherit,
         )
+      )
+    ),
+    "text-opacity": (
+      css-var: true,
+      class: text-opacity,
+      values: (
+        25: .25,
+        50: .5,
+        75: .75
       )
     ),
     // scss-docs-end utils-color
@@ -519,12 +526,20 @@ $utilities: map-merge(
       property: background-color,
       class: bg,
       values: map-merge(
-        $theme-colors,
+        $utilities-bg-colors,
         (
-          "body": $body-bg,
-          "white": $white,
           "transparent": transparent
         )
+      )
+    ),
+    "bg-opacity": (
+      css-var: true,
+      class: bg-opacity,
+      values: (
+        10: .1,
+        25: .25,
+        50: .5,
+        75: .75
       )
     ),
     // scss-docs-end utils-bg-color

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -280,6 +280,56 @@ $body-bg:                   $white !default;
 $body-color:                $gray-900 !default;
 $body-text-align:           null !default;
 
+// Utilities maps
+
+// scss-docs-start theme-colors-rgb
+$theme-colors-rgb: (
+  "primary":   to-rgb($primary),
+  "secondary": to-rgb($secondary),
+  "success":   to-rgb($success),
+  "info":      to-rgb($info),
+  "warning":   to-rgb($warning),
+  "danger":    to-rgb($danger),
+  "light":     to-rgb($light),
+  "dark":      to-rgb($dark),
+  "black":     to-rgb($black),
+  "white":     to-rgb($white),
+  "body":      to-rgb($body-color)
+) !default;
+// scss-docs-end theme-colors-rgb
+
+// scss-docs-start utilities-text-colors
+$utilities-text-colors: (
+  "primary":   rgba(var(--bs-primary-rgb), var(--bs-text-opacity, 1)),
+  "secondary": rgba(var(--bs-secondary-rgb), var(--bs-text-opacity, 1)),
+  "success":   rgba(var(--bs-success-rgb), var(--bs-text-opacity, 1)),
+  "info":      rgba(var(--bs-info-rgb), var(--bs-text-opacity, 1)),
+  "warning":   rgba(var(--bs-warning-rgb), var(--bs-text-opacity, 1)),
+  "danger":    rgba(var(--bs-danger-rgb), var(--bs-text-opacity, 1)),
+  "light":     rgba(var(--bs-light-rgb), var(--bs-text-opacity, 1)),
+  "dark":      rgba(var(--bs-dark-rgb), var(--bs-text-opacity, 1)),
+  "black":     rgba(var(--bs-black-rgb), var(--bs-text-opacity, 1)),
+  "white":     rgba(var(--bs-white-rgb), var(--bs-text-opacity, 1)),
+  "body":      rgba(var(--bs-body-color-rgb), var(--bs-text-opacity, 1))
+) !default;
+// scss-docs-end utilities-text-colors
+
+// scss-docs-start utilities-bg-colors
+$utilities-bg-colors: (
+  "primary":   rgba(var(--bs-primary-rgb), var(--bs-bg-opacity, 1)),
+  "secondary": rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity, 1)),
+  "success":   rgba(var(--bs-success-rgb), var(--bs-bg-opacity, 1)),
+  "info":      rgba(var(--bs-info-rgb), var(--bs-bg-opacity, 1)),
+  "warning":   rgba(var(--bs-warning-rgb), var(--bs-bg-opacity, 1)),
+  "danger":    rgba(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)),
+  "light":     rgba(var(--bs-light-rgb), var(--bs-bg-opacity, 1)),
+  "dark":      rgba(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)),
+  "black":     rgba(var(--bs-black-rgb), var(--bs-bg-opacity, 1)),
+  "white":     rgba(var(--bs-white-rgb), var(--bs-bg-opacity, 1)),
+  "body":      rgba(var(--bs-body-color-rgb), var(--bs-bg-opacity, 1))
+) !default;
+// scss-docs-end utilities-bg-colors
+
 
 // Links
 //

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -283,51 +283,26 @@ $body-text-align:           null !default;
 // Utilities maps
 
 // scss-docs-start theme-colors-rgb
-$theme-colors-rgb: (
-  "primary":   to-rgb($primary),
-  "secondary": to-rgb($secondary),
-  "success":   to-rgb($success),
-  "info":      to-rgb($info),
-  "warning":   to-rgb($warning),
-  "danger":    to-rgb($danger),
-  "light":     to-rgb($light),
-  "dark":      to-rgb($dark),
-  "black":     to-rgb($black),
-  "white":     to-rgb($white),
-  "body":      to-rgb($body-color)
-) !default;
+$theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value") !default;
 // scss-docs-end theme-colors-rgb
 
-// scss-docs-start utilities-text-colors
-$utilities-text-colors: (
-  "primary":   rgba(var(--bs-primary-rgb), var(--bs-text-opacity, 1)),
-  "secondary": rgba(var(--bs-secondary-rgb), var(--bs-text-opacity, 1)),
-  "success":   rgba(var(--bs-success-rgb), var(--bs-text-opacity, 1)),
-  "info":      rgba(var(--bs-info-rgb), var(--bs-text-opacity, 1)),
-  "warning":   rgba(var(--bs-warning-rgb), var(--bs-text-opacity, 1)),
-  "danger":    rgba(var(--bs-danger-rgb), var(--bs-text-opacity, 1)),
-  "light":     rgba(var(--bs-light-rgb), var(--bs-text-opacity, 1)),
-  "dark":      rgba(var(--bs-dark-rgb), var(--bs-text-opacity, 1)),
-  "black":     rgba(var(--bs-black-rgb), var(--bs-text-opacity, 1)),
-  "white":     rgba(var(--bs-white-rgb), var(--bs-text-opacity, 1)),
-  "body":      rgba(var(--bs-body-color-rgb), var(--bs-text-opacity, 1))
+// scss-docs-start utilities-colors
+$utilities-colors: map-merge(
+  $theme-colors-rgb,
+  (
+    "black": to-rgb($black),
+    "white": to-rgb($white),
+    "body":  to-rgb($body-color)
+  )
 ) !default;
+// scss-docs-end utilities-colors
+
+// scss-docs-start utilities-text-colors
+$utilities-text-colors: map-loop($utilities-colors, rgba-css-var, "$key", "text") !default;
 // scss-docs-end utilities-text-colors
 
 // scss-docs-start utilities-bg-colors
-$utilities-bg-colors: (
-  "primary":   rgba(var(--bs-primary-rgb), var(--bs-bg-opacity, 1)),
-  "secondary": rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity, 1)),
-  "success":   rgba(var(--bs-success-rgb), var(--bs-bg-opacity, 1)),
-  "info":      rgba(var(--bs-info-rgb), var(--bs-bg-opacity, 1)),
-  "warning":   rgba(var(--bs-warning-rgb), var(--bs-bg-opacity, 1)),
-  "danger":    rgba(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)),
-  "light":     rgba(var(--bs-light-rgb), var(--bs-bg-opacity, 1)),
-  "dark":      rgba(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)),
-  "black":     rgba(var(--bs-black-rgb), var(--bs-bg-opacity, 1)),
-  "white":     rgba(var(--bs-white-rgb), var(--bs-bg-opacity, 1)),
-  "body":      rgba(var(--bs-body-color-rgb), var(--bs-bg-opacity, 1))
-) !default;
+$utilities-bg-colors: map-loop($utilities-colors, rgba-css-var, "$key", "bg") !default;
 // scss-docs-end utilities-bg-colors
 
 

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -41,25 +41,41 @@
       }
     }
 
+    $is-css-var: map-get($utility, css-var);
+
     $is-rtl: map-get($utility, rtl);
 
     @if $value != null {
       @if $is-rtl == false {
         /* rtl:begin:remove */
       }
-      .#{$property-class + $infix + $property-class-modifier} {
-        @each $property in $properties {
-          #{$property}: $value if($enable-important-utilities, !important, null);
-        }
-      }
 
-      @each $pseudo in $state {
-        .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
+      @if $is-css-var {
+        .#{$property-class + $infix + $property-class-modifier} {
+          --#{$variable-prefix}#{$property-class}: #{$value};
+        }
+
+        @each $pseudo in $state {
+          .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
+            --#{$variable-prefix}#{$property-class}: #{$value};
+          }
+        }
+      } @else {
+        .#{$property-class + $infix + $property-class-modifier} {
           @each $property in $properties {
             #{$property}: $value if($enable-important-utilities, !important, null);
           }
         }
+
+        @each $pseudo in $state {
+          .#{$property-class + $infix + $property-class-modifier}-#{$pseudo}:#{$pseudo} {
+            @each $property in $properties {
+              #{$property}: $value if($enable-important-utilities, !important, null);
+            }
+          }
+        }
       }
+
       @if $is-rtl == false {
         /* rtl:end:remove */
       }

--- a/site/content/docs/5.0/utilities/background.md
+++ b/site/content/docs/5.0/utilities/background.md
@@ -35,6 +35,41 @@ Do you need a gradient in your custom CSS? Just add `background-image: var(--bs-
 {{< /colors.inline >}}
 {{< /markdown >}}
 
+## Opacity
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.1.0</small>
+
+As of v5.1.0, `background-color` utilities are generated with Sass using CSS variables. This allows for real-time color changes without compilation and dynamic alpha transparency changes.
+
+### How it works
+
+Consider our default `.bg-success` utility.
+
+```css
+.bg-success {
+  background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+```
+
+We use an RGB version of our `--bs-succes` (with the value of `25, 135, 84`) CSS variable and attached a second CSS variable, `--bs-bg-opacity`, for the alpha transparency (with no default value, but a fallback of `1`). That means anytime you use `.bg-success` now, your computed `color` value is `rgba(25, 135, 84, 1)`.
+
+To change that opacity, override `--bs-bg-opacity` via custom styles or inline styles.
+
+{{< example >}}
+<div class="bg-success p-2 text-white">This is default success background</div>
+<div class="bg-success p-2 text-white" style="--bs-bg-opacity: .5;">This is 50% opacity success background</div>
+{{< /example >}}
+
+Or, choose from any of the `.bg-opacity` utilities:
+
+{{< example >}}
+<div class="bg-success p-2 text-white">This is default success background</div>
+<div class="bg-success p-2 text-white bg-opacity-75">This is 75% opacity success background</div>
+<div class="bg-success p-2 text-dark bg-opacity-50">This is 50% opacity success background</div>
+<div class="bg-success p-2 text-dark bg-opacity-25">This is 25% opacity success background</div>
+<div class="bg-success p-2 text-dark bg-opacity-10">This is 10% opacity success background</div>
+{{< /example >}}
+
 ## Sass
 
 In addition to the following Sass functionality, consider reading about our included [CSS custom properties]({{< docsref "/customize/css-variables" >}}) (aka CSS variables) for colors and more.
@@ -62,6 +97,14 @@ Theme colors are then put into a Sass map so we can loop over them to generate o
 Grayscale colors are also available as a Sass map. **This map is not used to generate any utilities.**
 
 {{< scss-docs name="gray-colors-map" file="scss/_variables.scss" >}}
+
+RGB colors are generated from a separate Sass map:
+
+{{< scss-docs name="theme-colors-rgb" file="scss/_variables.scss" >}}
+
+And background color opacities build on that with their own map that's consumed by the utilities API:
+
+{{< scss-docs name="utilities-bg-colors" file="scss/_variables.scss" >}}
 
 ### Mixins
 

--- a/site/content/docs/5.0/utilities/colors.md
+++ b/site/content/docs/5.0/utilities/colors.md
@@ -27,6 +27,40 @@ Colorize text with color utilities. If you want to colorize links, you can use t
 {{< partial "callout-warning-color-assistive-technologies.md" >}}
 {{< /callout >}}
 
+## Opacity
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.1.0</small>
+
+As of v5.1.0, text color utilities are generated with Sass using CSS variables. This allows for real-time color changes without compilation and dynamic alpha transparency changes.
+
+### How it works
+
+Consider our default `.text-primary` utility.
+
+```css
+.text-primary {
+  color: rgba(var(--bs-primary-rgb), var(--bs-text-opacity, 1)) !important;
+}
+```
+
+We use an RGB version of our `--bs-primary` (with the value of `13, 110, 253`) CSS variable and attached a second CSS variable, `--bs-text-opacity`, for the alpha transparency (with no default value, but a fallback of `1`). That means anytime you use `.text-primary` now, your computed `color` value is `rgba(13, 110, 253, 1)`.
+
+To change that opacity, override `--bs-text-opacity` via custom styles or inline styles.
+
+{{< example >}}
+<div class="text-primary">This is default primary text</div>
+<div class="text-primary" style="--bs-text-opacity: .5;">This is 50% opacity primary text</div>
+{{< /example >}}
+
+Or, choose from any of the `.text-opacity` utilities:
+
+{{< example >}}
+<div class="text-primary">This is default primary text</div>
+<div class="text-primary text-opacity-75">This is 75% opacity primary text</div>
+<div class="text-primary text-opacity-50">This is 50% opacity primary text</div>
+<div class="text-primary text-opacity-25">This is 25% opacity primary text</div>
+{{< /example >}}
+
 ## Specificity
 
 Sometimes contextual classes cannot be applied due to the specificity of another selector. In some cases, a sufficient workaround is to wrap your element's content in a `<div>` or more semantic element with the desired class.
@@ -47,6 +81,8 @@ Grayscale colors are also available, but only a subset are used to generate any 
 
 {{< scss-docs name="gray-color-variables" file="scss/_variables.scss" >}}
 
+RGB colors are generated from a separate Sass map
+
 ### Map
 
 Theme colors are then put into a Sass map so we can loop over them to generate our utilities, component modifiers, and more.
@@ -56,6 +92,14 @@ Theme colors are then put into a Sass map so we can loop over them to generate o
 Grayscale colors are also available as a Sass map. **This map is not used to generate any utilities.**
 
 {{< scss-docs name="gray-colors-map" file="scss/_variables.scss" >}}
+
+RGB colors are generated from a separate Sass map:
+
+{{< scss-docs name="theme-colors-rgb" file="scss/_variables.scss" >}}
+
+And color opacities build on that with their own map that's consumed by the utilities API:
+
+{{< scss-docs name="utilities-text-colors" file="scss/_variables.scss" >}}
 
 ### Utilities API
 


### PR DESCRIPTION
_There are a few unrelated changes here, but the bulk of this is all on topic. Will filter that out in subsequent commits._

### Summary

This PR updates our `generate-utility()` mixin and utilities API to add support for generating CSS variables. Alongside that, I've updated our `.text-*` `color` and `.bg-*` `background-color` utilities to use CSS variables that support an optional variable for alpha transparency with default fallback. I've enabled this by adding new RGB versions of our `:root` level theme color variables (e.g., `--bs-primary` and `--bs-primary-rgb`), and then using those variables instead of just Sass-generated hex values.

The utilities API has been updated with a new boolean `css-var` option that, if set to `true`, will generate just a variable inside a class instead of a `property: value` pair inside a class.

### Example

Here's an example for our updated `.text-primary` utility:

```css
.text-primary {
  color: rgba(var(--bs-primary-rgb), var(--bs-text-opacity, 1)) !important;
}
```

```html
<div class="text-primary">This is default primary text</div>
<div class="text-primary text-opacity-75">This is 75% opacity primary text</div>
<div class="text-primary text-opacity-50">This is 50% opacity primary text</div>
<div class="text-primary text-opacity-25">This is 25% opacity primary text</div>

<div class="text-primary" style="--bs-text-opacity: .5;">This is 50% opacity primary text</div>
```

### Help!?

Right now there are still too many pieces of this that are manual, especially the new `$theme-colors-rgb` and `$utilities-*-colors` maps. I'm wondering if there's a way to take the default `$theme-colors` map and loop over it to generate a new map. My Googling is inconclusive thus far. Any ideas for how to better automate this would be much appreciated!

### Todos

- [ ] Document new `css-var: true` option for utility API
- [ ] Deprecate `.text-white-50` and `.text-black-50`?

/cc @twbs/css-review 
