### PR TITLE
Adds named shortcode parameter `unindent`

### DIFF
--- a/site/content/docs/5.1/utilities/background.md
+++ b/site/content/docs/5.1/utilities/background.md
@@ -121,4 +121,4 @@ And background color opacities build on that with their own map that's consumed 
 
 Background utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-bg-color" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-bg-color" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/borders.md
+++ b/site/content/docs/5.1/utilities/borders.md
@@ -94,6 +94,6 @@ Use the scaling classes for larger or smaller rounded corners. Sizes range from 
 
 Border utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-borders" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-borders" file="scss/_utilities.scss" unindent=4 >}}
 
-{{< scss-docs name="utils-border-radius" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-border-radius" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/colors.md
+++ b/site/content/docs/5.1/utilities/colors.md
@@ -110,4 +110,4 @@ And color opacities build on that with their own map that's consumed by the util
 
 Color utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-color" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-color" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/display.md
+++ b/site/content/docs/5.1/utilities/display.md
@@ -157,4 +157,4 @@ The print and display classes can be combined.
 
 Display utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-display" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-display" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/flex.md
+++ b/site/content/docs/5.1/utilities/flex.md
@@ -662,4 +662,4 @@ And say you want to vertically center the content next to the image:
 
 Flexbox utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-flex" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-flex" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/float.md
+++ b/site/content/docs/5.1/utilities/float.md
@@ -45,4 +45,4 @@ Here are all the support classes:
 
 Float utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-float" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-float" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/interactions.md
+++ b/site/content/docs/5.1/utilities/interactions.md
@@ -39,4 +39,4 @@ If possible, the simpler solution is:
 
 Interaction utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-interaction" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-interaction" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/opacity.md
+++ b/site/content/docs/5.1/utilities/opacity.md
@@ -27,4 +27,4 @@ Set the `opacity` of an element using `.opacity-{value}` utilities.
 
 Opacity utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-opacity" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-opacity" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/overflow.md
+++ b/site/content/docs/5.1/utilities/overflow.md
@@ -37,4 +37,4 @@ Using Sass variables, you may customize the overflow utilities by changing the `
 
 Overflow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-overflow" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-overflow" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/position.md
+++ b/site/content/docs/5.1/utilities/position.md
@@ -127,4 +127,4 @@ Default position utility values are declared in a Sass map, then used to generat
 
 Position utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-position" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-position" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/shadows.md
+++ b/site/content/docs/5.1/utilities/shadows.md
@@ -27,4 +27,4 @@ While shadows on components are disabled by default in Bootstrap and can be enab
 
 Shadow utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-shadow" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-shadow" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/sizing.md
+++ b/site/content/docs/5.1/utilities/sizing.md
@@ -57,4 +57,4 @@ You can also use utilities to set the width and height relative to the viewport.
 
 Sizing utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-sizing" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-sizing" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/spacing.md
+++ b/site/content/docs/5.1/utilities/spacing.md
@@ -122,4 +122,4 @@ Spacing utilities are declared via Sass map and then generated with our utilitie
 
 Spacing utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-spacing" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-spacing" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/text.md
+++ b/site/content/docs/5.1/utilities/text.md
@@ -151,4 +151,4 @@ Font-size utilities are generated from this map, in combination with our utiliti
 
 Font and text utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-text" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-text" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/vertical-align.md
+++ b/site/content/docs/5.1/utilities/vertical-align.md
@@ -45,4 +45,4 @@ With table cells:
 
 Vertical align utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-vertical-align" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-vertical-align" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/content/docs/5.1/utilities/visibility.md
+++ b/site/content/docs/5.1/utilities/visibility.md
@@ -34,4 +34,4 @@ Apply `.visible` or `.invisible` as needed.
 
 Visibility utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]({{< docsref "/utilities/api#using-the-api" >}})
 
-{{< scss-docs name="utils-visibility" file="scss/_utilities.scss" >}}
+{{< scss-docs name="utils-visibility" file="scss/_utilities.scss" unindent=4 >}}

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -6,11 +6,13 @@
 
   Optional parameters:
     * strip-default: Remove the ` !default` flag from variable assignments - default: `true`
+    * unindent: Remove indentation by `n` spaces - default: `0`
 */ -}}
 
 {{- $name := .Get "name" -}}
 {{- $file := .Get "file" -}}
 {{- $strip_default := .Get "strip-default" | default "true" -}}
+{{- $unindent := .Get "unindent" | default 0 -}}
 
 {{- /* If any parameters are missing, print an error and exit */ -}}
 {{- if or (not $name) (not $file) -}}
@@ -39,5 +41,16 @@
     {{- $match = replace $match " !default" "" -}}
   {{- end -}}
 
-  {{- highlight $match "scss" "" -}}
+  {{- $output := "" -}}
+  {{- if (gt $unindent 0) -}}
+    {{- $prefix := (strings.Repeat $unindent " ") -}}
+    {{- range $line := split $match "\n" -}}
+      {{- $line = strings.TrimPrefix $prefix $line -}}
+      {{ $output = printf "%s%s\n" $output $line }}
+    {{- end -}}
+    {{- $output = chomp $output -}}
+  {{- else -}}
+    {{- $output = $match -}}
+  {{- end -}}
+  {{- highlight $output "scss" "" -}}
 {{- end -}}


### PR DESCRIPTION
# Resolves #34854

Resolves stale branch and rebases from `twbs/bootstrap main`
Validated http://localhost:9001/docs/5.1/utilities/colors/ - see:

![image](https://user-images.githubusercontent.com/906846/155085679-011f7801-eaea-4358-955a-53fcd705835c.png)

> Per [#35296](https://github.com/twbs/bootstrap/pull/35296)
> 👉 **TY @pouwerkerk** 🙌 

---

> Snippets in [Utilities documentation sections](https://getbootstrap.com/docs/5.1/utilities/colors/#utilities-api) have extra indentation, since they extract nested code from `scss/_utilities.scss`.
> 
> This PR adds a [named shortcode parameter](https://gohugo.io/templates/shortcode-templates/#positional-vs-named-parameters) (`unindent`) to the scss-docs template, which takes an integer to unindent the code by a maximum number of spaces. In all current over-indented examples, it's 4 extra spaces.
> 
> Before	After
> <img alt="Screen Shot 2021-10-28 at 06 23 21 PM" width="805" src="https://user-images.githubusercontent.com/101547/139349584-12df4d5f-ae3e-46ed-9480-caec6d5cac5d.png">	<img alt="Screen Shot 2021-10-28 at 06 22 54 PM" width="805" src="https://user-images.githubusercontent.com/101547/139349585-ea259a03-6662-4699-9a07-0b439aa7379e.png">

