### PR TITLE
Iterate on border utilities

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -57,7 +57,6 @@
   --#{$prefix}border-style: #{$border-style};
   --#{$prefix}border-color: #{$border-color};
   --#{$prefix}border-color-translucent: #{$border-color-translucent};
-  --#{$prefix}border-opacity: 1;
 
   --#{$prefix}border-radius: #{$border-radius};
   --#{$prefix}border-radius-sm: #{$border-radius-sm};

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -98,9 +98,6 @@ $utilities: map-merge(
     // scss-docs-start utils-borders
     "border": (
       property: border,
-      local-vars: (
-        "border-opacity": 1
-      ),
       values: (
         null: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color),
         0: 0,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -103,17 +103,6 @@ $utilities: map-merge(
         0: 0,
       )
     ),
-    "border-opacity": (
-      css-var: true,
-      class: border-opacity,
-      values: (
-        10: .1,
-        25: .25,
-        50: .5,
-        75: .75,
-        100: 1
-      )
-    ),
     "border-top": (
       property: border-top,
       values: (
@@ -147,6 +136,9 @@ $utilities: map-merge(
     "border-color": (
       property: border-color,
       class: border,
+      local-vars: (
+        "border-opacity": 1
+      ),
       values: $utilities-border-colors
     ),
     "border-width": (
@@ -154,6 +146,17 @@ $utilities: map-merge(
       css-variable-name: border-width,
       class: border,
       values: $border-widths
+    ),
+    "border-opacity": (
+      css-var: true,
+      class: border-opacity,
+      values: (
+        10: .1,
+        25: .25,
+        50: .5,
+        75: .75,
+        100: 1
+      )
     ),
     // scss-docs-end utils-borders
     // Sizing utilities

--- a/site/content/docs/5.1/utilities/borders.md
+++ b/site/content/docs/5.1/utilities/borders.md
@@ -12,6 +12,8 @@ Use border utilities to add or remove an element's borders. Choose from all bord
 
 ### Additive
 
+Add borders to custom elements:
+
 {{< example class="bd-example-border-utils" >}}
 <span class="border"></span>
 <span class="border-top"></span>
@@ -21,6 +23,8 @@ Use border utilities to add or remove an element's borders. Choose from all bord
 {{< /example >}}
 
 ### Subtractive
+
+Or remove borders:
 
 {{< example class="bd-example-border-utils bd-example-border-utils-0" >}}
 <span class="border-0"></span>
@@ -43,11 +47,22 @@ Change the border color using utilities built on our theme colors.
 <span class="border border-white"></span>
 {{< /example >}}
 
-{{< callout >}}
-Unlike text and background color utilities, border color utilities redeclare the `border-color` property **without** an additional `--bs-border-opacity`, as opposed to resetting only `--bs-border-color`. This ensures the backward compatibility of border color utilities applying to other components while providing additional functionality through CSS variables.
+Or modify the default `border-color` of a component:
 
-This will be revisited in a future major release.
-{{< /callout >}}
+{{< example >}}
+<div class="mb-4">
+  <label for="exampleFormControlInput1" class="form-label">Email address</label>
+  <input type="email" class="form-control border-success" id="exampleFormControlInput1" placeholder="name@example.com">
+</div>
+
+<div class="h4 pb-2 mb-4 text-danger border-bottom border-danger">
+  Dangerous heading
+</div>
+
+<div class="p-3 bg-info bg-opacity-10 border border-info border-start-0 rounded-end">
+  Changing border color and width
+</div>
+{{< /example >}}
 
 ## Opacity
 


### PR DESCRIPTION
We set `--bs-border-opacity: 1` globally at the `:root` level, so redeclaring it on every `.border-*` utility doesn't make much sense. I think we can drop this.

**Edit:** Per conversation below, I've also removed the global `--bs-border-opacity` and restored it on the `.border-{color}` utilities. There's no need for border opacity on default `.border` utilities, just the color ones, which now properly matches our `.text-{color}` and `.bg-{color}` utilities. In addition, this rearranged the utilities map to put `border-color` at the end (without which `.border-opacity-*` classes wouldn't work properly.