### PR TITLE
Docs: Slightly improve tooling setup description

### DIFF
--- a/site/content/docs/5.2/getting-started/contribute.md
+++ b/site/content/docs/5.2/getting-started/contribute.md
@@ -14,7 +14,7 @@ Bootstrap uses [npm scripts](https://docs.npmjs.com/misc/scripts/) to build the 
 To use our build system and run our documentation locally, you'll need a copy of Bootstrap's source files and Node. Follow these steps and you should be ready to rock:
 
 1. [Download and install Node.js](https://nodejs.org/en/download/), which we use to manage our dependencies.
-2. Either [download Bootstrap's sources]({{< param "download.source" >}}) or fork [Bootstrap's repository]({{< param repo >}}).
+2. Either [download Bootstrap's sources]({{< param "download.source" >}}) or fork and clone [Bootstrap's repository]({{< param repo >}}).
 3. Navigate to the root `/bootstrap` directory and run `npm install` to install our local dependencies listed in [package.json]({{< param repo >}}/blob/v{{< param current_version >}}/package.json).
 
 When completed, you'll be able to run the various commands provided from the command line.


### PR DESCRIPTION
### Description

Slightly improve Tooling setup section in Contribute documentation.

### Motivation & Context

The repository must be cloned before moving to the next steps. I've let the "fork" part because it is in the contribute part but we could only let the "clone" part without mentioning a fork.

### Type of changes

- [x] Enhancement (documentation)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] I have updated the documentation accordingly

#### Live previews

* https://deploy-preview-37271--twbs-bootstrap.netlify.app/docs/5.2/getting-started/contribute/#tooling-setup
