### PR TITLE
fix(dropdowns): RTL for `.dropdown-menu-*`

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -51,7 +51,7 @@
 
       &[data-bs-popper] {
         right: auto;
-        left: 0
+        left: 0;
       }
     }
 

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -50,8 +50,8 @@
       --bs-position: start;
 
       &[data-bs-popper] {
-        right: auto #{"/* rtl:ignore */"};
-        left: 0 #{"/* rtl:ignore */"};
+        right: auto;
+        left: 0
       }
     }
 
@@ -59,8 +59,8 @@
       --bs-position: end;
 
       &[data-bs-popper] {
-        right: 0 #{"/* rtl:ignore */"};
-        left: auto #{"/* rtl:ignore */"};
+        right: 0;
+        left: auto;
       }
     }
   }


### PR DESCRIPTION
Attempt to fix #34088

---

- @ferhado 's initial CodePen, using this PR's CSS RTL output: https://codepen.io/ffoodd/pen/ExWvdoY
- and RTL Cheatsheet still works fine: https://deploy-preview-34124--twbs-bootstrap.netlify.app/docs/5.0/examples/cheatsheet-rtl/#dropdowns

---

Any concern, @twbs/js-review —or does it look safe to you?