### PR TITLE
Variabilize backdrop class name (#34094)

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -61,6 +61,7 @@ const CLASS_NAME_OPEN = 'modal-open'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_STATIC = 'modal-static'
+const CLASS_NAME_BACKDROP = 'modal-backdrop'
 
 const SELECTOR_DIALOG = '.modal-dialog'
 const SELECTOR_MODAL_BODY = '.modal-body'
@@ -202,7 +203,8 @@ class Modal extends BaseComponent {
   _initializeBackDrop() {
     return new Backdrop({
       isVisible: Boolean(this._config.backdrop), // 'static' option will be translated to true, and booleans will keep their value
-      isAnimated: this._isAnimated()
+      isAnimated: this._isAnimated(),
+      backdropClassName: CLASS_NAME_BACKDROP
     })
   }
 

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -61,7 +61,6 @@ const CLASS_NAME_OPEN = 'modal-open'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_STATIC = 'modal-static'
-const CLASS_NAME_BACKDROP = 'modal-backdrop'
 
 const SELECTOR_DIALOG = '.modal-dialog'
 const SELECTOR_MODAL_BODY = '.modal-body'
@@ -203,8 +202,7 @@ class Modal extends BaseComponent {
   _initializeBackDrop() {
     return new Backdrop({
       isVisible: Boolean(this._config.backdrop), // 'static' option will be translated to true, and booleans will keep their value
-      isAnimated: this._isAnimated(),
-      backdropClassName: CLASS_NAME_BACKDROP
+      isAnimated: this._isAnimated()
     })
   }
 

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -45,6 +45,8 @@ const DefaultType = {
 }
 
 const CLASS_NAME_SHOW = 'show'
+const CLASS_NAME_BACKDROP = 'offcanvas-backdrop'
+
 const OPEN_SELECTOR = '.offcanvas.show'
 
 const EVENT_SHOW = `show${EVENT_KEY}`
@@ -180,6 +182,7 @@ class Offcanvas extends BaseComponent {
       isVisible: this._config.backdrop,
       isAnimated: true,
       rootElement: this._element.parentNode,
+      backdropClassName: CLASS_NAME_BACKDROP,
       clickCallback: () => this.hide()
     })
   }

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -46,7 +46,6 @@ const DefaultType = {
 
 const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_BACKDROP = 'offcanvas-backdrop'
-
 const OPEN_SELECTOR = '.offcanvas.show'
 
 const EVENT_SHOW = `show${EVENT_KEY}`
@@ -179,10 +178,10 @@ class Offcanvas extends BaseComponent {
 
   _initializeBackDrop() {
     return new Backdrop({
+      className: CLASS_NAME_BACKDROP,
       isVisible: this._config.backdrop,
       isAnimated: true,
       rootElement: this._element.parentNode,
-      backdropClassName: CLASS_NAME_BACKDROP,
       clickCallback: () => this.hide()
     })
   }

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -22,7 +22,6 @@ const DefaultType = {
   clickCallback: '(function|null)'
 }
 const NAME = 'backdrop'
-const CLASS_NAME_BACKDROP = 'modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 
@@ -73,7 +72,7 @@ class Backdrop {
   _getElement() {
     if (!this._element) {
       const backdrop = document.createElement('div')
-      backdrop.className = CLASS_NAME_BACKDROP
+      backdrop.className = this._config.backdropClassName
       if (this._config.isAnimated) {
         backdrop.classList.add(CLASS_NAME_FADE)
       }

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -9,6 +9,7 @@ import EventHandler from '../dom/event-handler'
 import { execute, executeAfterTransition, getElement, reflow, typeCheckConfig } from './index'
 
 const Default = {
+  className: 'modal-backdrop',
   isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
   isAnimated: false,
   rootElement: 'body', // give the choice to place backdrop under different elements
@@ -16,6 +17,7 @@ const Default = {
 }
 
 const DefaultType = {
+  className: 'string',
   isVisible: 'boolean',
   isAnimated: 'boolean',
   rootElement: '(element|string)',
@@ -72,7 +74,7 @@ class Backdrop {
   _getElement() {
     if (!this._element) {
       const backdrop = document.createElement('div')
-      backdrop.className = this._config.backdropClassName
+      backdrop.className = this._config.className
       if (this._config.isAnimated) {
         backdrop.classList.add(CLASS_NAME_FADE)
       }

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -3,7 +3,6 @@ import { getTransitionDurationFromElement } from '../../../src/util/index'
 import { clearFixture, getFixture } from '../../helpers/fixture'
 
 const CLASS_BACKDROP = '.modal-backdrop'
-const CLASS_NAME_BACKDROP = 'modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 
@@ -27,8 +26,7 @@ describe('Backdrop', () => {
     it('if it is "shown", should append the backdrop html once, on show, and contain "show" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: false,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: false
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -47,8 +45,7 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not append the backdrop html', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -62,8 +59,7 @@ describe('Backdrop', () => {
     it('if it is "shown" and "animated", should append the backdrop html once, and contain "fade" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -83,8 +79,7 @@ describe('Backdrop', () => {
     it('should remove the backdrop html', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
 
       const getElements = () => document.body.querySelectorAll(CLASS_BACKDROP)
@@ -102,8 +97,7 @@ describe('Backdrop', () => {
     it('should remove "show" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const elem = instance._getElement()
 
@@ -117,8 +111,7 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not try to remove Node on remove method', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
       const spy = spyOn(instance, 'dispose').and.callThrough()
@@ -142,8 +135,7 @@ describe('Backdrop', () => {
       const instance = new Backdrop({
         isVisible: true,
         isAnimated: true,
-        rootElement: wrapper,
-        backdropClassName: CLASS_NAME_BACKDROP
+        rootElement: wrapper
       })
 
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
@@ -165,7 +157,6 @@ describe('Backdrop', () => {
       const instance = new Backdrop({
         isVisible: true,
         isAnimated: false,
-        backdropClassName: CLASS_NAME_BACKDROP,
         clickCallback: () => spy()
       })
       const endTest = () => {
@@ -188,8 +179,7 @@ describe('Backdrop', () => {
     it('if it is animated, should show and hide backdrop after counting transition duration', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const spy2 = jasmine.createSpy('spy2')
 
@@ -212,8 +202,7 @@ describe('Backdrop', () => {
       const spy = jasmine.createSpy('spy', getTransitionDurationFromElement)
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: false,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: false
       })
       const spy2 = jasmine.createSpy('spy2')
 
@@ -230,8 +219,7 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not call delay callbacks', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+        isAnimated: true
       })
       const spy = jasmine.createSpy('spy', getTransitionDurationFromElement)
 
@@ -242,49 +230,62 @@ describe('Backdrop', () => {
       })
     })
   })
-
-  describe('rootElement initialization', () => {
-    it('Should be appended on "document.body" by default', done => {
-      const instance = new Backdrop({
-        isVisible: true,
-        backdropClassName: CLASS_NAME_BACKDROP
+  describe('Config', () => {
+    describe('rootElement initialization', () => {
+      it('Should be appended on "document.body" by default', done => {
+        const instance = new Backdrop({
+          isVisible: true
+        })
+        const getElement = () => document.querySelector(CLASS_BACKDROP)
+        instance.show(() => {
+          expect(getElement().parentElement).toEqual(document.body)
+          done()
+        })
       })
-      const getElement = () => document.querySelector(CLASS_BACKDROP)
-      instance.show(() => {
-        expect(getElement().parentElement).toEqual(document.body)
-        done()
+
+      it('Should find the rootElement if passed as a string', done => {
+        const instance = new Backdrop({
+          isVisible: true,
+          rootElement: 'body'
+        })
+        const getElement = () => document.querySelector(CLASS_BACKDROP)
+        instance.show(() => {
+          expect(getElement().parentElement).toEqual(document.body)
+          done()
+        })
+      })
+
+      it('Should appended on any element given by the proper config', done => {
+        fixtureEl.innerHTML = [
+          '<div id="wrapper">',
+          '</div>'
+        ].join('')
+
+        const wrapper = fixtureEl.querySelector('#wrapper')
+        const instance = new Backdrop({
+          isVisible: true,
+          rootElement: wrapper
+        })
+        const getElement = () => document.querySelector(CLASS_BACKDROP)
+        instance.show(() => {
+          expect(getElement().parentElement).toEqual(wrapper)
+          done()
+        })
       })
     })
 
-    it('Should find the rootElement if passed as a string', done => {
-      const instance = new Backdrop({
-        isVisible: true,
-        rootElement: 'body',
-        backdropClassName: CLASS_NAME_BACKDROP
-      })
-      const getElement = () => document.querySelector(CLASS_BACKDROP)
-      instance.show(() => {
-        expect(getElement().parentElement).toEqual(document.body)
-        done()
-      })
-    })
-
-    it('Should appended on any element given by the proper config', done => {
-      fixtureEl.innerHTML = [
-        '<div id="wrapper">',
-        '</div>'
-      ].join('')
-
-      const wrapper = fixtureEl.querySelector('#wrapper')
-      const instance = new Backdrop({
-        isVisible: true,
-        rootElement: wrapper,
-        backdropClassName: CLASS_NAME_BACKDROP
-      })
-      const getElement = () => document.querySelector(CLASS_BACKDROP)
-      instance.show(() => {
-        expect(getElement().parentElement).toEqual(wrapper)
-        done()
+    describe('ClassName', () => {
+      it('Should be able to have different classNames than default', done => {
+        const instance = new Backdrop({
+          isVisible: true,
+          className: 'foo'
+        })
+        const getElement = () => document.querySelector('.foo')
+        instance.show(() => {
+          expect(getElement()).toEqual(instance._getElement())
+          instance.dispose()
+          done()
+        })
       })
     })
   })

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -3,6 +3,7 @@ import { getTransitionDurationFromElement } from '../../../src/util/index'
 import { clearFixture, getFixture } from '../../helpers/fixture'
 
 const CLASS_BACKDROP = '.modal-backdrop'
+const CLASS_NAME_BACKDROP = 'modal-backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 
@@ -26,7 +27,8 @@ describe('Backdrop', () => {
     it('if it is "shown", should append the backdrop html once, on show, and contain "show" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: false
+        isAnimated: false,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -45,7 +47,8 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not append the backdrop html', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -59,7 +62,8 @@ describe('Backdrop', () => {
     it('if it is "shown" and "animated", should append the backdrop html once, and contain "fade" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
 
@@ -79,7 +83,8 @@ describe('Backdrop', () => {
     it('should remove the backdrop html', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
 
       const getElements = () => document.body.querySelectorAll(CLASS_BACKDROP)
@@ -97,7 +102,8 @@ describe('Backdrop', () => {
     it('should remove "show" class', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const elem = instance._getElement()
 
@@ -111,7 +117,8 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not try to remove Node on remove method', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
       const spy = spyOn(instance, 'dispose').and.callThrough()
@@ -135,7 +142,8 @@ describe('Backdrop', () => {
       const instance = new Backdrop({
         isVisible: true,
         isAnimated: true,
-        rootElement: wrapper
+        rootElement: wrapper,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
 
       const getElements = () => document.querySelectorAll(CLASS_BACKDROP)
@@ -157,6 +165,7 @@ describe('Backdrop', () => {
       const instance = new Backdrop({
         isVisible: true,
         isAnimated: false,
+        backdropClassName: CLASS_NAME_BACKDROP,
         clickCallback: () => spy()
       })
       const endTest = () => {
@@ -179,7 +188,8 @@ describe('Backdrop', () => {
     it('if it is animated, should show and hide backdrop after counting transition duration', done => {
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const spy2 = jasmine.createSpy('spy2')
 
@@ -202,7 +212,8 @@ describe('Backdrop', () => {
       const spy = jasmine.createSpy('spy', getTransitionDurationFromElement)
       const instance = new Backdrop({
         isVisible: true,
-        isAnimated: false
+        isAnimated: false,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const spy2 = jasmine.createSpy('spy2')
 
@@ -219,7 +230,8 @@ describe('Backdrop', () => {
     it('if it is not "shown", should not call delay callbacks', done => {
       const instance = new Backdrop({
         isVisible: false,
-        isAnimated: true
+        isAnimated: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const spy = jasmine.createSpy('spy', getTransitionDurationFromElement)
 
@@ -234,7 +246,8 @@ describe('Backdrop', () => {
   describe('rootElement initialization', () => {
     it('Should be appended on "document.body" by default', done => {
       const instance = new Backdrop({
-        isVisible: true
+        isVisible: true,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElement = () => document.querySelector(CLASS_BACKDROP)
       instance.show(() => {
@@ -246,7 +259,8 @@ describe('Backdrop', () => {
     it('Should find the rootElement if passed as a string', done => {
       const instance = new Backdrop({
         isVisible: true,
-        rootElement: 'body'
+        rootElement: 'body',
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElement = () => document.querySelector(CLASS_BACKDROP)
       instance.show(() => {
@@ -264,7 +278,8 @@ describe('Backdrop', () => {
       const wrapper = fixtureEl.querySelector('#wrapper')
       const instance = new Backdrop({
         isVisible: true,
-        rootElement: wrapper
+        rootElement: wrapper,
+        backdropClassName: CLASS_NAME_BACKDROP
       })
       const getElement = () => document.querySelector(CLASS_BACKDROP)
       instance.show(() => {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -22,6 +22,7 @@
 
 // Components
 @import "mixins/alert";
+@import "mixins/backdrop";
 @import "mixins/buttons";
 @import "mixins/caret";
 @import "mixins/pagination";

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -85,17 +85,7 @@
 
 // Modal background
 .modal-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: $zindex-modal-backdrop;
-  width: 100vw;
-  height: 100vh;
-  background-color: $modal-backdrop-bg;
-
-  // Fade for backdrop
-  &.fade { opacity: 0; }
-  &.show { opacity: $modal-backdrop-opacity; }
+  @include overlay-backdrop($zindex-modal-backdrop, $modal-backdrop-bg, $modal-backdrop-opacity);
 }
 
 // Modal header

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -98,10 +98,6 @@
   &.show { opacity: $modal-backdrop-opacity; }
 }
 
-.offcanvas-backdrop {
-  @extend .modal-backdrop;
-}
-
 // Modal header
 // Top section of the modal w/ title and dismiss
 .modal-header {

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -98,6 +98,10 @@
   &.show { opacity: $modal-backdrop-opacity; }
 }
 
+.offcanvas-backdrop {
+  @extend .modal-backdrop;
+}
+
 // Modal header
 // Top section of the modal w/ title and dismiss
 .modal-header {

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -14,6 +14,10 @@
   @include transition(transform $offcanvas-transition-duration ease-in-out);
 }
 
+.offcanvas-backdrop {
+  @include overlay-backdrop($zindex-offcanvas, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
+}
+
 .offcanvas-header {
   display: flex;
   align-items: center;

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -14,6 +14,10 @@
   @include transition(transform $offcanvas-transition-duration ease-in-out);
 }
 
+.offcanvas-backdrop {
+  @extend .modal-backdrop;
+}
+
 .offcanvas-header {
   display: flex;
   align-items: center;

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -15,7 +15,7 @@
 }
 
 .offcanvas-backdrop {
-  @include overlay-backdrop($zindex-offcanvas, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
+  @include overlay-backdrop(subtract($zindex-offcanvas, 1), $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
 }
 
 .offcanvas-header {

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -14,10 +14,6 @@
   @include transition(transform $offcanvas-transition-duration ease-in-out);
 }
 
-.offcanvas-backdrop {
-  @extend .modal-backdrop;
-}
-
 .offcanvas-header {
   display: flex;
   align-items: center;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1453,6 +1453,8 @@ $offcanvas-title-line-height:       $modal-title-line-height !default;
 $offcanvas-bg-color:                $modal-content-bg !default;
 $offcanvas-color:                   $modal-content-color !default;
 $offcanvas-box-shadow:              $modal-content-box-shadow-xs !default;
+$offcanvas-backdrop-bg:             $modal-backdrop-bg !default;
+$offcanvas-backdrop-opacity:        $modal-backdrop-opacity !default;
 // scss-docs-end offcanvas-variables
 
 // Code

--- a/scss/mixins/_backdrop.scss
+++ b/scss/mixins/_backdrop.scss
@@ -3,12 +3,12 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: $zindex-modal-backdrop;
+  z-index: $zindex;
   width: 100vw;
   height: 100vh;
-  background-color: $modal-backdrop-bg;
+  background-color: $backdrop-bg;
 
   // Fade for backdrop
   &.fade { opacity: 0; }
-  &.show { opacity: $modal-backdrop-opacity; }
+  &.show { opacity: $backdrop-opacity; }
 }

--- a/scss/mixins/_backdrop.scss
+++ b/scss/mixins/_backdrop.scss
@@ -1,0 +1,14 @@
+// Shared between modals and offcanvases
+@mixin overlay-backdrop($zindex, $backdrop-bg, $backdrop-opacity) {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: $zindex-modal-backdrop;
+  width: 100vw;
+  height: 100vh;
+  background-color: $modal-backdrop-bg;
+
+  // Fade for backdrop
+  &.fade { opacity: 0; }
+  &.show { opacity: $modal-backdrop-opacity; }
+}


### PR DESCRIPTION
To resolve #34094, create a new class `offcanvas-backdrop` which extends `modal-backdrop`. It helps avoid confusion if an offcanvas and a modal is open and two backdrop are shown.