### PR TITLE
JS: tests fixes & standardization of spies usage 

### DIFF
--- a/js/tests/unit/alert.spec.js
+++ b/js/tests/unit/alert.spec.js
@@ -148,14 +148,14 @@ describe('Alert', () => {
       const alertEl = fixtureEl.querySelector('.alert')
       const alert = new Alert(alertEl)
 
-      spyOn(alert, 'close')
+      const spy = spyOn(alert, 'close')
 
       jQueryMock.fn.alert = Alert.jQueryInterface
       jQueryMock.elements = [alertEl]
 
       jQueryMock.fn.alert.call(jQueryMock, 'close')
 
-      expect(alert.close).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should create new alert instance and call close', () => {

--- a/js/tests/unit/base-component.spec.js
+++ b/js/tests/unit/base-component.spec.js
@@ -108,11 +108,11 @@ describe('Base Component', () => {
 
       it('should de-register element event listeners', () => {
         createInstance()
-        spyOn(EventHandler, 'off')
+        const spy = spyOn(EventHandler, 'off')
 
         instance.dispose()
 
-        expect(EventHandler.off).toHaveBeenCalledWith(element, DummyClass.EVENT_KEY)
+        expect(spy).toHaveBeenCalledWith(element, DummyClass.EVENT_KEY)
       })
     })
 

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -100,14 +100,14 @@ describe('Button', () => {
       const btnEl = fixtureEl.querySelector('.btn')
       const button = new Button(btnEl)
 
-      spyOn(button, 'toggle')
+      const spy = spyOn(button, 'toggle')
 
       jQueryMock.fn.button = Button.jQueryInterface
       jQueryMock.elements = [btnEl]
 
       jQueryMock.fn.button.call(jQueryMock, 'toggle')
 
-      expect(button.toggle).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should create new button instance and call toggle', () => {

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -94,11 +94,11 @@ describe('Carousel', () => {
           keyboard: true
         })
 
-        spyOn(carousel, '_keydown').and.callThrough()
+        const spy = spyOn(carousel, '_keydown').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', () => {
           expect(fixtureEl.querySelector('.active')).toEqual(fixtureEl.querySelector('#item2'))
-          expect(carousel._keydown).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -119,11 +119,11 @@ describe('Carousel', () => {
         '</div>'
       ].join('')
 
-      spyOn(EventHandler, 'trigger').and.callThrough()
+      const spy = spyOn(EventHandler, 'trigger').and.callThrough()
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       // eslint-disable-next-line no-new
       new Carousel('#myCarousel')
-      expect(EventHandler.trigger).not.toHaveBeenCalledWith(carouselEl, 'keydown.bs.carousel', jasmine.any(Function))
+      expect(spy).not.toHaveBeenCalledWith(carouselEl, 'keydown.bs.carousel', jasmine.any(Function))
     })
 
     it('should ignore mouse events if data-bs-pause=false', () => {
@@ -136,11 +136,11 @@ describe('Carousel', () => {
         '</div>'
       ].join('')
 
-      spyOn(EventHandler, 'trigger').and.callThrough()
+      const spy = spyOn(EventHandler, 'trigger').and.callThrough()
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       // eslint-disable-next-line no-new
       new Carousel('#myCarousel')
-      expect(EventHandler.trigger).not.toHaveBeenCalledWith(carouselEl, 'hover.bs.carousel', jasmine.any(Function))
+      expect(spy).not.toHaveBeenCalledWith(carouselEl, 'hover.bs.carousel', jasmine.any(Function))
     })
 
     it('should go to previous item if left arrow key is pressed', () => {
@@ -160,11 +160,11 @@ describe('Carousel', () => {
           keyboard: true
         })
 
-        spyOn(carousel, '_keydown').and.callThrough()
+        const spy = spyOn(carousel, '_keydown').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', () => {
           expect(fixtureEl.querySelector('.active')).toEqual(fixtureEl.querySelector('#item1'))
-          expect(carousel._keydown).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -192,10 +192,10 @@ describe('Carousel', () => {
           keyboard: true
         })
 
-        spyOn(carousel, '_keydown').and.callThrough()
+        const spy = spyOn(carousel, '_keydown').and.callThrough()
 
         carouselEl.addEventListener('keydown', event => {
-          expect(carousel._keydown).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           expect(event.defaultPrevented).toBeFalse()
           resolve()
         })
@@ -262,7 +262,7 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       carousel._isSliding = true
 
@@ -273,7 +273,7 @@ describe('Carousel', () => {
         carouselEl.dispatchEvent(keydown)
       }
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should wrap around from end to start when wrap option is true', () => {
@@ -351,13 +351,13 @@ describe('Carousel', () => {
 
       const carouselEl = fixtureEl.querySelector('div')
 
-      spyOn(Carousel.prototype, '_addTouchEventListeners')
+      const spy = spyOn(Carousel.prototype, '_addTouchEventListeners')
 
       const carousel = new Carousel(carouselEl, {
         touch: false
       })
 
-      expect(carousel._addTouchEventListeners).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
       expect(carousel._swipeHelper).toBeNull()
     })
 
@@ -370,11 +370,11 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl)
       EventHandler.off(carouselEl, Carousel.EVENT_KEY)
 
-      spyOn(carousel, '_addTouchEventListeners')
+      const spy = spyOn(carousel, '_addTouchEventListeners')
 
       carousel._addEventListeners()
 
-      expect(carousel._addTouchEventListeners).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
       expect(carousel._swipeHelper).toBeNull()
     })
 
@@ -422,11 +422,11 @@ describe('Carousel', () => {
         const item = fixtureEl.querySelector('#item')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, '_slide').and.callThrough()
+        const spy = spyOn(carousel, '_slide').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', event => {
           expect(item).toHaveClass('active')
-          expect(carousel._slide).toHaveBeenCalledWith('prev')
+          expect(spy).toHaveBeenCalledWith('prev')
           expect(event.direction).toEqual('right')
           stylesCarousel.remove()
           delete document.documentElement.ontouchstart
@@ -469,11 +469,11 @@ describe('Carousel', () => {
         const item = fixtureEl.querySelector('#item')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, '_slide').and.callThrough()
+        const spy = spyOn(carousel, '_slide').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', event => {
           expect(item).not.toHaveClass('active')
-          expect(carousel._slide).toHaveBeenCalledWith('next')
+          expect(spy).toHaveBeenCalledWith('next')
           expect(event.direction).toEqual('left')
           stylesCarousel.remove()
           delete document.documentElement.ontouchstart
@@ -511,11 +511,11 @@ describe('Carousel', () => {
         const item = fixtureEl.querySelector('#item')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, '_slide').and.callThrough()
+        const spy = spyOn(carousel, '_slide').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', event => {
           expect(item).toHaveClass('active')
-          expect(carousel._slide).toHaveBeenCalledWith('prev')
+          expect(spy).toHaveBeenCalledWith('prev')
           expect(event.direction).toEqual('right')
           delete document.documentElement.ontouchstart
           restorePointerEvents()
@@ -552,11 +552,11 @@ describe('Carousel', () => {
         const item = fixtureEl.querySelector('#item')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, '_slide').and.callThrough()
+        const spy = spyOn(carousel, '_slide').and.callThrough()
 
         carouselEl.addEventListener('slid.bs.carousel', event => {
           expect(item).not.toHaveClass('active')
-          expect(carousel._slide).toHaveBeenCalledWith('next')
+          expect(spy).toHaveBeenCalledWith('next')
           expect(event.direction).toEqual('left')
           delete document.documentElement.ontouchstart
           restorePointerEvents()
@@ -594,7 +594,7 @@ describe('Carousel', () => {
         const carousel = new Carousel(carouselEl)
         carousel._isSliding = true
 
-        spyOn(EventHandler, 'trigger')
+        const spy = spyOn(EventHandler, 'trigger')
 
         Simulator.gestures.swipe(carouselEl, {
           deltaX: 300,
@@ -608,7 +608,7 @@ describe('Carousel', () => {
         })
 
         setTimeout(() => {
-          expect(EventHandler.trigger).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           delete document.documentElement.ontouchstart
           restorePointerEvents()
           resolve()
@@ -648,13 +648,13 @@ describe('Carousel', () => {
         const carouselEl = fixtureEl.querySelector('.carousel')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, 'pause')
+        const spy = spyOn(carousel, 'pause')
 
         const mouseOverEvent = createEvent('mouseover')
         carouselEl.dispatchEvent(mouseOverEvent)
 
         setTimeout(() => {
-          expect(carousel.pause).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         }, 10)
       })
@@ -667,15 +667,15 @@ describe('Carousel', () => {
         const carouselEl = fixtureEl.querySelector('.carousel')
         const carousel = new Carousel(carouselEl)
 
-        spyOn(carousel, '_maybeEnableCycle').and.callThrough()
-        spyOn(carousel, 'cycle')
+        const spyEnable = spyOn(carousel, '_maybeEnableCycle').and.callThrough()
+        const spyCycle = spyOn(carousel, 'cycle')
 
         const mouseOutEvent = createEvent('mouseout')
         carouselEl.dispatchEvent(mouseOutEvent)
 
         setTimeout(() => {
-          expect(carousel._maybeEnableCycle).toHaveBeenCalled()
-          expect(carousel.cycle).toHaveBeenCalled()
+          expect(spyEnable).toHaveBeenCalled()
+          expect(spyCycle).toHaveBeenCalled()
           resolve()
         }, 10)
       })
@@ -689,12 +689,12 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       carousel._isSliding = true
       carousel.next()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should not fire slid when slide is prevented', () => {
@@ -831,14 +831,14 @@ describe('Carousel', () => {
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       const carousel = new Carousel(carouselEl)
-      spyOn(carousel, 'cycle')
+      const spy = spyOn(carousel, 'cycle')
 
       carousel.next()
-      expect(carousel.cycle).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
 
       carousel.cycle()
       carousel.next()
-      expect(carousel.cycle).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledTimes(1)
     })
 
     it('should update indicators if present', () => {
@@ -895,14 +895,14 @@ describe('Carousel', () => {
       const carousel = new Carousel(carouselEl)
       const nextSpy = spyOn(carousel, 'next')
       const prevSpy = spyOn(carousel, 'prev')
-      spyOn(carousel, '_maybeEnableCycle')
+      const spyEnable = spyOn(carousel, '_maybeEnableCycle')
 
       nextBtnEl.click()
       prevBtnEl.click()
 
       expect(nextSpy).toHaveBeenCalled()
       expect(prevSpy).toHaveBeenCalled()
-      expect(carousel._maybeEnableCycle).toHaveBeenCalled()
+      expect(spyEnable).toHaveBeenCalled()
     })
   })
 
@@ -917,11 +917,11 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('.carousel')
       const carousel = new Carousel(carouselEl)
 
-      spyOn(carousel, 'next')
+      const spy = spyOn(carousel, 'next')
 
       carousel.nextWhenVisible()
 
-      expect(carousel.next).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 
@@ -932,12 +932,12 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('div')
       const carousel = new Carousel(carouselEl, {})
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       carousel._isSliding = true
       carousel.prev()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 
@@ -958,13 +958,13 @@ describe('Carousel', () => {
 
         const carouselEl = fixtureEl.querySelector('#myCarousel')
         const carousel = new Carousel(carouselEl)
+        const spy = spyOn(carousel, '_clearInterval')
 
         carouselEl.addEventListener('transitionend', () => {
-          expect(carousel._clearInterval).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
-        spyOn(carousel, '_clearInterval')
         carousel._slide('next')
         carousel.pause()
       })
@@ -988,11 +988,11 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       const carousel = new Carousel(carouselEl)
 
-      spyOn(window, 'setInterval').and.callThrough()
+      const spy = spyOn(window, 'setInterval').and.callThrough()
 
       carousel.cycle()
 
-      expect(window.setInterval).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should clear interval if there is one', () => {
@@ -1013,13 +1013,13 @@ describe('Carousel', () => {
 
       carousel._interval = setInterval(noop, 10)
 
-      spyOn(window, 'setInterval').and.callThrough()
-      spyOn(window, 'clearInterval').and.callThrough()
+      const spySet = spyOn(window, 'setInterval').and.callThrough()
+      const spyClear = spyOn(window, 'clearInterval').and.callThrough()
 
       carousel.cycle()
 
-      expect(window.setInterval).toHaveBeenCalled()
-      expect(window.clearInterval).toHaveBeenCalled()
+      expect(spySet).toHaveBeenCalled()
+      expect(spyClear).toHaveBeenCalled()
     })
 
     it('should get interval from data attribute on the active item element', () => {
@@ -1146,13 +1146,11 @@ describe('Carousel', () => {
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       const carousel = new Carousel(carouselEl, {})
 
-      spyOn(carousel, '_slide')
-      spyOn(carousel, 'pause')
-      spyOn(carousel, 'cycle')
+      const spy = spyOn(carousel, '_slide')
 
       carousel.to(0)
 
-      expect(carousel._slide).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should wait before performing to if a slide is sliding', () => {
@@ -1170,21 +1168,21 @@ describe('Carousel', () => {
         const carouselEl = fixtureEl.querySelector('#myCarousel')
         const carousel = new Carousel(carouselEl, {})
 
-        spyOn(EventHandler, 'one').and.callThrough()
-        spyOn(carousel, '_slide')
+        const spyOne = spyOn(EventHandler, 'one').and.callThrough()
+        const spySlide = spyOn(carousel, '_slide')
 
         carousel._isSliding = true
         carousel.to(1)
 
-        expect(carousel._slide).not.toHaveBeenCalled()
-        expect(EventHandler.one).toHaveBeenCalled()
+        expect(spySlide).not.toHaveBeenCalled()
+        expect(spyOne).toHaveBeenCalled()
 
-        spyOn(carousel, 'to')
+        const spyTo = spyOn(carousel, 'to')
 
         EventHandler.trigger(carouselEl, 'slid.bs.carousel')
 
         setTimeout(() => {
-          expect(carousel.to).toHaveBeenCalledWith(1)
+          expect(spyTo).toHaveBeenCalledWith(1)
           resolve()
         })
       })
@@ -1414,14 +1412,14 @@ describe('Carousel', () => {
       const carousel = new Carousel(div)
       const slideTo = 2
 
-      spyOn(carousel, 'to')
+      const spy = spyOn(carousel, 'to')
 
       jQueryMock.fn.carousel = Carousel.jQueryInterface
       jQueryMock.elements = [div]
 
       jQueryMock.fn.carousel.call(jQueryMock, slideTo)
 
-      expect(carousel.to).toHaveBeenCalledWith(slideTo)
+      expect(spy).toHaveBeenCalledWith(slideTo)
     })
 
     it('should throw error on undefined method', () => {

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -660,7 +660,7 @@ describe('Carousel', () => {
       })
     })
 
-    it('should call `maybeCycle` on mouse out with pause equal to hover', () => {
+    it('should call `maybeEnableCycle` on mouse out with pause equal to hover', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="carousel" data-bs-ride="true"></div>'
 

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -838,7 +838,7 @@ describe('Carousel', () => {
 
       carousel.cycle()
       carousel.next()
-      expect(carousel.cycle).toHaveBeenCalled()
+      expect(carousel.cycle).toHaveBeenCalledTimes(1)
     })
 
     it('should update indicators if present', () => {

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -112,11 +112,11 @@ describe('Collapse', () => {
       const collapseEl = fixtureEl.querySelector('div')
       const collapse = new Collapse(collapseEl)
 
-      spyOn(collapse, 'show')
+      const spy = spyOn(collapse, 'show')
 
       collapse.toggle()
 
-      expect(collapse.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should call hide method if show class is present', () => {
@@ -127,11 +127,11 @@ describe('Collapse', () => {
         toggle: false
       })
 
-      spyOn(collapse, 'hide')
+      const spy = spyOn(collapse, 'hide')
 
       collapse.toggle()
 
-      expect(collapse.hide).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should find collapse children if they have collapse class too not only data-bs-parent', () => {
@@ -174,7 +174,7 @@ describe('Collapse', () => {
     it('should do nothing if is transitioning', () => {
       fixtureEl.innerHTML = '<div></div>'
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
       const collapse = new Collapse(collapseEl, {
@@ -184,13 +184,13 @@ describe('Collapse', () => {
       collapse._isTransitioning = true
       collapse.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should do nothing if already shown', () => {
       fixtureEl.innerHTML = '<div class="show"></div>'
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
       const collapse = new Collapse(collapseEl, {
@@ -199,7 +199,7 @@ describe('Collapse', () => {
 
       collapse.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should show a collapsed element', () => {
@@ -418,7 +418,7 @@ describe('Collapse', () => {
     it('should do nothing if is transitioning', () => {
       fixtureEl.innerHTML = '<div></div>'
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
       const collapse = new Collapse(collapseEl, {
@@ -428,13 +428,13 @@ describe('Collapse', () => {
       collapse._isTransitioning = true
       collapse.hide()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should do nothing if already shown', () => {
       fixtureEl.innerHTML = '<div></div>'
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
       const collapse = new Collapse(collapseEl, {
@@ -443,7 +443,7 @@ describe('Collapse', () => {
 
       collapse.hide()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should hide a collapsed element', () => {
@@ -525,12 +525,12 @@ describe('Collapse', () => {
         const triggerEl = fixtureEl.querySelector('a')
         const nestedTriggerEl = fixtureEl.querySelector('#nested')
 
-        spyOn(Event.prototype, 'preventDefault').and.callThrough()
+        const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
         triggerEl.addEventListener('click', event => {
           expect(event.target.isEqualNode(nestedTriggerEl)).toBeTrue()
           expect(event.delegateTarget.isEqualNode(triggerEl)).toBeTrue()
-          expect(Event.prototype.preventDefault).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -231,13 +231,13 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btnDropdown)
 
         document.documentElement.ontouchstart = noop
-        spyOn(EventHandler, 'on')
-        spyOn(EventHandler, 'off')
+        const spy = spyOn(EventHandler, 'on')
+        const spyOff = spyOn(EventHandler, 'off')
 
         btnDropdown.addEventListener('shown.bs.dropdown', () => {
           expect(btnDropdown).toHaveClass('show')
           expect(btnDropdown.getAttribute('aria-expanded')).toEqual('true')
-          expect(EventHandler.on).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
+          expect(spy).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
 
           dropdown.toggle()
         })
@@ -245,7 +245,7 @@ describe('Dropdown', () => {
         btnDropdown.addEventListener('hidden.bs.dropdown', () => {
           expect(btnDropdown).not.toHaveClass('show')
           expect(btnDropdown.getAttribute('aria-expanded')).toEqual('false')
-          expect(EventHandler.off).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
+          expect(spyOff).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
 
           document.documentElement.ontouchstart = defaultValueOnTouchStart
           resolve()
@@ -547,7 +547,7 @@ describe('Dropdown', () => {
           reference: virtualElement,
           popperConfig: {
             onFirstUpdate() {
-              expect(virtualElement.getBoundingClientRect).toHaveBeenCalled()
+              expect(spy).toHaveBeenCalled()
               expect(btnDropdown).toHaveClass('show')
               expect(btnDropdown.getAttribute('aria-expanded')).toEqual('true')
               resolve()
@@ -555,7 +555,7 @@ describe('Dropdown', () => {
           }
         })
 
-        spyOn(virtualElement, 'getBoundingClientRect').and.callThrough()
+        const spy = spyOn(virtualElement, 'getBoundingClientRect').and.callThrough()
 
         dropdown.toggle()
       })
@@ -996,7 +996,7 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(btnDropdown)
 
         document.documentElement.ontouchstart = noop
-        spyOn(EventHandler, 'off')
+        const spy = spyOn(EventHandler, 'off')
 
         btnDropdown.addEventListener('shown.bs.dropdown', () => {
           dropdown.hide()
@@ -1005,7 +1005,7 @@ describe('Dropdown', () => {
         btnDropdown.addEventListener('hidden.bs.dropdown', () => {
           expect(btnDropdown).not.toHaveClass('show')
           expect(btnDropdown.getAttribute('aria-expanded')).toEqual('false')
-          expect(EventHandler.off).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
 
           document.documentElement.ontouchstart = defaultValueOnTouchStart
           resolve()
@@ -1034,13 +1034,13 @@ describe('Dropdown', () => {
       expect(dropdown._popper).toBeNull()
       expect(dropdown._menu).not.toBeNull()
       expect(dropdown._element).not.toBeNull()
-      spyOn(EventHandler, 'off')
+      const spy = spyOn(EventHandler, 'off')
 
       dropdown.dispose()
 
       expect(dropdown._menu).toBeNull()
       expect(dropdown._element).toBeNull()
-      expect(EventHandler.off).toHaveBeenCalledWith(btnDropdown, Dropdown.EVENT_KEY)
+      expect(spy).toHaveBeenCalledWith(btnDropdown, Dropdown.EVENT_KEY)
     })
 
     it('should dispose dropdown with Popper', () => {
@@ -1088,13 +1088,13 @@ describe('Dropdown', () => {
 
       expect(dropdown._popper).not.toBeNull()
 
-      spyOn(dropdown._popper, 'update')
-      spyOn(dropdown, '_detectNavbar')
+      const spyUpdate = spyOn(dropdown._popper, 'update')
+      const spyDetect = spyOn(dropdown, '_detectNavbar')
 
       dropdown.update()
 
-      expect(dropdown._popper.update).toHaveBeenCalled()
-      expect(dropdown._detectNavbar).toHaveBeenCalled()
+      expect(spyUpdate).toHaveBeenCalled()
+      expect(spyDetect).toHaveBeenCalled()
     })
 
     it('should just detect navbar on update', () => {
@@ -1110,12 +1110,12 @@ describe('Dropdown', () => {
       const btnDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
       const dropdown = new Dropdown(btnDropdown)
 
-      spyOn(dropdown, '_detectNavbar')
+      const spy = spyOn(dropdown, '_detectNavbar')
 
       dropdown.update()
 
       expect(dropdown._popper).toBeNull()
-      expect(dropdown._detectNavbar).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
   })
 
@@ -1891,7 +1891,7 @@ describe('Dropdown', () => {
         const dropdown = new Dropdown(triggerDropdown)
         const button = fixtureEl.querySelector('button[data-bs-toggle="dropdown"]')
 
-        spyOn(dropdown, 'toggle')
+        const spy = spyOn(dropdown, 'toggle')
 
         // Key escape
         button.focus()
@@ -1901,7 +1901,7 @@ describe('Dropdown', () => {
         button.dispatchEvent(keydownEscape)
 
         setTimeout(() => {
-          expect(dropdown.toggle).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           expect(triggerDropdown).not.toHaveClass('show')
           resolve()
         }, 20)

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -60,18 +60,18 @@ describe('Modal', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="modal"><div class="modal-dialog"></div></div>'
 
-        spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
-        spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
+        const spyHide = spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
+        const spyReset = spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
         const modalEl = fixtureEl.querySelector('.modal')
         const modal = new Modal(modalEl)
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(ScrollBarHelper.prototype.hide).toHaveBeenCalled()
+          expect(spyHide).toHaveBeenCalled()
           modal.toggle()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(ScrollBarHelper.prototype.reset).toHaveBeenCalled()
+          expect(spyReset).toHaveBeenCalled()
           resolve()
         })
 
@@ -159,12 +159,12 @@ describe('Modal', () => {
       const modalEl = fixtureEl.querySelector('.modal')
       const modal = new Modal(modalEl)
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
       modal._isShown = true
 
       modal.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should do nothing if a modal is transitioning', () => {
@@ -173,12 +173,12 @@ describe('Modal', () => {
       const modalEl = fixtureEl.querySelector('.modal')
       const modal = new Modal(modalEl)
 
-      spyOn(EventHandler, 'trigger')
+      const spy = spyOn(EventHandler, 'trigger')
       modal._isTransitioning = true
 
       modal.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should not fire shown event when show is prevented', () => {
@@ -273,14 +273,14 @@ describe('Modal', () => {
         const btnClose = fixtureEl.querySelector('[data-bs-dismiss="modal"]')
         const modal = new Modal(modalEl)
 
-        spyOn(modal, 'hide').and.callThrough()
+        const spy = spyOn(modal, 'hide').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           btnClose.click()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -301,14 +301,14 @@ describe('Modal', () => {
         const btnClose = fixtureEl.querySelector('[data-bs-dismiss="modal"]')
         const modal = new Modal(modalEl)
 
-        spyOn(modal, 'hide').and.callThrough()
+        const spy = spyOn(modal, 'hide').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           btnClose.click()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -368,10 +368,10 @@ describe('Modal', () => {
           focus: false
         })
 
-        spyOn(modal._focustrap, 'activate').and.callThrough()
+        const spy = spyOn(modal._focustrap, 'activate').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(modal._focustrap.activate).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -386,7 +386,7 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const modal = new Modal(modalEl)
 
-        spyOn(modal, 'hide').and.callThrough()
+        const spy = spyOn(modal, 'hide').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           const keydownEscape = createEvent('keydown')
@@ -396,7 +396,7 @@ describe('Modal', () => {
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -411,10 +411,10 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const modal = new Modal(modalEl)
 
-        spyOn(modal, 'hide')
+        const spy = spyOn(modal, 'hide')
 
         const expectDone = () => {
-          expect(modal.hide).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
 
           resolve()
         }
@@ -662,10 +662,10 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const modal = new Modal(modalEl)
 
-        spyOn(modal._focustrap, 'activate').and.callThrough()
+        const spy = spyOn(modal._focustrap, 'activate').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(modal._focustrap.activate).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -783,14 +783,14 @@ describe('Modal', () => {
 
         const modalEl = fixtureEl.querySelector('.modal')
         const modal = new Modal(modalEl)
-        spyOn(modal._focustrap, 'deactivate').and.callThrough()
+        const spy = spyOn(modal._focustrap, 'deactivate').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           modal.hide()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(modal._focustrap.deactivate).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -806,17 +806,17 @@ describe('Modal', () => {
       const modalEl = fixtureEl.querySelector('.modal')
       const modal = new Modal(modalEl)
       const focustrap = modal._focustrap
-      spyOn(focustrap, 'deactivate').and.callThrough()
+      const spyDeactivate = spyOn(focustrap, 'deactivate').and.callThrough()
 
       expect(Modal.getInstance(modalEl)).toEqual(modal)
 
-      spyOn(EventHandler, 'off')
+      const spyOff = spyOn(EventHandler, 'off')
 
       modal.dispose()
 
       expect(Modal.getInstance(modalEl)).toBeNull()
-      expect(EventHandler.off).toHaveBeenCalledTimes(3)
-      expect(focustrap.deactivate).toHaveBeenCalled()
+      expect(spyOff).toHaveBeenCalledTimes(3)
+      expect(spyDeactivate).toHaveBeenCalled()
     })
   })
 
@@ -827,11 +827,11 @@ describe('Modal', () => {
       const modalEl = fixtureEl.querySelector('.modal')
       const modal = new Modal(modalEl)
 
-      spyOn(modal, '_adjustDialog')
+      const spy = spyOn(modal, '_adjustDialog')
 
       modal.handleUpdate()
 
-      expect(modal._adjustDialog).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
   })
 
@@ -879,10 +879,10 @@ describe('Modal', () => {
         const modal = new Modal(modalEl)
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
 
-        spyOn(modal, 'show').and.callThrough()
+        const spy = spyOn(modal, 'show').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
-          expect(modal.show).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -900,7 +900,7 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
 
-        spyOn(Event.prototype, 'preventDefault').and.callThrough()
+        const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           expect(modalEl.getAttribute('aria-modal')).toEqual('true')
@@ -908,7 +908,7 @@ describe('Modal', () => {
           expect(modalEl.getAttribute('aria-hidden')).toBeNull()
           expect(modalEl.style.display).toEqual('block')
           expect(document.querySelector('.modal-backdrop')).not.toBeNull()
-          expect(Event.prototype.preventDefault).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -926,7 +926,7 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
 
-        spyOn(trigger, 'focus')
+        const spy = spyOn(trigger, 'focus')
 
         modalEl.addEventListener('shown.bs.modal', () => {
           const modal = Modal.getInstance(modalEl)
@@ -936,7 +936,7 @@ describe('Modal', () => {
 
         const hideListener = () => {
           setTimeout(() => {
-            expect(trigger.focus).toHaveBeenCalled()
+            expect(spy).toHaveBeenCalled()
             resolve()
           }, 20)
         }
@@ -962,14 +962,14 @@ describe('Modal', () => {
         const btnClose = fixtureEl.querySelector('button[data-bs-dismiss="modal"]')
         const modal = new Modal(modalEl)
 
-        spyOn(Event.prototype, 'preventDefault').and.callThrough()
+        const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           btnClose.click()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(Event.prototype.preventDefault).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -991,14 +991,14 @@ describe('Modal', () => {
         const btnClose = fixtureEl.querySelector('a[data-bs-dismiss="modal"]')
         const modal = new Modal(modalEl)
 
-        spyOn(Event.prototype, 'preventDefault').and.callThrough()
+        const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
         modalEl.addEventListener('shown.bs.modal', () => {
           btnClose.click()
         })
 
         modalEl.addEventListener('hidden.bs.modal', () => {
-          expect(Event.prototype.preventDefault).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -1015,7 +1015,7 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
 
-        spyOn(trigger, 'focus')
+        const spy = spyOn(trigger, 'focus')
 
         modalEl.addEventListener('shown.bs.modal', () => {
           const modal = Modal.getInstance(modalEl)
@@ -1025,7 +1025,7 @@ describe('Modal', () => {
 
         const hideListener = () => {
           setTimeout(() => {
-            expect(trigger.focus).not.toHaveBeenCalled()
+            expect(spy).not.toHaveBeenCalled()
             resolve()
           }, 20)
         }
@@ -1047,11 +1047,11 @@ describe('Modal', () => {
         const modalEl = fixtureEl.querySelector('.modal')
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
 
-        spyOn(trigger, 'focus')
+        const spy = spyOn(trigger, 'focus')
 
         const showListener = () => {
           setTimeout(() => {
-            expect(trigger.focus).not.toHaveBeenCalled()
+            expect(spy).not.toHaveBeenCalled()
             resolve()
           }, 10)
         }
@@ -1113,8 +1113,8 @@ describe('Modal', () => {
       jQueryMock.elements = [div]
 
       jQueryMock.fn.modal.call(jQueryMock, { keyboard: false })
-      spyOn(Modal.prototype, 'constructor')
-      expect(Modal.prototype.constructor).not.toHaveBeenCalledWith(div, { keyboard: false })
+      const spy = spyOn(Modal.prototype, 'constructor')
+      expect(spy).not.toHaveBeenCalledWith(div, { keyboard: false })
 
       const modal = Modal.getInstance(div)
       expect(modal).not.toBeNull()
@@ -1158,11 +1158,11 @@ describe('Modal', () => {
       jQueryMock.fn.modal = Modal.jQueryInterface
       jQueryMock.elements = [div]
 
-      spyOn(modal, 'show')
+      const spy = spyOn(modal, 'show')
 
       jQueryMock.fn.modal.call(jQueryMock, 'show')
 
-      expect(modal.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should not call show method', () => {
@@ -1173,11 +1173,11 @@ describe('Modal', () => {
       jQueryMock.fn.modal = Modal.jQueryInterface
       jQueryMock.elements = [div]
 
-      spyOn(Modal.prototype, 'show')
+      const spy = spyOn(Modal.prototype, 'show')
 
       jQueryMock.fn.modal.call(jQueryMock)
 
-      expect(Modal.prototype.show).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -51,12 +51,12 @@ describe('Offcanvas', () => {
       const closeEl = fixtureEl.querySelector('a')
       const offCanvas = new Offcanvas(offCanvasEl)
 
-      spyOn(offCanvas, 'hide')
+      const spy = spyOn(offCanvas, 'hide')
 
       closeEl.click()
 
       expect(offCanvas._config.keyboard).toBeTrue()
-      expect(offCanvas.hide).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should hide if esc is pressed', () => {
@@ -67,11 +67,11 @@ describe('Offcanvas', () => {
       const keyDownEsc = createEvent('keydown')
       keyDownEsc.key = 'Escape'
 
-      spyOn(offCanvas, 'hide')
+      const spy = spyOn(offCanvas, 'hide')
 
       offCanvasEl.dispatchEvent(keyDownEsc)
 
-      expect(offCanvas.hide).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should hide if esc is pressed and backdrop is static', () => {
@@ -82,11 +82,11 @@ describe('Offcanvas', () => {
       const keyDownEsc = createEvent('keydown')
       keyDownEsc.key = 'Escape'
 
-      spyOn(offCanvas, 'hide')
+      const spy = spyOn(offCanvas, 'hide')
 
       offCanvasEl.dispatchEvent(keyDownEsc)
 
-      expect(offCanvas.hide).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should not hide if esc is not pressed', () => {
@@ -97,11 +97,11 @@ describe('Offcanvas', () => {
       const keydownTab = createEvent('keydown')
       keydownTab.key = 'Tab'
 
-      spyOn(offCanvas, 'hide')
+      const spy = spyOn(offCanvas, 'hide')
 
       offCanvasEl.dispatchEvent(keydownTab)
 
-      expect(offCanvas.hide).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should not hide if esc is pressed but with keyboard = false', () => {
@@ -113,7 +113,7 @@ describe('Offcanvas', () => {
         const keyDownEsc = createEvent('keydown')
         keyDownEsc.key = 'Escape'
 
-        spyOn(offCanvas, 'hide')
+        const spy = spyOn(offCanvas, 'hide')
         const hidePreventedSpy = jasmine.createSpy('hidePrevented')
         offCanvasEl.addEventListener('hidePrevented.bs.offcanvas', hidePreventedSpy)
 
@@ -122,7 +122,7 @@ describe('Offcanvas', () => {
           offCanvasEl.dispatchEvent(keyDownEsc)
 
           expect(hidePreventedSpy).toHaveBeenCalled()
-          expect(offCanvas.hide).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -138,17 +138,17 @@ describe('Offcanvas', () => {
         const offCanvas = new Offcanvas(offCanvasEl, { backdrop: 'static' })
 
         const clickEvent = new Event('mousedown', { bubbles: true, cancelable: true })
-        spyOn(offCanvas._backdrop._config, 'clickCallback').and.callThrough()
-        spyOn(offCanvas._backdrop, 'hide').and.callThrough()
+        const spyClick = spyOn(offCanvas._backdrop._config, 'clickCallback').and.callThrough()
+        const spyHide = spyOn(offCanvas._backdrop, 'hide').and.callThrough()
         const hidePreventedSpy = jasmine.createSpy('hidePrevented')
         offCanvasEl.addEventListener('hidePrevented.bs.offcanvas', hidePreventedSpy)
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
-          expect(offCanvas._backdrop._config.clickCallback).toEqual(jasmine.any(Function))
+          expect(spyClick).toEqual(jasmine.any(Function))
 
           offCanvas._backdrop._getElement().dispatchEvent(clickEvent)
           expect(hidePreventedSpy).toHaveBeenCalled()
-          expect(offCanvas._backdrop.hide).not.toHaveBeenCalled()
+          expect(spyHide).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -163,14 +163,14 @@ describe('Offcanvas', () => {
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
 
-        spyOn(offCanvas, 'hide').and.callThrough()
+        const spy = spyOn(offCanvas, 'hide').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
           const resizeEvent = createEvent('resize')
           offCanvasEl.style.removeProperty('position')
 
           window.dispatchEvent(resizeEvent)
-          expect(offCanvas.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -224,17 +224,17 @@ describe('Offcanvas', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="offcanvas"></div>'
 
-        spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
-        spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
+        const spyHide = spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
+        const spyReset = spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
         const offCanvasEl = fixtureEl.querySelector('.offcanvas')
         const offCanvas = new Offcanvas(offCanvasEl, { scroll: true })
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
-          expect(ScrollBarHelper.prototype.hide).not.toHaveBeenCalled()
+          expect(spyHide).not.toHaveBeenCalled()
           offCanvas.hide()
         })
         offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
-          expect(ScrollBarHelper.prototype.reset).not.toHaveBeenCalled()
+          expect(spyReset).not.toHaveBeenCalled()
           resolve()
         })
         offCanvas.show()
@@ -245,17 +245,17 @@ describe('Offcanvas', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="offcanvas"></div>'
 
-        spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
-        spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
+        const spyHide = spyOn(ScrollBarHelper.prototype, 'hide').and.callThrough()
+        const spyReset = spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
         const offCanvasEl = fixtureEl.querySelector('.offcanvas')
         const offCanvas = new Offcanvas(offCanvasEl, { scroll: false })
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
-          expect(ScrollBarHelper.prototype.hide).toHaveBeenCalled()
+          expect(spyHide).toHaveBeenCalled()
           offCanvas.hide()
         })
         offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
-          expect(ScrollBarHelper.prototype.reset).toHaveBeenCalled()
+          expect(spyReset).toHaveBeenCalled()
           resolve()
         })
         offCanvas.show()
@@ -270,7 +270,7 @@ describe('Offcanvas', () => {
         const offCanvas = new Offcanvas(offCanvasEl, { backdrop: true })
 
         const clickEvent = new Event('mousedown', { bubbles: true, cancelable: true })
-        spyOn(offCanvas._backdrop._config, 'clickCallback').and.callThrough()
+        const spy = spyOn(offCanvas._backdrop._config, 'clickCallback').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
           expect(offCanvas._backdrop._config.clickCallback).toEqual(jasmine.any(Function))
@@ -279,7 +279,7 @@ describe('Offcanvas', () => {
         })
 
         offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
-          expect(offCanvas._backdrop._config.clickCallback).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -296,10 +296,10 @@ describe('Offcanvas', () => {
           scroll: true
         })
 
-        spyOn(offCanvas._focustrap, 'activate').and.callThrough()
+        const spy = spyOn(offCanvas._focustrap, 'activate').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
-          expect(offCanvas._focustrap.activate).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -315,11 +315,11 @@ describe('Offcanvas', () => {
       const offCanvasEl = fixtureEl.querySelector('.offcanvas')
       const offCanvas = new Offcanvas(offCanvasEl)
 
-      spyOn(offCanvas, 'show')
+      const spy = spyOn(offCanvas, 'show')
 
       offCanvas.toggle()
 
-      expect(offCanvas.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should call hide method if show class is present', () => {
@@ -331,11 +331,11 @@ describe('Offcanvas', () => {
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
           expect(offCanvasEl).toHaveClass('show')
-          spyOn(offCanvas, 'hide')
+          const spy = spyOn(offCanvas, 'hide')
 
           offCanvas.toggle()
 
-          expect(offCanvas.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -375,12 +375,12 @@ describe('Offcanvas', () => {
 
       expect(offCanvasEl).toHaveClass('show')
 
-      spyOn(offCanvas._backdrop, 'show').and.callThrough()
-      spyOn(EventHandler, 'trigger').and.callThrough()
+      const spyShow = spyOn(offCanvas._backdrop, 'show').and.callThrough()
+      const spyTrigger = spyOn(EventHandler, 'trigger').and.callThrough()
       offCanvas.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
-      expect(offCanvas._backdrop.show).not.toHaveBeenCalled()
+      expect(spyTrigger).not.toHaveBeenCalled()
+      expect(spyShow).not.toHaveBeenCalled()
     })
 
     it('should show a hidden element', () => {
@@ -389,11 +389,11 @@ describe('Offcanvas', () => {
 
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
-        spyOn(offCanvas._backdrop, 'show').and.callThrough()
+        const spy = spyOn(offCanvas._backdrop, 'show').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
           expect(offCanvasEl).toHaveClass('show')
-          expect(offCanvas._backdrop.show).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -407,11 +407,11 @@ describe('Offcanvas', () => {
 
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
-        spyOn(offCanvas._backdrop, 'show').and.callThrough()
+        const spy = spyOn(offCanvas._backdrop, 'show').and.callThrough()
 
         const expectEnd = () => {
           setTimeout(() => {
-            expect(offCanvas._backdrop.show).not.toHaveBeenCalled()
+            expect(spy).not.toHaveBeenCalled()
             resolve()
           }, 10)
         }
@@ -434,7 +434,7 @@ describe('Offcanvas', () => {
         fixtureEl.innerHTML = '<div class="offcanvas show"></div>'
 
         const offCanvasEl = fixtureEl.querySelector('div')
-        spyOn(Offcanvas.prototype, 'show').and.callThrough()
+        const spy = spyOn(Offcanvas.prototype, 'show').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
           resolve()
@@ -444,7 +444,7 @@ describe('Offcanvas', () => {
 
         const instance = Offcanvas.getInstance(offCanvasEl)
         expect(instance).not.toBeNull()
-        expect(Offcanvas.prototype.show).toHaveBeenCalled()
+        expect(spy).toHaveBeenCalled()
       })
     })
 
@@ -455,10 +455,10 @@ describe('Offcanvas', () => {
         const offCanvasEl = fixtureEl.querySelector('.offcanvas')
         const offCanvas = new Offcanvas(offCanvasEl)
 
-        spyOn(offCanvas._focustrap, 'activate').and.callThrough()
+        const spy = spyOn(offCanvas._focustrap, 'activate').and.callThrough()
 
         offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
-          expect(offCanvas._focustrap.activate).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -497,15 +497,15 @@ describe('Offcanvas', () => {
     it('should do nothing if already shown', () => {
       fixtureEl.innerHTML = '<div class="offcanvas"></div>'
 
-      spyOn(EventHandler, 'trigger').and.callThrough()
+      const spyTrigger = spyOn(EventHandler, 'trigger').and.callThrough()
 
       const offCanvasEl = fixtureEl.querySelector('div')
       const offCanvas = new Offcanvas(offCanvasEl)
-      spyOn(offCanvas._backdrop, 'hide').and.callThrough()
+      const spyHide = spyOn(offCanvas._backdrop, 'hide').and.callThrough()
 
       offCanvas.hide()
-      expect(offCanvas._backdrop.hide).not.toHaveBeenCalled()
-      expect(EventHandler.trigger).not.toHaveBeenCalled()
+      expect(spyHide).not.toHaveBeenCalled()
+      expect(spyTrigger).not.toHaveBeenCalled()
     })
 
     it('should hide a shown element', () => {
@@ -514,12 +514,12 @@ describe('Offcanvas', () => {
 
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
-        spyOn(offCanvas._backdrop, 'hide').and.callThrough()
+        const spy = spyOn(offCanvas._backdrop, 'hide').and.callThrough()
         offCanvas.show()
 
         offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
           expect(offCanvasEl).not.toHaveClass('show')
-          expect(offCanvas._backdrop.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -533,13 +533,13 @@ describe('Offcanvas', () => {
 
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
-        spyOn(offCanvas._backdrop, 'hide').and.callThrough()
+        const spy = spyOn(offCanvas._backdrop, 'hide').and.callThrough()
 
         offCanvas.show()
 
         const expectEnd = () => {
           setTimeout(() => {
-            expect(offCanvas._backdrop.hide).not.toHaveBeenCalled()
+            expect(spy).not.toHaveBeenCalled()
             resolve()
           }, 10)
         }
@@ -563,11 +563,11 @@ describe('Offcanvas', () => {
 
         const offCanvasEl = fixtureEl.querySelector('div')
         const offCanvas = new Offcanvas(offCanvasEl)
-        spyOn(offCanvas._focustrap, 'deactivate').and.callThrough()
+        const spy = spyOn(offCanvas._focustrap, 'deactivate').and.callThrough()
         offCanvas.show()
 
         offCanvasEl.addEventListener('hidden.bs.offcanvas', () => {
-          expect(offCanvas._focustrap.deactivate).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -583,19 +583,17 @@ describe('Offcanvas', () => {
       const offCanvasEl = fixtureEl.querySelector('div')
       const offCanvas = new Offcanvas(offCanvasEl)
       const backdrop = offCanvas._backdrop
-      spyOn(backdrop, 'dispose').and.callThrough()
+      const spyDispose = spyOn(backdrop, 'dispose').and.callThrough()
       const focustrap = offCanvas._focustrap
-      spyOn(focustrap, 'deactivate').and.callThrough()
+      const spyDeactivate = spyOn(focustrap, 'deactivate').and.callThrough()
 
       expect(Offcanvas.getInstance(offCanvasEl)).toEqual(offCanvas)
 
-      spyOn(EventHandler, 'off')
-
       offCanvas.dispose()
 
-      expect(backdrop.dispose).toHaveBeenCalled()
+      expect(spyDispose).toHaveBeenCalled()
       expect(offCanvas._backdrop).toBeNull()
-      expect(focustrap.deactivate).toHaveBeenCalled()
+      expect(spyDeactivate).toHaveBeenCalled()
       expect(offCanvas._focustrap).toBeNull()
       expect(Offcanvas.getInstance(offCanvasEl)).toBeNull()
     })
@@ -630,11 +628,11 @@ describe('Offcanvas', () => {
 
       const target = fixtureEl.querySelector('a')
 
-      spyOn(Offcanvas.prototype, 'toggle')
+      const spy = spyOn(Offcanvas.prototype, 'toggle')
 
       target.click()
 
-      expect(Offcanvas.prototype.toggle).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should call hide first, if another offcanvas is open', () => {
@@ -671,14 +669,14 @@ describe('Offcanvas', () => {
         const trigger = fixtureEl.querySelector('#btn')
         const offcanvasEl = fixtureEl.querySelector('#offcanvas')
         const offcanvas = new Offcanvas(offcanvasEl)
-        spyOn(trigger, 'focus')
+        const spy = spyOn(trigger, 'focus')
 
         offcanvasEl.addEventListener('shown.bs.offcanvas', () => {
           offcanvas.hide()
         })
         offcanvasEl.addEventListener('hidden.bs.offcanvas', () => {
           setTimeout(() => {
-            expect(trigger.focus).toHaveBeenCalled()
+            expect(spy).toHaveBeenCalled()
             resolve()
           }, 5)
         })
@@ -697,7 +695,7 @@ describe('Offcanvas', () => {
         const trigger = fixtureEl.querySelector('#btn')
         const offcanvasEl = fixtureEl.querySelector('#offcanvas')
         const offcanvas = new Offcanvas(offcanvasEl)
-        spyOn(trigger, 'focus')
+        const spy = spyOn(trigger, 'focus')
 
         offcanvasEl.addEventListener('shown.bs.offcanvas', () => {
           trigger.style.display = 'none'
@@ -706,7 +704,7 @@ describe('Offcanvas', () => {
         offcanvasEl.addEventListener('hidden.bs.offcanvas', () => {
           setTimeout(() => {
             expect(isVisible(trigger)).toBeFalse()
-            expect(trigger.focus).not.toHaveBeenCalled()
+            expect(spy).not.toHaveBeenCalled()
             resolve()
           }, 5)
         })
@@ -791,13 +789,13 @@ describe('Offcanvas', () => {
 
       const div = fixtureEl.querySelector('div')
 
-      spyOn(Offcanvas.prototype, 'show')
+      const spy = spyOn(Offcanvas.prototype, 'show')
 
       jQueryMock.fn.offcanvas = Offcanvas.jQueryInterface
       jQueryMock.elements = [div]
 
       jQueryMock.fn.offcanvas.call(jQueryMock, 'show')
-      expect(Offcanvas.prototype.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should create a offcanvas with given config', () => {

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -164,11 +164,11 @@ describe('Popover', () => {
 
       const popoverEl = fixtureEl.querySelector('a')
       const popover = new Popover(popoverEl, { animation: false })
-      spyOn(EventHandler, 'trigger').and.callThrough()
+      const spy = spyOn(EventHandler, 'trigger').and.callThrough()
 
       popover.show()
 
-      expect(EventHandler.trigger).not.toHaveBeenCalledWith(popoverEl, Popover.eventName('show'))
+      expect(spy).not.toHaveBeenCalledWith(popoverEl, Popover.eventName('show'))
       expect(document.querySelector('.popover')).toBeNull()
     })
 
@@ -329,11 +329,11 @@ describe('Popover', () => {
       jQueryMock.fn.popover = Popover.jQueryInterface
       jQueryMock.elements = [popoverEl]
 
-      spyOn(popover, 'show')
+      const spy = spyOn(popover, 'show')
 
       jQueryMock.fn.popover.call(jQueryMock, 'show')
 
-      expect(popover.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
   })
 

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -199,11 +199,11 @@ describe('ScrollSpy', () => {
           target: 'ss-target'
         })
 
-        spyOn(scrollSpy, '_process').and.callThrough()
+        const spy = spyOn(scrollSpy, '_process').and.callThrough()
 
         onScrollStop(() => {
           expect(rootEl).toHaveClass('active')
-          expect(scrollSpy._process).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         }, scrollSpyEl)
 
@@ -277,12 +277,12 @@ describe('ScrollSpy', () => {
           target: fixtureEl.querySelector('#ss-target')
         })
 
-        spyOn(scrollSpy, '_process').and.callThrough()
+        const spy = spyOn(scrollSpy, '_process').and.callThrough()
 
         onScrollStop(() => {
           expect(rootEl).toHaveClass('active')
           expect(scrollSpy._activeTarget).toEqual(fixtureEl.querySelector('[href="#detail"]'))
-          expect(scrollSpy._process).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         }, scrollSpyEl)
 
@@ -581,11 +581,11 @@ describe('ScrollSpy', () => {
       const el = fixtureEl.querySelector('.content')
       const scrollSpy = new ScrollSpy(el)
 
-      spyOn(scrollSpy._observer, 'disconnect')
+      const spy = spyOn(scrollSpy._observer, 'disconnect')
 
       scrollSpy.refresh()
 
-      expect(scrollSpy._observer.disconnect).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
   })
 
@@ -627,8 +627,8 @@ describe('ScrollSpy', () => {
       jQueryMock.elements = [div]
 
       jQueryMock.fn.scrollspy.call(jQueryMock, { rootMargin: '100px' })
-      spyOn(ScrollSpy.prototype, 'constructor')
-      expect(ScrollSpy.prototype.constructor).not.toHaveBeenCalledWith(div, { rootMargin: '100px' })
+      const spy = spyOn(ScrollSpy.prototype, 'constructor')
+      expect(spy).not.toHaveBeenCalledWith(div, { rootMargin: '100px' })
 
       const scrollspy = ScrollSpy.getInstance(div)
       expect(scrollspy).not.toBeNull()
@@ -655,7 +655,7 @@ describe('ScrollSpy', () => {
       const div = fixtureEl.querySelector('.content')
       const scrollSpy = new ScrollSpy(div)
 
-      spyOn(scrollSpy, 'refresh')
+      const spy = spyOn(scrollSpy, 'refresh')
 
       jQueryMock.fn.scrollspy = ScrollSpy.jQueryInterface
       jQueryMock.elements = [div]
@@ -663,7 +663,7 @@ describe('ScrollSpy', () => {
       jQueryMock.fn.scrollspy.call(jQueryMock, 'refresh')
 
       expect(ScrollSpy.getInstance(div)).toEqual(scrollSpy)
-      expect(scrollSpy.refresh).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should throw error on undefined method', () => {

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -412,9 +412,9 @@ describe('Tab', () => {
       const tab = new Tab(tabEl)
       const spy = jasmine.createSpy('spy')
 
-      spyOn(tab, '_queueCallback')
+      const spyQueue = spyOn(tab, '_queueCallback')
       tab._activate(null, spy)
-      expect(tab._queueCallback).not.toHaveBeenCalled()
+      expect(spyQueue).not.toHaveBeenCalled()
       expect(spy).not.toHaveBeenCalled()
     })
   })
@@ -468,17 +468,17 @@ describe('Tab', () => {
 
       const keydown = createEvent('keydown')
       keydown.key = 'Enter'
-      spyOn(Event.prototype, 'stopPropagation').and.callThrough()
-      spyOn(Event.prototype, 'preventDefault').and.callThrough()
-      spyOn(tab, '_keydown')
-      spyOn(tab, '_getChildren')
+      const spyStop = spyOn(Event.prototype, 'stopPropagation').and.callThrough()
+      const spyPrevent = spyOn(Event.prototype, 'preventDefault').and.callThrough()
+      const spyKeydown = spyOn(tab, '_keydown')
+      const spyGet = spyOn(tab, '_getChildren')
 
       tabEl.dispatchEvent(keydown)
-      expect(tab._keydown).toHaveBeenCalled()
-      expect(tab._getChildren).not.toHaveBeenCalled()
+      expect(spyKeydown).toHaveBeenCalled()
+      expect(spyGet).not.toHaveBeenCalled()
 
-      expect(Event.prototype.stopPropagation).not.toHaveBeenCalled()
-      expect(Event.prototype.preventDefault).not.toHaveBeenCalled()
+      expect(spyStop).not.toHaveBeenCalled()
+      expect(spyPrevent).not.toHaveBeenCalled()
     })
 
     it('if keydown event is right/down arrow, handle it', () => {
@@ -493,26 +493,26 @@ describe('Tab', () => {
       const tabEl2 = fixtureEl.querySelector('#tab2')
       const tab = new Tab(tabEl)
       const tab2 = new Tab(tabEl2)
-      spyOn(tab, 'show').and.callThrough()
-      spyOn(tab2, 'show').and.callThrough()
+      const spyShow1 = spyOn(tab, 'show').and.callThrough()
+      const spyShow2 = spyOn(tab2, 'show').and.callThrough()
 
-      spyOn(Event.prototype, 'stopPropagation').and.callThrough()
-      spyOn(Event.prototype, 'preventDefault').and.callThrough()
+      const spyStop = spyOn(Event.prototype, 'stopPropagation').and.callThrough()
+      const spyPrevent = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
       let keydown = createEvent('keydown')
       keydown.key = 'ArrowRight'
 
       tabEl.dispatchEvent(keydown)
-      expect(tab2.show).toHaveBeenCalled()
+      expect(spyShow2).toHaveBeenCalled()
 
       keydown = createEvent('keydown')
       keydown.key = 'ArrowDown'
 
       tabEl2.dispatchEvent(keydown)
-      expect(tab.show).toHaveBeenCalled()
+      expect(spyShow1).toHaveBeenCalled()
 
-      expect(Event.prototype.stopPropagation).toHaveBeenCalledTimes(2)
-      expect(Event.prototype.preventDefault).toHaveBeenCalledTimes(2)
+      expect(spyStop).toHaveBeenCalledTimes(2)
+      expect(spyPrevent).toHaveBeenCalledTimes(2)
     })
 
     it('if keydown event is left arrow, handle it', () => {
@@ -527,26 +527,26 @@ describe('Tab', () => {
       const tabEl2 = fixtureEl.querySelector('#tab2')
       const tab = new Tab(tabEl)
       const tab2 = new Tab(tabEl2)
-      spyOn(tab, 'show').and.callThrough()
-      spyOn(tab2, 'show').and.callThrough()
+      const spyShow1 = spyOn(tab, 'show').and.callThrough()
+      const spyShow2 = spyOn(tab2, 'show').and.callThrough()
 
-      spyOn(Event.prototype, 'stopPropagation').and.callThrough()
-      spyOn(Event.prototype, 'preventDefault').and.callThrough()
+      const spyStop = spyOn(Event.prototype, 'stopPropagation').and.callThrough()
+      const spyPrevent = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
       let keydown = createEvent('keydown')
       keydown.key = 'ArrowLeft'
 
       tabEl2.dispatchEvent(keydown)
-      expect(tab.show).toHaveBeenCalled()
+      expect(spyShow1).toHaveBeenCalled()
 
       keydown = createEvent('keydown')
       keydown.key = 'ArrowUp'
 
       tabEl.dispatchEvent(keydown)
-      expect(tab2.show).toHaveBeenCalled()
+      expect(spyShow2).toHaveBeenCalled()
 
-      expect(Event.prototype.stopPropagation).toHaveBeenCalledTimes(2)
-      expect(Event.prototype.preventDefault).toHaveBeenCalledTimes(2)
+      expect(spyStop).toHaveBeenCalledTimes(2)
+      expect(spyPrevent).toHaveBeenCalledTimes(2)
     })
 
     it('if keydown event is right arrow and next element is disabled', () => {
@@ -567,19 +567,19 @@ describe('Tab', () => {
       const tab2 = new Tab(tabEl2)
       const tab3 = new Tab(tabEl3)
       const tab4 = new Tab(tabEl4)
-      spyOn(tab, 'show').and.callThrough()
-      spyOn(tab2, 'show').and.callThrough()
-      spyOn(tab3, 'show').and.callThrough()
-      spyOn(tab4, 'show').and.callThrough()
+      const spy1 = spyOn(tab, 'show').and.callThrough()
+      const spy2 = spyOn(tab2, 'show').and.callThrough()
+      const spy3 = spyOn(tab3, 'show').and.callThrough()
+      const spy4 = spyOn(tab4, 'show').and.callThrough()
 
       const keydown = createEvent('keydown')
       keydown.key = 'ArrowRight'
 
       tabEl.dispatchEvent(keydown)
-      expect(tab.show).not.toHaveBeenCalled()
-      expect(tab2.show).not.toHaveBeenCalled()
-      expect(tab3.show).not.toHaveBeenCalled()
-      expect(tab4.show).toHaveBeenCalledTimes(1)
+      expect(spy1).not.toHaveBeenCalled()
+      expect(spy2).not.toHaveBeenCalled()
+      expect(spy3).not.toHaveBeenCalled()
+      expect(spy4).toHaveBeenCalledTimes(1)
     })
 
     it('if keydown event is left arrow and next element is disabled', () => {
@@ -600,19 +600,19 @@ describe('Tab', () => {
       const tab2 = new Tab(tabEl2)
       const tab3 = new Tab(tabEl3)
       const tab4 = new Tab(tabEl4)
-      spyOn(tab, 'show').and.callThrough()
-      spyOn(tab2, 'show').and.callThrough()
-      spyOn(tab3, 'show').and.callThrough()
-      spyOn(tab4, 'show').and.callThrough()
+      const spy1 = spyOn(tab, 'show').and.callThrough()
+      const spy2 = spyOn(tab2, 'show').and.callThrough()
+      const spy3 = spyOn(tab3, 'show').and.callThrough()
+      const spy4 = spyOn(tab4, 'show').and.callThrough()
 
       const keydown = createEvent('keydown')
       keydown.key = 'ArrowLeft'
 
       tabEl4.dispatchEvent(keydown)
-      expect(tab4.show).not.toHaveBeenCalled()
-      expect(tab3.show).not.toHaveBeenCalled()
-      expect(tab2.show).not.toHaveBeenCalled()
-      expect(tab.show).toHaveBeenCalledTimes(1)
+      expect(spy4).not.toHaveBeenCalled()
+      expect(spy3).not.toHaveBeenCalled()
+      expect(spy2).not.toHaveBeenCalled()
+      expect(spy1).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -650,7 +650,7 @@ describe('Tab', () => {
       const div = fixtureEl.querySelector('.nav > div')
       const tab = new Tab(div)
 
-      spyOn(tab, 'show')
+      const spy = spyOn(tab, 'show')
 
       jQueryMock.fn.tab = Tab.jQueryInterface
       jQueryMock.elements = [div]
@@ -658,7 +658,7 @@ describe('Tab', () => {
       jQueryMock.fn.tab.call(jQueryMock, 'show')
 
       expect(Tab.getInstance(div)).toEqual(tab)
-      expect(tab.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should throw error on undefined method', () => {
@@ -972,11 +972,11 @@ describe('Tab', () => {
         ].join('')
 
         const tabEl = fixtureEl.querySelector('[href="#test2"]')
-        spyOn(Event.prototype, 'preventDefault').and.callThrough()
+        const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
         tabEl.addEventListener('shown.bs.tab', () => {
           expect(tabEl).toHaveClass('active')
-          expect(Event.prototype.preventDefault).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -208,14 +208,14 @@ describe('Toast', () => {
         setTimeout(() => {
           toast._config.autohide = false
           toastEl.addEventListener('shown.bs.toast', () => {
-            expect(toast._clearTimeout).toHaveBeenCalled()
+            expect(spy).toHaveBeenCalled()
             expect(toast._timeout).toBeNull()
             resolve()
           })
           toast.show()
         }, toast._config.delay / 2)
 
-        spyOn(toast, '_clearTimeout').and.callThrough()
+        const spy = spyOn(toast, '_clearTimeout').and.callThrough()
 
         toast.show()
       })
@@ -441,11 +441,11 @@ describe('Toast', () => {
       const toastEl = fixtureEl.querySelector('div')
       const toast = new Toast(toastEl)
 
-      spyOn(toastEl.classList, 'contains')
+      const spy = spyOn(toastEl.classList, 'contains')
 
       toast.hide()
 
-      expect(toastEl.classList.contains).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should not trigger hidden if hide is prevented', () => {
@@ -568,7 +568,7 @@ describe('Toast', () => {
       const div = fixtureEl.querySelector('div')
       const toast = new Toast(div)
 
-      spyOn(toast, 'show')
+      const spy = spyOn(toast, 'show')
 
       jQueryMock.fn.toast = Toast.jQueryInterface
       jQueryMock.elements = [div]
@@ -576,7 +576,7 @@ describe('Toast', () => {
       jQueryMock.fn.toast.call(jQueryMock, 'show')
 
       expect(Toast.getInstance(div)).toEqual(toast)
-      expect(toast.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should throw error on undefined method', () => {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -296,10 +296,10 @@ describe('Tooltip', () => {
           trigger: 'click'
         })
 
-        spyOn(tooltip, 'toggle').and.callThrough()
+        const spy = spyOn(tooltip, 'toggle').and.callThrough()
 
         tooltipEl.addEventListener('shown.bs.tooltip', () => {
-          expect(tooltip.toggle).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -336,14 +336,14 @@ describe('Tooltip', () => {
           trigger: 'click'
         })
 
-        spyOn(tooltip, 'toggle').and.callThrough()
+        const spy = spyOn(tooltip, 'toggle').and.callThrough()
 
         tooltipEl.addEventListener('shown.bs.tooltip', () => {
           tooltipEl.click()
         })
 
         tooltipEl.addEventListener('hidden.bs.tooltip', () => {
-          expect(tooltip.toggle).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -456,12 +456,12 @@ describe('Tooltip', () => {
         const tooltipEl = fixtureEl.querySelector('a')
         const tooltip = new Tooltip(tooltipEl)
 
-        spyOn(tooltip, 'show')
+        const spy = spyOn(tooltip, 'show')
 
         tooltipEl.querySelector('rect').dispatchEvent(createEvent('mouseover', { bubbles: true }))
 
         setTimeout(() => {
-          expect(tooltip.show).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         }, 0)
       })
@@ -475,11 +475,11 @@ describe('Tooltip', () => {
         const tooltip = new Tooltip(tooltipEl)
         document.documentElement.ontouchstart = noop
 
-        spyOn(EventHandler, 'on').and.callThrough()
+        const spy = spyOn(EventHandler, 'on').and.callThrough()
 
         tooltipEl.addEventListener('shown.bs.tooltip', () => {
           expect(document.querySelector('.tooltip')).not.toBeNull()
-          expect(EventHandler.on).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
+          expect(spy).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
           document.documentElement.ontouchstart = undefined
           resolve()
         })
@@ -687,14 +687,14 @@ describe('Tooltip', () => {
           delay: 150
         })
 
-        spyOn(tooltip, 'show')
+        const spy = spyOn(tooltip, 'show')
 
         setTimeout(() => {
-          expect(tooltip.show).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
         }, 100)
 
         setTimeout(() => {
-          expect(tooltip.show).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         }, 200)
 
@@ -711,15 +711,15 @@ describe('Tooltip', () => {
           delay: 150
         })
 
-        spyOn(tooltip, 'show')
+        const spy = spyOn(tooltip, 'show')
 
         setTimeout(() => {
-          expect(tooltip.show).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           tooltipEl.dispatchEvent(createEvent('mouseover'))
         }, 100)
 
         setTimeout(() => {
-          expect(tooltip.show).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           expect(document.querySelectorAll('.tooltip')).toHaveSize(0)
           resolve()
         }, 200)
@@ -770,7 +770,7 @@ describe('Tooltip', () => {
         const tooltip = new Tooltip(tooltipEl)
         const triggerChild = tooltipEl.querySelector('b')
 
-        spyOn(tooltip, 'hide').and.callThrough()
+        const spy = spyOn(tooltip, 'hide').and.callThrough()
 
         tooltipEl.addEventListener('mouseover', () => {
           const moveMouseToChildEvent = createEvent('mouseout')
@@ -782,7 +782,7 @@ describe('Tooltip', () => {
         })
 
         tooltipEl.addEventListener('mouseout', () => {
-          expect(tooltip.hide).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           resolve()
         })
 
@@ -959,16 +959,16 @@ describe('Tooltip', () => {
 
         const tooltipEl = fixtureEl.querySelector('a')
         const tooltip = new Tooltip(tooltipEl)
+        const spy = spyOn(EventHandler, 'off')
 
         tooltipEl.addEventListener('shown.bs.tooltip', () => {
           document.documentElement.ontouchstart = noop
-          spyOn(EventHandler, 'off')
           tooltip.hide()
         })
 
         tooltipEl.addEventListener('hidden.bs.tooltip', () => {
           expect(document.querySelector('.tooltip')).toBeNull()
-          expect(EventHandler.off).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
+          expect(spy).toHaveBeenCalledWith(jasmine.any(Object), 'mouseover', noop)
           document.documentElement.ontouchstart = undefined
           resolve()
         })
@@ -1050,11 +1050,11 @@ describe('Tooltip', () => {
         const tooltip = new Tooltip(tooltipEl)
 
         tooltipEl.addEventListener('shown.bs.tooltip', () => {
-          spyOn(tooltip._popper, 'update')
+          const spy = spyOn(tooltip._popper, 'update')
 
           tooltip.update()
 
-          expect(tooltip._popper.update).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 
@@ -1100,10 +1100,10 @@ describe('Tooltip', () => {
       const tooltipEl = fixtureEl.querySelector('a')
       const tooltip = new Tooltip(tooltipEl)
 
-      spyOn(document, 'createElement').and.callThrough()
+      const spy = spyOn(document, 'createElement').and.callThrough()
 
       expect(tooltip._getTipElement()).toBeDefined()
-      expect(document.createElement).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should return the created tip element', () => {
@@ -1483,7 +1483,7 @@ describe('Tooltip', () => {
       const div = fixtureEl.querySelector('div')
       const tooltip = new Tooltip(div)
 
-      spyOn(tooltip, 'show')
+      const spy = spyOn(tooltip, 'show')
 
       jQueryMock.fn.tooltip = Tooltip.jQueryInterface
       jQueryMock.elements = [div]
@@ -1491,7 +1491,7 @@ describe('Tooltip', () => {
       jQueryMock.fn.tooltip.call(jQueryMock, 'show')
 
       expect(Tooltip.getInstance(div)).toEqual(tooltip)
-      expect(tooltip.show).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('should throw error on undefined method', () => {

--- a/js/tests/unit/util/component-functions.spec.js
+++ b/js/tests/unit/util/component-functions.spec.js
@@ -37,8 +37,8 @@ describe('Plugin functions', () => {
         '</div>'
       ].join('')
 
-      spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
-      spyOn(DummyClass2.prototype, 'testMethod')
+      const spyGet = spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
+      const spyTest = spyOn(DummyClass2.prototype, 'testMethod')
       const componentWrapper = fixtureEl.querySelector('#foo')
       const btnClose = fixtureEl.querySelector('[data-bs-dismiss="test"]')
       const event = createEvent('click')
@@ -46,8 +46,8 @@ describe('Plugin functions', () => {
       enableDismissTrigger(DummyClass2, 'testMethod')
       btnClose.dispatchEvent(event)
 
-      expect(DummyClass2.getOrCreateInstance).toHaveBeenCalledWith(componentWrapper)
-      expect(DummyClass2.prototype.testMethod).toHaveBeenCalled()
+      expect(spyGet).toHaveBeenCalledWith(componentWrapper)
+      expect(spyTest).toHaveBeenCalled()
     })
 
     it('if data-bs-dismiss="PluginName" hasn\'t got "data-bs-target", "getOrCreateInstance" has to be initialized by closest "plugin.Name" class', () => {
@@ -57,8 +57,8 @@ describe('Plugin functions', () => {
         '</div>'
       ].join('')
 
-      spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
-      spyOn(DummyClass2.prototype, 'hide')
+      const spyGet = spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
+      const spyHide = spyOn(DummyClass2.prototype, 'hide')
       const componentWrapper = fixtureEl.querySelector('#foo')
       const btnClose = fixtureEl.querySelector('[data-bs-dismiss="test"]')
       const event = createEvent('click')
@@ -66,8 +66,8 @@ describe('Plugin functions', () => {
       enableDismissTrigger(DummyClass2)
       btnClose.dispatchEvent(event)
 
-      expect(DummyClass2.getOrCreateInstance).toHaveBeenCalledWith(componentWrapper)
-      expect(DummyClass2.prototype.hide).toHaveBeenCalled()
+      expect(spyGet).toHaveBeenCalledWith(componentWrapper)
+      expect(spyHide).toHaveBeenCalled()
     })
 
     it('if data-bs-dismiss="PluginName" is disabled, must not trigger function', () => {
@@ -77,14 +77,14 @@ describe('Plugin functions', () => {
         '</div>'
       ].join('')
 
-      spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
+      const spy = spyOn(DummyClass2, 'getOrCreateInstance').and.callThrough()
       const btnClose = fixtureEl.querySelector('[data-bs-dismiss="test"]')
       const event = createEvent('click')
 
       enableDismissTrigger(DummyClass2)
       btnClose.dispatchEvent(event)
 
-      expect(DummyClass2.getOrCreateInstance).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should prevent default when the trigger is <a> or <area>', () => {
@@ -98,11 +98,11 @@ describe('Plugin functions', () => {
       const event = createEvent('click')
 
       enableDismissTrigger(DummyClass2)
-      spyOn(Event.prototype, 'preventDefault').and.callThrough()
+      const spy = spyOn(Event.prototype, 'preventDefault').and.callThrough()
 
       btnClose.dispatchEvent(event)
 
-      expect(Event.prototype.preventDefault).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
   })
 })

--- a/js/tests/unit/util/focustrap.spec.js
+++ b/js/tests/unit/util/focustrap.spec.js
@@ -20,12 +20,12 @@ describe('FocusTrap', () => {
 
       const trapElement = fixtureEl.querySelector('div')
 
-      spyOn(trapElement, 'focus')
+      const spy = spyOn(trapElement, 'focus')
 
       const focustrap = new FocusTrap({ trapElement })
       focustrap.activate()
 
-      expect(trapElement.focus).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('if configured not to autofocus, should not autofocus itself', () => {
@@ -33,12 +33,12 @@ describe('FocusTrap', () => {
 
       const trapElement = fixtureEl.querySelector('div')
 
-      spyOn(trapElement, 'focus')
+      const spy = spyOn(trapElement, 'focus')
 
       const focustrap = new FocusTrap({ trapElement, autofocus: false })
       focustrap.activate()
 
-      expect(trapElement.focus).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should force focus inside focus trap if it can', () => {
@@ -57,12 +57,12 @@ describe('FocusTrap', () => {
         const inside = document.getElementById('inside')
 
         const focusInListener = () => {
-          expect(inside.focus).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           document.removeEventListener('focusin', focusInListener)
           resolve()
         }
 
-        spyOn(inside, 'focus')
+        const spy = spyOn(inside, 'focus')
         spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [inside])
 
         document.addEventListener('focusin', focusInListener)
@@ -97,10 +97,10 @@ describe('FocusTrap', () => {
         const outside = document.getElementById('outside')
 
         spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [first, inside, last])
-        spyOn(first, 'focus').and.callThrough()
+        const spy = spyOn(first, 'focus').and.callThrough()
 
         const focusInListener = () => {
-          expect(first.focus).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           first.removeEventListener('focusin', focusInListener)
           resolve()
         }
@@ -136,10 +136,10 @@ describe('FocusTrap', () => {
         const outside = document.getElementById('outside')
 
         spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [first, inside, last])
-        spyOn(last, 'focus').and.callThrough()
+        const spy = spyOn(last, 'focus').and.callThrough()
 
         const focusInListener = () => {
-          expect(last.focus).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           last.removeEventListener('focusin', focusInListener)
           resolve()
         }
@@ -167,12 +167,12 @@ describe('FocusTrap', () => {
         focustrap.activate()
 
         const focusInListener = () => {
-          expect(focustrap._config.trapElement.focus).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           document.removeEventListener('focusin', focusInListener)
           resolve()
         }
 
-        spyOn(focustrap._config.trapElement, 'focus')
+        const spy = spyOn(focustrap._config.trapElement, 'focus')
 
         document.addEventListener('focusin', focusInListener)
 
@@ -200,19 +200,19 @@ describe('FocusTrap', () => {
       const focustrap = new FocusTrap({ trapElement: fixtureEl })
       focustrap.activate()
 
-      spyOn(EventHandler, 'off')
+      const spy = spyOn(EventHandler, 'off')
       focustrap.deactivate()
 
-      expect(EventHandler.off).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
     })
 
     it('doesn\'t try removing event listeners unless it needs to (in case it hasn\'t been activated)', () => {
       const focustrap = new FocusTrap({ trapElement: fixtureEl })
 
-      spyOn(EventHandler, 'off')
+      const spy = spyOn(EventHandler, 'off')
       focustrap.deactivate()
 
-      expect(EventHandler.off).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
   })
 })

--- a/js/tests/unit/util/index.spec.js
+++ b/js/tests/unit/util/index.spec.js
@@ -576,7 +576,7 @@ describe('Util', () => {
       const spy = jasmine.createSpy()
       const spy2 = jasmine.createSpy()
 
-      spyOn(document, 'addEventListener').and.callThrough()
+      const spyAdd = spyOn(document, 'addEventListener').and.callThrough()
       spyOnProperty(document, 'readyState').and.returnValue('loading')
 
       Util.onDOMContentLoaded(spy)
@@ -589,7 +589,7 @@ describe('Util', () => {
 
       expect(spy).toHaveBeenCalled()
       expect(spy2).toHaveBeenCalled()
-      expect(document.addEventListener).toHaveBeenCalledTimes(1)
+      expect(spyAdd).toHaveBeenCalledTimes(1)
     })
 
     it('should execute callback if readyState is not "loading"', () => {

--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -84,12 +84,12 @@ describe('Sanitizer', () => {
         return htmlUnsafe
       }
 
-      spyOn(DOMParser.prototype, 'parseFromString')
+      const spy = spyOn(DOMParser.prototype, 'parseFromString')
 
       const result = sanitizeHtml(template, DefaultAllowlist, mySanitize)
 
       expect(result).toEqual(template)
-      expect(DOMParser.prototype.parseFromString).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should allow multiple sanitation passes of the same template', () => {

--- a/js/tests/unit/util/swipe.spec.js
+++ b/js/tests/unit/util/swipe.spec.js
@@ -163,7 +163,7 @@ describe('Swipe', () => {
       deleteDocumentElementOntouchstart()
 
       const swipe = new Swipe(swipeEl)
-      spyOn(swipe, '_handleSwipe')
+      const spy = spyOn(swipe, '_handleSwipe')
 
       mockSwipeGesture(swipeEl, {
         pos: [300, 10],
@@ -173,7 +173,7 @@ describe('Swipe', () => {
       })
 
       restorePointerEvents()
-      expect(swipe._handleSwipe).not.toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('should allow swipeRight and call "rightCallback" with pointer events', () => {


### PR DESCRIPTION
Here are the issues concerning the CSS part, we encountered with @julien-deramond.

The commits can be splited if needed or wanted or even be in another PR. I'm open to every comment that could help fix these issues.

### Tackled by the PR:
#### Typo with (https://github.com/twbs/bootstrap/pull/36398/commits/5b133f5206fbb2d2196d447217c94c5e7c71c2a6)
Carousel test typo error with `maybeEnableCycle`.

#### Test improvement with (https://github.com/twbs/bootstrap/pull/36398/commits/41c228b67715c26013f7ac048aa73d4c832a8a04)
Carousel test since the test looked weird to me (Calling the function and expected to be called)

#### Spy declaration with (https://github.com/twbs/bootstrap/pull/36398/commits/505175a553718f497ca6a07e0b4e4904ea8e6c49)
Make the spy declaration almost the same everywhere to be more consistent. Not sure if this is mandatory.