### PR TITLE
Fix "back to first" modal button in documentation

### DIFF
--- a/site/content/docs/5.1/components/modal.md
+++ b/site/content/docs/5.1/components/modal.md
@@ -528,7 +528,7 @@ Toggle between multiple modals with some clever placement of the `data-bs-target
         Hide this modal and show the first with the button below.
       </div>
       <div class="modal-footer">
-        <button class="btn btn-primary" data-bs-target="#exampleModalToggle" data-bs-toggle="modal">Back to first</button>
+        <button class="btn btn-primary" data-bs-target="#exampleModalToggle2" data-bs-toggle="modal">Back to first</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The "back to first" button currently triggers the modal behind it, not the current modal.

This pr fixes this behaviour.

Try it out in the current documentation here: https://getbootstrap.com/docs/5.1/components/modal/#toggle-between-modals

Best regards