### PR TITLE
Improve use of CSS vars in Toasts

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -2,6 +2,7 @@
   // scss-docs-start toast-css-vars
   --#{$prefix}toast-padding-x: #{$toast-padding-x};
   --#{$prefix}toast-padding-y: #{$toast-padding-y};
+  --#{$prefix}toast-spacing: #{$toast-spacing};
   --#{$prefix}toast-max-width: #{$toast-max-width};
   @include rfs($toast-font-size, --#{$prefix}toast-font-size);
   --#{$prefix}toast-color: #{$toast-color}; // stylelint-disable-line custom-property-empty-line-before
@@ -17,7 +18,7 @@
 
   width: var(--#{$prefix}toast-max-width);
   max-width: 100%;
-  @include font-size($toast-font-size);
+  @include font-size(var(--#{$prefix}toast-font-size));
   color: var(--#{$prefix}toast-color);
   pointer-events: auto;
   background-color: var(--#{$prefix}toast-bg);
@@ -43,7 +44,7 @@
   pointer-events: none;
 
   > :not(:last-child) {
-    margin-bottom: $toast-spacing;
+    margin-bottom: var(--#{$prefix}toast-spacing);
   }
 }
 


### PR DESCRIPTION
### Description

- Create a new `--bs-toast-spacing` CSS var linked to `$toast-spacing`
- Use `--bs-toast-font-size` in `@include font-size()`

### Motivation & Context

Get rid of all remaining `$toast-*` SCSS vars in `_toasts.scss`.

### Types of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-36145--twbs-bootstrap.netlify.app/docs/5.1/components/toasts/)
