### PR TITLE
Use JSON.parse in dropdown.js for passing JSON as data attribute

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -266,10 +266,10 @@ class Dropdown extends BaseComponent {
       ...Manipulator.getDataAttributes(this._element),
       ...config
     }
-    
+
     if (typeof config.popperConfig === 'string') {
       try {
-        config.popperConfig = JSON.parse(popperConfigHolder)
+        config.popperConfig = JSON.parse(config.popperConfig)
       } catch {
         // we swallow the JSON.parse error here, because it will be caught by the typeCheckConfig below
       }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -266,6 +266,14 @@ class Dropdown extends BaseComponent {
       ...Manipulator.getDataAttributes(this._element),
       ...config
     }
+    
+    if (typeof config.popperConfig === 'string') {
+      try {
+        config.popperConfig = JSON.parse(popperConfigHolder)
+      } catch {
+        // we swallow the JSON.parse error here, because it will be caught by the typeCheckConfig below
+      }
+    }
 
     typeCheckConfig(NAME, config, this.constructor.DefaultType)
 

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -674,6 +674,14 @@ class Tooltip extends BaseComponent {
       config.content = config.content.toString()
     }
 
+    if (typeof config.popperConfig === 'string') {
+      try {
+        config.popperConfig = JSON.parse(config.popperConfig)
+      } catch {
+        // we swallow the JSON.parse error here, because it will be caught by the typeCheckConfig below
+      }
+    }
+
     typeCheckConfig(NAME, config, this.constructor.DefaultType)
 
     if (config.sanitize) {

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -1078,7 +1078,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>
         <p>To change Bootstrap's default Popper config, see <a href="https://popper.js.org/docs/v2/constructors/#options">Popper's configuration</a>.</p>
         <p>When a function is used to create the Popper configuration, it's called with an object that contains the Bootstrap's default Popper configuration. It helps you use and merge the default with your own configuration. The function must return a configuration object for Popper.</p>
-        <p>Note that if you pass a string value, Bootstrap will attempt to JSON.parse the value into an object</p>
+        <p>Note that if you pass a string value, Bootstrap will attempt to JSON.parse the value into an object.</p>
       </td>
     </tr>
   </tbody>

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -1078,6 +1078,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
       <td>
         <p>To change Bootstrap's default Popper config, see <a href="https://popper.js.org/docs/v2/constructors/#options">Popper's configuration</a>.</p>
         <p>When a function is used to create the Popper configuration, it's called with an object that contains the Bootstrap's default Popper configuration. It helps you use and merge the default with your own configuration. The function must return a configuration object for Popper.</p>
+        <p>Note that if you pass a string value, Bootstrap will attempt to JSON.parse the value into an object</p>
       </td>
     </tr>
   </tbody>

--- a/site/content/docs/5.0/components/tooltips.md
+++ b/site/content/docs/5.0/components/tooltips.md
@@ -315,6 +315,7 @@ Note that for security reasons the `sanitize`, `sanitizeFn`, and `allowList` opt
       <td>
         <p>To change Bootstrap's default Popper config, see <a href="https://popper.js.org/docs/v2/constructors/#options">Popper's configuration</a>.</p>
         <p>When a function is used to create the Popper configuration, it's called with an object that contains the Bootstrap's default Popper configuration. It helps you use and merge the default with your own configuration. The function must return a configuration object for Popper.</p>
+        <p>Note that if you pass a string value, Bootstrap will attempt to JSON.parse the value into an object.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
@GeoSot

1. There is literally only a try catch around a JSON.parse, before the config types are checked. I don't think it should be abstracted out at this point. Too simple.
2. I did not throw an error, since it happens before "DefaultType" check as you mentioned, so the "DefaultType" check catches any errors anyway. So, I'm swallowing JSON.parse errors as before
3. I'm not really sure this needs major testing, it's fairly straightforward to me, but let me know.

I guess the only question I have now is, is it worth it to Bootstrap author to include this? As a reminder, the whole point of this PR was to get popper to expose "strategy" parameter, which, IMO, is a commonly used parameter for popper integrations to escape overflow problems. Certainly this PR allows for more options, and it is fairly simple in code addition. I went ahead and added the same configuration to the only other component I saw using popper, tooltip.js