### PR TITLE
feat#35412: Added possibility to make accordion card disabled

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -78,7 +78,9 @@
   border-bottom: $card-border-width solid $card-border-color;
 
   &:first-child {
-    @include border-radius($card-inner-border-radius $card-inner-border-radius 0 0);
+    @include border-radius(
+      $card-inner-border-radius $card-inner-border-radius 0 0
+    );
   }
 
   + .list-group {
@@ -94,10 +96,11 @@
   border-top: $card-border-width solid $card-border-color;
 
   &:last-child {
-    @include border-radius(0 0 $card-inner-border-radius $card-inner-border-radius);
+    @include border-radius(
+      0 0 $card-inner-border-radius $card-inner-border-radius
+    );
   }
 }
-
 
 //
 // Header navs
@@ -149,7 +152,6 @@
   @include border-bottom-radius($card-inner-border-radius);
 }
 
-
 // Card deck
 
 .card-deck {
@@ -172,7 +174,6 @@
     }
   }
 }
-
 
 //
 // Card groups
@@ -236,7 +237,6 @@
   }
 }
 
-
 //
 // Accordion
 //
@@ -257,6 +257,10 @@
     > .card-header {
       @include border-radius(0);
       margin-bottom: -$card-border-width;
+    }
+
+    .disabled {
+      pointer-events: none;
     }
   }
 }

--- a/site/content/docs/4.3/components/collapse.md
+++ b/site/content/docs/4.3/components/collapse.md
@@ -25,6 +25,7 @@ Click the buttons below to show and hide another element via class changes:
 You can use a link with the `href` attribute, or a button with the `data-target` attribute. In both cases, the `data-toggle="collapse"` is required.
 
 {{< example >}}
+
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
     Link with href
@@ -46,6 +47,7 @@ A `<button>` or `<a>` can show and hide multiple elements by referencing them wi
 Multiple `<button>` or `<a>` can show and hide an element if they each reference it with their `href` or `data-target` attribute
 
 {{< example >}}
+
 <p>
   <a class="btn btn-primary" data-toggle="collapse" href="#multiCollapseExample1" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">Toggle first element</a>
   <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#multiCollapseExample2" aria-expanded="false" aria-controls="multiCollapseExample2">Toggle second element</button>
@@ -74,6 +76,7 @@ Multiple `<button>` or `<a>` can show and hide an element if they each reference
 Using the [card]({{< docsref "/components/card" >}}) component, you can extend the default collapse behavior to create an accordion. To properly achieve the accordion style, be sure to use `.accordion` as a wrapper.
 
 {{< example >}}
+
 <div class="accordion" id="accordionExample">
   <div class="card">
     <div class="card-header" id="headingOne">
@@ -89,6 +92,7 @@ Using the [card]({{< docsref "/components/card" >}}) component, you can extend t
         Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
       </div>
     </div>
+
   </div>
   <div class="card">
     <div class="card-header" id="headingTwo">
@@ -139,6 +143,10 @@ The collapse plugin utilizes a few classes to handle the heavy lifting:
 
 These classes can be found in `_transitions.scss`.
 
+- `.disabled` makes it impossible to interact until the class is removed.
+
+This has been added to `_card.scss`.
+
 ### Via data attributes
 
 Just add `data-toggle="collapse"` and a `data-target` to the element to automatically assign control of one or more collapsible elements. The `data-target` attribute accepts a CSS selector to apply the collapse to. Be sure to add the class `collapse` to the collapsible element. If you'd like it to default open, add the additional class `show`.
@@ -152,7 +160,7 @@ Enable manually with:
 {{< highlight js >}}
 var collapseElementList = [].slice.call(document.querySelectorAll('.collapse'))
 var collapseList = collapseElementList.map(function (collapseEl) {
-  return new bootstrap.Collapse(collapseEl)
+return new bootstrap.Collapse(collapseEl)
 })
 {{< /highlight >}}
 
@@ -198,7 +206,7 @@ You can create a collapse instance with the constructor, for example:
 {{< highlight js >}}
 var myCollapse = document.getElementById('myCollapse')
 var bsCollapse = new bootstrap.Collapse(myCollapse, {
-  toggle: false
+toggle: false
 })
 {{< /highlight >}}
 
@@ -267,6 +275,6 @@ Bootstrap's collapse class exposes a few events for hooking into collapse functi
 {{< highlight js >}}
 var myCollapsible = document.getElementById('myCollapsible')
 myCollapsible.addEventListener('hidden.bs.collapse', function () {
-  // do something...
+// do something...
 })
 {{< /highlight >}}


### PR DESCRIPTION
This is a response to https://github.com/twbs/bootstrap/issues/35412. 
It introduces the .disabled class on .accordion > .card to make it not clickable until the class has been removed.