### PR TITLE
docs: Use `param` to set Bootstrap version in Contents page

### DIFF
--- a/site/content/docs/5.1/getting-started/contents.md
+++ b/site/content/docs/5.1/getting-started/contents.md
@@ -171,7 +171,7 @@ bootstrap/
 ├── site/
 │   └──content/
 │      └── docs/
-│          └── 5.1/
+│          └── {{< param docs_version >}}/
 │              └── examples/
 ├── js/
 └── scss/


### PR DESCRIPTION
This PR proposes to use the `docs_version` param in the **Getting Started > Contents** documentation to avoid to forget update it after a change of version.

Note: could be done in the `v4-dev` branch as well if approved.

**Preview**: https://deploy-preview-35556--twbs-bootstrap.netlify.app/docs/5.1/getting-started/contents/#bootstrap-source-code