### PR TITLE
form-select-disabled style modification

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -806,6 +806,7 @@ $form-select-bg-position:           right $form-select-padding-x center !default
 $form-select-bg-size:               16px 12px !default; // In pixels because image dimensions
 $form-select-indicator-color:       $gray-800 !default;
 $form-select-indicator:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>") !default;
+$form-select-disabled-opacity:        .5 !default;
 
 $form-select-feedback-icon-padding-end: $form-select-padding-x * 2.5 + $form-select-indicator-padding !default;
 $form-select-feedback-icon-position:    center right $form-select-indicator-padding !default;

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -15,15 +15,35 @@
   line-height: $form-select-line-height;
   color: $form-select-color;
   background-color: $form-select-bg;
-  background-image: escape-svg($form-select-indicator);
-  background-repeat: no-repeat;
-  background-position: $form-select-bg-position;
-  background-size: $form-select-bg-size;
+  // background-image: escape-svg($form-select-indicator);
+  // background-repeat: no-repeat;
+  // background-position: $form-select-bg-position;
+  // background-size: $form-select-bg-size;
   border: $form-select-border-width solid $form-select-border-color;
   @include border-radius($form-select-border-radius, 0);
   @include box-shadow($form-select-box-shadow);
   @include transition($form-select-transition);
   appearance: none;
+  position: relative;
+
+  &::after {
+    display: block;
+    position: absolute;
+    width: 16px;
+    height: 12px;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    // border: none;
+    background-image: escape-svg($form-select-indicator);
+    background-repeat: no-repeat;
+    background-position: $form-select-bg-position;
+    background-size: $form-select-bg-size;
+  }
+
+  &::after:disabled {
+    opacity: $form-select-disabled-opacity;
+  }
 
   &:focus {
     border-color: $form-select-focus-border-color;


### PR DESCRIPTION
when other form controls disabled, they become gray color and less notable. But the form-select has a **dark** dropdown arrow, makes it conspicuous and not fit in. I made the arrow as background, so can be adjust it's transparency.
based on https://css-tricks.com/snippets/css/transparent-background-images/

Hope I helped.