### PR TITLE
Remove print thead rule

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -55,15 +55,6 @@
       page-break-inside: avoid;
     }
 
-    //
-    // Printing Tables:
-    // https://web.archive.org/web/20180815150934/http://css-discuss.incutio.com/wiki/Printing_Tables
-    //
-
-    thead {
-      display: table-header-group;
-    }
-
     tr,
     img {
       page-break-inside: avoid;


### PR DESCRIPTION
The ``thead`` rule is safe to remove -- it was a workaround for browsers that didn't conform to this part of the CSS 2.1 spec. (https://www.w3.org/TR/CSS21/tables.html#table-display)
In practice, this meant IE 6 & IE 7.

(thanks to @mattbrundage for this PR upstream for the main.css project (https://github.com/h5bp/main.css/pull/101)