### PR TITLE
Fix modal SASS when $spacer is of the pixels unit

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1365,7 +1365,7 @@ $badge-border-radius:               $border-radius !default;
 // scss-docs-start modal-variables
 $modal-inner-padding:               $spacer !default;
 
-$modal-footer-margin-between:       .5rem !default;
+$modal-footer-margin-between:       $spacer * .5 !default;
 
 $modal-dialog-margin:               .5rem !default;
 $modal-dialog-margin-y-sm-up:       1.75rem !default;


### PR DESCRIPTION
Setting the `$spacer` variable to a `pixels` unit breaks the compilation due to a calculation that's happening in the modal SASS:
```
SassError: 8px and 0.25rem have incompatible units.
    ╷
131 │   padding: $modal-inner-padding - $modal-footer-margin-between * .5;
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
  node_modules\bootstrap\scss\_modal.scss 131:12  @import
  .scss\bootstrap.scss 29:9                       @import
```
It's actually line `132` now ([click](https://github.com/twbs/bootstrap/blob/main/scss/_modal.scss#L132)).

Since it's half the size of the spacer, might as well calculate the size.