### PR TITLE
Fix missing Swag Store URL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,6 +65,7 @@ params:
   blog:                 "https://blog.getbootstrap.com/"
   themes:               "https://themes.getbootstrap.com/"
   icons:                "https://icons.getbootstrap.com/"
+  swag:                 "https://cottonbureau.com/people/bootstrap"
 
   download:
     source:             "https://github.com/twbs/bootstrap/archive/v5.2.0-beta1.zip"


### PR DESCRIPTION
Fixes #36370 

Gave it a try with the URL I've found on Twitter.
Feel free to close this PR if the URL is not the good one :)

### [LIve preview](https://deploy-preview-36376--twbs-bootstrap.netlify.app/)

/CC @mdo 