### PR TITLE
Doc: mention Popper instead of Popper.js

### DIFF
--- a/site/content/docs/5.1/migration.md
+++ b/site/content/docs/5.1/migration.md
@@ -110,7 +110,7 @@ For a complete list of changes, [see the v5.2.0 project on GitHub](https://githu
 
 - **Added new snippet examples based to show how to customize our components. —** Pull ready to use customized components and other common design patterns with our new [Snippets examples]({{< docsref "/examples#snippets" >}}). Includes [footers]({{< docsref "/examples/footers/" >}}), [dropdowns]({{< docsref "/examples/dropdowns/" >}}), [list groups]({{< docsref "/examples/list-groups/" >}}), and [modals]({{< docsref "/examples/modals/" >}}).
 
-- **Removed unused positioning styles from popovers and tooltips** as these are handled solely by Popper.js. `$tooltip-margin` has been deprecated and set to `null` in the process.
+- **Removed unused positioning styles from popovers and tooltips** as these are handled solely by Popper. `$tooltip-margin` has been deprecated and set to `null` in the process.
 
 Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.com/2021/08/04/bootstrap-5-1-0/)
 

--- a/site/data/plugins.yml
+++ b/site/data/plugins.yml
@@ -27,7 +27,7 @@
   link: components/offcanvas/
 
 - name: Popover
-  description: Create custom overlays. Built on Popper.js.
+  description: Create custom overlays. Built on Popper.
   link: components/popovers/
 
 - name: Scrollspy
@@ -43,5 +43,5 @@
   link: components/toasts/
 
 - name: Tooltip
-  description: Replace browser tooltips with custom ones. Built on Popper.js.
+  description: Replace browser tooltips with custom ones. Built on Popper.
   link: components/tooltips/


### PR DESCRIPTION
### Description

Replace "Popper.js" by "Popper" in the documentation.

### Motivation & Context

This change brings consistency in the documentation compared to other pages where "Popper" is mentioned instead of "Popper.js".

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

### Related issues

N/A

### Live previews
- [Main page > Comprehensive set of plugins](https://deploy-preview-36218--twbs-bootstrap.netlify.app/)
- [Migration guide](https://deploy-preview-36218--twbs-bootstrap.netlify.app/docs/5.1/migration/#v510)