### PR TITLE
fix #36662 List-group-item margin-top is offset when importing sass in a nested class

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -104,6 +104,7 @@
     border-color: var(--#{$prefix}list-group-active-border-color);
   }
 
+  // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
   & + .list-group-item {
     border-top-width: 0;
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -104,7 +104,7 @@
     border-color: var(--#{$prefix}list-group-active-border-color);
   }
 
-  & + & {
+  & + .list-group-item {
     border-top-width: 0;
 
     &.active {


### PR DESCRIPTION
Closes #36662  
Consisting in changing sass operator `&` to the class `list-group-item` to work when nested in imports  