### PR TITLE
Add new `.text-bg-{color}` helpers

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,15 +18,15 @@
     },
     {
       "path": "./dist/css/bootstrap-utilities.css",
-      "maxSize": "7.75 kB"
+      "maxSize": "8.0 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.min.css",
-      "maxSize": "7.0 kB"
+      "maxSize": "7.25 kB"
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "28.5 kB"
+      "maxSize": "28.75 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -1,4 +1,5 @@
 @import "helpers/clearfix";
+@import "helpers/color-bg";
 @import "helpers/colored-links";
 @import "helpers/ratio";
 @import "helpers/position";

--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -1,0 +1,10 @@
+// stylelint-disable declaration-no-important, function-name-case
+
+// All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
+@each $color, $value in $theme-colors {
+  $color-rgb: to-rgb($value);
+  .text-bg-#{$color} {
+    color: color-contrast($value) !important;
+    background-color: RGBA($color-rgb, var(--#{$prefix}bg-opacity, 1)) !important;
+  }
+}

--- a/site/content/docs/5.1/components/badge.md
+++ b/site/content/docs/5.1/components/badge.md
@@ -27,7 +27,7 @@ Badges can be used as part of links or buttons to provide a counter.
 
 {{< example >}}
 <button type="button" class="btn btn-primary">
-  Notifications <span class="badge bg-secondary">4</span>
+  Notifications <span class="badge text-bg-secondary">4</span>
 </button>
 {{< /example >}}
 
@@ -62,12 +62,14 @@ You can also replace the `.badge` class with a few more utilities without a coun
 
 ## Background colors
 
-Use our background utility classes to quickly change the appearance of a badge. Please note that when using Bootstrap's default `.bg-light`, you'll likely need a text color utility like `.text-dark` for proper styling. This is because background utilities do not set anything but `background-color`.
+{{< added-in "5.2.0" >}}
+
+Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}`]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}`]({{< docsref "/utilities/background" >}}) utilities for styling, which you still may use if you prefer.
 
 {{< example >}}
 {{< badge.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<span class="badge bg-{{ .name }}{{ with .contrast_color }} text-{{ . }}{{ end }}">{{ .name | title }}</span>{{- end -}}
+<span class="badge text-bg-{{ .name }}">{{ .name | title }}</span>{{- end -}}
 {{< /badge.inline >}}
 {{< /example >}}
 
@@ -82,7 +84,7 @@ Use the `.rounded-pill` utility class to make badges more rounded with a larger 
 {{< example >}}
 {{< badge.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<span class="badge rounded-pill bg-{{ .name }}{{ with .contrast_color }} text-{{ . }}{{ end }}">{{ .name | title }}</span>{{- end -}}
+<span class="badge rounded-pill text-bg-{{ .name }}">{{ .name | title }}</span>{{- end -}}
 {{< /badge.inline >}}
 {{< /example >}}
 

--- a/site/content/docs/5.1/components/card.md
+++ b/site/content/docs/5.1/components/card.md
@@ -417,12 +417,14 @@ Cards include various options for customizing their backgrounds, borders, and co
 
 ### Background and color
 
-Use [text color]({{< docsref "/utilities/colors" >}}) and [background utilities]({{< docsref "/utilities/background" >}}) to change the appearance of a card.
+{{< added-in "5.2.0" >}}
+
+Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers]({{< docsref "helpers/color-background" >}}). Previously it was required to manually pair your choice of [`.text-{color}`]({{< docsref "/utilities/colors" >}}) and [`.bg-{color}`]({{< docsref "/utilities/background" >}}) utilities for styling, which you still may use if you prefer.
 
 {{< example >}}
 {{< card.inline >}}
 {{- range (index $.Site.Data "theme-colors") }}
-<div class="card{{ if .contrast_color }} text-{{ .contrast_color }}{{ else }} text-white{{ end }} bg-{{ .name }} mb-3" style="max-width: 18rem;">
+<div class="card text-bg-{{ .name }} mb-3" style="max-width: 18rem;">
   <div class="card-header">Header</div>
   <div class="card-body">
     <h5 class="card-title">{{ .name | title }} card title</h5>

--- a/site/content/docs/5.1/components/toasts.md
+++ b/site/content/docs/5.1/components/toasts.md
@@ -180,10 +180,10 @@ Alternatively, you can also add additional controls and components to toasts.
 
 ### Color schemes
 
-Building on the above example, you can create different toast color schemes with our [color]({{< docsref "/utilities/colors" >}}) and [background]({{< docsref "/utilities/background" >}}) utilities. Here we've added `.bg-primary` and `.text-white` to the `.toast`, and then added `.btn-close-white` to our close button. For a crisp edge, we remove the default border with `.border-0`.
+Building on the above example, you can create different toast color schemes with our [color]({{< docsref "/utilities/colors" >}}) and [background]({{< docsref "/utilities/background" >}}) utilities. Here we've added `.text-bg-primary` to the `.toast`, and then added `.btn-close-white` to our close button. For a crisp edge, we remove the default border with `.border-0`.
 
 {{< example class="bg-light" >}}
-<div class="toast align-items-center text-white bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true">
+<div class="toast align-items-center text-bg-primary border-0" role="alert" aria-live="assertive" aria-atomic="true">
   <div class="d-flex">
     <div class="toast-body">
       Hello, world! This is a toast message.

--- a/site/content/docs/5.1/helpers/color-background.md
+++ b/site/content/docs/5.1/helpers/color-background.md
@@ -1,0 +1,52 @@
+---
+layout: docs
+title: Color & background
+description: Set a background color with contrasting foreground color.
+group: helpers
+toc: true
+added: "5.2"
+---
+
+## Overview
+
+{{< added-in "5.2.0" >}}
+
+Color and background helpers combine the power of our [`.text-*` utilities]({{< docsref "/utilities/colors" >}}) and [`.bg-*` utilities]({{< docsref "/utilities/background" >}}) in one class. Using our Sass `color-contrast()` function, we automatically determine a contrasting `color` for a particular `background-color`.
+
+{{< callout warning >}}
+**Heads up!** There's currently no support for a CSS-native `color-contrast` function, so we use our own via Sass. This means that customizing our theme colors via CSS variables may cause color contrast issues with these utilities.
+{{< /callout >}}
+
+{{< example >}}
+{{< text-bg.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<div class="text-bg-{{ .name }} p-3">{{ .name | title }} with contrasting color</div>
+{{- end -}}
+{{< /text-bg.inline >}}
+{{< /example >}}
+
+## With components
+
+Use them in place of combined `.text-*` and `.bg-*` classes, like on [badges]({{< docsref "/components/badge#background-colors" >}}):
+
+{{< example >}}
+<span class="badge text-bg-primary">Primary</span>
+<span class="badge text-bg-info">Info</span>
+{{< /example >}}
+
+Or on [cards]({{< docsref "/components/card#background-and-color" >}}):
+
+{{< example >}}
+<div class="card text-bg-primary mb-3" style="max-width: 18rem;">
+  <div class="card-header">Header</div>
+  <div class="card-body">
+    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+  </div>
+</div>
+<div class="card text-bg-info mb-3" style="max-width: 18rem;">
+  <div class="card-header">Header</div>
+  <div class="card-body">
+    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+  </div>
+</div>
+{{< /example >}}

--- a/site/content/docs/5.1/migration.md
+++ b/site/content/docs/5.1/migration.md
@@ -84,6 +84,8 @@ Your custom Bootstrap CSS builds should now look something like this with a sepa
 
 - **Popovers and tooltips now use CSS variables.** Some CSS variables have been updated from their Sass counterparts to reduce the number of variables. As a result, three variables have been deprecated in this release: `$popover-arrow-color`, `$popover-arrow-outer-color`, and `$tooltip-arrow-color`.
 
+- **Added new `.text-bg-{color}` helpers.** Instead of setting individual `.text-*` and `.bg-*` utilities, you can now use [the `.text-bg-*` helpers]({{< docsref "helpers/color-background" >}}) to set a `background-color` with contrasting foreground `color`.
+
 - Added `.form-check-reverse` modifier to flip the order of labels and associated checkboxes/radios.
 
 - Added [striped columns]({{< docsref "/content/tables#striped-columns" >}}) support to tables via the new `.table-striped-columns` class.

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -100,6 +100,7 @@
   icon_color: orange
   pages:
     - title: Clearfix
+    - title: Color & background
     - title: Colored links
     - title: Ratio
     - title: Position

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -22,10 +22,14 @@
       </a>
     </li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
+      {{- if (eq .Page.Params.added "5.2") }}
+        <div class="dropdown-item disabled">v5.1.3</div>
+      {{- else }}
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
+      {{- end }}
     </li>
     <li>
-      {{- if eq .Page.Params.added "5.1" }}
+      {{- if or (eq .Page.Params.added "5.1") (eq .Page.Params.added "5.2") }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ .Scratch.Get "versions_link" }}">v5.0.2</a>


### PR DESCRIPTION
<img width="822" alt="Screen Shot 2022-04-28 at 4 21 17 PM" src="https://user-images.githubusercontent.com/98681/165863229-273d9f38-5996-4ccf-b2e2-2ac3477c3fac.png">

These new helpers aim to replace the instances where you must declare a contrasting `color` and `background-color` on the same element. Currently we defer to the developer/designer to decide how to handle this via separate utilities, which is kind of a shitty experience. Since we cannot use the completely unsupported native color contrast CSS function (you can opt into it in Safari dev tools though), we rely on our own custom `color-contrast()` function. As such, the contrast action doesn't happen _live_ in browser, but at compilation time via Sass.

These new helpers are great for common component use cases like badges and cards, as shown below.

<img width="822" alt="Screen Shot 2022-04-28 at 4 21 43 PM" src="https://user-images.githubusercontent.com/98681/165863224-47e2fd31-1c56-4c9f-a285-2c7ef9b8911b.png">

---

These utilities also ship with a local CSS variable for `--bs-bg-opacity`, so you can also do fun stuff like:

```html
<span class="badge text-bg-info bg-opacity-25">Light info</span>
```

Note that these are _helpers_ because utilities, at least in our definition, are singular `property` and `value` pairings. Helpers are small snippets of code.

---

### Todos:

- [x] Bundlewatch
- [x] Update badges and cards pages to use new helpers
- [x] Update migration guide
