### PR TITLE
Fix tooltip/badge border radius when rounded disabled

### DIFF
--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -22,7 +22,7 @@
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: var(--#{$prefix}badge-border-radius, 0); // stylelint-disable-line property-disallowed-list
+  @include border-radius(var(--#{$prefix}badge-border-radius));
   @include gradient-bg();
 
   // Empty badges collapse automatically

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -116,5 +116,5 @@
   color: var(--#{$prefix}tooltip-color);
   text-align: center;
   background-color: var(--#{$prefix}tooltip-bg);
-  border-radius: var(--#{$prefix}tooltip-border-radius, 0); // stylelint-disable-line property-disallowed-list
+  @include border-radius(var(--#{$prefix}tooltip-border-radius));
 }


### PR DESCRIPTION
Following up https://github.com/twbs/bootstrap/pull/36461, same modification should be applied to __badge.scss_ and __tooltip.scss_ to retrieve the behavior that was present before the addition of CSS vars for these components.

### References - History

- [Badge modification for CSS variables](https://github.com/twbs/bootstrap/commit/7e71fe7bae443f6a7cabac6422514c45601f8b4e#diff-b6fee26aa0a780f5f5b88fa4dd32db1a60619cc9aa74bbe406348bc260b3d7b8)
- [Tooltip modification for CSS variables](https://github.com/twbs/bootstrap/commit/fdcbbe3d92925305031ff76988d8276afb6a3277#diff-e8a1ed084f5e1df29caf257153dc7f5a9507e15e64dc8d98964d85c2e9928924)

### How to test

Set locally `$enable-rounded: false !default` in __variables.css_ and check corresponding pages in the docs.