### PR TITLE
Prevent RTL CSS conversion from breaking Carousel example

### DIFF
--- a/site/content/docs/5.1/examples/carousel/carousel.css
+++ b/site/content/docs/5.1/examples/carousel/carousel.css
@@ -53,7 +53,6 @@ body {
 
 /* Thin out the marketing headings */
 .featurette-heading {
-  /* rtl:remove */
   letter-spacing: -.05rem;
 }
 

--- a/site/content/docs/5.1/examples/carousel/carousel.rtl.css
+++ b/site/content/docs/5.1/examples/carousel/carousel.rtl.css
@@ -49,6 +49,11 @@ body {
   margin: 5rem 0; /* Space out the Bootstrap <hr> more */
 }
 
+/* Thin out the marketing headings */
+.featurette-heading {
+  letter-spacing: -.05rem;
+}
+
 
 /* RESPONSIVE CSS
 -------------------------------------------------- */

--- a/site/content/docs/5.1/examples/carousel/carousel.rtl.css
+++ b/site/content/docs/5.1/examples/carousel/carousel.rtl.css
@@ -50,9 +50,11 @@ body {
 }
 
 /* Thin out the marketing headings */
+/* rtl:begin:remove */
 .featurette-heading {
   letter-spacing: -.05rem;
 }
+/* rtl:end:remove */
 
 
 /* RESPONSIVE CSS


### PR DESCRIPTION
This causes errors right now because it creates an empty ruleset. For now I just left it as rendering to the RTL example, but maybe there's another way to do it.

/cc @twbs/css-review 