### PR TITLE
Revert "Allow individual grid classes to override `.row-cols`"

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -66,8 +66,8 @@
 
 @mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
   @each $breakpoint in map-keys($breakpoints) {
-    // .row-cols defaults must all appear before .col overrides so they can be overridden.
     $infix: breakpoint-infix($breakpoint, $breakpoints);
+
     @include media-breakpoint-up($breakpoint, $breakpoints) {
       // Provide basic `.col-{bp}` classes for equal-width flexbox columns
       .col#{$infix} {
@@ -85,13 +85,7 @@
           }
         }
       }
-    }
-  }
 
-  @each $breakpoint in map-keys($breakpoints) {
-    $infix: breakpoint-infix($breakpoint, $breakpoints);
-
-    @include media-breakpoint-up($breakpoint, $breakpoints) {
       .col#{$infix}-auto {
         @include make-col-auto();
       }

--- a/site/content/docs/5.0/layout/grid.md
+++ b/site/content/docs/5.0/layout/grid.md
@@ -299,9 +299,9 @@ Don't want your columns to simply stack in some grid tiers? Use a combination of
 
 ### Row columns
 
-Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.col-md-4`), the row columns classes are set on the parent `.row` as a default for contained columns. With `.row-cols-auto` you can give the columns their natural width.
+Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.col-md-4`), the row columns classes are set on the parent `.row` as a shortcut. With `.row-cols-auto` you can give the columns their natural width.
 
-Use these row columns classes to quickly create basic grid layouts or to control your card layouts and override when needed at the column level.
+Use these row columns classes to quickly create basic grid layouts or to control your card layouts.
 
 {{< example class="bd-example-row" >}}
 <div class="container">
@@ -365,25 +365,6 @@ Use these row columns classes to quickly create basic grid layouts or to control
     <div class="col">Column</div>
     <div class="col">Column</div>
     <div class="col">Column</div>
-  </div>
-</div>
-{{< /example >}}
-
-{{< example class="bd-example-row" >}}
-<div class="container">
-  <div class="row row-cols-2 row-cols-lg-3">
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
-    <div class="col-4 col-lg-2">Column</div>
   </div>
 </div>
 {{< /example >}}


### PR DESCRIPTION
Reverts twbs/bootstrap#33621.

Rather than go through the motions of splitting our grid, no generating some classes, or generating different classes in different places, I'm proposing we revert this outright and address it properly when we can devote the time to it. Right now this breaks too many things and I'm not sure what the best solution is just yet.

Fixes #34611, fixes #34564, fixes #34335, fixes #34363.