### PR TITLE
RTL arrows for popovers and tooltips

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -52,6 +52,7 @@
   }
 }
 
+/* rtl:begin:ignore */
 .bs-popover-end {
   > .popover-arrow {
     left: subtract(-$popover-arrow-height, $popover-border-width);
@@ -71,6 +72,8 @@
     }
   }
 }
+
+/* rtl:end:ignore */
 
 .bs-popover-bottom {
   > .popover-arrow {
@@ -102,6 +105,7 @@
   }
 }
 
+/* rtl:begin:ignore */
 .bs-popover-start {
   > .popover-arrow {
     right: subtract(-$popover-arrow-height, $popover-border-width);
@@ -121,6 +125,8 @@
     }
   }
 }
+
+/* rtl:end:ignore */
 
 .bs-popover-auto {
   &[data-popper-placement^="top"] {

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -43,6 +43,7 @@
   }
 }
 
+/* rtl:begin:ignore */
 .bs-tooltip-end {
   padding: 0 $tooltip-arrow-height;
 
@@ -59,6 +60,8 @@
   }
 }
 
+/* rtl:end:ignore */
+
 .bs-tooltip-bottom {
   padding: $tooltip-arrow-height 0;
 
@@ -73,6 +76,7 @@
   }
 }
 
+/* rtl:begin:ignore */
 .bs-tooltip-start {
   padding: 0 $tooltip-arrow-height;
 
@@ -88,6 +92,8 @@
     }
   }
 }
+
+/* rtl:end:ignore */
 
 .bs-tooltip-auto {
   &[data-popper-placement^="top"] {


### PR DESCRIPTION
Replacement for / closes #35864

Not quite sure what happened there, but ignoring the whole `.bs-*-start` and `.bs-*-end` from RTLCSS seems to fix this.

---
Preview: https://deploy-preview-35918--twbs-bootstrap.netlify.app/docs/5.1/examples/cheatsheet-rtl/#popovers