### PR TITLE
Docs: Remove `.is-invalid` from textarea validation example

### DIFF
--- a/site/content/docs/5.2/forms/validation.md
+++ b/site/content/docs/5.2/forms/validation.md
@@ -246,7 +246,7 @@ Validation styles are available for the following form controls and components:
 <form class="was-validated">
   <div class="mb-3">
     <label for="validationTextarea" class="form-label">Textarea</label>
-    <textarea class="form-control is-invalid" id="validationTextarea" placeholder="Required example textarea" required></textarea>
+    <textarea class="form-control" id="validationTextarea" placeholder="Required example textarea" required></textarea>
     <div class="invalid-feedback">
       Please enter a message in the textarea.
     </div>


### PR DESCRIPTION
<https://getbootstrap.com/docs/5.2/forms/validation/#supported-elements>

I'm not sure whether the CSS class `.is-invalid` has been added on purpose or not, but the incorrectly remaining invalid-feedback really confused me when I saw it for the first time until I inspected the source code.

Before | After
------ | -----
<img width="759" alt="截屏2022-05-21 15.20.06.png" src="https://user-images.githubusercontent.com/29367025/169641002-3cdc0276-554c-4283-8cbc-12b6be3a7776.png"> | <img width="761" alt="截屏2022-05-21 15.19.15.png" src="https://user-images.githubusercontent.com/29367025/169641010-9914179a-d8d5-4895-8509-32e2a13cd449.png">

