### PR TITLE
Add some `calc()` for manipulating new CSS variable version of border-width

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -63,7 +63,7 @@
     border-top-width: 0;
 
     &.active {
-      margin-top: -$list-group-border-width;
+      margin-top: calc($list-group-border-width * -1); // stylelint-disable-line function-disallowed-list
       border-top-width: $list-group-border-width;
     }
   }
@@ -125,7 +125,7 @@
           border-left-width: 0;
 
           &.active {
-            margin-left: -$list-group-border-width;
+            margin-left: calc($list-group-border-width * -1); // stylelint-disable-line function-disallowed-list
             border-left-width: $list-group-border-width;
           }
         }

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -42,7 +42,7 @@
   border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
 
   .nav-link {
-    margin-bottom: -$nav-tabs-border-width;
+    margin-bottom: calc($nav-tabs-border-width * -1); // stylelint-disable-line function-disallowed-list
     background: none;
     border: $nav-tabs-border-width solid transparent;
     @include border-top-radius($nav-tabs-border-radius);
@@ -70,7 +70,7 @@
 
   .dropdown-menu {
     // Make dropdown border overlap tab border
-    margin-top: -$nav-tabs-border-width;
+    margin-top: calc($nav-tabs-border-width * -1); // stylelint-disable-line function-disallowed-list
     // Remove the top rounded corners here since there is a hard edge above the menu
     @include border-top-radius(0);
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1187,7 +1187,7 @@ $pagination-color:                  $link-color !default;
 $pagination-bg:                     $white !default;
 $pagination-border-radius:          $border-radius !default;
 $pagination-border-width:           var(--#{$variable-prefix}border-width) !default;
-$pagination-margin-start:           -$pagination-border-width !default;
+$pagination-margin-start:           calc($pagination-border-width * -1) !default; // stylelint-disable-line function-disallowed-list
 $pagination-border-color:           $gray-300 !default;
 
 $pagination-focus-color:            $link-hover-color !default;


### PR DESCRIPTION
We rely on some lazy Sass math like `-$border-width`, so in these early steps of migrating to CSS variables, we're bound to find some issues. In this case, we're generating bad CSS because of that lazy math (`-var(--bs-border-width)`). The fix is using `calc()` to multiply by `-1`. I thought about reverting the change for these instances, but it'd just be ducking the inevitable, so decided to push it here for now.

Fixes #35986.