### PR TITLE
Set isolate for unicode-bidi in code tags

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -280,7 +280,7 @@ samp {
   font-family: $font-family-code;
   @include font-size(1em); // Correct the odd `em` font sizing in all browsers.
   direction: ltr #{"/* rtl:ignore */"};
-  unicode-bidi: bidi-override;
+  unicode-bidi: isolate;
 }
 
 // 1. Remove browser default top margin


### PR DESCRIPTION
```
bidi-override should almost never be used for any modern
html page as it actually flips and make illegible any
RTL text contained in LTR context and vice versa. This
switches it with isolate which likely was the intention
and improves the tags to work actually work in mixed
direction pages.
```

Spotted the issue while reading https://getbootstrap.com/docs/5.1/getting-started/rtl/#starter-template

<img width="656" alt="image" src="https://user-images.githubusercontent.com/833473/138907101-1543a14a-33c7-46a7-9739-7c8872cd0a47.png">

The highlighted text is flipped and illegible, bidi-override shouldn't be used here at all as it has flipped the text contained in code tags making it completely unreadable. It should've been like this instead which is actually readable text:

<img width="810" alt="image" src="https://user-images.githubusercontent.com/833473/138910176-f6b222c3-8f03-4f0d-8014-028928aca3cd.png">

See also similar issues got fixed by removing bidi-override,
* My patch in WebKit's WebInspector, https://github.com/WebKit/WebKit/commit/4ed77fae3f6d0843e8ccb729a5bf17cae0d7e6f9 for this file https://bugs.webkit.org/show_bug.cgi?id=220241
* https://github.com/ajaxorg/ace/issues/1429#issuecomment-35064710

This should be back ported also to every release branches with bidi-override use, https://github.com/twbs/bootstrap/commit/9488978fb55286ba83e8193a871d1ff9815045b9 CC from the change: @ffoodd @XhmikosR
