### PR TITLE
Scrollspy: enable `smooth-scroll` behavior

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -128,7 +128,7 @@ class ScrollSpy extends BaseComponent {
         const root = this._rootElement || window
         const height = observableSection.offsetTop - this._element.offsetTop
         if (root.scrollTo) {
-          root.scrollTo({ top: height })
+          root.scrollTo({ top: height, behavior: 'smooth' })
           return
         }
 

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -889,7 +889,7 @@ describe('ScrollSpy', () => {
 
       setTimeout(() => {
         if (div.scrollTo) {
-          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop })
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'smooth' })
         } else {
           expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
         }


### PR DESCRIPTION
closes  #36372

Enable ScrollSpy smooth scroll behavior during `element.scrolTo` usage

Preview: https://deploy-preview-36528--twbs-bootstrap.netlify.app/docs/5.2/components/scrollspy/#content