### PR TITLE
Enrich Tab Test for keyboard handler

### DIFF
--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -513,15 +513,19 @@ describe('Tab', () => {
         '<div class="nav">',
         '  <span id="tab1" class="nav-link" data-bs-toggle="tab"></span>',
         '  <span id="tab2" class="nav-link" data-bs-toggle="tab"></span>',
+        '  <span id="tab3" class="nav-link" data-bs-toggle="tab"></span>',
         '</div>'
       ].join('')
 
-      const tabEl = fixtureEl.querySelector('#tab1')
+      const tabEl1 = fixtureEl.querySelector('#tab1')
       const tabEl2 = fixtureEl.querySelector('#tab2')
-      const tab = new Tab(tabEl)
+      const tabEl3 = fixtureEl.querySelector('#tab3')
+      const tab1 = new Tab(tabEl1)
       const tab2 = new Tab(tabEl2)
-      const spyShow1 = spyOn(tab, 'show').and.callThrough()
+      const tab3 = new Tab(tabEl3)
+      const spyShow1 = spyOn(tab1, 'show').and.callThrough()
       const spyShow2 = spyOn(tab2, 'show').and.callThrough()
+      const spyShow3 = spyOn(tab3, 'show').and.callThrough()
 
       const spyStop = spyOn(Event.prototype, 'stopPropagation').and.callThrough()
       const spyPrevent = spyOn(Event.prototype, 'preventDefault').and.callThrough()
@@ -529,17 +533,20 @@ describe('Tab', () => {
       let keydown = createEvent('keydown')
       keydown.key = 'ArrowRight'
 
-      tabEl.dispatchEvent(keydown)
+      tabEl1.dispatchEvent(keydown)
       expect(spyShow2).toHaveBeenCalled()
 
       keydown = createEvent('keydown')
       keydown.key = 'ArrowDown'
 
       tabEl2.dispatchEvent(keydown)
+      expect(spyShow3).toHaveBeenCalled()
+
+      tabEl3.dispatchEvent(keydown)
       expect(spyShow1).toHaveBeenCalled()
 
-      expect(spyStop).toHaveBeenCalledTimes(2)
-      expect(spyPrevent).toHaveBeenCalledTimes(2)
+      expect(spyStop).toHaveBeenCalledTimes(3)
+      expect(spyPrevent).toHaveBeenCalledTimes(3)
     })
 
     it('if keydown event is left arrow, handle it', () => {


### PR DESCRIPTION
As I fell in a browser glitch, I decided to reassure the keyboard functionality in more than two tab instances