### PR TITLE
Limit `abbr[title]` style to browsers that support hover

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "29.5 kB"
+      "maxSize": "29.75 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -133,15 +133,23 @@ p {
 
 
 // Abbreviations
-//
-// 1. Add the correct text decoration in Chrome, Edge, Opera, and Safari.
-// 2. Add explicit cursor to indicate changed behavior.
-// 3. Prevent the text-decoration to be skipped.
 
-abbr[title] {
-  text-decoration: underline dotted; // 1
-  cursor: help; // 2
-  text-decoration-skip-ink: none; // 3
+@media (hover: none) {
+  abbr[title] {
+    text-decoration: none;
+  }
+}
+
+@media (hover: hover) {
+  // 1. Add the correct text decoration in Chrome, Edge, Opera, and Safari.
+  // 2. Add explicit cursor to indicate changed behavior.
+  // 3. Prevent the text-decoration to be skipped.
+
+  abbr[title] {
+    text-decoration: underline dotted; // 1
+    cursor: help; // 2
+    text-decoration-skip-ink: none; // 3
+  }
 }
 
 

--- a/site/content/docs/5.2/content/typography.md
+++ b/site/content/docs/5.2/content/typography.md
@@ -141,6 +141,10 @@ Change text alignment, transform, style, weight, line-height, decoration and col
 
 Stylized implementation of HTML's `<abbr>` element for abbreviations and acronyms to show the expanded version on hover. Abbreviations have a default underline and gain a help cursor to provide additional context on hover and to users of assistive technologies.
 
+{{< callout info >}}
+This stylized implementation will only be rendered if the primary input mechanism can conveniently hover over elements.
+{{< /callout >}}
+
 Add `.initialism` to an abbreviation for a slightly smaller font-size.
 
 {{< example >}}


### PR DESCRIPTION
> **Warning**
> Draft PR to benefit from the Netlify deployment

### Description

This change is based on the suggestion made by @coliff in #36607.

Apparently we wouldn't need to precise `-webkit-text-decoration: none;` since it is not added by Autoprefixer while the latter will automatically add `-webkit-text-decoration: underline dotted;` and `-webkit-text-decoration-skip-ink: none;` when needed.

### Motivation & Context

This change will avoid the frustration of users that could see the underline dotted text decoration on their devices but couldn't have access to the information.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

#### Specific to this PR

- [ ] Check the result of this Netlify deployment with different combinations of browsers, OSs and versions.
- [ ] Do we embed https://github.com/twbs/bootstrap/issues/36607#issuecomment-1163610342 in the docs as a trick?
- [ ] Check with @patrickhlauke if it can't mess up with some input mechanisms used for accessibility because the notion of "primary input mechanism" seems prone to mistakes when using multiple input devices.
  - [ ] Read https://css-tricks.com/interaction-media-features-and-their-potential-for-incorrect-assumptions/ and apply the correct fix to this PR 

#### Generic
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37338--twbs-bootstrap.netlify.app/docs/5.2/content/typography/#abbreviations

### Related issues

Closes #36607
