### PR TITLE
Add check to `rgba-css-var` function for body or bg

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -37,11 +37,17 @@
   @return red($value), green($value), blue($value);
 }
 
+// stylelint-disable scss/dollar-variable-pattern
 @function rgba-css-var($identifier, $target) {
-  @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  @if $identifier == "body" and $target == "bg" {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-bg-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  } @if $identifier == "body" and $target == "text" {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-color-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  } @else {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  }
 }
 
-// stylelint-disable scss/dollar-variable-pattern
 @function map-loop($map, $func, $args...) {
   $_map: ();
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -23,7 +23,8 @@
 
   --#{$variable-prefix}white-rgb: #{to-rgb($white)};
   --#{$variable-prefix}black-rgb: #{to-rgb($black)};
-  --#{$variable-prefix}body-rgb: #{to-rgb($body-color)};
+  --#{$variable-prefix}body-color-rgb: #{to-rgb($body-color)};
+  --#{$variable-prefix}body-bg-rgb: #{to-rgb($body-bg)};
 
   // Fonts
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -409,23 +409,33 @@ $body-text-align:           null !default;
 //
 // Extends the default `$theme-colors` maps to help create our utilities.
 
+// Come v6, we'll de-dupe these variables. Until then, for backward compatibility, we keep them to reassign.
 // scss-docs-start utilities-colors
-$utilities-colors: map-merge(
-  $theme-colors-rgb,
-  (
-    "black": to-rgb($black),
-    "white": to-rgb($white),
-    "body":  to-rgb($body-color)
-  )
-) !default;
+$utilities-colors: $theme-colors-rgb !default;
 // scss-docs-end utilities-colors
 
 // scss-docs-start utilities-text-colors
-$utilities-text-colors: map-loop($utilities-colors, rgba-css-var, "$key", "text") !default;
+$utilities-text: map-merge(
+  $utilities-colors,
+  (
+    "black": to-rgb($black),
+    "white": to-rgb($white),
+    "body": to-rgb($body-color)
+  )
+) !default;
+$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text") !default;
 // scss-docs-end utilities-text-colors
 
 // scss-docs-start utilities-bg-colors
-$utilities-bg-colors: map-loop($utilities-colors, rgba-css-var, "$key", "bg") !default;
+$utilities-bg: map-merge(
+  $utilities-colors,
+  (
+    "black": to-rgb($black),
+    "white": to-rgb($white),
+    "body": to-rgb($body-bg)
+  )
+) !default;
+$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg") !default;
 // scss-docs-end utilities-bg-colors
 
 // Links


### PR DESCRIPTION
This is the most straightforward fix I can think of for this situation. It's definitely a my bad for not thinking about the new CSS var `--body-rgb` and there needing to be two separate CSS vars. This PR drops the `--bs-body-rgb` for two separate ones (so it's a small breaking change), but keeps the `.bg-body` and `.text-body` intact without change. it also required duplicating the utilities maps a bit—so we can differentiate at the Sass map level between bg and color. I think this is an acceptable solution, but definitely want to hear thoughts.

Fixes #34688.

/cc @ffoodd 