### PR TITLE
docs(style): fix display of nested `<ul><li>`

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -22,12 +22,12 @@
   > ol li {
     margin-bottom: .25rem;
 
-    // stylelint-disable selector-max-type
-    > ul {
+    // stylelint-disable selector-max-type, selector-max-compound-selectors
+    > p ~ ul {
       margin-top: -.5rem;
       margin-bottom: 1rem;
     }
-    // stylelint-enable selector-max-type
+    // stylelint-enable selector-max-type, selector-max-compound-selectors
   }
 
   // Override Bootstrap defaults


### PR DESCRIPTION
From what I understand, this rule has been created in order to improve the migration guide.

But it has also an impact on the display of [Reboot > Page defaults](https://getbootstrap.com/docs/5.0/content/reboot/#page-defaults) where the sentence "No base[...]" is too close to "The box-sizing".

It is more obvious in our [fork of Bootstrap](https://boosted.orange.com/docs/5.0/content/reboot/#page-defaults).

This PR propose to specify a bit more the selector to match only the specific case in the migration guide.