### PR TITLE
add `type="button"` to Bootstrap versions dropdown

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -11,7 +11,7 @@
 {{- end }}
 
 <li class="nav-item dropdown">
-  <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
+  <button type="button" class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
     <span class="d-lg-none" aria-hidden="true">Bootstrap</span><span class="visually-hidden">Bootstrap&nbsp;</span> v{{ .Site.Params.docs_version }} <span class="visually-hidden">(switch to other versions)</span>
   </button>
   <ul class="dropdown-menu dropdown-menu-end">


### PR DESCRIPTION
minor accessibility issue fix reported by webhint.io browser extension.

![image](https://user-images.githubusercontent.com/1212885/177761517-88613599-44a2-4b19-9f4e-8b3661c810c2.png)
