### PR TITLE
Search modal: Set cursor on auto

### DIFF
--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -23,7 +23,7 @@
   --docsearch-hit-shadow: none;
 
   z-index: 2000; // Make sure to be over all components showcased in the documentation
-  cursor: auto;
+  cursor: auto; // Needed because of [role="button"] in Algolia search modal. Remove once https://github.com/algolia/docsearch/issues/1370 is tackled.
 
   @include media-breakpoint-up(lg) {
     padding-top: 4rem;

--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -23,6 +23,7 @@
   --docsearch-hit-shadow: none;
 
   z-index: 2000; // Make sure to be over all components showcased in the documentation
+  cursor: auto;
 
   @include media-breakpoint-up(lg) {
     padding-top: 4rem;


### PR DESCRIPTION
The search container `.DocSearch-Container` contains a `[role="button"]` leading to a pointer cursor on every part of the modal. This is just a quick fix, but I'm actually wondering why there is that `[role="button"]` on that container. I should maybe open an issue on [Algolia](https://github.com/algolia/docsearch) side ?