### PR TITLE
fix(forms): unitless `line-height` for floating labels

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -859,7 +859,7 @@ $form-file-button-hover-bg:       shade-color($form-file-button-bg, 5%) !default
 
 // scss-docs-start form-floating-variables
 $form-floating-height:            add(3.5rem, $input-height-border) !default;
-$form-floating-line-height:       1.25rem !default;
+$form-floating-line-height:       1.25 !default;
 $form-floating-padding-x:         $input-padding-x !default;
 $form-floating-padding-y:         1rem !default;
 $form-floating-input-padding-t:   1.625rem !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -859,6 +859,7 @@ $form-file-button-hover-bg:       shade-color($form-file-button-bg, 5%) !default
 
 // scss-docs-start form-floating-variables
 $form-floating-height:            add(3.5rem, $input-height-border) !default;
+$form-floating-line-height:       1.25rem !default;
 $form-floating-padding-x:         $input-padding-x !default;
 $form-floating-padding-y:         1rem !default;
 $form-floating-input-padding-t:   1.625rem !default;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -4,6 +4,7 @@
   > .form-control,
   > .form-select {
     height: $form-floating-height;
+    line-height: $form-floating-line-height;
   }
 
   > label {


### PR DESCRIPTION
Fixes #32672

---

- Preview: https://deploy-preview-34161--twbs-bootstrap.netlify.app/docs/5.0/forms/floating-labels/
- Forked reduced test case with this PR's CSS: https://codepen.io/ffoodd/pen/GRWyBRj