### PR TITLE
CSS: few proposals

### DIFF
--- a/scss/helpers/_color-bg.scss
+++ b/scss/helpers/_color-bg.scss
@@ -1,10 +1,10 @@
-// stylelint-disable declaration-no-important, function-name-case
+// stylelint-disable function-name-case
 
 // All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
 @each $color, $value in $theme-colors {
   $color-rgb: to-rgb($value);
   .text-bg-#{$color} {
-    color: color-contrast($value) !important;
-    background-color: RGBA($color-rgb, var(--#{$prefix}bg-opacity, 1)) !important;
+    color: color-contrast($value) if($enable-important-utilities, !important, null);
+    background-color: RGBA($color-rgb, var(--#{$prefix}bg-opacity, 1)) if($enable-important-utilities, !important, null);
   }
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -257,12 +257,6 @@
   }
 }
 
-.bd-example-border-utils-0 {
-  [class^="border"] {
-    border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
-  }
-}
-
 .bd-example-rounded-utils {
   [class*="rounded"] {
     margin: .25rem;

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -319,8 +319,8 @@
 
   pre {
     padding: 0;
-    margin-top: .65rem;
-    margin-bottom: .65rem;
+    margin-top: .625rem;
+    margin-bottom: .625rem;
     white-space: pre;
     background-color: transparent;
     border: 0;

--- a/site/content/docs/5.2/utilities/borders.md
+++ b/site/content/docs/5.2/utilities/borders.md
@@ -26,12 +26,12 @@ Add borders to custom elements:
 
 Or remove borders:
 
-{{< example class="bd-example-border-utils bd-example-border-utils-0" >}}
-<span class="border-0"></span>
-<span class="border-top-0"></span>
-<span class="border-end-0"></span>
-<span class="border-bottom-0"></span>
-<span class="border-start-0"></span>
+{{< example class="bd-example-border-utils" >}}
+<span class="border border-0"></span>
+<span class="border border-top-0"></span>
+<span class="border border-end-0"></span>
+<span class="border border-bottom-0"></span>
+<span class="border border-start-0"></span>
 {{< /example >}}
 
 ## Color


### PR DESCRIPTION
Here are the issues concerning the CSS part, we encountered with @julien-deramond.

The commits can be splited if needed or wanted or even be in another PR. I'm open to every comment that could help fix these issues.

### Tackled by the PR:

#### `!important` with (https://github.com/twbs/bootstrap/pull/36406/commits/ca48cc8d18b07fd011bab5052e726dced8446b35)
This PR adds a check for important utilities. It doesn't change anything on Bootstrap side, but might be useful for people that don't want `!important` in their code. If this commit is approved, it might lead to refactor some helpers' scss files.

#### `Border-*-0` with (https://github.com/twbs/bootstrap/pull/36406/commits/adc78d0c843b005c49eb2cf975d468f9f8af2cf9)
This PR tries to make the `.border-*-0` utility more understandable. It could be useful too, since the Stackblitz example doesn't take into account the examples' classes.

#### Rounded numbers with (https://github.com/twbs/bootstrap/pull/36406/commits/dee2d265d9a706d86105db2e8b14c7374e816268)
Having a rounded number of pixels for people that use `1rem = 16px`.