### PR TITLE
Floating labels in input group: Border fix

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -120,10 +120,13 @@
     $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
   }
 
-  > :not(:first-child):not(.dropdown-menu):not(.form-floating)#{$validation-messages},
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    margin-left: -$input-border-width;
+    @include border-start-radius(0);
+  }
+
   > .form-floating:not(:first-child) > .form-control,
   > .form-floating:not(:first-child) > .form-select {
-    margin-left: -$input-border-width;
     @include border-start-radius(0);
   }
 }


### PR DESCRIPTION
Fixes #36868 

The issue comes from #36759.

### Problem explanation

From what I understand, the `.form-control`/`.form-select` is shifted of 1px compared to `.form-floating` (which is not shifted himself). So the content following `.form-floating` is shifted of 1px compared to `.form-floating`. As we have the same shift inside and following `.form-floating`, the following content seems not to be shifted compared to the input.

### Solution

Shift the `.form-floating` himself instead of its children.