### PR TITLE
docs: Move `gap` utility API from "Flex" to "Spacing"

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -236,12 +236,6 @@ $utilities: map-merge(
       class: flex,
       values: wrap nowrap wrap-reverse
     ),
-    "gap": (
-      responsive: true,
-      property: gap,
-      class: gap,
-      values: $spacers
-    ),
     "justify-content": (
       responsive: true,
       property: justify-content,
@@ -432,6 +426,13 @@ $utilities: map-merge(
       responsive: true,
       property: padding-left,
       class: ps,
+      values: $spacers
+    ),
+    // Gap utility
+    "gap": (
+      responsive: true,
+      property: gap,
+      class: gap,
       values: $spacers
     ),
     // scss-docs-end utils-spacing


### PR DESCRIPTION
The `gap` utility is described on the [Spacing page][1] but is not actually mentioned on the [Flex page][2] (apart from the [API section][3]).

[1]: https://getbootstrap.com/docs/5.1/utilities/spacing/
[2]: https://getbootstrap.com/docs/5.1/utilities/flex/
[3]: https://getbootstrap.com/docs/5.1/utilities/flex/#utilities-api