### PR TITLE
Handle non-empty whitespace textContent in Tooltip trigger

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -518,7 +518,7 @@ class Tooltip extends BaseComponent {
       return
     }
 
-    if (!this._element.getAttribute('aria-label') && !this._element.textContent) {
+    if (!this._element.getAttribute('aria-label') && !this._element.textContent.trim()) {
       this._element.setAttribute('aria-label', title)
     }
 

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1358,6 +1358,25 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should add the aria-label attribute when element text content is a whitespace string', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="A tooltip"><span>    </span></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        tooltipEl.addEventListener('shown.bs.tooltip', () => {
+          const tooltipShown = document.querySelector('.tooltip')
+
+          expect(tooltipShown).not.toBeNull()
+          expect(tooltipEl.getAttribute('aria-label')).toEqual('A tooltip')
+          resolve()
+        })
+
+        tooltip.show()
+      })
+    })
+
     it('should not add the aria-label attribute if the attribute already exists', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#" rel="tooltip" aria-label="Different label" title="Another tooltip"></a>'


### PR DESCRIPTION
If a Tooltip trigger has non-empty `textContent` that consists solely of whitespace, Bootstrap will remove the `title` but won't add an `aria-label` with the contents of `title`. Here's a reproduction of this: https://jsfiddle.net/nwalters512/7y8edzxr/7/. This is a poor experience for folks using screen readers, as they won't have any accessible label for the trigger.

This PR changes the JS to check the falseyness of `textContent.trim()` instead of `textContent` directly.