### PR TITLE
add back focus box shadow to `btn-link`

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -133,6 +133,7 @@
   --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
   --#{$prefix}btn-disabled-border-color: transparent;
   --#{$prefix}btn-box-shadow: none;
+  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb(mix(color-contrast($primary), $primary, 15%))};
 
   text-decoration: $link-decoration;
 


### PR DESCRIPTION
5.2.0-beta1 looks to have accidentally dropped the box shadow around `btn-link` buttons on focus. You can see this by tab navigating to a `btn-link` on both 5.1.x and 5.2.0-beta1 and comparing 

- [5.2 beta button example](https://getbootstrap.com/docs/5.2/components/buttons/#examples)
- [5.1 button example](https://getbootstrap.com/docs/5.1/components/buttons/#examples)

This is because the `--#{$prefix}btn-focus-shadow-rgb` variable is undefined in the context of `btn-link`. My solution here does involve code duplication from the `button-variant()` mixin - I'm certainly open to other solutions, however this illustrates the problem and a potential solution.

Preview link: [https://deploy-preview-36366--twbs-bootstrap.netlify.app/docs/5.2/components/buttons/#examples](https://deploy-preview-36366--twbs-bootstrap.netlify.app/docs/5.2/components/buttons/#examples)