### PR TITLE
Fix active/focused button link text color

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "26.5 kB"
+      "maxSize": "26.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -147,6 +147,7 @@
   --#{$prefix}btn-border-color: transparent;
   --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
   --#{$prefix}btn-hover-border-color: transparent;
+  --#{$prefix}btn-active-color: #{$btn-link-hover-color};
   --#{$prefix}btn-active-border-color: transparent;
   --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
   --#{$prefix}btn-disabled-border-color: transparent;
@@ -158,6 +159,14 @@
   &:hover,
   &:focus {
     text-decoration: $link-hover-decoration;
+  }
+
+  &:focus {
+    color: var(--#{$prefix}btn-color);
+  }
+
+  &:hover {
+    color: var(--#{$prefix}btn-hover-color);
   }
 
   // No need for an active state here


### PR DESCRIPTION
Fixes #36744 (see https://github.com/twbs/bootstrap/issues/36744#issuecomment-1186124342)

This PR proposes some changed for `.btn-link`s to retrieve the same behavior from 5.1 regarding focus, active, hover and all combinations between those states.

### [Live preview](https://deploy-preview-36747--twbs-bootstrap.netlify.app/docs/5.2/components/buttons/#examples)

/CC @mdo - IMHO a fix for this one should be embedded if possible in the v5.2.0