### PR TITLE
Update input-group.md with form text example

### DIFF
--- a/site/content/docs/5.2/forms/input-group.md
+++ b/site/content/docs/5.2/forms/input-group.md
@@ -26,6 +26,7 @@ Place one add-on or button on either side of an input. You may also place one on
   <span class="input-group-text" id="basic-addon3">https://example.com/users/</span>
   <input type="text" class="form-control" id="basic-url" aria-describedby="basic-addon3">
 </div>
+<div id="passwordHelpBlock" class="form-text">Choose wisely</div>
 
 <div class="input-group mb-3">
   <span class="input-group-text">$</span>

--- a/site/content/docs/5.2/forms/input-group.md
+++ b/site/content/docs/5.2/forms/input-group.md
@@ -21,12 +21,14 @@ Place one add-on or button on either side of an input. You may also place one on
   <span class="input-group-text" id="basic-addon2">@example.com</span>
 </div>
 
-<label for="basic-url" class="form-label">Your vanity URL</label>
-<div class="input-group mb-3">
-  <span class="input-group-text" id="basic-addon3">https://example.com/users/</span>
-  <input type="text" class="form-control" id="basic-url" aria-describedby="basic-addon3">
+<div class="mb-3">
+  <label for="basic-url" class="form-label">Your vanity URL</label>
+  <div class="input-group">
+    <span class="input-group-text" id="basic-addon3">https://example.com/users/</span>
+    <input type="text" class="form-control" id="basic-url" aria-describedby="basic-addon3">
+  </div>
+  <div id="passwordHelpBlock" class="form-text">Choose wisely</div>
 </div>
-<div id="passwordHelpBlock" class="form-text">Choose wisely</div>
 
 <div class="input-group mb-3">
   <span class="input-group-text">$</span>

--- a/site/content/docs/5.2/forms/input-group.md
+++ b/site/content/docs/5.2/forms/input-group.md
@@ -27,7 +27,7 @@ Place one add-on or button on either side of an input. You may also place one on
     <span class="input-group-text" id="basic-addon3">https://example.com/users/</span>
     <input type="text" class="form-control" id="basic-url" aria-describedby="basic-addon3">
   </div>
-  <div id="passwordHelpBlock" class="form-text">Choose wisely</div>
+  <div class="form-text">Example help text goes outside the input group.</div>
 </div>
 
 <div class="input-group mb-3">


### PR DESCRIPTION
### Description

This updated example shows where to correctly put form text (i.e. not inside the input group).

### Motivation & Context

I was putting the form text elements inside the `input-group` until I realized this was wrong. There doesn't seem to be any examples indicating where to put this.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-37406--twbs-bootstrap.netlify.app/docs/5.2/forms/input-group/>