### PR TITLE
Optimize `fixed-*`, `.sticky*-top` classes

### DIFF
--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -26,6 +26,8 @@
     .sticky#{$infix}-top {
       position: sticky;
       top: 0;
+      right: 0;
+      left: 0;
       z-index: $zindex-sticky;
       will-change: transform;
     }

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -6,6 +6,8 @@
   right: 0;
   left: 0;
   z-index: $zindex-fixed;
+  // To render the element in it's own layer, improving repaint speed and
+  // therefore improving performance and accessibility.
   will-change: transform;
 }
 

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -6,6 +6,7 @@
   right: 0;
   left: 0;
   z-index: $zindex-fixed;
+  will-change: transform;
 }
 
 .fixed-bottom {
@@ -14,6 +15,7 @@
   bottom: 0;
   left: 0;
   z-index: $zindex-fixed;
+  will-change: transform;
 }
 
 // Responsive sticky top
@@ -25,6 +27,7 @@
       position: sticky;
       top: 0;
       z-index: $zindex-sticky;
+      will-change: transform;
     }
   }
 }


### PR DESCRIPTION
This solution based on [Mozilla manual](https://developer.mozilla.org/en-US/docs/Web/CSS/position#performance_accessibility)