### PR TITLE
Fix docs typo of `.form-checkbox` -> `.form-check`

### DIFF
--- a/site/content/docs/5.2/forms/layout.md
+++ b/site/content/docs/5.2/forms/layout.md
@@ -291,7 +291,7 @@ You can then remix that once again with size-specific column classes.
 
 ## Inline forms
 
-Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes]({{< docsref "/layout/gutters" >}}), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-checkbox` align properly.
+Use the `.row-cols-*` classes to create responsive horizontal layouts. By adding [gutter modifier classes]({{< docsref "/layout/gutters" >}}), we'll have gutters in horizontal and vertical directions. On narrow mobile viewports, the `.col-12` helps stack the form controls and more. The `.align-items-center` aligns the form elements to the middle, making the `.form-check` align properly.
 
 {{< example >}}
 <form class="row row-cols-lg-auto g-3 align-items-center">


### PR DESCRIPTION
The class `.form-checkbox` is not used in Bootstrap and here it should instead be `.form-check` (as shown in the example below).