### PR TITLE
Move tooltip over SVG example from docs to visual tests

### DIFF
--- a/js/tests/visual/tooltip.html
+++ b/js/tests/visual/tooltip.html
@@ -75,7 +75,7 @@
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left" title="<img src=1 onerror=alert(123)>">
             Tooltip with XSS title
           </button>
-          <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip with XSS" data-bs-container="<img src=1 onerror=alert(123)>">
+          <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip-xss-container" data-bs-placement="left" title="Tooltip with XSS" data-bs-container="<img src=1 onerror=alert(123)>">
             Tooltip with XSS container
           </button>
         </p>
@@ -110,6 +110,13 @@
       var tooltipElements = document.querySelectorAll('[data-bs-toggle="tooltip"]')
       for (const tooltipEl of tooltipElements) {
         new bootstrap.Tooltip(tooltipEl)
+      }
+
+      var tooltipXSSContainerElement = document.querySelector('[data-bs-toggle="tooltip-xss-container"]')
+      try {
+        new bootstrap.Tooltip(tooltipXSSContainerElement)
+      } catch {
+        // Should fail
       }
 
       var tooltipElement = document.getElementById('tooltipElement')

--- a/js/tests/visual/tooltip.html
+++ b/js/tests/visual/tooltip.html
@@ -66,19 +66,15 @@
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip with container (selector)" data-bs-container="#customContainer">
             Tooltip with container (selector)
           </button>
-
           <button id="tooltipElement" type="button" class="btn btn-secondary" data-bs-placement="left" title="Tooltip with container (element)">
             Tooltip with container (element)
           </button>
-
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
             Tooltip with HTML
           </button>
-
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left" title="<img src=1 onerror=alert(123)>">
             Tooltip with XSS title
           </button>
-
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip with XSS" data-bs-container="<img src=1 onerror=alert(123)>">
             Tooltip with XSS container
           </button>

--- a/js/tests/visual/tooltip.html
+++ b/js/tests/visual/tooltip.html
@@ -20,7 +20,25 @@
     <div class="container">
       <h1>Tooltip <small>Bootstrap Visual Test</small></h1>
 
-      <p class="text-muted">Tight pants next level keffiyeh <a href="#" data-bs-toggle="tooltip" title="Default tooltip">you probably</a> haven't heard of them. Photo booth beard raw denim letterpress vegan messenger bag stumptown. Farm-to-table seitan, mcsweeney's fixie sustainable quinoa 8-bit american apparel <a href="#" data-bs-toggle="tooltip" title="Another tooltip">have a</a> terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo thundercats. Tofu biodiesel williamsburg marfa, four loko mcsweeney's cleanse vegan chambray. A really ironic artisan <a href="#" data-bs-toggle="tooltip" title="Another one here too">whatever keytar</a>, scenester farm-to-table banksy Austin <a href="#" data-bs-toggle="tooltip" title="The last tip!">twitter handle</a> freegan cred raw denim single-origin coffee viral.</p>
+      <p class="text-muted">
+        Tight pants next level keffiyeh <a href="#" data-bs-toggle="tooltip" title="Default tooltip">you probably</a> haven't heard of them.
+        Photo booth beard raw denim letterpress vegan messenger bag stumptown.
+        Farm-to-table seitan, mcsweeney's fixie sustainable quinoa 8-bit american apparel
+        <a href="#" data-bs-toggle="tooltip" title="Another tooltip">have a</a>
+        terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo thundercats.
+        Tofu biodiesel williamsburg marfa, four loko mcsweeney's cleanse vegan chambray.
+        A really ironic artisan <a href="#" data-bs-toggle="tooltip" title="Another one here too">whatever keytar</a>,
+        scenester farm-to-table banksy Austin <a href="#" data-bs-toggle="tooltip" title="The last tip!">twitter handle</a>
+        freegan cred raw denim single-origin coffee viral.
+      </p>
+
+      Tooltip over SVG
+      <a href="#" class="d-inline-block" data-bs-toggle="tooltip" title="Tooltip over SVG">
+        <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100">
+          <rect width="100%" height="100%" fill="#563d7c"/>
+          <circle cx="50" cy="50" r="30" fill="#007bff"/>
+        </svg>
+      </a>
 
       <hr>
 
@@ -48,14 +66,21 @@
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip with container (selector)" data-bs-container="#customContainer">
             Tooltip with container (selector)
           </button>
+
           <button id="tooltipElement" type="button" class="btn btn-secondary" data-bs-placement="left" title="Tooltip with container (element)">
             Tooltip with container (element)
           </button>
+
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-html="true" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">
             Tooltip with HTML
           </button>
+
+          <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="left" title="<img src=1 onerror=alert(123)>">
+            Tooltip with XSS title
+          </button>
+
           <button type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="left" title="Tooltip with XSS" data-bs-container="<img src=1 onerror=alert(123)>">
-            Tooltip with XSS
+            Tooltip with XSS container
           </button>
         </p>
       </div>

--- a/site/content/docs/5.2/components/tooltips.md
+++ b/site/content/docs/5.2/components/tooltips.md
@@ -109,17 +109,6 @@ And with custom HTML added:
 </button>
 ```
 
-With an SVG:
-
-<div class="bd-example tooltip-demo">
-  <a href="#" class="d-inline-block" data-bs-toggle="tooltip" data-bs-title="Default tooltip">
-    <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 100">
-      <rect width="100%" height="100%" fill="#563d7c"/>
-      <circle cx="50" cy="50" r="30" fill="#007bff"/>
-    </svg>
-  </a>
-</div>
-
 ## CSS
 
 ### Variables


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/32715 https://github.com/twbs/bootstrap/issues/32715#issuecomment-886745329


Problem: the tooltip visual tests are already broken (not related to this PR).

> Uncaught DOMException: Failed to execute 'querySelector' on 'Document': `'<img src=1 onerror=alert(123)>'` is not a valid selector.

This is because of:
```HTML
<button ... data-bs-container="<img src=1 onerror=alert(123)>">
  Tooltip with XSS container
</button>
```

Visual tests should be played by Playwright (or similar) to avoid this kind of breakage

FYI the original tooltip over SVG example was introduced here: https://github.com/twbs/bootstrap/pull/30928