### PR TITLE
Reuse all breadcrumb CSS vars available

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -31,8 +31,8 @@
 
     &::before {
       float: left; // Suppress inline spacings and underlining of the separator
-      padding-right: $breadcrumb-item-padding-x;
-      color: $breadcrumb-divider-color;
+      padding-right: var(--#{$prefix}breadcrumb-item-padding-x);
+      color: var(--#{$prefix}breadcrumb-divider-color);
       content: var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)) #{"/* rtl:"} var(--#{$prefix}breadcrumb-divider, escape-svg($breadcrumb-divider-flipped)) #{"*/"};
     }
   }


### PR DESCRIPTION
Introduced in https://github.com/twbs/bootstrap/commit/e567d511d4c94617510ef592ab804ec273e93480 and then removed (I suppose unintentionally) in https://github.com/twbs/bootstrap/commit/acf6ea74a74328bcaa9f1c354f27e602cfbb8968.