### PR TITLE
v4: Horizontal collapse

### DIFF
--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -17,4 +17,10 @@
   height: 0;
   overflow: hidden;
   @include transition($transition-collapse);
+
+  &.width {
+    width: 0;
+    height: auto;
+    @include transition($transition-collapse-width);
+  }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -257,6 +257,7 @@ $caret-spacing:               $caret-width * .85 !default;
 $transition-base:             all .2s ease-in-out !default;
 $transition-fade:             opacity .15s linear !default;
 $transition-collapse:         height .35s ease !default;
+$transition-collapse-width:   width .35s ease !default;
 
 $embed-responsive-aspect-ratios: () !default;
 $embed-responsive-aspect-ratios: join(

--- a/site/content/docs/4.6/components/collapse.md
+++ b/site/content/docs/4.6/components/collapse.md
@@ -40,6 +40,29 @@ Generally, we recommend using a button with the `data-target` attribute. While n
 </div>
 {{< /example >}}
 
+## Horizontal
+
+The collapse plugin also supports horizontal collapsing. Add the `.width` modifier class to transition the `width` instead of `height` and set a `width` on the immediate child element. Feel free to write your own custom Sass, use inline styles, or use our [width utilities]({{< docsref "/utilities/sizing" >}}).
+
+{{< callout info >}}
+Please note that while the example below has a `min-height` set to avoid excessive repaints in our docs, this is not explicitly required. **Only the `width` on the child element is required.**
+{{< /callout >}}
+
+{{< example >}}
+<p>
+  <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseWidthExample" aria-expanded="false" aria-controls="collapseWidthExample">
+    Toggle width collapse
+  </button>
+</p>
+<div style="min-height: 120px;">
+  <div class="collapse width" id="collapseWidthExample">
+    <div class="card card-body" style="width: 320px;">
+      This is some placeholder content for a horizontal collapse. It's hidden by default and shown when triggered.
+    </div>
+  </div>
+</div>
+{{< /example >}}
+
 ## Multiple targets
 
 A `<button>` or `<a>` can show and hide multiple elements by referencing them with a JQuery selector in its `href` or `data-target` attribute.


### PR DESCRIPTION
Backports #34253 to v4. Changes the `collapse-horizontal` to `width` for those who've secretly been using this feature for years in Bootstrap 4 but never saw official support.
