### PR TITLE
examples: Add `role="switch"` to switches

### DIFF
--- a/site/content/docs/5.1/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.1/examples/cheatsheet-rtl/index.html
@@ -355,7 +355,7 @@ direction: rtl
             <input type="file" class="form-control" id="customFile">
           </div>
           <div class="mb-3 form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="flexSwitchCheckChecked" checked>
+            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
             <label class="form-check-label" for="flexSwitchCheckChecked">زر على شكل مفتاح اختيار.</label>
           </div>
           <div class="mb-3">
@@ -411,7 +411,7 @@ direction: rtl
               <input type="file" class="form-control" id="disabledCustomFile" disabled>
             </div>
             <div class="mb-3 form-check form-switch">
-              <input class="form-check-input" type="checkbox" id="disabledSwitchCheckChecked" checked disabled>
+              <input class="form-check-input" type="checkbox" role="switch" id="disabledSwitchCheckChecked" checked disabled>
               <label class="form-check-label" for="disabledSwitchCheckChecked">زر معطل على شكل مفتاح اختيار.</label>
             </div>
             <div class="mb-3">

--- a/site/content/docs/5.1/examples/cheatsheet/index.html
+++ b/site/content/docs/5.1/examples/cheatsheet/index.html
@@ -354,7 +354,7 @@ body_class: "bg-light"
             <input type="file" class="form-control" id="customFile">
           </div>
           <div class="mb-3 form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="flexSwitchCheckChecked" checked>
+            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
             <label class="form-check-label" for="flexSwitchCheckChecked">Checked switch checkbox input</label>
           </div>
           <div class="mb-3">
@@ -410,7 +410,7 @@ body_class: "bg-light"
               <input type="file" class="form-control" id="disabledCustomFile" disabled>
             </div>
             <div class="mb-3 form-check form-switch">
-              <input class="form-check-input" type="checkbox" id="disabledSwitchCheckChecked" checked disabled>
+              <input class="form-check-input" type="checkbox" role="switch" id="disabledSwitchCheckChecked" checked disabled>
               <label class="form-check-label" for="disabledSwitchCheckChecked">Disabled checked switch checkbox input</label>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
Add `role="switch"` to switches in examples according to https://github.com/twbs/bootstrap/commit/cb87ed2a7985744f042b663d2c87653ce68da476