### PR TITLE
Fix offcanvas not showing with `.showing`

### DIFF
--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -43,17 +43,6 @@
       @include box-shadow(var(--#{$prefix}offcanvas-box-shadow));
       @include transition(transform $offcanvas-transition-duration ease-in-out);
 
-      &.showing,
-      &.show:not(.hiding) {
-        transform: none;
-      }
-
-      &.showing,
-      &.hiding,
-      &.show {
-        visibility: visible;
-      }
-
       &.offcanvas-start {
         top: 0;
         left: 0;
@@ -87,6 +76,17 @@
         max-height: 100%;
         border-top: var(--#{$prefix}offcanvas-border-width) solid var(--#{$prefix}offcanvas-border-color);
         transform: translateY(100%);
+      }
+
+      &.showing,
+      &.show:not(.hiding) {
+        transform: none;
+      }
+
+      &.showing,
+      &.hiding,
+      &.show {
+        visibility: visible;
       }
     }
 


### PR DESCRIPTION
The `transform` of `.showing` was being overridden by `.offcanvas.offcanvas-start`, while `.show` wasn't. This resulted in an illusion of the offcanvas waiting for the backdrop, reported in #36347. Moving the show classes below the position classes fixes this problem.

Fixes #36347 