### PR TITLE
Doc: fix text overflow example

### DIFF
--- a/site/content/docs/5.1/utilities/text.md
+++ b/site/content/docs/5.1/utilities/text.md
@@ -38,7 +38,7 @@ Wrap text with a `.text-wrap` class.
 Prevent text from wrapping with a `.text-nowrap` class.
 
 {{< example >}}
-<div class="text-nowrap bd-highlight" style="width: 8rem;">
+<div class="text-nowrap bg-light border" style="width: 8rem;">
   This text should overflow the parent.
 </div>
 {{< /example >}}


### PR DESCRIPTION
`.bd-highlight` has been removed in https://github.com/twbs/bootstrap/commit/e089aef00fef68c6a815327d8b988e14cfcf4d9b. One use case is remaining in text overflow example.

I replaced the use of this class by a combination of `.bg-light` and `.border`. The rendering is not exactly the same but should do the job.

* [Before - Live preview](https://getbootstrap.com/docs/5.1/utilities/text/#text-wrapping-and-overflow)
* [Now - Live preview](https://deploy-preview-36333--twbs-bootstrap.netlify.app/docs/5.1/utilities/text/#text-wrapping-and-overflow)