### PR TITLE
[WIP] Hide or fix StackBlitz examples

### DIFF
--- a/site/content/docs/5.1/components/alerts.md
+++ b/site/content/docs/5.1/components/alerts.md
@@ -27,7 +27,7 @@ Alerts are available for any length of text, as well as an optional close button
 
 Click the button below to show an alert (hidden with inline styles to start), then dismiss (and destroy) it with the built-in close button.
 
-{{< example >}}
+{{< example show_edit_btn="false" >}}
 <div id="liveAlertPlaceholder"></div>
 <button type="button" class="btn btn-primary" id="liveAlertBtn">Show live alert</button>
 {{< /example >}}

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -6,6 +6,7 @@
     * class: any extra class(es) to be added to the `div` - default: ""
     * show_preview: if the preview should be output in the HTML - default: `true`
     * show_markup: if the markup should be output in the HTML - default: `true`
+    * show_edit_btn: if the edit button should be displayed - default: `true`
 */ -}}
 
 {{- $id := .Get "id" -}}
@@ -13,6 +14,7 @@
 {{- $lang := .Get "lang" | default "html" -}}
 {{- $show_preview := .Get "show_preview" | default true -}}
 {{- $show_markup := .Get "show_markup" | default true -}}
+{{- $show_edit_btn := .Get "show_edit_btn" | default true -}}
 {{- $input := .Inner -}}
 
 {{- if eq $show_preview true -}}
@@ -22,9 +24,11 @@
 {{- end -}}
 
 {{- if eq $show_markup true -}}
+  {{- if eq $show_edit_btn true -}}
   <div class="bd-edit">
     <button type="button" class="btn-edit text-nowrap" title="Try it on StackBlitz">Try it</button>
   </div>
+  {{- end -}}
   {{- $content := replaceRE `<svg class="bd-placeholder-img(?:-lg)?(?: *?bd-placeholder-img-lg)? ?(.*?)".*?<\/svg>\n` `<img src="..." class="$1" alt="...">` $input -}}
   {{- $content = replaceRE ` (class=" *?")` "" $content -}}
   {{- highlight (trim $content "\n") $lang "" -}}


### PR DESCRIPTION
### Description

Initially in https://github.com/twbs/bootstrap/pull/36088, this PR proposes to hide or fix examples that doesn't work with StackBlitz.

This PR adds a new parameter `{{< example show_edit_btn="false" >}}` to hide the StackBlitz edit button for examples that cannot work easily: need extra HTML or JS code; for example the alert's live example.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related PR

https://github.com/twbs/bootstrap/pull/36088

### Live previews

- [x] Accordions (3 examples) 
- [x] Alerts (7 examples)
  - [ ] [Live example](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/alerts/#live-example): hidden for the moment to test the hidden feature. TODO: try to embed the JS.
- [x] Badge - 6 examples
- [x] Breadcrumb - 4 examples
- [x] Button Group - TODO
  - [Sizing](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/button-group/#sizing) and [Vertical variation](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/button-group/#vertical-variation) could be examples 
- [x] Buttons - 15 examples
- [x] Card - 30 examples
  - In all card examples, the image text is not centered nor with the good size 
- [x] Carousel - 8 examples
- [x] Close Button - 3 examples
  - [White variant](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/close-button/#white-variant): Not linked to this PR but we could pass a parameter to define a background color (here black). 
- [x] Collapse - 3 examples
- [x] Dropdowns - 21 examples
  -  Colored dropdowns don't have their edit button
  - [Split button](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#split-button) doesn't have any edit button
  - [Sizing](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#sizing) doesn't have any edit button
  - [Dropup](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropup) doesn't have any edit button
  - [Dropend](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropend) doesn't have any edit button
  - [Dropstart](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropstart) doesn't have any edit button
  - [ ] [Menu items 2](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#menu-items) is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu items > Active](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#active)  is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu items > Disabled](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#disabled)  is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu Content - Headers](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#headers)  is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu Content - Dividers](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dividers)  is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu Content - Text](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#text) is not working because of the `display: none` of `.dropdown-menu`.
  - [ ] [Menu Content - Forms](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#forms) both examples are not working because of the `display: none` of `.dropdown-menu`.
- [x] List Group - 15 examples
- [x] Modal - 2 examples
  - Maybe some other examples could be edited
- [x] Navbar - 26 examples
  - [ ] [Image](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/navbar/#image) and [Image and text](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/navbar/#image-and-text) are not working because of the image relative path. Could be modified in the shortcode?
  - [Toggler](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/navbar/#toggler) Don't see the toggler but I suppose this is because of a difference between 5.1 and 5.2
- [x] Nav Tabs - 15 examples
- [x] Offcanvas - 8 examples
  - [ ] [Offcanvas components](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/offcanvas/#offcanvas-components) is not working
  - Check https://github.com/twbs/bootstrap/pull/36151 created after this PR
- [x] Pagination - 8 examples
- [x] Placeholders - 5 examples
- [x] Popovers - 5 examples
  - [ ] None of the examples are working - see https://github.com/twbs/bootstrap/pull/36127
- [x] Progress - 8 examples
- [x] Spinners - 13 examples
- [x] Toasts - 10 examples
  - Funny but good to know. If you click on the cross in the doc and then click on the "Try it" button, the environment won't display the toast.
  - [ ] [Placement](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/components/toasts/#placement): changing toast placement doesn't move the toast. The second example is not working as well
- [x] Tooltips - 2 examples
  - [ ] None of the examples are working
- [x] Figures - 2 examples
  - [ ] "400x300" are not centered correctly as in the cards and carousels 
- [x] Images - 5 examples
  - [ ] Same observation as for the Figures 
- [x] Reboot - 8 examples
- [x] Tables - 2 examples
- [x] Typography - 12 examples
- [x] Forms > Check Radios - 17 examples
  - [ ] [Indetermediate](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/forms/checks-radios/#indeterminate) doesn't seem to work 
- [x] Forms > Floating Labels - 8 examples
- [x] Forms > Form Control - 9 examples
- [x] Forms > Input Group - 11 examples
- [x] Forms > Layout - 10 examples
- [x] Forms > Overview - 4 examples
- [x] Forms > Range - 4 examples
- [x] Forms > Select - 5 examples
- [x] Forms > Validation - 6 examples
  - [ ] [Custom validation](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/forms/validation/#custom-styles) doesn't work because of the missing JS explained just after 
  - [ ] [Tooltips](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/forms/validation/#tooltips) doesn't work (see Tooltips section probably)
- [x] Helpers > Clearfix - 1 example
- [x] Helpers > Colored links - 1 example
- [x] Helpers > Ratio - 4 examples
  - [ ] [Aspect ratios](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/helpers/ratio/#aspect-ratios) and [Custom ratios](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/helpers/ratio/#custom-ratios) are not working because of the specific CSS for `.bd-example-ratios .ratio`
- [x] Helpers > Stacks - 6 examples
- [x] Helpers > Stretched Link - 4 examples
- [x] Helpers > Text Truncation - 1 example
- [x] Helpers > Vertical rule - 3 examples
- [x] Helpers > Visually hidden - 1 example
- [x] Layout > Columns - 13 examples
  - [ ] Issues with the rendering because of `.bd-example-row-flex-cols .row` rules 
- [x] Layout > CSS Grid - 15 examples
  - [ ] Issues with the rendering because of `.bd-example-cssgrid .grid > *`
- [x] Layout > Grid - 15 examples
  - [ ] Issues with the rendering because of `.bd-example-row .row > .col, .bd-example-row .row > [class^="col-"]` 
- [x] Layout > Gutters - 6 examples
  - [ ] Some issues with the rendering of some examples because of `.bd-example-row .row > .col, .bd-example-row .row > [class^="col-"]` 
- [x] Utilities > Background - 3 examples
- [x] Utilities > Borders - 8 examples
  - [ ] Issues with rendering because of `.bd-example-border-utils [class^="border"]` specific rule 
- [x] Utilities > Colors - 3 examples
- [x] Utilities > Display - 4 examples
- [x] Utilities > Flex - 12 examples
  - [ ] Some issues with the rendering because of `.bd-example` specific rule
- [x] Utilities > Float - 2 examples
- [x] Utilities > Interactions - 2 examples
- [x] Utilities > Position - 5 examples
  - [ ] Issues with rendering because of `.bd-example-position-utils .position-absolute` specific rule 
- [x] Utilities > Shadow - 1 example
- [x] Utilities > Sizing - 4 examples
- [x] Utilities > Spacing - 1 example
- [x] Utilities > Text - 11 examples
  - [ ] [Text wrapping and overflow](https://deploy-preview-36091--twbs-bootstrap.netlify.app/docs/5.1/utilities/text/#text-wrapping-and-overflow): the 2nd example doesn't work because of `.bd-highlight` coming from the docs CSS 
- [x] Utilities > Vertical Align - 2 examples
