### PR TITLE
Add missing CSS vars for `.navbar-nav`

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -87,6 +87,8 @@
   // scss-docs-start navbar-nav-css-vars
   --#{$prefix}nav-link-padding-x: 0;
   --#{$prefix}nav-link-padding-y: #{$nav-link-padding-y};
+  @include rfs($nav-link-font-size, --#{$prefix}nav-link-font-size);
+  --#{$prefix}nav-link-font-weight: #{$nav-link-font-weight};
   --#{$prefix}nav-link-color: var(--#{$prefix}navbar-color);
   --#{$prefix}nav-link-hover-color: var(--#{$prefix}navbar-hover-color);
   --#{$prefix}nav-link-disabled-color: var(--#{$prefix}navbar-disabled-color);


### PR DESCRIPTION
While answering to https://github.com/twbs/bootstrap/issues/36684, I may have spotted an issue regarding the definition of `--#{$prefix}nav-link-font-size` and `--#{$prefix}nav-link-font-weight` in `.navbar-nav`.

Without this fix, locally, if you change this in `_variables.css`:
```scss
$nav-link-font-size:                30px !default;
$nav-link-font-weight:              700 !default;
```
The change is only observable in pages like `/docs/5.2/components/navs-tabs/` that use `.nav` and `.nav-link`s inside.
The change is not observable in the main header of the docs for example that use `.navbar-nav` and `.nav-links`s inside.

With this fix we can see the big bold font everywhere where we have `.nav`|`.navbar-nav` and `.nav-link`s inside.