### PR TITLE
Fix accordion button color

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -13,7 +13,7 @@
   --#{$prefix}accordion-inner-border-radius: #{$accordion-inner-border-radius};
   --#{$prefix}accordion-btn-padding-x: #{$accordion-button-padding-x};
   --#{$prefix}accordion-btn-padding-y: #{$accordion-button-padding-y};
-  --#{$prefix}accordion-btn-color: #{$accordion-color};
+  --#{$prefix}accordion-btn-color: #{$accordion-button-color};
   --#{$prefix}accordion-btn-bg: #{$accordion-button-bg};
   --#{$prefix}accordion-btn-icon: #{escape-svg($accordion-button-icon)};
   --#{$prefix}accordion-btn-icon-width: #{$accordion-icon-width};


### PR DESCRIPTION
Fixes #37092  bei using the Sass variable `$accordion-button-color` as value for the CSS custom property `--bs-accordion-btn-color`.