### PR TITLE
Fix pagination page items border radius

### DIFF
--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -75,7 +75,7 @@
     margin-left: $pagination-margin-start;
   }
 
-  @if $pagination-margin-start == (calc($pagination-border-width * -1)) {
+  @if $pagination-margin-start == ($pagination-border-width * -1) {
     &:first-child {
       .page-link {
         @include border-start-radius(var(--#{$prefix}pagination-border-radius));


### PR DESCRIPTION
### Description

Modify `@if $pagination-margin-start == (calc($pagination-border-width * -1)) {` to work like the recent fix done in https://github.com/twbs/bootstrap/commit/154916ca2e9160cc17c21c7a8e5938832ab186b3.

### Motivation & Context

In some Sass compilers `($pagination-border-width * -1) == (calc($pagination-border-width * -1))` is evaluated to `false` and some users, like the issue's author, can see an unexpected border radius for `.page-item`s in a pagination.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- ~~My change introduces changes to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests passed

### Related issues

Fixes #36820

### Live preview
- [Components > Pagination](https://deploy-preview-36828--twbs-bootstrap.netlify.app/docs/5.2/components/pagination/) for non-regression
