### PR TITLE
Update tooltips.md

### DIFF
--- a/site/content/docs/5.2/components/tooltips.md
+++ b/site/content/docs/5.2/components/tooltips.md
@@ -46,8 +46,27 @@ const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstra
 Hover over the links below to see tooltips:
 
 {{< example class="tooltip-demo" stackblitz_add_js="true" >}}
-<p class="muted">Placeholder text to demonstrate some <a href="#" data-bs-toggle="tooltip" data-bs-title="Default tooltip">inline links</a> with tooltips. This is now just filler, no killer. Content placed here just to mimic the presence of <a href="#" data-bs-toggle="tooltip" data-bs-title="Another tooltip">real text</a>. And all that just to give you an idea of how tooltips would look when used in real-world situations. So hopefully you've now seen how <a href="#" data-bs-toggle="tooltip" data-bs-title="Another one here too">these tooltips on links</a> can work in practice, once you use them on <a href="#" data-bs-toggle="tooltip" data-bs-title="The last tip!">your own</a> site or project.
+<p class="muted">
+  Placeholder text to demonstrate some
+  <a href="#" data-bs-toggle="tooltip" data-bs-title="Default tooltip"
+    >inline links</a
+  >
+  with tooltips. This is now just filler, no killer. Content placed here just to
+  mimic the presence of
+  <a href="#" data-bs-toggle="tooltip" data-bs-title="Another tooltip"
+    >real text</a
+  >. And all that just to give you an idea of how tooltips would look when used
+  in real-world situations. So hopefully you've now seen how
+  <a href="#" data-bs-toggle="tooltip" data-bs-title="Another one here too"
+    >these tooltips on links</a
+  >
+  can work in practice, once you use them on
+  <a href="#" data-bs-toggle="tooltip" data-bs-title="The last tip!"
+    >your own</a
+  >
+  site or project.
 </p>
+
 {{< /example >}}
 
 {{< callout warning >}}


### PR DESCRIPTION
replace single line raw HTML code in `#tooltips-on-links` to multi-line indented raw code for better readability. 
### Description

<!-- Describe your changes in detail -->
The raw code in the example on `#tooltips-on-links` has a very long horizontal scrollbar which makes it difficult to read. I thought an indented multi-line code would be better. 


### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
On the website docs, the sample code for `#tooltips-on-links` section has a very long horizontal scrollbar making the code difficult to read. I indented the code with Prettier vs-code extension and it made the code much more readable so I created a PR so that others can also see the example much more clearly.


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-37411--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/#tooltips-on-links>

### Related issues

<!-- Please link any related issues here. -->
