### PR TITLE
[docs] Document BootstrapVue being outdated

### DIFF
--- a/site/content/docs/5.2/getting-started/javascript.md
+++ b/site/content/docs/5.2/getting-started/javascript.md
@@ -19,7 +19,7 @@ While the Bootstrap CSS can be used with any framework, **the Bootstrap JavaScri
 A better alternative for those using this type of frameworks is to use a framework-specific package **instead of** the Bootstrap JavaScript. Here are some of the most popular options:
 
 - React: [React Bootstrap](https://react-bootstrap.github.io/)
-- Vue: [BootstrapVue](https://bootstrap-vue.org/)
+- Vue: [BootstrapVue](https://bootstrap-vue.org/) (currently only supports Vue 2 and Bootstrap 4)
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
 
 ## Using Bootstrap as a module


### PR DESCRIPTION
@dosstx said:

> The docs state that it is suggested to use an alternative bootstrap javascript framework. I have a Vue background and the docs link to bootstrap-vue as an option. However, Bootstrap-vue is NOT compatible with the current Vue version (Vue 3) and it can lead to confusion for folks. Can we somehow make an update about this ? Due to the war in Ukraine, it seems the some of the core members will not be make any migration to Vue 3.

