### PR TITLE
Fix modal event-listeners during dismiss click

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43.0 kB"
+      "maxSize": "43.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -50,7 +50,7 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "28.5 kB"
+      "maxSize": "28.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -31,7 +31,7 @@ const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_RESIZE = `resize${EVENT_KEY}`
 const EVENT_CLICK_DISMISS = `click.dismiss${EVENT_KEY}`
-const EVENT_MOUSDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
+const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
 const EVENT_KEYDOWN_DISMISS = `keydown.dismiss${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
@@ -222,7 +222,7 @@ class Modal extends BaseComponent {
       }
     })
 
-    EventHandler.on(this._element, EVENT_MOUSDOWN_DISMISS, event => {
+    EventHandler.on(this._element, EVENT_MOUSEDOWN_DISMISS, event => {
       EventHandler.one(this._element, EVENT_CLICK_DISMISS, event2 => {
         // a bad trick to segregate clicks that may start inside dialog but end outside, and avoid listen to scrollbar clicks
         if (this._dialog.contains(event.target) || this._dialog.contains(event2.target)) {

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -30,7 +30,8 @@ const EVENT_HIDDEN = `hidden${EVENT_KEY}`
 const EVENT_SHOW = `show${EVENT_KEY}`
 const EVENT_SHOWN = `shown${EVENT_KEY}`
 const EVENT_RESIZE = `resize${EVENT_KEY}`
-const EVENT_MOUSEDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
+const EVENT_CLICK_DISMISS = `click.dismiss${EVENT_KEY}`
+const EVENT_MOUSDOWN_DISMISS = `mousedown.dismiss${EVENT_KEY}`
 const EVENT_KEYDOWN_DISMISS = `keydown.dismiss${EVENT_KEY}`
 const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 
@@ -221,19 +222,22 @@ class Modal extends BaseComponent {
       }
     })
 
-    EventHandler.on(this._element, EVENT_MOUSEDOWN_DISMISS, event => {
-      if (event.target !== event.currentTarget) { // click is inside modal-dialog
-        return
-      }
+    EventHandler.on(this._element, EVENT_MOUSDOWN_DISMISS, event => {
+      EventHandler.one(this._element, EVENT_CLICK_DISMISS, event2 => {
+        // a bad trick to segregate clicks that may start inside dialog but end outside, and avoid listen to scrollbar clicks
+        if (this._dialog.contains(event.target) || this._dialog.contains(event2.target)) {
+          return
+        }
 
-      if (this._config.backdrop === 'static') {
-        this._triggerBackdropTransition()
-        return
-      }
+        if (this._config.backdrop === 'static') {
+          this._triggerBackdropTransition()
+          return
+        }
 
-      if (this._config.backdrop) {
-        this.hide()
-      }
+        if (this._config.backdrop) {
+          this.hide()
+        }
+      })
     })
   }
 

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -644,7 +644,9 @@ describe('Modal', () => {
           const mouseDown = createEvent('mousedown')
 
           modalEl.dispatchEvent(mouseDown)
+          modalEl.click()
           modalEl.dispatchEvent(mouseDown)
+          modalEl.click()
 
           setTimeout(() => {
             expect(spy).toHaveBeenCalledTimes(1)
@@ -719,9 +721,11 @@ describe('Modal', () => {
           const mouseDown = createEvent('mousedown')
 
           dialogEl.dispatchEvent(mouseDown)
+          modalEl.click()
           expect(spy).not.toHaveBeenCalled()
 
           modalEl.dispatchEvent(mouseDown)
+          modalEl.click()
           expect(spy).toHaveBeenCalled()
           resolve()
         })


### PR DESCRIPTION
Partially regression of #36401.

Fixes modal listeners in order to:
* ignore clicks on scrollbar
    * `mousedown`, `mouseup` listen to scrollbar click
    * `click` ignores scrollbar click
* ignores clicks that starts inside `.modal-dialog`, but ends outside of it
* react on clicks that start & end outside `.modal-dialog`

closes: #36855

alternative approach https://github.com/twbs/bootstrap/issues/36855#issuecomment-1206174935