### PR TITLE
Minor fixes

### DIFF
--- a/site/assets/scss/_clipboard-js.scss
+++ b/site/assets/scss/_clipboard-js.scss
@@ -30,6 +30,10 @@
   &:hover {
     color: $primary;
   }
+
+  &:focus {
+    z-index: 3;
+  }
 }
 
 .btn-clipboard {

--- a/site/content/docs/5.1/components/dropdowns.md
+++ b/site/content/docs/5.1/components/dropdowns.md
@@ -881,7 +881,7 @@ Put a form within a dropdown menu, or make it into a dropdown menu, and use [mar
 
 {{< example >}}
 <div class="dropdown">
-  <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+  <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside">
     Dropdown form
   </button>
   <form class="dropdown-menu p-4">


### PR DESCRIPTION
@julien-deramond found a bug clicking on labels in [form dropdown](https://twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#forms) closes the dropdown menu. Here is a proposal to correct it.

There was an issue focusing StackBlitz button with keyboard : focus was behind the edit button. Another solution could be to increase the z-index on `:focus`.