### PR TITLE
Regression on tooltip template creation process.

### DIFF
--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -84,9 +84,7 @@ class Popover extends Tooltip {
     return this.getTitle() || this._getContent()
   }
 
-  setContent() {
-    const tip = this.getTipElement()
-
+  setContent(tip) {
     this._sanitizeAndSetContent(tip, this.getTitle(), SELECTOR_TITLE)
     this._sanitizeAndSetContent(tip, this._getContent(), SELECTOR_CONTENT)
   }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -243,8 +243,6 @@ class Tooltip extends BaseComponent {
     tip.setAttribute('id', tipId)
     this._element.setAttribute('aria-describedby', tipId)
 
-    this.setContent()
-
     if (this._config.animation) {
       tip.classList.add(CLASS_NAME_FADE)
     }
@@ -371,22 +369,19 @@ class Tooltip extends BaseComponent {
     element.innerHTML = this._config.template
 
     const tip = element.children[0]
+    this.setContent(tip)
     tip.classList.remove(CLASS_NAME_FADE, CLASS_NAME_SHOW)
 
     this.tip = tip
     return this.tip
   }
 
-  setContent() {
-    const tip = this.getTipElement()
+  setContent(tip) {
     this._sanitizeAndSetContent(tip, this.getTitle(), SELECTOR_TOOLTIP_INNER)
   }
 
   _sanitizeAndSetContent(template, content, selector) {
     const templateElement = SelectorEngine.findOne(selector, template)
-    if (!templateElement) {
-      return
-    }
 
     if (!content) {
       templateElement.remove()

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -384,6 +384,10 @@ class Tooltip extends BaseComponent {
 
   _sanitizeAndSetContent(template, content, selector) {
     const templateElement = SelectorEngine.findOne(selector, template)
+    if (!templateElement) {
+      return
+    }
+
     if (!content) {
       templateElement.remove()
       return

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -383,7 +383,7 @@ class Tooltip extends BaseComponent {
   _sanitizeAndSetContent(template, content, selector) {
     const templateElement = SelectorEngine.findOne(selector, template)
 
-    if (!content) {
+    if (!content && templateElement) {
       templateElement.remove()
       return
     }

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -1,7 +1,7 @@
 import Popover from '../../src/popover'
 
 /** Test helpers */
-import { getFixture, clearFixture, jQueryMock } from '../helpers/fixture'
+import { clearFixture, getFixture, jQueryMock } from '../helpers/fixture'
 
 describe('Popover', () => {
   let fixtureEl
@@ -154,6 +154,36 @@ describe('Popover', () => {
         done()
       })
 
+      popover.show()
+    })
+
+    it('should call setContent Once', done => {
+      fixtureEl.innerHTML = '<a href="#">BS twitter</a>'
+
+      const popoverEl = fixtureEl.querySelector('a')
+      const popover = new Popover(popoverEl, {
+        content: 'Popover content'
+      })
+
+      const spy = spyOn(popover, 'setContent').and.callThrough()
+      let times = 1
+
+      popoverEl.addEventListener('hidden.bs.popover', () => {
+        popover.show()
+      })
+      popoverEl.addEventListener('shown.bs.popover', () => {
+        const popoverDisplayed = document.querySelector('.popover')
+
+        expect(popoverDisplayed).not.toBeNull()
+        expect(popoverDisplayed.querySelector('.popover-body').textContent).toEqual('Popover content')
+        expect(spy).toHaveBeenCalledTimes(1)
+        if (times > 1) {
+          done()
+        }
+
+        times++
+        popover.hide()
+      })
       popover.show()
     })
 

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -157,7 +157,7 @@ describe('Popover', () => {
       popover.show()
     })
 
-    it('should call setContent Once', done => {
+    it('should call setContent once', done => {
       fixtureEl.innerHTML = '<a href="#">BS twitter</a>'
 
       const popoverEl = fixtureEl.querySelector('a')
@@ -171,6 +171,7 @@ describe('Popover', () => {
       popoverEl.addEventListener('hidden.bs.popover', () => {
         popover.show()
       })
+
       popoverEl.addEventListener('shown.bs.popover', () => {
         const popoverDisplayed = document.querySelector('.popover')
 

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1045,9 +1045,9 @@ describe('Tooltip', () => {
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl)
 
-      tooltip.setContent()
-
       const tip = tooltip.getTipElement()
+
+      tooltip.setContent(tip)
 
       expect(tip.classList.contains('show')).toEqual(false)
       expect(tip.classList.contains('fade')).toEqual(false)


### PR DESCRIPTION
~~Return if template content does not exist (Ex: popover without title)~~

set content only once over an existing tip element


**Replicate**

Go to https://twbs-bootstrap.netlify.app/docs/5.0/components/popovers/#four-directions open js console. Click popover button three times (open->close->open)  
As the code tries to every time to set content, it fails to remove an already removed element