### PR TITLE
V4 src/tooltip.js Optimization

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -238,7 +238,7 @@ class Tooltip {
 
       const shadowRoot = Util.findShadowRoot(this.element)
       const isInTheDom = $.contains(
-        shadowRoot !== null ? shadowRoot : this.element.ownerDocument.documentElement,
+        shadowRoot || this.element.ownerDocument.documentElement,
         this.element
       )
 


### PR DESCRIPTION
Util.findShadowRoot() returns either null or an object.

It cannot return falsy, which allows this optimization.