### PR TITLE
Fix search with xs to md breakpoints

### DIFF
--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -17,7 +17,7 @@
       <svg class="bi" width="24" height="24" aria-hidden="true"><use xlink:href="#three-dots"></use></svg>
     </button>
 
-    <div class="offcanvas-lg offcanvas-end flex-grow-1" id="bdNavbar" aria-labelledby="bdNavbarOffcanvasLabel">
+    <div class="offcanvas-lg offcanvas-end flex-grow-1" id="bdNavbar" aria-labelledby="bdNavbarOffcanvasLabel" data-bs-scroll="true">
       <div class="offcanvas-header px-4 pb-0">
         <h5 class="offcanvas-title text-white" id="bdNavbarOffcanvasLabel">Bootstrap</h5>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#bdNavbar"></button>


### PR DESCRIPTION
On your browser in responsive mode with a width of 991px or under OR with your mobile phone:

1. Go to https://deploy-preview-36307--twbs-bootstrap.netlify.app/docs/5.1/getting-started/introduction/
2. Click on "..."
3. Click on search input → search popup appears
4. Search input in the popup now gains automatically the focus. Search is now possible.

Fixes #36306