### PR TITLE
Fix the integrity value of Popperjs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,4 +76,4 @@ params:
     js_bundle:        "https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
     js_bundle_hash:   "sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
     popper:           "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"
-    popper_hash:      "sha384-W8fXfP3gkOKtndU4JGtKDvXbO53Wy8SZCQHczT5FMiiqmQfUpWbYdTil/SxwZgAN"
+    popper_hash:      "sha384-eMNCOe7tC1doHpGoWe/6oMVemdAVTMs2xqW4mwXrXsW0L84Iytr2wi5v2QjrP/xp"


### PR DESCRIPTION
According to https://www.srihash.org/, The correct value for Popperjs 2.9.3 (`https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js`) with sha-384 should be:

```
sha384-eMNCOe7tC1doHpGoWe/6oMVemdAVTMs2xqW4mwXrXsW0L84Iytr2wi5v2QjrP/xp
```

The current value is for Popperjs 2.10.1.

- fixes #35000