### PR TITLE
Reduce change-version.js's scope of modifications

### DIFF
--- a/build/change-version.js
+++ b/build/change-version.js
@@ -41,8 +41,8 @@ async function replaceRecursively(file, oldVersion, newVersion, limitNumberOfRep
   const originalString = await fs.readFile(file, 'utf8')
   let newString = originalString
 
-  if (0 < limitNumberOfReplacements) {
-    for (var i = 0 ; i < limitNumberOfReplacements ; i++) {
+  if (limitNumberOfReplacements > 0) {
+    for (let i = 0; i < limitNumberOfReplacements; i++) {
       newString = newString.replace(oldVersion, newVersion)
     }
   } else {
@@ -85,8 +85,8 @@ async function main(args) {
     const oldVersionJSONString = `"version": "${oldVersion}"`
     const newVersionJSONString = `"version": "${newVersion}"`
 
-    await replaceRecursively('package.json', oldVersionJSONString, newVersionJSONString, 1);
-    await replaceRecursively('package-lock.json', oldVersionJSONString, newVersionJSONString, 2);
+    await replaceRecursively('package.json', oldVersionJSONString, newVersionJSONString, 1)
+    await replaceRecursively('package-lock.json', oldVersionJSONString, newVersionJSONString, 2)
 
     await Promise.all(filteredFiles.map(file => replaceRecursively(file, oldVersion, newVersion)))
   } catch (error) {

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -72,15 +72,14 @@ async function main(args) {
   // Strip any leading `v` from arguments because otherwise we will end up with duplicate `v`s
   [oldVersion, newVersion] = [oldVersion, newVersion].map(arg => arg.startsWith('v') ? arg.slice(1) : arg)
 
-  // Modify specifically package*.json files to avoid modifying other dependencies versions
-  const oldVersionJSONString = '"version": "' + oldVersion + '"'
-  const newVersionJSONString = '"version": "' + newVersion + '"'
-  replaceRecursively('package.json', oldVersionJSONString, newVersionJSONString, true)
-  replaceRecursively('package-lock.json', oldVersionJSONString, newVersionJSONString, true)
-
   try {
     const allFiles = await globby(GLOB, GLOBBY_OPTIONS)
     const filteredFiles = allFiles.filter(file => !EXCLUDE_FILES_PATTERN.test(file))
+
+    // Modify specifically package*.json files to avoid modifying other dependencies versions
+    const oldVersionJSONString = `"version": "${oldVersion}"`
+    const newVersionJSONString = `"version": "${newVersion}"`
+    await Promise.all(['package.json', 'package-lock.json'].map(file => replaceRecursively(file, oldVersionJSONString, newVersionJSONString, true)))
 
     await Promise.all(filteredFiles.map(file => replaceRecursively(file, oldVersion, newVersion)))
   } catch (error) {

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -26,7 +26,7 @@ const GLOBBY_OPTIONS = {
 }
 
 // Avoid modifying documentation content and dependencies in package*.json files matching the newVersion
-const EXCLUDE_FILES_PATTERN = '^(site/content/docs/|package.json|package-lock.json)'
+const EXCLUDE_FILES_PATTERN = /^(site\/content\/docs\/|package\.json|package-lock\.json)/
 
 // Blame TC39... https://github.com/benjamingr/RegExp.escape/issues/37
 function regExpQuote(string) {
@@ -79,9 +79,10 @@ async function main(args) {
   replaceRecursively('package-lock.json', oldVersionJSONString, newVersionJSONString, true)
 
   try {
-    const files = (await globby(GLOB, GLOBBY_OPTIONS)).filter(file => !(new RegExp(EXCLUDE_FILES_PATTERN).test(file)))
+    const allFiles = await globby(GLOB, GLOBBY_OPTIONS)
+    const filteredFiles = allFiles.filter(file => !EXCLUDE_FILES_PATTERN.test(file))
 
-    await Promise.all(files.map(file => replaceRecursively(file, oldVersion, newVersion)))
+    await Promise.all(filteredFiles.map(file => replaceRecursively(file, oldVersion, newVersion)))
   } catch (error) {
     console.error(error)
     process.exit(1)

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -42,7 +42,7 @@ async function replaceRecursively(file, oldVersion, newVersion, onlyFirstMatch =
 
   const newString = onlyFirstMatch ?
     originalString.replace(oldVersion, newVersion) :
-    originalString.replace(new RegExp(regExpQuote(oldVersion), 'g', regExpQuoteReplacement(newVersion)))
+    originalString.replace(new RegExp(regExpQuote(oldVersion), 'g'), regExpQuoteReplacement(newVersion))
 
   // No need to move any further if the strings are identical
   if (originalString === newString) {

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -26,6 +26,7 @@ const GLOBBY_OPTIONS = {
 }
 
 // Avoid modifying documentation content, **/dist files and dependencies in package*.json files matching the newVersion
+// We'll modify package*.json later explicitly
 const EXCLUDE_FILES_PATTERN = /^(site\/content\/docs\/|package\.json|package-lock\.json|(.*\/)?dist\/)/
 
 // Blame TC39... https://github.com/benjamingr/RegExp.escape/issues/37

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -42,9 +42,7 @@ async function replaceRecursively(file, oldVersion, newVersion, onlyFirstMatch =
 
   const newString = onlyFirstMatch ?
     originalString.replace(oldVersion, newVersion) :
-    originalString.replace(
-      new RegExp(regExpQuote(oldVersion), 'g', regExpQuoteReplacement(newVersion))
-    )
+    originalString.replace(new RegExp(regExpQuote(oldVersion), 'g', regExpQuoteReplacement(newVersion)))
 
   // No need to move any further if the strings are identical
   if (originalString === newString) {


### PR DESCRIPTION
This PR is a suggestion to reduce the `build/change-version.js` scope of modifications after having seen those issues while releasing [Boosted](https://boosted.orange.com/):

* Only modify Bootstrap version in package*.json
* Don't modify versions in site/content/docs files

Let's go back a few days with the commit before "Release v5.1.1":

```
git checkout b6855ae13817f516f63bd2916ead5243e07f210b
npm i
npm run release-version 5.1.0 5.1.1
```

From here:

* `package.json` and `package-lock.json` are modified but "bootstrap" package version isn't the only one to be modified:

```diff
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
modified: package.json
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@ package.json:4 @
{
  "name": "bootstrap",
  "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
  "version": "5.1.0",
  "version": "5.1.1",
  "config": {
    "version_short": "5.1"
  },
@ package.json:148 @
    "shelljs": "^0.8.4",
    "stylelint": "^13.13.1",
    "stylelint-config-twbs-bootstrap": "^2.2.3",
    "terser": "5.1.0",
    "terser": "5.1.1",
    "vnu-jar": "21.9.2"
  },
  "files": [
```

so if the release manager doesn't see it, some packages will be updated

* `site/content/docs/5.1/**/*.md` are modified (4 files are concerned when bumping from 5.1.0 to 5.1.1). This is the type of modifications that we can observe:

```diff
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
modified: site/content/docs/5.1/customize/color.md
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@ color.md:112 @ Here's how you can use these in your Sass:

## Generating utilities

<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.1.0</small>
<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.1.1</small>

Bootstrap doesn't include `color` and `background-color` utilities for every color variable, but you can generate these yourself with our [utility API]({{< docsref "/utilities/api" >}}) and our extended Sass maps added in v5.1.0.
Bootstrap doesn't include `color` and `background-color` utilities for every color variable, but you can generate these yourself with our [utility API]({{< docsref "/utilities/api" >}}) and our extended Sass maps added in v5.1.1.

1. To start, make sure you've imported our functions, variables, mixins, and utilities.
2. Use our `map-merge-multiple()` function to quickly merge multiple Sass maps together in a new map.
```

But as well, those are unwanted updates because those versions must remain the same. I don't know well the history of the project but this type of information ("added in v5.x.x") is relatively new.

