### PR TITLE
Update Sass for computing `.table-group-divider` border

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -42,7 +42,7 @@
 }
 
 .table-group-divider {
-  border-top: calc(2 * $table-border-width) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
+  border-top: ($table-border-width * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
 }
 
 //

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -42,7 +42,7 @@
 }
 
 .table-group-divider {
-  border-top: ($table-border-width * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
+  border-top: ($table-border-width * 2) solid $table-group-separator-color;
 }
 
 //


### PR DESCRIPTION
Fixes #36441.

For context, reverted the `calc()` usage here because we're not able to fully utilize CSS vars for `border-width` yet, due to existing Sass math usage.