### PR TITLE
Update `$border-color` to use `rgba()`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -484,7 +484,7 @@ $border-widths: (
   5: 5px
 ) !default;
 
-$border-color:                $gray-300 !default;
+$border-color:                rgba($black, .15) !default;
 // scss-docs-end border-variables
 
 // scss-docs-start border-radius-variables


### PR DESCRIPTION
Fixes #35987.

The move to `rgba()` was coming anyway with the design tweaks in v5.2.0 and v5.3.0 (for dark mode), so just moving this up to fix it now for all components.