### PR TITLE
Replace non-existent `--bs-btn-padding` by `--bs-btn-padding-{x|y}`

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -63,7 +63,8 @@
 
 // scss-docs-start btn-size-mixin
 @mixin button-size($padding-y, $padding-x, $font-size, $border-radius) {
-  --#{$variable-prefix}btn-padding: #{$padding-y} #{$padding-x};
+  --#{$variable-prefix}btn-padding-y: #{$padding-y};
+  --#{$variable-prefix}btn-padding-x: #{$padding-x};
   @include rfs($font-size, --#{$variable-prefix}btn-font-size);
   --#{$variable-prefix}btn-border-radius: #{$border-radius};
 }

--- a/site/content/docs/5.1/components/buttons.md
+++ b/site/content/docs/5.1/components/buttons.md
@@ -76,7 +76,7 @@ You can even roll your own custom sizing with CSS variables:
 
 {{< example >}}
 <button type="button" class="btn btn-primary"
-        style="--bs-btn-padding: .25rem .5rem; --bs-btn-font-size: .75rem;">
+        style="--bs-btn-padding-y: .25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;">
   Custom button
 </button>
 {{< /example >}}


### PR DESCRIPTION
`--#{$variable-prefix}btn-padding` doesn't exist so the custom sizing button with CSS variables is not fully functional.

In this fix, I chose to keep 2 separate vars but it could probably be only 1 var.

[Preview](https://deploy-preview-35886--twbs-bootstrap.netlify.app/docs/5.1/components/buttons/#sizes)

---

**Note**: there is another bug that can be seen in this page: the last buttons are not vertically aligned with the other buttons in a same row in the examples. It is probably due to the new rule in https://github.com/twbs/bootstrap/commit/37f3977e6d96e274cb73255d99e3e4ec60f03c0f:
```scss
> :not(hr):last-child {
  margin-bottom: 0;
}
```
![Capture d’écran 2022-02-23 à 14 18 02](https://user-images.githubusercontent.com/17381666/155326959-b31d2551-35b3-49df-b3ed-2b8059fe9587.png)

I can create an issue if needed.
