### PR TITLE
BrowserStack: add Firefox 60 and Chrome 60

### DIFF
--- a/js/tests/browsers.js
+++ b/js/tests/browsers.js
@@ -28,9 +28,23 @@ const browsers = {
     os: 'Windows',
     os_version: '10',
     browser: 'Chrome',
-    browser_version: 'latest'
+    browser_version: '60'
   },
   firefoxWin10: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '10',
+    browser: 'Firefox',
+    browser_version: '60'
+  },
+  chromeWin10Latest: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '10',
+    browser: 'Chrome',
+    browser_version: 'latest'
+  },
+  firefoxWin10Latest: {
     base: 'BrowserStack',
     os: 'Windows',
     os_version: '10',


### PR DESCRIPTION
These are the minimum supported versions, so this patch makes sure everything works there too.