### PR TITLE
Scrollspy: add history state in every click, when `smoothScroll` options, is activated

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -127,7 +127,6 @@ class ScrollSpy extends BaseComponent {
         event.preventDefault()
         const root = this._rootElement || window
         const height = observableSection.offsetTop - this._element.offsetTop
-        window.history.pushState(null, null, event.target.hash)
         if (root.scrollTo) {
           root.scrollTo({ top: height, behavior: 'smooth' })
           return
@@ -222,6 +221,8 @@ class ScrollSpy extends BaseComponent {
 
     this._clearActiveClass(this._config.target)
     this._activeTarget = target
+
+    window.history.pushState(null, null, target.hash)
     target.classList.add(CLASS_NAME_ACTIVE)
     this._activateParents(target)
 

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -127,6 +127,7 @@ class ScrollSpy extends BaseComponent {
         event.preventDefault()
         const root = this._rootElement || window
         const height = observableSection.offsetTop - this._element.offsetTop
+        window.history.pushState(null, null, event.target.hash)
         if (root.scrollTo) {
           root.scrollTo({ top: height, behavior: 'smooth' })
           return


### PR DESCRIPTION
As the new **ScrollSpy** `smoothScroll` option, prevents default action that in every user click, appends anchor hash on `window.location`, we can programmatically achieve the same attitude using `history.pushstate`

Any feedback will be appreciated. 


Disclaimer: Just trying a suggestion/feature (I really do not know). I am not sure this PR adds any value in user experience

closes #36291
closes #36387
