### PR TITLE
Fix a small spelling mistake

### DIFF
--- a/site/content/docs/5.1/getting-started/introduction.md
+++ b/site/content/docs/5.1/getting-started/introduction.md
@@ -12,7 +12,7 @@ toc: true
 
 ## Quick start
 
-Looking to quickly add Bootstrap to your project? Use jsDelivr, a free open source CDN. Using a package manager or need to download the source files? [Head to the downloads page]({{< docsref "/getting-started/download" >}}).
+Looking to quickly add Bootstrap to your project? Use jsDelivr, a free, open source CDN. Using a package manager or need to download the source files? [Head to the downloads page]({{< docsref "/getting-started/download" >}}).
 
 ### CSS
 


### PR DESCRIPTION
In the docs, it says "jsDelivr, a free open source CDN" while it should be "A free, open source CDN".