### PR TITLE
Add Hash/History helper to handle offcanvas functionality

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43.0 kB"
+      "maxSize": "43.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/bootstrap.esm.js",
-      "maxSize": "27.75 kB"
+      "maxSize": "28.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.min.js",
@@ -50,7 +50,7 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "28.5 kB"
+      "maxSize": "29 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -18,6 +18,7 @@ import SelectorEngine from './dom/selector-engine'
 import Backdrop from './util/backdrop'
 import FocusTrap from './util/focustrap'
 import { enableDismissTrigger } from './util/component-functions'
+import HistoryHelper from './util/history'
 
 /**
  * Constants
@@ -70,6 +71,7 @@ class Offcanvas extends BaseComponent {
     this._isShown = false
     this._backdrop = this._initializeBackDrop()
     this._focustrap = this._initializeFocusTrap()
+    this._historyHelper = new HistoryHelper(this._element, { prefix: this.constructor.NAME })
     this._addEventListeners()
   }
 
@@ -112,6 +114,7 @@ class Offcanvas extends BaseComponent {
     this._element.setAttribute('aria-modal', true)
     this._element.setAttribute('role', 'dialog')
     this._element.classList.add(CLASS_NAME_SHOWING)
+    this._historyHelper.add()
 
     const completeCallBack = () => {
       if (!this._config.scroll || this._config.backdrop) {
@@ -152,6 +155,7 @@ class Offcanvas extends BaseComponent {
         new ScrollBarHelper().reset()
       }
 
+      this._historyHelper.remove()
       EventHandler.trigger(this._element, EVENT_HIDDEN)
     }
 
@@ -269,6 +273,17 @@ EventHandler.on(window, EVENT_RESIZE, () => {
     if (getComputedStyle(element).position !== 'fixed') {
       Offcanvas.getOrCreateInstance(element).hide()
     }
+  }
+})
+
+HistoryHelper.onChange(Offcanvas, (newUrl, oldUrl) => {
+  if (oldUrl) {
+    Offcanvas.getOrCreateInstance(oldUrl).hide()
+    return
+  }
+
+  if (newUrl) {
+    Offcanvas.getOrCreateInstance(newUrl).show()
   }
 })
 

--- a/js/src/util/history.js
+++ b/js/src/util/history.js
@@ -1,0 +1,90 @@
+/**
+ * --------------------------------------------------------------------------
+ * Bootstrap (v5.2.0-beta1): util/history.js
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+
+import Config from './config'
+import EventHandler from '../dom/event-handler'
+
+/**
+ * Constants
+ */
+
+const NAME = 'history'
+
+const Default = {
+  prefix: null
+}
+
+const DefaultType = {
+  prefix: 'string'
+}
+
+/**
+ * Class definition
+ */
+
+class HistoryHelper extends Config {
+  constructor(element, config) {
+    super()
+    this._element = element
+    this._config = this._getConfig(config)
+  }
+
+  // Getters
+  static get Default() {
+    return Default
+  }
+
+  static get DefaultType() {
+    return DefaultType
+  }
+
+  static get NAME() {
+    return NAME
+  }
+
+  add() {
+    const url = new window.URL(window.location)
+    url.hash = this._getHash()
+    window.history.pushState({}, '', url)
+  }
+
+  remove() {
+    if (window.location.hash === `#${this._getHash()}`) {
+      const url = new window.URL(window.location)
+      url.hash = ''
+      window.history.replaceState({}, '', url)
+    }
+  }
+
+  static onChange(plugin, callback) {
+    const prefix = `bs-${plugin.NAME}-`
+    const getHash = url => new window.URL(url)?.hash
+    const sanitize = hash => hash.replace(prefix, '')
+
+    EventHandler.on(window, 'load', () => {
+      const hash = getHash(window.location)
+      if (hash.includes(prefix)) {
+        callback(sanitize(hash), '')
+      }
+    })
+
+    EventHandler.on(window, 'hashchange', ev => {
+      const oldHash = getHash(ev.oldURL)
+      const newHash = getHash(ev.newURL)
+
+      if (oldHash.includes(prefix) || newHash.includes(prefix)) {
+        callback(sanitize(newHash), sanitize(oldHash))
+      }
+    })
+  }
+
+  _getHash() {
+    return `bs-${this._config.prefix}-${this._element.id}`
+  }
+}
+
+export default HistoryHelper


### PR DESCRIPTION
This PR is a first approach trying to make some UX improvements on Offcanvas plugin

It has been buzzing to my ears many times (mostly by designers), that Modals & Offcanvases in order to provide a better user experience, should react on browser history changes. 

The simple requirement was : "_**Should close when the user goes back (swipe back / press back btn, etc)**_"

So as the #36604 was just another one trigger that shouted the same need

#### Main functionality:
- `offcanvasInstance.show()` => adds a hash on our browser address bar (`window.location`) & adds an entry to the browser's session history stack.
- `offcanvasInstance.hide()` => removes the hash from our address bar & replicates a history backward step
- if User change the hash on his/her address bar, and the `hash` matches to a component registered pattern, we call a callback where we can decide if we are going to handle. In the specific case, we toggle the offcanvas according to the `hash` existence. Cases:
    - when user goes back & forward,
    - if user adds/removes a `hash` 
    - if User enters a link on his/her browser address bar and contains a `hash`

### Preview: 
https://deploy-preview-36648--twbs-bootstrap.netlify.app/docs/5.2/components/offcanvas/#bs-offcanvas-staticBackdrop



#### Needs: 
* [ ] **Feedback**  (programmatic & functional scope)
* [ ] tests (test new functionality, check existing)



closes #36647

#### Future applications:
*  Modal can copy the same functionality.
* ScrollSpy may use it on `smoothscroll` 
ref:
   * #36387 
   * #36402
* Tabs could be open (pretty sure we had an issue for this)
   ref:
  * #25220
* Collapsibles could be triggered
  ref:
   *  #34299
* Tabs could be shown
    * #25220 
