### PR TITLE
Stylelint: Disable `custom-property-empty-line-before`

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
     "stylelint-config-twbs-bootstrap"
   ],
   "rules": {
+    "custom-property-empty-line-before": null,
     "declaration-property-value-disallowed-list": {
       "border": "none",
       "outline": "none"

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 // Base class
 //
 // Requires one of the contextual, color modifier classes for `color` and

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 .breadcrumb {
   // scss-docs-start breadcrumb-css-vars
   --#{$prefix}breadcrumb-padding-x: #{$breadcrumb-padding-x};

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 //
 // Base styles
 //

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -23,7 +23,7 @@
   --#{$prefix}dropdown-padding-y: #{$dropdown-padding-y};
   --#{$prefix}dropdown-spacer: #{$dropdown-spacer};
   @include rfs($dropdown-font-size, --#{$prefix}dropdown-font-size);
-  --#{$prefix}dropdown-color: #{$dropdown-color}; // stylelint-disable-line custom-property-empty-line-before
+  --#{$prefix}dropdown-color: #{$dropdown-color};
   --#{$prefix}dropdown-bg: #{$dropdown-bg};
   --#{$prefix}dropdown-border-color: #{$dropdown-border-color};
   --#{$prefix}dropdown-border-radius: #{$dropdown-border-radius};

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -8,7 +8,7 @@
   --#{$prefix}nav-link-padding-x: #{$nav-link-padding-x};
   --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
   @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
-  --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight}; // stylelint-disable-line custom-property-empty-line-before
+  --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
   --#{$prefix}nav-link-color: #{$nav-link-color};
   --#{$prefix}nav-link-hover-color: #{$nav-link-hover-color};
   --#{$prefix}nav-link-disabled-color: #{$nav-link-disabled-color};

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 .pagination {
   // scss-docs-start pagination-css-vars
   --#{$prefix}pagination-padding-x: #{$pagination-padding-x};

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 .popover {
   // scss-docs-start popover-css-vars
   --#{$prefix}popover-zindex: #{$zindex-popover};

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -12,7 +12,7 @@
   // scss-docs-start progress-css-vars
   --#{$prefix}progress-height: #{$progress-height};
   @include rfs($progress-font-size, --#{$prefix}progress-font-size);
-  --#{$prefix}progress-bg: #{$progress-bg}; // stylelint-disable-line custom-property-empty-line-before
+  --#{$prefix}progress-bg: #{$progress-bg};
   --#{$prefix}progress-border-radius: #{$progress-border-radius};
   --#{$prefix}progress-box-shadow: #{$progress-box-shadow};
   --#{$prefix}progress-bar-color: #{$progress-bar-color};

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 :root {
   // Note: Custom variable values only support SassScript inside `#{}`.
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -5,7 +5,7 @@
   --#{$prefix}toast-spacing: #{$toast-spacing};
   --#{$prefix}toast-max-width: #{$toast-max-width};
   @include rfs($toast-font-size, --#{$prefix}toast-font-size);
-  --#{$prefix}toast-color: #{$toast-color}; // stylelint-disable-line custom-property-empty-line-before
+  --#{$prefix}toast-color: #{$toast-color};
   --#{$prefix}toast-bg: #{$toast-background-color};
   --#{$prefix}toast-border-width: #{$toast-border-width};
   --#{$prefix}toast-border-color: #{$toast-border-color};

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 // Base class
 .tooltip {
   // scss-docs-start tooltip-css-vars

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -1,5 +1,3 @@
-// stylelint-disable custom-property-empty-line-before
-
 // Button variants
 //
 // Easily pump out default styles, as well as :hover, :focus, :active,

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -5,6 +5,6 @@
   --#{$prefix}pagination-padding-x: #{$padding-x};
   --#{$prefix}pagination-padding-y: #{$padding-y};
   @include rfs($font-size, --#{$prefix}pagination-font-size);
-  --#{$prefix}pagination-border-radius: #{$border-radius}; // stylelint-disable-line custom-property-empty-line-before
+  --#{$prefix}pagination-border-radius: #{$border-radius};
 }
 // scss-docs-end pagination-mixin


### PR DESCRIPTION
Cleans up a ton of CSS comments where we've disabled the rule.