### PR TITLE
Clean up last `$variable-prefix` usages

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1253,7 +1253,7 @@ $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     1rem !default;
 $accordion-padding-x:                     1.25rem !default;
-$accordion-color:                         var(--#{$variable-prefix}body-color) !default;
+$accordion-color:                         var(--#{$prefix}body-color) !default;
 $accordion-bg:                            $body-bg !default;
 $accordion-border-width:                  $border-width !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
@@ -1266,7 +1266,7 @@ $accordion-body-padding-x:                $accordion-padding-x !default;
 $accordion-button-padding-y:              $accordion-padding-y !default;
 $accordion-button-padding-x:              $accordion-padding-x !default;
 $accordion-button-color:                  $accordion-color !default;
-$accordion-button-bg:                     var(--#{$variable-prefix}accordion-bg) !default;
+$accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
 $accordion-button-active-bg:              tint-color($component-active-bg, 90%) !default;
 $accordion-button-active-color:           shade-color($primary, 10%) !default;

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -69,9 +69,9 @@
   }
 
   .dropdown-menu {
-    --#{$variable-prefix}dropdown-min-width: 12rem;
-    --#{$variable-prefix}dropdown-link-hover-bg: rgba(var(--bd-violet-rgb), .1);
-    @include rfs(.875rem, --#{$variable-prefix}dropdown-font-size);
+    --#{$prefix}dropdown-min-width: 12rem;
+    --#{$prefix}dropdown-link-hover-bg: rgba(var(--bd-violet-rgb), .1);
+    @include rfs(.875rem, --#{$prefix}dropdown-font-size);
     box-shadow: $dropdown-box-shadow;
   }
 

--- a/site/layouts/partials/home/masthead-followup.html
+++ b/site/layouts/partials/home/masthead-followup.html
@@ -66,7 +66,7 @@
       {{ highlight (printf `// Variable overrides first
 $primary: #900;
 $enable-shadows: true;
-$variable-prefix: "mo-";
+$prefix: "mo-";
 
 // Then import Bootstrap
 @import "../node_modules/bootstrap/scss/bootstrap";
@@ -82,7 +82,7 @@ $variable-prefix: "mo-";
 // Variable overrides second
 $primary: #900;
 $enable-shadows: true;
-$variable-prefix: "mo-";
+$prefix: "mo-";
 
 // Required Bootstrap imports
 @import "../node_modules/bootstrap/scss/variables";


### PR DESCRIPTION
This PR cleans up the remaining `$variable-prefix` usages found in Scss files and in the masthead documentation.

Indeed `$variable-prefix` is now deprecated in the _main_ branch (in 5.2.0).

### Live previews
- [Accordions](https://deploy-preview-36220--twbs-bootstrap.netlify.app/docs/5.1/components/accordion/)
- [Navbars examples](https://deploy-preview-36220--twbs-bootstrap.netlify.app/docs/5.1/examples/navbars/)
- [Main doc page > Build and extend in real-time with CSS variables](https://deploy-preview-36220--twbs-bootstrap.netlify.app)