### PR TITLE
Fixing pagination compile issue

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1196,7 +1196,7 @@ $pagination-color:                  var(--#{$prefix}link-color) !default;
 $pagination-bg:                     $white !default;
 $pagination-border-radius:          $border-radius !default;
 $pagination-border-width:           $border-width !default;
-$pagination-margin-start:           calc($pagination-border-width * -1) !default; // stylelint-disable-line function-disallowed-list
+$pagination-margin-start:           ($pagination-border-width * -1) !default;
 $pagination-border-color:           $gray-300 !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;


### PR DESCRIPTION
This was an issue with the tables as well, but that has been updated here - 4a3c004c349ec9b20990c8aa760d12c50c450bbd

This was also noted here -[ #1153187062_](https://github.com/twbs/bootstrap/issues/36501#issuecomment-1153187062_) and closed to see if others ran into the same issue.

This effects the 5.2 beta1 that is released on the homepage.

Whats happening is with a fresh download and compile, with some compilers, I noticed not all of them run into this issue, we get the Sass variable showing up and not the actual value.

Steps to reproduce - 
 - Download the source code form the docs for beta 2 and extract
 - Open VSCode -> open folder to the bootstrap directory you just extracted
 - Install [Sass/Less/Stylus/Pug/Jade/Typescript/Javascript Compile Hero Pro](https://marketplace.visualstudio.com/items?itemName=Wscats.eno) v2.3.53 by Eno Yao extension
 ---- Might have to restart VSCode
 - Go to that extensions settings, and set the SASS and SCSS directory to save the output / compiled version to `../dist`
 - Tap that Compile Hero on the bottom to activate the extension
 - Open `bootstrap.scss` add a space or a new line and save it
 - Check the compiles version and you should see the errors