### PR TITLE
Set toast z-index variable in the correct spot

### DIFF
--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -38,6 +38,8 @@
 }
 
 .toast-container {
+  --#{$prefix}toast-zindex: #{$zindex-toast};
+
   position: absolute;
   z-index: var(--#{$prefix}toast-zindex);
   width: max-content;


### PR DESCRIPTION
The`.toast-container` tries to use the z-index CSS variable, which is defined under `.toast`.  

However, this variable is not accessible to the `.toast-container`, because it is the **_parent_** of `.toast`. This PR copies the variable to the spot where it can be used.

Fixes #37136
Fixes #37175

I'm not sure how to handle the documentation in this case.
