### PR TITLE
Fix possible bug on event handler

### DIFF
--- a/js/src/dom/event-handler.js
+++ b/js/src/dom/event-handler.js
@@ -234,7 +234,7 @@ const EventHandler = {
 
     if (typeof callable !== 'undefined') {
       // Simplest case: handler is passed, remove that listener ONLY.
-      if (!storeElementEvent) {
+      if (!Object.keys(storeElementEvent).length) {
         return
       }
 


### PR DESCRIPTION
Based on a bug was caused on #35857, some browsers validate the empty object as `true`, so it is safer to use an explicit check