### PR TITLE
Use 'needs-example' label to trigger live demo bot message

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: awaiting reply
-        if: github.event.label.name == 'awaiting-reply'
+        if: github.event.label.name == 'needs-example'
         uses: actions-cool/issues-helper@v3
         with:
           actions: "create-comment"


### PR DESCRIPTION
This PR proposes to separate `awaiting-reply` automatic actions.
At the end:
- `awaiting-reply` will automatically closes the issue in 14 days
- :new: `needs-example` will trigger the 'live demo' bot message

- [x] Needs creation of the `needs-example` label in the repository