### PR TITLE
Allow `data-toggle="dropdown"` and form click events to bubble (Backport #33442)

### DIFF
--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -1658,4 +1658,60 @@ $(function () {
 
     $dropdown.trigger('click')
   })
+
+  QUnit.test('should allow `data-bs-toggle="dropdown"` click events to bubble up', function (assert) {
+    assert.expect(2)
+    var fixtureHtml = [
+      '<div class="dropdown">',
+      '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+      '  <div class="dropdown-menu">',
+      '    <a class="dropdown-item" href="#">Secondary link</a>',
+      '  </div>',
+      '</div>'
+    ].join('')
+
+    $(fixtureHtml).appendTo('#qunit-fixture')
+    var btnDropdown = $('[data-bs-toggle="dropdown"]')
+    var clickListener = sinon.spy('clickListener')
+    var delegatedClickListener = sinon.spy('delegatedClickListener')
+
+    btnDropdown.addEventListener('click', clickListener)
+    document.addEventListener('click', delegatedClickListener)
+
+    btnDropdown.click()
+
+    sinon.assert.calledOnce(clickListener)
+    sinon.assert.calledOnce(delegatedClickListener)
+  })
+
+  QUnit.test('should open the dropdown when clicking the child element inside `data-bs-toggle="dropdown"`', function (assert) {
+    assert.expect(3)
+    var done = assert.async()
+    var fixtureHtml = [
+      '<div class="container">',
+      '  <div class="dropdown">',
+      '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown"><span id="childElement">Dropdown</span></button>',
+      '    <div class="dropdown-menu">',
+      '      <a class="dropdown-item" href="#subMenu">Sub menu</a>',
+      '    </div>',
+      '  </div>',
+      '</div>'
+    ].join('')
+
+    $(fixtureHtml).appendTo('#qunit-fixture')
+
+    var btnDropdown = $('[data-bs-toggle="dropdown"]')
+    var childElement = $('#childElement')
+
+    btnDropdown.addEventListener('shown.bs.dropdown', function () {
+      setTimeout(function () {
+        assert.true(btnDropdown.classList.contains('show'))
+        assert.true(btnDropdown.getAttribute('aria-expanded'))
+        done()
+      })
+    })
+
+
+    childElement.click()
+  })
 })


### PR DESCRIPTION
Allow data-toggle="dropdown" and form click events to bubble (Backport of #33442)

* remove stopPropagation from button click event
* test for delegated click events
* ensure button children can open menu
* test to ensure clicking button opens the menu
* check current element and parents
* allow dropdown form click events to bubble

**Needs**

* [ ] check  todo `composedPath` not supported on IE
* [ ] check tests
