### PR TITLE
Allow popovers examples to be tried on StackBlitz

### DIFF
--- a/site/assets/js/snippets-popover-demo.js
+++ b/site/assets/js/snippets-popover-demo.js
@@ -1,0 +1,22 @@
+// NOTICE!! DO NOT USE ANY OF THIS JAVASCRIPT
+// IT'S ALL JUST JUNK FOR OUR DOCS!
+// ++++++++++++++++++++++++++++++++++++++++++
+
+/*!
+ * JavaScript for Bootstrap's docs (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under the Creative Commons Attribution 3.0 Unported License.
+ * For details, see https://creativecommons.org/licenses/by/3.0/.
+ */
+
+/* global bootstrap: false */
+
+(function () {
+  'use strict'
+
+  document.querySelectorAll('[data-bs-toggle="popover"]')
+    .forEach(popover => {
+      new bootstrap.Popover(popover)
+    })
+})()

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -15,16 +15,10 @@
 (() => {
   'use strict'
 
-  // Tooltip and popover demos
-  // Tooltip and popover demos
+  // Tooltip demos
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
       new bootstrap.Tooltip(tooltip)
-    })
-
-  document.querySelectorAll('[data-bs-toggle="popover"]')
-    .forEach(popover => {
-      new bootstrap.Popover(popover)
     })
 
   const toastPlacement = document.getElementById('toastPlacement')

--- a/site/content/docs/5.1/components/popovers.md
+++ b/site/content/docs/5.1/components/popovers.md
@@ -46,7 +46,7 @@ const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstra
 
 We use JavaScript similar to the snippet above to render the following live popover. Titles are set via `title` attribute and body content is set via `data-bs-content`.
 
-{{< example >}}
+{{< example js_file="snippets-popover-demo.js" >}}
 <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 {{< /example >}}
 
@@ -54,7 +54,7 @@ We use JavaScript similar to the snippet above to render the following live popo
 
 Four options are available: top, right, bottom, and left. Directions are mirrored when using Bootstrap in RTL. Set `data-bs-placement` to change the direction.
 
-{{< example >}}
+{{< example js_file="snippets-popover-demo.js" >}}
 <button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="top" data-bs-content="Top popover">
   Popover on top
 </button>
@@ -87,7 +87,7 @@ You can customize the appearance of popovers using [CSS variables](#variables). 
 
 {{< scss-docs name="custom-popovers" file="site/assets/scss/_component-examples.scss" >}}
 
-{{< example class="custom-popover-demo" >}}
+{{< example js_file="snippets-popover-demo.js" >}}
 <button type="button" class="btn btn-secondary"
         data-bs-toggle="popover" data-bs-placement="right"
         data-bs-custom-class="custom-popover"
@@ -107,7 +107,7 @@ Use the `focus` trigger to dismiss popovers on the user's next click of a differ
 For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 {{< /callout >}}
 
-{{< example >}}
+{{< example js_file="snippets-popover-demo.js" >}}
 <a tabindex="0" class="btn btn-lg btn-danger" role="button" data-bs-toggle="popover" data-bs-trigger="focus" title="Dismissible popover" data-bs-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>
 {{< /example >}}
 
@@ -123,7 +123,7 @@ Elements with the `disabled` attribute aren't interactive, meaning users cannot 
 
 For disabled popover triggers, you may also prefer `data-bs-trigger="hover focus"` so that the popover appears as immediate visual feedback to your users as they may not expect to _click_ on a disabled element.
 
-{{< example >}}
+{{< example js_file="snippets-popover-demo.js" >}}
 <span class="d-inline-block" tabindex="0" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Disabled popover">
   <button class="btn btn-primary" type="button" disabled>Disabled button</button>
 </span>

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -26,11 +26,12 @@
   document.querySelectorAll('.btn-edit').forEach(btn => {
     btn.addEventListener('click', event => {
       const htmlSnippet = event.target.closest('.bd-code-snippet').querySelector('.bd-example').innerHTML
-      StackBlitzSDK.openBootstrapSnippet(htmlSnippet)
+      const externalJavaScriptFileContent = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-js-file')
+      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, externalJavaScriptFileContent)
     })
   })
 
-  StackBlitzSDK.openBootstrapSnippet = snippet => {
+  StackBlitzSDK.openBootstrapSnippet = (snippet, externalJavaScriptFileContent) => {
     const markup = `<!doctype html>
 <html lang="en">
   <head>
@@ -38,24 +39,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ .Site.Params.cdn.css }}" rel="stylesheet">
     <title>Bootstrap Example</title>
+    <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
   <body>
 
     <!-- Example Code -->
 ${snippet.replace(/^/gm, '    ')}
     <!-- End Example Code -->
-
-    <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </body>
 </html>`
 
     const project = {
       files: {
-        'index.html': markup
+        'index.html': markup,
+        'index.js': externalJavaScriptFileContent
       },
       title: 'Bootstrap Example',
       description: `Official example from ${window.location.href}`,
-      template: 'html',
+      template: 'javascript',
       tags: ['bootstrap']
     }
 

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -4,16 +4,23 @@
   `args` are all optional and can be one of the following:
     * id: the `div`'s id - default: ""
     * class: any extra class(es) to be added to the `div` - default: ""
+    * js_file: extra JavaScript file to include
     * show_preview: if the preview should be output in the HTML - default: `true`
     * show_markup: if the markup should be output in the HTML - default: `true`
 */ -}}
 
 {{- $id := .Get "id" -}}
 {{- $class := .Get "class" -}}
+{{- $js_file := .Get "js_file" -}}
 {{- $lang := .Get "lang" | default "html" -}}
 {{- $show_preview := .Get "show_preview" | default true -}}
 {{- $show_markup := .Get "show_markup" | default true -}}
 {{- $input := .Inner -}}
+
+{{ $js_file_content := "" }}
+{{ if $js_file }}
+  {{ $js_file_content = readFile (path.Join "site/assets/js/" $js_file) }}
+{{ end }}
 
 <div class="bd-example-snippet bd-code-snippet">
   {{- if eq $show_preview true -}}
@@ -24,10 +31,10 @@
 
   {{- if eq $show_markup true -}}
     {{- if eq $show_preview true -}}
-      <div class="d-flex align-items-center highlight-toolbar bg-light  ps-3 pe-2 py-1">
+      <div class="d-flex align-items-center highlight-toolbar bg-light ps-3 pe-2 py-1">
         <small class="font-monospace text-muted text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
-          <button type="button" class="btn-edit text-nowrap" title="Try it on StackBlitz">
+          <button type="button" class="btn-edit text-nowrap"{{ with $js_file_content }} data-js-file="{{ $js_file_content }}"{{ end }} title="Try it on StackBlitz">
             <svg class="bi" width="1em" height="1em" fill="currentColor" role="img" aria-label="Copy"><use xlink:href="#lightning-charge-fill"/></svg>
           </button>
           <button type="button" class="btn-clipboard" title="Copy to clipboard">


### PR DESCRIPTION
This PR tries to allow popovers examples to be tried on StackBlitz.

In the documentation, they need some JS available in `site/assets/js/snippets.js`.
IMHO it would be troubling to have all this file integrated in StackBlitz.
So in this PR I'm trying to:
- Split `site/assets/js/snippets.js` into small reusable parts
- Create a new `javascript` parameter for the `example` shortcode containing the name of the reusable JS file to embed into StackBlitz
- Allow `site/layouts/partials/scripts.html` to gather this information and embed the content of the JS file in a `<script>`.

## Sub-tasks
- [x] Instead of using `<script>`, try to create a real `index.js` file in StackBlitz imported by `index.html`.
- ~~Find a better way to share the JS name between the doc, the shortcode and the `site/layouts/partials/scripts.html`~~
- [ ] Security concerns to gather some JS file content?

## Live previews
- [Live demo](https://deploy-preview-36127--twbs-bootstrap.netlify.app/docs/5.1/components/popovers/#live-demo)
- [Four directions](https://deploy-preview-36127--twbs-bootstrap.netlify.app/docs/5.1/components/popovers/#four-directions)
- [Custom popovers](https://deploy-preview-36127--twbs-bootstrap.netlify.app/docs/5.1/components/popovers/#custom-popovers)—Not working because doesn't exist in 5.1.3
  - That's a problem because we will only be able to suppose that the components will work on StackBlitz when we develop them. We will have to wait until it they are released in order to see if it is OK or not.
-  [Dismiss on next click](https://deploy-preview-36127--twbs-bootstrap.netlify.app/docs/5.1/components/popovers/#dismiss-on-next-click)
- [Disabled elements](https://deploy-preview-36127--twbs-bootstrap.netlify.app/docs/5.1/components/popovers/#disabled-elements)

## Not tackled here

- Be able to pass multiple JS files (might be useful for other examples more complex)—we will see that while developing the fix for the other components
- Be able to split the SCSS file used by examples and to pass it (them) like the JS files
- (Optional) Hide some examples if too complex or impossible to try on StackBlitz