### PR TITLE
Docs: Add Callout to Stacks Helper page about limited flexbox gap support

### DIFF
--- a/site/content/docs/5.1/helpers/stacks.md
+++ b/site/content/docs/5.1/helpers/stacks.md
@@ -9,7 +9,7 @@ toc: true
 Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
 
 {{< callout warning >}}
-{{< partial "callout-warning-flexbox-gap.md" >}}
+Heads up! Support for gap utilities with flexbox was recently added to Safari, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).
 {{< /callout >}}
 
 ## Vertical

--- a/site/content/docs/5.1/helpers/stacks.md
+++ b/site/content/docs/5.1/helpers/stacks.md
@@ -8,6 +8,10 @@ toc: true
 
 Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
 
+{{< callout warning >}}
+{{< partial "callout-warning-flexbox-gap.md" >}}
+{{< /callout >}}
+
 ## Vertical
 
 Use `.vstack` to create vertical layouts. Stacked items are full-width by default. Use `.gap-*` utilities to add space between items.

--- a/site/layouts/partials/callout-warning-flexbox-gap.md
+++ b/site/layouts/partials/callout-warning-flexbox-gap.md
@@ -1,0 +1,1 @@
+Heads up! Support for gap utilities with flexbox was recently added to Safari, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).

--- a/site/layouts/partials/callout-warning-flexbox-gap.md
+++ b/site/layouts/partials/callout-warning-flexbox-gap.md
@@ -1,1 +1,0 @@
-Heads up! Support for gap utilities with flexbox was recently added to Safari, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).


### PR DESCRIPTION
Fixes: #34737

Preview screenshot from localhost
![localhost_9001_docs_5 1_helpers_stacks_(iPad Pro)](https://user-images.githubusercontent.com/1212885/132213955-1b2198de-7756-4a7e-b52c-e951d0789abd.png)
