### PR TITLE
Fix missing `--bs-btn-disabled-border-color` in `button-outline-variant` mixin

### DIFF
--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -55,6 +55,7 @@
   --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
   --#{$prefix}btn-disabled-color: #{$color};
   --#{$prefix}btn-disabled-bg: transparent;
+  --#{$prefix}btn-disabled-border-color: #{$color};
   --#{$prefix}gradient: none;
 }
 // scss-docs-end btn-outline-variant-mixin


### PR DESCRIPTION
Closes #36702  