### PR TITLE
Updated the small-font-size to use a round value

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -319,7 +319,7 @@ $display-line-height:         $headings-line-height !default;
 $lead-font-size:              $font-size-base * 1.25 !default;
 $lead-font-weight:            300 !default;
 
-$small-font-size:             80% !default;
+$small-font-size:             .875em !default;
 
 $text-muted:                  $gray-600 !default;
 


### PR DESCRIPTION
This is a backport from BS5 to BS4.

It fixes https://github.com/twbs/bootstrap/issues/35553 (for the vast majority of cases) and also increases text legibility.

The ```small-font-size``` will actually increase from ```13px``` to ```14px``` with this change. Personally I prefer doing it the BS5 way (```14px```), as the text is more readable now.

If it's needed, I can do another PR with the ```$small-font-size:             .8125rem !default;``` to resemble BS4 more closely but I feel like this would be a move forward even for BS4.