### PR TITLE
Fix Chroma line highlight style

### DIFF
--- a/site/assets/scss/_syntax.scss
+++ b/site/assets/scss/_syntax.scss
@@ -17,7 +17,7 @@
   --base0F: #333;
 }
 
-.hll { background-color: #fff; }
+.hl { background-color: var(--base02); }
 .c { color: var(--base03); }
 .err { color: var(--base08); }
 .k { color: var(--base0E); }


### PR DESCRIPTION
This PR proposes to fix the typo of the class for the line highlight: `.hl` → `.hll` (I've checked the other classes and they seem OK).

:information_source: Nice to know, it is possible to retrieve the list of classes (and meaning) by executing `hugo gen chromastyles > chroma.css ; cat chroma.css`

The following examples can be reproduced by integrating the following code in one of our Markdown pages:

```md
{{< highlight go "linenos=table,hl_lines=8 15-17,linenostart=199" >}}
// GetTitleFunc returns a func that can be used to transform a string to
// title case.
//
// The supported styles are
//
// - "Go" (strings.Title)
// - "AP" (see https://www.apstylebook.com/)
// - "Chicago" (see https://www.chicagomanualofstyle.org/home.html)
//
// If an unknown or empty style is provided, AP style is what you get.
func GetTitleFunc(style string) func(s string) string {
  switch strings.ToLower(style) {
  case "go":
    return strings.Title
  case "chicago":
    return transform.NewTitleConverter(transform.ChicagoStyle)
  default:
    return transform.NewTitleConverter(transform.APStyle)
  }
}
{{< / highlight >}}
```

### Before

(Nothing is highlighted)

![Screenshot from 2022-04-14 19-09-07](https://user-images.githubusercontent.com/17381666/163439881-b7b61eeb-b046-4d2e-ac34-06aedd3b58ae.png)

### With the modification

![Screenshot from 2022-04-14 19-08-43](https://user-images.githubusercontent.com/17381666/163439939-508feaef-1231-42fc-933f-4a9a5b235b89.png)

IMO white highlight is very difficult to see, so I tried in this PR `--base02: #c8c8fa`. Here is the rendering:

![Screenshot from 2022-04-14 19-08-55](https://user-images.githubusercontent.com/17381666/163440101-7c68af47-288f-4184-9cd2-957cc3f942a7.png)

I'm not sure about the contrast and the color but that seemed the best choice regarding the available color palette.
If not we could introduce in the color palette of this file a light yellow :shrug: 



