### PR TITLE
Add `$display-font-family` and `$display-font-style`

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -35,6 +35,8 @@
 @each $display, $font-size in $display-font-sizes {
   .display-#{$display} {
     @include font-size($font-size);
+    font-family: $display-font-family;
+    font-style: $display-font-style;
     font-weight: $display-font-weight;
     line-height: $display-line-height;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -604,6 +604,8 @@ $display-font-sizes: (
   6: 2.5rem
 ) !default;
 
+$display-font-family: null !default;
+$display-font-style:  null !default;
 $display-font-weight: 300 !default;
 $display-line-height: $headings-line-height !default;
 // scss-docs-end display-headings

--- a/site/content/docs/5.2/content/typography.md
+++ b/site/content/docs/5.2/content/typography.md
@@ -88,6 +88,8 @@ Traditional heading elements are designed to work best in the meat of your page 
 
 Display headings are configured via the `$display-font-sizes` Sass map and two variables, `$display-font-weight` and `$display-line-height`.
 
+Display headings are customizable via two variables, `$display-font-family` and `$display-font-style`.
+
 {{< scss-docs name="display-headings" file="scss/_variables.scss" >}}
 
 ## Lead


### PR DESCRIPTION
Closes #36701

The request from adding `$display-font-family` seemed valid to me in order to have the same customizing possibilities for display and _normal_ headings.
By comparing the customization options regarding the font, I'm proposing to add `$display-font-style` as well for more consistency.

### [Live preview](https://deploy-preview-36711--twbs-bootstrap.netlify.app/docs/5.2/content/typography/#display-headings)

_Note: haven't associated this development to any projects yet. Depending if this is judged to be a useful addition for the CSS reviewers and if we have time to review it before v5.2 release._