### PR TITLE
Fixed Toast notifications not having background blur.

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -9,6 +9,7 @@
   background-clip: padding-box;
   border: $toast-border-width solid $toast-border-color;
   box-shadow: $toast-box-shadow;
+  backdrop-filter: blur(10px);
   opacity: 0;
   @include border-radius($toast-border-radius);
 


### PR DESCRIPTION
Hello guys,

I believe the background blur from Toasts was mistakenly removed. The background blur on toasts was available up until bootstrap 4.5.0, in v4.5.1 there were some changes, in which it seems that the background blur got removed.

The Bootstrap Documentation for v4.6.0 also mentions that there's an attempt to blur the background under the Toast but there's no such code to do it: https://getbootstrap.com/docs/4.6/components/toasts/#translucent

I've noticed this now that we've upgraded to the latest stable 4.6.x version and it looks yuck 😅.

Thank you.