### PR TITLE
Allow floating label to take full width when floating (scaled down)

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1000,8 +1000,9 @@ $form-floating-padding-y:         1rem !default;
 $form-floating-input-padding-t:   1.625rem !default;
 $form-floating-input-padding-b:   .625rem !default;
 $form-floating-label-opacity:     .65 !default;
-$form-floating-label-transform:   scale(.85) translateY(-.5rem) translateX(.15rem) !default;
-$form-floating-transition:        opacity .1s ease-in-out, transform .1s ease-in-out !default;
+$form-floating-label-scale:       .85 !default;
+$form-floating-label-transform:   scale($form-floating-label-scale) translateY(-.5rem) translateX(.15rem) !default;
+$form-floating-transition:        opacity .1s ease-in-out, transform .1s ease-in-out, width .1s ease-in-out !default;
 // scss-docs-end form-floating-variables
 
 // Form validation

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -54,6 +54,7 @@
   > .form-control-plaintext,
   > .form-select {
     ~ label {
+      width: 100% / $form-floating-label-scale;
       opacity: $form-floating-label-opacity;
       transform: $form-floating-label-transform;
     }
@@ -61,6 +62,7 @@
   // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
   > .form-control:-webkit-autofill {
     ~ label {
+      width: 100% / $form-floating-label-scale;
       opacity: $form-floating-label-opacity;
       transform: $form-floating-label-transform;
     }


### PR DESCRIPTION
This change allows the floating label to expand its width as it's scaled down because the `width: 100%` as defined in https://github.com/twbs/bootstrap/pull/36327 will no longer be correct.

I'm not sure about the process for adding new variables and if this is acceptable. I also realize that `/` outside of `calc(...)` is deprecated but I don't see any uses of `@use 'sass:math'` in the codebase and `calc(...)` was complaining it was not allowed when running `npm run test` and I was not sure if I should modify an allowlist or what would be preferred here.