### PR TITLE
Docs extended for navbar events with collapse

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -732,3 +732,7 @@ To create an offcanvas navbar that expands into a normal navbar at a specific br
 [Responsive navbar expand/collapse classes](#responsive-behaviors) (e.g., `.navbar-expand-lg`) are combined with the `$breakpoints` map and generated through a loop in `scss/_navbar.scss`.
 
 {{< scss-docs name="navbar-expand-loop" file="scss/_navbar.scss" >}}
+
+## Events
+To see how expose custom events through javascript, please see the [collapse component documentation](https://getbootstrap.com/docs/5.1/components/collapse/#events)
+


### PR DESCRIPTION
The documentation should have a reference to the collapse component events section. This is essential if trying to tie into event triggers from the navigation toggle button.