### PR TITLE
v5.2 border-width is disabled

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -155,6 +155,7 @@ $utilities: map-merge(
     ),
     "border-width": (
       css-var: true,
+      css-variable-name: border-width,
       class: border,
       values: $border-widths
     ),


### PR DESCRIPTION
Convert border utilities to CSS variables in https://github.com/twbs/bootstrap/pull/35428, but the border width is disabled.

https://deploy-preview-35428--twbs-bootstrap.netlify.app/docs/5.1/utilities/borders/#width
![Screenshot 2022-03-02 at 20-38-40 Borders](https://user-images.githubusercontent.com/26200725/156354998-4808da4d-7696-4538-a8fc-33eaafa63746.png)

This is probably because a new `--bs-border-width` CSS variable was created, but the properties of each` .border- * `class are still` --bs-border`.

So I added the `css-variable-name` option as well as the` --bs-border-color`.

Please consider.

