### PR TITLE
src/tooltip.js Optimization

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -199,9 +199,7 @@ class Tooltip extends BaseComponent {
 
     const showEvent = EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SHOW))
     const shadowRoot = findShadowRoot(this._element)
-    const isInTheDom = shadowRoot === null ?
-      this._element.ownerDocument.documentElement.contains(this._element) :
-      shadowRoot.contains(this._element)
+    const isInTheDom = (shadowRoot || this._element.ownerDocument.documentElement).contains(this._element)
 
     if (showEvent.defaultPrevented || !isInTheDom) {
       return


### PR DESCRIPTION
Util.findShadowRoot() returns either null or an object.

It cannot return falsy, which allows this optimization.