### PR TITLE
Add :root css vars for bs-breakpoints

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -71,4 +71,8 @@
   --#{$prefix}code-color: #{$code-color};
 
   --#{$prefix}highlight-bg: #{$mark-bg};
+
+  @each $breakpoint, $breakpoint-value in $grid-breakpoints {
+    --#{$prefix}breakpoint-#{$breakpoint}: #{$breakpoint-value};
+  }
 }


### PR DESCRIPTION
breakpoint css vars can then be read in javascript code, e.g.:
```js
const breakpoint_md = parseInt(
    window.getComputedStyle(document.documentElement).getPropertyValue('--bs-breakpoint-md')
);
```