### PR TITLE
Updated wording in column breaks documentation

### DIFF
--- a/site/content/docs/5.2/layout/columns.md
+++ b/site/content/docs/5.2/layout/columns.md
@@ -149,7 +149,7 @@ If more than 12 columns are placed within a single row, each group of extra colu
 
 ### Column breaks
 
-Breaking columns to a new line in flexbox requires a small hack: add an element with `width: 100%` wherever you want to wrap your columns to a new line. Normally this is accomplished with multiple `.row`s, but not every implementation method can account for this.
+Breaking columns to a new line in flexbox requires a small hack: add an element with `width: 100%` wherever you want to wrap your columns to a new line. Normally this is accomplished with multiple `.row` definitions, but not every implementation method can account for this.
 
 {{< example class="bd-example-row" >}}
 <div class="container text-center">


### PR DESCRIPTION
Updated wording in column break documentation. The use of a `.class` in plural form looks strange and the suggested wording change will avoid this.

Original text
![image](https://user-images.githubusercontent.com/47271795/185800512-181f3b28-6868-4c13-900f-61d6ddd2a598.png)
