### PR TITLE
Nested accordions radii

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -64,7 +64,7 @@
   &:first-of-type {
     @include border-top-radius($accordion-border-radius);
 
-    .accordion-button {
+    > * > .accordion-button {
       @include border-top-radius($accordion-inner-border-radius);
     }
   }
@@ -77,7 +77,7 @@
   &:last-of-type {
     @include border-bottom-radius($accordion-border-radius);
 
-    .accordion-button {
+    > * > .accordion-button {
       &.collapsed {
         @include border-bottom-radius($accordion-inner-border-radius);
       }


### PR DESCRIPTION
Fixes #34583

Can't figure out another way to prevent this while keeping the feature intact. The main drawback is the adherence to HTML structure (requiring an intermediate element, being `.accordion-header`) but I tend to prefer that to adding another selector to handle direct children.

---

- Demo [on CodePen](https://codepen.io/ffoodd/pen/wveGweW?editors=1000)