### PR TITLE
Rename grays tints in $grays

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -10,7 +10,7 @@
   }
 
   @each $color, $value in $grays {
-    --#{$variable-prefix}gray-#{$color}: #{$value};
+    --#{$variable-prefix}#{$color}: #{$value};
   }
 
   @each $color, $value in $theme-colors {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -22,15 +22,15 @@ $black:    #000 !default;
 // fusv-disable
 // scss-docs-start gray-colors-map
 $grays: (
-  "100": $gray-100,
-  "200": $gray-200,
-  "300": $gray-300,
-  "400": $gray-400,
-  "500": $gray-500,
-  "600": $gray-600,
-  "700": $gray-700,
-  "800": $gray-800,
-  "900": $gray-900
+  "gray-100": $gray-100,
+  "gray-200": $gray-200,
+  "gray-300": $gray-300,
+  "gray-400": $gray-400,
+  "gray-500": $gray-500,
+  "gray-600": $gray-600,
+  "gray-700": $gray-700,
+  "gray-800": $gray-800,
+  "gray-900": $gray-900
 ) !default;
 // scss-docs-end gray-colors-map
 // fusv-enable


### PR DESCRIPTION
In `_variables.scss` file, there are lists of colors: $blues, $indigos, etc.. With names like blue-100, blue-200, etc... But for grays, names are just 100, 200, 300.

In case we want to refer to that lists in maps, we need to recreate in `_custom.scss` the list of grays to have: bg-gray-200 for exemple instead of bg-200 in rhe actual case.

I've found only one reference to this variable in `_root.scss`.