### PR TITLE
Bind popper disposal with tooltip removal, trying to fix tooltip/popper inconsistencies

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -172,10 +172,6 @@ class Tooltip extends BaseComponent {
 
     EventHandler.off(this._element.closest(SELECTOR_MODAL), EVENT_MODAL_HIDE, this._hideModalHandler)
 
-    if (this.tip) {
-      this.tip.remove()
-    }
-
     if (this._element.getAttribute('data-bs-original-title')) {
       this._element.setAttribute('title', this._element.getAttribute('data-bs-original-title'))
     }
@@ -202,10 +198,7 @@ class Tooltip extends BaseComponent {
     }
 
     // todo v6 remove this OR make it optional
-    if (this.tip) {
-      this.tip.remove()
-      this.tip = null
-    }
+    this._disposePopper()
 
     const tip = this._getTipElement()
 
@@ -218,11 +211,7 @@ class Tooltip extends BaseComponent {
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_INSERTED))
     }
 
-    if (this._popper) {
-      this._popper.update()
-    } else {
-      this._popper = this._createPopper(tip)
-    }
+    this._popper = this._createPopper(tip)
 
     tip.classList.add(CLASS_NAME_SHOW)
 
@@ -281,13 +270,11 @@ class Tooltip extends BaseComponent {
       }
 
       if (!this._isHovered) {
-        tip.remove()
+        this._disposePopper()
       }
 
       this._element.removeAttribute('aria-describedby')
       EventHandler.trigger(this._element, this.constructor.eventName(EVENT_HIDDEN))
-
-      this._disposePopper()
     }
 
     this._queueCallback(complete, this.tip, this._isAnimated())
@@ -611,6 +598,11 @@ class Tooltip extends BaseComponent {
     if (this._popper) {
       this._popper.destroy()
       this._popper = null
+    }
+
+    if (this.tip) {
+      this.tip.remove()
+      this.tip = null
     }
   }
 


### PR DESCRIPTION
### Description

According to #37068, it seems there is a case, where we initialize tooltip without popper, or we keep tooltip shown while we are destroying popper instance. The result is a tooltip without being styled 

<img width="383" alt="Screen Shot 2022-09-01 at 14 58 48" src="https://user-images.githubusercontent.com/1476544/188020852-1ad5a635-7408-4cff-aff6-125bfe06aec7.png">


 So I am experimenting on a continuous binding between popper instance disposal and tip element removal


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-37235--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/#custom-tooltips

### Related issues

closes #37068