### PR TITLE
Docs: Replace wrong mobile OS Windows with iOS

### DIFF
--- a/site/content/docs/5.2/getting-started/browsers-devices.md
+++ b/site/content/docs/5.2/getting-started/browsers-devices.md
@@ -30,7 +30,7 @@ Generally speaking, Bootstrap supports the latest versions of each major platfor
 | | Chrome | Firefox | Safari | Android Browser &amp; WebView |
 | --- | --- | --- | --- | --- |
 | **Android** | Supported | Supported | <span class="text-muted">&mdash;</span> | v6.0+ |
-| **Windows** | Supported | Supported | Supported | <span class="text-muted">&mdash;</span> |
+| **iOS** | Supported | Supported | Supported | <span class="text-muted">&mdash;</span> |
 {{< /bs-table >}}
 
 ### Desktop browsers


### PR DESCRIPTION
Windows Mobile is dead, and iOS is missing.