### PR TITLE
Fixed border radius var name and .show target in buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -66,7 +66,7 @@
   .btn-check:active + &,
   &:active,
   &.active,
-  .show > &.dropdown-toggle {
+  &.show {
     color: var(--#{$variable-prefix}btn-active-color);
     background-color: var(--#{$variable-prefix}btn-active-bg);
     // Remove CSS gradients if they're enabled

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -65,6 +65,6 @@
 @mixin button-size($padding-y, $padding-x, $font-size, $border-radius) {
   --#{$variable-prefix}btn-padding: #{$padding-y} #{$padding-x};
   @include rfs($font-size, --#{$variable-prefix}btn-font-size);
-  --#{$variable-prefix}btn-radius: #{$border-radius};
+  --#{$variable-prefix}btn-border-radius: #{$border-radius};
 }
 // scss-docs-end btn-size-mixin


### PR DESCRIPTION
These were skipped in original PR, so raising a new one.

1.  `.show` doesn't work on parent element, because it's toggled on `.dropdown-toggle` itself
2. Button border radius variable is incorrect