### PR TITLE
Re-ordering js default objects

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -80,8 +80,8 @@ const Default = {
 const DefaultType = {
   interval: '(number|boolean)',
   keyboard: 'boolean',
-  ride: '(boolean|string)',
   pause: '(string|boolean)',
+  ride: '(boolean|string)',
   touch: 'boolean',
   wrap: 'boolean'
 }

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -45,13 +45,13 @@ const SELECTOR_ACTIVES = '.collapse.show, .collapse.collapsing'
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="collapse"]'
 
 const Default = {
-  toggle: true,
-  parent: null
+  parent: null,
+  toggle: true
 }
 
 const DefaultType = {
-  toggle: 'boolean',
-  parent: '(null|element)'
+  parent: '(null|element)',
+  toggle: 'boolean'
 }
 
 /**

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -68,21 +68,21 @@ const PLACEMENT_TOPCENTER = 'top'
 const PLACEMENT_BOTTOMCENTER = 'bottom'
 
 const Default = {
-  offset: [0, 2],
+  autoClose: true,
   boundary: 'clippingParents',
-  reference: 'toggle',
   display: 'dynamic',
+  offset: [0, 2],
   popperConfig: null,
-  autoClose: true
+  reference: 'toggle'
 }
 
 const DefaultType = {
-  offset: '(array|string|function)',
+  autoClose: '(boolean|string)',
   boundary: '(string|element)',
-  reference: '(string|element|object)',
   display: 'string',
+  offset: '(array|string|function)',
   popperConfig: '(null|object|function)',
-  autoClose: '(boolean|string)'
+  reference: '(string|element|object)'
 }
 
 /**

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -46,14 +46,14 @@ const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="modal"]'
 
 const Default = {
   backdrop: true,
-  keyboard: true,
-  focus: true
+  focus: true,
+  keyboard: true
 }
 
 const DefaultType = {
   backdrop: '(boolean|string)',
-  keyboard: 'boolean',
-  focus: 'boolean'
+  focus: 'boolean',
+  keyboard: 'boolean'
 }
 
 /**

--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -19,15 +19,15 @@ const SELECTOR_CONTENT = '.popover-body'
 
 const Default = {
   ...Tooltip.Default,
-  placement: 'right',
-  offset: [0, 8],
-  trigger: 'click',
   content: '',
+  offset: [0, 8],
+  placement: 'right',
   template: '<div class="popover" role="tooltip">' +
-              '<div class="popover-arrow"></div>' +
-              '<h3 class="popover-header"></h3>' +
-              '<div class="popover-body"></div>' +
-            '</div>'
+    '<div class="popover-arrow"></div>' +
+    '<h3 class="popover-header"></h3>' +
+    '<div class="popover-body"></div>' +
+    '</div>',
+  trigger: 'click'
 }
 
 const DefaultType = {

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -54,46 +54,46 @@ const AttachmentMap = {
 }
 
 const Default = {
+  allowList: DefaultAllowlist,
   animation: true,
-  template: '<div class="tooltip" role="tooltip">' +
-              '<div class="tooltip-arrow"></div>' +
-              '<div class="tooltip-inner"></div>' +
-            '</div>',
-  trigger: 'hover focus',
-  title: '',
-  delay: 0,
-  html: false,
-  selector: false,
-  placement: 'top',
-  offset: [0, 0],
-  container: false,
-  fallbackPlacements: ['top', 'right', 'bottom', 'left'],
   boundary: 'clippingParents',
+  container: false,
   customClass: '',
+  delay: 0,
+  fallbackPlacements: ['top', 'right', 'bottom', 'left'],
+  html: false,
+  offset: [0, 0],
+  placement: 'top',
+  popperConfig: null,
   sanitize: true,
   sanitizeFn: null,
-  allowList: DefaultAllowlist,
-  popperConfig: null
+  selector: false,
+  template: '<div class="tooltip" role="tooltip">' +
+            '<div class="tooltip-arrow"></div>' +
+            '<div class="tooltip-inner"></div>' +
+            '</div>',
+  title: '',
+  trigger: 'hover focus'
 }
 
 const DefaultType = {
+  allowList: 'object',
   animation: 'boolean',
-  template: 'string',
-  title: '(string|element|function)',
-  trigger: 'string',
-  delay: '(number|object)',
-  html: 'boolean',
-  selector: '(string|boolean)',
-  placement: '(string|function)',
-  offset: '(array|string|function)',
-  container: '(string|element|boolean)',
-  fallbackPlacements: 'array',
   boundary: '(string|element)',
+  container: '(string|element|boolean)',
   customClass: '(string|function)',
+  delay: '(number|object)',
+  fallbackPlacements: 'array',
+  html: 'boolean',
+  offset: '(array|string|function)',
+  placement: '(string|function)',
+  popperConfig: '(null|object|function)',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
-  allowList: 'object',
-  popperConfig: '(null|object|function)'
+  selector: '(string|boolean)',
+  template: 'string',
+  title: '(string|element|function)',
+  trigger: 'string'
 }
 
 /**

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -20,18 +20,18 @@ const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 
 const Default = {
   className: 'modal-backdrop',
-  isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
+  clickCallback: null,
   isAnimated: false,
-  rootElement: 'body', // give the choice to place backdrop under different elements
-  clickCallback: null
+  isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
+  rootElement: 'body' // give the choice to place backdrop under different elements
 }
 
 const DefaultType = {
   className: 'string',
-  isVisible: 'boolean',
+  clickCallback: '(function|null)',
   isAnimated: 'boolean',
-  rootElement: '(element|string)',
-  clickCallback: '(function|null)'
+  isVisible: 'boolean',
+  rootElement: '(element|string)'
 }
 
 /**

--- a/js/src/util/focustrap.js
+++ b/js/src/util/focustrap.js
@@ -24,13 +24,13 @@ const TAB_NAV_FORWARD = 'forward'
 const TAB_NAV_BACKWARD = 'backward'
 
 const Default = {
-  trapElement: null, // The element to trap focus inside of
-  autofocus: true
+  autofocus: true,
+  trapElement: null // The element to trap focus inside of
 }
 
 const DefaultType = {
-  trapElement: 'element',
-  autofocus: 'boolean'
+  autofocus: 'boolean',
+  trapElement: 'element'
 }
 
 /**

--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -26,15 +26,15 @@ const CLASS_NAME_POINTER_EVENT = 'pointer-event'
 const SWIPE_THRESHOLD = 40
 
 const Default = {
+  endCallback: null,
   leftCallback: null,
-  rightCallback: null,
-  endCallback: null
+  rightCallback: null
 }
 
 const DefaultType = {
+  endCallback: '(function|null)',
   leftCallback: '(function|null)',
-  rightCallback: '(function|null)',
-  endCallback: '(function|null)'
+  rightCallback: '(function|null)'
 }
 
 /**

--- a/js/src/util/template-factory.js
+++ b/js/src/util/template-factory.js
@@ -17,28 +17,28 @@ import Config from './config'
 const NAME = 'TemplateFactory'
 
 const Default = {
-  extraClass: '',
-  template: '<div></div>',
+  allowList: DefaultAllowlist,
   content: {}, // { selector : text ,  selector2 : text2 , }
+  extraClass: '',
   html: false,
   sanitize: true,
   sanitizeFn: null,
-  allowList: DefaultAllowlist
+  template: '<div></div>'
 }
 
 const DefaultType = {
-  extraClass: '(string|function)',
-  template: 'string',
+  allowList: 'object',
   content: 'object',
+  extraClass: '(string|function)',
   html: 'boolean',
   sanitize: 'boolean',
   sanitizeFn: '(null|function)',
-  allowList: 'object'
+  template: 'string'
 }
 
 const DefaultContentType = {
-  selector: '(string|element)',
-  entry: '(string|element|function|null)'
+  entry: '(string|element|function|null)',
+  selector: '(string|element)'
 }
 
 /**


### PR DESCRIPTION
Here are the issues concerning the CSS part, we encountered with @julien-deramond.

This PR is a split of #36398 

### Tackled by the PR
#### Re-order for default objects with (https://github.com/twbs/bootstrap/pull/36398/commits/633fca4fc3e6a97fc0064f803f4a85fe79afbcc4)
Alphabetical reordering of the default objects. If these changes are approved, it might be great to see if other objects could be updated this way. Just as an example : https://github.com/twbs/bootstrap/blob/416f4905f13c2ca3096343e0a5a4934c8c0ced3f/js/src/dom/event-handler.js#L24