### PR TITLE
Remove `--bs-headings-color` CSS variable due to backward compatibility issues

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -87,7 +87,7 @@ hr {
   font-style: $headings-font-style;
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;
-  color: var(--#{$prefix}heading-color);
+  color: $headings-color;
 }
 
 h1 {

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -64,7 +64,6 @@
   --#{$prefix}border-radius-pill: #{$border-radius-pill};
   // scss-docs-end root-border-var
 
-  --#{$prefix}heading-color: #{$headings-color};
   --#{$prefix}link-color: #{$link-color};
   --#{$prefix}link-hover-color: #{$link-hover-color};
 


### PR DESCRIPTION
Fixes #36365.

The null value breaks existing styling where hyperlinks with a heading helper class no longer appear blue. This will have to be resolved most likely in v6 I'd think to avoid any other BC issues.
