### PR TITLE
Doc: Reorder alphabetically lists of components

### DIFF
--- a/site/content/docs/4.6/getting-started/introduction.md
+++ b/site/content/docs/4.6/getting-started/introduction.md
@@ -61,8 +61,8 @@ Curious which components explicitly require jQuery, our JavaScript, and Popper? 
 - Dropdowns for displaying and positioning (also requires [Popper](https://popper.js.org/))
 - Modals for displaying, positioning, and scroll behavior
 - Navbar for extending our Collapse plugin to implement responsive behavior
-- Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
 - Scrollspy for scroll behavior and navigation updates
+- Tooltips and popovers for displaying and positioning (also requires [Popper](https://popper.js.org/))
 {{< /markdown >}}
 </details>
 


### PR DESCRIPTION
In the same spirit as https://github.com/twbs/bootstrap/pull/36123 reorder alphabetically lists of components (actually only 1 in v4) in the documentation.