### PR TITLE
docs: add missing `.dropup` in dropup centered example

### DIFF
--- a/site/content/docs/5.1/components/dropdowns.md
+++ b/site/content/docs/5.1/components/dropdowns.md
@@ -481,7 +481,7 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 Make the dropup menu centered above the toggle with `.dropup-center` on the parent element.
 
 {{< example >}}
-<div class="dropup-center">
+<div class="dropup-center dropup">
   <button class="btn btn-secondary dropdown-toggle" type="button" id="dropupCenterBtn" data-bs-toggle="dropdown" aria-expanded="false">
     Centered dropup
   </button>


### PR DESCRIPTION
### Description

Add missing `.dropup` for the dropup centered example.

### Motivation & Context

The arrow is in the wrong direction; should point to the top.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- ~~I have added tests to cover my changes~~
- [w] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-35948--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropup-centered)
