### PR TITLE
Fix alert border radius

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -20,7 +20,7 @@
   color: var(--#{$prefix}alert-color);
   background-color: var(--#{$prefix}alert-bg);
   border: var(--#{$prefix}alert-border);
-  border-radius: var(--#{$prefix}alert-border-radius, 0); // stylelint-disable-line property-disallowed-list
+  @include border-radius(var(--#{$prefix}alert-border-radius));
 }
 
 // Headings for larger alerts


### PR DESCRIPTION
Was not using the mixin, which makes it not work properly with `$enable-rounded: false`. Also var fallback was 0, but variable is scoped in the class, and no other usages of border radius seem to do this, so removed.