### PR TITLE
Fix site params variable on themes section

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -18,7 +18,7 @@
           <li class="mb-2"><a href="/">Home</a></li>
           <li class="mb-2"><a href="/docs/{{ .Site.Params.docs_version }}/">Docs</a></li>
           <li class="mb-2"><a href="/docs/{{ .Site.Params.docs_version }}/examples/">Examples</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.opencollective }}">Themes</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.themes }}">Themes</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.blog }}">Blog</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Fix redirect from opencollective.com/bootstrap to themes.getbootstrap.com under footer links.