### PR TITLE
Don't redefine `$border-color` in `table-variant` mixin

### DIFF
--- a/scss/mixins/_table-variants.scss
+++ b/scss/mixins/_table-variants.scss
@@ -5,11 +5,11 @@
     $hover-bg: mix($color, $background, percentage($table-hover-bg-factor));
     $striped-bg: mix($color, $background, percentage($table-striped-bg-factor));
     $active-bg: mix($color, $background, percentage($table-active-bg-factor));
-    $border-color: mix($color, $background, percentage($table-border-factor));
+    $table-border-color: mix($color, $background, percentage($table-border-factor));
 
     --#{$prefix}table-color: #{$color};
     --#{$prefix}table-bg: #{$background};
-    --#{$prefix}table-border-color: #{$border-color};
+    --#{$prefix}table-border-color: #{$table-border-color};
     --#{$prefix}table-striped-bg: #{$striped-bg};
     --#{$prefix}table-striped-color: #{color-contrast($striped-bg)};
     --#{$prefix}table-active-bg: #{$active-bg};


### PR DESCRIPTION
### Related issues

Closes #37225 

### Description

Avoid redefining `$border-color` in `table-variant` mixin.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed

#### Live previews

* https://deploy-preview-37239--twbs-bootstrap.netlify.app/: check for non-regression in all of our tables

### How to test locally

* Create a local project thanks to [our Vite guide](https://getbootstrap.com/docs/5.2/getting-started/vite/)
* Change the content of `styles.scss` by:
```scss
html.light {
  $border-color: #dbe6ee;

  @debug ('light border color before bootstrap #{$border-color}');
  @import '~bootstrap/scss/bootstrap';
  @debug ('light border color after bootstrap #{$border-color}');

  .side-menu {
    border: 1px solid $border-color;
  }
}

html.dark {
  $border-color: #313131;

  @debug ('dark border color before bootstrap #{$border-color}');
  @import '~bootstrap/scss/bootstrap';
  @debug ('dark border color after bootstrap #{$border-color}');

  .side-menu {
    border: 1px solid $border-color;
  }
}
```
* Change the content of `src/index.html` by:
```html
<!DOCTYPE html>
<html class="dark" lang="en">
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>Bootstrap w/ Vite</title>
    <link rel="stylesheet" href="scss/styles.scss" />
    <script type="module" src="./js/main.js"></script>
  </head>
  <body>
    <div class="side-menu">test</div>

    <table class="table mt-5">
      <thead>
        <tr>
          <th scope="col">#</th>
          <th scope="col">First</th>
          <th scope="col">Last</th>
          <th scope="col">Handle</th>
        </tr>
      </thead>
      <tbody>
        <tr>
          <th scope="row">1</th>
          <td>Mark</td>
          <td>Otto</td>
          <td>@mdo</td>
        </tr>
        <tr>
          <th scope="row">2</th>
          <td>Jacob</td>
          <td>Thornton</td>
          <td>@fat</td>
        </tr>
        <tr>
          <th scope="row">3</th>
          <td colspan="2">Larry the Bird</td>
          <td>@twitter</td>
        </tr>
      </tbody>
    </table>
  </body>
</html>
```
* Modify `node_modules/bootstrap/scss/mixins/_table-variants.scss` to apply the modification in this PR
* **Expected**: right overriden color when `html.dark` and `html.light` when `.side-menu` is used