### PR TITLE
Fix for missing CSS variables on `.navbar-nav`

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -84,26 +84,19 @@
 // Custom navbar navigation (doesn't require `.nav`, but does make use of `.nav-link`).
 
 .navbar-nav {
+  // scss-docs-start navbar-nav-css-vars
+  --#{$prefix}nav-link-padding-x: 0;
+  --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
+  --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
+  --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color);
+  --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color);
+  // scss-docs-end navbar-nav-css-vars
+
   display: flex;
   flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
-
-  .nav-link {
-    padding-right: 0;
-    padding-left: 0;
-    color: var(--#{$prefix}navbar-color);
-
-    &:hover,
-    &:focus {
-      color: var(--#{$prefix}navbar-hover-color);
-    }
-
-    &.disabled {
-      color: var(--#{$prefix}navbar-disabled-color);
-    }
-  }
 
   .show > .nav-link,
   .nav-link.active {

--- a/site/content/docs/5.1/components/navbar.md
+++ b/site/content/docs/5.1/components/navbar.md
@@ -742,6 +742,10 @@ As part of Bootstrap's evolving CSS variables approach, navbars now use local CS
 
 {{< scss-docs name="navbar-css-vars" file="scss/_navbar.scss" >}}
 
+Some additional CSS variables are also present on `.navbar-nav`:
+
+{{< scss-docs name="navbar-nav-css-vars" file="scss/_navbar.scss" >}}
+
 ### Sass variables
 
 {{< scss-docs name="navbar-variables" file="scss/_variables.scss" >}}


### PR DESCRIPTION
Fixes #36097.

This brings some CSS variables from `.nav` over to `.navbar-nav` so we can have proper styling for `.nav-link`s inside the navbar. I think this is the best direction to fixing this issue as we can't require `.nav` as a base class here all of a sudden.