### PR TITLE
Doc: Reorder alphabetically lists of components

### DIFF
--- a/site/content/docs/5.1/customize/overview.md
+++ b/site/content/docs/5.1/customize/overview.md
@@ -40,12 +40,12 @@ As you familiarize yourself with Bootstrap, continue exploring this section for 
 Several Bootstrap components include embedded SVGs in our CSS to style components consistently and easily across browsers and devices. **For organizations with more strict <abbr title="Content Security Policy">CSP</abbr> configurations**, we've documented all instances of our embedded SVGs (all of which are applied via `background-image`) so you can more thoroughly review your options.
 
 - [Accordion]({{< docsref "/components/accordion" >}})
+- [Carousel controls]({{< docsref "/components/carousel#with-controls" >}})
 - [Close button]({{< docsref "/components/close-button" >}}) (used in alerts and modals)
 - [Form checkboxes and radio buttons]({{< docsref "/forms/checks-radios" >}})
 - [Form switches]({{< docsref "/forms/checks-radios#switches" >}})
 - [Form validation icons]({{< docsref "/forms/validation#server-side" >}})
-- [Select menus]({{< docsref "/forms/select" >}})
-- [Carousel controls]({{< docsref "/components/carousel#with-controls" >}})
 - [Navbar toggle buttons]({{< docsref "/components/navbar#responsive-behaviors" >}})
+- [Select menus]({{< docsref "/forms/select" >}})
 
 Based on [community conversation](https://github.com/twbs/bootstrap/issues/25394), some options for addressing this in your own codebase include replacing the URLs with locally hosted assets, removing the images and using inline images (not possible in all components), and modifying your CSP. Our recommendation is to carefully review your own security policies and decide on the best path forward, if necessary.

--- a/site/content/docs/5.1/getting-started/introduction.md
+++ b/site/content/docs/5.1/getting-started/introduction.md
@@ -62,9 +62,9 @@ Curious which components explicitly require our JavaScript and Popper? Click the
 - Modals for displaying, positioning, and scroll behavior
 - Navbar for extending our Collapse plugin to implement responsive behavior
 - Offcanvases for displaying, positioning, and scroll behavior
+- Scrollspy for scroll behavior and navigation updates
 - Toasts for displaying and dismissing
 - Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
-- Scrollspy for scroll behavior and navigation updates
 {{< /markdown >}}
 </details>
 


### PR DESCRIPTION
### Description

Reorder alphabetically two lists of components in the documentation:
- `site/content/docs/5.1/customize/overview.md`
- `site/content/docs/5.1/getting-started/introduction.md`

**Note**: If this PR is merged, a similar PR could be created for `v4-dev` branch if necessary.

### Motivation & Context

IMO it is easier for the user to find information in an alphabetical ordered list.

### Types of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related issues

N/A

### Live previews
* [Customize > Overview > CSPs and embedded SVGs](https://deploy-preview-36123--twbs-bootstrap.netlify.app/docs/5.1/customize/overview/#csps-and-embedded-svgs)
* [Getting started > Introduction](https://deploy-preview-36123--twbs-bootstrap.netlify.app/docs/5.1/getting-started/introduction/#components)
