### PR TITLE
Remove unneeded `.text-white-50` CSS rule from Offcanvas Example

### DIFF
--- a/site/content/docs/5.0/examples/offcanvas-navbar/offcanvas.css
+++ b/site/content/docs/5.0/examples/offcanvas-navbar/offcanvas.css
@@ -62,6 +62,6 @@ body {
   color: #343a40;
 }
 
-.text-white-50 { color: rgba(255, 255, 255, .5); }
-
-.bg-purple { background-color: #6f42c1; }
+.bg-purple {
+  background-color: #6f42c1;
+}


### PR DESCRIPTION
This is already part of Bootstrap 4.6 and 5.0
Also format the indentation `.bg-purple` rules to be consistent.

(this can be backported to the v4 https://getbootstrap.com/docs/4.6/examples/offcanvas/ CSS too)