### PR TITLE
docs: fix typos in approach and placeholders

### DIFF
--- a/site/content/docs/5.1/components/placeholders.md
+++ b/site/content/docs/5.1/components/placeholders.md
@@ -101,7 +101,7 @@ You can change the `width` through grid column classes, width utilities, or inli
 
 ### Color
 
-By default, the `placeholder` uses `currentColor`. This can be overriden with a custom color or utility class.
+By default, the `placeholder` uses `currentColor`. This can be overridden with a custom color or utility class.
 
 {{< example >}}
 <span class="placeholder col-12"></span>

--- a/site/content/docs/5.1/extend/approach.md
+++ b/site/content/docs/5.1/extend/approach.md
@@ -79,7 +79,7 @@ While not always possible, we strive to avoid being overly dogmatic in our HTML 
 
 ## Code conventions
 
-[Code Guide](https://codeguide.co/) (from Bootstrap co-creator, @mdo) documents how we write our HTML and CSS across Bootstrap. It specifices guidelines for general formatting, common sense defaults, property and attribute orders, and more.
+[Code Guide](https://codeguide.co/) (from Bootstrap co-creator, @mdo) documents how we write our HTML and CSS across Bootstrap. It specifies guidelines for general formatting, common sense defaults, property and attribute orders, and more.
 
 We use [Stylelint](https://stylelint.io/) to enforce these standards and more in our Sass/CSS. [Our custom Stylelint config](https://github.com/twbs/stylelint-config-twbs-bootstrap) is open source and available for others to use and extend.
 


### PR DESCRIPTION
made corrections to the typos i have found in the documentations.