### PR TITLE
Base `.text-muted` on body color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -609,7 +609,7 @@ $small-font-size:             .875em !default;
 
 $sub-sup-font-size:           .75em !default;
 
-$text-muted:                  $gray-600 !default;
+$text-muted:                  rgba(var(--#{$variable-prefix}body-color-rgb), .75) !default;
 
 $initialism-font-size:        $small-font-size !default;
 


### PR DESCRIPTION
Not an exact match, but close enough and still maintaining color contrast. Fixes #34457.