### PR TITLE
Don't style `readonly` inputs as `disabled`

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -64,8 +64,7 @@
   // HTML5 says that controls under a fieldset > legend:first-child won't be
   // disabled if the fieldset is disabled. Due to implementation difficulty, we
   // don't honor that edge case; we style them as disabled anyway.
-  &:disabled,
-  &[readonly] {
+  &:disabled {
     color: $input-disabled-color;
     background-color: $input-disabled-bg;
     border-color: $input-disabled-border-color;
@@ -109,6 +108,10 @@
   background-color: transparent;
   border: solid transparent;
   border-width: $input-border-width 0;
+
+  &:focus {
+    outline: 0;
+  }
 
   &.form-control-sm,
   &.form-control-lg {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -59,7 +59,7 @@
     opacity: 1;
   }
 
-  // Disabled and read-only inputs
+  // Disabled inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
   // disabled if the fieldset is disabled. Due to implementation difficulty, we

--- a/site/content/docs/5.2/forms/form-control.md
+++ b/site/content/docs/5.2/forms/form-control.md
@@ -31,7 +31,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 
 ## Disabled
 
-Add the `disabled` boolean attribute on an input to give it a grayed out appearance and remove pointer events.
+Add the `disabled` boolean attribute on an input to give it a grayed out appearance, remove pointer events, and prevent focusing.
 
 {{< example >}}
 <input class="form-control" type="text" placeholder="Disabled input" aria-label="Disabled input example" disabled>
@@ -40,7 +40,7 @@ Add the `disabled` boolean attribute on an input to give it a grayed out appeara
 
 ## Readonly
 
-Add the `readonly` boolean attribute on an input to prevent modification of the input's value.
+Add the `readonly` boolean attribute on an input to prevent modification of the input's value. `readonly` inputs can still be focused and selected, while `disabled` inputs cannot.
 
 {{< example >}}
 <input class="form-control" type="text" value="Readonly input here..." aria-label="readonly input example" readonly>
@@ -48,7 +48,7 @@ Add the `readonly` boolean attribute on an input to prevent modification of the 
 
 ## Readonly plain text
 
-If you want to have `<input readonly>` elements in your form styled as plain text, use the `.form-control-plaintext` class to remove the default form field styling and preserve the correct margin and padding.
+If you want to have `<input readonly>` elements in your form styled as plain text, replace `.form-control` with `.form-control-plaintext` to remove the default form field styling and preserve the correct `margin` and `padding`.
 
 {{< example >}}
   <div class="mb-3 row">


### PR DESCRIPTION
Fixes #33925.

For awhile now we've styled `readonly` text inputs as `disabled` by graying out their background. However, these two input attributes do different things and shouldn't be styled the same. Here's how it works with this PR, and in most browsers by default:

- `disabled` inputs essentially have no interaction—you can't tab to them, you can click or focus into them. You can select their text. These will have a light gray background applied to them.

- `readonly` inputs can be focused and their text selected. These will look and feel like normal inputs, but you can't modify their values.

Relatedly, I've also removed the Chrome-specific focus styling from readonly `.form-control-plaintext` class here. This just brings it further in line with "plain text" and fixes a visual glitch as this doesn't appear in say Safari.

Biggest question I have is should we have some other indicator that something is readonly? /cc @julien-deramond and @patrickhlauke for thoughts.

---

- [ ] Update docs copy to reflect these changes
