### PR TITLE
Define correctly `$popover-header-color`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1333,7 +1333,7 @@ $popover-box-shadow:                $box-shadow !default;
 
 $popover-header-font-size:          $font-size-base !default;
 $popover-header-bg:                 shade-color($popover-bg, 6%) !default;
-$popover-header-color:              var(--#{$prefix}heading-color) !default;
+$popover-header-color:              $headings-color !default;
 $popover-header-padding-y:          .5rem !default;
 $popover-header-padding-x:          $spacer !default;
 


### PR DESCRIPTION
Fixes #36847

* `--#{$prefix}heading-color` wasn't defined anymore anywhere
* ~~I chose to create it in `scss/_root.scss` like the `--{prefix}link-*` CSS vars~~