### PR TITLE
Fix spacing utility classes mentioned in navbar supported content documentation

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -74,7 +74,7 @@ Here's an example of all the sub-components included in a responsive light-theme
 </nav>
 {{< /example >}}
 
-This example uses [background]({{< docsref "/utilities/background" >}}) (`bg-light`) and [spacing]({{< docsref "/utilities/spacing" >}}) (`my-2`, `my-lg-0`, `me-sm-0`, `my-sm-0`) utility classes.
+This example uses [background]({{< docsref "/utilities/background" >}}) (`bg-light`) and [spacing]({{< docsref "/utilities/spacing" >}}) (`me-auto`, `mb-2`, `mb-lg-0`, `me-2`) utility classes.
 
 ### Brand
 


### PR DESCRIPTION
This PR proposes to fix spacing utility classes mentioned  in the [Navbar > Supported content description](https://getbootstrap.com/docs/5.1/components/navbar/#supported-content).

Preview: https://deploy-preview-35328--twbs-bootstrap.netlify.app/docs/5.1/components/navbar/#supported-content