### PR TITLE
Removed check for _isTransitioning in Modal hide method

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -148,7 +148,7 @@ class Modal extends BaseComponent {
       event.preventDefault()
     }
 
-    if (!this._isShown || this._isTransitioning) {
+    if (!this._isShown) {
       return
     }
 


### PR DESCRIPTION
This is a solution to hide() method not working when fade css class is used. It is unnecessary to check whether the modal is transitioning before hiding the modal.
Issue: https://github.com/twbs/bootstrap/issues/34213