### PR TITLE
Fix disabled floating labels and add some examples of it in the docs

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,7 +1,7 @@
 .form-floating {
   position: relative;
 
-  &::before {
+  &::before:not(.form-control:disabled) {
     position: absolute;
     top: $input-border-width;
     left: $input-border-width;

--- a/site/content/docs/5.2/forms/floating-labels.md
+++ b/site/content/docs/5.2/forms/floating-labels.md
@@ -75,6 +75,30 @@ Other than `.form-control`, floating labels are only available on `.form-select`
 </div>
 {{< /example >}}
 
+## Disabled
+
+Add the `disabled` boolean attribute on an input, a textarea or a select to give it a grayed out appearance, remove pointer events, and prevent focusing.
+
+{{< example >}}
+<div class="form-floating mb-3">
+  <input type="email" class="form-control" id="floatingInputDisabled" placeholder="name@example.com" disabled>
+  <label for="floatingInputDisabled">Email address</label>
+</div>
+<div class="form-floating mb-3">
+  <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextareaDisabled" disabled></textarea>
+  <label for="floatingTextareaDisabled">Comments</label>
+</div>
+<div class="form-floating">
+  <select class="form-select" id="floatingSelectDisabled" aria-label="Floating label disabled select example" disabled>
+    <option selected>Open this select menu</option>
+    <option value="1">One</option>
+    <option value="2">Two</option>
+    <option value="3">Three</option>
+  </select>
+  <label for="floatingSelectDisabled">Works with selects</label>
+</div>
+{{< /example >}}
+
 ## Readonly plaintext
 
 Floating labels also support `.form-control-plaintext`, which can be helpful for toggling from an editable `<input>` to a plaintext value without affecting the page layout.

--- a/site/content/docs/5.2/forms/floating-labels.md
+++ b/site/content/docs/5.2/forms/floating-labels.md
@@ -88,6 +88,10 @@ Add the `disabled` boolean attribute on an input, a textarea or a select to give
   <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextareaDisabled" disabled></textarea>
   <label for="floatingTextareaDisabled">Comments</label>
 </div>
+<div class="form-floating mb-3">
+  <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2Disabled" style="height: 100px" disabled></textarea>
+  <label for="floatingTextarea2Disabled">Comments</label>
+</div>
 <div class="form-floating">
   <select class="form-select" id="floatingSelectDisabled" aria-label="Floating label disabled select example" disabled>
     <option selected>Open this select menu</option>


### PR DESCRIPTION
### Description

* Fixes the rendering when a disabled input is used in a floating label
* Add some documentation to reflect this use case

### Motivation & Context

I'm suggesting to add a new "Disabled" section in the documentation to be consistent with other form controls, and it will help us detect regression in the future.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

* https://deploy-preview-37299--twbs-bootstrap.netlify.app/docs/5.2/forms/floating-labels/#disabled

### Related issues

Closes #37297
Closes #37330 (and might replace #37359)
