### PR TITLE
[WIP] Fix documentation versions selection

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -1,7 +1,3 @@
-{{- $url := split .Permalink "/" -}}
-{{- $group_slug := index $url (sub (len $url) 3) -}}
-{{- $page_slug := index $url (sub (len $url) 2) -}}
-
 <li class="nav-item dropdown">
   <a href="#" class="nav-link py-2 px-0 px-lg-2 dropdown-toggle" id="bd-versions" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
     <span class="d-lg-none">Bootstrap</span> v{{ .Site.Params.docs_version }}
@@ -9,16 +5,8 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li><a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest ({{ .Site.Params.docs_version }}.x)</a></li>
-    <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ $group_slug }}/{{ $page_slug }}/">v5.1.3</a>
-    </li>
-    <li>
-      {{- if eq .Page.Params.added "5.1" }}
-        <div class="dropdown-item disabled">v5.0.2</div>
-      {{- else }}
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ $group_slug }}/{{ $page_slug }}/">v5.0.2</a>
-      {{- end }}
-    </li>
+    <li><a class="dropdown-item" href="https://getbootstrap.com/docs/5.1">v5.1.3</a></li>
+    <li><a class="dropdown-item" href="https://getbootstrap.com/docs/5.0">v5.0.2</a></li>
     <li><hr class="dropdown-divider"></li>
     <li><h6 class="dropdown-header">Previous releases</h6></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>


### PR DESCRIPTION
This PR is for the moment a proposal to revert modifications added to handle the versions in the dropdown in the header.

Here are the issues that I can observe:

* 🔴 Go to https://twbs-bootstrap.netlify.app/. Click on the versions dropdown, choose v5.0.2. You'll be redirected to https://getbootstrap.com/docs/5.0//main--twbs-bootstrap.netlify.app/. Same thing for v5.1.3.
* 🔴 Go to https://twbs-bootstrap.netlify.app/docs/5.1/examples/. Click on the versions dropdown, choose v5.0.2. You'll be redirected to https://getbootstrap.com/docs/5.0/5.1/examples/. Same thing for v5.1.3.
* 🟢 Go to https://twbs-bootstrap.netlify.app/docs/5.1/getting-started/accessibility/. Click on the versions dropdown, choose v5.0.2. You'll be redirected to https://getbootstrap.com/docs/5.0/getting-started/accessibility/.
* 🟡 Go to https://twbs-bootstrap.netlify.app/docs/5.1/components/placeholders/. Click on the versions dropdown. v5.0.2 is disabled because this page didn't exist in v5.0. I find it a little bit disturbing (even if I understand this choice): if I want to go to the v5.0 documentation, I have to change my current page.
* 🟡 Go to https://twbs-bootstrap.netlify.app/docs/5.1/utilities/opacity/. Click on the versions dropdown, choose v5.0.2. You'll be redirected to https://getbootstrap.com/docs/5.0/utilities/opacity/ with a 404 File not found.

Based on this obervation even if I understand perfectly the need I'm wondering if this system of keeping the context will be easy to maintain in the future. If we decide to change the doc or examples sitemaps, none of the links would work without a modification of the previous documentations.

Depending on when the v5.2.0 will be released, it could be safer to revert this mechanism and implement it with all the cases in v5.2.1 or v5.3.0. Thoughts?

/CC @mdo 

_Feel free to close this PR if it's already been discussed_

### [Live preview](https://deploy-preview-36221--twbs-bootstrap.netlify.app/)
