### PR TITLE
Fix popover live demo to use `data-bs-title` instead of `title`

### DIFF
--- a/site/content/docs/5.2/components/popovers.md
+++ b/site/content/docs/5.2/components/popovers.md
@@ -51,7 +51,7 @@ We use JavaScript similar to the snippet above to render the following live popo
 {{< /callout >}}
 
 {{< example stackblitz_add_js="true" >}}
-<button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
+<button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
 {{< /example >}}
 
 ### Four directions


### PR DESCRIPTION
:sweat_smile: Forgot to update one example in https://github.com/twbs/bootstrap/pull/36449. This live demo example must use `data-bs-title` instead of `title` for consistency with the other examples and the callout message, and for the title to be displayed in StackBlitz.

Before, if "Edit on StackBlitz" button is clicked, the title won't be displayed in StackBlitz after clicking on the "Click to toggle popover".

### [Live preview](https://deploy-preview-36613--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#live-demo)

/CC @GeoSot 