### PR TITLE
Improve `divide()` function

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -242,5 +242,5 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
   @if $remainder > 0 and $precision > 0 {
     $remainder: divide($remainder * 10, $divisor, $precision - 1) * .1;
   }
-  @return ($quotient + $remainder) * $sign;
+  @return ($quotient + if($precision > 0, $remainder, if($remainder * 10 >= $divisor * 5, 1, 0))) * $sign;
 }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -29,7 +29,7 @@
 @mixin make-col($size: false, $columns: $grid-columns) {
   @if $size {
     flex: 0 0 auto;
-    width: percentage(divide($size, $columns));
+    width: percentage(divide($size, $columns, 12));
 
   } @else {
     flex: 1 1 0;
@@ -55,7 +55,7 @@
 @mixin row-cols($count) {
   > * {
     flex: 0 0 auto;
-    width: divide(100%, $count);
+    width: percentage(divide(1, $count, 12));
   }
 }
 


### PR DESCRIPTION
Thanks to @alpadev for the improvements! The diff for our grid classes should now be nullified with proper rounding across the board.