### PR TITLE
Dropdown: support dynamic popper on navbar

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -55,7 +55,6 @@ const CLASS_NAME_DROPDOWN_CENTER = 'dropdown-center'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="dropdown"]:not(.disabled):not(:disabled)'
 const SELECTOR_DATA_TOGGLE_SHOWN = `${SELECTOR_DATA_TOGGLE}.${CLASS_NAME_SHOW}`
 const SELECTOR_MENU = '.dropdown-menu'
-const SELECTOR_NAVBAR = '.navbar'
 const SELECTOR_NAVBAR_NAV = '.navbar-nav'
 const SELECTOR_VISIBLE_ITEMS = '.dropdown-menu .dropdown-item:not(.disabled):not(:disabled)'
 
@@ -136,7 +135,7 @@ class Dropdown extends BaseComponent {
       return
     }
 
-    this._createPopper()
+    this._popper = this._createPopper()
 
     // If this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;
@@ -177,7 +176,6 @@ class Dropdown extends BaseComponent {
   }
 
   update() {
-    this._inNavbar = this._detectNavbar()
     if (this._popper) {
       this._popper.update()
     }
@@ -238,7 +236,7 @@ class Dropdown extends BaseComponent {
     }
 
     const popperConfig = this._getPopperConfig()
-    this._popper = Popper.createPopper(referenceElement, this._menu, popperConfig)
+    return Popper.createPopper(referenceElement, this._menu, popperConfig)
   }
 
   _isShown() {
@@ -274,10 +272,6 @@ class Dropdown extends BaseComponent {
     return isEnd ? PLACEMENT_BOTTOMEND : PLACEMENT_BOTTOM
   }
 
-  _detectNavbar() {
-    return this._element.closest(SELECTOR_NAVBAR) !== null
-  }
-
   _getOffset() {
     const { offset } = this._config
 
@@ -306,15 +300,21 @@ class Dropdown extends BaseComponent {
         options: {
           offset: this._getOffset()
         }
-      }]
-    }
-
-    // Disable Popper if we have a static display or Dropdown is in Navbar
-    if (this._inNavbar || this._config.display === 'static') {
-      Manipulator.setDataAttribute(this._menu, 'popper', 'static') // todo:v6 remove
-      defaultBsPopperConfig.modifiers = [{
-        name: 'applyStyles',
-        enabled: false
+      },
+      {
+        name: 'applyCustomStyles',
+        enabled: true,
+        phase: 'afterWrite',
+        fn: () => {
+          this._menu.style.removeProperty('position')
+          const initialPosition = getComputedStyle(this._menu).position
+          if (this._config.display === 'static' || initialPosition === 'static') {
+            // this._menu.style.position = 'static'
+            this._menu.style.removeProperty('margin')
+            this._menu.style.removeProperty('transform')
+            Manipulator.setDataAttribute(this._menu, 'popper', 'static') // todo:v6 remove?
+          }
+        }
       }]
     }
 

--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -10,6 +10,68 @@
     <div class="container">
       <h1>Dropdown <small>Bootstrap Visual Test</small></h1>
 
+
+      <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+          <a class="navbar-brand" href="#">Expand at lg</a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample05" aria-controls="navbarsExample05" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+
+          <div class="collapse navbar-collapse" id="navbarsExample05">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="#">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#">Link</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link disabled">Disabled</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="dropdown05" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</a>
+                <ul class="dropdown-menu" aria-labelledby="dropdown05">
+                  <li><a class="dropdown-item" href="#">Action</a></li>
+                  <li><a class="dropdown-item" href="#">Another action</a></li>
+                  <li><a class="dropdown-item" href="#">Something else here</a></li>
+                </ul>
+              </li>
+            </ul>
+            <form role="search">
+              <input class="form-control" type="search" placeholder="Search" aria-label="Search">
+            </form>
+            <div class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Positioned dropdown
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <li><a class="dropdown-item" href="#">Action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="#">Something else here</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+
       <nav class="navbar navbar-expand-md bg-light">
         <a class="navbar-brand" href="#">Navbar</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
@@ -28,7 +90,7 @@
               <a class="nav-link" href="#">Link</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false">Dropdown</a>
+              <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-offset="0,20" aria-expanded="false">Dropdown</a>
               <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Action</a></li>
                 <li><a class="dropdown-item" href="#">Another action</a></li>

--- a/site/content/docs/5.2/examples/headers/headers.css
+++ b/site/content/docs/5.2/examples/headers/headers.css
@@ -1,3 +1,7 @@
+body {
+  padding-top: 5rem;
+}
+
 .form-control-dark {
   border-color: var(--bs-gray);
 }

--- a/site/content/docs/5.2/examples/headers/headers.css
+++ b/site/content/docs/5.2/examples/headers/headers.css
@@ -1,7 +1,3 @@
-body {
-  padding-top: 5rem;
-}
-
 .form-control-dark {
   border-color: var(--bs-gray);
 }


### PR DESCRIPTION
Support popper configurations on navbar dynamically. 

Changes: 
* we do not search for navbar parents
* popper can handle the element style, during resizing
* we **gain** :
    * popper `offset`configuration, while we have dynamic positioned dropdown
    * popper `preventOverflow` functionality on navbar dropdowns


~~Preview:~~
~~https://deploy-preview-35901--twbs-bootstrap.netlify.app/docs/5.1/examples/headers/~~
~~(I have added the previously not working example on preview, adding offset)~~

@mdo & @twbs/css-review  I will need your help on this, in case I am missing something



**Todo**:

- [x] fix/add tests
- [x] revert headers example

Closes #35397
Closes #34471 and
Closes #33957
closes #36897
closes #36789
