### PR TITLE
Docs: add missing test to display added-in info for pages

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -17,7 +17,9 @@
       <div class="bd-intro pt-2 ps-lg-2">
         <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
           <div class="mb-3 mb-md-0 d-flex">
+            {{ if .Page.Params.added }}
             <small class="d-inline-flex px-2 py-1 fw-semibold text-success bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2 me-2">Added in v{{ .Page.Params.added }}</small>
+            {{ end }}
             <a class="btn btn-sm btn-bd-light rounded-2" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/site/content/{{ .Page.File.Path | replaceRE `\\` "/" }}" title="View and edit this file on GitHub" target="_blank" rel="noopener">
               View on GitHub
             </a>


### PR DESCRIPTION
### Description

Add a test to display or not the "added-in" information for full pages.

### Motivation & Context

This change fixes the fact that the "added-in" was always displayed in all pages 😬 

**Before:** https://twbs-bootstrap.netlify.app/docs/5.2/getting-started/introduction/

![Screenshot 2022-10-31 at 06 44 10](https://user-images.githubusercontent.com/17381666/198939688-e25fde48-c8c3-49a2-a46c-b0db43c07d80.png)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly

#### Live previews

- <https://deploy-preview-37401--twbs-bootstrap.netlify.app/docs/5.2/getting-started/introduction/> must not contain the added-in information
- <https://deploy-preview-37401--twbs-bootstrap.netlify.app/docs/5.2/helpers/color-background/> must contain the added-in information
