### PR TITLE
Docs: fix Reboot Horizontal rules using border utilities

### DIFF
--- a/site/content/docs/5.2/content/reboot.md
+++ b/site/content/docs/5.2/content/reboot.md
@@ -106,8 +106,8 @@ The `<hr>` element has been simplified. Similar to browser defaults, `<hr>`s are
   <hr>
 </div>
 
-<hr class="text-danger border-2 opacity-50">
-<hr class="border-primary border-3 opacity-75">
+<hr class="border border-danger border-2 opacity-50">
+<hr class="border border-primary border-3 opacity-75">
 {{< /example >}}
 
 ## Lists


### PR DESCRIPTION
In the current _main_ branch we can see in [Reboot > Horizontal rules](https://twbs-bootstrap.netlify.app/docs/5.2/content/reboot/#horizontal-rules) that all borders have the same thickness, event with `.border-2` and `.border-3`.

This PR proposes to add `.border` for `.border-3` and `.border-3` to be actually applied.

It also means that we can't use anymore `.text-danger` but replace it by `.border-danger` due to the use of CSS vars.

I believe that the description associated with this example is still accurate but I'd appreciate a double-check.

### [Live preview](https://deploy-preview-36476--twbs-bootstrap.netlify.app/docs/5.2/content/reboot/#horizontal-rules)