### PR TITLE
Doc: fix offset content for examples page

### DIFF
--- a/site/content/docs/5.1/examples/_index.md
+++ b/site/content/docs/5.1/examples/_index.md
@@ -8,7 +8,7 @@ aliases: "/examples/"
 {{< list-examples.inline >}}
 {{ range $entry := $.Site.Data.examples -}}
 <div class="row g-lg-5 mb-5">
-  <div class="col-lg-3">
+  <div class="bd-content col-lg-3">
     <h2 id="{{ $entry.category | urlize }}">{{ $entry.category }}</h2>
     <p>{{ $entry.description }}</p>
     {{ if eq $entry.category "RTL" -}}


### PR DESCRIPTION
### Description

This PR adds `.bd-content` to the heading surrounding `<div>` to apply an offset.

### Motivation & Context

This change is required to fix the rendering after the following navigation:
1. Go to https://twbs-bootstrap.netlify.app/
2. In **Components, meet the Utility API**, click on **Explore customized components**
3. You'll be redirected to https://twbs-bootstrap.netlify.app/docs/5.1/examples/#snippets which automatically scrolls to "Snippets" header:

![Capture d’écran 2022-04-25 à 08 32 37](https://user-images.githubusercontent.com/17381666/165032940-b63b40a3-923f-4ea3-b8ad-ae17da6fc6f6.png)

but the header and a part of the content are hidden under the nav bar.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] All new and existing tests passed

### Related issues

N/A

### [Live preview](https://deploy-preview-36219--twbs-bootstrap.netlify.app/docs/5.1/examples/#snippets)
