### PR TITLE
Add row-gap and column-gap utils

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -231,6 +231,18 @@ $utilities: map-merge(
       class: gap,
       values: $spacers
     ),
+    "row-gap": (
+      responsive: true,
+      property: row-gap,
+      class: row-gap,
+      values: $spacers
+    ),
+    "column-gap": (
+      responsive: true,
+      property: column-gap,
+      class: column-gap,
+      values: $spacers
+    ),
     "justify-content": (
       responsive: true,
       property: justify-content,

--- a/site/content/docs/5.0/utilities/spacing.md
+++ b/site/content/docs/5.0/utilities/spacing.md
@@ -111,6 +111,7 @@ When using `display: grid`, you can make use of `gap` utilities on the parent gr
 Support includes responsive options for all of Bootstrap's grid breakpoints, as well as six sizes from the `$spacers` map (`0`–`5`). There is no `.gap-auto` utility class as it's effectively the same as `.gap-0`.
 
 Also, you can use `.row-gap-*` and `.column-gap-*` to specify gaps for rows and columns separately.
+
 {{< example html >}}
 <div class="d-grid row-gap-2 column-gap-3" style="grid-template-columns: 1fr 2fr;">
   <div class="p-2 bg-light border">Grid item 1</div>

--- a/site/content/docs/5.0/utilities/spacing.md
+++ b/site/content/docs/5.0/utilities/spacing.md
@@ -110,6 +110,16 @@ When using `display: grid`, you can make use of `gap` utilities on the parent gr
 
 Support includes responsive options for all of Bootstrap's grid breakpoints, as well as six sizes from the `$spacers` map (`0`–`5`). There is no `.gap-auto` utility class as it's effectively the same as `.gap-0`.
 
+Also, you can use `.row-gap-*` and `.column-gap-*` to specify gaps for rows and columns separately.
+{{< example html >}}
+<div class="d-grid row-gap-2 column-gap-3" style="grid-template-columns: 1fr 2fr;">
+  <div class="p-2 bg-light border">Grid item 1</div>
+  <div class="p-2 bg-light border">Grid item 2</div>
+  <div class="p-2 bg-light border">Grid item 3</div>
+  <div class="p-2 bg-light border">Grid item 4</div>
+</div>
+{{< /example >}}
+
 ## Sass
 
 ### Maps


### PR DESCRIPTION
Add row-gap and column-gap utils in addition to the existing gap utils

Fixes #34314

![gap-utils](https://user-images.githubusercontent.com/47745140/122777238-6be9f700-d2de-11eb-8ebf-e5e0824a5b8b.JPG)
