### PR TITLE
Fix CSpell by adding 'Analyser'

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
   "words": [
     "affordance",
     "allowfullscreen",
+    "Analyser",
     "autohide",
     "autohiding",
     "autoplay",


### PR DESCRIPTION
This PR fixes CSpell check.

Indeed in the current `main` branch:

```
 Error: Unknown word (Analyser)
site/content/docs/5.1/getting-started/accessibility.md:58:19 Unknown word (Analyser)
Files checked: 111, Issues found: 1 in 1 files.
Error: 1 spelling issue found in 1 of the 111 files checked.
```

(Error can be found here for example: https://github.com/twbs/bootstrap/runs/5793443218?check_suite_focus=true)