### PR TITLE
Doc: remove `role="group"` from some split drop* buttons

### DIFF
--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -103,7 +103,7 @@
         </div>
 
         <div class="col-sm-12 mt-4">
-          <div class="btn-group dropup" role="group">
+          <div class="btn-group dropup">
             <a href="#" class="btn btn-secondary">Dropup split align end</a>
             <button type="button" id="dropdown-page-subheader-button-3" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
               <span class="visually-hidden">Product actions</span>
@@ -125,7 +125,7 @@
         </div>
 
         <div class="col-sm-12 mt-4">
-          <div class="btn-group dropend" role="group">
+          <div class="btn-group dropend">
             <a href="#" class="btn btn-secondary">Dropend split</a>
             <button type="button" id="dropdown-page-subheader-button-4" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
               <span class="visually-hidden">Product actions</span>
@@ -147,7 +147,7 @@
             </div>
           </div>
           <!-- dropstart -->
-          <div class="btn-group dropstart" role="group">
+          <div class="btn-group dropstart">
             <a href="#" class="btn btn-secondary">Dropstart split</a>
             <button type="button" id="dropdown-page-subheader-button-5" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
               <span class="visually-hidden">Product actions</span>

--- a/site/content/docs/5.1/components/dropdowns.md
+++ b/site/content/docs/5.1/components/dropdowns.md
@@ -569,7 +569,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
       <li><a class="dropdown-item" href="#">Separated link</a></li>
     </ul>
   </div>
-  <div class="btn-group dropstart" role="group">
+  <div class="btn-group dropstart">
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
       <span class="visually-hidden">Toggle Dropstart</span>
     </button>
@@ -598,7 +598,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropstart` to the
 </div>
 
 <!-- Split dropstart button -->
-<div class="btn-group dropstart" role="group">
+<div class="btn-group dropstart">
   <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
     <span class="visually-hidden">Toggle Dropstart</span>
   </button>


### PR DESCRIPTION
### Description

* Remove `role="group"` from the split dropstart button in the documentation
* Remove `role="group"` from visual JS tests

### Motivation & Context

Since v4.6.1 (at least), the [split dropstart button](https://twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropstart) example in the documentation has a `role="group"`. But this is the only example having it.

We don't see this role for [split dropend](https://twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropend) and [split dropup](https://twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropup), and ["normal" split buttons](https://twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#split-button).

This PR brings more consistency in the examples by removing this extra-role.

:warning: However, I don't have the expertise to say if it could be useful in terms of a11y. In this case, this PR should rather be updated to add this role wherever it is useful.

**Note:** Since it is observed in v4.x as well, whatever the final modification will be, I suppose it could be backported in v4 as well.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-36212--twbs-bootstrap.netlify.app/docs/5.1/components/dropdowns/#dropstart)
