### PR TITLE
Dropdown remove redundant code

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -39,8 +39,6 @@ const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
 const RIGHT_MOUSE_BUTTON = 2 // MouseEvent.button value for the secondary button, usually the right button
 
-const REGEXP_KEYDOWN = new RegExp(`${ARROW_UP_KEY}|${ARROW_DOWN_KEY}|${ESCAPE_KEY}`)
-
 const EVENT_HIDE = `hide${EVENT_KEY}`
 const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
@@ -407,12 +405,21 @@ class Dropdown extends BaseComponent {
     //  - If key is other than escape
     //    - If key is not up or down => not a dropdown command
     //    - If trigger inside the menu => not a dropdown command
-    if (/input|textarea/i.test(event.target.tagName) ?
-      event.key === SPACE_KEY || (event.key !== ESCAPE_KEY &&
-      ((event.key !== ARROW_DOWN_KEY && event.key !== ARROW_UP_KEY) ||
-        event.target.closest(SELECTOR_MENU))) :
-      !REGEXP_KEYDOWN.test(event.key)) {
+
+    const isInput = /input|textarea/i.test(event.target.tagName)
+    const eventKey = event.key
+    if (!isInput && ![ARROW_UP_KEY, ARROW_DOWN_KEY, ESCAPE_KEY].includes(eventKey)) {
       return
+    }
+
+    if (isInput) {
+      if (eventKey === SPACE_KEY) {
+        return
+      }
+
+      if (eventKey !== ESCAPE_KEY && (![ARROW_UP_KEY, ARROW_DOWN_KEY].includes(eventKey) || event.target.closest(SELECTOR_MENU))) {
+        return
+      }
     }
 
     const isActive = this.classList.contains(CLASS_NAME_SHOW)

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -133,12 +133,8 @@ class Dropdown extends BaseComponent {
     }
 
     const parent = getElementFromSelector(this._element) || this._element.parentNode
-    // Totally disable Popper for Dropdowns in Navbar
-    if (this._inNavbar) {
-      Manipulator.setDataAttribute(this._menu, 'popper', 'none')
-    } else {
-      this._createPopper(parent)
-    }
+
+    this._createPopper(parent)
 
     // If this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;
@@ -246,13 +242,7 @@ class Dropdown extends BaseComponent {
     }
 
     const popperConfig = this._getPopperConfig()
-    const isDisplayStatic = popperConfig.modifiers.find(modifier => modifier.name === 'applyStyles' && modifier.enabled === false)
-
     this._popper = Popper.createPopper(referenceElement, this._menu, popperConfig)
-
-    if (isDisplayStatic) {
-      Manipulator.setDataAttribute(this._menu, 'popper', 'static')
-    }
   }
 
   _isShown(element = this._element) {
@@ -319,8 +309,9 @@ class Dropdown extends BaseComponent {
       }]
     }
 
-    // Disable Popper if we have a static display
-    if (this._config.display === 'static') {
+    // Disable Popper if we have a static display or Dropdown is in Navbar
+    if (this._inNavbar || this._config.display === 'static') {
+      Manipulator.setDataAttribute(this._menu, 'popper', 'static') // todo:v6 remove
       defaultBsPopperConfig.modifiers = [{
         name: 'applyStyles',
         enabled: false

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -405,21 +405,23 @@ class Dropdown extends BaseComponent {
     //    - If trigger inside the menu => not a dropdown command
 
     const isInput = /input|textarea/i.test(event.target.tagName)
-    const eventKey = event.key
-    if (!isInput && ![ARROW_UP_KEY, ARROW_DOWN_KEY, ESCAPE_KEY].includes(eventKey)) {
+    const isEscapeEvent = event.key === ESCAPE_KEY
+    const isUpOrDownEvent = [ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)
+
+    if (!isInput && !(isUpOrDownEvent || isEscapeEvent)) {
       return
     }
 
     if (isInput) {
       // eslint-disable-next-line unicorn/no-lonely-if
-      if (eventKey !== ESCAPE_KEY && (![ARROW_UP_KEY, ARROW_DOWN_KEY].includes(eventKey) || event.target.closest(SELECTOR_MENU))) {
+      if (!isEscapeEvent && (!isUpOrDownEvent || event.target.closest(SELECTOR_MENU))) {
         return
       }
     }
 
     const isActive = this.classList.contains(CLASS_NAME_SHOW)
 
-    if (!isActive && event.key === ESCAPE_KEY) {
+    if (!isActive && isEscapeEvent) {
       return
     }
 
@@ -433,12 +435,12 @@ class Dropdown extends BaseComponent {
     const getToggleButton = this.matches(SELECTOR_DATA_TOGGLE) ? this : SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0]
     const instance = Dropdown.getOrCreateInstance(getToggleButton)
 
-    if (event.key === ESCAPE_KEY) {
+    if (isEscapeEvent) {
       instance.hide()
       return
     }
 
-    if (event.key === ARROW_UP_KEY || event.key === ARROW_DOWN_KEY) {
+    if (isUpOrDownEvent) {
       instance.show()
       instance._selectMenuItem(event)
     }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -33,7 +33,6 @@ const EVENT_KEY = `.${DATA_KEY}`
 const DATA_API_KEY = '.data-api'
 
 const ESCAPE_KEY = 'Escape'
-const SPACE_KEY = 'Space'
 const TAB_KEY = 'Tab'
 const ARROW_UP_KEY = 'ArrowUp'
 const ARROW_DOWN_KEY = 'ArrowDown'
@@ -399,11 +398,10 @@ class Dropdown extends BaseComponent {
 
   static dataApiKeydownHandler(event) {
     // If not input/textarea:
-    //  - And not a key in REGEXP_KEYDOWN => not a dropdown command
+    //  - And not a key in UP | DOWN | ESCAPE => not a dropdown command
     // If input/textarea:
-    //  - If space key => not a dropdown command
-    //  - If key is other than escape
-    //    - If key is not up or down => not a dropdown command
+    //  - If key is other than ESCAPE
+    //    - If key is not UP or DOWN => not a dropdown command
     //    - If trigger inside the menu => not a dropdown command
 
     const isInput = /input|textarea/i.test(event.target.tagName)
@@ -413,10 +411,7 @@ class Dropdown extends BaseComponent {
     }
 
     if (isInput) {
-      if (eventKey === SPACE_KEY) {
-        return
-      }
-
+      // eslint-disable-next-line unicorn/no-lonely-if
       if (eventKey !== ESCAPE_KEY && (![ARROW_UP_KEY, ARROW_DOWN_KEY].includes(eventKey) || event.target.closest(SELECTOR_MENU))) {
         return
       }
@@ -446,11 +441,6 @@ class Dropdown extends BaseComponent {
     if (event.key === ARROW_UP_KEY || event.key === ARROW_DOWN_KEY) {
       instance.show()
       instance._selectMenuItem(event)
-      return
-    }
-
-    if (!isActive || event.key === SPACE_KEY) {
-      Dropdown.clearMenus()
     }
   }
 }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -437,10 +437,7 @@ class Dropdown extends BaseComponent {
     }
 
     if (event.key === ARROW_UP_KEY || event.key === ARROW_DOWN_KEY) {
-      if (!isActive) {
-        instance.show()
-      }
-
+      instance.show()
       instance._selectMenuItem(event)
       return
     }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -132,7 +132,7 @@ class Dropdown extends BaseComponent {
       return
     }
 
-    const parent = Dropdown.getParentFromElement(this._element)
+    const parent = getElementFromSelector(this._element) || this._element.parentNode
     // Totally disable Popper for Dropdowns in Navbar
     if (this._inNavbar) {
       Manipulator.setDataAttribute(this._menu, 'popper', 'none')
@@ -406,10 +406,6 @@ class Dropdown extends BaseComponent {
 
       context._completeHide(relatedTarget)
     }
-  }
-
-  static getParentFromElement(element) {
-    return getElementFromSelector(element) || element.parentNode
   }
 
   static dataApiKeydownHandler(event) {

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -399,8 +399,7 @@ class Dropdown extends BaseComponent {
   static dataApiKeydownHandler(event) {
     // If not input/textarea:
     //  - And not a key in UP | DOWN | ESCAPE => not a dropdown command
-    // If input/textarea:
-    //  - If key is other than ESCAPE
+    // If input/textarea && If key is other than ESCAPE
     //    - If key is not UP or DOWN => not a dropdown command
     //    - If trigger inside the menu => not a dropdown command
 
@@ -412,9 +411,9 @@ class Dropdown extends BaseComponent {
       return
     }
 
-    if (isInput) {
+    if (isInput && !isEscapeEvent) {
       // eslint-disable-next-line unicorn/no-lonely-if
-      if (!isEscapeEvent && (!isUpOrDownEvent || event.target.closest(SELECTOR_MENU))) {
+      if (!isUpOrDownEvent || event.target.closest(SELECTOR_MENU)) {
         return
       }
     }

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -53,10 +53,10 @@ const CLASS_NAME_SHOW = 'show'
 const CLASS_NAME_DROPUP = 'dropup'
 const CLASS_NAME_DROPEND = 'dropend'
 const CLASS_NAME_DROPSTART = 'dropstart'
-const CLASS_NAME_NAVBAR = 'navbar'
 
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="dropdown"]'
 const SELECTOR_MENU = '.dropdown-menu'
+const SELECTOR_NAVBAR = '.navbar'
 const SELECTOR_NAVBAR_NAV = '.navbar-nav'
 const SELECTOR_VISIBLE_ITEMS = '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
 
@@ -275,7 +275,7 @@ class Dropdown extends BaseComponent {
   }
 
   _detectNavbar() {
-    return this._element.closest(`.${CLASS_NAME_NAVBAR}`) !== null
+    return this._element.closest(SELECTOR_NAVBAR) !== null
   }
 
   _getOffset() {

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -351,7 +351,7 @@ class Dropdown extends BaseComponent {
   }
 
   static clearMenus(event) {
-    if (event && (event.button === RIGHT_MOUSE_BUTTON || (event.type === 'keyup' && event.key !== TAB_KEY))) {
+    if (event.button === RIGHT_MOUSE_BUTTON || (event.type === 'keyup' && event.key !== TAB_KEY)) {
       return
     }
 
@@ -371,25 +371,23 @@ class Dropdown extends BaseComponent {
         relatedTarget: context._element
       }
 
-      if (event) {
-        const composedPath = event.composedPath()
-        const isMenuTarget = composedPath.includes(context._menu)
-        if (
-          composedPath.includes(context._element) ||
-          (context._config.autoClose === 'inside' && !isMenuTarget) ||
-          (context._config.autoClose === 'outside' && isMenuTarget)
-        ) {
-          continue
-        }
+      const composedPath = event.composedPath()
+      const isMenuTarget = composedPath.includes(context._menu)
+      if (
+        composedPath.includes(context._element) ||
+        (context._config.autoClose === 'inside' && !isMenuTarget) ||
+        (context._config.autoClose === 'outside' && isMenuTarget)
+      ) {
+        continue
+      }
 
-        // Tab navigation through the dropdown menu or events from contained inputs shouldn't close the menu
-        if (context._menu.contains(event.target) && ((event.type === 'keyup' && event.key === TAB_KEY) || /input|select|option|textarea|form/i.test(event.target.tagName))) {
-          continue
-        }
+      // Tab navigation through the dropdown menu or events from contained inputs shouldn't close the menu
+      if (context._menu.contains(event.target) && ((event.type === 'keyup' && event.key === TAB_KEY) || /input|select|option|textarea|form/i.test(event.target.tagName))) {
+        continue
+      }
 
-        if (event.type === 'click') {
-          relatedTarget.clickEvent = event
-        }
+      if (event.type === 'click') {
+        relatedTarget.clickEvent = event
       }
 
       context._completeHide(relatedTarget)

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1054,7 +1054,7 @@ describe('Dropdown', () => {
       btnDropdown.click()
     })
 
-    it('should not use Popper in navbar', done => {
+    it('should not use "static" Popper in navbar', done => {
       fixtureEl.innerHTML = [
         '<nav class="navbar navbar-expand-md navbar-light bg-light">',
         '  <div class="dropdown">',
@@ -1071,8 +1071,8 @@ describe('Dropdown', () => {
       const dropdown = new Dropdown(btnDropdown)
 
       btnDropdown.addEventListener('shown.bs.dropdown', () => {
-        expect(dropdown._popper).toBeNull()
-        expect(dropdownMenu.getAttribute('style')).toBeNull()
+        expect(dropdown._popper).not.toBeNull()
+        expect(dropdownMenu.getAttribute('data-bs-popper')).toEqual('static')
         done()
       })
 
@@ -1120,7 +1120,7 @@ describe('Dropdown', () => {
       dropdown.show()
     })
 
-    it('should manage bs attribute `data-bs-popper`="none" when dropdown is in navbar', done => {
+    it('should manage bs attribute `data-bs-popper`="static" when dropdown is in navbar', done => {
       fixtureEl.innerHTML = [
         '<nav class="navbar navbar-expand-md navbar-light bg-light">',
         '  <div class="dropdown">',
@@ -1137,7 +1137,7 @@ describe('Dropdown', () => {
       const dropdown = new Dropdown(btnDropdown)
 
       btnDropdown.addEventListener('shown.bs.dropdown', () => {
-        expect(dropdownMenu.getAttribute('data-bs-popper')).toEqual('none')
+        expect(dropdownMenu.getAttribute('data-bs-popper')).toEqual('static')
         dropdown.hide()
       })
 

--- a/site/content/docs/5.1/migration.md
+++ b/site/content/docs/5.1/migration.md
@@ -297,7 +297,7 @@ Your custom Bootstrap CSS builds should now look something like this with a sepa
 
 - <span class="badge bg-danger">Breaking</span> All the events for the dropdown are now triggered on the dropdown toggle button and then bubbled up to the parent element.
 
-- Dropdown menus now have a `data-bs-popper="static"` attribute set when the positioning of the dropdown is static and `data-bs-popper="none"` when dropdown is in the navbar. This is added by our JavaScript and helps us use custom position styles without interfering with Popper's positioning.
+- Dropdown menus now have a `data-bs-popper="static"` attribute set when the positioning of the dropdown is static, or dropdown is in the navbar. This is added by our JavaScript and helps us use custom position styles without interfering with Popper's positioning.
 
 - <span class="badge bg-danger">Breaking</span> Dropped `flip` option for dropdown plugin in favor of native Popper configuration. You can now disable the flipping behavior by passing an empty array for [`fallbackPlacements`](https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements) option in [flip](https://popper.js.org/docs/v2/modifiers/flip/) modifier.
 


### PR DESCRIPTION
This MR,
*  merges the `data-bs-display="static"` & `isNavBar` case handling
*  refactors the `dataApiKeydownHandler` simplifying the checks, and shows that a code block was useless
*  it also removes a static method that was called once

------

NOTE for reviewers:

Better review it, commit by commit. It will help you with the proper message and will guide you with sanity to follow the logic
