### PR TITLE
Define missing "default" `.btn` CSS variables

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -19,6 +19,16 @@
   --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
   --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
   --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), .5);
+  --#{$prefix}btn-hover-color: #{color-contrast($btn-hover-bg)};
+  --#{$prefix}btn-hover-bg: #{$btn-hover-bg};
+  --#{$prefix}btn-active-color: #{color-contrast($btn-active-bg)};
+  --#{$prefix}btn-active-bg: #{$btn-active-bg};
+  --#{$prefix}btn-active-border-color: transparent;
+  --#{$prefix}btn-active-shadow: #{$btn-active-box-shadow};
+  --#{$prefix}btn-disabled-color: #{color-contrast($btn-disabled-bg)};
+  --#{$prefix}btn-disabled-bg: #{$btn-disabled-bg};
+  --#{$prefix}btn-disabled-border-color: transparent;
+  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb($btn-hover-bg)};
   // scss-docs-end btn-css-vars
 
   display: inline-block;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -787,6 +787,10 @@ $btn-active-bg-shade-amount:      20% !default;
 $btn-active-bg-tint-amount:       20% !default;
 $btn-active-border-shade-amount:  25% !default;
 $btn-active-border-tint-amount:   10% !default;
+
+$btn-hover-bg:                    shade-color($body-bg, $btn-hover-bg-shade-amount) !default;
+$btn-active-bg:                   shade-color($body-bg, $btn-active-bg-shade-amount) !default;
+$btn-disabled-bg:                 $body-bg !default;
 // scss-docs-end btn-variables
 
 


### PR DESCRIPTION
Buttons that do not specify any variant, did not have all CSS variables defined, such as `--#{$prefix}btn-hover-bg`. Those were defined only by the button-variant mixins.

Variables of this PR mimic what the button-variant mixins would do (more or less), but applied to so-called "default" `.btn` (my own terminology invention) with transparent background and, for example, `:hover` background shaded against `$body-bg`.

Should not affect anything else, but those using `.btn` without accompanying `.btn-#{$variant}`, which most likely is rare...?

Our project happens to use buttons in this obscure way, and noticed something changed in v5.2 release regarding the `:hover` behavior of our "naked" buttons 😺

Any comments are welcome. Also, I understand if this is seen as unnecessary. But my Inspector would be free of grayish `--bs-btn-hover-bg is not defined` stains 🙄