### PR TITLE
Add missing things in `hide` method of dropdown

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -202,11 +202,18 @@ class Dropdown {
       return
     }
 
+    // If this is a touch-enabled device we remove the extra
+    // empty mouseover listeners we added for iOS support
+    if ('ontouchstart' in document.documentElement) {
+      $(document.body).children().off('mouseover', null, $.noop)
+    }
+
     if (this._popper) {
       this._popper.destroy()
     }
 
     $(this._menu).toggleClass(CLASS_NAME_SHOW)
+    this._element.setAttribute('aria-expanded', false)
     $(parent)
       .toggleClass(CLASS_NAME_SHOW)
       .trigger($.Event(EVENT_HIDDEN, relatedTarget))
@@ -404,13 +411,12 @@ class Dropdown {
         $(document.body).children().off('mouseover', null, $.noop)
       }
 
-      toggles[i].setAttribute('aria-expanded', 'false')
-
       if (context._popper) {
         context._popper.destroy()
       }
 
       $(dropdownMenu).removeClass(CLASS_NAME_SHOW)
+      toggles[i].setAttribute('aria-expanded', 'false')
       $(parent)
         .removeClass(CLASS_NAME_SHOW)
         .trigger($.Event(EVENT_HIDDEN, relatedTarget))

--- a/js/tests/unit/dropdown.js
+++ b/js/tests/unit/dropdown.js
@@ -1585,12 +1585,12 @@ $(function () {
   })
 
   QUnit.test('should hide a dropdown and destroy popper', function (assert) {
-    assert.expect(1)
+    assert.expect(2)
     var done = assert.async()
 
     var fixtureHtml = [
       '<div class="dropdown">',
-      '  <button href="#" class="btn dropdown-toggle" data-toggle="dropdown">Dropdown</button>',
+      '  <button href="#" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="true">Dropdown</button>',
       '  <div class="dropdown-menu">',
       '    <a class="dropdown-item" href="#">Secondary link</a>',
       '  </div>',
@@ -1600,9 +1600,8 @@ $(function () {
     $(fixtureHtml).appendTo('#qunit-fixture')
 
     var $dropdownEl = $('.dropdown')
-    var dropdown = $('[data-toggle="dropdown"]')
-      .bootstrapDropdown()
-      .data('bs.dropdown')
+    var $btnDropdown = $('[data-toggle="dropdown"]').bootstrapDropdown()
+    var dropdown = $btnDropdown.data('bs.dropdown')
     var spyPopper
 
     $dropdownEl.one('shown.bs.dropdown', function () {
@@ -1612,6 +1611,7 @@ $(function () {
 
     $dropdownEl.one('hidden.bs.dropdown', function () {
       assert.true(spyPopper.called)
+      assert.strictEqual($btnDropdown.attr('aria-expanded'), 'false', 'aria-expanded is set to string "false" on hide')
       done()
     })
 


### PR DESCRIPTION
Gave a try to backport https://github.com/twbs/bootstrap/pull/33451 to v4.

Feel free to modify it directly or close it if it is too far from what's expected here.

I haven't backported the new unit test `it('should remove event listener on touch-enabled device that was added in show method', done => {` because in v4 there was no existing test in that spirit. In v5 there are tests of `EventHandler.off` and `EventHandler.on` but not in v4.
