### PR TITLE
Site assets: `.bd-bg-purple-bright` → `.bd-bg-violet` and drop unused `.bd-text-purple-bright`

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -76,10 +76,6 @@
   font-weight: 300;
 }
 
-.bd-text-purple-bright {
-  color: $bd-violet;
-}
-
-.bd-bg-purple-bright {
+.bd-bg-violet {
   background-color: $bd-violet;
 }

--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -43,7 +43,7 @@
 
   <section class="row mb-5 pb-md-4 align-items-center">
     <div class="col-md-5">
-      <div class="masthead-followup-icon d-inline-block mb-2 text-white bd-bg-purple-bright">
+      <div class="masthead-followup-icon d-inline-block mb-2 text-white bd-bg-violet">
         {{ partial "icons/circle-square.svg" (dict "width" "32" "height" "32") }}
       </div>
       <h2 class="display-5 fw-normal">Bootstrap Icons</h2>


### PR DESCRIPTION
### Description

* `.bd-bg-purple-bright` → `.bd-bg-violet`
* Drop unused `.bd-text-purple-bright`

### Motivation & Context

All "purple bright" references have been changed in https://github.com/twbs/bootstrap/commit/3e6265ac55cd8548a83f2470a19ff1dcf28d3b0a except `.bd-bg-purple-bright` and `.bd-text-purple-bright`.
I think it can bring more coherence in the naming to rename `.bd-bg-purple-bright` in `.bd-bg-violet`.

`.bd-text-purple-bright` is not used so it could be dropped.

### Types of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-35905--twbs-bootstrap.netlify.app/)
