### PR TITLE
Correct the horizontal padding on grid containers

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -467,7 +467,7 @@ $grid-row-columns:            6 !default;
 
 // Container padding
 
-$container-padding-x: $grid-gutter-width * .5 !default;
+$container-padding-x: $grid-gutter-width !default;
 
 
 // Components

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -4,8 +4,8 @@
   --#{$variable-prefix}gutter-x: #{$gutter};
   --#{$variable-prefix}gutter-y: 0;
   width: 100%;
-  padding-right: var(--#{$variable-prefix}gutter-x, #{$gutter});
-  padding-left: var(--#{$variable-prefix}gutter-x, #{$gutter});
+  padding-right: calc(var(--#{$variable-prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-left: calc(var(--#{$variable-prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
   margin-right: auto;
   margin-left: auto;
 }


### PR DESCRIPTION
While investigating #35282, I realized we're not halving the grid gutter values in our container classes. This was unintentional as the goal of the containers, rows, and columns is for all their padding and negative margin to seamlessly align.

An alternative approach here would be to halve the local CSS variable, but I think being consistent here is a good move.

/cc @ffoodd 

---

Closes #35282.
