### PR TITLE
fix(dropdown): Add missing $variable-prefix

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -47,7 +47,7 @@
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
     .dropdown-menu#{$infix}-start {
-      --bs-position: start;
+      --#{$variable-prefix}position: start;
 
       &[data-bs-popper] {
         right: auto;
@@ -56,7 +56,7 @@
     }
 
     .dropdown-menu#{$infix}-end {
-      --bs-position: end;
+      --#{$variable-prefix}position: end;
 
       &[data-bs-popper] {
         right: 0;


### PR DESCRIPTION
Changes the static `bs-` prefix to use the variable as everywhere else.