### PR TITLE
fix isVisible behavior with new chrome version

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -129,6 +129,7 @@ const isVisible = element => {
   }
 
   const elementIsVisible = getComputedStyle(element).getPropertyValue('visibility') === 'visible'
+  // Handle `details` element as its content may falsie appear visible when it is closed
   const closedDetails = element.closest('details:not([open])')
 
   if (!closedDetails) {

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -146,10 +146,6 @@ const isVisible = element => {
     }
   }
 
-  if (closedDetails.parentNode.closest('details:not([open])')) {
-    return false
-  }
-
   return elementIsVisible
 }
 

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -128,10 +128,15 @@ const isVisible = element => {
     return false
   }
 
+  const elementIsVisible = getComputedStyle(element).getPropertyValue('visibility') === 'visible'
   const closedDetails = element.closest('details:not([open])')
-  const summary = element.closest('summary')
 
-  if (closedDetails && closedDetails !== element) {
+  if (!closedDetails) {
+    return elementIsVisible
+  }
+
+  if (closedDetails !== element) {
+    const summary = element.closest('summary')
     if (summary && summary.parentNode !== closedDetails) {
       return false
     }
@@ -141,11 +146,11 @@ const isVisible = element => {
     }
   }
 
-  if (closedDetails && closedDetails.parentNode.closest('details:not([open])')) {
+  if (closedDetails.parentNode.closest('details:not([open])')) {
     return false
   }
 
-  return getComputedStyle(element).getPropertyValue('visibility') === 'visible'
+  return elementIsVisible
 }
 
 const isDisabled = element => {

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -128,6 +128,23 @@ const isVisible = element => {
     return false
   }
 
+  const closedDetails = element.closest('details:not([open])')
+  const summary = element.closest('summary')
+
+  if (closedDetails && closedDetails !== element) {
+    if (summary && summary.parentNode !== closedDetails) {
+      return false
+    }
+
+    if (summary === null) {
+      return false
+    }
+  }
+
+  if (closedDetails && closedDetails.parentNode.closest('details:not([open])')) {
+    return false
+  }
+
   return getComputedStyle(element).getPropertyValue('visibility') === 'visible'
 }
 

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -356,30 +356,6 @@ describe('Util', () => {
       expect(Util.isVisible(element1)).toBeTrue()
       expect(Util.isVisible(element2)).toBeTrue()
     })
-
-    it('should return true if the element is a details element in an open details element', () => {
-      fixtureEl.innerHTML = [
-        '<details open>',
-        '  <details id="element"></details>',
-        '</details>'
-      ].join('')
-
-      const div = fixtureEl.querySelector('#element')
-
-      expect(Util.isVisible(div)).toBeTrue()
-    })
-
-    it('should return false if the element is an open details element in a closed details element', () => {
-      fixtureEl.innerHTML = [
-        '<details>',
-        '  <details id="element" open></details>',
-        '</details>'
-      ].join('')
-
-      const div = fixtureEl.querySelector('#element')
-
-      expect(Util.isVisible(div)).toBeFalse()
-    })
   })
 
   describe('isDisabled', () => {

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -320,6 +320,94 @@ describe('Util', () => {
 
       expect(Util.isVisible(div)).toBeFalse()
     })
+
+    it('should return true if its a closed details element', () => {
+      fixtureEl.innerHTML = '<details id="element"></details>'
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeTrue()
+    })
+
+    it('should return true if the element is visible inside an open details element', () => {
+      fixtureEl.innerHTML = [
+        '<details open>',
+        '  <div id="element"></div>',
+        '</details>'
+      ].join('')
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeTrue()
+    })
+
+    it('should return true if the element is a visible summary in a closed details element', () => {
+      fixtureEl.innerHTML = [
+        '<details>',
+        '  <summary id="element-1">',
+        '    <span id="element-2"></span>',
+        '  </summary>',
+        '</details>'
+      ].join('')
+
+      const element1 = fixtureEl.querySelector('#element-1')
+      const element2 = fixtureEl.querySelector('#element-2')
+
+      expect(Util.isVisible(element1)).toBeTrue()
+      expect(Util.isVisible(element2)).toBeTrue()
+    })
+
+    it('should return true if the element is a visible summary in open, closed details element', () => {
+      fixtureEl.innerHTML = [
+        '<details open>',
+        '  <details>',
+        '    <summary id="element"></summary>',
+        '  </details>',
+        '</details>'
+      ].join('')
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeTrue()
+    })
+
+    it('should return true if the element is a details element in an open details element', () => {
+      fixtureEl.innerHTML = [
+        '<details open>',
+        '  <details id="element"></details>',
+        '</details>'
+      ].join('')
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeTrue()
+    })
+
+    it('should return false if the element is a summary in closed, closed details element', () => {
+      fixtureEl.innerHTML = [
+        '<details>',
+        '  <details>',
+        '    <summary id="element"></summary>',
+        '  </details>',
+        '</details>'
+      ].join('')
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeFalse()
+    })
+
+    it('should return false if the element is an open details element in a closed details element', () => {
+      fixtureEl.innerHTML = [
+        '<details>',
+        '  <details id="element" open></details>',
+        '</details>'
+      ].join('')
+
+      const div = fixtureEl.querySelector('#element')
+
+      expect(Util.isVisible(div)).toBeFalse()
+    })
   })
 
   describe('isDisabled', () => {

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -357,20 +357,6 @@ describe('Util', () => {
       expect(Util.isVisible(element2)).toBeTrue()
     })
 
-    it('should return true if the element is a visible summary in open, closed details element', () => {
-      fixtureEl.innerHTML = [
-        '<details open>',
-        '  <details>',
-        '    <summary id="element"></summary>',
-        '  </details>',
-        '</details>'
-      ].join('')
-
-      const div = fixtureEl.querySelector('#element')
-
-      expect(Util.isVisible(div)).toBeTrue()
-    })
-
     it('should return true if the element is a details element in an open details element', () => {
       fixtureEl.innerHTML = [
         '<details open>',
@@ -381,20 +367,6 @@ describe('Util', () => {
       const div = fixtureEl.querySelector('#element')
 
       expect(Util.isVisible(div)).toBeTrue()
-    })
-
-    it('should return false if the element is a summary in closed, closed details element', () => {
-      fixtureEl.innerHTML = [
-        '<details>',
-        '  <details>',
-        '    <summary id="element"></summary>',
-        '  </details>',
-        '</details>'
-      ].join('')
-
-      const div = fixtureEl.querySelector('#element')
-
-      expect(Util.isVisible(div)).toBeFalse()
     })
 
     it('should return false if the element is an open details element in a closed details element', () => {


### PR DESCRIPTION
First found in #35659 [(specific comment with details)](https://github.com/twbs/bootstrap/pull/35659#issuecomment-1009980611), this fixes a bug in the `isVisible` utility that was introduced with the latest version of chrome 97.0.4692.71. Previous to the chrome update the following html would produce a 0 length [`getClientRects()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects) when run on the span being checked.

```html
<details>
   <span>This is the element being checked by isVisible</span>
</details>
```

This meant that we didn't need any special handling for this case. However, after the chrome update, it returns non-zero length results, and it doesn't look like we can rely on it for all our visibility information. The changes in this PR add explicit support for checking visibility of elements inside the `<details>` element. Should chrome ever revert their behavior, this should certainly still function, albeit a bit redundant.