### PR TITLE
Move DocSearch out of offcanvas to always show it on mobile

### DIFF
--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -4,6 +4,12 @@
   background-image: linear-gradient(to bottom, rgba(var(--bd-violet-rgb), 1), rgba(var(--bd-violet-rgb), .95));
   box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15), inset 0 -1px 0 rgba(0, 0, 0, .15);
 
+  .bd-navbar-toggle {
+    @include media-breakpoint-down(lg) {
+      width: 4.25rem;
+    }
+  }
+
   .navbar-toggler {
     padding: 0;
     margin-right: -.5rem;

--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -2,7 +2,6 @@
 
 .bd-search {
   position: relative;
-  // width: 100%;
 
   @include media-breakpoint-up(lg) {
     position: absolute;
@@ -70,7 +69,13 @@
       box-shadow: var(--docsearch-searchbox-shadow);
     }
   }
+}
 
+.DocSearch-Button-Keys,
+.DocSearch-Button-Placeholder {
+  @include media-breakpoint-down(lg) {
+    display: none;
+  }
 }
 
 .DocSearch-Button-Keys {

--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -2,7 +2,7 @@
 
 .bd-search {
   position: relative;
-  width: 100%;
+  // width: 100%;
 
   @include media-breakpoint-up(lg) {
     position: absolute;
@@ -57,6 +57,20 @@
       opacity: 1;
     }
   }
+
+  @include media-breakpoint-down(lg) {
+    &,
+    &:hover,
+    &:focus {
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+    }
+    &:focus {
+      box-shadow: var(--docsearch-searchbox-shadow);
+    }
+  }
+
 }
 
 .DocSearch-Button-Keys {

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -1,21 +1,31 @@
 <header class="navbar navbar-expand-lg navbar-dark bd-navbar sticky-top">
   <nav class="container-xxl bd-gutter flex-wrap flex-lg-nowrap" aria-label="Main navigation">
     {{- if eq .Layout "docs" }}
+    <div class="bd-navbar-toggle">
       <button class="navbar-toggler p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bdSidebar" aria-controls="bdSidebar" aria-label="Toggle docs navigation">
         {{ partial "icons/hamburger.svg" (dict "class" "bi" "width" "24" "height" "24") }}
         <span class="d-none fs-6 pe-1">Browse</span>
       </button>
+    </div>
     {{- else }}
-      <div class="d-lg-none" style="width: 2.25rem;"></div>
+      <!-- <div class="d-lg-none" style="width: 2.25rem;"></div> -->
     {{- end }}
 
     <a class="navbar-brand p-0 me-0 me-lg-2" href="/" aria-label="Bootstrap">
       {{ partial "icons/bootstrap-white-fill.svg" (dict "class" "d-block my-1" "width" "40" "height" "32") }}
     </a>
 
-    <button class="navbar-toggler d-flex d-lg-none order-3 p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bdNavbar" aria-controls="bdNavbar" aria-label="Toggle navigation">
-      <svg class="bi" aria-hidden="true"><use xlink:href="#three-dots"></use></svg>
-    </button>
+    <div class="d-flex">
+      {{ if eq .Layout "docs" }}
+      <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
+
+      <!-- <hr class="d-lg-none text-white-50"> -->
+      {{ end }}
+
+      <button class="navbar-toggler d-flex d-lg-none order-3 p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bdNavbar" aria-controls="bdNavbar" aria-label="Toggle navigation">
+        <svg class="bi" aria-hidden="true"><use xlink:href="#three-dots"></use></svg>
+      </button>
+    </div>
 
     <div class="offcanvas-lg offcanvas-end flex-grow-1" tabindex="-1" id="bdNavbar" aria-labelledby="bdNavbarOffcanvasLabel" data-bs-scroll="true">
       <div class="offcanvas-header px-4 pb-0">
@@ -44,12 +54,6 @@
         </ul>
 
         <hr class="d-lg-none text-white-50">
-
-        {{ if eq .Layout "docs" }}
-        <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
-
-        <hr class="d-lg-none text-white-50">
-        {{ end }}
 
         <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
           <li class="nav-item col-6 col-lg-auto">

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -8,7 +8,7 @@
       </button>
     </div>
     {{- else }}
-      <!-- <div class="d-lg-none" style="width: 2.25rem;"></div> -->
+      <div class="d-lg-none" style="width: 1.5rem;"></div>
     {{- end }}
 
     <a class="navbar-brand p-0 me-0 me-lg-2" href="/" aria-label="Bootstrap">
@@ -17,9 +17,7 @@
 
     <div class="d-flex">
       {{ if eq .Layout "docs" }}
-      <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
-
-      <!-- <hr class="d-lg-none text-white-50"> -->
+        <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
       {{ end }}
 
       <button class="navbar-toggler d-flex d-lg-none order-3 p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bdNavbar" aria-controls="bdNavbar" aria-label="Toggle navigation">


### PR DESCRIPTION
Easier fix than continuing to mess with offcanvas options or consider building on top of DocSearch itself. This moves the partial out of the navbar offcanvas so that it can be always visible on mobile. I've added some additional styles to make the mobile state better match our navbar iconography as well.

/cc @julien-deramond @GeoSot 

Fixes #36822.