### PR TITLE
Use Sass variable for accordion color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1256,7 +1256,7 @@ $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     1rem !default;
 $accordion-padding-x:                     1.25rem !default;
-$accordion-color:                         var(--#{$prefix}body-color) !default;
+$accordion-color:                         $body-color !default; // Sass variable because of $accordion-button-icon
 $accordion-bg:                            $body-bg !default;
 $accordion-border-width:                  $border-width !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;


### PR DESCRIPTION
Fixes #37144

This needs a bigger solve in v5.3 and v6 I think. Makes me want to move to an SVG sprite for all our images so that we have more control over color and can use CSS variables + inheritance to properly color and style these items. Also solves the CSP issues folks have with embedded SVGs. But, that's for another time.