### PR TITLE
border-radius() mixin should have 1 argument, 2 passed.

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -128,6 +128,6 @@
   padding: $padding-y $padding-x;
   @include font-size($font-size);
   // Manually declare to provide an override to the browser default
-  @include border-radius($border-radius, 0);
+  @include border-radius($border-radius);
 }
 // scss-docs-end btn-size-mixin


### PR DESCRIPTION
when I try to use button-size() mixin in my project as below:

```
@include button-size(10px, 10px, 20px, 6px); 
```

I get this error:
```
SassError: Only 1 argument allowed, but 2 were passed.
   ┌──> node_modules\bootstrap\scss\mixins\_buttons.scss
109│   @include border-radius($border-radius, 0);
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invocation
```

Which is because of 2 arguments being passed to border-radius() method.