### PR TITLE
Bring back tooltip/popover absolute position

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -22,6 +22,7 @@
   --#{$prefix}popover-arrow-border: var(--#{$prefix}popover-border-color);
   // scss-docs-end popover-css-vars
 
+  position: absolute; //It is covered from popper, but we keep it to avoid doc overflowing in edge cases
   z-index: var(--#{$prefix}popover-zindex);
   display: block;
   max-width: var(--#{$prefix}popover-max-width);

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -15,6 +15,7 @@
   --#{$prefix}tooltip-arrow-height: #{$tooltip-arrow-height};
   // scss-docs-end tooltip-css-vars
 
+  position: absolute; //It is covered from popper, but we keep it to avoid doc overflowing in edge cases
   z-index: var(--#{$prefix}tooltip-zindex);
   display: block;
   padding: var(--#{$prefix}tooltip-arrow-height);


### PR DESCRIPTION
<del>
Bring back tooltip/popover absolute position (css) as it protects us from instantly replayable hovering, that in edge cases add a scrolling bar to doc


closes #36875


</del>

edit: wrong guess