### PR TITLE
Do a major cleanup in Collapse.js

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -113,7 +113,7 @@ class Collapse extends BaseComponent {
   // Public
 
   toggle() {
-    if (this._element.classList.contains(CLASS_NAME_SHOW)) {
+    if (this._isShown()) {
       this.hide()
     } else {
       this.show()
@@ -121,7 +121,7 @@ class Collapse extends BaseComponent {
   }
 
   show() {
-    if (this._isTransitioning || this._element.classList.contains(CLASS_NAME_SHOW)) {
+    if (this._isTransitioning || this._isShown()) {
       return
     }
 
@@ -184,15 +184,15 @@ class Collapse extends BaseComponent {
       })
     }
 
-    this.setTransitioning(true)
+    this._isTransitioning = true
 
     const complete = () => {
+      this._isTransitioning = false
+
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
 
       this._element.style[dimension] = ''
-
-      this.setTransitioning(false)
 
       EventHandler.trigger(this._element, EVENT_SHOWN)
     }
@@ -205,7 +205,7 @@ class Collapse extends BaseComponent {
   }
 
   hide() {
-    if (this._isTransitioning || !this._element.classList.contains(CLASS_NAME_SHOW)) {
+    if (this._isTransitioning || !this._isShown()) {
       return
     }
 
@@ -229,17 +229,17 @@ class Collapse extends BaseComponent {
         const trigger = this._triggerArray[i]
         const elem = getElementFromSelector(trigger)
 
-        if (elem && !elem.classList.contains(CLASS_NAME_SHOW)) {
+        if (elem && !this._isShown(elem)) {
           trigger.classList.add(CLASS_NAME_COLLAPSED)
           trigger.setAttribute('aria-expanded', false)
         }
       }
     }
 
-    this.setTransitioning(true)
+    this._isTransitioning = true
 
     const complete = () => {
-      this.setTransitioning(false)
+      this._isTransitioning = false
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE)
       EventHandler.trigger(this._element, EVENT_HIDDEN)
@@ -250,8 +250,8 @@ class Collapse extends BaseComponent {
     this._queueCallback(complete, this._element, true)
   }
 
-  setTransitioning(isTransitioning) {
-    this._isTransitioning = isTransitioning
+  _isShown(element = this._element) {
+    return element.classList.contains(CLASS_NAME_SHOW)
   }
 
   // Private
@@ -296,7 +296,7 @@ class Collapse extends BaseComponent {
       return
     }
 
-    const isOpen = element.classList.contains(CLASS_NAME_SHOW)
+    const isOpen = this._isShown(element)
 
     triggerArray.forEach(elem => {
       if (isOpen) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -347,26 +347,16 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
     event.preventDefault()
   }
 
-  const triggerData = Manipulator.getDataAttributes(this)
   const selector = getSelectorFromElement(this)
   const selectorElements = SelectorEngine.find(selector)
 
   selectorElements.forEach(element => {
     const data = Collapse.getInstance(element)
-    let config
     if (data) {
-      // update parent attribute
-      if (data._parent === null && typeof triggerData.parent === 'string') {
-        data._config.parent = triggerData.parent
-        data._parent = data._getParent()
-      }
-
-      config = 'toggle'
+      data.toggle()
     } else {
-      config = triggerData
+      Collapse.getOrCreateInstance(element)
     }
-
-    Collapse.collapseInterface(element, config)
   })
 })
 

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -322,12 +322,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   const selectorElements = SelectorEngine.find(selector)
 
   selectorElements.forEach(element => {
-    const data = Collapse.getInstance(element)
-    if (data) {
-      data.toggle()
-    } else {
-      Collapse.getOrCreateInstance(element)
-    }
+    Collapse.getOrCreateInstance(element, { toggle: false }).toggle()
   })
 })
 

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -259,6 +259,7 @@ class Collapse extends BaseComponent {
   _getConfig(config) {
     config = {
       ...Default,
+      ...Manipulator.getDataAttributes(this._element),
       ...config
     }
     config.toggle = Boolean(config.toggle) // Coerce string values
@@ -311,20 +312,12 @@ class Collapse extends BaseComponent {
   // Static
 
   static collapseInterface(element, config) {
-    let data = Collapse.getInstance(element)
-    const _config = {
-      ...Default,
-      ...Manipulator.getDataAttributes(element),
-      ...(typeof config === 'object' && config ? config : {})
-    }
-
-    if (!data && _config.toggle && typeof config === 'string' && /show|hide/.test(config)) {
+    const _config = {}
+    if (typeof config === 'string' && /show|hide/.test(config)) {
       _config.toggle = false
     }
 
-    if (!data) {
-      data = new Collapse(element, _config)
-    }
+    const data = Collapse.getOrCreateInstance(element, _config)
 
     if (typeof config === 'string') {
       if (typeof data[config] === 'undefined') {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -92,7 +92,7 @@ class Collapse extends BaseComponent {
     this._parent = this._config.parent ? this._getParent() : null
 
     if (!this._config.parent) {
-      this._addAriaAndCollapsedClass(this._element, this._triggerArray)
+      this._addAriaAndCollapsedClass(this._triggerArray, this._isShown())
     }
 
     if (this._config.toggle) {
@@ -177,13 +177,7 @@ class Collapse extends BaseComponent {
 
     this._element.style[dimension] = 0
 
-    if (this._triggerArray.length) {
-      this._triggerArray.forEach(element => {
-        element.classList.remove(CLASS_NAME_COLLAPSED)
-        element.setAttribute('aria-expanded', true)
-      })
-    }
-
+    this._addAriaAndCollapsedClass(this._triggerArray, true)
     this._isTransitioning = true
 
     const complete = () => {
@@ -224,15 +218,12 @@ class Collapse extends BaseComponent {
     this._element.classList.remove(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
 
     const triggerArrayLength = this._triggerArray.length
-    if (triggerArrayLength > 0) {
-      for (let i = 0; i < triggerArrayLength; i++) {
-        const trigger = this._triggerArray[i]
-        const elem = getElementFromSelector(trigger)
+    for (let i = 0; i < triggerArrayLength; i++) {
+      const trigger = this._triggerArray[i]
+      const elem = getElementFromSelector(trigger)
 
-        if (elem && !this._isShown(elem)) {
-          trigger.classList.add(CLASS_NAME_COLLAPSED)
-          trigger.setAttribute('aria-expanded', false)
-        }
+      if (elem && !this._isShown(elem)) {
+        this._addAriaAndCollapsedClass([trigger], false)
       }
     }
 
@@ -282,21 +273,18 @@ class Collapse extends BaseComponent {
       .forEach(element => {
         const selected = getElementFromSelector(element)
 
-        this._addAriaAndCollapsedClass(
-          selected,
-          [element]
-        )
+        if (selected) {
+          this._addAriaAndCollapsedClass([element], this._isShown(selected))
+        }
       })
 
     return parent
   }
 
-  _addAriaAndCollapsedClass(element, triggerArray) {
-    if (!element || !triggerArray.length) {
+  _addAriaAndCollapsedClass(triggerArray, isOpen) {
+    if (!triggerArray.length) {
       return
     }
-
-    const isOpen = this._isShown(element)
 
     triggerArray.forEach(elem => {
       if (isOpen) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -129,14 +129,8 @@ class Collapse extends BaseComponent {
     let activesData
 
     if (this._parent) {
-      actives = SelectorEngine.find(SELECTOR_ACTIVES, this._parent)
-        .filter(elem => {
-          if (typeof this._config.parent === 'string') {
-            return elem.getAttribute('data-bs-parent') === this._config.parent
-          }
-
-          return elem.classList.contains(CLASS_NAME_COLLAPSE)
-        })
+      const children = SelectorEngine.find(`.${CLASS_NAME_COLLAPSE} .${CLASS_NAME_COLLAPSE}`, this._parent)
+      actives = SelectorEngine.find(SELECTOR_ACTIVES, this._parent).filter(elem => !children.includes(elem)) // remove children if greater depth
     }
 
     const container = SelectorEngine.findOne(this._selector)

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -32,12 +32,12 @@ const DATA_API_KEY = '.data-api'
 
 const Default = {
   toggle: true,
-  parent: ''
+  parent: null
 }
 
 const DefaultType = {
   toggle: 'boolean',
-  parent: '(string|element)'
+  parent: '(null|element)'
 }
 
 const EVENT_SHOW = `show${EVENT_KEY}`
@@ -86,7 +86,7 @@ class Collapse extends BaseComponent {
       }
     }
 
-    this._parent = this._config.parent ? this._getParent() : null
+    this._initializeChildren()
 
     if (!this._config.parent) {
       this._addAriaAndCollapsedClass(this._triggerArray, this._isShown())
@@ -125,9 +125,9 @@ class Collapse extends BaseComponent {
     let actives = []
     let activesData
 
-    if (this._parent) {
-      const children = SelectorEngine.find(`.${CLASS_NAME_COLLAPSE} .${CLASS_NAME_COLLAPSE}`, this._parent)
-      actives = SelectorEngine.find(SELECTOR_ACTIVES, this._parent).filter(elem => !children.includes(elem)) // remove children if greater depth
+    if (this._config.parent) {
+      const children = SelectorEngine.find(`.${CLASS_NAME_COLLAPSE} .${CLASS_NAME_COLLAPSE}`, this._config.parent)
+      actives = SelectorEngine.find(SELECTOR_ACTIVES, this._config.parent).filter(elem => !children.includes(elem)) // remove children if greater depth
     }
 
     const container = SelectorEngine.findOne(this._selector)
@@ -239,6 +239,7 @@ class Collapse extends BaseComponent {
       ...config
     }
     config.toggle = Boolean(config.toggle) // Coerce string values
+    config.parent = getElement(config.parent)
     typeCheckConfig(NAME, config, DefaultType)
     return config
   }
@@ -247,14 +248,13 @@ class Collapse extends BaseComponent {
     return this._element.classList.contains(CLASS_NAME_HORIZONTAL) ? WIDTH : HEIGHT
   }
 
-  _getParent() {
-    let { parent } = this._config
+  _initializeChildren() {
+    if (!this._config.parent) {
+      return
+    }
 
-    parent = getElement(parent)
-
-    const selector = `${SELECTOR_DATA_TOGGLE}[data-bs-parent="${parent}"]`
-
-    SelectorEngine.find(selector, parent)
+    const children = SelectorEngine.find(`.${CLASS_NAME_COLLAPSE} .${CLASS_NAME_COLLAPSE}`, this._config.parent)
+    SelectorEngine.find(SELECTOR_DATA_TOGGLE, this._config.parent).filter(elem => !children.includes(elem))
       .forEach(element => {
         const selected = getElementFromSelector(element)
 
@@ -262,8 +262,6 @@ class Collapse extends BaseComponent {
           this._addAriaAndCollapsedClass([element], this._isShown(selected))
         }
       })
-
-    return parent
   }
 
   _addAriaAndCollapsedClass(triggerArray, isOpen) {

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -147,7 +147,7 @@ class Collapse extends BaseComponent {
 
     actives.forEach(elemActive => {
       if (container !== elemActive) {
-        Collapse.collapseInterface(elemActive, 'hide')
+        Collapse.getOrCreateInstance(elemActive, { toggle: false }).hide()
       }
 
       if (!activesData) {
@@ -282,26 +282,22 @@ class Collapse extends BaseComponent {
 
   // Static
 
-  static collapseInterface(element, config) {
-    const _config = {}
-    if (typeof config === 'string' && /show|hide/.test(config)) {
-      _config.toggle = false
-    }
-
-    const data = Collapse.getOrCreateInstance(element, _config)
-
-    if (typeof config === 'string') {
-      if (typeof data[config] === 'undefined') {
-        throw new TypeError(`No method named "${config}"`)
-      }
-
-      data[config]()
-    }
-  }
-
   static jQueryInterface(config) {
     return this.each(function () {
-      Collapse.collapseInterface(this, config)
+      const _config = {}
+      if (typeof config === 'string' && /show|hide/.test(config)) {
+        _config.toggle = false
+      }
+
+      const data = Collapse.getOrCreateInstance(this, _config)
+
+      if (typeof config === 'string') {
+        if (typeof data[config] === 'undefined') {
+          throw new TypeError(`No method named "${config}"`)
+        }
+
+        data[config]()
+      }
     })
   }
 }

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -125,7 +125,7 @@ class Collapse extends BaseComponent {
       return
     }
 
-    let actives
+    let actives = []
     let activesData
 
     if (this._parent) {
@@ -137,14 +137,10 @@ class Collapse extends BaseComponent {
 
           return elem.classList.contains(CLASS_NAME_COLLAPSE)
         })
-
-      if (actives.length === 0) {
-        actives = null
-      }
     }
 
     const container = SelectorEngine.findOne(this._selector)
-    if (actives) {
+    if (actives.length) {
       const tempActiveData = actives.find(elem => container !== elem)
       activesData = tempActiveData ? Collapse.getInstance(tempActiveData) : null
 
@@ -158,17 +154,15 @@ class Collapse extends BaseComponent {
       return
     }
 
-    if (actives) {
-      actives.forEach(elemActive => {
-        if (container !== elemActive) {
-          Collapse.collapseInterface(elemActive, 'hide')
-        }
+    actives.forEach(elemActive => {
+      if (container !== elemActive) {
+        Collapse.collapseInterface(elemActive, 'hide')
+      }
 
-        if (!activesData) {
-          Data.set(elemActive, DATA_KEY, null)
-        }
-      })
-    }
+      if (!activesData) {
+        Data.set(elemActive, DATA_KEY, null)
+      }
+    })
 
     const dimension = this._getDimension()
 

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -70,10 +70,7 @@ class Collapse extends BaseComponent {
 
     this._isTransitioning = false
     this._config = this._getConfig(config)
-    this._triggerArray = SelectorEngine.find(
-      `${SELECTOR_DATA_TOGGLE}[href="#${this._element.id}"],` +
-      `${SELECTOR_DATA_TOGGLE}[data-bs-target="#${this._element.id}"]`
-    )
+    this._triggerArray = []
 
     const toggleList = SelectorEngine.find(SELECTOR_DATA_TOGGLE)
 

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -65,8 +65,7 @@ describe('Collapse', () => {
         parent: fakejQueryObject
       })
 
-      expect(collapse._config.parent).toEqual(fakejQueryObject)
-      expect(collapse._getParent()).toEqual(myCollapseEl)
+      expect(collapse._config.parent).toEqual(myCollapseEl)
     })
 
     it('should allow non jquery object in parent config', () => {
@@ -104,8 +103,7 @@ describe('Collapse', () => {
         parent: 'div.my-collapse'
       })
 
-      expect(collapse._config.parent).toEqual('div.my-collapse')
-      expect(collapse._getParent()).toEqual(myCollapseEl)
+      expect(collapse._config.parent).toEqual(myCollapseEl)
     })
   })
 


### PR DESCRIPTION
* streamline `_getConfig` & interface
* Remove redundant check on `data-toggle` click, as it was assuming that trigger element would own separate config than the collapse itself (wasn't documented)
* Use helper function to check show 
* Remove helper for `isTransitioning`
* Use `forEach` for all iterations 
* refactor privatef unction to use it in more cases
* initialize array variable properly
* Simplify check for children and make it generic
* remove duplicated `Selector.find`
* keep parent only as element
* simplify initialization on `data-toggle` click
* transfer interface inside jQueryInterface 


### NOTE for reviewers:
Better review it, commit by commit. It will help you with the proper message and will guide you with sanity to follow the logic 


Closes #34408