### PR TITLE
Update .browserslistrc

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "29.5 kB"
+      "maxSize": "29.75 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,9 +3107,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
       "funding": [
         {
@@ -12741,9 +12741,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001414",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz",
-      "integrity": "sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "caw": {

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -55,7 +55,7 @@
   }
 
   &:focus-visible {
-    color: var(--#{$prefix}btn-hover-color);
+    color: #ffc0cb;
     @include gradient-bg(var(--#{$prefix}btn-hover-bg));
     border-color: var(--#{$prefix}btn-hover-border-color);
     outline: 0;
@@ -68,6 +68,7 @@
   }
 
   .btn-check:focus-visible + & {
+    color: #ffc0cb;
     border-color: var(--#{$prefix}btn-hover-border-color);
     outline: 0;
     // Avoid using mixin so we can pass custom focus shadow properly
@@ -91,6 +92,8 @@
     @include box-shadow(var(--#{$prefix}btn-active-shadow));
 
     &:focus-visible {
+      color: #ffc0cb;
+
       // Avoid using mixin so we can pass custom focus shadow properly
       @if $enable-shadows {
         box-shadow: var(--#{$prefix}btn-active-shadow), var(--#{$prefix}btn-focus-box-shadow);
@@ -179,11 +182,12 @@
 
   &:hover,
   &:focus-visible {
+    color: #ffc0cb;
     text-decoration: $link-hover-decoration;
   }
 
   &:focus-visible {
-    color: var(--#{$prefix}btn-color);
+    color: #ffc0cb;
   }
 
   &:hover {

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -397,6 +397,7 @@ button {
 // confused and applies its very visible two-tone outline anyway.
 
 button:focus:not(:focus-visible) {
+  color: #cbf;
   outline: 0;
 }
 

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -70,6 +70,7 @@
 
   .dropdown-toggle {
     &:focus:not(:focus-visible) {
+      color: #cbf;
       outline: 0;
     }
   }

--- a/site/content/docs/5.2/helpers/stacks.md
+++ b/site/content/docs/5.2/helpers/stacks.md
@@ -9,10 +9,6 @@ added: "5.1"
 
 Stacks offer a shortcut for applying a number of flexbox properties to quickly and easily create layouts in Bootstrap. All credit for the concept and implementation goes to the open source [Pylon project](https://almonk.github.io/pylon/).
 
-{{< callout warning >}}
-Heads up! Support for gap utilities with flexbox was recently added to Safari, so consider verifying your intended browser support. Grid layout should have no issues. [Read more](https://caniuse.com/flexbox-gap).
-{{< /callout >}}
-
 ## Vertical
 
 Use `.vstack` to create vertical layouts. Stacked items are full-width by default. Use `.gap-*` utilities to add space between items.


### PR DESCRIPTION
> **Warning**
> Work In Progress

### Description / Motivation & Context

Based on https://github.com/twbs/bootstrap/discussions/37306, I'm starting a PR to update our list of supported browsers contained in `.browserslistrc`. 

#### Actual support

<details>
<summary>npx autoprefixer --info</summary>
npx autoprefixer --info                                                                                                                                                             (0.000679 hrs)
Browsers:
  Chrome for Android: 106
  Firefox for Android: 105
  QQ Browser: 13.1
  UC for Android: 13.4
  Android: 106
  Chrome: 106, 105, 104, 103, 102, 101, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60
  Edge: 106, 105, 104
  Firefox: 105, 104, 103, 102, 101, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60
  iOS Safari: 16.0, 15.6, 15.5, 15.4, 15.2-15.3, 15.0-15.1, 14.5-14.8, 14.0-14.4, 13.4-13.7, 13.3, 13.2, 13.0-13.1, 12.2-12.5, 12.0-12.1
  KaiOS Browser: 2.5
  Opera Mini: all
  Opera Mobile: 64
  Opera: 91, 90
  Safari: 16.0, 15.6, 15.5, 15.4, 15.2-15.3, 15.1, 15, 14.1, 14, 13.1, 13, 12.1, 12
  Samsung Internet: 18.0, 17.0

These browsers account for 95.92% of all users globally
</details>

#### `:focus-visible`

We already began to use `:focus-visible` but haven't updated yet our `.browserslistrc`. Let's check what is the impact and if we can consider that we live with this mismatch we have now and fix it for the next v5.3.0.

⚠️ Temporary added https://github.com/twbs/bootstrap/pull/37309/commits/60ff612061f3a61be1472001f09b8605b37ae0b3 in this PR in order to do some BrowserStack testing.

See also https://github.com/orgs/twbs/discussions/37306

* [Caniuse reference](https://caniuse.com/?search=focus-visible)

TODO: check what values would need to be changed and what is the impact
TODO: change values in `.browserslistrc`

#### `prefers-color-scheme`

Will be used in the dark mode.
TODO: add more details

* [Caniuse reference](https://caniuse.com/?search=prefers-color-scheme)

TODO: explain what values need to be changed
TODO: change values in `.browserslistrc`

#### `xlink:href` → `href`

See https://github.com/twbs/bootstrap/pull/39222

### Breaking changes too important for now

* [Dialog element](https://caniuse.com/dialog)
* [gap property for flexbox](https://caniuse.com/?search=gap)
  * But what about https://github.com/twbs/bootstrap/blob/42e99cc59f6e87795e25d751bcfaf3be711191b4/scss/_nav.scss#L147 

### Others

- [ ] https://github.com/twbs/bootstrap/pull/35857/files#r1031450909 (linear gradient)
- [ ] https://github.com/twbs/bootstrap/pull/38159 (`:has` selector)
- [ ] https://mastodon.social/@patrick_h_lauke/110708951082107982 (`:has` selector + `:focus-visible`)
- [x] https://github.com/twbs/bootstrap/issues/39705
- [ ] If Safari version >= 14.5 see https://github.com/twbs/bootstrap/pull/40844 via https://github.com/twbs/bootstrap/pull/37309/commits/e5fdf7f0edbf04a9d9c1c9f87f0ad6404cfcc810
- [ ] `gap` of `.nav-underline`
- [x] https://github.com/twbs/bootstrap/issues/41046

### Type of changes

- [x] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] Run `npx update-browserslist-db@latest` to update our `package-lock.json`
- [ ] Check if we don't need other features in a near future
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes