### PR TITLE
[v4] Doc: remove `role="group"` from some split drop* buttons

### DIFF
--- a/js/tests/visual/dropdown.html
+++ b/js/tests/visual/dropdown.html
@@ -95,7 +95,7 @@
         </div>
 
         <div class="col-sm-12 mt-4">
-          <div class="btn-group dropup" role="group">
+          <div class="btn-group dropup">
             <a href="#" class="btn btn-secondary">Dropup split align right</a>
             <button type="button" id="dropdown-page-subheader-button-3" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
               <span class="sr-only">Product actions</span>
@@ -117,7 +117,7 @@
         </div>
 
         <div class="col-sm-12 mt-4">
-          <div class="btn-group dropright" role="group">
+          <div class="btn-group dropright">
             <a href="#" class="btn btn-secondary">Dropright split</a>
             <button type="button" id="dropdown-page-subheader-button-4" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
               <span class="sr-only">Product actions</span>
@@ -139,7 +139,7 @@
             </div>
           </div>
           <!-- dropleft -->
-          <div class="btn-group dropleft" role="group">
+          <div class="btn-group dropleft">
             <a href="#" class="btn btn-secondary">Dropleft split</a>
             <button type="button" id="dropdown-page-subheader-button-5" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
               <span class="sr-only">Product actions</span>

--- a/site/content/docs/4.6/components/dropdowns.md
+++ b/site/content/docs/4.6/components/dropdowns.md
@@ -488,7 +488,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropleft` to the 
     </div>
   </div>
   <div class="btn-group">
-    <div class="btn-group dropleft" role="group">
+    <div class="btn-group dropleft">
       <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
         <span class="sr-only">Toggle Dropleft</span>
       </button>
@@ -519,7 +519,7 @@ Trigger dropdown menus at the left of the elements by adding `.dropleft` to the 
 
 <!-- Split dropleft button -->
 <div class="btn-group">
-  <div class="btn-group dropleft" role="group">
+  <div class="btn-group dropleft">
     <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
       <span class="sr-only">Toggle Dropleft</span>
     </button>


### PR DESCRIPTION
This PR backports https://github.com/twbs/bootstrap/pull/36212 to `v4-dev`.

### [Live preview](https://deploy-preview-36254--twbs-bootstrap.netlify.app/docs/4.6/components/dropdowns/#dropleft)