### PR TITLE
Fix unexpected scrollbar in the y-axis in starter-template

### DIFF
--- a/site/content/docs/5.2/examples/starter-template/index.html
+++ b/site/content/docs/5.2/examples/starter-template/index.html
@@ -13,7 +13,7 @@ extra_css:
     </a>
   </header>
 
-  <main>
+  <main class="overflow-hidden">
     <h1>Get started with Bootstrap</h1>
     <p class="fs-5 col-md-8">Quickly and easily get started with Bootstrap's compiled, production-ready files with this barebones example featuring some basic HTML and helpful links. Download all our examples to get started.</p>
 


### PR DESCRIPTION
![Screen Shot 2022-08-18 at 16.38.38.png](https://user-images.githubusercontent.com/29367025/185350852-6e847cfa-59cb-4432-9768-fce050764bf2.png)

Add `.overflow-hidden` to `<main>` in [starter-template](https://getbootstrap.com/docs/5.2/examples/starter-template/).

Reference: https://getbootstrap.com/docs/5.2/layout/gutters/#vertical-gutters