### PR TITLE
build: read & dynamically resolve `imports` on plugins build

### DIFF
--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -21,16 +21,17 @@ const jsFiles = glob.sync(srcPath + '/**/*.js')
 // Array which holds the resolved plugins
 const resolved = []
 
-// trims 'js' extension, and Uppercases => first letter, hyphens, backslashes & slashes
-const filenameToEntity = filename => filename.replace('.js', '').replace(/(?:^|-|\/|\\)[a-z]/g, char => char.slice(-1).toUpperCase())
+// Trims the "js" extension and uppercases => first letter, hyphens, backslashes & slashes
+const filenameToEntity = filename => filename.replace('.js', '')
+  .replace(/(?:^|-|\/|\\)[a-z]/g, char => char.slice(-1).toUpperCase())
 
 for (const file of jsFiles) {
   resolved.push({
     src: file.replace('.js', ''),
     dist: file.replace('src', 'dist'),
     fileName: path.basename(file),
-    className: filenameToEntity(path.basename(file)),
-    safeClassName: filenameToEntity(path.relative(srcPath, file))
+    className: filenameToEntity(path.basename(file))
+    // safeClassName: filenameToEntity(path.relative(srcPath, file))
   })
 }
 
@@ -48,10 +49,10 @@ const build = async plugin => {
       })
     ],
     external: source => {
-      // Replace starting with ./ or ../
+      // Pattern to identify local files
       const pattern = /^(\.{1,2})\//
 
-      // It's probably a Node.js package
+      // It's not a local file, e.g a Node.js package
       if (!pattern.test(source)) {
         globals[source] = source
         return true
@@ -65,6 +66,8 @@ const build = async plugin => {
         throw new Error(`Source ${source} is not mapped!`)
       }
 
+      // We can change `Index` with `UtilIndex` etc if we use
+      // `safeClassName` instead of `className` everywhere
       globals[path.normalize(usedPlugin.src)] = usedPlugin.className
       return true
     }

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -19,14 +19,14 @@ const srcPath = path.resolve(__dirname, '../js/src/')
 const jsFiles = glob.sync(srcPath + '/**/*.js')
 
 // Array which holds the resolved plugins
-const resolved = []
+const resolvedPlugins = []
 
 // Trims the "js" extension and uppercases => first letter, hyphens, backslashes & slashes
 const filenameToEntity = filename => filename.replace('.js', '')
-  .replace(/(?:^|-|\/|\\)[a-z]/g, char => char.slice(-1).toUpperCase())
+  .replace(/(?:^|-|\/|\\)[a-z]/g, str => str.slice(-1).toUpperCase())
 
 for (const file of jsFiles) {
-  resolved.push({
+  resolvedPlugins.push({
     src: file.replace('.js', ''),
     dist: file.replace('src', 'dist'),
     fileName: path.basename(file),
@@ -58,7 +58,7 @@ const build = async plugin => {
         return true
       }
 
-      const usedPlugin = resolved.find(plugin => {
+      const usedPlugin = resolvedPlugins.find(plugin => {
         return plugin.src.includes(source.replace(pattern, ''))
       })
 
@@ -94,7 +94,7 @@ const build = async plugin => {
     console.log('Building individual plugins...')
     console.time(timeLabel)
 
-    await Promise.all(Object.values(resolved).map(plugin => build(plugin)))
+    await Promise.all(Object.values(resolvedPlugins).map(plugin => build(plugin)))
 
     console.timeEnd(timeLabel)
   } catch (error) {

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -49,7 +49,7 @@ const build = async plugin => {
     ],
     external: source => {
       // Replace starting with ./ or ../
-      const pattern = /^(\.+)\//
+      const pattern = /^(\.{1,2})\//
 
       // It's probably a Node.js package
       if (!pattern.test(source)) {

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -16,20 +16,21 @@ const { babel } = require('@rollup/plugin-babel')
 const banner = require('./banner.js')
 
 const srcPath = path.resolve(__dirname, '../js/src/')
-const jsFiles = glob.sync(srcPath + '/**/*.js') // path.posix.normalize(srcPath)
+const jsFiles = glob.sync(srcPath + '/**/*.js')
 
 // Array which holds the resolved plugins
 const resolved = []
 
-const filenameToEntity = filename => filename.replace(/(?:^|-|\/)[a-z]/g, char => char.slice(-1).toUpperCase())
+// trims 'js' extension, and Uppercases => first letter, hyphens, backslashes & slashes
+const filenameToEntity = filename => filename.replace('.js', '').replace(/(?:^|-|\/|\\)[a-z]/g, char => char.slice(-1).toUpperCase())
 
 for (const file of jsFiles) {
   resolved.push({
     src: file.replace('.js', ''),
     dist: file.replace('src', 'dist'),
-    relativePath: path.relative(srcPath, file),
-    name: filenameToEntity(path.basename(file, '.js')),
-    safeName: filenameToEntity(path.relative(srcPath, file)).replace('.js', '')
+    fileName: path.basename(file),
+    className: filenameToEntity(path.basename(file)),
+    safeClassName: filenameToEntity(path.relative(srcPath, file))
   })
 }
 
@@ -64,22 +65,22 @@ const build = async plugin => {
         throw new Error(`Source ${source} is not mapped!`)
       }
 
-      globals[path.normalize(usedPlugin.src)] = usedPlugin.name
+      globals[path.normalize(usedPlugin.src)] = usedPlugin.className
       return true
     }
   })
 
   await bundle.write({
-    banner: banner(path.basename(plugin.relativePath)),
+    banner: banner(plugin.fileName),
     format: 'umd',
-    name: plugin.name,
+    name: plugin.className,
     sourcemap: true,
     globals,
     generatedCode: 'es2015',
     file: plugin.dist
   })
 
-  console.log(`Built ${plugin.name}`)
+  console.log(`Built ${plugin.className}`)
 }
 
 (async () => {

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -69,7 +69,7 @@ const build = async plugin => {
   })
 
   await bundle.write({
-    banner: banner(plugin.relativePath),
+    banner: banner(path.basename(plugin.relativePath)),
     format: 'umd',
     name: plugin.name,
     sourcemap: true,

--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -21,14 +21,15 @@ const jsFiles = glob.sync(srcPath + '/**/*.js') // path.posix.normalize(srcPath)
 // Array which holds the resolved plugins
 const resolved = []
 
-const filenameToEntity = filename => filename.replace(/(?:^|-)[a-z]/g, char => char.slice(-1).toUpperCase())
+const filenameToEntity = filename => filename.replace(/(?:^|-|\/)[a-z]/g, char => char.slice(-1).toUpperCase())
 
 for (const file of jsFiles) {
   resolved.push({
     src: file.replace('.js', ''),
     dist: file.replace('src', 'dist'),
     relativePath: path.relative(srcPath, file),
-    name: filenameToEntity(path.basename(file, '.js'))
+    name: filenameToEntity(path.basename(file, '.js')),
+    safeName: filenameToEntity(path.relative(srcPath, file)).replace('.js', '')
   })
 }
 


### PR DESCRIPTION
Separate each module/usage to another file dynamically in order to minimize total sizes, and keep our builds always updated

Fixes #34248

TODO:

- [x] mention a couple of before/after comparisons
- [ ] fix foo/index in log being "Built Index"
- [x] finish with the TODO comments
- [x] fix paths to use `/` in banner and in console.log regardless of the OS


Old sizes per module
![old-compile](https://user-images.githubusercontent.com/22406063/140499215-000da46e-a078-43dd-ad6e-bf770ae8a84b.PNG)

New sizes per module
![New-compile](https://user-images.githubusercontent.com/22406063/140499311-7b0f1637-574b-4bd6-8419-26c7fc9143e4.PNG)

