### PR TITLE
Docs: Use const in js examples

### DIFF
--- a/site/content/docs/5.0/components/alerts.md
+++ b/site/content/docs/5.0/components/alerts.md
@@ -191,8 +191,8 @@ Loop that generates the modifier classes with the `alert-variant()` mixin.
 Initialize elements as alerts
 
 ```js
-var alertList = document.querySelectorAll('.alert')
-var alerts =  [].slice.call(alertList).map(function (element) {
+const alertList = document.querySelectorAll('.alert')
+const alerts =  [].slice.call(alertList).map(function (element) {
   return new bootstrap.Alert(element)
 })
 ```
@@ -265,8 +265,8 @@ or on a button **outside the alert** using the `data-bs-target` as demonstrated 
 </table>
 
 ```js
-var alertNode = document.querySelector('.alert')
-var alert = bootstrap.Alert.getInstance(alertNode)
+const alertNode = document.querySelector('.alert')
+const alert = bootstrap.Alert.getInstance(alertNode)
 alert.close()
 ```
 
@@ -298,7 +298,7 @@ Bootstrap's alert plugin exposes a few events for hooking into alert functionali
 </table>
 
 ```js
-var myAlert = document.getElementById('myAlert')
+const myAlert = document.getElementById('myAlert')
 myAlert.addEventListener('closed.bs.alert', function () {
   // do something, for instance, explicitly move focus to the most appropriate element,
   // so it doesn't get lost/reset to the start of the page

--- a/site/content/docs/5.0/components/buttons.md
+++ b/site/content/docs/5.0/components/buttons.md
@@ -165,8 +165,8 @@ Add `data-bs-toggle="button"` to toggle a button's `active` state. If you're pre
 You can create a button instance with the button constructor, for example:
 
 ```js
-var button = document.getElementById('myButton')
-var bsButton = new bootstrap.Button(button)
+const button = document.getElementById('myButton')
+const bsButton = new bootstrap.Button(button)
 ```
 
 <table class="table">
@@ -216,9 +216,9 @@ var bsButton = new bootstrap.Button(button)
 For example, to toggle all buttons
 
 ```js
-var buttons = document.querySelectorAll('.btn')
+const buttons = document.querySelectorAll('.btn')
 buttons.forEach(function (button) {
-  var button = new bootstrap.Button(button)
+  const button = new bootstrap.Button(button)
   button.toggle()
 })
 ```

--- a/site/content/docs/5.0/components/carousel.md
+++ b/site/content/docs/5.0/components/carousel.md
@@ -302,8 +302,8 @@ The `data-bs-ride="carousel"` attribute is used to mark a carousel as animating 
 Call carousel manually with:
 
 ```js
-var myCarousel = document.querySelector('#myCarousel')
-var carousel = new bootstrap.Carousel(myCarousel)
+const myCarousel = document.querySelector('#myCarousel')
+const carousel = new bootstrap.Carousel(myCarousel)
 ```
 
 ### Options
@@ -369,8 +369,8 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 You can create a carousel instance with the carousel constructor, for example, to initialize with additional options and start cycling through items:
 
 ```js
-var myCarousel = document.querySelector('#myCarousel')
-var carousel = new bootstrap.Carousel(myCarousel, {
+const myCarousel = document.querySelector('#myCarousel')
+const carousel = new bootstrap.Carousel(myCarousel, {
   interval: 2000,
   wrap: false
 })
@@ -463,7 +463,7 @@ All carousel events are fired at the carousel itself (i.e. at the `<div class="c
 </table>
 
 ```js
-var myCarousel = document.getElementById('myCarousel')
+const myCarousel = document.getElementById('myCarousel')
 
 myCarousel.addEventListener('slide.bs.carousel', function () {
   // do something...

--- a/site/content/docs/5.0/components/collapse.md
+++ b/site/content/docs/5.0/components/collapse.md
@@ -110,8 +110,8 @@ To add accordion-like group management to a collapsible area, add the data attri
 Enable manually with:
 
 ```js
-var collapseElementList = [].slice.call(document.querySelectorAll('.collapse'))
-var collapseList = collapseElementList.map(function (collapseEl) {
+const collapseElementList = [].slice.call(document.querySelectorAll('.collapse'))
+const collapseList = collapseElementList.map(function (collapseEl) {
   return new bootstrap.Collapse(collapseEl)
 })
 ```
@@ -156,8 +156,8 @@ Activates your content as a collapsible element. Accepts an optional options `ob
 You can create a collapse instance with the constructor, for example:
 
 ```js
-var myCollapse = document.getElementById('myCollapse')
-var bsCollapse = new bootstrap.Collapse(myCollapse, {
+const myCollapse = document.getElementById('myCollapse')
+const bsCollapse = new bootstrap.Collapse(myCollapse, {
   toggle: false
 })
 ```
@@ -238,7 +238,7 @@ Bootstrap's collapse class exposes a few events for hooking into collapse functi
 </table>
 
 ```js
-var myCollapsible = document.getElementById('myCollapsible')
+const myCollapsible = document.getElementById('myCollapsible')
 myCollapsible.addEventListener('hidden.bs.collapse', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/dropdowns.md
+++ b/site/content/docs/5.0/components/dropdowns.md
@@ -1003,8 +1003,8 @@ Add `data-bs-toggle="dropdown"` to a link or button to toggle a dropdown.
 Call the dropdowns via JavaScript:
 
 ```js
-var dropdownElementList = [].slice.call(document.querySelectorAll('.dropdown-toggle'))
-var dropdownList = dropdownElementList.map(function (dropdownToggleEl) {
+const dropdownElementList = [].slice.call(document.querySelectorAll('.dropdown-toggle'))
+const dropdownList = dropdownElementList.map(function (dropdownToggleEl) {
   return new bootstrap.Dropdown(dropdownToggleEl)
 })
 ```
@@ -1086,9 +1086,9 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 #### Using function with `popperConfig`
 
 ```js
-var dropdown = new bootstrap.Dropdown(element, {
+const dropdown = new bootstrap.Dropdown(element, {
   popperConfig: function (defaultBsPopperConfig) {
-    // var newPopperConfig = {...}
+    // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
     // return newPopperConfig
   }
@@ -1203,7 +1203,7 @@ All dropdown events are fired at the toggling element and then bubbled up. So yo
 </table>
 
 ```js
-var myDropdown = document.getElementById('myDropdown')
+const myDropdown = document.getElementById('myDropdown')
 myDropdown.addEventListener('show.bs.dropdown', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/list-group.md
+++ b/site/content/docs/5.0/components/list-group.md
@@ -397,9 +397,9 @@ You can activate a list group navigation without writing any JavaScript by simpl
 Enable tabbable list item via JavaScript (each list item needs to be activated individually):
 
 ```js
-var triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
+const triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
 triggerTabList.forEach(function (triggerEl) {
-  var tabTrigger = new bootstrap.Tab(triggerEl)
+  const tabTrigger = new bootstrap.Tab(triggerEl)
 
   triggerEl.addEventListener('click', function (event) {
     event.preventDefault()
@@ -411,10 +411,10 @@ triggerTabList.forEach(function (triggerEl) {
 You can activate individual list item in several ways:
 
 ```js
-var triggerEl = document.querySelector('#myTab a[href="#profile"]')
+const triggerEl = document.querySelector('#myTab a[href="#profile"]')
 bootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
 
-var triggerFirstTabEl = document.querySelector('#myTab li:first-child a')
+const triggerFirstTabEl = document.querySelector('#myTab li:first-child a')
 bootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
@@ -453,8 +453,8 @@ Activates a list item element and content container. Tab should have either a `d
 </div>
 
 <script>
-  var firstTabEl = document.querySelector('#myTab a:last-child')
-  var firstTab = new bootstrap.Tab(firstTabEl)
+  const firstTabEl = document.querySelector('#myTab a:last-child')
+  const firstTab = new bootstrap.Tab(firstTabEl)
 
   firstTab.show()
 </script>
@@ -465,8 +465,8 @@ Activates a list item element and content container. Tab should have either a `d
 Selects the given list item and shows its associated pane. Any other list item that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (for example, before the `shown.bs.tab` event occurs).
 
 ```js
-  var someListItemEl = document.querySelector('#someListItem')
-  var tab = new bootstrap.Tab(someListItemEl)
+  const someListItemEl = document.querySelector('#someListItem')
+  const tab = new bootstrap.Tab(someListItemEl)
 
   tab.show()
 ```
@@ -480,8 +480,8 @@ Destroys an element's tab.
 *Static* method which allows you to get the tab instance associated with a DOM element
 
 ```js
-var triggerEl = document.querySelector('#trigger')
-var tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instance
+const triggerEl = document.querySelector('#trigger')
+const tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instance
 ```
 
 #### getOrCreateInstance
@@ -489,8 +489,8 @@ var tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instan
 *Static* method which allows you to get the tab instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var triggerEl = document.querySelector('#trigger')
-var tab = bootstrap.Tab.getOrCreateInstance(triggerEl) // Returns a Bootstrap tab instance
+const triggerEl = document.querySelector('#trigger')
+const tab = bootstrap.Tab.getOrCreateInstance(triggerEl) // Returns a Bootstrap tab instance
 ```
 
 ### Events
@@ -532,7 +532,7 @@ If no tab was already active, the `hide.bs.tab` and `hidden.bs.tab` events will 
 </table>
 
 ```js
-var tabElms = document.querySelectorAll('a[data-bs-toggle="list"]')
+const tabElms = document.querySelectorAll('a[data-bs-toggle="list"]')
 tabElms.forEach(function(tabElm) {
   tabElm.addEventListener('shown.bs.tab', function (event) {
     event.target // newly activated tab

--- a/site/content/docs/5.0/components/modal.md
+++ b/site/content/docs/5.0/components/modal.md
@@ -18,8 +18,8 @@ Before getting started with Bootstrap's modal component, be sure to read the fol
 - Due to how HTML5 defines its semantics, [the `autofocus` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) has no effect in Bootstrap modals. To achieve the same effect, use some custom JavaScript:
 
 ```js
-var myModal = document.getElementById('myModal')
-var myInput = document.getElementById('myInput')
+const myModal = document.getElementById('myModal')
+const myInput = document.getElementById('myInput')
 
 myModal.addEventListener('shown.bs.modal', function () {
   myInput.focus()
@@ -478,18 +478,18 @@ Below is a live demo followed by example HTML and JavaScript. For more informati
 {{< /example >}}
 
 ```js
-var exampleModal = document.getElementById('exampleModal')
+const exampleModal = document.getElementById('exampleModal')
 exampleModal.addEventListener('show.bs.modal', function (event) {
   // Button that triggered the modal
-  var button = event.relatedTarget
+  const button = event.relatedTarget
   // Extract info from data-bs-* attributes
-  var recipient = button.getAttribute('data-bs-whatever')
+  const recipient = button.getAttribute('data-bs-whatever')
   // If necessary, you could initiate an AJAX request here
   // and then do the updating in a callback.
   //
   // Update the modal's content.
-  var modalTitle = exampleModal.querySelector('.modal-title')
-  var modalBodyInput = exampleModal.querySelector('.modal-body input')
+  const modalTitle = exampleModal.querySelector('.modal-title')
+  const modalBodyInput = exampleModal.querySelector('.modal-body input')
 
   modalTitle.textContent = 'New message to ' + recipient
   modalBodyInput.value = recipient
@@ -891,7 +891,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 Activates your content as a modal. Accepts an optional options `object`.
 
 ```js
-var myModal = new bootstrap.Modal(document.getElementById('myModal'), {
+const myModal = new bootstrap.Modal(document.getElementById('myModal'), {
   keyboard: false
 })
 ```
@@ -915,7 +915,7 @@ myModal.show()
 Also, you can pass a DOM element as an argument that can be received in the modal events (as the `relatedTarget` property).
 
 ```js
-var modalToggle = document.getElementById('toggleMyModal') // relatedTarget
+const modalToggle = document.getElementById('toggleMyModal') // relatedTarget
 myModal.show(modalToggle)
 ```
 
@@ -948,8 +948,8 @@ myModal.dispose()
 *Static* method which allows you to get the modal instance associated with a DOM element
 
 ```js
-var myModalEl = document.getElementById('myModal')
-var modal = bootstrap.Modal.getInstance(myModalEl) // Returns a Bootstrap modal instance
+const myModalEl = document.getElementById('myModal')
+const modal = bootstrap.Modal.getInstance(myModalEl) // Returns a Bootstrap modal instance
 ```
 
 #### getOrCreateInstance
@@ -957,8 +957,8 @@ var modal = bootstrap.Modal.getInstance(myModalEl) // Returns a Bootstrap modal 
 *Static* method which allows you to get the modal instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var myModalEl = document.querySelector('#myModal')
-var modal = bootstrap.Modal.getOrCreateInstance(myModalEl) // Returns a Bootstrap modal instance
+const myModalEl = document.querySelector('#myModal')
+const modal = bootstrap.Modal.getOrCreateInstance(myModalEl) // Returns a Bootstrap modal instance
 ```
 
 ### Events
@@ -997,7 +997,7 @@ Bootstrap's modal class exposes a few events for hooking into modal functionalit
 </table>
 
 ```js
-var myModalEl = document.getElementById('myModal')
+const myModalEl = document.getElementById('myModal')
 myModalEl.addEventListener('hidden.bs.modal', function (event) {
   // do something...
 })

--- a/site/content/docs/5.0/components/navs-tabs.md
+++ b/site/content/docs/5.0/components/navs-tabs.md
@@ -525,9 +525,9 @@ You can activate a tab or pill navigation without writing any JavaScript by simp
 Enable tabbable tabs via JavaScript (each tab needs to be activated individually):
 
 ```js
-var triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
+const triggerTabList = [].slice.call(document.querySelectorAll('#myTab a'))
 triggerTabList.forEach(function (triggerEl) {
-  var tabTrigger = new bootstrap.Tab(triggerEl)
+  const tabTrigger = new bootstrap.Tab(triggerEl)
 
   triggerEl.addEventListener('click', function (event) {
     event.preventDefault()
@@ -539,10 +539,10 @@ triggerTabList.forEach(function (triggerEl) {
 You can activate individual tabs in several ways:
 
 ```js
-var triggerEl = document.querySelector('#myTab a[href="#profile"]')
+const triggerEl = document.querySelector('#myTab a[href="#profile"]')
 bootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
 
-var triggerFirstTabEl = document.querySelector('#myTab li:first-child a')
+const triggerFirstTabEl = document.querySelector('#myTab li:first-child a')
 bootstrap.Tab.getInstance(triggerFirstTabEl).show() // Select first tab
 ```
 
@@ -593,8 +593,8 @@ Activates a tab element and content container. Tab should have either a `data-bs
 </div>
 
 <script>
-  var firstTabEl = document.querySelector('#myTab li:last-child a')
-  var firstTab = new bootstrap.Tab(firstTabEl)
+  const firstTabEl = document.querySelector('#myTab li:last-child a')
+  const firstTab = new bootstrap.Tab(firstTabEl)
 
   firstTab.show()
 </script>
@@ -605,8 +605,8 @@ Activates a tab element and content container. Tab should have either a `data-bs
 Selects the given tab and shows its associated pane. Any other tab that was previously selected becomes unselected and its associated pane is hidden. **Returns to the caller before the tab pane has actually been shown** (i.e. before the `shown.bs.tab` event occurs).
 
 ```js
-  var someTabTriggerEl = document.querySelector('#someTabTrigger')
-  var tab = new bootstrap.Tab(someTabTriggerEl)
+  const someTabTriggerEl = document.querySelector('#someTabTrigger')
+  const tab = new bootstrap.Tab(someTabTriggerEl)
 
   tab.show()
 ```
@@ -620,8 +620,8 @@ Destroys an element's tab.
 *Static* method which allows you to get the tab instance associated with a DOM element
 
 ```js
-var triggerEl = document.querySelector('#trigger')
-var tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instance
+const triggerEl = document.querySelector('#trigger')
+const tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instance
 ```
 
 #### getOrCreateInstance
@@ -629,8 +629,8 @@ var tab = bootstrap.Tab.getInstance(triggerEl) // Returns a Bootstrap tab instan
 *Static* method which allows you to get the tab instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var triggerEl = document.querySelector('#trigger')
-var tab = bootstrap.Tab.getOrCreateInstance(triggerEl) // Returns a Bootstrap tab instance
+const triggerEl = document.querySelector('#trigger')
+const tab = bootstrap.Tab.getOrCreateInstance(triggerEl) // Returns a Bootstrap tab instance
 ```
 
 ### Events
@@ -672,7 +672,7 @@ If no tab was already active, then the `hide.bs.tab` and `hidden.bs.tab` events 
 </table>
 
 ```js
-var tabEl = document.querySelector('button[data-bs-toggle="tab"]')
+const tabEl = document.querySelector('button[data-bs-toggle="tab"]')
 tabEl.addEventListener('shown.bs.tab', function (event) {
   event.target // newly activated tab
   event.relatedTarget // previous active tab

--- a/site/content/docs/5.0/components/offcanvas.md
+++ b/site/content/docs/5.0/components/offcanvas.md
@@ -201,8 +201,8 @@ Add `data-bs-toggle="offcanvas"` and a `data-bs-target` or `href` to the element
 Enable manually with:
 
 ```js
-var offcanvasElementList = [].slice.call(document.querySelectorAll('.offcanvas'))
-var offcanvasList = offcanvasElementList.map(function (offcanvasEl) {
+const offcanvasElementList = [].slice.call(document.querySelectorAll('.offcanvas'))
+const offcanvasList = offcanvasElementList.map(function (offcanvasEl) {
   return new bootstrap.Offcanvas(offcanvasEl)
 })
 ```
@@ -230,8 +230,8 @@ Activates your content as an offcanvas element. Accepts an optional options `obj
 You can create an offcanvas instance with the constructor, for example:
 
 ```js
-var myOffcanvas = document.getElementById('myOffcanvas')
-var bsOffcanvas = new bootstrap.Offcanvas(myOffcanvas)
+const myOffcanvas = document.getElementById('myOffcanvas')
+const bsOffcanvas = new bootstrap.Offcanvas(myOffcanvas)
 ```
 
 {{< bs-table "table" >}}
@@ -258,7 +258,7 @@ Bootstrap's offcanvas class exposes a few events for hooking into offcanvas func
 {{< /bs-table >}}
 
 ```js
-var myOffcanvas = document.getElementById('myOffcanvas')
+const myOffcanvas = document.getElementById('myOffcanvas')
 myOffcanvas.addEventListener('hidden.bs.offcanvas', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/popovers.md
+++ b/site/content/docs/5.0/components/popovers.md
@@ -36,8 +36,8 @@ Keep reading to see how popovers work with some examples.
 One way to initialize all popovers on a page would be to select them by their `data-bs-toggle` attribute:
 
 ```js
-var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
-var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
+const popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
+const popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
   return new bootstrap.Popover(popoverTriggerEl)
 })
 ```
@@ -47,7 +47,7 @@ var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
 When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead.
 
 ```js
-var popover = new bootstrap.Popover(document.querySelector('.example-popover'), {
+const popover = new bootstrap.Popover(document.querySelector('.example-popover'), {
   container: 'body'
 })
 ```
@@ -92,7 +92,7 @@ For proper cross-browser and cross-platform behavior, you must use the `<a>` tag
 {{< /example >}}
 
 ```js
-var popover = new bootstrap.Popover(document.querySelector('.popover-dismiss'), {
+const popover = new bootstrap.Popover(document.querySelector('.popover-dismiss'), {
   trigger: 'focus'
 })
 ```
@@ -120,8 +120,8 @@ For disabled popover triggers, you may also prefer `data-bs-trigger="hover focus
 Enable popovers via JavaScript:
 
 ```js
-var exampleEl = document.getElementById('example')
-var popover = new bootstrap.Popover(exampleEl, options)
+const exampleEl = document.getElementById('example')
+const popover = new bootstrap.Popover(exampleEl, options)
 ```
 
 {{< callout warning >}}
@@ -304,9 +304,9 @@ Options for individual popovers can alternatively be specified through the use o
 #### Using function with `popperConfig`
 
 ```js
-var popover = new bootstrap.Popover(element, {
+const popover = new bootstrap.Popover(element, {
   popperConfig: function (defaultBsPopperConfig) {
-    // var newPopperConfig = {...}
+    // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
     // return newPopperConfig
   }
@@ -389,8 +389,8 @@ myPopover.update()
 *Static* method which allows you to get the popover instance associated with a DOM element
 
 ```js
-var exampleTriggerEl = document.getElementById('example')
-var popover = bootstrap.Popover.getInstance(exampleTriggerEl) // Returns a Bootstrap popover instance
+const exampleTriggerEl = document.getElementById('example')
+const popover = bootstrap.Popover.getInstance(exampleTriggerEl) // Returns a Bootstrap popover instance
 ```
 
 #### getOrCreateInstance
@@ -398,8 +398,8 @@ var popover = bootstrap.Popover.getInstance(exampleTriggerEl) // Returns a Boots
 *Static* method which allows you to get the popover instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var exampleTriggerEl = document.getElementById('example')
-var popover = bootstrap.Popover.getOrCreateInstance(exampleTriggerEl) // Returns a Bootstrap popover instance
+const exampleTriggerEl = document.getElementById('example')
+const popover = bootstrap.Popover.getOrCreateInstance(exampleTriggerEl) // Returns a Bootstrap popover instance
 ```
 
 ### Events
@@ -436,7 +436,7 @@ var popover = bootstrap.Popover.getOrCreateInstance(exampleTriggerEl) // Returns
 </table>
 
 ```js
-var myPopoverTrigger = document.getElementById('myPopover')
+const myPopoverTrigger = document.getElementById('myPopover')
 myPopoverTrigger.addEventListener('hidden.bs.popover', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/scrollspy.md
+++ b/site/content/docs/5.0/components/scrollspy.md
@@ -254,7 +254,7 @@ body {
 After adding `position: relative;` in your CSS, call the scrollspy via JavaScript:
 
 ```js
-var scrollSpy = new bootstrap.ScrollSpy(document.body, {
+const scrollSpy = new bootstrap.ScrollSpy(document.body, {
   target: '#navbar-example'
 })
 ```
@@ -278,7 +278,7 @@ Target elements that are not visible will be ignored and their corresponding nav
 When using scrollspy in conjunction with adding or removing of elements from the DOM, you'll need to call the refresh method like so:
 
 ```js
-var dataSpyList = [].slice.call(document.querySelectorAll('[data-bs-spy="scroll"]'))
+const dataSpyList = [].slice.call(document.querySelectorAll('[data-bs-spy="scroll"]'))
 dataSpyList.forEach(function (dataSpyEl) {
   bootstrap.ScrollSpy.getInstance(dataSpyEl)
     .refresh()
@@ -294,8 +294,8 @@ Destroys an element's scrollspy. (Removes stored data on the DOM element)
 *Static* method which allows you to get the scrollspy instance associated with a DOM element
 
 ```js
-var scrollSpyContentEl = document.getElementById('content')
-var scrollSpy = bootstrap.ScrollSpy.getInstance(scrollSpyContentEl) // Returns a Bootstrap scrollspy instance
+const scrollSpyContentEl = document.getElementById('content')
+const scrollSpy = bootstrap.ScrollSpy.getInstance(scrollSpyContentEl) // Returns a Bootstrap scrollspy instance
 ```
 
 #### getOrCreateInstance
@@ -303,8 +303,8 @@ var scrollSpy = bootstrap.ScrollSpy.getInstance(scrollSpyContentEl) // Returns a
 *Static* method which allows you to get the scrollspy instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var scrollSpyContentEl = document.getElementById('content')
-var scrollSpy = bootstrap.ScrollSpy.getOrCreateInstance(scrollSpyContentEl) // Returns a Bootstrap scrollspy instance
+const scrollSpyContentEl = document.getElementById('content')
+const scrollSpy = bootstrap.ScrollSpy.getOrCreateInstance(scrollSpyContentEl) // Returns a Bootstrap scrollspy instance
 ```
 
 ### Options
@@ -360,7 +360,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </table>
 
 ```js
-var firstScrollSpyEl = document.querySelector('[data-bs-spy="scroll"]')
+const firstScrollSpyEl = document.querySelector('[data-bs-spy="scroll"]')
 firstScrollSpyEl.addEventListener('activate.bs.scrollspy', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/toasts.md
+++ b/site/content/docs/5.0/components/toasts.md
@@ -331,8 +331,8 @@ While technically it's possible to add focusable/actionable controls (such as ad
 Initialize toasts via JavaScript:
 
 ```js
-var toastElList = [].slice.call(document.querySelectorAll('.toast'))
-var toastList = toastElList.map(function (toastEl) {
+const toastElList = [].slice.call(document.querySelectorAll('.toast'))
+const toastList = toastElList.map(function (toastEl) {
   return new bootstrap.Toast(toastEl, option)
 })
 ```
@@ -410,8 +410,8 @@ toast.dispose()
 *Static* method which allows you to get the scrollspy instance associated with a DOM element
 
 ```js
-var myToastEl = document.getElementById('myToastEl')
-var myToast = bootstrap.Toast.getInstance(myToastEl) // Returns a Bootstrap toast instance
+const myToastEl = document.getElementById('myToastEl')
+const myToast = bootstrap.Toast.getInstance(myToastEl) // Returns a Bootstrap toast instance
 ```
 
 #### getOrCreateInstance
@@ -419,8 +419,8 @@ var myToast = bootstrap.Toast.getInstance(myToastEl) // Returns a Bootstrap toas
 *Static* method which allows you to get the scrollspy instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var myToastEl = document.getElementById('myToastEl')
-var myToast = bootstrap.Toast.getOrCreateInstance(myToastEl) // Returns a Bootstrap toast instance
+const myToastEl = document.getElementById('myToastEl')
+const myToast = bootstrap.Toast.getOrCreateInstance(myToastEl) // Returns a Bootstrap toast instance
 ```
 
 ### Events
@@ -453,7 +453,7 @@ var myToast = bootstrap.Toast.getOrCreateInstance(myToastEl) // Returns a Bootst
 </table>
 
 ```js
-var myToastEl = document.getElementById('myToast')
+const myToastEl = document.getElementById('myToast')
 myToastEl.addEventListener('hidden.bs.toast', function () {
   // do something...
 })

--- a/site/content/docs/5.0/components/tooltips.md
+++ b/site/content/docs/5.0/components/tooltips.md
@@ -35,8 +35,8 @@ Got all that? Great, let's see how they work with some examples.
 One way to initialize all tooltips on a page would be to select them by their `data-bs-toggle` attribute:
 
 ```js
-var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
-var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+const tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
   return new bootstrap.Tooltip(tooltipTriggerEl)
 })
 ```
@@ -109,8 +109,8 @@ The tooltip plugin generates content and markup on demand, and by default places
 Trigger the tooltip via JavaScript:
 
 ```js
-var exampleEl = document.getElementById('example')
-var tooltip = new bootstrap.Tooltip(exampleEl, options)
+const exampleEl = document.getElementById('example')
+const tooltip = new bootstrap.Tooltip(exampleEl, options)
 ```
 
 {{< callout warning >}}
@@ -119,8 +119,8 @@ var tooltip = new bootstrap.Tooltip(exampleEl, options)
 Tooltip position attempts to automatically change when a **parent container** has `overflow: auto` or `overflow: scroll` like our `.table-responsive`, but still keeps the original placement's positioning. To resolve this, set the [`boundary` option](https://popper.js.org/docs/v2/modifiers/flip/#boundary) (for the flip modifier using the `popperConfig` option) to any HTMLElement to override the default value, `'clippingParents'`, such as `document.body`:
 
 ```js
-var exampleEl = document.getElementById('example')
-var tooltip = new bootstrap.Tooltip(exampleEl, {
+const exampleEl = document.getElementById('example')
+const tooltip = new bootstrap.Tooltip(exampleEl, {
   boundary: document.body // or document.querySelector('#boundary')
 })
 ```
@@ -329,9 +329,9 @@ Options for individual tooltips can alternatively be specified through the use o
 #### Using function with `popperConfig`
 
 ```js
-var tooltip = new bootstrap.Tooltip(element, {
+const tooltip = new bootstrap.Tooltip(element, {
   popperConfig: function (defaultBsPopperConfig) {
-    // var newPopperConfig = {...}
+    // const newPopperConfig = {...}
     // use defaultBsPopperConfig if needed...
     // return newPopperConfig
   }
@@ -413,8 +413,8 @@ tooltip.update()
 *Static* method which allows you to get the tooltip instance associated with a DOM element
 
 ```js
-var exampleTriggerEl = document.getElementById('example')
-var tooltip = bootstrap.Tooltip.getInstance(exampleTriggerEl) // Returns a Bootstrap tooltip instance
+const exampleTriggerEl = document.getElementById('example')
+const tooltip = bootstrap.Tooltip.getInstance(exampleTriggerEl) // Returns a Bootstrap tooltip instance
 ```
 
 #### getOrCreateInstance
@@ -422,8 +422,8 @@ var tooltip = bootstrap.Tooltip.getInstance(exampleTriggerEl) // Returns a Boots
 *Static* method which allows you to get the tooltip instance associated with a DOM element, or create a new one in case it wasn't initialised
 
 ```js
-var exampleTriggerEl = document.getElementById('example')
-var tooltip = bootstrap.Tooltip.getOrCreateInstance(exampleTriggerEl) // Returns a Bootstrap tooltip instance
+const exampleTriggerEl = document.getElementById('example')
+const tooltip = bootstrap.Tooltip.getOrCreateInstance(exampleTriggerEl) // Returns a Bootstrap tooltip instance
 ```
 
 ### Events
@@ -460,8 +460,8 @@ var tooltip = bootstrap.Tooltip.getOrCreateInstance(exampleTriggerEl) // Returns
 </table>
 
 ```js
-var myTooltipEl = document.getElementById('myTooltip')
-var tooltip = new bootstrap.Tooltip(myTooltipEl)
+const myTooltipEl = document.getElementById('myTooltip')
+const tooltip = new bootstrap.Tooltip(myTooltipEl)
 
 myTooltipEl.addEventListener('hidden.bs.tooltip', function () {
   // do something...

--- a/site/content/docs/5.0/examples/.eslintrc.json
+++ b/site/content/docs/5.0/examples/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+}

--- a/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
+++ b/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
@@ -18,7 +18,7 @@
 
   document.querySelectorAll('.toast')
     .forEach(function (toastNode) {
-      const toast = new bootstrap.Toast(toastNode, { 
+      const toast = new bootstrap.Toast(toastNode, {
         autohide: false
       })
 

--- a/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
+++ b/site/content/docs/5.0/examples/cheatsheet/cheatsheet.js
@@ -18,7 +18,7 @@
 
   document.querySelectorAll('.toast')
     .forEach(function (toastNode) {
-      var toast = new bootstrap.Toast(toastNode, {
+      const toast = new bootstrap.Toast(toastNode, { 
         autohide: false
       })
 
@@ -34,20 +34,20 @@
     })
 
   function setActiveItem() {
-    var hash = window.location.hash
+    const hash = window.location.hash
 
     if (hash === '') {
       return
     }
 
-    var link = document.querySelector('.bd-aside a[href="' + hash + '"]')
+    const link = document.querySelector('.bd-aside a[href="' + hash + '"]')
 
     if (!link) {
       return
     }
 
-    var active = document.querySelector('.bd-aside .active')
-    var parent = link.parentNode.parentNode.previousElementSibling
+    const active = document.querySelector('.bd-aside .active')
+    const parent = link.parentNode.parentNode.previousElementSibling
 
     link.classList.add('active')
 
@@ -59,7 +59,7 @@
       return
     }
 
-    var expanded = active.parentNode.parentNode.previousElementSibling
+    const expanded = active.parentNode.parentNode.previousElementSibling
 
     active.classList.remove('active')
 

--- a/site/content/docs/5.0/examples/checkout/form-validation.js
+++ b/site/content/docs/5.0/examples/checkout/form-validation.js
@@ -3,7 +3,7 @@
   'use strict'
 
   // Fetch all the forms we want to apply custom Bootstrap validation styles to
-  var forms = document.querySelectorAll('.needs-validation')
+  const forms = document.querySelectorAll('.needs-validation')
 
   // Loop over them and prevent submission
   Array.prototype.slice.call(forms)

--- a/site/content/docs/5.0/examples/dashboard-rtl/dashboard.js
+++ b/site/content/docs/5.0/examples/dashboard-rtl/dashboard.js
@@ -6,9 +6,9 @@
   feather.replace({ 'aria-hidden': 'true' })
 
   // Graphs
-  var ctx = document.getElementById('myChart')
+  const ctx = document.getElementById('myChart')
   // eslint-disable-next-line no-unused-vars
-  var myChart = new Chart(ctx, {
+  const myChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels: [

--- a/site/content/docs/5.0/examples/dashboard/dashboard.js
+++ b/site/content/docs/5.0/examples/dashboard/dashboard.js
@@ -6,9 +6,9 @@
   feather.replace({ 'aria-hidden': 'true' })
 
   // Graphs
-  var ctx = document.getElementById('myChart')
+  const ctx = document.getElementById('myChart')
   // eslint-disable-next-line no-unused-vars
-  var myChart = new Chart(ctx, {
+  const myChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels: [

--- a/site/content/docs/5.0/examples/sidebars/sidebars.js
+++ b/site/content/docs/5.0/examples/sidebars/sidebars.js
@@ -1,7 +1,7 @@
 /* global bootstrap: false */
 (function () {
   'use strict'
-  var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
   tooltipTriggerList.forEach(function (tooltipTriggerEl) {
     new bootstrap.Tooltip(tooltipTriggerEl)
   })

--- a/site/content/docs/5.0/getting-started/javascript.md
+++ b/site/content/docs/5.0/getting-started/javascript.md
@@ -59,7 +59,7 @@ Bootstrap provides custom events for most plugins' unique actions. Generally, th
 All infinitive events provide [`preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) functionality. This provides the ability to stop the execution of an action before it starts. Returning false from an event handler will also automatically call `preventDefault()`.
 
 ```js
-var myModal = document.getElementById('myModal')
+const myModal = document.getElementById('myModal')
 
 myModal.addEventListener('show.bs.modal', function (event) {
   if (!data) {
@@ -85,10 +85,10 @@ $('#myTab a').on('shown.bs.tab', function () {
 All constructors accept an optional options object or nothing (which initiates a plugin with its default behavior):
 
 ```js
-var myModalEl = document.getElementById('myModal')
+const myModalEl = document.getElementById('myModal')
 
-var modal = new bootstrap.Modal(myModalEl) // initialized with defaults
-var modal = new bootstrap.Modal(myModalEl, { keyboard: false }) // initialized with no keyboard
+const modal = new bootstrap.Modal(myModalEl) // initialized with defaults
+const modal = new bootstrap.Modal(myModalEl, { keyboard: false }) // initialized with no keyboard
 ```
 
 If you'd like to get a particular plugin instance, each plugin exposes a `getInstance` method. In order to retrieve it directly from an element, do this: `bootstrap.Popover.getInstance(myPopoverEl)`.
@@ -98,8 +98,8 @@ If you'd like to get a particular plugin instance, each plugin exposes a `getIns
 You can also use a CSS selector as the first argument instead of a DOM element to initialize the plugin. Currently the element for the plugin is found by the `querySelector` method since our plugins support a single element only.
 
 ```js
-var modal = new bootstrap.Modal('#myModal')
-var dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]')
+const modal = new bootstrap.Modal('#myModal')
+const dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]')
 ```
 
 ### Asynchronous functions and transitions
@@ -109,7 +109,7 @@ All programmatic API methods are **asynchronous** and return to the caller once 
 In order to execute an action once the transition is complete, you can listen to the corresponding event.
 
 ```js
-var myCollapseEl = document.getElementById('myCollapse')
+const myCollapseEl = document.getElementById('myCollapse')
 
 myCollapseEl.addEventListener('shown.bs.collapse', function (event) {
   // Action to execute once the collapsible area is expanded
@@ -119,8 +119,8 @@ myCollapseEl.addEventListener('shown.bs.collapse', function (event) {
 In addition a method call on a **transitioning component will be ignored**.
 
 ```js
-var myCarouselEl = document.getElementById('myCarousel')
-var carousel = bootstrap.Carousel.getInstance(myCarouselEl) // Retrieve a Carousel instance
+const myCarouselEl = document.getElementById('myCarousel')
+const carousel = bootstrap.Carousel.getInstance(myCarouselEl) // Retrieve a Carousel instance
 
 myCarouselEl.addEventListener('slid.bs.carousel', function (event) {
   carousel.to('2') // Will slide to the slide 2 as soon as the transition to slide 1 is finished
@@ -144,7 +144,7 @@ bootstrap.Modal.Default.keyboard = false
 Sometimes it is necessary to use Bootstrap plugins with other UI frameworks. In these circumstances, namespace collisions can occasionally occur. If this happens, you may call `.noConflict` on the plugin you wish to revert the value of.
 
 ```js
-var bootstrapButton = $.fn.button.noConflict() // return $.fn.button to previously assigned value
+const bootstrapButton = $.fn.button.noConflict() // return $.fn.button to previously assigned value
 $.fn.bootstrapBtn = bootstrapButton // give $().bootstrapBtn the Bootstrap functionality
 ```
 
@@ -173,8 +173,8 @@ Tooltips and Popovers use our built-in sanitizer to sanitize options which accep
 The default `allowList` value is the following:
 
 ```js
-var ARIA_ATTRIBUTE_PATTERN = /^aria-[\w-]*$/i
-var DefaultAllowlist = {
+const ARIA_ATTRIBUTE_PATTERN = /^aria-[\w-]*$/i
+const DefaultAllowlist = {
   // Global attributes allowed on any supplied element below.
   '*': ['class', 'dir', 'id', 'lang', 'role', ARIA_ATTRIBUTE_PATTERN],
   a: ['target', 'href', 'title', 'rel'],
@@ -212,7 +212,7 @@ var DefaultAllowlist = {
 If you want to add new values to this default `allowList` you can do the following:
 
 ```js
-var myDefaultAllowList = bootstrap.Tooltip.Default.allowList
+const myDefaultAllowList = bootstrap.Tooltip.Default.allowList
 
 // To allow table elements
 myDefaultAllowList.table = []
@@ -222,15 +222,15 @@ myDefaultAllowList.td = ['data-bs-option']
 
 // You can push your custom regex to validate your attributes.
 // Be careful about your regular expressions being too lax
-var myCustomRegex = /^data-my-app-[\w-]+/
+const myCustomRegex = /^data-my-app-[\w-]+/
 myDefaultAllowList['*'].push(myCustomRegex)
 ```
 
 If you want to bypass our sanitizer because you prefer to use a dedicated library, for example [DOMPurify](https://www.npmjs.com/package/dompurify), you should do the following:
 
 ```js
-var yourTooltipEl = document.getElementById('yourTooltip')
-var tooltip = new bootstrap.Tooltip(yourTooltipEl, {
+const yourTooltipEl = document.getElementById('yourTooltip')
+const tooltip = new bootstrap.Tooltip(yourTooltipEl, {
   sanitizeFn: function (content) {
     return DOMPurify.sanitize(content)
   }

--- a/site/content/docs/5.0/migration.md
+++ b/site/content/docs/5.0/migration.md
@@ -372,8 +372,8 @@ toc: true
 - **All plugins can now accept a CSS selector as the first argument.** You can either pass a DOM element or any valid CSS selector to create a new instance of the plugin:
 
   ```js
-  var modal = new bootstrap.Modal('#myModal')
-  var dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]')
+  const modal = new bootstrap.Modal('#myModal')
+  const dropdown = new bootstrap.Dropdown('[data-bs-toggle="dropdown"]')
   ```
 
 - `popperConfig` can be passed as a function that accepts the Bootstrap's default Popper config as an argument, so that you can merge this default configuration in your way. **Applies to dropdowns, popovers, and tooltips.**


### PR DESCRIPTION
Fixes #33713 

The change in the .md files were straightforward.

Changes in the examples/**/*.js files led to eslint parsing errors (e.g. [Stackoverflow: The keyword 'const' is reserved](https://stackoverflow.com/questions/42706584/eslint-error-parsing-error-the-keyword-const-is-reserved)).  I wrote a separate site/content/docs/5.0/examples/.eslintrc.json file to override the parser options in site/.eslintrc.json. If you'd prefer a different method of resolving those errors, let me know how you'd like to proceed.