### PR TITLE
Bug fix: tooltip

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -537,8 +537,6 @@ class Tooltip extends BaseComponent {
     if (!this._element.getAttribute('aria-label') && !this._element.textContent) {
       this._element.setAttribute('aria-label', title)
     }
-
-    this._element.removeAttribute('title')
   }
 
   _enter() {


### PR DESCRIPTION
When a copy button is hovered after a click, it doesn't display its content anymore. I'm not sure if this fix goes and fit to your concerns and to the function atm, I could check a bit deeper if needed.

**(I'll update the tests if the solution is approved)**

Bug reduced test case : launch main branch, go on any page, click on any copy button, then hover it.