### PR TITLE
Distinguish for the term 'compiled' and 'precompiled'

### DIFF
--- a/site/content/docs/5.2/getting-started/contents.md
+++ b/site/content/docs/5.2/getting-started/contents.md
@@ -1,12 +1,12 @@
 ---
 layout: docs
 title: Contents
-description: Discover what's included in Bootstrap, including our precompiled and source code flavors.
+description: Discover what's included in Bootstrap, including our compiled CSS, JavaScript, and precompiled source code flavors.
 group: getting-started
 toc: true
 ---
 
-## Precompiled Bootstrap
+## Compiled Bootstrap
 
 Once downloaded, unzip the compressed folder and you'll see something like this:
 
@@ -62,7 +62,7 @@ bootstrap/
     └── bootstrap.min.js.map
 ```
 
-This is the most basic form of Bootstrap: precompiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (`bootstrap.*`), as well as compiled and minified CSS and JS (`bootstrap.min.*`). [Source maps](https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps) (`bootstrap.*.map`) are available for use with certain browsers' developer tools. Bundled JS files (`bootstrap.bundle.js` and minified `bootstrap.bundle.min.js`) include [Popper](https://popper.js.org/).
+This is the most basic form of Bootstrap: Compiled files for quick drop-in usage in nearly any web project. We provide compiled CSS and JS (`bootstrap.*`), as well as compiled and minified CSS and JS (`bootstrap.min.*`). [Source maps](https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps) (`bootstrap.*.map`) are available for use with certain browsers' developer tools. Bundled JS files (`bootstrap.bundle.js` and minified `bootstrap.bundle.min.js`) include [Popper](https://popper.js.org/).
 
 ## CSS files
 
@@ -106,4 +106,4 @@ bootstrap/
 └── scss/
 ```
 
-The `scss/` and `js/` are the source code for our CSS and JavaScript. The `dist/` folder includes everything listed in the precompiled download section above. The `site/docs/` folder includes the source code for our documentation, and `examples/` of Bootstrap usage. Beyond that, any other included file provides support for packages, license information, and development.
+The `scss/` and `js/` are the source code for our CSS and JavaScript. The `dist/` folder includes everything listed in the Compiled download section above. The `site/docs/` folder includes the source code for our documentation, and `examples/` of Bootstrap usage. Beyond that, any other included file provides support for packages, license information, and development.

--- a/site/content/docs/5.2/getting-started/download.md
+++ b/site/content/docs/5.2/getting-started/download.md
@@ -19,7 +19,7 @@ This doesn't include documentation, source files, or any optional JavaScript dep
 
 ## Source files
 
-Compile Bootstrap with your own asset pipeline by downloading our source Sass, JavaScript, and documentation files. This option requires some additional tooling:
+Precompile Bootstrap with your own asset pipeline by downloading our source Sass, JavaScript, and documentation files. This option requires some additional tooling:
 
 - [Sass compiler]({{< docsref "/getting-started/contribute#sass" >}}) for compiling Sass source files into CSS files
 - [Autoprefixer](https://github.com/postcss/autoprefixer) for CSS vendor prefixing
@@ -52,7 +52,7 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 
 ## Package managers
 
-Pull in Bootstrap's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Bootstrap will **require a [Sass compiler]({{< docsref "/getting-started/contribute#sass" >}}) and [Autoprefixer](https://github.com/postcss/autoprefixer)** for a setup that matches our official compiled versions.
+Pull in Bootstrap's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Bootstrap will **require a [Sass compiler]({{< docsref "/getting-started/contribute#sass" >}}) and [Autoprefixer](https://github.com/postcss/autoprefixer)** for a setup that matches our official precompiled versions.
 
 ### npm
 
@@ -68,7 +68,7 @@ The `bootstrap` module itself exports all of our plugins. You can manually load 
 Bootstrap's `package.json` contains some additional metadata under the following keys:
 
 - `sass` - path to Bootstrap's main [Sass](https://sass-lang.com/) source file
-- `style` - path to Bootstrap's non-minified CSS that's been precompiled using the default settings (no customization)
+- `style` - path to Bootstrap's non-minified CSS that's been compiled using the default settings (no customization)
 
 {{< callout info >}}
 {{< partial "callout-info-npm-starter.md" >}}


### PR DESCRIPTION
Our documentation mixes and doesn't distinguish these two terms, which is shown in two ways.

# 1. Confliction on titles
[This download](https://getbootstrap.com/docs/5.2/getting-started/download/#compiled-css-and-js) is for ready-to-use Bootstrap archive. It's title is 'Compiled...'.
[Here](https://getbootstrap.com/docs/5.2/getting-started/contents/#precompiled-bootstrap) is the directory structure of the above archive, and it's title is 'Precompiled...'

# 2. Confusion of these two terms
They appear in the article [Download](https://getbootstrap.com/docs/5.2/getting-started/download/), and [Contribute](https://getbootstrap.com/docs/5.2/getting-started/contribute/).
I think we should describe this way. `.map` and `.scss` is pre-compiled, `.css` and `.js` is compiled.
See my change please.
___
See also. [What does it mean for "Bootstrap" to be precompiled?](https://softwareengineering.stackexchange.com/questions/221332/what-does-it-mean-for-bootstrap-to-be-precompiled)