### PR TITLE
Translation version update

### DIFF
--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -3,22 +3,17 @@
   description: Bootstrap 5 باللغة العربية
   url: https://bootstrap.mahdi.style/
 
-- name: Chinese
-  code: zh
-  description: Bootstrap 5 · 全球最流行的 HTML、CSS 和 JS 工具库。
-  url: https://code.z01.com/bootstrap/
-
-- name: Japanese
+- name: 日本語
   code: ja
   description: Bootstrap 5 日本語リファレンス
   url: https://getbootstrap.jp/
 
-- name: Russian
+- name: Русский
   code: ru
   description: Bootstrap 5 на русском
   url: https://getbootstrap.su/
 
-- name: Korean
+- name: 한국어
   code: ko
   description: Bootstrap 5 한국어 문서
   url: https://getbootstrap.kr/

--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -3,24 +3,14 @@
   description: Bootstrap 5 باللغة العربية
   url: https://bootstrap.mahdi.style/
 
-- name: 中文(繁體)
-  code: zh-tw
-  description: Bootstrap 4 繁體中文手冊
-  url: https://bootstrap.hexschool.com/
-
 - name: Chinese
   code: zh
-  description: Bootstrap 4 · 全球最流行的 HTML、CSS 和 JS 工具库。
-  url: https://code.z01.com/v4/
-
-- name: Brazilian Portuguese
-  code: pt-BR
-  description: Bootstrap 4 Português do Brasil
-  url: https://getbootstrap.com.br/v4/
+  description: Bootstrap 5 · 全球最流行的 HTML、CSS 和 JS 工具库。
+  url: https://code.z01.com/bootstrap/
 
 - name: Japanese
   code: ja
-  description: Bootstrap 4 日本語リファレンス
+  description: Bootstrap 5 日本語リファレンス
   url: https://getbootstrap.jp/
 
 - name: Russian

--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -23,7 +23,7 @@
   description: Bootstrap 5 繁體中文手冊
   url: https://bootstrap5.hexschool.com/
 
-- name: Simplified Chinese
+- name: 中文 (简体)
   code: zh-CN
   description: Bootstrap 5 中文文档
   url: https://v5.bootcss.com/


### PR DESCRIPTION
* `ja` now supports v5
 * `pt-BR` stopped translation
 * `zh-tw` is duplicated
 * `zh`(code.z01.com) is too customized
 * Localized `ja`, `ru`, `ko`, `zh-CN` name