### PR TITLE
docs: add `$enable-smooth-scroll` to Sass options page

### DIFF
--- a/site/content/docs/5.1/customize/options.md
+++ b/site/content/docs/5.1/customize/options.md
@@ -26,4 +26,5 @@ You can find and customize these variables for key global options in Bootstrap's
 | `$enable-negative-margins`     | `true` or `false` (default)        | Enables the generation of [negative margin utilities]({{< docsref "/utilities/spacing#negative-margin" >}}). |
 | `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in `v6`. |
 | `$enable-important-utilities`  | `true` (default) or `false`        | Enables the `!important` suffix in utility classes. |
+| `$enable-smooth-scroll`        | `true` (default) or `false`        | Applies `scroll-behavior: smooth` globally, except for users asking for reduced motion through [`prefers-reduced-motion` media query]({{< docsref "/getting-started/accessibility#reduced-motion" >}}) |
 {{< /bs-table >}}


### PR DESCRIPTION
This PR adds `$enable-smooth-scroll` to the Sass options page, fixes #34866

![image](https://user-images.githubusercontent.com/4368481/131881716-b62016ae-aa26-4794-816f-97c91e284f63.png)
