### PR TITLE
Add color CSS vars for .alert-link

### DIFF
--- a/scss/mixins/_alert.scss
+++ b/scss/mixins/_alert.scss
@@ -3,7 +3,7 @@
   --#{$prefix}alert-color: #{$color};
   --#{$prefix}alert-bg: #{$background};
   --#{$prefix}alert-border-color: #{$border};
-  --#{$prefix}alert-link-color: #{ shade-color($color, 20%) };
+  --#{$prefix}alert-link-color: #{shade-color($color, 20%)};
 
   @if $enable-gradients {
     background-image: var(--#{$prefix}gradient);

--- a/scss/mixins/_alert.scss
+++ b/scss/mixins/_alert.scss
@@ -3,13 +3,14 @@
   --#{$prefix}alert-color: #{$color};
   --#{$prefix}alert-bg: #{$background};
   --#{$prefix}alert-border-color: #{$border};
+  --#{$prefix}alert-link-color: #{ shade-color($color, 20%) };
 
   @if $enable-gradients {
     background-image: var(--#{$prefix}gradient);
   }
 
   .alert-link {
-    color: shade-color($color, 20%);
+    color: var(--#{$prefix}alert-link-color);
   }
 }
 // scss-docs-end alert-variant-mixin


### PR DESCRIPTION
Adding color CSS vars for `.alert-link`.

Partial fix for issue #36454