### PR TITLE
Move focus styles from `.btn-link` to base `.btn`

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -15,9 +15,12 @@
   --#{$prefix}btn-border-width: #{$btn-border-width};
   --#{$prefix}btn-border-color: transparent;
   --#{$prefix}btn-border-radius: #{$btn-border-radius};
+  --#{$prefix}btn-active-border-color: transparent;
+  --#{$prefix}btn-hover-border-color: transparent;
   --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
   --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
-  --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), .5);
+  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb($btn-focus-color)};
+  --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), #{$btn-focus-color-opacity});
   // scss-docs-end btn-css-vars
 
   display: inline-block;
@@ -144,15 +147,11 @@
   --#{$prefix}btn-font-weight: #{$font-weight-normal};
   --#{$prefix}btn-color: #{$btn-link-color};
   --#{$prefix}btn-bg: transparent;
-  --#{$prefix}btn-border-color: transparent;
   --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
-  --#{$prefix}btn-hover-border-color: transparent;
   --#{$prefix}btn-active-color: #{$btn-link-hover-color};
-  --#{$prefix}btn-active-border-color: transparent;
   --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
   --#{$prefix}btn-disabled-border-color: transparent;
   --#{$prefix}btn-box-shadow: none;
-  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb(mix(color-contrast($primary), $primary, 15%))};
 
   text-decoration: $link-decoration;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -765,6 +765,8 @@ $btn-font-weight:             $font-weight-normal !default;
 $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
 $btn-focus-width:             $input-btn-focus-width !default;
 $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
+$btn-focus-color-opacity:     $input-btn-focus-color-opacity !default;
+$btn-focus-color:             $input-btn-focus-color !default;
 $btn-disabled-opacity:        .65 !default;
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 


### PR DESCRIPTION
This moves some resets from `.btn-link` to the base `.btn` to conform to the previous v5.1 `.btn` behaviour.

In 5.1:

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/9486206/180032625-46b5bdce-550b-4ee1-9add-5a956a2b037a.png">

In 5.2:

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/9486206/180031887-5057041b-1fb3-4f54-8f48-e6a4954ba35d.png">

After this PR:

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/9486206/180033117-21bef8be-569b-451c-8715-0470a3e3fc35.png">


