### PR TITLE
rollup: specify `generatedCode: 'es2015'`

### DIFF
--- a/build/build-plugins.js
+++ b/build/build-plugins.js
@@ -163,6 +163,7 @@ const build = async plugin => {
     name: plugin,
     sourcemap: true,
     globals,
+    generatedCode: 'es2015',
     file: path.resolve(__dirname, `${pluginPath}/${pluginFilename}`)
   })
 

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -43,7 +43,8 @@ const rollupConfig = {
     banner,
     file: path.resolve(__dirname, `../dist/js/${fileDest}.js`),
     format: ESM ? 'esm' : 'umd',
-    globals
+    globals,
+    generatedCode: 'es2015'
   },
   external,
   plugins

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -98,7 +98,8 @@ const conf = {
     output: {
       format: 'iife',
       name: 'bootstrapTest',
-      sourcemap: 'inline'
+      sourcemap: 'inline',
+      generatedCode: 'es2015'
     }
   }
 }


### PR DESCRIPTION
This will make use of `const` and modern features (which we are already using in our code) in the generated rollup code.

TODO:

- [x] **Revert the dist commits before merging**