### PR TITLE
fix docs for .text-muted

### DIFF
--- a/site/content/docs/5.1/utilities/text.md
+++ b/site/content/docs/5.1/utilities/text.md
@@ -116,13 +116,13 @@ Change a selection to our monospace font stack with `.font-monospace`.
 <p class="font-monospace">This is in monospace</p>
 {{< /example >}}
 
-## Reset color
+## Muted color
 
-Reset a text or link's color with `.text-reset`, so that it inherits the color from its parent.
+Mute text color with `.text-muted`
 
 {{< example >}}
 <p class="text-muted">
-  Muted text with a <a href="#" class="text-reset">reset link</a>.
+  This text is muted
 </p>
 {{< /example >}}
 


### PR DESCRIPTION
It looks like the docs for `text-reset` were copied to document `.text-muted` but weren't properly re-written to actually discuss `.text-muted`

Before:
![Screen Shot 2022-03-11 at 15 59 47](https://user-images.githubusercontent.com/7769215/157965039-6ad196b9-066e-4dc8-83fa-b1598dab99be.png)


After:
![Screen Shot 2022-03-11 at 16 00 25](https://user-images.githubusercontent.com/7769215/157965303-9cf4cd65-e03d-4a14-aee0-c28f36cebcbe.png)

