### PR TITLE
Fix a race condition between _queueCallback and dispose.

### DIFF
--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -6,7 +6,7 @@
  */
 
 import Data from './dom/data'
-import { executeAfterTransition, getElement } from './util/index'
+import { executeAfterTransition, getElement, execute } from './util/index'
 import EventHandler from './dom/event-handler'
 import Config from './util/config'
 
@@ -46,7 +46,12 @@ class BaseComponent extends Config {
   }
 
   _queueCallback(callback, element, isAnimated = true) {
-    executeAfterTransition(callback, element, isAnimated)
+    executeAfterTransition(() => {
+      // Do not execute callback if this component has been disposed.
+      if (this._element) {
+        execute(callback)
+      }
+    }, element, isAnimated)
   }
 
   _getConfig(config) {


### PR DESCRIPTION
if _queueCallback is called just before dispose the transition
complete callback will be called on the disposed component and almost
certainly error out.

This can happen if a tooltip is removed just as it gets hidden.