### PR TITLE
Backdrop: Fix stale body by removing unnecessary default

### DIFF
--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -6,19 +6,19 @@
  */
 
 import EventHandler from '../dom/event-handler'
-import { emulateTransitionEnd, execute, getTransitionDurationFromElement, reflow, typeCheckConfig } from './index'
+import { emulateTransitionEnd, execute, getElement, getTransitionDurationFromElement, reflow, typeCheckConfig } from './index'
 
 const Default = {
   isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
   isAnimated: false,
-  rootElement: document.body, // give the choice to place backdrop under different elements
+  rootElement: 'body', // give the choice to place backdrop under different elements
   clickCallback: null
 }
 
 const DefaultType = {
   isVisible: 'boolean',
   isAnimated: 'boolean',
-  rootElement: 'element',
+  rootElement: '(element|string)',
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'
@@ -90,7 +90,8 @@ class Backdrop {
       ...(typeof config === 'object' ? config : {})
     }
 
-    config.rootElement = config.rootElement || document.body
+    // use getElement() with the default "body" to get a fresh Element on each instantiation
+    config.rootElement = getElement(config.rootElement)
     typeCheckConfig(NAME, config, DefaultType)
     return config
   }

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -243,10 +243,10 @@ describe('Backdrop', () => {
       })
     })
 
-    it('Should default parent element to "document.body" when config value is null', done => {
+    it('Should find the rootElement if passed as a string', done => {
       const instance = new Backdrop({
         isVisible: true,
-        rootElement: null
+        rootElement: 'body'
       })
       const getElement = () => document.querySelector(CLASS_BACKDROP)
       instance.show(() => {


### PR DESCRIPTION
Hi there!

I'm using [Turbo](https://github.com/hotwired/turbo), where the entire `body` element is swapped out at times. This causes a bug with Backdrop, as it stores the original `body` element in the `Default` object. This is the flow:

1) Open a Modal / Backdrop
2) Navigate to another page (i.e. swap the `body` for a new `body` Element)
3) Open another Modal / Backdrop

On (3), the `Backdrop` will append itself to the original `body` Element from (1), not the new body element.

Also, the default is unnecessary: in `_getConfig()`, if `config.rootElement` is falsy, then it already defaults to `document.body` (which is why I didn't add any tests: there are tests already to make sure the `rootElement` can be configured):

https://github.com/twbs/bootstrap/blob/136665903b50988002380f512342dcb584e1bed4/js/src/util/backdrop.js#L93

Please let me know if any tweaks are needed.

Thanks!