### PR TITLE
Remove a unused sass parameter from banner mixin

### DIFF
--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,4 +1,4 @@
-@mixin bsBanner($file, $suffix:"") {
+@mixin bsBanner($file) {
   /*!
    * Bootstrap #{$file} v5.2.0 (https://getbootstrap.com/)
    * Copyright 2011-2022 The Bootstrap Authors


### PR DESCRIPTION
https://github.com/twbs/bootstrap/pull/36178 accidentally introduced an unused parameter and this PR removes it.