### PR TITLE
Fix bump `@popperjs` from 2.11.5 to 2.11.6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -80,8 +80,8 @@ params:
     js_hash:          "sha384-ODmDIVzN+pFdexxHEHFBQH3/9/vQ9uori45z4JjnFsRydbmQbmL5t1tQ0culUzyK"
     js_bundle:        "https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
     js_bundle_hash:   "sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
-    popper:           "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.5/dist/umd/popper.min.js"
-    popper_hash:      "sha384-Xe+8cL9oJa6tN/veChSP7q+mnSPaj5Bcu9mPX5F5xIGE0DVittaqT5lorf0EI7Vk"
+    popper:           "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
+    popper_hash:      "sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
 
   anchors:
     min: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vnu-jar": "21.10.12"
       },
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "watch-js-docs": "nodemon --watch site/assets/js/ --ext js --exec \"npm run js-lint\""
   },
   "peerDependencies": {
-    "@popperjs/core": "^2.11.5"
+    "@popperjs/core": "^2.11.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",
@@ -174,7 +174,7 @@
     },
     "dependencies": {},
     "peerDependencies": {
-      "@popperjs/core": "^2.11.5"
+      "@popperjs/core": "^2.11.6"
     }
   }
 }


### PR DESCRIPTION
IMO something's missing in the update dependencies commit https://github.com/twbs/bootstrap/commit/db3490788775ac88cc8dcc32f9b8bcd66f95859e about `@popperjs`.

Here is a proposal to complete this update.

/cc @mdo or @XhmikosR 