### PR TITLE
Fix a11y issues in `.hstack` example and placeholder 'How it works' example

### DIFF
--- a/site/content/docs/5.1/components/placeholders.md
+++ b/site/content/docs/5.1/components/placeholders.md
@@ -82,7 +82,7 @@ We apply additional styling to `.btn`s via `::before` to ensure the `height` is 
   <span class="placeholder col-6"></span>
 </p>
 
-<a href="#" class="btn btn-primary disabled placeholder col-4" aria-hidden="true"></a>
+<a href="#" tabindex="-1" class="btn btn-primary disabled placeholder col-4" aria-hidden="true"></a>
 {{< /example >}}
 
 {{< callout info >}}

--- a/site/content/docs/5.1/helpers/stacks.md
+++ b/site/content/docs/5.1/helpers/stacks.md
@@ -68,7 +68,7 @@ Create an inline form with `.hstack`:
 
 {{< example >}}
 <div class="hstack gap-3">
-  <input class="form-control me-auto" type="text" placeholder="Add your item here...">
+  <input class="form-control me-auto" type="text" placeholder="Add your item here..." aria-label="Add your item here...">
   <button type="button" class="btn btn-secondary">Submit</button>
   <div class="vr"></div>
   <button type="button" class="btn btn-outline-danger">Reset</button>


### PR DESCRIPTION
2 issues have been found by running pa11y after having merged commits from Bootstrap 5.1.0 into Boosted:
- [Form `<input>` elements must have labels](https://dequeuniversity.com/rules/axe/3.5/label?application=axeAPI)
- [`aria-hidden` elements do not contain focusable elements](https://dequeuniversity.com/rules/axe/3.5/aria-hidden-focus?application=axeAP)

This PR is a proposal to fix those a11y issues.