### PR TITLE
Docs: remove unnecessary title test from single layout page

### DIFF
--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -5,12 +5,10 @@
         <div class="col-xl-8">
           <h1 class="bd-title mt-0">{{ .Title | markdownify }}</h1>
           <p class="bd-lead">{{ .Page.Params.Description | markdownify }}</p>
-          {{ if eq .Title "Examples" }}
           <div class="d-flex flex-column flex-sm-row">
             <a href="{{ .Site.Params.download.dist_examples }}" class="btn btn-lg btn-bd-primary" onclick="ga('send', 'event', 'Examples', 'Hero', 'Download Examples');">Download examples</a>
             <a href="{{ .Site.Params.download.source }}" class="btn btn-lg btn-outline-secondary mt-3 mt-sm-0 ms-sm-3" onclick="ga('send', 'event', 'Examples', 'Hero', 'Download');">Download source code</a>
           </div>
-          {{ end }}
         </div>
         <div class="col-xl-4 d-lg-flex justify-content-xl-end">
           {{ partial "ads" . }}
@@ -22,26 +20,23 @@
   <main class="bd-content order-1 py-5" id="content">
     <div class="container">
       {{ .Content }}
-
-      {{ if eq .Title "Examples" }}
-        <hr class="my-5">
-        <div class="container">
-          <div class="text-center">
-            <div class="masthead-followup-icon d-inline-block mb-2 text-white bg-danger">
-              {{ partial "icons/droplet-fill.svg" (dict "width" "32" "height" "32") }}
-            </div>
-              <h2 class="display-6 fw-normal">Go further with Bootstrap Themes</h2>
-            <p class="col-md-10 col-lg-8 mx-auto lead">
-              Need something more than these examples? Take Bootstrap to the next level with premium themes from the <a href="{{ .Site.Params.themes }}">official Bootstrap Themes marketplace</a>. They’re built as their own extended frameworks, rich with new components and plugins, documentation, and powerful build tools.
-            </p>
-            <a href="{{ .Site.Params.themes }}" class="btn btn-lg btn-outline-primary mb-3">Browse themes</a>
+      <hr class="my-5">
+      <div class="container">
+        <div class="text-center">
+          <div class="masthead-followup-icon d-inline-block mb-2 text-white bg-danger">
+            {{ partial "icons/droplet-fill.svg" (dict "width" "32" "height" "32") }}
           </div>
-          <img class="d-block img-fluid mt-3 mx-auto" srcset="/docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage.png,
-                                                              /docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage@2x.png 2x"
-                                                        src="/docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage.png"
-                                                        alt="Bootstrap Themes" width="1150" height="320" loading="lazy">
+            <h2 class="display-6 fw-normal">Go further with Bootstrap Themes</h2>
+          <p class="col-md-10 col-lg-8 mx-auto lead">
+            Need something more than these examples? Take Bootstrap to the next level with premium themes from the <a href="{{ .Site.Params.themes }}">official Bootstrap Themes marketplace</a>. They’re built as their own extended frameworks, rich with new components and plugins, documentation, and powerful build tools.
+          </p>
+          <a href="{{ .Site.Params.themes }}" class="btn btn-lg btn-outline-primary mb-3">Browse themes</a>
         </div>
-      {{ end }}
+        <img class="d-block img-fluid mt-3 mx-auto" srcset="/docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage.png,
+                                                            /docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage@2x.png 2x"
+                                                      src="/docs/{{ .Site.Params.docs_version }}/assets/img/bootstrap-themes-collage.png"
+                                                      alt="Bootstrap Themes" width="1150" height="320" loading="lazy">
+      </div>
     </div>
   </main>
 {{ end }}


### PR DESCRIPTION
### Description

`layout: single` seems to be used only for examples page so `{{ if eq .Title "Examples" }}` becomes unnecessary IMO.

### Motivation & Context

This change would remove unused code and simplify this page.

### Types of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### Related issues

No related issues.

### [Live preview](https://deploy-preview-35622--twbs-bootstrap.netlify.app/docs/5.1/examples/)
