### PR TITLE
Navbar height error, different theme names,  hide offcanvas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,14 @@
     "xo",
     "xo/browser"
   ],
+  "globals": {
+    "bootstrap": false
+  },
   "rules": {
+    "no-redeclare": [ "error", {
+        "builtinGlobals": false
+      }
+    ],
     "arrow-body-style": "off",
     "capitalized-comments": "off",
     "comma-dangle": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,14 +7,7 @@
     "xo",
     "xo/browser"
   ],
-  "globals": {
-    "bootstrap": false
-  },
   "rules": {
-    "no-redeclare": [ "error", {
-        "builtinGlobals": false
-      }
-    ],
     "arrow-body-style": "off",
     "capitalized-comments": "off",
     "comma-dangle": [

--- a/site/assets/js/color-modes/index.js
+++ b/site/assets/js/color-modes/index.js
@@ -72,7 +72,6 @@
           // After changing the theme, hide offcanvas
           const oc = document.querySelector('[aria-modal][class*=show][class*=offcanvas-]')
           if (oc !== null) {
-            // eslint-disable-next-line no-undef
             bootstrap.Offcanvas.getInstance(oc).hide()
           }
         })

--- a/site/assets/js/color-modes/index.js
+++ b/site/assets/js/color-modes/index.js
@@ -36,14 +36,20 @@
   const showActiveTheme = theme => {
     const activeThemeIcon = document.querySelector('.theme-icon-active use')
     const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
-    const svgOfActiveBtn = btnToActive.querySelector('svg use').getAttribute('href')
+    try {
+      const svgOfActiveBtn = btnToActive.querySelector('svg use').getAttribute('href')
 
-    document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
-      element.classList.remove('active')
-    })
+      document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
+        element.classList.remove('active')
+      })
 
-    btnToActive.classList.add('active')
-    activeThemeIcon.setAttribute('href', svgOfActiveBtn)
+      btnToActive.classList.add('active')
+      if (activeThemeIcon !== null) {
+        activeThemeIcon.setAttribute('href', svgOfActiveBtn)
+      }
+    } catch {
+      // Using different theme names. Not just dark and light.
+    }
   }
 
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -62,6 +68,13 @@
           localStorage.setItem('theme', theme)
           setTheme(theme)
           showActiveTheme(theme)
+
+          // After changing the theme, hide offcanvas
+          const oc = document.querySelector('[aria-modal][class*=show][class*=offcanvas-]')
+          if (oc !== null) {
+            // eslint-disable-next-line no-undef
+            bootstrap.Offcanvas.getInstance(oc).hide()
+          }
         })
       })
   })

--- a/site/assets/js/color-modes/index.js
+++ b/site/assets/js/color-modes/index.js
@@ -10,6 +10,8 @@
  * For details, see https://creativecommons.org/licenses/by/3.0/.
  */
 
+/* global bootstrap: false */
+
 (() => {
   'use strict'
 

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -5,7 +5,8 @@
   box-shadow: 0 .5rem 1rem rgba($black, .15), inset 0 -1px 0 rgba($white, .15);
 
   [data-bs-theme="dark"] & {
-    backdrop-filter: blur(.25rem);
+    // Navbar height error
+    // backdrop-filter: blur(.25rem);
     background-image: linear-gradient(to bottom, rgba(var(--bd-violet-rgb), 1), rgba(var(--bd-violet-rgb), .75));
     box-shadow: 0 .5rem 1rem rgba($black, .15), inset 0 -1px 0 rgba($white, .15);
   }


### PR DESCRIPTION
# index.js
Using different theme names. Not just dark and light. 
After changing the theme, hide offcanvas.

# _navbar.scss
Navbar height error.  The problem is due to the backdrop filter.

```css
[data-bs-theme="dark"] & {
    // Navbar height error
    // backdrop-filter: blur(.25rem);
    background-image: linear-gradient(to bottom, rgba(var(--bd-violet-rgb), 1), rgba(var(--bd-violet-rgb), .75));
    box-shadow: 0 .5rem 1rem rgba($black, .15), inset 0 -1px 0 rgba($white, .15);
}
```