### PR TITLE
Fix duplicate border radius CSS var definition

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -56,7 +56,6 @@
   --#{$prefix}border-width: #{$border-width};
   --#{$prefix}border-style: #{$border-style};
   --#{$prefix}border-color: #{$border-color};
-  --#{$prefix}border-radius: #{$border-radius};
   --#{$prefix}border-opacity: 1;
 
   --#{$prefix}border-radius: #{$border-radius};


### PR DESCRIPTION
Closes #36074

This duplicate came from https://github.com/twbs/bootstrap/commit/acf6ea74a74328bcaa9f1c354f27e602cfbb8968