### PR TITLE
Fix proposal for Tooltips

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -19,6 +19,7 @@
 
   z-index: var(--#{$prefix}tooltip-zindex);
   display: block;
+  padding: var(--#{$prefix}tooltip-arrow-height);
   margin: var(--#{$prefix}tooltip-margin);
   @include deprecate("`$tooltip-margin`", "v5", "v5.x", );
   // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
@@ -45,67 +46,51 @@
   }
 }
 
-.bs-tooltip-top {
-  padding: var(--#{$prefix}tooltip-arrow-height) 0;
+.bs-tooltip-top .tooltip-arrow {
+  bottom: 0;
 
-  .tooltip-arrow {
-    bottom: 0;
-
-    &::before {
-      top: -1px;
-      border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-      border-top-color: var(--#{$prefix}tooltip-bg);
-    }
+  &::before {
+    top: -1px;
+    border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+    border-top-color: var(--#{$prefix}tooltip-bg);
   }
 }
 
 /* rtl:begin:ignore */
-.bs-tooltip-end {
-  padding: 0 var(--#{$prefix}tooltip-arrow-height);
+.bs-tooltip-end .tooltip-arrow {
+  left: 0;
+  width: var(--#{$prefix}tooltip-arrow-height);
+  height: var(--#{$prefix}tooltip-arrow-width);
 
-  .tooltip-arrow {
-    left: 0;
-    width: var(--#{$prefix}tooltip-arrow-height);
-    height: var(--#{$prefix}tooltip-arrow-width);
-
-    &::before {
-      right: -1px;
-      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
-      border-right-color: var(--#{$prefix}tooltip-bg);
-    }
+  &::before {
+    right: -1px;
+    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+    border-right-color: var(--#{$prefix}tooltip-bg);
   }
 }
 
 /* rtl:end:ignore */
 
-.bs-tooltip-bottom {
-  padding: var(--#{$prefix}tooltip-arrow-height) 0;
+.bs-tooltip-bottom .tooltip-arrow {
+  top: 0;
 
-  .tooltip-arrow {
-    top: 0;
-
-    &::before {
-      bottom: -1px;
-      border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-      border-bottom-color: var(--#{$prefix}tooltip-bg);
-    }
+  &::before {
+    bottom: -1px;
+    border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+    border-bottom-color: var(--#{$prefix}tooltip-bg);
   }
 }
 
 /* rtl:begin:ignore */
-.bs-tooltip-start {
-  padding: 0 var(--#{$prefix}tooltip-arrow-height);
+.bs-tooltip-start .tooltip-arrow {
+  right: 0;
+  width: var(--#{$prefix}tooltip-arrow-height);
+  height: var(--#{$prefix}tooltip-arrow-width);
 
-  .tooltip-arrow {
-    right: 0;
-    width: var(--#{$prefix}tooltip-arrow-height);
-    height: var(--#{$prefix}tooltip-arrow-width);
-
-    &::before {
-      left: -1px;
-      border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
-      border-left-color: var(--#{$prefix}tooltip-bg);
-    }
+  &::before {
+    left: -1px;
+    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+    border-left-color: var(--#{$prefix}tooltip-bg);
   }
 }
 


### PR DESCRIPTION
Closes #36069 

### Solutions

Thanks to everyone that contributed to the issue, here are the different solutions that came to my mind : 
- @atomiks : Change the CSS to have the expected behavior. (Which is actually implemented in the PR)
- @GeoSot : Change the js file to have a different behavior which contains some bugs in rare cases imo. (Which modifies the PopperConfig modifier)

I tried for this to modify https://github.com/twbs/bootstrap/blob/51535cd95ac8eb5746e19c057aeabdbcafef3a8b/js/src/tooltip.js#L425 in order to have : 
```js
fallbackPlacements: (this._config.placement === 'top' || this._config.placement === 'bottom') ? ['top', 'bottom', 'right', 'left'] : ['right', 'left', 'top', 'bottom']
```
As the CSS solution seems to do the trick, I didn't explored too much in this way, and the bug remains (just moved away), but I could try to if needed !

---

Thanks again for the contributors of the issue ❤️ 