### PR TITLE
Fix containers page in docs to re-order list so it matches sections b…

### DIFF
--- a/site/content/docs/5.1/layout/containers.md
+++ b/site/content/docs/5.1/layout/containers.md
@@ -13,8 +13,8 @@ Containers are the most basic layout element in Bootstrap and are **required whe
 Bootstrap comes with three different containers:
 
 - `.container`, which sets a `max-width` at each responsive breakpoint
-- `.container-fluid`, which is `width: 100%` at all breakpoints
 - `.container-{breakpoint}`, which is `width: 100%` until the specified breakpoint
+- `.container-fluid`, which is `width: 100%` at all breakpoints
 
 The table below illustrates how each container's `max-width` compares to the original `.container` and `.container-fluid` across each breakpoint.
 


### PR DESCRIPTION
This is a documentation fix. The list of 3 different container classes doesn't match the sections below it. This confused me when I read it, so hopefully, it helps someone else!