### PR TITLE
Fix tooltip arrow alignment on rtl

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -93,14 +93,33 @@
   &[data-popper-placement^="top"] {
     @extend .bs-tooltip-top;
   }
-  &[data-popper-placement^="right"] {
-    @extend .bs-tooltip-end;
-  }
   &[data-popper-placement^="bottom"] {
     @extend .bs-tooltip-bottom;
   }
+
+  /* rtl:begin:remove */
+  &[data-popper-placement^="right"] {
+    @extend .bs-tooltip-end;
+  }
   &[data-popper-placement^="left"] {
     @extend .bs-tooltip-start;
+  }
+
+  /* rtl:end:remove */
+}
+
+
+[dir="rtl"] .bs-tooltip-auto {
+  &[data-popper-placement^="right"] {
+    @extend .bs-tooltip-start;
+
+    .tooltip-arrow {
+      left: auto;
+    }
+  }
+
+  &[data-popper-placement^="left"] {
+    @extend .bs-tooltip-end;
   }
 }
 


### PR DESCRIPTION
It seems is a regression of #32692, after tooltip.js cleanup .

@twbs/css-review  need your help here

Thanks to @ffoodd https://github.com/twbs/bootstrap/pull/34627#issuecomment-1039941967