### PR TITLE
Offset content from fixed navbar without adding padding-top to heading

### DIFF
--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -137,6 +137,10 @@
     })
   }
 
+  // Offset content from fixed navbar when jumping to headings
+  const navigationHeight = document.querySelector('header').offsetHeight
+  document.documentElement.style.setProperty('--scroll-padding', navigationHeight + 15 + "px")
+
   // -------------------------------
   // Offcanvas
   // -------------------------------

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -2,10 +2,14 @@
 // Bootstrap docs content theming
 //
 
+// Add a scroll-padding custom property to the html element
+html {
+  scroll-padding-top: var(--scroll-padding, 50px);
+}
+
 .bd-content {
   // Offset content from fixed navbar when jumping to headings
   > :target {
-    padding-top: 5rem;
     margin-top: -5rem;
   }
 


### PR DESCRIPTION
I removed the padding-top property on the :target pseudo class of the .bd-content element in order to stop the padding-top being added to the heading whenever the hyperlink is clicked.
Also, added a scroll-padding-top custom property to the html element which I went ahead and set in the snippets.js file as the height of the header element.