### PR TITLE
Fix disposing a modal after hiding error

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -188,7 +188,7 @@ class Modal extends BaseComponent {
     this._element.classList.add(CLASS_NAME_SHOW)
 
     const transitionComplete = () => {
-      if (this._config.focus) {
+      if ("undefined" != typeof this._config.focus && this._config.focus) {
         this._focustrap.activate()
       }
 


### PR DESCRIPTION
### Description

Checking if the focus property has been set before reading it.

### Motivation & Context

When you dispose a modal after hiding it, it throws an error.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

### Related issues

Fixes #37409.

<!-- Please link any related issues here. -->
