### PR TITLE
fix scrollbar padding

### DIFF
--- a/js/src/util/scrollbar.js
+++ b/js/src/util/scrollbar.js
@@ -15,7 +15,6 @@ import { isElement } from './index'
 
 const SELECTOR_FIXED_CONTENT = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top'
 const SELECTOR_STICKY_CONTENT = '.sticky-top'
-const PROPERTY_PADDING = 'padding-right'
 const PROPERTY_MARGIN = 'margin-right'
 
 /**
@@ -37,17 +36,12 @@ class ScrollBarHelper {
   hide() {
     const width = this.getWidth()
     this._disableOverFlow()
-    // give padding to element to balance the hidden scrollbar width
-    this._setElementAttributes(this._element, PROPERTY_PADDING, calculatedValue => calculatedValue + width)
     // trick: We adjust positive paddingRight and negative marginRight to sticky-top elements to keep showing fullwidth
-    this._setElementAttributes(SELECTOR_FIXED_CONTENT, PROPERTY_PADDING, calculatedValue => calculatedValue + width)
     this._setElementAttributes(SELECTOR_STICKY_CONTENT, PROPERTY_MARGIN, calculatedValue => calculatedValue - width)
   }
 
   reset() {
     this._resetElementAttributes(this._element, 'overflow')
-    this._resetElementAttributes(this._element, PROPERTY_PADDING)
-    this._resetElementAttributes(SELECTOR_FIXED_CONTENT, PROPERTY_PADDING)
     this._resetElementAttributes(SELECTOR_STICKY_CONTENT, PROPERTY_MARGIN)
   }
 


### PR DESCRIPTION
I had an issue with scroll bar padding on opening modals shifting everything (including navbar) to the right. So I made this patch to fix it, however, I did not contemplate other use cases that this commit may interfere with, so am sorry if this conflicts with a function. 