### PR TITLE
Allow click events within dropdown

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -498,7 +498,6 @@ EventHandler.on(document, EVENT_KEYDOWN_DATA_API, SELECTOR_MENU, Dropdown.dataAp
 EventHandler.on(document, EVENT_CLICK_DATA_API, Dropdown.clearMenus)
 EventHandler.on(document, EVENT_KEYUP_DATA_API, Dropdown.clearMenus)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
-  event.preventDefault()
   Dropdown.dropdownInterface(this)
 })
 

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -231,7 +231,6 @@ class Dropdown extends BaseComponent {
 
   _addEventListeners() {
     EventHandler.on(this._element, EVENT_CLICK, event => {
-      event.preventDefault()
       this.toggle()
     })
   }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -230,7 +230,7 @@ class Dropdown extends BaseComponent {
   // Private
 
   _addEventListeners() {
-    EventHandler.on(this._element, EVENT_CLICK, event => {
+    EventHandler.on(this._element, EVENT_CLICK, () => {
       this.toggle()
     })
   }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -497,7 +497,7 @@ EventHandler.on(document, EVENT_KEYDOWN_DATA_API, SELECTOR_DATA_TOGGLE, Dropdown
 EventHandler.on(document, EVENT_KEYDOWN_DATA_API, SELECTOR_MENU, Dropdown.dataApiKeydownHandler)
 EventHandler.on(document, EVENT_CLICK_DATA_API, Dropdown.clearMenus)
 EventHandler.on(document, EVENT_KEYUP_DATA_API, Dropdown.clearMenus)
-EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
+EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function () {
   Dropdown.dropdownInterface(this)
 })
 


### PR DESCRIPTION
I have dropdowns that also have links inside them (the links changed based on what is selected inside the dropdown)
This allows links to be clickable within a dropdown toggle to avoid problems like this:

https://jsfiddle.net/jr3eb15g/

I'm not sure why you'd want to avoid the behavior of having links not work inside of the dropdowns?

closes #34400
