### PR TITLE
Revert db61cf3 for `$text-muted` default value

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -616,7 +616,7 @@ $small-font-size:             .875em !default;
 
 $sub-sup-font-size:           .75em !default;
 
-$text-muted:                  rgba(var(--#{$prefix}body-color-rgb), .75) !default;
+$text-muted:                  $gray-600 !default;
 
 $initialism-font-size:        $small-font-size !default;
 


### PR DESCRIPTION
Fixes #36096 

Proposing to revert https://github.com/twbs/bootstrap/commit/db61cf3d6a907756aee2b0c4ee2cb6488c0ed459; probably the safest move here for the v5.2.0.

(_Haven't yet looked at the Dark Mode PR but depending on how themes are handled and if dynamic/contextual dark theme are possible, that could help with this definition of `.text-muted`_)

If this PR is merged we could reopen https://github.com/twbs/bootstrap/issues/34457 and try to tackle it for v5.3.0.

### [Live preview](https://deploy-preview-36680--twbs-bootstrap.netlify.app/docs/5.2/components/navbar/#external-content)

/cc @mdo 