### PR TITLE
Use `defineJQueryPlugin` method only in the base component

### DIFF
--- a/js/src/alert.js
+++ b/js/src/alert.js
@@ -5,10 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
-import {
-  defineJQueryPlugin,
-  getElementFromSelector
-} from './util/index'
+import { getElementFromSelector } from './util/index'
 import Data from './dom/data'
 import EventHandler from './dom/event-handler'
 import BaseComponent from './base-component'
@@ -117,14 +114,5 @@ class Alert extends BaseComponent {
  */
 
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DISMISS, Alert.handleDismiss(new Alert()))
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Alert to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Alert)
 
 export default Alert

--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -10,7 +10,8 @@ import {
   emulateTransitionEnd,
   execute,
   getElement,
-  getTransitionDurationFromElement
+  getTransitionDurationFromElement,
+  defineJQueryPlugin
 } from './util/index'
 import EventHandler from './dom/event-handler'
 
@@ -77,5 +78,7 @@ class BaseComponent {
     return `.${this.DATA_KEY}`
   }
 }
+
+defineJQueryPlugin()
 
 export default BaseComponent

--- a/js/src/button.js
+++ b/js/src/button.js
@@ -5,7 +5,6 @@
  * --------------------------------------------------------------------------
  */
 
-import { defineJQueryPlugin } from './util/index'
 import Data from './dom/data'
 import EventHandler from './dom/event-handler'
 import BaseComponent from './base-component'
@@ -82,14 +81,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, event => {
 
   data.toggle()
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Button to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Button)
 
 export default Button

--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   getElementFromSelector,
   isRTL,
   isVisible,
@@ -577,14 +576,5 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
     Carousel.carouselInterface(carousels[i], Data.get(carousels[i], DATA_KEY))
   }
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Carousel to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Carousel)
 
 export default Carousel

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   getElement,
   getSelectorFromElement,
   getElementFromSelector,
@@ -375,14 +374,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
     Collapse.collapseInterface(element, config)
   })
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Collapse to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Collapse)
 
 export default Collapse

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -8,7 +8,6 @@
 import * as Popper from '@popperjs/core'
 
 import {
-  defineJQueryPlugin,
   getElement,
   getElementFromSelector,
   isDisabled,
@@ -507,14 +506,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   event.preventDefault()
   Dropdown.dropdownInterface(this)
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Dropdown to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Dropdown)
 
 export default Dropdown

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   emulateTransitionEnd,
   getElementFromSelector,
   getTransitionDurationFromElement,
@@ -433,14 +432,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
   data.toggle(this)
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Modal to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Modal)
 
 export default Modal

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   getElementFromSelector,
   isDisabled,
   isVisible,
@@ -264,13 +263,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
   SelectorEngine.find(OPEN_SELECTOR).forEach(el => (Data.get(el, DATA_KEY) || new Offcanvas(el)).show())
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- */
-
-defineJQueryPlugin(Offcanvas)
 
 export default Offcanvas

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -5,7 +5,6 @@
  * --------------------------------------------------------------------------
  */
 
-import { defineJQueryPlugin } from './util/index'
 import Data from './dom/data'
 import SelectorEngine from './dom/selector-engine'
 import Tooltip from './tooltip'
@@ -164,14 +163,5 @@ class Popover extends Tooltip {
     })
   }
 }
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Popover to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Popover)
 
 export default Popover

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   getSelectorFromElement,
   getUID,
   isElement,
@@ -295,14 +294,5 @@ EventHandler.on(window, EVENT_LOAD_DATA_API, () => {
   SelectorEngine.find(SELECTOR_DATA_SPY)
     .forEach(spy => new ScrollSpy(spy))
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .ScrollSpy to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(ScrollSpy)
 
 export default ScrollSpy

--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   getElementFromSelector,
   isDisabled,
   reflow
@@ -212,14 +211,5 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   const data = Data.get(this, DATA_KEY) || new Tab(this)
   data.show()
 })
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Tab to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Tab)
 
 export default Tab

--- a/js/src/toast.js
+++ b/js/src/toast.js
@@ -6,7 +6,6 @@
  */
 
 import {
-  defineJQueryPlugin,
   reflow,
   typeCheckConfig
 } from './util/index'
@@ -235,14 +234,5 @@ class Toast extends BaseComponent {
     })
   }
 }
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Toast to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Toast)
 
 export default Toast

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -8,7 +8,6 @@
 import * as Popper from '@popperjs/core'
 
 import {
-  defineJQueryPlugin,
   findShadowRoot,
   getElement,
   getUID,
@@ -739,14 +738,5 @@ class Tooltip extends BaseComponent {
     })
   }
 }
-
-/**
- * ------------------------------------------------------------------------
- * jQuery
- * ------------------------------------------------------------------------
- * add .Tooltip to jQuery only if jQuery is present
- */
-
-defineJQueryPlugin(Tooltip)
 
 export default Tooltip

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -229,19 +229,37 @@ const onDOMContentLoaded = callback => {
 
 const isRTL = () => document.documentElement.dir === 'rtl'
 
-const defineJQueryPlugin = plugin => {
+const defineJQueryPlugin = () => {
   onDOMContentLoaded(() => {
     const $ = getjQuery()
     /* istanbul ignore if */
     if ($) {
-      const name = plugin.NAME
-      const JQUERY_NO_CONFLICT = $.fn[name]
-      $.fn[name] = plugin.jQueryInterface
-      $.fn[name].Constructor = plugin
-      $.fn[name].noConflict = () => {
-        $.fn[name] = JQUERY_NO_CONFLICT
-        return plugin.jQueryInterface
-      }
+      [
+        'Alert',
+        'Button',
+        'Carousel',
+        'Collapse',
+        'Dropdown',
+        'Modal',
+        'Offcanvas',
+        'Popover',
+        'ScrollSpy',
+        'Tab',
+        'Toast',
+        'Tooltip'
+      ].forEach(pluginName => {
+        const plugin = window.bootstrap[pluginName]
+        if (plugin) {
+          const name = plugin.NAME
+          const JQUERY_NO_CONFLICT = $.fn[name]
+          $.fn[name] = plugin.jQueryInterface
+          $.fn[name].Constructor = plugin
+          $.fn[name].noConflict = () => {
+            $.fn[name] = JQUERY_NO_CONFLICT
+            return plugin.jQueryInterface
+          }
+        }
+      })
     }
   })
 }


### PR DESCRIPTION
Fixes #34103

There are multiple duplicated `DOMContentLoaded` events attached to the document, they are not really needed. 

It is the very beginning of the idea, this approach may work IMO.
_:warning: Tests are not updated yet_

/CC @twbs/js-review for the early feedback :slightly_smiling_face: