### PR TITLE
Truncate text to prevent multiline floating label

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -12,8 +12,12 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     pointer-events: none;
     border: $input-border-width solid transparent; // Required for aligning label's text with the input as it affects inner box model
     transform-origin: 0 0;


### PR DESCRIPTION
Add css properties to label that will truncate long texts to prevent multi-line floating texts

Addresses [#36270
](https://github.com/twbs/bootstrap/issues/36270)