### PR TITLE
Dropdown: don't close menu on click inside input or textareas

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -436,7 +436,11 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, Dropdown.clearMenus)
 EventHandler.on(document, EVENT_KEYUP_DATA_API, Dropdown.clearMenus)
 EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (event) {
   event.preventDefault()
-  Dropdown.getOrCreateInstance(this).toggle()
+  if (/input|textarea/i.test(event.target.tagName)) {
+    Dropdown.getOrCreateInstance(this).show()
+  } else {
+    Dropdown.getOrCreateInstance(this).toggle()
+  }
 })
 
 /**


### PR DESCRIPTION
Using dropdowns together with input fields as trigger works pretty well. After clicking into the input field, the drop down appears. Clicking a second time into the input field (e.g. to move the cursor) closes the dropdown menu. The second click works as expected on buttons but on input fields the feels confusing. The PR simply always calls show on input and textarea input fields and calls toggle on all other as before.