### PR TITLE
The breakpoint-min() function should return null for the first element

### DIFF
--- a/scss/_containers.scss
+++ b/scss/_containers.scss
@@ -12,7 +12,7 @@
 
   // Responsive containers that are 100% wide until a breakpoint
   @each $breakpoint, $container-max-width in $container-max-widths {
-    .container-#{$breakpoint} {
+    .container#{breakpoint-infix($breakpoint, $container-max-widths)} {
       @extend .container-fluid;
     }
 

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -28,7 +28,9 @@
 //    576px
 @function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
   $min: map-get($breakpoints, $name);
-  @return if($min != 0, $min, null);
+  $keys: map-keys($grid-breakpoints);
+  $smallest: if(length($keys) > 0, $name == nth($keys, 1), false);
+  @return if($smallest, null, $min);
 }
 
 // Maximum breakpoint width.


### PR DESCRIPTION
# Description
The `breakpoint-min()` function should return `null` for the first element in the map, even if its value is not `0`. Currently, this function returns `null` only when the value is `0`, so when calling this function with a map other than `$grid-breakpoints`, such as `$container-max-widths`, it will return the value of the first element, instead of `null`.

Also, the `scss/_container.sass` script directly generates responsive container selectors with `.container-#{$breakpoint}`, instead of `.container#{breakpoint-infix($breakpoint, $container-max-widths)}`, so it may generate unnecessary selectors such as `.container-xs` under certain circumstances.

# How to Reproduce
## Initialization
```bash
$ cd ~
$ mkdir test
$ cd test
$ yarn init -y
$ yarn add --dev sass bootstrap
```

## Create a Test File
Create `test.scss` with the following content:
```scss
// test.scss
@import "node_modules/bootstrap/scss/functions";                                                                         
$container-max-widths: (                                                                                                 
  xs: 540px,                                                                                                             
  sm: 540px,                                                                                                             
  md: 720px,                                                                                                             
  lg: 960px,                                                                                                             
  xl: 992px,                                                                                                             
  xxl: 992px                                                                                                             
);                                                                                                                       
@import "node_modules/bootstrap/scss/variables";                                                                         
@import "node_modules/bootstrap/scss/mixins";                                                                            
@import "node_modules/bootstrap/scss/containers";                                                                        
@import "node_modules/bootstrap/scss/navbar"; 
```

## Test
```bash
$ yarn sass test.scss test.css
```
You should be able to find a few selectors that include `.container-xs` in `test.css`, which is incorrect because any presence of `.container-xs` should have been replaced by `.container`. 
