### PR TITLE
Docs: change some title containing '&' to bypass Algolia issue

### DIFF
--- a/site/content/docs/5.3/getting-started/parcel.md
+++ b/site/content/docs/5.3/getting-started/parcel.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: "Bootstrap & Parcel"
+title: Bootstrap and Parcel
 description: The official guide for how to include and bundle Bootstrap's CSS and JavaScript in your project using Parcel.
 group: getting-started
 toc: true

--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: "Bootstrap & Vite"
+title: Bootstrap and Vite
 description: The official guide for how to include and bundle Bootstrap's CSS and JavaScript in your project using Vite.
 group: getting-started
 toc: true

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: "Bootstrap & Webpack"
+title: Bootstrap and Webpack
 description: The official guide for how to include and bundle Bootstrap's CSS and JavaScript in your project using Webpack.
 group: getting-started
 toc: true


### PR DESCRIPTION
### Related

* https://github.com/twbs/bootstrap/pull/37397
* https://github.com/twbs/bootstrap/issues/37342

### Description

Change "&" in "and" in h1 titles to bypass an Algolia issue displaying them as "&amp;" in the results.

### Motivation & Context

Some other titles need to be modified in the same spirit as https://github.com/twbs/bootstrap/pull/37397.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly

#### Live previews

- <https://deploy-preview-37400--twbs-bootstrap.netlify.app/docs/5.2/getting-started/webpack/>
- <https://deploy-preview-37400--twbs-bootstrap.netlify.app/docs/5.2/getting-started/vite/>
- <https://deploy-preview-37400--twbs-bootstrap.netlify.app/docs/5.2/getting-started/parcel/>

