### PR TITLE
Doc: update path to `@popperjs/core` in parcel.md

### DIFF
--- a/site/content/docs/5.1/getting-started/parcel.md
+++ b/site/content/docs/5.1/getting-started/parcel.md
@@ -23,7 +23,8 @@ project-name/
 ├── build/
 ├── node_modules/
 │   └── bootstrap/
-│   └── popper.js/
+│   └── @popperjs/
+|       └── core/
 ├── scss/
 │   └── custom.scss
 ├── src/


### PR DESCRIPTION
```diff
 ├── node_modules/
 │   └── bootstrap/
-│   └── popper.js/
+│   └── @popperjs/
+|       └── core/
```

According to [popper.js](https://www.npmjs.com/package/popper.js) on npm, this package has been deprecated.
Bootstrap is now using [@popperjs/core](https://www.npmjs.com/package/@popperjs/core) instead.