### PR TITLE
Revert "Add `align-self: center` to buttons for improved rendering in flex containers"

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -4,7 +4,6 @@
 
 .btn {
   display: inline-block;
-  align-self: center;
   font-family: $btn-font-family;
   font-weight: $btn-font-weight;
   line-height: $btn-line-height;


### PR DESCRIPTION
Reverts twbs/bootstrap#34834. Fixes #35126.

/cc @ffoodd 