### PR TITLE
Allows to mix html5 validation with bootstrap validation

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -4,7 +4,7 @@
 // scss-docs-start form-validation-mixins
 @mixin form-validation-state-selector($state) {
   @if ($state == "valid" or $state == "invalid") {
-    .was-validated #{if(&, "&", "")}:#{$state},
+    .was-validated #{if(&, "&", "")}:#{$state}#{if($state == "valid", ":not(.is-invalid)", "")},
     #{if(&, "&", "")}.is-#{$state} {
       @content;
     }


### PR DESCRIPTION
It still shows field as invalid if html5 validation fails while bootstrap validation says it is valid. Useful to mix validation results from backend.

Before (the problem):
<img width="1362" alt="Screenshot 2022-08-16 at 12 07 00" src="https://user-images.githubusercontent.com/10140482/184854138-3db95f54-eb7f-449d-8935-f8eeb4360462.png">


After (the solution):
<img width="1357" alt="Screenshot 2022-08-16 at 12 05 08" src="https://user-images.githubusercontent.com/10140482/184854175-d1c68072-3b45-4f67-9a62-35e197594ffd.png">

