### PR TITLE
Manually set hover and active backgrounds and borders for dark and light buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -103,7 +103,27 @@
 // scss-docs-start btn-variant-loops
 @each $color, $value in $theme-colors {
   .btn-#{$color} {
-    @include button-variant($value, $value);
+    @if $color == "light" {
+      @include button-variant(
+        $value,
+        $value,
+        $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
+        $hover-border: shade-color($value, $btn-hover-border-shade-amount),
+        $active-background: shade-color($value, $btn-active-bg-shade-amount),
+        $active-border: shade-color($value, $btn-active-border-shade-amount)
+      );
+    } @else if $color == "dark" {
+      @include button-variant(
+        $value,
+        $value,
+        $hover-background: tint-color($value, $btn-hover-bg-tint-amount),
+        $hover-border: tint-color($value, $btn-hover-border-tint-amount),
+        $active-background: tint-color($value, $btn-active-bg-tint-amount),
+        $active-border: tint-color($value, $btn-active-border-tint-amount)
+      );
+    } @else {
+      @include button-variant($value, $value);
+    }
   }
 }
 


### PR DESCRIPTION
This isn't elegant at all, and is actually rather annoying for others, but it fixes a problem, so here it goes.

This PR aims to improve the color contrast on hover and active state for light and dark buttons. There's no other way I can find to do this without it being a complete rewrite of the component at this point. Placing two custom conditions in here though—based on the extremes of our color palette—seems _okay_ though.

I'd rather go this route than #35293 because this keeps the customization in the usage of the mixin as opposed to the logic of the mixin. Ideally we could setup custom color functions like #34013, but I can only see us doing that with a rewrite of the mixin as well (which could include an optional parameter or something for specifying `tint` or `shade`.

Lastly, I don't see this needing to affect outline buttons. Those have separate issues, yes, but for the moment they have a clear enough hover state at least (though not a clear enough active one).

Definitely need some more thoughts though from @twbs/css-review :).

Closes #35293.
Fixes #34123.

