### PR TITLE
Standardization of `spyOn` usage

### DIFF
--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -713,16 +713,16 @@ describe('Modal', () => {
         const dialogEl = modalEl.querySelector('.modal-dialog')
         const modal = new Modal(modalEl)
 
-        spyOn(modal, 'hide')
+        const spy = spyOn(modal, 'hide')
 
         modalEl.addEventListener('shown.bs.modal', () => {
           const mouseDown = createEvent('mousedown')
 
           dialogEl.dispatchEvent(mouseDown)
-          expect(modal.hide).not.toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
 
           modalEl.dispatchEvent(mouseDown)
-          expect(modal.hide).toHaveBeenCalled()
+          expect(spy).toHaveBeenCalled()
           resolve()
         })
 


### PR DESCRIPTION
Based on the global standardization that has been done in https://github.com/twbs/bootstrap/commit/d388bd6e1b0a21733a157182e1098b02a0449274, this PR proposes to fix what's been introduced in https://github.com/twbs/bootstrap/commit/d05c42a3979be30efc7a932c3c0f483098841b19 to keep some consistency.