### PR TITLE
docs: make use of the `.Site.Params.docs_version` variable

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -3,7 +3,7 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v{{ .Site.Params.docs_version }}
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest (5.0.x)</a></li>
+    <li><a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest ({{ .Site.Params.docs_version }}.x)</a></li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>


### PR DESCRIPTION
This PR is a proposal to use the `.Site.Params.docs_version` to display the latest version in the versions selector to avoid having `5.0.x` instead of `5.1.x`:

![Capture d’écran 2021-09-06 à 17 41 50](https://user-images.githubusercontent.com/17381666/132240608-e5e684fe-c25b-4a89-a555-dc18a5fa8eea.png)
