### PR TITLE
Add missing root border opacity CSS var

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -56,6 +56,7 @@
   --#{$variable-prefix}border-style: solid;
   --#{$variable-prefix}border-color: #{$border-color};
   --#{$variable-prefix}border-radius: #{$border-radius};
+  --#{$variable-prefix}border-opacity: 1;
   // scss-docs-end root-border-var
   // stylelint-enable custom-property-empty-line-before
 }


### PR DESCRIPTION
### Description

It looks like there is an issue with the latest modifications of the border colors on the _main_ branch. Let's add `.border-warning` in the documentation when `.border` is not used:

```md
### Additive

{{< example class="bd-example-border-utils" >}}
<span class="border border-warning"></span>
<span class="border-top border-warning"></span>
<span class="border-end border-warning"></span>
<span class="border-bottom border-warning"></span>
<span class="border-start border-warning"></span>
{{< /example >}}

### Subtractive

{{< example class="bd-example-border-utils bd-example-border-utils-0" >}}
<span class="border-0 border-warning"></span>
<span class="border-top-0 border-warning"></span>
<span class="border-end-0 border-warning"></span>
<span class="border-bottom-0 border-warning"></span>
<span class="border-start-0 border-warning"></span>
{{< /example >}}
```

Here is the rendering:

![Screenshot from 2022-03-03 13-20-07](https://user-images.githubusercontent.com/17381666/156564238-61c56ffb-0bea-40e9-bf9a-024c334ebd72.png)

We can see in the browser that `--bs-border-opacity` is not set in those cases:

![Screenshot from 2022-03-03 13-20-16](https://user-images.githubusercontent.com/17381666/156564585-9bb9f03c-1598-40ee-9ae5-62f2a8173d29.png)

This PR is a proposal to define a default value for this CSS var in `_root.scss`.

**Note**: if this modification is correct, I didn't know if you prefer to have the value stored in `$border-opacity` or not.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-35943--twbs-bootstrap.netlify.app/docs/5.1/utilities/borders/)