### PR TITLE
Fixes missing variable issue with `media-breakpoint-only`

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -109,7 +109,7 @@
 @mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
   $min:  breakpoint-min($name, $breakpoints);
   $next: breakpoint-next($name, $breakpoints);
-  $max:  breakpoint-max($next);
+  $max:  breakpoint-max($next, $breakpoints);
 
   @if $min != null and $max != null {
     @media (min-width: $min) and (max-width: $max) {


### PR DESCRIPTION
`media-breakpoint-only` now passes `$breakpoints` int `breakpoint-max`.  Fixes #35084.