### PR TITLE
Add black to colors map

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -60,6 +60,7 @@ $colors: (
   "green":      $green,
   "teal":       $teal,
   "cyan":       $cyan,
+  "black":      $black,
   "white":      $white,
   "gray":       $gray-600,
   "gray-dark":  $gray-800


### PR DESCRIPTION
White is already in the map and therefore allows `var(—bs-white)` by default. This PR would allow the same access to black as a root variable.

Black and white are both outputted as root RGB variables so it would make sense to have both in the `$colors` map too.