### PR TITLE
Update new docs version picker to work on home and examples pages

### DIFF
--- a/site/content/docs/5.1/helpers/stacks.md
+++ b/site/content/docs/5.1/helpers/stacks.md
@@ -4,6 +4,7 @@ title: Stacks
 description: Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever.
 group: helpers
 toc: true
+added: "5.1"
 ---
 
 Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).

--- a/site/content/docs/5.1/helpers/vertical-rule.md
+++ b/site/content/docs/5.1/helpers/vertical-rule.md
@@ -4,6 +4,7 @@ title: Vertical rule
 description: Use the custom vertical rule helper to create vertical dividers like the `<hr>` element.
 group: helpers
 toc: true
+added: "5.1"
 ---
 
 ## How it works

--- a/site/content/docs/5.1/utilities/opacity.md
+++ b/site/content/docs/5.1/utilities/opacity.md
@@ -3,6 +3,7 @@ layout: docs
 title: Opacity
 description: Control the opacity of elements.
 group: utilities
+added: "5.1"
 ---
 
 The `opacity` property sets the opacity level for an element. The opacity level describes the transparency level, where `1` is not transparent at all, `.5` is 50% visible, and `0` is completely transparent.

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -2,21 +2,32 @@
 {{- $group_slug := index $url (sub (len $url) 3) -}}
 {{- $page_slug := index $url (sub (len $url) 2) -}}
 
+{{- $versions_link := "" -}}
+{{- if (eq .Layout "docs") }}
+  {{- .Scratch.Set "versions_link" (printf "%s/%s/" $group_slug $page_slug) -}}
+{{- else if (eq .Layout "single") }}
+  {{- .Scratch.Set "versions_link" (printf "%s/" $page_slug) -}}
+{{- end }}
+
 <li class="nav-item dropdown">
   <a href="#" class="nav-link py-2 px-0 px-lg-2 dropdown-toggle" id="bd-versions" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
     <span class="d-lg-none">Bootstrap</span> v{{ .Site.Params.docs_version }}
   </a>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/">Latest ({{ .Site.Params.docs_version }}.x)</a></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ $group_slug }}/{{ $page_slug }}/">v5.1.3</a>
+      <a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/{{ .Scratch.Get "versions_link" }}">
+        Latest ({{ .Site.Params.docs_version }}.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
     </li>
     <li>
       {{- if eq .Page.Params.added "5.1" }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ $group_slug }}/{{ $page_slug }}/">v5.0.2</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ .Scratch.Get "versions_link" }}">v5.0.2</a>
       {{- end }}
     </li>
     <li><hr class="dropdown-divider"></li>

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -21,7 +21,7 @@
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
     </li>
     <li>
       {{- if eq .Page.Params.added "5.1" }}

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -1,9 +1,10 @@
 {{- $url := split .Permalink "/" -}}
+{{- $page_version := index $url (sub (len $url) 4) -}}
 {{- $group_slug := index $url (sub (len $url) 3) -}}
 {{- $page_slug := index $url (sub (len $url) 2) -}}
 
 {{- $versions_link := "" -}}
-{{- if (eq .Layout "docs") }}
+{{- if and (eq .Layout "docs") (eq $page_version .Site.Params.docs_version) -}}
   {{- .Scratch.Set "versions_link" (printf "%s/%s/" $group_slug $page_slug) -}}
 {{- else if (eq .Layout "single") }}
   {{- .Scratch.Set "versions_link" (printf "%s/" $page_slug) -}}


### PR DESCRIPTION
Alternate fix to #36221.

This doesn't address every issue, but it fixes the broken links for Home and Examples. This also fixes the 404 for the `utilities/opacity/` page. What remains is figuring out what to do about two situations:

- Disabled links for components added in later releases (e.g., https://twbs-bootstrap.netlify.app/docs/5.1/components/placeholders/)
- Providing a general "v5.1 docs link" instead of a page-specific link

TBD on both those.

/cc @julien-deramond 