### PR TITLE
Fail gracefully on selectors with invalid syntax

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -63,7 +63,11 @@ const getSelectorFromElement = element => {
   const selector = getSelector(element)
 
   if (selector) {
-    return document.querySelector(selector) ? selector : null
+    try {
+      return document.querySelector(selector) ? selector : null
+    } catch {
+      return null
+    }
   }
 
   return null
@@ -72,7 +76,11 @@ const getSelectorFromElement = element => {
 const getElementFromSelector = element => {
   const selector = getSelector(element)
 
-  return selector ? document.querySelector(selector) : null
+  try {
+    return selector ? document.querySelector(selector) : null
+  } catch {
+    return null
+  }
 }
 
 const getTransitionDurationFromElement = element => {


### PR DESCRIPTION
This pull request partially addresses issues #34381 (Scrollspy), #31099 (Dynamic Tabs), #31005 (Collapse), and #32826 (nav-tab anchors).

`document.querySelector()` throws an exception when the given selector is not a valid CSS selector, such as when it is an ID-selector starting with a number - e.g., `document.querySelector("#3rd")`. (Note that the ID "3rd" is a valid HTML5 id, but "#3rd" is an invalid CSS selector.) This commit catches that exception and returns null instead of propagating that exception.

With this change, the various Bootstrap JS features can now still partially work, instead of failing completely. For example, Scrollspy should now continue to work on elements whose IDs start with ASCII letters, even if there are elements on the same page whose IDs start with digits.

@XhmikosR @ffoodd 