### PR TITLE
docs: update v5 version docs version dropdown to include updated v5.2 dropdown

### DIFF
--- a/docs/5.0/about/brand/index.html
+++ b/docs/5.0/about/brand/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/about/license/index.html
+++ b/docs/5.0/about/license/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/about/overview/index.html
+++ b/docs/5.0/about/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/about/team/index.html
+++ b/docs/5.0/about/team/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/about/translations/index.html
+++ b/docs/5.0/about/translations/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/accordion/index.html
+++ b/docs/5.0/components/accordion/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/alerts/index.html
+++ b/docs/5.0/components/alerts/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/badge/index.html
+++ b/docs/5.0/components/badge/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/breadcrumb/index.html
+++ b/docs/5.0/components/breadcrumb/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/button-group/index.html
+++ b/docs/5.0/components/button-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/buttons/index.html
+++ b/docs/5.0/components/buttons/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/card/index.html
+++ b/docs/5.0/components/card/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/carousel/index.html
+++ b/docs/5.0/components/carousel/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/close-button/index.html
+++ b/docs/5.0/components/close-button/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/collapse/index.html
+++ b/docs/5.0/components/collapse/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/dropdowns/index.html
+++ b/docs/5.0/components/dropdowns/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/list-group/index.html
+++ b/docs/5.0/components/list-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/modal/index.html
+++ b/docs/5.0/components/modal/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/navbar/index.html
+++ b/docs/5.0/components/navbar/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/navs-tabs/index.html
+++ b/docs/5.0/components/navs-tabs/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/offcanvas/index.html
+++ b/docs/5.0/components/offcanvas/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/pagination/index.html
+++ b/docs/5.0/components/pagination/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/popovers/index.html
+++ b/docs/5.0/components/popovers/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/progress/index.html
+++ b/docs/5.0/components/progress/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/scrollspy/index.html
+++ b/docs/5.0/components/scrollspy/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/spinners/index.html
+++ b/docs/5.0/components/spinners/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/toasts/index.html
+++ b/docs/5.0/components/toasts/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/components/tooltips/index.html
+++ b/docs/5.0/components/tooltips/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/content/figures/index.html
+++ b/docs/5.0/content/figures/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/content/images/index.html
+++ b/docs/5.0/content/images/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/content/reboot/index.html
+++ b/docs/5.0/content/reboot/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/content/tables/index.html
+++ b/docs/5.0/content/tables/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/content/typography/index.html
+++ b/docs/5.0/content/typography/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/color/index.html
+++ b/docs/5.0/customize/color/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/components/index.html
+++ b/docs/5.0/customize/components/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/css-variables/index.html
+++ b/docs/5.0/customize/css-variables/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/optimize/index.html
+++ b/docs/5.0/customize/optimize/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/options/index.html
+++ b/docs/5.0/customize/options/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/overview/index.html
+++ b/docs/5.0/customize/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/customize/sass/index.html
+++ b/docs/5.0/customize/sass/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/extend/approach/index.html
+++ b/docs/5.0/extend/approach/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/extend/icons/index.html
+++ b/docs/5.0/extend/icons/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/checks-radios/index.html
+++ b/docs/5.0/forms/checks-radios/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/floating-labels/index.html
+++ b/docs/5.0/forms/floating-labels/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/form-control/index.html
+++ b/docs/5.0/forms/form-control/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/input-group/index.html
+++ b/docs/5.0/forms/input-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/layout/index.html
+++ b/docs/5.0/forms/layout/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/overview/index.html
+++ b/docs/5.0/forms/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/range/index.html
+++ b/docs/5.0/forms/range/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/select/index.html
+++ b/docs/5.0/forms/select/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/forms/validation/index.html
+++ b/docs/5.0/forms/validation/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/accessibility/index.html
+++ b/docs/5.0/getting-started/accessibility/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/best-practices/index.html
+++ b/docs/5.0/getting-started/best-practices/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/browsers-devices/index.html
+++ b/docs/5.0/getting-started/browsers-devices/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/build-tools/index.html
+++ b/docs/5.0/getting-started/build-tools/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/contents/index.html
+++ b/docs/5.0/getting-started/contents/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/download/index.html
+++ b/docs/5.0/getting-started/download/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/introduction/index.html
+++ b/docs/5.0/getting-started/introduction/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/javascript/index.html
+++ b/docs/5.0/getting-started/javascript/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/parcel/index.html
+++ b/docs/5.0/getting-started/parcel/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/rfs/index.html
+++ b/docs/5.0/getting-started/rfs/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/rtl/index.html
+++ b/docs/5.0/getting-started/rtl/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/getting-started/webpack/index.html
+++ b/docs/5.0/getting-started/webpack/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/clearfix/index.html
+++ b/docs/5.0/helpers/clearfix/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/colored-links/index.html
+++ b/docs/5.0/helpers/colored-links/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/position/index.html
+++ b/docs/5.0/helpers/position/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/ratio/index.html
+++ b/docs/5.0/helpers/ratio/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/stretched-link/index.html
+++ b/docs/5.0/helpers/stretched-link/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/text-truncation/index.html
+++ b/docs/5.0/helpers/text-truncation/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/helpers/visually-hidden/index.html
+++ b/docs/5.0/helpers/visually-hidden/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/breakpoints/index.html
+++ b/docs/5.0/layout/breakpoints/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/columns/index.html
+++ b/docs/5.0/layout/columns/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/containers/index.html
+++ b/docs/5.0/layout/containers/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/grid/index.html
+++ b/docs/5.0/layout/grid/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/gutters/index.html
+++ b/docs/5.0/layout/gutters/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/utilities/index.html
+++ b/docs/5.0/layout/utilities/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/layout/z-index/index.html
+++ b/docs/5.0/layout/z-index/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/migration/index.html
+++ b/docs/5.0/migration/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/api/index.html
+++ b/docs/5.0/utilities/api/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/background/index.html
+++ b/docs/5.0/utilities/background/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/borders/index.html
+++ b/docs/5.0/utilities/borders/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/colors/index.html
+++ b/docs/5.0/utilities/colors/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/display/index.html
+++ b/docs/5.0/utilities/display/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/flex/index.html
+++ b/docs/5.0/utilities/flex/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/float/index.html
+++ b/docs/5.0/utilities/float/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/interactions/index.html
+++ b/docs/5.0/utilities/interactions/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/overflow/index.html
+++ b/docs/5.0/utilities/overflow/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/position/index.html
+++ b/docs/5.0/utilities/position/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/shadows/index.html
+++ b/docs/5.0/utilities/shadows/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/sizing/index.html
+++ b/docs/5.0/utilities/sizing/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/spacing/index.html
+++ b/docs/5.0/utilities/spacing/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/text/index.html
+++ b/docs/5.0/utilities/text/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/vertical-align/index.html
+++ b/docs/5.0/utilities/vertical-align/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.0/utilities/visibility/index.html
+++ b/docs/5.0/utilities/visibility/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.0
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.0/">Latest (5.0.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/about/brand/index.html
+++ b/docs/5.1/about/brand/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/about/license/index.html
+++ b/docs/5.1/about/license/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/about/overview/index.html
+++ b/docs/5.1/about/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/about/team/index.html
+++ b/docs/5.1/about/team/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/about/translations/index.html
+++ b/docs/5.1/about/translations/index.html
@@ -149,7 +149,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/accordion/index.html
+++ b/docs/5.1/components/accordion/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/alerts/index.html
+++ b/docs/5.1/components/alerts/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/badge/index.html
+++ b/docs/5.1/components/badge/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/breadcrumb/index.html
+++ b/docs/5.1/components/breadcrumb/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/button-group/index.html
+++ b/docs/5.1/components/button-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/buttons/index.html
+++ b/docs/5.1/components/buttons/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/card/index.html
+++ b/docs/5.1/components/card/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/carousel/index.html
+++ b/docs/5.1/components/carousel/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/close-button/index.html
+++ b/docs/5.1/components/close-button/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/collapse/index.html
+++ b/docs/5.1/components/collapse/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/dropdowns/index.html
+++ b/docs/5.1/components/dropdowns/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/list-group/index.html
+++ b/docs/5.1/components/list-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/modal/index.html
+++ b/docs/5.1/components/modal/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/navbar/index.html
+++ b/docs/5.1/components/navbar/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/navs-tabs/index.html
+++ b/docs/5.1/components/navs-tabs/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/offcanvas/index.html
+++ b/docs/5.1/components/offcanvas/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/pagination/index.html
+++ b/docs/5.1/components/pagination/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/placeholders/index.html
+++ b/docs/5.1/components/placeholders/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/popovers/index.html
+++ b/docs/5.1/components/popovers/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/progress/index.html
+++ b/docs/5.1/components/progress/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/scrollspy/index.html
+++ b/docs/5.1/components/scrollspy/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/spinners/index.html
+++ b/docs/5.1/components/spinners/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/toasts/index.html
+++ b/docs/5.1/components/toasts/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/components/tooltips/index.html
+++ b/docs/5.1/components/tooltips/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/content/figures/index.html
+++ b/docs/5.1/content/figures/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/content/images/index.html
+++ b/docs/5.1/content/images/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/content/reboot/index.html
+++ b/docs/5.1/content/reboot/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/content/tables/index.html
+++ b/docs/5.1/content/tables/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/content/typography/index.html
+++ b/docs/5.1/content/typography/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/color/index.html
+++ b/docs/5.1/customize/color/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/components/index.html
+++ b/docs/5.1/customize/components/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/css-variables/index.html
+++ b/docs/5.1/customize/css-variables/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/optimize/index.html
+++ b/docs/5.1/customize/optimize/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/options/index.html
+++ b/docs/5.1/customize/options/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/overview/index.html
+++ b/docs/5.1/customize/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/customize/sass/index.html
+++ b/docs/5.1/customize/sass/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/extend/approach/index.html
+++ b/docs/5.1/extend/approach/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/extend/icons/index.html
+++ b/docs/5.1/extend/icons/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/checks-radios/index.html
+++ b/docs/5.1/forms/checks-radios/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/floating-labels/index.html
+++ b/docs/5.1/forms/floating-labels/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/form-control/index.html
+++ b/docs/5.1/forms/form-control/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/input-group/index.html
+++ b/docs/5.1/forms/input-group/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/layout/index.html
+++ b/docs/5.1/forms/layout/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/overview/index.html
+++ b/docs/5.1/forms/overview/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/range/index.html
+++ b/docs/5.1/forms/range/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/select/index.html
+++ b/docs/5.1/forms/select/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/forms/validation/index.html
+++ b/docs/5.1/forms/validation/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/accessibility/index.html
+++ b/docs/5.1/getting-started/accessibility/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/best-practices/index.html
+++ b/docs/5.1/getting-started/best-practices/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/browsers-devices/index.html
+++ b/docs/5.1/getting-started/browsers-devices/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/contents/index.html
+++ b/docs/5.1/getting-started/contents/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/contribute/index.html
+++ b/docs/5.1/getting-started/contribute/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/download/index.html
+++ b/docs/5.1/getting-started/download/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/introduction/index.html
+++ b/docs/5.1/getting-started/introduction/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/javascript/index.html
+++ b/docs/5.1/getting-started/javascript/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/parcel/index.html
+++ b/docs/5.1/getting-started/parcel/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/rfs/index.html
+++ b/docs/5.1/getting-started/rfs/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/rtl/index.html
+++ b/docs/5.1/getting-started/rtl/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/getting-started/webpack/index.html
+++ b/docs/5.1/getting-started/webpack/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/clearfix/index.html
+++ b/docs/5.1/helpers/clearfix/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/colored-links/index.html
+++ b/docs/5.1/helpers/colored-links/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/position/index.html
+++ b/docs/5.1/helpers/position/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/ratio/index.html
+++ b/docs/5.1/helpers/ratio/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/stacks/index.html
+++ b/docs/5.1/helpers/stacks/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/stretched-link/index.html
+++ b/docs/5.1/helpers/stretched-link/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/text-truncation/index.html
+++ b/docs/5.1/helpers/text-truncation/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/vertical-rule/index.html
+++ b/docs/5.1/helpers/vertical-rule/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/helpers/visually-hidden/index.html
+++ b/docs/5.1/helpers/visually-hidden/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/breakpoints/index.html
+++ b/docs/5.1/layout/breakpoints/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/columns/index.html
+++ b/docs/5.1/layout/columns/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/containers/index.html
+++ b/docs/5.1/layout/containers/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/css-grid/index.html
+++ b/docs/5.1/layout/css-grid/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/grid/index.html
+++ b/docs/5.1/layout/grid/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/gutters/index.html
+++ b/docs/5.1/layout/gutters/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/utilities/index.html
+++ b/docs/5.1/layout/utilities/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/layout/z-index/index.html
+++ b/docs/5.1/layout/z-index/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/migration/index.html
+++ b/docs/5.1/migration/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/api/index.html
+++ b/docs/5.1/utilities/api/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/background/index.html
+++ b/docs/5.1/utilities/background/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/borders/index.html
+++ b/docs/5.1/utilities/borders/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/colors/index.html
+++ b/docs/5.1/utilities/colors/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/display/index.html
+++ b/docs/5.1/utilities/display/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/flex/index.html
+++ b/docs/5.1/utilities/flex/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/float/index.html
+++ b/docs/5.1/utilities/float/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/interactions/index.html
+++ b/docs/5.1/utilities/interactions/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/opacity/index.html
+++ b/docs/5.1/utilities/opacity/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/overflow/index.html
+++ b/docs/5.1/utilities/overflow/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/position/index.html
+++ b/docs/5.1/utilities/position/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/shadows/index.html
+++ b/docs/5.1/utilities/shadows/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/sizing/index.html
+++ b/docs/5.1/utilities/sizing/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/spacing/index.html
+++ b/docs/5.1/utilities/spacing/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/text/index.html
+++ b/docs/5.1/utilities/text/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/vertical-align/index.html
+++ b/docs/5.1/utilities/vertical-align/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>

--- a/docs/5.1/utilities/visibility/index.html
+++ b/docs/5.1/utilities/visibility/index.html
@@ -150,7 +150,18 @@
     <span class="d-none d-lg-inline">Bootstrap</span> v5.1
   </button>
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
-    <li><a class="dropdown-item current" aria-current="true" href="/docs/5.1/">Latest (5.1.x)</a></li>
+    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li>
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+        Latest (5.2.x)
+      </a>
+    </li>
+    <li>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+    </li>
+    <li>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+    </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>


### PR DESCRIPTION
This updates the v5.1 and v5.0 dropdowns to include the updated v5.2 dropdown. They both now include the actual v5.2 as latest. In my dev environment, I checked that each had the correct dropdown, but my dev environment did not include the css. Everything functionally worked, but please checkout and make sure everything looks correct. I didn't spend a huge amount of time on it and didn't want to figure out why the css wasn't loading. ✌️ Also, here was my original issue https://github.com/twbs/bootstrap/issues/36990