### PR TITLE
Fix a typo in the documentation masthead

### DIFF
--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -3,7 +3,7 @@
     <div class="col-md-8 mx-auto text-center">
       <a class="d-flex flex-column flex-lg-row justify-content-center align-items-center mb-4 text-dark lh-sm text-decoration-none" href="https://blog.getbootstrap.com/2022/05/13/bootstrap-5-2-0-beta/">
         <strong class="d-sm-inline-block p-2 me-2 mb-2 mb-lg-0 rounded-3 masthead-notice">New in v5.2</strong>
-        <span class="text-muted">CSS variables, responsive offcanvas, new utilites, and more!</span>
+        <span class="text-muted">CSS variables, responsive offcanvas, new utilities, and more!</span>
       </a>
       <img src="/docs/{{ .Site.Params.docs_version }}/assets/brand/bootstrap-logo-shadow.png" width="200" height="165" alt="Bootstrap" class="d-block mx-auto mb-3">
       <h1 class="mb-3 fw-semibold">Build fast, responsive sites with&nbsp;Bootstrap</h1>


### PR DESCRIPTION
Found a small typo on the homepage!

utilites -> utilities