### PR TITLE
Progress page: remove toggle animation button

### DIFF
--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -117,17 +117,6 @@
     })
   }
 
-  // Activate animated progress bar
-  var btnToggleAnimatedProgress = document.getElementById('btnToggleAnimatedProgress')
-  if (btnToggleAnimatedProgress) {
-    btnToggleAnimatedProgress.addEventListener('click', function () {
-      btnToggleAnimatedProgress.parentNode
-        .querySelector('.progress-bar-striped')
-        .classList
-        .toggle('progress-bar-animated')
-    })
-  }
-
   // Insert copy to clipboard button before .highlight
   var btnHtml = '<div class="bd-clipboard"><button type="button" class="btn-clipboard" title="Copy to clipboard">Copy</button></div>'
   document.querySelectorAll('div.highlight')

--- a/site/content/docs/5.1/components/progress.md
+++ b/site/content/docs/5.1/components/progress.md
@@ -123,20 +123,11 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
 
 The striped gradient can also be animated. Add `.progress-bar-animated` to `.progress-bar` to animate the stripes right to left via CSS3 animations.
 
-<div class="bd-example">
-  <div class="progress">
-    <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div>
-  </div>
-  <button type="button" class="btn btn-secondary mt-3" data-bs-toggle="button" id="btnToggleAnimatedProgress" aria-pressed="false" autocomplete="off">
-    Toggle animation
-  </button>
-</div>
-
-```html
+{{< example >}}
 <div class="progress">
   <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div>
 </div>
-```
+{{< /example >}}
 
 ## Sass
 


### PR DESCRIPTION
We don't use the same approach with a button on the Placeholders page.

Preview: https://deploy-preview-34787--twbs-bootstrap.netlify.app/docs/5.1/components/progress/#animated-stripes