### PR TITLE
Use the `border-color` property instead of the CSS variable in border color utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -148,8 +148,7 @@ $utilities: map-merge(
       )
     ),
     "border-color": (
-      css-var: true,
-      css-variable-name: border-color,
+      property: border-color,
       class: border,
       values: $utilities-border-colors
     ),

--- a/site/content/docs/5.1/utilities/borders.md
+++ b/site/content/docs/5.1/utilities/borders.md
@@ -43,6 +43,12 @@ Change the border color using utilities built on our theme colors.
 <span class="border border-white"></span>
 {{< /example >}}
 
+{{< callout >}}
+Unlike text and background color utilities, border color utilities redeclare the `border-color` property **without** an additional `--bs-border-opacity`, as opposed to resetting only `--bs-border-color`. This ensures the backward compatibility of border color utilities applying to other components while providing additional functionality through CSS variables.
+
+This will be revisited in a future major release.
+{{< /callout >}}
+
 ## Opacity
 
 {{< added-in "5.2.0" >}}


### PR DESCRIPTION
Fixes #36087.

Also adds a note to our docs about how these utilities are slightly different than `.text-*` and `.bg-*` utilities in that they do not come with an additional `--bs-border-opacity` CSS variable as that variable is already present on `.border-*` classes, and not applicable (yet) on other components where these utilities may be used presently.

/cc @julien-deramond 