### PR TITLE
Docs: Add 'Icons' link in footer

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -18,6 +18,7 @@
           <li class="mb-2"><a href="/">Home</a></li>
           <li class="mb-2"><a href="/docs/{{ .Site.Params.docs_version }}/">Docs</a></li>
           <li class="mb-2"><a href="/docs/{{ .Site.Params.docs_version }}/examples/">Examples</a></li>
+          <li class="mb-2"><a href="{{ .Site.Params.icons }}">Icons</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.themes }}">Themes</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.blog }}">Blog</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.swag }}">Swag Store</a></li>


### PR DESCRIPTION
This PR proposes to add an 'Icons' link in the footer; being the only one missing by comparing to the links in the header.

I was just not sure that it was removed because a design limit to 6 elements max in each footer section.

### [Live preview](https://deploy-preview-36706--twbs-bootstrap.netlify.app/)