### PR TITLE
Add `z-index` utilities, `.z-*`

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "29.5 kB"
+      "maxSize": "29.75 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -707,7 +707,7 @@ $utilities: map-merge(
     // scss-docs-end utils-visibility
     "z-index": (
       property: z-index,
-      class: z
+      class: z,
       values: $zindex-levels,
     )
   ),

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -703,8 +703,13 @@ $utilities: map-merge(
         visible: visible,
         invisible: hidden,
       )
-    )
+    ),
     // scss-docs-end utils-visibility
+    "z-index": (
+      property: z-index,
+      class: z
+      values: $zindex-levels,
+    )
   ),
   $utilities
 );

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1061,7 +1061,7 @@ $zindex-levels: (
   1: 1,
   2: 2,
   3: 3
- ) !default;
+) !default;
 // scss-docs-end zindex-levels-map
 
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1054,6 +1054,16 @@ $zindex-tooltip:                    1080 !default;
 $zindex-toast:                      1090 !default;
 // scss-docs-end zindex-stack
 
+// scss-docs-start zindex-levels-map
+$zindex-levels: (
+  n1: -1,
+  0: 0,
+  1: 1,
+  2: 2,
+  3: 3
+ ) !default;
+// scss-docs-end zindex-levels-map
+
 
 // Navs
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -305,6 +305,11 @@
 .bd-example-zindex-levels {
   min-height: 15rem;
 
+  > div {
+    background-color: lighten($bd-violet, 35%);
+    border: 1px solid lighten($bd-violet, 20%);
+  }
+
   > :nth-child(2) {
     top: 3rem;
     left: 3rem;

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -306,8 +306,8 @@
   min-height: 15rem;
 
   > div {
-    background-color: lighten($bd-violet, 35%);
-    border: 1px solid lighten($bd-violet, 20%);
+    background-color: tint-color($bd-violet, 75%);
+    border: 1px solid tint-color($bd-violet, 50%);
   }
 
   > :nth-child(2) {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -302,6 +302,27 @@
   min-height: 240px;
 }
 
+.bd-example-zindex-levels {
+  min-height: 15rem;
+
+  > :nth-child(2) {
+    top: 3rem;
+    left: 3rem;
+  }
+  > :nth-child(3) {
+    top: 4.5rem;
+    left: 4.5rem;
+  }
+  > :nth-child(4) {
+    top: 6rem;
+    left: 6rem;
+  }
+  > :nth-child(5) {
+    top: 7.5rem;
+    left: 7.5rem;
+  }
+}
+
 //
 // Code snippets
 //

--- a/site/content/docs/5.2/utilities/z-index.md
+++ b/site/content/docs/5.2/utilities/z-index.md
@@ -1,0 +1,46 @@
+---
+layout: docs
+title: z-index
+description: Use our low-level `z-index` utilities to quickly change the stack level of an element or component.
+group: utilities
+toc: true
+---
+
+## Example
+
+{{< added-in "5.3.0" >}}
+
+Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles or using our [position utilities]({{< docsref "/utilities/position/" >}}).
+
+{{< callout >}}
+We call these "low-level" `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. High-level `z-index` values are used for overlay components like modals and tooltips.
+{{< /callout >}}
+
+{{< example class="bd-example-zindex-levels position-relative" >}}
+<div class="z-n1 position-absolute p-5 bg-primary bg-opacity-25"></div>
+<div class="z-0 position-absolute p-5 bg-primary bg-opacity-25"></div>
+<div class="z-1 position-absolute p-5 bg-primary bg-opacity-25"></div>
+<div class="z-2 position-absolute p-5 bg-primary bg-opacity-25"></div>
+<div class="z-3 position-absolute p-5 bg-primary bg-opacity-25"></div>
+{{< /example >}}
+
+## Overlays
+
+Bootstrap overlay components—dropdown, modal, offcanvas, popover, toast, and tooltip—all have their own `z-index` values to ensure a usable experience with competing "layers" of an interface.
+
+Read about them in the [`z-index` layout page]({{< docsref "/layout/z-index" >}}).
+
+## Component approach
+
+On some components, we use our low-level `z-index` values to manage repeating elements that overlap one another (like buttons in a button group or items in a list group).
+
+Learn about our [`z-index` approach]({{< docsref "/extend/approach#z-index-scales" >}}).
+
+## CSS
+
+### Sass map
+
+Customize this Sass map to change the available values and generated utilities.
+
+{{< scss-docs name="zindex-levels-map" file="scss/_variables.scss" >}}
+

--- a/site/content/docs/5.2/utilities/z-index.md
+++ b/site/content/docs/5.2/utilities/z-index.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: z-index
+title: Z-index
 description: Use our low-level `z-index` utilities to quickly change the stack level of an element or component.
 group: utilities
 toc: true

--- a/site/content/docs/5.2/utilities/z-index.md
+++ b/site/content/docs/5.2/utilities/z-index.md
@@ -17,11 +17,11 @@ We call these "low-level" `z-index` utilities because of their default values of
 {{< /callout >}}
 
 {{< example class="bd-example-zindex-levels position-relative" >}}
-<div class="z-n1 position-absolute p-5 bg-primary bg-opacity-25"></div>
-<div class="z-0 position-absolute p-5 bg-primary bg-opacity-25"></div>
-<div class="z-1 position-absolute p-5 bg-primary bg-opacity-25"></div>
-<div class="z-2 position-absolute p-5 bg-primary bg-opacity-25"></div>
-<div class="z-3 position-absolute p-5 bg-primary bg-opacity-25"></div>
+<div class="z-n1 position-absolute p-5 rounded-3"></div>
+<div class="z-0 position-absolute p-5 rounded-3"></div>
+<div class="z-1 position-absolute p-5 rounded-3"></div>
+<div class="z-2 position-absolute p-5 rounded-3"></div>
+<div class="z-3 position-absolute p-5 rounded-3"></div>
 {{< /example >}}
 
 ## Overlays

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -133,6 +133,7 @@
     - title: Text
     - title: Vertical align
     - title: Visibility
+    - title: Z-index
 
 - title: Extend
   icon: tools


### PR DESCRIPTION
Fixes #31054. Closes #31486, which had conflicts.

This also extends the scale from that original PR to include a `3` value. In addition, I’ve added some documentation to cross-link to other `z-index` page mentions.

### [Live preview](https://deploy-preview-37317--twbs-bootstrap.netlify.app/docs/5.2/utilities/z-index/)