### PR TITLE
[DRAFT] Use postcss-drop-empty-css-vars to remove empty CSS variables

### DIFF
--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -10,6 +10,7 @@ module.exports = context => {
   return {
     map: context.file.dirname.includes('examples') ? false : mapConfig,
     plugins: {
+      "postcss-drop-empty-css-vars": {},
       autoprefixer: {
         cascade: false
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.14",
         "postcss-cli": "^10.0.0",
+        "postcss-drop-empty-css-vars": "^0.0.0",
         "rollup": "^2.76.0",
         "rollup-plugin-istanbul": "^3.0.0",
         "rtlcss": "^3.5.0",
@@ -7960,6 +7961,18 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/postcss-drop-empty-css-vars": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-drop-empty-css-vars/-/postcss-drop-empty-css-vars-0.0.0.tgz",
+      "integrity": "sha512-qJhXM6CIA0GE5FQjIO4697xpHQt9mK+EiCC8p7zv44mOvyj6uNb8GnPZhr+ZETYngfWFMOTXZqShChJHGOoyEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.0"
       }
     },
     "node_modules/postcss-load-config": {
@@ -16306,6 +16319,13 @@
           "dev": true
         }
       }
+    },
+    "postcss-drop-empty-css-vars": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-drop-empty-css-vars/-/postcss-drop-empty-css-vars-0.0.0.tgz",
+      "integrity": "sha512-qJhXM6CIA0GE5FQjIO4697xpHQt9mK+EiCC8p7zv44mOvyj6uNb8GnPZhr+ZETYngfWFMOTXZqShChJHGOoyEw==",
+      "dev": true,
+      "requires": {}
     },
     "postcss-load-config": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.14",
     "postcss-cli": "^10.0.0",
+    "postcss-drop-empty-css-vars": "^0.0.0",
     "rollup": "^2.76.0",
     "rollup-plugin-istanbul": "^3.0.0",
     "rtlcss": "^3.5.0",


### PR DESCRIPTION
> **Warning**
> Heavily draft

Linked to the discussion in https://github.com/twbs/bootstrap/pull/36597 and potentially addresses https://github.com/twbs/bootstrap/issues/36595.
I've tried here to create a very simple PostCSS plugin to remove empty CSS vars.

Plugin repo: https://github.com/julien-deramond/postcss-drop-empty-css-vars
Plugin code (very basic just to test the idea): https://github.com/julien-deramond/postcss-drop-empty-css-vars/blob/main/index.js

The plugin is deployed in 0.0.0 version

Running `npm run css` with and without this plugin gives this diff:
```diff
2801d2800
<   --bs-btn-font-family: ;
3506d3504
<   --bs-dropdown-box-shadow: ;
3620d3617
<   --bs-nav-link-font-weight: ;
3794d3790
<   --bs-nav-link-font-weight: ;
4168d4163
<   --bs-card-box-shadow: ;
4173,4175d4167
<   --bs-card-cap-color: ;
<   --bs-card-height: ;
<   --bs-card-color: ;
4482,4483d4473
<   --bs-breadcrumb-bg: ;
<   --bs-breadcrumb-border-radius: ;
5191d5180
<   --bs-toast-color: ;
5257d5245
<   --bs-modal-color: ;
5271d5258
<   --bs-modal-footer-bg: ;
5549d5535
<   --bs-tooltip-margin: ;
6094d6079
<   --bs-offcanvas-color: ;
```

/CC @mdo for thoughts