### PR TITLE
fix accessibility issue on sidebars example

### DIFF
--- a/site/content/docs/5.0/examples/sidebars/index.html
+++ b/site/content/docs/5.0/examples/sidebars/index.html
@@ -195,22 +195,22 @@ body_class: ""
       </li>
       <li>
         <a href="#" class="nav-link py-3 border-bottom" title="Dashboard" data-bs-toggle="tooltip" data-bs-placement="right">
-          <svg class="bi" width="24" height="24"><use xlink:href="#speedometer2"/></svg>
+          <svg class="bi" width="24" height="24" role="img" aria-label="Dashboard"><use xlink:href="#speedometer2"/></svg>
         </a>
       </li>
       <li>
         <a href="#" class="nav-link py-3 border-bottom" title="Orders" data-bs-toggle="tooltip" data-bs-placement="right">
-          <svg class="bi" width="24" height="24"><use xlink:href="#table"/></svg>
+          <svg class="bi" width="24" height="24" role="img" aria-label="Orders"><use xlink:href="#table"/></svg>
         </a>
       </li>
       <li>
         <a href="#" class="nav-link py-3 border-bottom" title="Products" data-bs-toggle="tooltip" data-bs-placement="right">
-          <svg class="bi" width="24" height="24"><use xlink:href="#grid"/></svg>
+          <svg class="bi" width="24" height="24" role="img" aria-label="Products"><use xlink:href="#grid"/></svg>
         </a>
       </li>
       <li>
         <a href="#" class="nav-link py-3 border-bottom" title="Customers" data-bs-toggle="tooltip" data-bs-placement="right">
-          <svg class="bi" width="24" height="24"><use xlink:href="#people-circle"/></svg>
+          <svg class="bi" width="24" height="24" role="img" aria-label="Customers"><use xlink:href="#people-circle"/></svg>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
On sidebar sample with icons only `img`role and `aria-label` were missing on dashboard, orders, products and customers so just reproduce the solution used for the home svg