### PR TITLE
Fix StackBlitz examples by embedding snippets.js when needed

### DIFF
--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -17,21 +17,27 @@
 (() => {
   'use strict'
 
+  // --------
   // Tooltips
+  // --------
   // Instanciate all tooltips in a page
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
       new bootstrap.Tooltip(tooltip)
     })
 
+  // --------
   // Popovers
+  // --------
   // Instanciate all popovers in a page
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
       new bootstrap.Popover(popover)
     })
 
+  // -------------------------------
   // Toasts
+  // -------------------------------
   // Used by 'Placement' docs example
   const toastPlacement = document.getElementById('toastPlacement')
   if (toastPlacement) {
@@ -44,6 +50,8 @@
     })
   }
 
+  // Instanciate all toasts in a page
+  // Not useful in StackBlitz examples
   document.querySelectorAll('.bd-example .toast')
     .forEach(toastNode => {
       const toast = new bootstrap.Toast(toastNode, {
@@ -53,6 +61,8 @@
       toast.show()
     })
 
+  // Used in 'Show live toast' docs example
+  // Not useful in StackBlitz examples
   const toastTrigger = document.getElementById('liveToastBtn')
   const toastLiveExample = document.getElementById('liveToast')
   if (toastTrigger) {
@@ -63,6 +73,9 @@
     })
   }
 
+  // -------------------------------
+  // Alerts
+  // -------------------------------
   const alertPlaceholder = document.getElementById('liveAlertPlaceholder')
   const alertTrigger = document.getElementById('liveAlertBtn')
 
@@ -84,12 +97,18 @@
     })
   }
 
+  // -------------------------------
+  // Checkboxes
+  // -------------------------------
   // Indeterminate checkbox example
   document.querySelectorAll('.bd-example-indeterminate [type="checkbox"]')
     .forEach(checkbox => {
       checkbox.indeterminate = true
     })
 
+  // -------------------------------
+  // Links
+  // -------------------------------
   // Disable empty links in docs examples
   document.querySelectorAll('.bd-content [href="#"]')
     .forEach(link => {
@@ -98,6 +117,9 @@
       })
     })
 
+  // -------------------------------
+  // Modal
+  // -------------------------------
   // Modal relatedTarget demo
   const exampleModal = document.getElementById('exampleModal')
   if (exampleModal) {
@@ -116,6 +138,9 @@
     })
   }
 
+  // -------------------------------
+  // Offcanvas
+  // -------------------------------
   // Offcanvas demo
   const myOffcanvas = document.querySelector('.bd-example-offcanvas #offcanvas')
   if (myOffcanvas) {

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -97,9 +97,9 @@
   }
 
   // -------------------------------
-  // Checkboxes
+  // Checks & Radios
   // -------------------------------
-  // Indeterminate checkbox example
+  // Indeterminate checkbox example in docs and StackBlitz
   document.querySelectorAll('.bd-example-indeterminate [type="checkbox"]')
     .forEach(checkbox => {
       checkbox.indeterminate = true
@@ -108,7 +108,7 @@
   // -------------------------------
   // Links
   // -------------------------------
-  // Disable empty links in docs examples
+  // Disable empty links in docs examples only
   document.querySelectorAll('.bd-content [href="#"]')
     .forEach(link => {
       link.addEventListener('click', event => {

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -119,7 +119,7 @@
   // -------------------------------
   // Modal
   // -------------------------------
-  // Modal relatedTarget demo
+  // Modal 'Varying modal content' example in docs and StackBlitz
   const exampleModal = document.getElementById('exampleModal')
   if (exampleModal) {
     exampleModal.addEventListener('show.bs.modal', event => {

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -20,7 +20,7 @@
   // --------
   // Tooltips
   // --------
-  // Instanciate all tooltips in a page
+  // Instanciate all tooltips in a docs or StackBlitz page
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
       new bootstrap.Tooltip(tooltip)
@@ -29,7 +29,7 @@
   // --------
   // Popovers
   // --------
-  // Instanciate all popovers in a page
+  // Instanciate all popovers in a docs or StackBlitz page
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
       new bootstrap.Popover(popover)
@@ -38,7 +38,7 @@
   // -------------------------------
   // Toasts
   // -------------------------------
-  // Used by 'Placement' docs example
+  // Used by 'Placement' example in docs or StackBlitz
   const toastPlacement = document.getElementById('toastPlacement')
   if (toastPlacement) {
     document.getElementById('selectToastPlacement').addEventListener('change', function () {
@@ -50,8 +50,7 @@
     })
   }
 
-  // Instanciate all toasts in a page
-  // Not useful in StackBlitz examples
+  // Instanciate all toasts in a docs page only
   document.querySelectorAll('.bd-example .toast')
     .forEach(toastNode => {
       const toast = new bootstrap.Toast(toastNode, {
@@ -61,8 +60,7 @@
       toast.show()
     })
 
-  // Used in 'Show live toast' docs example
-  // Not useful in StackBlitz examples
+  // Instanciate all toasts in a docs page only
   const toastTrigger = document.getElementById('liveToastBtn')
   const toastLiveExample = document.getElementById('liveToast')
   if (toastTrigger) {
@@ -76,6 +74,7 @@
   // -------------------------------
   // Alerts
   // -------------------------------
+  // Used in 'Show live toast' example in docs or StackBlitz
   const alertPlaceholder = document.getElementById('liveAlertPlaceholder')
   const alertTrigger = document.getElementById('liveAlertBtn')
 

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -140,7 +140,7 @@
   // -------------------------------
   // Offcanvas
   // -------------------------------
-  // Offcanvas demo
+  // 'Offcanvas components' example in docs only
   const myOffcanvas = document.querySelector('.bd-example-offcanvas #offcanvas')
   if (myOffcanvas) {
     myOffcanvas.addEventListener('show.bs.offcanvas', event => {

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -1,5 +1,7 @@
-// NOTICE!! DO NOT USE ANY OF THIS JAVASCRIPT
-// IT'S ALL JUST JUNK FOR OUR DOCS!
+// NOTICE!!! Initially embedded in our docs this JavaScript
+// file contains elements that can help you create reproducible
+// use cases in StackBlitz for instance.
+// In a real project please adapt this content to your needs.
 // ++++++++++++++++++++++++++++++++++++++++++
 
 /*!
@@ -15,13 +17,15 @@
 (() => {
   'use strict'
 
-  // Tooltip and popover demos
-  // Tooltip and popover demos
+  // Tooltips
+  // Instanciate all tooltips in a page
   document.querySelectorAll('[data-bs-toggle="tooltip"]')
     .forEach(tooltip => {
       new bootstrap.Tooltip(tooltip)
     })
 
+  // Popovers
+  // Instanciate all popovers in a page
   document.querySelectorAll('[data-bs-toggle="popover"]')
     .forEach(popover => {
       new bootstrap.Popover(popover)

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -31,6 +31,8 @@
       new bootstrap.Popover(popover)
     })
 
+  // Toasts
+  // Used by 'Placement' docs example
   const toastPlacement = document.getElementById('toastPlacement')
   if (toastPlacement) {
     document.getElementById('selectToastPlacement').addEventListener('change', function () {

--- a/site/content/docs/5.2/components/alerts.md
+++ b/site/content/docs/5.2/components/alerts.md
@@ -27,7 +27,7 @@ Alerts are available for any length of text, as well as an optional close button
 
 Click the button below to show an alert (hidden with inline styles to start), then dismiss (and destroy) it with the built-in close button.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <div id="liveAlertPlaceholder"></div>
 <button type="button" class="btn btn-primary" id="liveAlertBtn">Show live alert</button>
 {{< /example >}}

--- a/site/content/docs/5.2/components/modal.md
+++ b/site/content/docs/5.2/components/modal.md
@@ -444,7 +444,7 @@ Have a bunch of buttons that all trigger the same modal with slightly different 
 
 Below is a live demo followed by example HTML and JavaScript. For more information, [read the modal events docs](#events) for details on `relatedTarget`.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" data-bs-whatever="@mdo">Open modal for @mdo</button>
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" data-bs-whatever="@fat">Open modal for @fat</button>
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal" data-bs-whatever="@getbootstrap">Open modal for @getbootstrap</button>

--- a/site/content/docs/5.2/components/popovers.md
+++ b/site/content/docs/5.2/components/popovers.md
@@ -46,7 +46,7 @@ const popoverList = [...popoverTriggerList].map(popoverTriggerEl => new bootstra
 
 We use JavaScript similar to the snippet above to render the following live popover. Titles are set via `title` attribute and body content is set via `data-bs-content`.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 {{< /example >}}
 

--- a/site/content/docs/5.2/components/popovers.md
+++ b/site/content/docs/5.2/components/popovers.md
@@ -54,7 +54,7 @@ We use JavaScript similar to the snippet above to render the following live popo
 
 Four options are available: top, right, bottom, and left. Directions are mirrored when using Bootstrap in RTL. Set `data-bs-placement` to change the direction.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <button type="button" class="btn btn-secondary" data-bs-container="body" data-bs-toggle="popover" data-bs-placement="top" data-bs-content="Top popover">
   Popover on top
 </button>
@@ -87,7 +87,7 @@ You can customize the appearance of popovers using [CSS variables](#variables). 
 
 {{< scss-docs name="custom-popovers" file="site/assets/scss/_component-examples.scss" >}}
 
-{{< example class="custom-popover-demo" >}}
+{{< example class="custom-popover-demo" js_snippet="true" >}}
 <button type="button" class="btn btn-secondary"
         data-bs-toggle="popover" data-bs-placement="right"
         data-bs-custom-class="custom-popover"
@@ -107,7 +107,7 @@ Use the `focus` trigger to dismiss popovers on the user's next click of a differ
 For proper cross-browser and cross-platform behavior, you must use the `<a>` tag, _not_ the `<button>` tag, and you also must include a [`tabindex`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 {{< /callout >}}
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <a tabindex="0" class="btn btn-lg btn-danger" role="button" data-bs-toggle="popover" data-bs-trigger="focus" title="Dismissible popover" data-bs-content="And here's some amazing content. It's very engaging. Right?">Dismissible popover</a>
 {{< /example >}}
 
@@ -123,7 +123,7 @@ Elements with the `disabled` attribute aren't interactive, meaning users cannot 
 
 For disabled popover triggers, you may also prefer `data-bs-trigger="hover focus"` so that the popover appears as immediate visual feedback to your users as they may not expect to _click_ on a disabled element.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <span class="d-inline-block" tabindex="0" data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-content="Disabled popover">
   <button class="btn btn-primary" type="button" disabled>Disabled button</button>
 </span>

--- a/site/content/docs/5.2/components/toasts.md
+++ b/site/content/docs/5.2/components/toasts.md
@@ -197,7 +197,7 @@ Building on the above example, you can create different toast color schemes with
 
 Place toasts with custom CSS as you need them. The top right is often used for notifications, as is the top middle. If you're only ever going to show one toast at a time, put the positioning styles right on the `.toast`.
 
-{{< example >}}
+{{< example js_snippet="true" >}}
 <form>
   <div class="mb-3">
     <label for="selectToastPlacement">Toast placement</label>

--- a/site/content/docs/5.2/components/tooltips.md
+++ b/site/content/docs/5.2/components/tooltips.md
@@ -45,7 +45,7 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
 
 Hover over the links below to see tooltips:
 
-{{< example class="tooltip-demo" >}}
+{{< example class="tooltip-demo" js_snippet="true" >}}
 <p class="muted">Placeholder text to demonstrate some <a href="#" data-bs-toggle="tooltip" title="Default tooltip">inline links</a> with tooltips. This is now just filler, no killer. Content placed here just to mimic the presence of <a href="#" data-bs-toggle="tooltip" title="Another tooltip">real text</a>. And all that just to give you an idea of how tooltips would look when used in real-world situations. So hopefully you've now seen how <a href="#" data-bs-toggle="tooltip" title="Another one here too">these tooltips on links</a> can work in practice, once you use them on <a href="#" data-bs-toggle="tooltip" title="The last tip!">your own</a> site or project.
 </p>
 {{< /example >}}
@@ -59,7 +59,7 @@ You can customize the appearance of tooltips using [CSS variables](#variables). 
 {{< scss-docs name="custom-tooltip" file="site/assets/scss/_component-examples.scss" >}}
 
 
-{{< example class="tooltip-demo" >}}
+{{< example class="tooltip-demo" js_snippet="true" >}}
 <button type="button" class="btn btn-secondary"
         data-bs-toggle="tooltip" data-bs-placement="top"
         data-bs-custom-class="custom-tooltip"

--- a/site/content/docs/5.2/forms/checks-radios.md
+++ b/site/content/docs/5.2/forms/checks-radios.md
@@ -36,7 +36,7 @@ Our checks use custom Bootstrap icons to indicate checked or indeterminate state
 
 Checkboxes can utilize the `:indeterminate` pseudo class when manually set via JavaScript (there is no available HTML attribute for specifying it).
 
-{{< example class="bd-example-indeterminate">}}
+{{< example class="bd-example-indeterminate" js_snippet="true" >}}
 <div class="form-check">
   <input class="form-check-input" type="checkbox" value="" id="flexCheckIndeterminate">
   <label class="form-check-label" for="flexCheckIndeterminate">

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -26,12 +26,19 @@
   document.querySelectorAll('.btn-edit').forEach(btn => {
     btn.addEventListener('click', event => {
       const htmlSnippet = event.target.closest('.bd-code-snippet').querySelector('.bd-example').innerHTML
+
+      // Get extra classes for this example except '.bd-example'
+      const classes = event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList
+      if (classes) {
+        classes.remove('bd-example')
+      }
+
       const jsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-js-snippet')
-      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet)
+      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet, classes)
     })
   })
 
-  StackBlitzSDK.openBootstrapSnippet = (htmlSnippet, jsSnippet) => {
+  StackBlitzSDK.openBootstrapSnippet = (htmlSnippet, jsSnippet, classes) => {
     const markup = `<!doctype html>
 <html lang="en">
   <head>
@@ -41,7 +48,7 @@
     <title>Bootstrap Example</title>
     <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
-  <body>
+  <body class="${classes}">
 
     <!-- Example Code -->
 ${htmlSnippet.replace(/^/gm, '    ')}

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -28,10 +28,7 @@
       const htmlSnippet = event.target.closest('.bd-code-snippet').querySelector('.bd-example').innerHTML
 
       // Get extra classes for this example except '.bd-example'
-      const classes = event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList
-      if (classes) {
-        classes.remove('bd-example')
-      }
+      const classes = Array.from(event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList).filter(x => x !== 'bd-example').join(' ')
 
       const jsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-js-snippet')
       StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet, classes)

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -45,7 +45,7 @@
     <title>Bootstrap Example</title>
     <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
-  <body class="${classes}">
+  <body class="p-3 ${classes}">
 
     <!-- Example Code -->
 ${htmlSnippet.replace(/^/gm, '    ')}

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -26,11 +26,12 @@
   document.querySelectorAll('.btn-edit').forEach(btn => {
     btn.addEventListener('click', event => {
       const htmlSnippet = event.target.closest('.bd-code-snippet').querySelector('.bd-example').innerHTML
-      StackBlitzSDK.openBootstrapSnippet(htmlSnippet)
+      const jsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-js-snippet')
+      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet)
     })
   })
 
-  StackBlitzSDK.openBootstrapSnippet = snippet => {
+  StackBlitzSDK.openBootstrapSnippet = (htmlSnippet, jsSnippet) => {
     const markup = `<!doctype html>
 <html lang="en">
   <head>
@@ -38,24 +39,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ .Site.Params.cdn.css }}" rel="stylesheet">
     <title>Bootstrap Example</title>
+    <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
   <body>
 
     <!-- Example Code -->
-${snippet.replace(/^/gm, '    ')}
+${htmlSnippet.replace(/^/gm, '    ')}
     <!-- End Example Code -->
-
-    <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </body>
 </html>`
 
+    const jsSnippetContent = jsSnippet ? '{{ os.ReadFile "site/assets/js/snippets.js" }}' : null
     const project = {
       files: {
-        'index.html': markup
+        'index.html': markup,
+        'index.js': jsSnippetContent
       },
       title: 'Bootstrap Example',
       description: `Official example from ${window.location.href}`,
-      template: 'html',
+      template: jsSnippet ? 'javascript' : 'html',
       tags: ['bootstrap']
     }
 

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -4,6 +4,7 @@
   `args` are all optional and can be one of the following:
     * id: the `div`'s id - default: ""
     * class: any extra class(es) to be added to the `div` - default: ""
+    * js_snippet: add extra JS snippet to StackBlitz - default: `false`
     * show_preview: if the preview should be output in the HTML - default: `true`
     * show_markup: if the markup should be output in the HTML - default: `true`
 */ -}}
@@ -13,6 +14,7 @@
 {{- $lang := .Get "lang" | default "html" -}}
 {{- $show_preview := .Get "show_preview" | default true -}}
 {{- $show_markup := .Get "show_markup" | default true -}}
+{{- $js_snippet := .Get "js_snippet" | default false -}}
 {{- $input := .Inner -}}
 
 <div class="bd-example-snippet bd-code-snippet">
@@ -27,7 +29,7 @@
       <div class="d-flex align-items-center highlight-toolbar bg-light ps-3 pe-2 py-1">
         <small class="font-monospace text-muted text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
-          <button type="button" class="btn-edit text-nowrap" title="Try it on StackBlitz">
+          <button type="button" class="btn-edit text-nowrap"{{ with $js_snippet }} data-js-snippet="{{ $js_snippet }}"{{ end }} title="Try it on StackBlitz">
             <svg class="bi" role="img" aria-label="Try it"><use xlink:href="#lightning-charge-fill"/></svg>
           </button>
           <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">


### PR DESCRIPTION
Alternate version of https://github.com/twbs/bootstrap/pull/36127
Linked to tracking PR https://github.com/twbs/bootstrap/pull/36091

This PR is an alternate version of https://github.com/twbs/bootstrap/pull/36127 based on its comments.
The philosophy here is to indicate when needed that a given example needs to embed the extra file `snippets.js` in StackBlitz:
* by default, we create an HTML StackBlitz environment without this file
* by setting `data-js-snippet="true"` we create a JS StackBlitz environment with this file

In order for the user to understand the logic here (that all the JS file content is not needed) IMO `snippets.js` should be heavily commented and crystal clear)

At the moment this PR only show the architecture changes. We already know that the popover example should be at the end hidden.

Extra things modified:
- Gather other classes used in combination with `.bd-example`

Thoughts?

### Remaining tasks

- [x] Add comments in `snippets.js`
- [x] Use `data-js-snippet="true"` everywhere in the docs when needed (see https://github.com/twbs/bootstrap/pull/36091 to have the list)

### Tasks for other PRs
- In another PR handle the edge cases for tooltips and popovers examples that won't work anyway because of the `title` removed by JS in the DOM. They must be hidden.
- In another PR handle the CSS/SCSS reusable code needed by the examples.

### Live previews

#### Alerts

- [Live example](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/alerts/#live-example)

#### Checks & Radios

- [Indeterminate](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/forms/checks-radios/#indeterminate)

#### Modal

- [Varying modal content](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/modal/#varying-modal-content)

#### Popovers

- [Live Demo](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#live-demo): should be hidden in a next PR because `title` won't work as it is removed automatically by JS
- [Four directions](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#four-directions)
- [Custom popovers](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#custom-popovers): popover is triggered but the custom style should be handle in another PR.
- [Dismiss on next click](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#dismiss-on-next-click)
- [Disabled elements](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#disabled-elements)

#### Toasts

- [Placement](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/toasts/#placement): toasts are moving but will need corresponding CSS in the future

#### Tooltips

- [Tooltips on links](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/#tooltips-on-links): should be hidden in a next PR because `title` won't work as it is removed automatically by JS.
- [Custom tooltips](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/#custom-tooltips): should be hidden in a next PR because `title` won't work as it is removed automatically by JS.

#### Non-regression example (just `html`)
- [Accordion](https://deploy-preview-36352--twbs-bootstrap.netlify.app/docs/5.2/components/accordion/#example): `snippets.js` is not embedded in StackBlitz; there's no `index.js` created since no extra JS is needed.