### PR TITLE
Fix color-adjust with autoprefixer 10.4.6

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -37,7 +37,7 @@
   background-size: contain;
   border: $form-check-input-border;
   appearance: none;
-  color-adjust: exact; // Keep themed appearance for print
+  print-color-adjust: exact; // Keep themed appearance for print
   @include transition($form-check-transition);
 
   &[type="checkbox"] {


### PR DESCRIPTION
autoprefix, updated, and having trouble `color-adjust`.

[autoprefixer respository change log](https://github.com/postcss/autoprefixer/blob/main/CHANGELOG.md)
[developer.mozilla print-color-adjust description](https://developer.mozilla.org/en-US/docs/Web/CSS/print-color-adjust)