### PR TITLE
Add .offcanvas-expand-* functionality

### DIFF
--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -81,3 +81,48 @@
 .offcanvas.show {
   transform: none;
 }
+
+// Generate series of `.offcanvas-expand-*` responsive classes for configuring
+// where your offcanvas collapses.
+.offcanvas-expand {
+  @each $breakpoint in map-keys($grid-breakpoints) {
+    $next: breakpoint-next($breakpoint, $grid-breakpoints);
+    $infix: breakpoint-infix($next, $grid-breakpoints);
+
+    // stylelint-disable-next-line scss/selector-no-union-class-name
+    &#{$infix} {
+      @include media-breakpoint-up($next) {
+        .offcanvas-header {
+          display: none;
+        }
+
+        .offcanvas {
+          position: inherit;
+          bottom: 0;
+          z-index: 1000;
+          flex-grow: 1;
+          visibility: visible !important; // stylelint-disable-line declaration-no-important
+          background-color: transparent;
+          border-right: 0;
+          border-left: 0;
+          @include transition(none);
+          transform: none;
+        }
+
+        .offcanvas-top,
+        .offcanvas-bottom {
+          height: auto;
+          border-top: 0;
+          border-bottom: 0;
+        }
+
+        .offcanvas-body {
+          display: flex;
+          flex-grow: 0;
+          padding: 0;
+          overflow-y: visible;
+        }
+      }
+    }
+  }
+}

--- a/site/content/docs/5.1/components/offcanvas.md
+++ b/site/content/docs/5.1/components/offcanvas.md
@@ -170,6 +170,35 @@ Scrolling the `<body>` element is disabled when an offcanvas and its backdrop ar
 </div>
 {{< /example >}}
 
+## Responsive behaviors
+
+Offcanvas can be wrapped in an `.offcanvas-expand{-sm|-md|-lg|-xl|-xxl}` class to determine when it's content collapses behind a button. In combination with other utilities, you can easily choose when to show or hide particular elements.
+
+For Offcanvas that never collapse, wrap the Offcanvas with the `.offcanvas-expand` class. For Offcanvas that always collapse, don't wrap with any `.offcanvas-expand` class.
+
+{{< example >}}
+<div class="offcanvas-expand-md">
+    <button class="btn btn-primary d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasCollapse" aria-controls="offcanvasCollapse">
+        Show Offcanvas
+    </button>
+
+    <div id="offcanvasCollapse" class="offcanvas offcanvas-end" aria-labelledby="offcanvasTitle">
+        <div class="offcanvas-header">
+            <h2 class="offcanvas-title" id="offcanvasTitle">Title</h2>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+
+        <div class="offcanvas-body">
+            <ul>
+                <li>One</li>
+                <li>Two</li>
+            </ul>
+        </div>
+    </div>
+</div>
+{{< /example >}}
+
+
 ## Accessibility
 
 Since the offcanvas panel is conceptually a modal dialog, be sure to add `aria-labelledby="..."`—referencing the offcanvas title—to `.offcanvas`. Note that you don’t need to add `role="dialog"` since we already add it via JavaScript.


### PR DESCRIPTION
_Almost identical to how it works with the [Navbar that uses Offcanvas and expands to a normal navbar](https://getbootstrap.com/docs/5.1/components/navbar/#offcanvas)._

>Offcanvas can be wrapped in an `.offcanvas-expand{-sm|-md|-lg|-xl|-xxl}` class to determine when it's content collapses behind a button. In combination with other utilities, you can easily choose when to show or hide particular elements.
>
> For Offcanvas that never collapse, wrap the Offcanvas with the `.offcanvas-expand` class. For Offcanvas that always collapse, don't wrap with any `.offcanvas-expand` class.

## Usage
```html
<div class="offcanvas-expand-md">
    <button class="btn btn-primary d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasCollapse" aria-controls="offcanvasCollapse">
        Show Offcanvas
    </button>

    <div id="offcanvasCollapse" class="offcanvas offcanvas-end" aria-labelledby="offcanvasTitle">
        <div class="offcanvas-header">
            <h2 class="offcanvas-title" id="offcanvasTitle">Title</h2>
            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
        </div>

        <div class="offcanvas-body">
            <ul>
                <li>One</li>
                <li>Two</li>
            </ul>
        </div>
    </div>
</div>
```