### PR TITLE
Add fallback for missing target in Scrollspy

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -223,7 +223,6 @@ class ScrollSpy extends BaseComponent {
 
     if (!link) {
       console.warn(`Couldn't find target '${target}' while activating scrollspy. Please ensure all targeted elements exist.`)
-
     }
 
     link.classList.add(CLASS_NAME_ACTIVE)

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -221,35 +221,36 @@ class ScrollSpy extends BaseComponent {
 
     const link = SelectorEngine.findOne(queries.join(','), this._config.target)
 
-    if (link) {
-      link.classList.add(CLASS_NAME_ACTIVE)
-
-      if (link.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
-        SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, link.closest(SELECTOR_DROPDOWN))
-          .classList.add(CLASS_NAME_ACTIVE)
-      } else {
-        SelectorEngine.parents(link, SELECTOR_NAV_LIST_GROUP)
-          .forEach(listGroup => {
-            // Set triggered links parents as active
-            // With both <ul> and <nav> markup a parent is the previous sibling of any nav ancestor
-            SelectorEngine.prev(listGroup, `${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}`)
-              .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
-
-            // Handle special case when .nav-link is inside .nav-item
-            SelectorEngine.prev(listGroup, SELECTOR_NAV_ITEMS)
-              .forEach(navItem => {
-                SelectorEngine.children(navItem, SELECTOR_NAV_LINKS)
-                  .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
-              })
-          })
-      }
-
-      EventHandler.trigger(this._scrollElement, EVENT_ACTIVATE, {
-        relatedTarget: target
-      })
-    } else {
+    if (!link) {
       console.warn(`Couldn't find target '${target}' while activating scrollspy. Please ensure all targeted elements exist.`)
+
     }
+
+    link.classList.add(CLASS_NAME_ACTIVE)
+
+    if (link.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
+      SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, link.closest(SELECTOR_DROPDOWN))
+        .classList.add(CLASS_NAME_ACTIVE)
+    } else {
+      SelectorEngine.parents(link, SELECTOR_NAV_LIST_GROUP)
+        .forEach(listGroup => {
+          // Set triggered links parents as active
+          // With both <ul> and <nav> markup a parent is the previous sibling of any nav ancestor
+          SelectorEngine.prev(listGroup, `${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}`)
+            .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
+
+          // Handle special case when .nav-link is inside .nav-item
+          SelectorEngine.prev(listGroup, SELECTOR_NAV_ITEMS)
+            .forEach(navItem => {
+              SelectorEngine.children(navItem, SELECTOR_NAV_LINKS)
+                .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
+            })
+        })
+    }
+
+    EventHandler.trigger(this._scrollElement, EVENT_ACTIVATE, {
+      relatedTarget: target
+    }) 
   }
 
   _clear() {

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -221,7 +221,7 @@ class ScrollSpy extends BaseComponent {
 
     const link = SelectorEngine.findOne(queries.join(','), this._config.target)
 
-    if (link !== undefined && link !== null) {
+    if (link) {
       link.classList.add(CLASS_NAME_ACTIVE)
 
       if (link.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -221,30 +221,35 @@ class ScrollSpy extends BaseComponent {
 
     const link = SelectorEngine.findOne(queries.join(','), this._config.target)
 
-    link.classList.add(CLASS_NAME_ACTIVE)
-    if (link.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
-      SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, link.closest(SELECTOR_DROPDOWN))
-        .classList.add(CLASS_NAME_ACTIVE)
+    if (link !== undefined && link !== null) {
+      link.classList.add(CLASS_NAME_ACTIVE)
+
+      if (link.classList.contains(CLASS_NAME_DROPDOWN_ITEM)) {
+        SelectorEngine.findOne(SELECTOR_DROPDOWN_TOGGLE, link.closest(SELECTOR_DROPDOWN))
+          .classList.add(CLASS_NAME_ACTIVE)
+      } else {
+        SelectorEngine.parents(link, SELECTOR_NAV_LIST_GROUP)
+          .forEach(listGroup => {
+            // Set triggered links parents as active
+            // With both <ul> and <nav> markup a parent is the previous sibling of any nav ancestor
+            SelectorEngine.prev(listGroup, `${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}`)
+              .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
+
+            // Handle special case when .nav-link is inside .nav-item
+            SelectorEngine.prev(listGroup, SELECTOR_NAV_ITEMS)
+              .forEach(navItem => {
+                SelectorEngine.children(navItem, SELECTOR_NAV_LINKS)
+                  .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
+              })
+          })
+      }
+
+      EventHandler.trigger(this._scrollElement, EVENT_ACTIVATE, {
+        relatedTarget: target
+      })
     } else {
-      SelectorEngine.parents(link, SELECTOR_NAV_LIST_GROUP)
-        .forEach(listGroup => {
-          // Set triggered links parents as active
-          // With both <ul> and <nav> markup a parent is the previous sibling of any nav ancestor
-          SelectorEngine.prev(listGroup, `${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}`)
-            .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
-
-          // Handle special case when .nav-link is inside .nav-item
-          SelectorEngine.prev(listGroup, SELECTOR_NAV_ITEMS)
-            .forEach(navItem => {
-              SelectorEngine.children(navItem, SELECTOR_NAV_LINKS)
-                .forEach(item => item.classList.add(CLASS_NAME_ACTIVE))
-            })
-        })
+      console.warn(`Couldn't find target '${target}' while activating scrollspy. Please ensure all targeted elements exist.`)
     }
-
-    EventHandler.trigger(this._scrollElement, EVENT_ACTIVATE, {
-      relatedTarget: target
-    })
   }
 
   _clear() {

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -223,6 +223,7 @@ class ScrollSpy extends BaseComponent {
 
     if (!link) {
       console.warn(`Couldn't find target '${target}' while activating scrollspy. Please ensure all targeted elements exist.`)
+      return
     }
 
     link.classList.add(CLASS_NAME_ACTIVE)

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -250,7 +250,7 @@ class ScrollSpy extends BaseComponent {
 
     EventHandler.trigger(this._scrollElement, EVENT_ACTIVATE, {
       relatedTarget: target
-    }) 
+    })
   }
 
   _clear() {


### PR DESCRIPTION
Fix  #33943 by adding the suggested check by @yura-x with fallback to console warning. The current fallback message can most likely be enhanced, but it was the best/ most concise thing I could come up with for now.