### PR TITLE
allow to specify the backdrop parent for the modal component

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -45,12 +45,14 @@ const SELECTOR_MODAL_BODY = '.modal-body'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="modal"]'
 
 const Default = {
+  backdropParent: 'body',
   backdrop: true,
   keyboard: true,
   focus: true
 }
 
 const DefaultType = {
+  backdropParent: '(element|string)',
   backdrop: '(boolean|string)',
   keyboard: 'boolean',
   focus: 'boolean'
@@ -160,7 +162,8 @@ class Modal extends BaseComponent {
   _initializeBackDrop() {
     return new Backdrop({
       isVisible: Boolean(this._config.backdrop), // 'static' option will be translated to true, and booleans will keep their value
-      isAnimated: this._isAnimated()
+      isAnimated: this._isAnimated(),
+      rootElement: this._config.backdropParent
     })
   }
 

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -90,11 +90,14 @@ describe('Modal', () => {
       })
 
       modalEl.addEventListener('shown.bs.modal', () => {
+        const backdropEl = document.querySelector('.modal-backdrop')
+
         expect(modalEl.getAttribute('aria-modal')).toEqual('true')
         expect(modalEl.getAttribute('role')).toEqual('dialog')
         expect(modalEl.getAttribute('aria-hidden')).toBeNull()
         expect(modalEl.style.display).toEqual('block')
-        expect(document.querySelector('.modal-backdrop')).not.toBeNull()
+        expect(backdropEl).not.toBeNull()
+        expect(backdropEl.parentNode).toEqual(document.body)
         done()
       })
 
@@ -119,6 +122,28 @@ describe('Modal', () => {
         expect(modalEl.getAttribute('aria-hidden')).toBeNull()
         expect(modalEl.style.display).toEqual('block')
         expect(document.querySelector('.modal-backdrop')).toBeNull()
+        done()
+      })
+
+      modal.show()
+    })
+
+    it('should show a modal and backdrop to the specified element', done => {
+      fixtureEl.innerHTML = '<div id="rootModal"></div><div class="modal"><div class="modal-dialog"></div></div></div>'
+
+      const rootModalEl = fixtureEl.querySelector('#rootModal')
+      const modalEl = fixtureEl.querySelector('.modal')
+      const modal = new Modal(modalEl, { backdropParent: rootModalEl })
+
+      modalEl.addEventListener('show.bs.modal', event => {
+        expect(event).toBeDefined()
+      })
+
+      modalEl.addEventListener('shown.bs.modal', () => {
+        const backdropEl = document.querySelector('.modal-backdrop')
+
+        expect(backdropEl).not.toBeNull()
+        expect(backdropEl.parentNode).toEqual(rootModalEl)
         done()
       })
 

--- a/site/content/docs/5.1/components/modal.md
+++ b/site/content/docs/5.1/components/modal.md
@@ -870,6 +870,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
   </thead>
   <tbody>
     <tr>
+      <td><code>backdropParent</code></td>
+      <td>element or a string</td>
+      <td><code>'body'</code></td>
+      <td>The modal-backdrop element will be append at the end of this element.</td>
+    </tr>
+    <tr>
       <td><code>backdrop</code></td>
       <td>boolean or the string <code>'static'</code></td>
       <td><code>true</code></td>


### PR DESCRIPTION
Hi everybody!
I hope you're doing well, I wish you the best for this new year!

A small PR, to allow to specify the root element for the modal backdrop, it can be useful for users who use Bootstrap with Gatsby for example

Edit: The build failed on something I didn't changed, that's strange 🤔 