### PR TITLE
Fix search modal z-index to be on top of all docs showcased components

### DIFF
--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -23,7 +23,7 @@
   --docsearch-muted-color: #{$text-muted};
   --docsearch-hit-shadow: none;
 
-  z-index: 1030;
+  z-index: 2000; // Make sure to be over all components showcased in the documentation
 
   @include media-breakpoint-up(lg) {
     padding-top: 4rem;


### PR DESCRIPTION
Search modal currently has a `z-index` set to `1030`. That makes it under some showcased components in the documentation; especially the ones that stay displayed even if one clicks outside of it.

Here are two examples, popover and toast:

![Screenshot from 2022-06-23 19-51-41](https://user-images.githubusercontent.com/17381666/175363004-8145af40-2def-4d0d-b01c-c75fade17ead.png)
![Screenshot from 2022-06-23 19-50-56](https://user-images.githubusercontent.com/17381666/175363007-9febcf4b-53c0-4a80-99d0-474d3574f31c.png)

In `_variables.scss` we have this list of z-indexes:
```scss
$zindex-dropdown:                   1000 !default;
$zindex-sticky:                     1020 !default;
$zindex-fixed:                      1030 !default;
$zindex-offcanvas-backdrop:         1040 !default;
$zindex-offcanvas:                  1045 !default;
$zindex-modal-backdrop:             1050 !default;
$zindex-modal:                      1055 !default;
$zindex-popover:                    1070 !default;
$zindex-tooltip:                    1080 !default;
$zindex-toast:                      1090 !default;
```

I chose `2000` as a value here (maybe too extreme) just to be sure that it will always work in the future.

###  Live previews
* [Popover - Live demo](https://deploy-preview-36627--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#live-demo)
* [Toast - Live example](https://deploy-preview-36627--twbs-bootstrap.netlify.app/docs/5.2/components/toasts/#live-example)

_Thanks @louismaximepiton for this catch_