### PR TITLE
Fix active class toggling of tabs within dropdown

### DIFF
--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -38,7 +38,6 @@ const CLASS_DROPDOWN = 'dropdown'
 
 const SELECTOR_DROPDOWN_TOGGLE = '.dropdown-toggle'
 const SELECTOR_DROPDOWN_MENU = '.dropdown-menu'
-const SELECTOR_DROPDOWN_ITEM = '.dropdown-item'
 const NOT_SELECTOR_DROPDOWN_TOGGLE = ':not(.dropdown-toggle)'
 
 const SELECTOR_TAB_PANEL = '.list-group, .nav, [role="tablist"]'
@@ -231,7 +230,6 @@ class Tab extends BaseComponent {
 
     toggle(SELECTOR_DROPDOWN_TOGGLE, CLASS_NAME_ACTIVE)
     toggle(SELECTOR_DROPDOWN_MENU, CLASS_NAME_SHOW)
-    toggle(SELECTOR_DROPDOWN_ITEM, CLASS_NAME_ACTIVE)
     outerElem.setAttribute('aria-expanded', open)
   }
 

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -843,7 +843,7 @@ describe('Tab', () => {
       const dropItems = fixtureEl.querySelectorAll('.dropdown-item')
 
       dropItems[1].click()
-      expect(dropItems[0]).not.toHaveClass("active")
+      expect(dropItems[0]).not.toHaveClass('active')
       expect(dropItems[1]).toHaveClass('active')
       expect(fixtureEl.querySelector('.nav-link')).not.toHaveClass('active')
     })

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -840,10 +840,11 @@ describe('Tab', () => {
         '</ul>'
       ].join('')
 
-      const firstDropItem = fixtureEl.querySelector('.dropdown-item')
+      const dropItems = fixtureEl.querySelectorAll('.dropdown-item')
 
-      firstDropItem.click()
-      expect(firstDropItem).toHaveClass('active')
+      dropItems[1].click()
+      expect(dropItems[0]).not.toHaveClass("active")
+      expect(dropItems[1]).toHaveClass('active')
       expect(fixtureEl.querySelector('.nav-link')).not.toHaveClass('active')
     })
 


### PR DESCRIPTION
Closes #36947 (a regression introduced by https://github.com/twbs/bootstrap/pull/33079, cc @GeoSot)

As [the codepen](https://codepen.io/cpsievert/pen/OJvoYJb) in #36947 demonstrates, when clicking on the 2nd tab in a dropdown, _all_ the tabs within the dropdown are marked with an active class. This happens because, the current logic in `_toggleDropdown()` toggles the active class on the _first_ tab within the dropdown when it shouldn't be