### PR TITLE
Use all dropdowns CSS variables

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -25,7 +25,7 @@
   --#{$variable-prefix}dropdown-border-color: #{$dropdown-border-color};
   --#{$variable-prefix}dropdown-border-radius: #{$dropdown-border-radius};
   --#{$variable-prefix}dropdown-border-width: #{$dropdown-border-width};
-  --#{$variable-prefix}dropdown-inner-border: #{$dropdown-inner-border-radius};
+  --#{$variable-prefix}dropdown-inner-border-radius: #{$dropdown-inner-border-radius};
   --#{$variable-prefix}dropdown-divider-bg: #{$dropdown-divider-bg};
   --#{$variable-prefix}dropdown-divider-margin-y: #{$dropdown-divider-margin-y};
   --#{$variable-prefix}dropdown-box-shadow: #{$dropdown-box-shadow};
@@ -145,7 +145,7 @@
 // Dividers (basically an `<hr>`) within the dropdown
 .dropdown-divider {
   height: 0;
-  margin: $dropdown-divider-margin-y 0;
+  margin: var(--#{$variable-prefix}dropdown-divider-margin-y) 0;
   overflow: hidden;
   border-top: 1px solid var(--#{$variable-prefix}dropdown-divider-bg);
 }
@@ -170,11 +170,11 @@
   // See https://github.com/twbs/bootstrap/pull/27703
   @if $dropdown-padding-y == 0 {
     &:first-child {
-      @include border-top-radius($dropdown-inner-border-radius);
+      @include border-top-radius(var(--#{$variable-prefix}dropdown-inner-border-radius));
     }
 
     &:last-child {
-      @include border-bottom-radius($dropdown-inner-border-radius);
+      @include border-bottom-radius(var(--#{$variable-prefix}dropdown-inner-border-radius));
     }
   }
 


### PR DESCRIPTION
### Description

This PR is a proposal to use all dropdowns CSS variables available:
* `--#{$variable-prefix}dropdown-inner-border` (that probably needed to be renamed in `--#{$variable-prefix}dropdown-inner-border-radius` since it is based on `$dropdown-inner-border-radius`)
* `--#{$variable-prefix}dropdown-divider-margin-y`

### Motivation & Context

`--#{$variable-prefix}dropdown-inner-border` and `--#{$variable-prefix}dropdown-divider-margin-y` were not used in the `_dropdown.scss` file.

### Types of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-35907--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/)
