### PR TITLE
tests: increase Jasmine's `timeoutInterval` to 10s

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -62,7 +62,10 @@ const conf = {
   singleRun: true,
   concurrency: Number.POSITIVE_INFINITY,
   client: {
-    clearContext: false
+    clearContext: false,
+    jasmine: {
+      timeoutInterval: 10_000 // the default is 5000
+    }
   },
   files: [
     'node_modules/hammer-simulator/index.js',

--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -64,7 +64,7 @@ const conf = {
   client: {
     clearContext: false,
     jasmine: {
-      timeoutInterval: 10_000 // the default is 5000
+      timeoutInterval: 15_000 // the default is 5000
     }
   },
   files: [


### PR DESCRIPTION
This might fix the timeout failures we've been getting on Mobile Safari.