### PR TITLE
move theme-colors (vars+map) after color tints definitions

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -66,30 +66,6 @@ $colors: (
 ) !default;
 // scss-docs-end colors-map
 
-// scss-docs-start theme-color-variables
-$primary:       $blue !default;
-$secondary:     $gray-600 !default;
-$success:       $green !default;
-$info:          $cyan !default;
-$warning:       $yellow !default;
-$danger:        $red !default;
-$light:         $gray-100 !default;
-$dark:          $gray-900 !default;
-// scss-docs-end theme-color-variables
-
-// scss-docs-start theme-colors-map
-$theme-colors: (
-  "primary":    $primary,
-  "secondary":  $secondary,
-  "success":    $success,
-  "info":       $info,
-  "warning":    $warning,
-  "danger":     $danger,
-  "light":      $light,
-  "dark":       $dark
-) !default;
-// scss-docs-end theme-colors-map
-
 // The contrast ratio to reach against white, to determine if color changes from "light" to "dark". Acceptable values for WCAG 2.0 are 3, 4.5 and 7.
 // See https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast
 $min-contrast-ratio:   4.5 !default;
@@ -319,6 +295,30 @@ $cyans: (
   "cyan-900": $cyan-900
 ) !default;
 // fusv-enable
+
+// scss-docs-start theme-color-variables
+$primary:       $blue !default;
+$secondary:     $gray-600 !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$light:         $gray-100 !default;
+$dark:          $gray-900 !default;
+// scss-docs-end theme-color-variables
+
+// scss-docs-start theme-colors-map
+$theme-colors: (
+  "primary":    $primary,
+  "secondary":  $secondary,
+  "success":    $success,
+  "info":       $info,
+  "warning":    $warning,
+  "danger":     $danger,
+  "light":      $light,
+  "dark":       $dark
+) !default;
+// scss-docs-end theme-colors-map
 
 // Characters which are escaped by the escape-svg function
 $escaped-characters: (


### PR DESCRIPTION
In this way we can use color tints (other than grays) in our custom theme (e.g `$primary: $indigo-600;` ), w/o having to extend `$theme-colors` and redefine `$theme-colors-rgb`later. This could be done in the project variables file, but i believe most developers just include a full local copy of  `scss/_variables.scss` before the the original `default` file and change the values the need (maybe also removing the !default flag) so that it's easier to track changes and custom values during upgrades.