### PR TITLE
Explicitly target `.btn-check` and undo `:hover`

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -40,12 +40,18 @@
   @include box-shadow(var(--#{$prefix}btn-box-shadow));
   @include transition($btn-transition);
 
-  :not(.btn-check) + &:hover,
-  &:first-child:hover {
+  &:hover {
     color: var(--#{$prefix}btn-hover-color);
     text-decoration: if($link-hover-decoration == underline, none, null);
     background-color: var(--#{$prefix}btn-hover-bg);
     border-color: var(--#{$prefix}btn-hover-border-color);
+  }
+
+  .btn-check + &:hover {
+    // override for the checkbox/radio buttons
+    color: var(--#{$prefix}btn-color);
+    background-color: var(--#{$prefix}btn-bg);
+    border-color: var(--#{$prefix}btn-border-color);
   }
 
   &:focus-visible {


### PR DESCRIPTION
rather than the other way around, which caused specificity issues. Follow-up patch to https://github.com/twbs/bootstrap/pull/37026

closes https://github.com/twbs/bootstrap/issues/37130 (presumably?), closes https://github.com/twbs/bootstrap/issues/37115