### PR TITLE
Use `:host` in selectors to support Web Components

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -2,7 +2,8 @@
 //
 // Rows contain your columns.
 
-:root {
+:root,
+:host {
   @each $name, $value in $grid-breakpoints {
     --#{$prefix}breakpoint-#{$name}: #{$value};
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -25,7 +25,8 @@
 // Ability to the value of the root font sizes, affecting the value of `rem`.
 // null by default, thus nothing is generated.
 
-:root {
+:root,
+:host {
   @if $font-size-root != null {
     @include font-size(var(--#{$prefix}root-font-size));
   }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,4 +1,5 @@
 :root,
+:host,
 [data-bs-theme="light"] {
   // Note: Custom variable values only support SassScript inside `#{}`.
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -387,7 +387,7 @@ $enable-important-utilities:  true !default;
 $enable-dark-mode:            true !default;
 $color-mode-type:             data !default; // `data` or `media-query`
 
-// Prefix for :root CSS variables
+// Prefix for ':root, :host' CSS variables
 
 $variable-prefix:             bs- !default; // Deprecated in v5.2.0 for the shorter `$prefix`
 $prefix:                      $variable-prefix !default;

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -3,7 +3,8 @@
   @if $color-mode-type == "media-query" {
     @if $root == true {
       @media (prefers-color-scheme: $mode) {
-        :root, :host {
+        :root,
+        :host {
           @content;
         }
       }

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -3,7 +3,7 @@
   @if $color-mode-type == "media-query" {
     @if $root == true {
       @media (prefers-color-scheme: $mode) {
-        :root {
+        :root, :host {
           @content;
         }
       }

--- a/scss/tests/mixins/_color-modes.test.scss
+++ b/scss/tests/mixins/_color-modes.test.scss
@@ -57,7 +57,8 @@
           }
         }
         @media (prefers-color-scheme: dark) {
-          :root {
+          :root,
+          :host {
             --custom-color: #3a3ff8;
           }
         }

--- a/site/content/docs/5.3/customize/css-variables.md
+++ b/site/content/docs/5.3/customize/css-variables.md
@@ -21,7 +21,7 @@ These CSS variables are available everywhere, regardless of color mode.
 ```css
 {{< root.inline >}}
 {{- $css := readFile "dist/css/bootstrap.css" -}}
-{{- $match := findRE `:root,\n\[data-bs-theme=light\] {([^}]*)}` $css 1 -}}
+{{- $match := findRE `:root,\n:host,\n\[data-bs-theme=light\] {([^}]*)}` $css 1 -}}
 
 {{- if (eq (len $match) 0) -}}
 {{- errorf "Got no matches for :root in %q!" $.Page.Path -}}

--- a/site/content/docs/5.3/customize/css-variables.md
+++ b/site/content/docs/5.3/customize/css-variables.md
@@ -21,7 +21,7 @@ These CSS variables are available everywhere, regardless of color mode.
 ```css
 {{< root.inline >}}
 {{- $css := readFile "dist/css/bootstrap.css" -}}
-{{- $match := findRE `:root,\n:host,\n\[data-bs-theme=light\] {([^}]*)}` $css 1 -}}
+{{- $match := findRE `:root,\n\[data-bs-theme=light\] {([^}]*)}` $css 1 -}}
 
 {{- if (eq (len $match) 0) -}}
 {{- errorf "Got no matches for :root in %q!" $.Page.Path -}}


### PR DESCRIPTION
Fixes #36688

### Description

This PR suggests to change `:root` to `:root, :host` in order to have access to the CSS vars in [this type of example shown in the issue](https://codepen.io/julien-deramond/pen/MWBdpbz) where the `<link>` is in the web component definition but not loaded in the main document.

So I've added this extra-rule to the following files:
* `scss/_grid.scss` (tested in the CodePen via `height: var(--bs-breakpoint-sm)`)
* `scss/_reboot.scss`: ⚠️ not sur if it's really needed or not 🤔 
* `scss/_root.scss` (tested in the CodePen via `color: var(--bs-white); background-color: var(--bs-purple);`)
* `scss/mixins/_color-mode.scss`: ⚠️ not easily testable

On purpose, I haven't modified the following files only used for our docs. I assumed that it wasn't really useful for our users.
* `site/assets/scss/_search.scss`
* `site/assets/scss/_syntax.scss`
* `site/assets/scss/_variables.scss`

- **Important** This PR doesn't tackle the sub-issue regarding the rendering of the accordions from https://github.com/twbs/bootstrap/issues/36688#issuecomment-1177361155. IMO it's not exactly the same topic.

### Testing

I've [duplicated the example from the comments](https://codepen.io/julien-deramond/pen/dyevpvd).
Due to CORS issues and/or netlify deployment errors, I've copied the content of `dist/css/bootstrap.min.css` directly in the `<style>` of the web component to show that the fix work.
If you change it to `<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">` you'll see the non-working example.

### Other elements

- [ ] Add something in the Migration Guide for v5.3?
- [ ] `reboot.md`, `color.md`, `css-variables.md`, `focus-ring.md` and `partials/home/css-variables.html` mention the `:root` level. Do we need to modify the texts to mention the `:root, :host` level? Might be weird.