### PR TITLE
Added css variables for breakpoints

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -70,4 +70,8 @@
   --#{$prefix}code-color: #{$code-color};
 
   --#{$prefix}highlight-bg: #{$mark-bg};
+
+  @each $name, $value in $grid-breakpoints {
+    --#{$prefix}breakpoint-#{$name}: #{$value};
+  }
 }


### PR DESCRIPTION
See Issue https://github.com/twbs/bootstrap/issues/36094 "css variables for breakpoints are missing in Bootstrap 5".

The css variables for the breakpoints have been missing. I just added them in `scss/_root.scss`. 

Without them I have no idea how to detect the current breakpoint from JavaScript, like I do in my detection script [bootstrap-detect-breakpoint](https://github.com/shaack/bootstrap-detect-breakpoint) which works with BS 4 but not with BS 5 because of the missing css variables. 

Furthermore this should be present according to [the documentation](https://getbootstrap.com/docs/5.1/customize/css-variables/#grid-breakpoints): "[...]we include our grid breakpoints as CSS variables[...]".