### PR TITLE
Move "Navbar" before "Navs & Tabs" in sidebar

### DIFF
--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -71,8 +71,8 @@
     - title: Dropdowns
     - title: List group
     - title: Modal
-    - title: Navs & tabs
     - title: Navbar
+    - title: Navs & tabs
     - title: Offcanvas
     - title: Pagination
     - title: Placeholders


### PR DESCRIPTION
This ensures consistent alphabetic ordering.