### PR TITLE
fixed rtl issue with floating label

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1002,7 +1002,8 @@ $form-floating-padding-y:         1rem !default;
 $form-floating-input-padding-t:   1.625rem !default;
 $form-floating-input-padding-b:   .625rem !default;
 $form-floating-label-opacity:     .65 !default;
-$form-floating-label-transform:   scale(.85) translateY(-.5rem) translateX(.15rem) !default;
+$form-floating-label-transform:   translateY(-.5rem) translateX(.15rem) !default;
+$form-floating-label-font-size:   .85em !default;
 $form-floating-transition:        opacity .1s ease-in-out, transform .1s ease-in-out !default;
 // scss-docs-end form-floating-variables
 

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -57,6 +57,7 @@
     ~ label {
       opacity: $form-floating-label-opacity;
       transform: $form-floating-label-transform;
+      font-size: $form-floating-label-font-size;
     }
   }
   // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
@@ -64,6 +65,7 @@
     ~ label {
       opacity: $form-floating-label-opacity;
       transform: $form-floating-label-transform;
+      font-size: $form-floating-label-font-size;
     }
   }
 


### PR DESCRIPTION
I found the bug in floating label when we use bootstrap in RTL language. it because of transform scale. so i used font size instead to make label small

How label look like in RTL with scale transform
<img width="469" alt="image" src="https://user-images.githubusercontent.com/27342583/184477947-1787d7c2-b784-454b-9829-54e73ddca082.png">

so use font size instead