### PR TITLE
Doc: minor modifications in Scrollspy

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -236,7 +236,7 @@
   overflow: auto;
 }
 
-.scrollspy-example-2 {
+.scrollspy-example-3 {
   height: 350px;
   overflow: auto;
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -236,7 +236,7 @@
   overflow: auto;
 }
 
-.scrollspy-example-3 {
+.scrollspy-example-2 {
   height: 350px;
   overflow: auto;
 }

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -115,7 +115,7 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
       </nav>
     </div>
     <div class="col-8">
-      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-3" tabindex="0">
+      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
         <div id="item-1">
           <h4>Item 1</h4>
           <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -169,31 +169,31 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 
 <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" tabindex="0">
   <div id="item-1">
-    <h4 id="item-1">Item 1</h4>
+    <h4>Item 1</h4>
     <p>...</p>
   </div>
   <div id="item-1-1">
-    <h5 id="item-1-1">Item 1-1</h5>
+    <h5>Item 1-1</h5>
     <p>...</p>
   </div>
   <div id="item-1-2">
-    <h5 id="item-1-2">Item 1-2</h5>
+    <h5>Item 1-2</h5>
     <p>...</p>
   </div>
   <div id="item-2">
-    <h4 id="item-2">Item 2</h4>
+    <h4>Item 2</h4>
     <p>...</p>
   </div>
   <div id="item-3">
-    <h4 id="item-3">Item 3</h4>
+    <h4>Item 3</h4>
     <p>...</p>
   </div>
   <div id="item-3-1">
-    <h5 id="item-3-1">Item 3-1</h5>
+    <h5>Item 3-1</h5>
     <p>...</p>
   </div>
   <div id="item-3-2">
-    <h5 id="item-3-2">Item 3-2</h5>
+    <h5>Item 3-2</h5>
     <p>...</p>
   </div>
 </div>

--- a/site/content/docs/5.1/components/scrollspy.md
+++ b/site/content/docs/5.1/components/scrollspy.md
@@ -115,34 +115,34 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
       </nav>
     </div>
     <div class="col-8">
-      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-2" tabindex="0">
+      <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" class="scrollspy-example-3" tabindex="0">
         <div id="item-1">
-            <h4>Item 1</h4>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h4>Item 1</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-1-1">
-            <h5>Item 1-1</h5>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h5>Item 1-1</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-1-2">
-            <h5>Item 1-2</h5>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h5>Item 1-2</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-2">
-            <h4>Item 2</h4>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h4>Item 2</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-3">
-            <h4>Item 3</h4>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h4>Item 3</h4>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-3-1">
-            <h5>Item 3-1</h5>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h5>Item 3-1</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
         <div id="item-3-2">
-            <h5>Item 3-2</h5>
-            <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
+          <h5>Item 3-2</h5>
+          <p>This is some placeholder content for the scrollspy page. Note that as you scroll down the page, the appropriate navigation link is highlighted. It's repeated throughout the component example. We keep adding some more example copy here to emphasize the scrolling and highlighting.</p>
         </div>
       </div>
     </div>
@@ -168,20 +168,34 @@ Scrollspy also works with nested `.nav`s. If a nested `.nav` is `.active`, its p
 </nav>
 
 <div data-bs-spy="scroll" data-bs-target="#navbar-example3" data-bs-offset="0" tabindex="0">
-  <h4 id="item-1">Item 1</h4>
-  <p>...</p>
-  <h5 id="item-1-1">Item 1-1</h5>
-  <p>...</p>
-  <h5 id="item-1-2">Item 1-2</h5>
-  <p>...</p>
-  <h4 id="item-2">Item 2</h4>
-  <p>...</p>
-  <h4 id="item-3">Item 3</h4>
-  <p>...</p>
-  <h5 id="item-3-1">Item 3-1</h5>
-  <p>...</p>
-  <h5 id="item-3-2">Item 3-2</h5>
-  <p>...</p>
+  <div id="item-1">
+    <h4 id="item-1">Item 1</h4>
+    <p>...</p>
+  </div>
+  <div id="item-1-1">
+    <h5 id="item-1-1">Item 1-1</h5>
+    <p>...</p>
+  </div>
+  <div id="item-1-2">
+    <h5 id="item-1-2">Item 1-2</h5>
+    <p>...</p>
+  </div>
+  <div id="item-2">
+    <h4 id="item-2">Item 2</h4>
+    <p>...</p>
+  </div>
+  <div id="item-3">
+    <h4 id="item-3">Item 3</h4>
+    <p>...</p>
+  </div>
+  <div id="item-3-1">
+    <h5 id="item-3-1">Item 3-1</h5>
+    <p>...</p>
+  </div>
+  <div id="item-3-2">
+    <h5 id="item-3-2">Item 3-2</h5>
+    <p>...</p>
+  </div>
 </div>
 ```
 


### PR DESCRIPTION
This PR proposes some minor modifications in the Scrollspy documentation after https://github.com/twbs/bootstrap/commit/ece16012270a9ef7781ce9269cb151c5e5961734.
- Remove extra line break in _site/assets/scss/\_component-examples.scss_
- Remove extra tabs in the HTML structure of the third example
~~- Change class name in the third example (`scrollspy-example-2` → `scrollspy-example-3`)~~
- Modify the displayed HTML structure of the third example

### [Live preview](https://deploy-preview-36195--twbs-bootstrap.netlify.app/docs/5.1/components/scrollspy/#example-with-nested-nav)