### PR TITLE
[WIP]: using fallback values insteead of explicit declarations

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "25.5 kB"
+      "maxSize": "25.7 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "23.25 kB"
+      "maxSize": "23.6 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -1,8 +1,10 @@
+// stylelint-disable custom-property-empty-line-before
+
 .popover {
   // scss-docs-start popover-css-vars
   --#{$variable-prefix}popover-zindex: #{$zindex-popover};
   --#{$variable-prefix}popover-max-width: #{$popover-max-width};
-  --#{$variable-prefix}popover-font-size: #{$popover-font-size};
+  @include rfs($popover-font-size, --#{$variable-prefix}popover-font-size);
   --#{$variable-prefix}popover-bg: #{$popover-bg};
   --#{$variable-prefix}popover-border-width: #{$popover-border-width};
   --#{$variable-prefix}popover-border-color: #{$popover-border-color};

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -1,27 +1,47 @@
 .popover {
+  // scss-docs-start popover-css-vars
+  --#{$variable-prefix}popover-zindex: #{$zindex-popover};
+  --#{$variable-prefix}popover-max-width: #{$popover-max-width};
+  --#{$variable-prefix}popover-font-size: #{$popover-font-size};
+  --#{$variable-prefix}popover-bg: #{$popover-bg};
+  --#{$variable-prefix}popover-border-width: #{$popover-border-width};
+  --#{$variable-prefix}popover-border-color: #{$popover-border-color};
+  --#{$variable-prefix}popover-border-radius: #{$popover-border-radius};
+  --#{$variable-prefix}popover-box-shadow: #{$popover-box-shadow};
+  --#{$variable-prefix}popover-header-padding: #{$popover-header-padding-y $popover-header-padding-x};
+  --#{$variable-prefix}popover-header-color: #{$popover-header-color};
+  --#{$variable-prefix}popover-header-bg: #{$popover-header-bg};
+  --#{$variable-prefix}popover-body-padding: #{$popover-body-padding-y $popover-body-padding-x};
+  --#{$variable-prefix}popover-body-color: #{$popover-body-color};
+  --#{$variable-prefix}popover-arrow-width: #{$popover-arrow-width};
+  --#{$variable-prefix}popover-arrow-height: #{$popover-arrow-height};
+  --#{$variable-prefix}popover-arrow-border: var(--#{$variable-prefix}popover-border-color);
+  // scss-docs-end popover-css-vars
+
   position: absolute;
   top: 0;
   left: 0 #{"/* rtl:ignore */"};
-  z-index: $zindex-popover;
+  z-index: var();
   display: block;
-  max-width: $popover-max-width;
+  max-width: var(--#{$variable-prefix}popover-max-width);
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
-  @include font-size($popover-font-size);
+  font-size: var(--#{$variable-prefix}popover-font-size);
   // Allow breaking very long words so they don't overflow the popover's bounds
   word-wrap: break-word;
-  background-color: $popover-bg;
+  background-color: var(--#{$variable-prefix}popover-bg);
   background-clip: padding-box;
-  border: $popover-border-width solid $popover-border-color;
-  @include border-radius($popover-border-radius);
-  @include box-shadow($popover-box-shadow);
+  border: var(--#{$variable-prefix}popover-border-width) solid var(--#{$variable-prefix}popover-border-color);
+  // border-radius: var(--#{$variable-prefix}popover-border-radius);
+  @include border-radius(var(--#{$variable-prefix}popover-border-radius));
+  @include box-shadow(var(--#{$variable-prefix}popover-bg));
 
   .popover-arrow {
     position: absolute;
     display: block;
-    width: $popover-arrow-width;
-    height: $popover-arrow-height;
+    width: var(--#{$variable-prefix}popover-arrow-width);
+    height: var(--#{$variable-prefix}popover-arrow-height);
 
     &::before,
     &::after {
@@ -30,62 +50,70 @@
       content: "";
       border-color: transparent;
       border-style: solid;
+      border-width: 0;
     }
   }
 }
 
+
 .bs-popover-top {
   > .popover-arrow {
-    bottom: subtract(-$popover-arrow-height, $popover-border-width);
+    bottom: calc((var(--#{$variable-prefix}popover-arrow-height)) * -1); // stylelint-disable-line function-disallowed-list
 
     &::before {
       bottom: 0;
-      border-width: $popover-arrow-height ($popover-arrow-width * .5) 0;
-      border-top-color: $popover-arrow-outer-color;
+      border-top-color: var(--#{$variable-prefix}popover-arrow-border);
+      border-top-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-inline-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
 
     &::after {
-      bottom: $popover-border-width;
-      border-width: $popover-arrow-height ($popover-arrow-width * .5) 0;
-      border-top-color: $popover-arrow-color;
+      bottom: var(--#{$variable-prefix}popover-border-width);
+      border-top-color: var(--#{$variable-prefix}popover-bg);
+      border-top-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-inline-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
   }
 }
 
 .bs-popover-end {
   > .popover-arrow {
-    left: subtract(-$popover-arrow-height, $popover-border-width);
-    width: $popover-arrow-height;
-    height: $popover-arrow-width;
+    left: calc((var(--#{$variable-prefix}popover-arrow-height)) * -1); // stylelint-disable-line function-disallowed-list
+    width: var(--#{$variable-prefix}popover-arrow-height);
+    height: var(--#{$variable-prefix}popover-arrow-width);
 
     &::before {
       left: 0;
-      border-width: ($popover-arrow-width * .5) $popover-arrow-height ($popover-arrow-width * .5) 0;
-      border-right-color: $popover-arrow-outer-color;
+      border-right-color: var(--#{$variable-prefix}popover-arrow-border);
+      border-right-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-block-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
 
     &::after {
-      left: $popover-border-width;
-      border-width: ($popover-arrow-width * .5) $popover-arrow-height ($popover-arrow-width * .5) 0;
-      border-right-color: $popover-arrow-color;
+      left: var(--#{$variable-prefix}popover-border-width);
+      border-right-color: var(--#{$variable-prefix}popover-bg);
+      border-right-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-block-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
   }
 }
 
 .bs-popover-bottom {
   > .popover-arrow {
-    top: subtract(-$popover-arrow-height, $popover-border-width);
+    top: calc((var(--#{$variable-prefix}popover-arrow-height)) * -1); // stylelint-disable-line function-disallowed-list
 
     &::before {
       top: 0;
-      border-width: 0 ($popover-arrow-width * .5) $popover-arrow-height ($popover-arrow-width * .5);
-      border-bottom-color: $popover-arrow-outer-color;
+      border-bottom-color: var(--#{$variable-prefix}popover-arrow-border);
+      border-bottom-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-inline-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
 
     &::after {
-      top: $popover-border-width;
-      border-width: 0 ($popover-arrow-width * .5) $popover-arrow-height ($popover-arrow-width * .5);
-      border-bottom-color: $popover-arrow-color;
+      top: var(--#{$variable-prefix}popover-border-width);
+      border-bottom-color: var(--#{$variable-prefix}popover-bg);
+      border-bottom-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-inline-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
   }
 
@@ -95,29 +123,31 @@
     top: 0;
     left: 50%;
     display: block;
-    width: $popover-arrow-width;
-    margin-left: -$popover-arrow-width * .5;
+    width: var(--#{$variable-prefix}popover-arrow-width);
+    margin-left: calc(var(--#{$variable-prefix}popover-arrow-width) * -.5); // stylelint-disable-line function-disallowed-list
     content: "";
-    border-bottom: $popover-border-width solid $popover-header-bg;
+    border-bottom: var(--#{$variable-prefix}popover-border-width) solid var(--#{$variable-prefix}popover-header-bg);
   }
 }
 
 .bs-popover-start {
   > .popover-arrow {
-    right: subtract(-$popover-arrow-height, $popover-border-width);
-    width: $popover-arrow-height;
-    height: $popover-arrow-width;
+    right: calc((var(--#{$variable-prefix}popover-arrow-height)) * -1); // stylelint-disable-line function-disallowed-list
+    width: var(--#{$variable-prefix}popover-arrow-height);
+    height: var(--#{$variable-prefix}popover-arrow-width);
 
     &::before {
       right: 0;
-      border-width: ($popover-arrow-width * .5) 0 ($popover-arrow-width * .5) $popover-arrow-height;
-      border-left-color: $popover-arrow-outer-color;
+      border-left-color: var(--#{$variable-prefix}popover-arrow-border);
+      border-left-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-block-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
 
     &::after {
-      right: $popover-border-width;
-      border-width: ($popover-arrow-width * .5) 0 ($popover-arrow-width * .5) $popover-arrow-height;
-      border-left-color: $popover-arrow-color;
+      right: var(--#{$variable-prefix}popover-border-width);
+      border-left-color: var(--#{$variable-prefix}popover-bg);
+      border-left-width: var(--#{$variable-prefix}popover-arrow-height);
+      border-block-width: calc(var(--#{$variable-prefix}popover-arrow-width) * .5); // stylelint-disable-line function-disallowed-list
     }
   }
 }
@@ -139,12 +169,12 @@
 
 // Offset the popover to account for the popover arrow
 .popover-header {
-  padding: $popover-header-padding-y $popover-header-padding-x;
+  padding: var(--#{$variable-prefix}popover-header-padding);
   margin-bottom: 0; // Reset the default from Reboot
   @include font-size($font-size-base);
-  color: $popover-header-color;
-  background-color: $popover-header-bg;
-  border-bottom: $popover-border-width solid $popover-border-color;
+  color: var(--#{$variable-prefix}popover-header-color);
+  background-color: var(--#{$variable-prefix}popover-header-bg);
+  border-bottom: var(--#{$variable-prefix}popover-border-width) solid var(--#{$variable-prefix}popover-border-color);
   @include border-top-radius($popover-inner-border-radius);
 
   &:empty {
@@ -153,6 +183,6 @@
 }
 
 .popover-body {
-  padding: $popover-body-padding-y $popover-body-padding-x;
-  color: $popover-body-color;
+  padding: var(--#{$variable-prefix}popover-body-padding);
+  color: var(--#{$variable-prefix}popover-body-color);
 }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -2,19 +2,19 @@
 
 .popover {
   // scss-docs-start popover-css-vars
-  --#{$variable-prefix}popover-zindex: #{$zindex-popover};
-  --#{$variable-prefix}popover-max-width: #{$popover-max-width};
+  // --#{$variable-prefix}popover-zindex: #{$zindex-popover};
+  // --#{$variable-prefix}popover-max-width: #{$popover-max-width};
   @include rfs($popover-font-size, --#{$variable-prefix}popover-font-size);
   --#{$variable-prefix}popover-bg: #{$popover-bg};
   --#{$variable-prefix}popover-border-width: #{$popover-border-width};
   --#{$variable-prefix}popover-border-color: #{$popover-border-color};
-  --#{$variable-prefix}popover-border-radius: #{$popover-border-radius};
-  --#{$variable-prefix}popover-box-shadow: #{$popover-box-shadow};
-  --#{$variable-prefix}popover-header-padding: #{$popover-header-padding-y $popover-header-padding-x};
-  --#{$variable-prefix}popover-header-color: #{$popover-header-color};
+  // --#{$variable-prefix}popover-border-radius: #{$popover-border-radius};
+  // --#{$variable-prefix}popover-box-shadow: #{$popover-box-shadow}; // Unused?
+  // --#{$variable-prefix}popover-header-padding: #{$popover-header-padding-y $popover-header-padding-x};
+  // --#{$variable-prefix}popover-header-color: #{$popover-header-color};
   --#{$variable-prefix}popover-header-bg: #{$popover-header-bg};
-  --#{$variable-prefix}popover-body-padding: #{$popover-body-padding-y $popover-body-padding-x};
-  --#{$variable-prefix}popover-body-color: #{$popover-body-color};
+  // --#{$variable-prefix}popover-body-padding: #{$popover-body-padding-y $popover-body-padding-x};
+  // --#{$variable-prefix}popover-body-color: #{$popover-body-color};
   --#{$variable-prefix}popover-arrow-width: #{$popover-arrow-width};
   --#{$variable-prefix}popover-arrow-height: #{$popover-arrow-height};
   --#{$variable-prefix}popover-arrow-border: var(--#{$variable-prefix}popover-border-color);
@@ -23,9 +23,9 @@
   position: absolute;
   top: 0;
   left: 0 #{"/* rtl:ignore */"};
-  z-index: var(--#{$variable-prefix}popover-zindex);
+  z-index: var(--#{$variable-prefix}popover-zindex, #{$zindex-popover});
   display: block;
-  max-width: var(--#{$variable-prefix}popover-max-width);
+  max-width: var(--#{$variable-prefix}popover-max-width, #{$popover-max-width});
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
@@ -35,8 +35,8 @@
   background-color: var(--#{$variable-prefix}popover-bg);
   background-clip: padding-box;
   border: var(--#{$variable-prefix}popover-border-width) solid var(--#{$variable-prefix}popover-border-color);
-  // border-radius: var(--#{$variable-prefix}popover-border-radius);
-  @include border-radius(var(--#{$variable-prefix}popover-border-radius));
+  // border-radius: var(--#{$variable-prefix}popover-border-radius, #{$popover-border-radius});
+  @include border-radius(var(--#{$variable-prefix}popover-border-radius, #{$popover-border-radius}));
   @include box-shadow(var(--#{$variable-prefix}popover-bg));
 
   .popover-arrow {
@@ -171,10 +171,10 @@
 
 // Offset the popover to account for the popover arrow
 .popover-header {
-  padding: var(--#{$variable-prefix}popover-header-padding);
+  padding: var(--#{$variable-prefix}popover-header-padding, #{$popover-header-padding-y $popover-header-padding-x});
   margin-bottom: 0; // Reset the default from Reboot
   @include font-size($font-size-base);
-  color: var(--#{$variable-prefix}popover-header-color);
+  color: var(--#{$variable-prefix}popover-header-color), #{$popover-header-color};
   background-color: var(--#{$variable-prefix}popover-header-bg);
   border-bottom: var(--#{$variable-prefix}popover-border-width) solid var(--#{$variable-prefix}popover-border-color);
   @include border-top-radius($popover-inner-border-radius);
@@ -185,6 +185,6 @@
 }
 
 .popover-body {
-  padding: var(--#{$variable-prefix}popover-body-padding);
-  color: var(--#{$variable-prefix}popover-body-color);
+  padding: var(--#{$variable-prefix}popover-body-padding, #{$popover-body-padding-y $popover-body-padding-x});
+  color: var(--#{$variable-prefix}popover-body-color, #{$popover-body-color});
 }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -21,7 +21,7 @@
   position: absolute;
   top: 0;
   left: 0 #{"/* rtl:ignore */"};
-  z-index: var();
+  z-index: var(--#{$variable-prefix}popover-zindex);
   display: block;
   max-width: var(--#{$variable-prefix}popover-max-width);
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -3,23 +3,23 @@
 // Base class
 .tooltip {
   // scss-docs-start tooltip-css-vars
-  --#{$variable-prefix}tooltip-zindex: #{$zindex-tooltip};
-  --#{$variable-prefix}tooltip-max-width: #{$tooltip-max-width};
-  --#{$variable-prefix}tooltip-padding: #{$tooltip-padding-y} #{$tooltip-padding-x};
-  --#{$variable-prefix}tooltip-margin: #{$tooltip-margin};
+  // --#{$variable-prefix}tooltip-zindex: #{$zindex-tooltip};
+  // --#{$variable-prefix}tooltip-max-width: #{$tooltip-max-width};
+  // --#{$variable-prefix}tooltip-padding: #{$tooltip-padding-y} #{$tooltip-padding-x};
+  // --#{$variable-prefix}tooltip-margin: #{$tooltip-margin};
   @include rfs($tooltip-font-size, --#{$variable-prefix}tooltip-font-size);
-  --#{$variable-prefix}tooltip-color: #{$tooltip-color};
+  // --#{$variable-prefix}tooltip-color: #{$tooltip-color};
   --#{$variable-prefix}tooltip-bg: #{$tooltip-bg};
-  --#{$variable-prefix}tooltip-border-radius: #{$tooltip-border-radius};
-  --#{$variable-prefix}tooltip-opacity: #{$tooltip-opacity};
+  // --#{$variable-prefix}tooltip-border-radius: #{$tooltip-border-radius};
+  // --#{$variable-prefix}tooltip-opacity: #{$tooltip-opacity};
   --#{$variable-prefix}tooltip-arrow-width: #{$tooltip-arrow-width};
   --#{$variable-prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
   // scss-docs-end tooltip-css-vars
 
   position: absolute;
-  z-index: var(--#{$variable-prefix}tooltip-zindex);
+  z-index: var(--#{$variable-prefix}tooltip-zindex, #{$zindex-tooltip});
   display: block;
-  margin: var(--#{$variable-prefix}tooltip-margin);
+  margin: var(--#{$variable-prefix}tooltip-margin, #{$tooltip-margin});
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
@@ -28,7 +28,7 @@
   word-wrap: break-word;
   opacity: 0;
 
-  &.show { opacity: var(--#{$variable-prefix}tooltip-opacity); }
+  &.show { opacity: var(--#{$variable-prefix}tooltip-opacity, #{$tooltip-opacity}); }
 
   .tooltip-arrow {
     position: absolute;
@@ -122,10 +122,10 @@
 
 // Wrapper for the tooltip content
 .tooltip-inner {
-  max-width: var(--#{$variable-prefix}tooltip-max-width);
-  padding: var(--#{$variable-prefix}tooltip-padding);
-  color: var(--#{$variable-prefix}tooltip-color);
+  max-width: var(--#{$variable-prefix}tooltip-max-width, #{$tooltip-max-width});
+  padding: var(--#{$variable-prefix}tooltip-padding, #{$tooltip-padding-y} #{$tooltip-padding-x});
+  color: var(--#{$variable-prefix}tooltip-color, #{$tooltip-color});
   text-align: center;
   background-color: var(--#{$variable-prefix}tooltip-bg);
-  border-radius: var(--#{$variable-prefix}tooltip-border-radius, 0); // stylelint-disable-line property-disallowed-list
+  border-radius: var(--#{$variable-prefix}tooltip-border-radius, #{$tooltip-border-radius}); // stylelint-disable-line property-disallowed-list
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -14,8 +14,6 @@
   --#{$variable-prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
   // scss-docs-end tooltip-css-vars
 
-  $tooltip-arrow-color: null;
-
   position: absolute;
   z-index: var(--#{$variable-prefix}tooltip-zindex);
   display: block;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,3 +1,5 @@
+// stylelint-disable custom-property-empty-line-before
+
 // Base class
 .tooltip {
   // scss-docs-start tooltip-css-vars
@@ -5,7 +7,7 @@
   --#{$variable-prefix}tooltip-max-width: #{$tooltip-max-width};
   --#{$variable-prefix}tooltip-padding: #{$tooltip-padding-y} #{$tooltip-padding-x};
   --#{$variable-prefix}tooltip-margin: #{$tooltip-margin};
-  --#{$variable-prefix}tooltip-font-size: #{$tooltip-font-size};
+  @include rfs($tooltip-font-size, --#{$variable-prefix}tooltip-font-size);
   --#{$variable-prefix}tooltip-color: #{$tooltip-color};
   --#{$variable-prefix}tooltip-bg: #{$tooltip-bg};
   --#{$variable-prefix}tooltip-border-radius: #{$tooltip-border-radius};

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,24 +1,39 @@
 // Base class
 .tooltip {
+  // scss-docs-start tooltip-css-vars
+  --#{$variable-prefix}tooltip-zindex: #{$zindex-tooltip};
+  --#{$variable-prefix}tooltip-max-width: #{$tooltip-max-width};
+  --#{$variable-prefix}tooltip-padding: #{$tooltip-padding-y} #{$tooltip-padding-x};
+  --#{$variable-prefix}tooltip-margin: #{$tooltip-margin};
+  --#{$variable-prefix}tooltip-font-size: #{$tooltip-font-size};
+  --#{$variable-prefix}tooltip-color: #{$tooltip-color};
+  --#{$variable-prefix}tooltip-bg: #{$tooltip-bg};
+  --#{$variable-prefix}tooltip-border-radius: #{$tooltip-border-radius};
+  --#{$variable-prefix}tooltip-opacity: #{$tooltip-opacity};
+  --#{$variable-prefix}tooltip-arrow-width: #{$tooltip-arrow-width};
+  --#{$variable-prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
+
+  $tooltip-arrow-color: null;
+
   position: absolute;
-  z-index: $zindex-tooltip;
+  z-index: var(--#{$variable-prefix}tooltip-zindex);
   display: block;
-  margin: $tooltip-margin;
+  margin: var(--#{$variable-prefix}tooltip-margin);
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.
   @include reset-text();
-  @include font-size($tooltip-font-size);
+  @include font-size(var(--#{$variable-prefix}tooltip-font-size));
   // Allow breaking very long words so they don't overflow the tooltip's bounds
   word-wrap: break-word;
   opacity: 0;
 
-  &.show { opacity: $tooltip-opacity; }
+  &.show { opacity: var(--#{$variable-prefix}tooltip-opacity); }
 
   .tooltip-arrow {
     position: absolute;
     display: block;
-    width: $tooltip-arrow-width;
-    height: $tooltip-arrow-height;
+    width: var(--#{$variable-prefix}tooltip-arrow-width);
+    height: var(--#{$variable-prefix}tooltip-arrow-height);
 
     &::before {
       position: absolute;
@@ -30,61 +45,61 @@
 }
 
 .bs-tooltip-top {
-  padding: $tooltip-arrow-height 0;
+  padding: var(--#{$variable-prefix}tooltip-arrow-height) 0;
 
   .tooltip-arrow {
     bottom: 0;
 
     &::before {
       top: -1px;
-      border-width: $tooltip-arrow-height ($tooltip-arrow-width * .5) 0;
-      border-top-color: $tooltip-arrow-color;
+      border-width: var(--#{$variable-prefix}tooltip-arrow-height) calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-top-color: var(--#{$variable-prefix}tooltip-bg);
     }
   }
 }
 
 .bs-tooltip-end {
-  padding: 0 $tooltip-arrow-height;
+  padding: 0 var(--#{$variable-prefix}tooltip-arrow-height);
 
   .tooltip-arrow {
     left: 0;
-    width: $tooltip-arrow-height;
-    height: $tooltip-arrow-width;
+    width: var(--#{$variable-prefix}tooltip-arrow-height);
+    height: var(--#{$variable-prefix}tooltip-arrow-width);
 
     &::before {
       right: -1px;
-      border-width: ($tooltip-arrow-width * .5) $tooltip-arrow-height ($tooltip-arrow-width * .5) 0;
-      border-right-color: $tooltip-arrow-color;
+      border-width: calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) var(--#{$variable-prefix}tooltip-arrow-height) calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-right-color: var(--#{$variable-prefix}tooltip-bg);
     }
   }
 }
 
 .bs-tooltip-bottom {
-  padding: $tooltip-arrow-height 0;
+  padding: var(--#{$variable-prefix}tooltip-arrow-height) 0;
 
   .tooltip-arrow {
     top: 0;
 
     &::before {
       bottom: -1px;
-      border-width: 0 ($tooltip-arrow-width * .5) $tooltip-arrow-height;
-      border-bottom-color: $tooltip-arrow-color;
+      border-width: 0 calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) var(--#{$variable-prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-bottom-color: var(--#{$variable-prefix}tooltip-bg);
     }
   }
 }
 
 .bs-tooltip-start {
-  padding: 0 $tooltip-arrow-height;
+  padding: 0 var(--#{$variable-prefix}tooltip-arrow-height);
 
   .tooltip-arrow {
     right: 0;
-    width: $tooltip-arrow-height;
-    height: $tooltip-arrow-width;
+    width: var(--#{$variable-prefix}tooltip-arrow-height);
+    height: var(--#{$variable-prefix}tooltip-arrow-width);
 
     &::before {
       left: -1px;
-      border-width: ($tooltip-arrow-width * .5) 0 ($tooltip-arrow-width * .5) $tooltip-arrow-height;
-      border-left-color: $tooltip-arrow-color;
+      border-width: calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$variable-prefix}tooltip-arrow-width) * .5) var(--#{$variable-prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-left-color: var(--#{$variable-prefix}tooltip-bg);
     }
   }
 }
@@ -106,10 +121,10 @@
 
 // Wrapper for the tooltip content
 .tooltip-inner {
-  max-width: $tooltip-max-width;
-  padding: $tooltip-padding-y $tooltip-padding-x;
-  color: $tooltip-color;
+  max-width: var(--#{$variable-prefix}tooltip-max-width);
+  padding: var(--#{$variable-prefix}tooltip-padding);
+  color: var(--#{$variable-prefix}tooltip-color);
   text-align: center;
-  background-color: $tooltip-bg;
-  @include border-radius($tooltip-border-radius);
+  background-color: var(--#{$variable-prefix}tooltip-bg);
+  border-radius: var(--#{$variable-prefix}tooltip-border-radius, 0); // stylelint-disable-line property-disallowed-list
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -12,6 +12,7 @@
   --#{$variable-prefix}tooltip-opacity: #{$tooltip-opacity};
   --#{$variable-prefix}tooltip-arrow-width: #{$tooltip-arrow-width};
   --#{$variable-prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
+  // scss-docs-end tooltip-css-vars
 
   $tooltip-arrow-color: null;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1324,7 +1324,9 @@ $tooltip-margin:                    0 !default;
 
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;
-$tooltip-arrow-color:               $tooltip-bg !default;
+// fusv-disable
+$tooltip-arrow-color:               null !default; // Deprecated in v5.2.0 for CSS variables
+// fusv-enable
 // scss-docs-end tooltip-variables
 
 // Form tooltips must come after regular tooltips

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1325,7 +1325,7 @@ $tooltip-margin:                    0 !default;
 $tooltip-arrow-width:               .8rem !default;
 $tooltip-arrow-height:              .4rem !default;
 // fusv-disable
-$tooltip-arrow-color:               null !default; // Deprecated in v5.2.0 for CSS variables
+$tooltip-arrow-color:               null !default; // Deprecated in Bootstrap 5.2.0 for CSS variables
 // fusv-enable
 // scss-docs-end tooltip-variables
 
@@ -1363,10 +1363,13 @@ $popover-body-padding-x:            $spacer !default;
 
 $popover-arrow-width:               1rem !default;
 $popover-arrow-height:              .5rem !default;
-$popover-arrow-color:               $popover-bg !default;
-
-$popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;
 // scss-docs-end popover-variables
+
+// fusv-disable
+// Deprecated in Bootstrap 5.2.0 for CSS variables
+$popover-arrow-color:               $popover-bg !default;
+$popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;
+// fusv-enable
 
 
 // Toasts

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -233,6 +233,10 @@
   white-space: nowrap;
 }
 
+.custom-tooltip {
+  --bs-tooltip-bg: var(--bs-primary);
+}
+
 // Scrollspy demo on fixed height div
 .scrollspy-example {
   position: relative;

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -237,6 +237,14 @@
   --bs-tooltip-bg: var(--bs-primary);
 }
 
+.custom-popover {
+  --bs-popover-max-width: 200px;
+  --bs-popover-border-color: var(--bs-primary);
+  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-header-color: var(--bs-white);
+  --bs-popover-body-padding: .5rem 1rem;
+}
+
 // Scrollspy demo on fixed height div
 .scrollspy-example {
   position: relative;

--- a/site/content/docs/5.1/components/popovers.md
+++ b/site/content/docs/5.1/components/popovers.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the popover plugin:
 
-- Popovers rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper in order for popovers to work!
+- Popovers rely on the third party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `bootstrap.js`, or use one `bootstrap.bundle.min.js` which contains Popper.
 - Popovers require the [tooltip plugin]({{< docsref "/components/tooltips" >}}) as a dependency.
 - Popovers are opt-in for performance reasons, so **you must initialize them yourself**.
 - Zero-length `title` and `content` values will never show a popover.
@@ -31,9 +31,11 @@ Things to know when using the popover plugin:
 
 Keep reading to see how popovers work with some examples.
 
-## Example: Enable popovers everywhere
+## Examples
 
-One way to initialize all popovers on a page would be to select them by their `data-bs-toggle` attribute:
+### Enable popovers
+
+As mentioned above, you must initialize popovers before they can be used. One way to initialize all popovers on a page would be to select them by their `data-bs-toggle` attribute, like so:
 
 ```js
 var popoverTriggerList = Array.prototype.slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
@@ -42,17 +44,9 @@ var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
 })
 ```
 
-## Example: Using the `container` option
+### Live demo
 
-When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead.
-
-```js
-var popover = new bootstrap.Popover(document.querySelector('.example-popover'), {
-  container: 'body'
-})
-```
-
-## Example
+We use JavaScript similar to the snippet above to render the following live popover. Titles are set via `title` attribute and body content is set via `data-bs-content`.
 
 {{< example >}}
 <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
@@ -60,7 +54,7 @@ var popover = new bootstrap.Popover(document.querySelector('.example-popover'), 
 
 ### Four directions
 
-Four options are available: top, right, bottom, and left aligned. Directions are mirrored when using Bootstrap in RTL.
+Four options are available: top, right, bottom, and left. Directions are mirrored when using Bootstrap in RTL. Set `data-bs-placement` to change the direction.
 
 {{< example >}}
 <button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="top" data-bs-content="Top popover">
@@ -74,6 +68,42 @@ Four options are available: top, right, bottom, and left aligned. Directions are
 </button>
 <button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="left" data-bs-content="Left popover">
   Popover on left
+</button>
+{{< /example >}}
+
+### Custom `container`
+
+When you have some styles on a parent element that interfere with a popover, you'll want to specify a custom `container` so that the popover's HTML appears within that element instead. This is common in responsive tables, input groups, and the like.
+
+```js
+var popover = new bootstrap.Popover(document.querySelector('.example-popover'), {
+  container: 'body'
+})
+```
+
+### Custom popovers
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.2.0</small>
+
+You can customize the appearance of popovers using [CSS variables](#variables). We set a custom class with `data-bs-custom-class="custom-popover"` to scope our custom appearance and use it to override some of the local CSS variables.
+
+```css
+.custom-popover {
+  --bs-popover-max-width: 200px;
+  --bs-popover-border-color: var(--bs-primary);
+  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-header-color: var(--bs-white);
+  --bs-popover-body-padding: .5rem 1rem;
+}
+```
+
+{{< example class="custom-popover-demo" >}}
+<button type="button" class="btn btn-secondary"
+        data-bs-toggle="popover" data-bs-placement="right"
+        data-bs-custom-class="custom-popover"
+        title="Custom popover"
+        data-bs-content="This popover is themed via CSS variables.">
+  Custom popover
 </button>
 {{< /example >}}
 
@@ -109,9 +139,17 @@ For disabled popover triggers, you may also prefer `data-bs-trigger="hover focus
 </span>
 {{< /example >}}
 
-## Sass
+## CSS
 
 ### Variables
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.2.0</small>
+
+As part of Bootstrap’s evolving CSS variables approach, popovers now use local CSS variables on `.popover` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="popover-css-vars" file="scss/_popover.scss" >}}
+
+### Sass variables
 
 {{< scss-docs name="popover-variables" file="scss/_variables.scss" >}}
 

--- a/site/content/docs/5.1/components/tooltips.md
+++ b/site/content/docs/5.1/components/tooltips.md
@@ -10,7 +10,7 @@ toc: true
 
 Things to know when using the tooltip plugin:
 
-- Tooltips rely on the 3rd party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before bootstrap.js or use `bootstrap.bundle.min.js` / `bootstrap.bundle.js` which contains Popper in order for tooltips to work!
+- Tooltips rely on the third party library [Popper](https://popper.js.org/) for positioning. You must include [popper.min.js]({{< param "cdn.popper" >}}) before `bootstrap.js`, or use one `bootstrap.bundle.min.js` which contains Popper.
 - Tooltips are opt-in for performance reasons, so **you must initialize them yourself**.
 - Tooltips with zero-length titles are never displayed.
 - Specify `container: 'body'` to avoid rendering problems in more complex components (like our input groups, button groups, etc).
@@ -20,6 +20,8 @@ Things to know when using the tooltip plugin:
 - Tooltips must be hidden before their corresponding elements have been removed from the DOM.
 - Tooltips can be triggered thanks to an element inside a shadow DOM.
 
+Got all that? Great, let's see how they work with some examples.
+
 {{< callout info >}}
 {{< partial "callout-info-sanitizer.md" >}}
 {{< /callout >}}
@@ -28,11 +30,11 @@ Things to know when using the tooltip plugin:
 {{< partial "callout-info-prefersreducedmotion.md" >}}
 {{< /callout >}}
 
-Got all that? Great, let's see how they work with some examples.
+## Examples
 
-## Example: Enable tooltips everywhere
+### Enable tooltips
 
-One way to initialize all tooltips on a page would be to select them by their `data-bs-toggle` attribute:
+As mentioned above, you must initialize tooltips before they can be used. One way to initialize all tooltips on a page would be to select them by their `data-bs-toggle` attribute, like so:
 
 ```js
 var tooltipTriggerList = Array.prototype.slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
@@ -41,7 +43,7 @@ var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
 })
 ```
 
-## Examples
+### Tooltips on links
 
 Hover over the links below to see tooltips:
 
@@ -119,9 +121,17 @@ With an SVG:
   </a>
 </div>
 
-## Sass
+## CSS
 
 ### Variables
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.2.0</small>
+
+As part of Bootstrap’s evolving CSS variables approach, tooltips now use local CSS variables on `.tooltip` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="tooltip-css-vars" file="scss/_tooltip.scss" >}}
+
+### Sass variables
 
 {{< scss-docs name="tooltip-variables" file="scss/_variables.scss" >}}
 

--- a/site/content/docs/5.1/components/tooltips.md
+++ b/site/content/docs/5.1/components/tooltips.md
@@ -50,6 +50,29 @@ Hover over the links below to see tooltips:
   </p>
 </div>
 
+### Custom tooltips
+
+<small class="d-inline-flex px-2 py-1 font-monospace text-muted border rounded-3">Added in v5.2.0</small>
+
+You can customize the appearance of tooltips using [CSS variables](#variables). We set a custom class with `data-bs-custom-class="custom-tooltip"` to scope our custom appearance and use it to override a local CSS variable.
+
+```scss
+.custom-tooltip {
+  --bs-tooltip-bg: var(--bs-primary);
+}
+```
+
+{{< example class="tooltip-demo" >}}
+<button type="button" class="btn btn-secondary"
+        data-bs-toggle="tooltip" data-bs-placement="top"
+        data-bs-custom-class="custom-tooltip"
+        title="This top tooltip is themed via CSS variables.">
+  Custom tooltip
+</button>
+{{< /example >}}
+
+### Directions
+
 Hover over the buttons below to see the four tooltips directions: top, right, bottom, and left. Directions are mirrored when using Bootstrap in RTL.
 
 <div class="bd-example tooltip-demo">

--- a/site/content/docs/5.1/migration.md
+++ b/site/content/docs/5.1/migration.md
@@ -11,6 +11,8 @@ toc: true
 
 - **Introduced new `$enable-container-classes` option.** Now when opting into the experimental CSS Grid layout, `.container-*` classes will still be compiled, unless this option is set to `false`.
 
+- **Popovers and tooltips now use CSS variables.** Both components have been updated to use CSS variables on their base classes, `.popover` and `.tooltip`. Some CSS variables have been updated from their Sass counterparts to reduce the number of variables. As a result, three variables have been deprecated in this release: `$popover-arrow-color`, `$popover-arrow-outer-color`, and `$tooltip-arrow-color`.
+
 ## Dependencies
 
 - Dropped jQuery.


### PR DESCRIPTION
Only a POC to check if using fallback values instead of explicit custom properties declarations could save bytes.

The rationale to switch to fallback values or not is the number of occurrences: (`, ` + value) × n occurrences should be longer than the whole explicit declaration. I did not count it for now but that should IMHO be the decision tree.

The only exception would be `font-size`s since RFS could behave differently depending on the value. Using its output as a fallback isn't safe.

Let's check Bundlewatch, now :D