### PR TITLE
Fix accessibility of examples buttons

### DIFF
--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -32,10 +32,10 @@
         <small class="font-monospace text-muted text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
           <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }} title="Try it on StackBlitz">
-            <svg class="bi" role="img" aria-label="Try it"><use xlink:href="#lightning-charge-fill"/></svg>
+            <svg class="bi" aria-hidden="true"><use xlink:href="#lightning-charge-fill"/></svg>
           </button>
           <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">
-            <svg class="bi" role="img" aria-label="Copy"><use xlink:href="#clipboard"/></svg>
+            <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"/></svg>
           </button>
         </div>
       </div>


### PR DESCRIPTION
### Description

Fix accessibility of 'Try it on StackBlitz' and 'Copy to clipboard' buttons.

### Motivation & Context

Svgs inside 'Try it on StackBlitz' and 'Copy to clipboard' buttons are pure decoration so they must be ignored by any assistive technology.

See [https://www.w3.org/TR/WCAG21/#non-text-content](https://www.w3.org/TR/WCAG21/#non-text-content) for more details.

### Type of changes

- [X] New feature (non-breaking change which adds functionality)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37498--twbs-bootstrap.netlify.app/>

