### PR TITLE
Remove extra spaces between navbar brand image and text

### DIFF
--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -121,10 +121,7 @@ You can also make use of some additional utilities to add an image and text at t
 {{< example >}}
 <nav class="navbar navbar-light bg-light">
   <div class="container-fluid">
-    <a class="navbar-brand" href="#">
-      <img src="/docs/{{< param docs_version >}}/assets/brand/bootstrap-logo.svg" alt="" width="30" height="24" class="d-inline-block align-text-top">
-      Bootstrap
-    </a>
+    <a class="navbar-brand" href="#"><img src="/docs/{{< param docs_version >}}/assets/brand/bootstrap-logo.svg" alt="" width="30" height="24" class="d-inline-block align-text-top me-1">Bootstrap</a>
   </div>
 </nav>
 {{< /example >}}


### PR DESCRIPTION
While working with navbars, I've spotted something that I think is not here on purpose.

Indeed, this is the line break in the source code that adds a space between the image and the text.

<img width="543" alt="Capture d’écran 2021-11-25 à 16 12 19" src="https://user-images.githubusercontent.com/17381666/143467366-a81ccd53-df51-4fa0-80dd-cbcb4999d96c.png">

If we remove this line break, the string doesn't have anymore those extra spaces and becomes right next to the image:
<img width="588" alt="Capture d’écran 2021-11-25 à 16 12 44" src="https://user-images.githubusercontent.com/17381666/143467497-87310d11-5e18-460f-85fb-8131a689b939.png">

This PR is a proposal to align all the content of the `<a>` and to handle the spacing with a `.me-1` ([see it in action here](https://deploy-preview-35398--twbs-bootstrap.netlify.app/docs/5.1/components/navbar/#image-and-text))

Another technique would be to do something like that whose I'm not a big fan of:

```html
<a class="navbar-brand" href="#">
  <img src="/docs/{{< param docs_version >}}/assets/brand/bootstrap-logo.svg" alt="" width="30" height="24" class="d-inline-block align-text-top me-1"><!--
  -->Bootstrap<!--
--></a>
```

Feel free to close this PR if you find it irrelevant or if it is something not very useful to change.

