### PR TITLE
Fix floating labels under `.text-center`

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -16,6 +16,7 @@
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
+    text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;


### PR DESCRIPTION
Fixes #36793

The bug seems to come from #36327 (that should close #36270) since we set `width: 100%`. Here is a proposal in order to keep this change (Based on [rabuckley's comment](https://github.com/twbs/bootstrap/issues/36793#issuecomment-1195778443)).