### PR TITLE
Wrong secondary hex code in docs

### DIFF
--- a/site/data/theme-colors.yml
+++ b/site/data/theme-colors.yml
@@ -1,7 +1,7 @@
 - name: primary
   hex: "#007bff"
 - name: secondary
-  hex: "#868e96"
+  hex: "#6c757d"
 - name: success
   hex: "#28a745"
 - name: danger


### PR DESCRIPTION
Closes #34146 

---

Not sure what happened but indeed, [our current `$secondary` is not what's shown in docs](https://github.com/twbs/bootstrap/blob/c2f949c1fdad09e30793b533e5502808c5e2d423/scss/_variables.scss#L68).

Preview: https://deploy-preview-34159--twbs-bootstrap.netlify.app/docs/4.6/getting-started/theming/#theme-colors