### PR TITLE
Docs: same text for disabled ranges and disabled form controls

### DIFF
--- a/site/content/docs/5.2/forms/range.md
+++ b/site/content/docs/5.2/forms/range.md
@@ -17,7 +17,7 @@ Create custom `<input type="range">` controls with `.form-range`. The track (the
 
 ## Disabled
 
-Add the `disabled` boolean attribute on an input to give it a grayed out appearance and remove pointer events.
+Add the `disabled` boolean attribute on an input to give it a grayed out appearance, remove pointer events, and prevent focusing.
 
 {{< example >}}
 <label for="disabledRange" class="form-label">Disabled range</label>


### PR DESCRIPTION
Bring some consistency between disabled ranges and disabled form controls in documentation after https://github.com/twbs/bootstrap/commit/ac0b87b2071ed5bedeaad47f2a909640c85323bc.

### Live preview
- [Forms > Range > Disabled](https://deploy-preview-36741--twbs-bootstrap.netlify.app/docs/5.2/forms/range/#disabled) to compare to [Forms > Form Controls > Disabled](https://twbs-bootstrap.netlify.app/docs/5.2/forms/form-control/#disabled)