### PR TITLE
Fix StackBlitz examples needing docs CSS

### DIFF
--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -27,8 +27,8 @@
     btn.addEventListener('click', event => {
       const htmlSnippet = event.target.closest('.bd-code-snippet').querySelector('.bd-example').innerHTML
 
-      // Get extra classes for this example except '.bd-example'
-      const classes = Array.from(event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList).filter(x => x !== 'bd-example').join(' ')
+      // Get extra classes for this example
+      const classes = Array.from(event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList).join(' ')
 
       const jsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-sb-js-snippet')
       StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet, classes)
@@ -42,10 +42,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ .Site.Params.cdn.css }}" rel="stylesheet">
+    <link href="https://getbootstrap.com/docs/{{ .Site.Params.docs_version }}/assets/css/docs.css" rel="stylesheet">
     <title>Bootstrap Example</title>
     <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
-  <body class="p-3 ${classes}">
+  <body class="p-3 m-0 border-0 ${classes}">
 
     <!-- Example Code -->
 ${htmlSnippet.replace(/^/gm, '    ')}


### PR DESCRIPTION
Reference #36391

Originally I wanted to be able to load only [_component-examples.scss](https://github.com/twbs/bootstrap/blob/main/site/assets/scss/_component-examples.scss) and only when needed. The main issue is that it contains Sass variables defined in other Sass files; including files in the framework.

It will be less obvious for the users but the only other way I found so far is to load directly in the `index.html` our `docs.css`...

Any other ideas?

### Fixed use cases
* All examples in [Layout > Grid](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/layout/grid/) (none of them displayed correctly the colored rectangles)
* All examples in [Layout > Columns](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/layout/columns/) (none of them displayed correctly the colored rectangles)
* [Layout > Gutters > No gutters](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/layout/gutters/#no-gutters)
* All examples in [Layout > CSS Grid](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/layout/css-grid/)
* All examples in [Content > Images](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/content/images/)
* All examples in [Content > Figures](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/content/figures/)
* Some examples in [Forms > Form control](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/forms/form-control/) that uses `.bd-example` in order to add margin tops between form controls.
* [Components > Alerts > Icons](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/alerts/#icons)
* [Components > Breadcrum > Dividers](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/breadcrumb/#dividers)
* All examples in [Components > Card](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/card/) that hadn't centered text in images
* All examples in [Components > Carousel](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/carousel/) that hadn't centered text in images
* [Components > Popovers > Custom popovers](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/popovers/#custom-popovers)
* [Components > Tooltips > Custom tooltips](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/#custom-tooltips)
* All examples in [Helpers > Ratio](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/helpers/ratio/#aspect-ratios) that display gray rectangles
* Most of the examples in [Utilities > Borders](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/utilities/borders/)
* All examples in [Utilities > Flex](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/utilities/flex/)
* Examples in [Utilities > Position](https://deploy-preview-36637--twbs-bootstrap.netlify.app/docs/5.2/utilities/position/) with black squares
