### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,8 +1,7 @@
 name: BrowserStack
 
 on:
-  push:
-
+  push: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -10,7 +9,9 @@ env:
 jobs:
   browserstack:
     runs-on: ubuntu-latest
-    if: github.repository == 'twbs/bootstrap' && (!contains(github.event.commits[0].message, '[ci skip]') && !contains(github.event.commits[0].message, '[skip ci]'))
+    if: github.repository == 'twbs/bootstrap' &&
+      (!contains(github.event.commits[0].message, '[ci skip]') &&
+      !contains(github.event.commits[0].message, '[skip ci]'))
     timeout-minutes: 30
 
     steps:
@@ -21,12 +22,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
+            hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,7 +1,7 @@
 name: BrowserStack
 
 on:
-  push: null
+  push:
 env:
   FORCE_COLOR: 2
   NODE: 14

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -24,16 +24,6 @@ jobs:
           node-version: "${{ env.NODE }}"
           cache: npm
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
-            hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,8 +1,8 @@
 name: Bundlewatch
 
 on:
-  push: null
-  pull_request: null
+  push:
+  pull_request:
 env:
   FORCE_COLOR: 2
   NODE: 14

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -21,16 +21,6 @@ jobs:
           node-version: "${{ env.NODE }}"
           cache: npm
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
-            hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,9 +1,8 @@
 name: Bundlewatch
 
 on:
-  push:
-  pull_request:
-
+  push: null
+  pull_request: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -20,12 +19,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
+            hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request:
-
+  pull_request: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -22,12 +21,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
+            hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request: null
+  pull_request:
 env:
   FORCE_COLOR: 2
   NODE: 14

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -23,16 +23,6 @@ jobs:
           node-version: "${{ env.NODE }}"
           cache: npm
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
-            hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request: null
+  pull_request:
 env:
   FORCE_COLOR: 2
   NODE: 14

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request:
-
+  pull_request: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -22,6 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - run: java -version
 
@@ -29,7 +29,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
+            hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,16 +25,6 @@ jobs:
 
       - run: java -version
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
-            hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request:
-
+  pull_request: null
 env:
   FORCE_COLOR: 2
 
@@ -27,12 +26,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package.json')
+            }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request: null
+  pull_request:
 env:
   FORCE_COLOR: 2
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -28,16 +28,6 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package.json')
-            }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request:
-
+  pull_request: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -22,12 +21,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - name: Set up npm cache
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          key:
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
+            hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request: null
+  pull_request:
 env:
   FORCE_COLOR: 2
   NODE: 14

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,16 +23,6 @@ jobs:
           node-version: "${{ env.NODE }}"
           cache: npm
 
-      - name: Set up npm cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key:
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{
-            hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request:
-
+  pull_request: null
 env:
   FORCE_COLOR: 2
   NODE: 14
@@ -22,6 +21,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ env.NODE }}"
+          cache: npm
 
       - name: Build CSS with node-sass
         run: |

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-  pull_request: null
+  pull_request:
 env:
   FORCE_COLOR: 2
   NODE: 14


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Fix #34422

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
