### PR TITLE
Add padding-bottom property to .chroma

### DIFF
--- a/site/assets/scss/_syntax.scss
+++ b/site/assets/scss/_syntax.scss
@@ -98,6 +98,8 @@
 .language-sh .c { color: var(--base03); }
 
 .chroma {
+  padding-bottom: 0.5rem !important;
+  
   .language-bash,
   .language-sh {
     &::before {


### PR DESCRIPTION
The code is too close to the scrollbar.
It is very hard to read or copy the code (part of it or selecting the code).
Site looks better and much more easier to learn when the scrollbar is a bit lowered.

# Before
![before](https://user-images.githubusercontent.com/78584173/164777291-0cbad4e0-9e13-4664-8b72-00f08160fc57.png)

# After
![after](https://user-images.githubusercontent.com/78584173/164777296-aaee80fd-64e3-41a1-b826-b39ef1056757.png)
