### PR TITLE
Fix table inconsistent border if caption exists

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -41,7 +41,7 @@
   }
 
   // Highlight border color between thead, tbody and tfoot.
-  > :not(:first-child) {
+  > tbody:first-of-type {
     border-top: (2 * $table-border-width) solid $table-group-separator-color;
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -53,7 +53,10 @@
 
 .caption-top {
   caption-side: top;
-  border-bottom: (2 * $table-border-width) solid $table-group-separator-color;
+
+  > :first-child {
+    border-bottom: (2 * $table-border-width) solid $table-group-separator-color;
+  }
 }
 
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -53,6 +53,7 @@
 
 .caption-top {
   caption-side: top;
+  border-bottom: (2 * $table-border-width) solid $table-group-separator-color;
 }
 
 
@@ -94,7 +95,7 @@
     border-bottom-width: 0;
   }
 
-  > :not(:first-child) {
+  > tbody:first-of-type, tfoot:first-of-type {
     border-top-width: 0;
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -41,7 +41,7 @@
   }
 
   // Highlight border color between thead, tbody and tfoot.
-  > tbody:first-of-type {
+  > tbody:first-of-type, tfoot:first-of-type {
     border-top: (2 * $table-border-width) solid $table-group-separator-color;
   }
 }


### PR DESCRIPTION
## Changes

The selector `:not(:first-child)` is changed to `tbody:first-of-type` so that the border-top has consistent results if there is or not a caption element

The problem is reproducible if the table has a caption element but the caption is visually hidden
 
For reference: https://github.com/joomla/joomla-cms/pull/35766#issuecomment-943248219 