### PR TITLE
ref: refactor `getSelector` not to be exported

### DIFF
--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -7,9 +7,31 @@
 
 import { isDisabled, isVisible, parseSelector } from '../util/index.js'
 
-/**
- * Constants
- */
+
+const getSelector = element => {
+  let selector = element.getAttribute('data-bs-target')
+
+  if (!selector || selector === '#') {
+    let hrefAttribute = element.getAttribute('href')
+
+    // The only valid content that could double as a selector are IDs or classes,
+    // so everything starting with `#` or `.`. If a "real" URL is used as the selector,
+    // `document.querySelector` will rightfully complain it is invalid.
+    // See https://github.com/twbs/bootstrap/issues/32273
+    if (!hrefAttribute || (!hrefAttribute.includes('#') && !hrefAttribute.startsWith('.'))) {
+      return null
+    }
+
+    // Just in case some CMS puts out a full URL with the anchor appended
+    if (hrefAttribute.includes('#') && !hrefAttribute.startsWith('#')) {
+      hrefAttribute = `#${hrefAttribute.split('#')[1]}`
+    }
+
+    selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
+  }
+
+  return parseSelector(selector)
+}
 
 const SelectorEngine = {
   find(selector, element = document.documentElement) {
@@ -79,34 +101,8 @@ const SelectorEngine = {
     return this.find(focusables, element).filter(el => !isDisabled(el) && isVisible(el))
   },
 
-  getSelector(element) {
-    let selector = element.getAttribute('data-bs-target')
-
-    if (!selector || selector === '#') {
-      let hrefAttribute = element.getAttribute('href')
-
-      // The only valid content that could double as a selector are IDs or classes,
-      // so everything starting with `#` or `.`. If a "real" URL is used as the selector,
-      // `document.querySelector` will rightfully complain it is invalid.
-      // See https://github.com/twbs/bootstrap/issues/32273
-      if (!hrefAttribute || (!hrefAttribute.includes('#') && !hrefAttribute.startsWith('.'))) {
-        return null
-      }
-
-      // Just in case some CMS puts out a full URL with the anchor appended
-      if (hrefAttribute.includes('#') && !hrefAttribute.startsWith('#')) {
-        hrefAttribute = `#${hrefAttribute.split('#')[1]}`
-      }
-
-      selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
-      selector = parseSelector(selector)
-    }
-
-    return selector
-  },
-
   getSelectorFromElement(element) {
-    const selector = SelectorEngine.getSelector(element)
+    const selector = getSelector(element)
 
     if (selector) {
       return SelectorEngine.findOne(selector) ? selector : null
@@ -116,13 +112,13 @@ const SelectorEngine = {
   },
 
   getElementFromSelector(element) {
-    const selector = SelectorEngine.getSelector(element)
+    const selector = getSelector(element)
 
     return selector ? SelectorEngine.findOne(selector) : null
   },
 
   getMultipleElementsFromSelector(element) {
-    const selector = SelectorEngine.getSelector(element)
+    const selector = getSelector(element)
 
     return selector ? SelectorEngine.find(selector) : []
   }

--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -7,7 +7,6 @@
 
 import { isDisabled, isVisible, parseSelector } from '../util/index.js'
 
-
 const getSelector = element => {
   let selector = element.getAttribute('data-bs-target')
 


### PR DESCRIPTION
### Description

Just a minor refactor in the scope of Selector-engine. Method `getSelector` doesn't need to be exported as it is used localy


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
