### PR TITLE
Fix StackBlitz edit feature by selecting the closest example

### DIFF
--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -26,7 +26,7 @@
   document.querySelectorAll('.btn-edit')
     .forEach(function (btn) {
       btn.addEventListener('click', function (event) {
-        var htmlSnippet = event.target.closest('.bd-content').querySelector('.bd-example').innerHTML
+        var htmlSnippet = event.target.closest('.bd-edit').previousSibling.innerHTML
 
         StackBlitzSDK.openBootstrapSnippet(htmlSnippet)
       })


### PR DESCRIPTION
### Description

This PR is a proposal to fix the fact that the StackBlitz edit button creates a StackBlitz env only with the first example of the page due to `event.target.closest('.bd-content')` and that pages only have one `.bd-content`.

For example https://twbs-bootstrap.netlify.app/docs/5.1/components/accordion/#flush will create a StackBlitz env with the content of https://twbs-bootstrap.netlify.app/docs/5.1/components/accordion/#example.

I've changed the selector in order to have the closest example of the edit button (the sibling example).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related issues

N/A

### Live previews

- [x] Accordions
  - [x] [Example](https://deploy-preview-36088--twbs-bootstrap.netlify.app/docs/5.1/components/accordion/#example)
  - [x] [Flush](https://deploy-preview-36088--twbs-bootstrap.netlify.app/docs/5.1/components/accordion/#flush)
  - [x] [Always open](https://deploy-preview-36088--twbs-bootstrap.netlify.app/docs/5.1/components/accordion/#always-open) 