### PR TITLE
Docs: add margin between buttons in tooltip examples

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -208,8 +208,14 @@
 }
 
 // Tooltips
-.tooltip-demo a {
-  white-space: nowrap;
+.tooltip-demo {
+  a {
+    white-space: nowrap;
+  }
+
+  .btn {
+    margin: .25rem .125rem;
+  }
 }
 
 // scss-docs-start custom-tooltip


### PR DESCRIPTION
### Description

This PR suggests to add some margin around the buttons used in [Docs > Tooltips > Directions example](https://getbootstrap.com/docs/5.2/components/tooltips/#directions). The values used are the same as the one used in the standard buttons example:

```scss
> .btn,
> .btn-group {
  margin: .25rem .125rem;
}
```

The Cheatsheet example is not impacted by this change because it has its own margin rules:

```scss
[id="tooltips"] .bd-example .btn {
  margin: 0 1rem 1rem 0;
}
```

### Motivation & Context

This change adds some space around the buttons when the screen width is reduced to avoid:
![Screenshot 2022-11-14 at 08 32 48](https://user-images.githubusercontent.com/17381666/201601486-50d294bb-8676-436d-b2d1-87ec5a9e518c.png)

### Type of changes

- Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37492--twbs-bootstrap.netlify.app/docs/5.2/components/tooltips/>
- <https://deploy-preview-37492--twbs-bootstrap.netlify.app/docs/5.2/examples/cheatsheet/#tooltips> (for non-regression testing)

### Related issues

N/A