### PR TITLE
docs: drop Scratch usage

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -5,9 +5,9 @@
 
 {{- $versions_link := "" -}}
 {{- if and (eq .Layout "docs") (eq $page_version .Site.Params.docs_version) -}}
-  {{- .Scratch.Set "versions_link" (printf "%s/%s/" $group_slug $page_slug) -}}
+  {{- $versions_link = printf "%s/%s/" $group_slug $page_slug -}}
 {{- else if (eq .Layout "single") }}
-  {{- .Scratch.Set "versions_link" (printf "%s/" $page_slug) -}}
+  {{- $versions_link = printf "%s/" $page_slug -}}
 {{- end }}
 
 <li class="nav-item dropdown">
@@ -17,7 +17,7 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/{{ .Scratch.Get "versions_link" }}">
+      <a class="dropdown-item current" aria-current="true" href="/docs/{{ .Site.Params.docs_version }}/{{ $versions_link }}">
         Latest ({{ .Site.Params.docs_version }}.x)
       </a>
     </li>
@@ -25,14 +25,14 @@
       {{- if (eq .Page.Params.added "5.2") }}
         <div class="dropdown-item disabled">v5.1.3</div>
       {{- else }}
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ .Scratch.Get "versions_link" }}">v5.1.3</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ $versions_link }}">v5.1.3</a>
       {{- end }}
     </li>
     <li>
       {{- if or (eq .Page.Params.added "5.1") (eq .Page.Params.added "5.2") }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ .Scratch.Get "versions_link" }}">v5.0.2</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ $versions_link }}">v5.0.2</a>
       {{- end }}
     </li>
     <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
We should automate the template to find the latest 5.1, 5.0 etc releases instead of hardcoding them later. If someone has time feel free to make a PR.