### PR TITLE
Fix arrow navigation in dropdown with input

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -389,7 +389,9 @@ class Dropdown extends BaseComponent {
 
   static dataApiKeydownHandler(event) {
     // If not an UP | DOWN | ESCAPE key => not a dropdown command
-    // If input/textarea && if key is other than ESCAPE => not a dropdown command
+    // If input/textarea && if key is other than ESCAPE
+    //    - If key is not UP or DOWN => not a dropdown command
+    //    - If trigger inside the menu => not a dropdown command
 
     const isInput = /input|textarea/i.test(event.target.tagName)
     const isEscapeEvent = event.key === ESCAPE_KEY
@@ -399,7 +401,7 @@ class Dropdown extends BaseComponent {
       return
     }
 
-    if (isInput && !isEscapeEvent) {
+    if (isInput && !isEscapeEvent && (!isUpOrDownEvent || event.target.closest(SELECTOR_MENU))) {
       return
     }
 

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -2127,6 +2127,34 @@ describe('Dropdown', () => {
       dropdownMenu.click()
       expect(spy).toHaveBeenCalledWith(dropdownToggle)
     })
+
+    it('should open the dropdown and focus on the first item when using ArrowDown for the first time on an input search', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <input id="search" class="form-control dropdown-toggle" type="text" placeholder="Search..."  data-bs-toggle="dropdown" aria-expanded="false" aria-label="Search...">',
+          '  <ul class="dropdown-menu mt-1 dropdown-menu-end" aria-labelledby="search">',
+          '    <a id="item1" class="dropdown-item" href="#">A link</a>',
+          '    <a id="item2" class="dropdown-item" href="#">Another link</a>',
+          '  </ul>',
+          '</div>'
+        ].join('')
+
+        const triggerDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const firstItem = fixtureEl.querySelector('#item1')
+
+        triggerDropdown.addEventListener('shown.bs.dropdown', () => {
+          setTimeout(() => {
+            expect(document.activeElement).toEqual(firstItem, 'item1 is focused')
+            resolve()
+          })
+        })
+
+        const keydown = createEvent('keydown')
+        keydown.key = 'ArrowDown'
+        triggerDropdown.dispatchEvent(keydown)
+      })
+    })
   })
 
   describe('jQueryInterface', () => {


### PR DESCRIPTION
Fixes #36598

Apparently due to https://github.com/twbs/bootstrap/commit/bb7664db0aea2dddbc637992d2d0e78632dc2e68 I tried to reintegrate the previous behavior for input/textarea. If it was removed on purpose in this commit, please close this PR and the corresponding issue.

### [Live preview](https://deploy-preview-36633--twbs-bootstrap.netlify.app/docs/5.2/components/dropdowns/)

_For non-regression testing_

### Manual test

```html
<div class="dropdown">
  <input id="search" class="form-control dropdown-toggle" type="text"
  placeholder="Search..." 
  data-bs-toggle="dropdown"
  aria-expanded="false" aria-label="Search...">
  <ul class="dropdown-menu mt-1 dropdown-menu-end" aria-labelledby="search">
      <li><a class="dropdown-item" href="#">Item 1</a></li>
      <li><a class="dropdown-item" href="#">Item 2</a></li>
      <li><a class="dropdown-item" href="#">Item 3</a></li>
      <li><a class="dropdown-item" href="#">Item 4</a></li>
      <li><a class="dropdown-item" href="#">Item 5</a></li>
  </ul>
</div>
```

And then press UP/DOWN key when the input is focused.