### PR TITLE
`rgba-css-var` only takes into account the keys

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -38,10 +38,23 @@
 }
 
 // stylelint-disable scss/dollar-variable-pattern
-@function rgba-css-var($identifier, $target, $value: null) {
+@function rgba-css-var($identifier, $target) {
+  @if $identifier == "body" and $target == "bg" {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-bg-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  } @if $identifier == "body" and $target == "text" { // Missing @else here in the original code
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-color-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  } @else {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  }
+}
+
+@function rgba-css-var-with-value($identifier, $target, $value: null) {
   @if ($identifier == "body" or $identifier == "white") and $target == "bg" {
-    @return rgba(var(--#{$variable-prefix}#{$value}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
   } @else if ($identifier == "body" or $identifier == "white") and $target == "text" {
+    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+    // Example of using $value for border colors redefinitions
+  } @else if ($identifier == "body" or $identifier == "white") and $target == "border" {
     @return rgba(var(--#{$variable-prefix}#{$value}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
   } @else {
     @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -48,6 +48,45 @@
   }
 }
 
+/* *
+   * First solution start
+   *
+   * Just need to uncomment below code when testing the first solution and comment the basic `rgba-css-var` function above
+   * */
+
+// @function rgba-css-var($identifier, $target) {
+//   @if $identifier == "body" and $target == "bg" {
+//     @return rgba(var(--#{$variable-prefix}#{$identifier}-bg-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   } @if $identifier == "body" and $target == "text" {
+//     @return rgba(var(--#{$variable-prefix}#{$identifier}-color-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   } @else {
+//     @return rgba(var(--#{$variable-prefix}#{$target}-#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   }
+// }
+
+
+/* *
+   * Second solution start
+   *
+   * Just need to uncomment below code when testing the second solution and comment the basic `rgba-css-var` function above
+   * */
+
+// @function rgba-css-var($identifier, $target, $value: null) {
+//   @if $identifier == "body" and $target == "bg" {
+//     @return rgba(var(--#{$variable-prefix}#{$identifier}-bg-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   } @else if $identifier == "body" and $target == "text" {
+//     @return rgba(var(--#{$variable-prefix}#{$identifier}-color-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   } @else if $value != null {
+//     @return rgba(to-rgb($value), var(--#{$variable-prefix}#{$target}-opacity));
+//   } @else {
+//     @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+//   }
+// }
+
+/* *
+   * Solutions proposal end
+   * */
+
 @function rgba-css-var-with-value($identifier, $target, $value: null) {
   @if ($identifier == "body" or $identifier == "white") and $target == "bg" {
     @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -38,11 +38,11 @@
 }
 
 // stylelint-disable scss/dollar-variable-pattern
-@function rgba-css-var($identifier, $target) {
-  @if $identifier == "body" and $target == "bg" {
-    @return rgba(var(--#{$variable-prefix}#{$identifier}-bg-rgb), var(--#{$variable-prefix}#{$target}-opacity));
-  } @if $identifier == "body" and $target == "text" {
-    @return rgba(var(--#{$variable-prefix}#{$identifier}-color-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+@function rgba-css-var($identifier, $target, $value: null) {
+  @if ($identifier == "body" or $identifier == "white") and $target == "bg" {
+    @return rgba(var(--#{$variable-prefix}#{$value}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
+  } @else if ($identifier == "body" or $identifier == "white") and $target == "text" {
+    @return rgba(var(--#{$variable-prefix}#{$value}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
   } @else {
     @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
   }

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -19,25 +19,36 @@ $utilities-colors: $theme-colors-rgb !default;
 $utilities-text: map-merge(
   $utilities-colors,
   (
-    // "black": to-rgb($warning), // A priori .text-black n'existe pas donc on pourrait le supprimer
-    "white": "warning",
-    "body": "warning",
+    "black": to-rgb($black), // .bg-black doesn't exist so we could remove it
+    "white": to-rgb($white),
+    "body": to-rgb($body-color)
   )
 ) !default;
-$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text", "$value") !default;
+$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text") !default;
 // scss-docs-end utilities-text-colors
 
 // scss-docs-start utilities-bg-colors
 $utilities-bg: map-merge(
   $utilities-colors,
   (
-    // "black": to-rgb($warning), // A priori .bg-black n'existe pas donc on pourrait le supprimer
-    "white": "warning",
-    "body": "warning",
+    "black": to-rgb($black), // .bg-black doesn't exist so we could remove it
+    "white": to-rgb($warning),
+    "body": null,
   )
 ) !default;
-$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg", "$value") !default;
+$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg") !default;
 // scss-docs-end utilities-bg-colors
+
+// scss-docs-start utilities-border-colors
+$utilities-border: map-merge(
+  $utilities-colors,
+  (
+    "white": "warning",
+    "body": "danger"
+  )
+) !default;
+$utilities-border-colors: map-loop($utilities-border, rgba-css-var-with-value, "$key", "border", "$value") !default;
+// scss-docs-end utilities-border-colors
 
 $negative-spacers: if($enable-negative-margins, negativify-map($spacers), null) !default;
 

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -37,6 +37,40 @@ $utilities-bg: map-merge(
   )
 ) !default;
 $utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg") !default;
+
+/* *
+   * Second solution start
+   *
+   * Just need to uncomment below code when testing the second solution and comment the code above
+   * */
+
+// $theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value") !default;
+
+// $utilities-colors: $theme-colors !default;
+
+// $utilities-text: map-merge(
+//   $utilities-colors,
+//   (
+//     "black": $black,
+//     "white": $white,
+//     "body": $body-color
+//   )
+// ) !default;
+// $utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text", "$value") !default;
+
+// $utilities-bg: map-merge(
+//   $utilities-colors,
+//   (
+//     "black": $success,
+//     "white": $primary,
+//     "body": null,
+//   )
+// ) !default;
+// $utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg", "$value") !default;
+
+/* *
+   * Solutions proposal end
+   * */
 // scss-docs-end utilities-bg-colors
 
 // scss-docs-start utilities-border-colors

--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -19,35 +19,25 @@ $utilities-colors: $theme-colors-rgb !default;
 $utilities-text: map-merge(
   $utilities-colors,
   (
-    "black": to-rgb($black),
-    "white": to-rgb($white),
-    "body": to-rgb($body-color)
+    // "black": to-rgb($warning), // A priori .text-black n'existe pas donc on pourrait le supprimer
+    "white": "warning",
+    "body": "warning",
   )
 ) !default;
-$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text") !default;
+$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text", "$value") !default;
 // scss-docs-end utilities-text-colors
 
 // scss-docs-start utilities-bg-colors
 $utilities-bg: map-merge(
   $utilities-colors,
   (
-    "black": to-rgb($black),
-    "white": to-rgb($white),
-    "body": to-rgb($body-bg)
+    // "black": to-rgb($warning), // A priori .bg-black n'existe pas donc on pourrait le supprimer
+    "white": "warning",
+    "body": "warning",
   )
 ) !default;
-$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg") !default;
+$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg", "$value") !default;
 // scss-docs-end utilities-bg-colors
-
-// scss-docs-start utilities-border-colors
-$utilities-border: map-merge(
-  $utilities-colors,
-  (
-    "white": to-rgb($white)
-  )
-) !default;
-$utilities-border-colors: map-loop($utilities-border, rgba-css-var, "$key", "border") !default;
-// scss-docs-end utilities-border-colors
 
 $negative-spacers: if($enable-negative-margins, negativify-map($spacers), null) !default;
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -58,4 +58,26 @@
   --#{$variable-prefix}border-radius: #{$border-radius};
   // scss-docs-end root-border-var
   // stylelint-enable custom-property-empty-line-before
+
+  /* *
+     * First solution start
+     *
+     * Just need to uncomment below code when testing the first solution
+     * */
+
+  // @each $color, $value in $utilities-text {
+  //   --#{$variable-prefix}text-#{$color}-rgb: #{$value};
+  // }
+
+  // @each $color, $value in $utilities-bg {
+  //   --#{$variable-prefix}bg-#{$color}-rgb: #{$value};
+  // }
+
+  // @each $color, $value in $utilities-border {
+  //   --#{$variable-prefix}border-#{$color}-rgb: #{$value};
+  // }
+
+  /* *
+     * Solutions proposal end
+     * */
 }


### PR DESCRIPTION
This PR is more an issue than a PR but the Netlify deployment will help to understand it. We tried few things but we would like to have your thoughts about it as well :)
I already talked about it a little bit with @ffoodd. 

## Before

Some recent PRs created `_map.scss` and so `$utilities-text-colors`, `$utilities-bg-colors` and `$utilities-border-colors`. This new system doesn't contain any regressions for a Bootstrap user but we have spotted a limitation.

Let's take a look at how the border colors were created:
```scss
"border-color": (
   property: border-color,
   class: border,
   values: map-merge($theme-colors, ("white": $white))
),
```

At that time it was possible to change the value associated with "white". For example you could do the following and the `.border-white` would display a yellow border:
```scss
"border-color": (
    property: border-color,
    class: border,
    values: map-merge($theme-colors, ("white": $warning))
 ),
```

## Now

The new system in `_maps.scss` is a little bit different but seems very close:
```scss
$utilities-border: map-merge(
  $utilities-colors,
  (
    "white": to-rgb($white)
  )
) !default;
$utilities-border-colors: map-loop($utilities-border, rgba-css-var, "$key", "border") !default;
```

But if you try to modify the value associated with "white", it doesn't do anything:

```scss
$utilities-border: map-merge(
  $utilities-colors,
  (
    "white": to-rgb($warning)
  )
) !default;
$utilities-border-colors: map-loop($utilities-border, rgba-css-var, "$key", "border") !default;
```

It can be seen [here](https://deploy-preview-35949--twbs-bootstrap.netlify.app/docs/5.1/utilities/background/#background-color) where I try to change to "white" value to have a yellow background displayed with a `bg-white`. It stays white because of `var(--bs-white-rgb)`.

## Why?

The explanation seems to come from `rgba-css-var` that in fact only uses the key (in fact `--bs-{key-name}-rgb`) and not the value.
It means that you could do:
```scss
$utilities-border: map-merge(
  $utilities-colors,
  (
    "white": null
  )
) !default;
$utilities-border-colors: map-loop($utilities-border, rgba-css-var, "$key", "border") !default;
```
Only matters the fact that the key is added to the `map-merge`.
It can be seen [here](https://deploy-preview-35949--twbs-bootstrap.netlify.app/docs/5.1/utilities/background/#background-color) where I set a `null` value to the "body" key and it still works; `var(--bs-body-bg-rgb)` is used.

## Impact and bypass

In Boosted, we used this possibility to change the value for a given key. In this PR, one of the solution find to retrieve this same behavior was to add an extra parameter to `rgba-css-var` to provide the modified value:

```scss
// _maps.scss
$utilities-border: map-merge(
  $utilities-colors,
  (
    "white": "warning",
    "body": "danger"
  )
) !default;
$utilities-border-colors: map-loop($utilities-border, rgba-css-var-with-value, "$key", "border", "$value") !default;

// _utilities.scss
@function rgba-css-var-with-value($identifier, $target, $value: null) {
  @if ($identifier == "body" or $identifier == "white") and $target == "bg" {
    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
  } @else if ($identifier == "body" or $identifier == "white") and $target == "text" {
    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
    // Example of using $value for border colors redefinitions
  } @else if ($identifier == "body" or $identifier == "white") and $target == "border" {
    @return rgba(var(--#{$variable-prefix}#{$value}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
  } @else {
    @return rgba(var(--#{$variable-prefix}#{$identifier}-rgb), var(--#{$variable-prefix}#{$target}-opacity));
  }
} 
```

The result can be seen [here](https://deploy-preview-35949--twbs-bootstrap.netlify.app/docs/5.1/utilities/borders/#color) where `.border-white` displays a yellow border.

It is kinda ugly and it doesn't work combined to the opacities.

## Other solutions

@louismaximepiton tried 2 other different approaches.

### First solution

This solution adds more CSS variables; maybe too much (bundle will be bigger).

To try it, please uncomment `scss/_functions.scss` and `scss_root.scss` what is between "First solution start" and "Solutions proposal end".

### Second solution

This version gets rid of `to-rgb`s in `_maps.scss` and use the value but we don't like this version too much because CSS variables wouldn't be used anymore.

To try it, please uncomment `scss/_functions.scss` and `scss/_maps.scss` what is between "Second solution start" and "Solutions proposal end".