### PR TITLE
Remove border of disabled calendar buttons in Dropdowns example

### DIFF
--- a/site/content/docs/5.1/examples/dropdowns/dropdowns.css
+++ b/site/content/docs/5.1/examples/dropdowns/dropdowns.css
@@ -52,6 +52,7 @@
   background-color: rgba(0, 0, 0, .05);
 }
 .cal-btn[disabled] {
+  border: 0;
   opacity: .5;
 }
 


### PR DESCRIPTION
### Description

Add a new rule in `examples/dropdowns/dropdowns.css` to remove the border for disabled calendar buttons.

### Motivation & Context

This change is required to retrieve the same rendering before ef9d8538a06f43f74f49d6829cbf301773381488 that introduces for the buttons:

```scss
&:disabled,
&.disabled,
fieldset:disabled & {
  /*...*/
  border-color: var(--#{$variable-prefix}btn-disabled-border-color);
  /*...*/
}
``` 

Rendering of the current _main_ branch to compare to [the current Dropdowns example](https://getbootstrap.com/docs/5.1/examples/dropdowns/):

![Screenshot from 2022-02-24 08-10-22](https://user-images.githubusercontent.com/17381666/155475796-3614280d-de4e-472a-9584-a7d03d543d49.png)


### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### [Live preview](https://deploy-preview-35898--twbs-bootstrap.netlify.app/docs/5.1/examples/dropdowns/)
