### PR TITLE
Add options to not automatically generate component variants

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -56,16 +56,18 @@
 // scss-docs-start alert-modifiers
 // Generate contextual modifier classes for colorizing the alert.
 
-@each $state, $value in $theme-colors {
-  $alert-background: shift-color($value, $alert-bg-scale);
-  $alert-border: shift-color($value, $alert-border-scale);
-  $alert-color: shift-color($value, $alert-color-scale);
+@if ($enable-alert-variants) {
+  @each $state, $value in $theme-colors {
+    $alert-background: shift-color($value, $alert-bg-scale);
+    $alert-border: shift-color($value, $alert-border-scale);
+    $alert-color: shift-color($value, $alert-color-scale);
 
-  @if (contrast-ratio($alert-background, $alert-color) < $min-contrast-ratio) {
-    $alert-color: mix($value, color-contrast($alert-background), abs($alert-color-scale));
-  }
-  .alert-#{$state} {
-    @include alert-variant($alert-background, $alert-border, $alert-color);
+    @if (contrast-ratio($alert-background, $alert-color) < $min-contrast-ratio) {
+      $alert-color: mix($value, color-contrast($alert-background), abs($alert-color-scale));
+    }
+    .alert-#{$state} {
+      @include alert-variant($alert-background, $alert-border, $alert-color);
+    }
   }
 }
 // scss-docs-end alert-modifiers

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -101,35 +101,39 @@
 //
 
 // scss-docs-start btn-variant-loops
-@each $color, $value in $theme-colors {
-  .btn-#{$color} {
-    @if $color == "light" {
-      @include button-variant(
-        $value,
-        $value,
-        $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
-        $hover-border: shade-color($value, $btn-hover-border-shade-amount),
-        $active-background: shade-color($value, $btn-active-bg-shade-amount),
-        $active-border: shade-color($value, $btn-active-border-shade-amount)
-      );
-    } @else if $color == "dark" {
-      @include button-variant(
-        $value,
-        $value,
-        $hover-background: tint-color($value, $btn-hover-bg-tint-amount),
-        $hover-border: tint-color($value, $btn-hover-border-tint-amount),
-        $active-background: tint-color($value, $btn-active-bg-tint-amount),
-        $active-border: tint-color($value, $btn-active-border-tint-amount)
-      );
-    } @else {
-      @include button-variant($value, $value);
+@if ($enable-button-variants) {
+  @each $color, $value in $theme-colors {
+    .btn-#{$color} {
+      @if $color == "light" {
+        @include button-variant(
+          $value,
+          $value,
+          $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
+          $hover-border: shade-color($value, $btn-hover-border-shade-amount),
+          $active-background: shade-color($value, $btn-active-bg-shade-amount),
+          $active-border: shade-color($value, $btn-active-border-shade-amount)
+        );
+      } @else if $color == "dark" {
+        @include button-variant(
+          $value,
+          $value,
+          $hover-background: tint-color($value, $btn-hover-bg-tint-amount),
+          $hover-border: tint-color($value, $btn-hover-border-tint-amount),
+          $active-background: tint-color($value, $btn-active-bg-tint-amount),
+          $active-border: tint-color($value, $btn-active-border-tint-amount)
+        );
+      } @else {
+        @include button-variant($value, $value);
+      }
     }
   }
 }
 
-@each $color, $value in $theme-colors {
-  .btn-outline-#{$color} {
-    @include button-outline-variant($value);
+@if ($enable-button-outline-variants) {
+  @each $color, $value in $theme-colors {
+    .btn-outline-#{$color} {
+      @include button-outline-variant($value);
+    }
   }
 }
 // scss-docs-end btn-variant-loops

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -143,8 +143,10 @@
 // Table variants set the table cell backgrounds, border colors
 // and the colors of the striped, hovered & active tables
 
-@each $color, $value in $table-variants {
-  @include table-variant($color, $value);
+@if ($enable-table-variants) {
+  @each $color, $value in $table-variants {
+    @include table-variant($color, $value);
+  }
 }
 
 // Responsive tables

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -351,6 +351,11 @@ $enable-negative-margins:     false !default;
 $enable-deprecation-messages: true !default;
 $enable-important-utilities:  true !default;
 
+$enable-alert-variants:           true !default;
+$enable-button-variants:          true !default;
+$enable-button-outline-variants:  true !default;
+$enable-table-variants:           true !default;
+
 // Prefix for :root CSS variables
 
 $variable-prefix:             bs- !default; // Deprecated in v5.2.0 for the shorter `$prefix`


### PR DESCRIPTION
I was wanting to customise alerts (specifically, removing the border by making it transparent), but I don't want to copy and paste the base (`.alert`) component out of the imported file (and also `.alert-heading`, `.alert-link`, and `.alert-dismissible`). 

Currently if you import the component file there is no way to _not have the component variants added too_, and these cannot be customised to the same extent as through direct use of the mixins.

This PR adds the option to enable or disable variants through sass option variables, so you could import alerts but set `$enable-alert-variants` to false to only get the base classes. Then you can import your own file using the mixins directly for custom variants.

For consistency, I have added options for:

- Alerts
- Buttons
- Buttons outlines
- Tables

But there may be more that I've missed?

If you're happy with the changes I will add documentation in the options (or component?) page.