### PR TITLE
Add color CSS vars for blockquote-footer, .img-thumbnail, .figure-caption & .offcanvas-backdrop

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -12,9 +12,12 @@
 
 // Image thumbnails
 .img-thumbnail {
+  --#{$prefix}thumbnail-bg: #{$thumbnail-bg};
+  --#{$prefix}thumbnail-border-color: #{$thumbnail-border-color};
+
   padding: $thumbnail-padding;
-  background-color: $thumbnail-bg;
-  border: $thumbnail-border-width solid $thumbnail-border-color;
+  background-color: var(--#{$prefix}thumbnail-bg);
+  border: $thumbnail-border-width solid var(--#{$prefix}thumbnail-border-color);
   @include border-radius($thumbnail-border-radius);
   @include box-shadow($thumbnail-box-shadow);
 
@@ -37,6 +40,8 @@
 }
 
 .figure-caption {
+  --#{$prefix}figure-caption-color: #{$figure-caption-color};
+
   @include font-size($figure-caption-font-size);
-  color: $figure-caption-color;
+  color: var(--#{$prefix}figure-caption-color);
 }

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -114,7 +114,13 @@
 }
 
 .offcanvas-backdrop {
-  @include overlay-backdrop($zindex-offcanvas-backdrop, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
+  // scss-docs-start offcanvas-backdrop-css-vars
+  --#{$prefix}backdrop-zindex: #{$zindex-offcanvas-backdrop};
+  --#{$prefix}backdrop-bg: #{$offcanvas-backdrop-bg};
+  --#{$prefix}backdrop-opacity: #{$offcanvas-backdrop-opacity};
+  // scss-docs-end offcanvas-backdrop-css-vars
+
+  @include overlay-backdrop(var(--#{$prefix}backdrop-zindex), var(--#{$prefix}backdrop-bg), var(--#{$prefix}backdrop-opacity));
 }
 
 .offcanvas-header {

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -93,10 +93,12 @@
 }
 
 .blockquote-footer {
+  --#{$prefix}blockquote-footer-color: #{$blockquote-footer-color};
+
   margin-top: -$blockquote-margin-y;
   margin-bottom: $blockquote-margin-y;
   @include font-size($blockquote-footer-font-size);
-  color: $blockquote-footer-color;
+  color: var(--#{$prefix}blockquote-footer-color);
 
   &::before {
     content: "\2014\00A0"; // em dash, nbsp

--- a/site/content/docs/5.2/components/offcanvas.md
+++ b/site/content/docs/5.2/components/offcanvas.md
@@ -235,6 +235,8 @@ As part of Bootstrap's evolving CSS variables approach, offcanvas now uses local
 
 {{< scss-docs name="offcanvas-css-vars" file="scss/_offcanvas.scss" >}}
 
+{{< scss-docs name="offcanvas-backdrop-css-vars" file="scss/_offcanvas.scss" >}}
+
 ### Sass variables
 
 {{< scss-docs name="offcanvas-variables" file="scss/_variables.scss" >}}


### PR DESCRIPTION
Adding color CSS vars to:
- `blockquote-footer`
- `.img-thumbnail`
- `.figure-caption`
- `.offcanvas-backdrop`

Partial fix for issue #36454