### PR TITLE
Remove remaining "master" branch references

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -1,7 +1,7 @@
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v5.1.1): offcanvas.js
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  * --------------------------------------------------------------------------
  */
 

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -1,7 +1,7 @@
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v5.1.1): util/backdrop.js
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  * --------------------------------------------------------------------------
  */
 

--- a/js/src/util/focustrap.js
+++ b/js/src/util/focustrap.js
@@ -1,7 +1,7 @@
 /**
  * --------------------------------------------------------------------------
  * Bootstrap (v5.1.1): util/focustrap.js
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  * --------------------------------------------------------------------------
  */
 


### PR DESCRIPTION
There are some remaining "master" branch references

Before this PR, `grep -r -l -E "bootstrap/blob/master" *`:
```
dist/js/bootstrap.esm.js
dist/js/bootstrap.bundle.js
dist/js/bootstrap.bundle.min.js.map
dist/js/bootstrap.bundle.js.map
dist/js/bootstrap.esm.js.map
dist/js/bootstrap.js
dist/js/bootstrap.esm.min.js.map
dist/js/bootstrap.js.map
dist/js/bootstrap.min.js.map
js/dist/offcanvas.js
js/dist/modal.js.map
js/dist/offcanvas.js.map
js/dist/modal.js
```

With this PR, after running `npm run release`, the command `grep -r -l -E "bootstrap/blob/master" *` doesn't return anything.