### PR TITLE
Remove unused `.border-right` rule from modal example CSS file

### DIFF
--- a/site/content/docs/5.1/examples/modals/modals.css
+++ b/site/content/docs/5.1/examples/modals/modals.css
@@ -10,8 +10,6 @@
   width: 380px;
 }
 
-.border-right { border-right: 1px solid #eee; }
-
 .modal-tour .modal-dialog {
   width: 380px;
 }


### PR DESCRIPTION
This PR removes the unused `.border-right` rule from modal example CSS file after the modification done in https://github.com/twbs/bootstrap/commit/5602093c7be8726f1b1043b3d71bb887d6f1f607.

[Live preview](https://deploy-preview-36328--twbs-bootstrap.netlify.app/docs/5.1/examples/modals/) for non-regression testing of the "Enable this setting?" modal buttons.