### PR TITLE
Fix `$dropdown-link-hover-color` variable color value in _variable.scss file

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1167,7 +1167,7 @@ $dropdown-divider-margin-y:         $spacer * .5 !default;
 $dropdown-box-shadow:               $box-shadow !default;
 
 $dropdown-link-color:               $gray-900 !default;
-$dropdown-link-hover-color:         shade-color($gray-900, 10%) !default;
+$dropdown-link-hover-color:         shade-color($dropdown-link-color, 10%) !default;
 $dropdown-link-hover-bg:            $gray-200 !default;
 
 $dropdown-link-active-color:        $component-active-color !default;


### PR DESCRIPTION
- Fixes #34746 
- Changed: `$gray-900` to `$dropdown-link-color` variable in `line number 1170`

![Screenshot (167)](https://user-images.githubusercontent.com/54969439/130130875-912a912e-5535-4642-a6b9-6e0372532a93.png)

Fixes #34746 