### PR TITLE
Fixed components/spinners page link to text alignment utility

### DIFF
--- a/site/content/docs/5.0/components/spinners.md
+++ b/site/content/docs/5.0/components/spinners.md
@@ -192,4 +192,4 @@ Used for creating the CSS animations for our spinners. Included in `scss/_spinne
 [float]:   {{< docsref "/utilities/float" >}}
 [margin]:  {{< docsref "/utilities/spacing" >}}
 [sizing]:  {{< docsref "/utilities/sizing" >}}
-[text]:    {{< docsref "/content/typography" >}}
+[text]:    {{< docsref "/utilities/text" >}}


### PR DESCRIPTION
Fixes #34113

### Changes
Just a quick link swap in `spinners.md`.

### Description
https://getbootstrap.com/docs/5.0/components/spinners/#placement suggests a link to the text alignment utility; however, the link takes you to https://getbootstrap.com/docs/5.0/content/typography/ instead of https://getbootstrap.com/docs/5.0/utilities/text/.

I already tested it locally with `npm run test` and `npm run docs-serve` and it works; however, doing so modified some `dist` files shown in the image below which I didn't include in this pull request. Just making sure I can leave it out of the PR?
![image](https://user-images.githubusercontent.com/32887362/119716027-8765fd00-be19-11eb-8a48-72734ac3b916.png)
 