### PR TITLE
img in horizontal card

### DIFF
--- a/site/content/docs/5.0/components/card.md
+++ b/site/content/docs/5.0/components/card.md
@@ -398,7 +398,7 @@ Using a combination of grid and utility classes, cards can be made horizontal in
 <div class="card mb-3" style="max-width: 540px;">
   <div class="row g-0">
     <div class="col-md-4">
-      {{< placeholder width="100%" height="250" text="Image" >}}
+      {{< placeholder width="100%" height="250" text="Image" class="img-fluid rounded-start">}}
     </div>
     <div class="col-md-8">
       <div class="card-body">

--- a/site/content/docs/5.0/components/card.md
+++ b/site/content/docs/5.0/components/card.md
@@ -398,7 +398,7 @@ Using a combination of grid and utility classes, cards can be made horizontal in
 <div class="card mb-3" style="max-width: 540px;">
   <div class="row g-0">
     <div class="col-md-4">
-      {{< placeholder width="100%" height="250" text="Image" class="img-fluid rounded-start">}}
+      {{< placeholder width="100%" height="250" text="Image" class="img-fluid rounded-start" >}}
     </div>
     <div class="col-md-8">
       <div class="card-body">


### PR DESCRIPTION
Closes #34145 

Simply adds `img-fluid` and `rounded-start` classes to horizontal card example to ensure copy-pasting from the docs matches the expectation.

Preview: https://deploy-preview-34159--twbs-bootstrap.netlify.app/docs/4.6/getting-started/theming/#theme-colors