### PR TITLE
Carousel: Fix RTL `translate()` direction

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -42,7 +42,6 @@
   display: block;
 }
 
-/* rtl:begin:ignore */
 .carousel-item-next:not(.carousel-item-start),
 .active.carousel-item-end {
   transform: translateX(100%);
@@ -52,8 +51,6 @@
 .active.carousel-item-start {
   transform: translateX(-100%);
 }
-
-/* rtl:end:ignore */
 
 
 //


### PR DESCRIPTION
Fixes #37180

#### Live previews

* https://deploy-preview-37266--twbs-bootstrap.netlify.app/docs/5.2/examples/carousel-rtl/