### PR TITLE
Update parcel.md

### DIFF
--- a/site/content/docs/5.1/getting-started/parcel.md
+++ b/site/content/docs/5.1/getting-started/parcel.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Install Parcel
 
-Install [Parcel Bundler](https://en.parceljs.org/getting_started.html).
+Install [Parcel Bundler](https://parceljs.org/getting-started/webapp/).
 
 ## Install Bootstrap
 
@@ -65,7 +65,7 @@ Include `src/index.js` before the closing `</body>` tag.
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <script src="./index.js"></script>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>
 ```
@@ -78,7 +78,7 @@ Add `dev` and `build` scripts in your `package.json` file.
 "scripts": {
   "dev": "parcel ./src/index.html",
   "prebuild": "npx rimraf build",
-  "build": "parcel build --public-url ./ ./src/index.html --experimental-scope-hoisting --out-dir build"
+  "build": "parcel build --public-url ./ ./src/index.html --dist-dir build"
 }
 ```
 


### PR DESCRIPTION
Following the Parcel v1 installation guide seems to install the latest version of Parcel (v2), which makes several instructions in this guide throw errors. Therefore, I have updated the guide to work with version 2 of Parcel.

Change Details:
- Update the URL to point to the latest doc pages.
- Use the `type="module"` HTML attribute to reference a module. Source: [Parcel migration](https://parceljs.org/getting-started/migration/#code-changes)
- The `--out-dir <dir>` CLI parameter has been changed to `--dist-dir <dir>`. Source: [Parcel CLI](https://parceljs.org/features/cli/#parameters)
-  For a reason I'm unsure of, `--experimental-scope-hoisting` throws the following error: `error: unknown option '--experimental-scope-hoisting'`, so I removed it to get the build to work. This issue may warrant additional attention.