### PR TITLE
Accordion color should use $accordion-color

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -4,7 +4,7 @@
 
 .accordion {
   // scss-docs-start accordion-css-vars
-  --#{$prefix}accordion-color: #{color-contrast($accordion-bg)};
+  --#{$prefix}accordion-color: #{$accordion-color};
   --#{$prefix}accordion-bg: #{$accordion-bg};
   --#{$prefix}accordion-transition: #{$accordion-transition};
   --#{$prefix}accordion-border-color: #{$accordion-border-color};


### PR DESCRIPTION
This makes it possible to easily override the color without breaking the SASS compilation.

e.g. `color-contrast(...)` requires a valid color. There are scenarios where it's interesting to pass a CSS variable, which can't be computed by `color-contrast`.
For example, `$accordion-bg: var(--my-accordion-bg)` currently breaks the build.

Besides, `$accordion-color` already exists, so it makes sense to use it.