### PR TITLE
POC using postcss-banner & terser preamble

### DIFF
--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const pkg = require('../package.json')
-const year = new Date().getFullYear()
+const banner = require('./banner.js')
 
 const mapConfig = {
   inline: false,
@@ -9,23 +8,22 @@ const mapConfig = {
   sourcesContent: true
 }
 
+const sanitizeFileName = fileName => {
+  const cleanName = fileName.replace('bootstrap', '').replace('-', '').replace('.css', '')
+  return cleanName.charAt(0).toUpperCase() + cleanName.slice(1)
+}
+
 module.exports = context => {
   return {
     map: context.file.dirname.includes('examples') ? false : mapConfig,
     plugins: {
+      'postcss-header': {
+        header: context.file.basename.includes('bootstrap') && !context.file.basename.includes('rtl') ? banner(sanitizeFileName(context.file.basename)) : ''
+      },
       autoprefixer: {
         cascade: false
       },
-      rtlcss: context.env === 'RTL',
-      'postcss-banner': {
-        important: true,
-        banner: context.file.basename.includes('bootstrap') ?
-          `${pkg.name} ${context.file.basename.split('-').length > 1 ? `${context.file.basename.split('-')[1].split('.')[0]} ` : ''}v${pkg.version} (${pkg.homepage})
-Copyright 2011-${year} ${pkg.author}
-Copyright 2011-${year} ${pkg.contributors[0]}
-Licensed under ${pkg.license} (https://github.com/twbs/bootstrap/blob/main/LICENSE)` :
-          ''
-      }
+      rtlcss: context.env === 'RTL'
     }
   }
 }

--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const pkg = require('../package.json')
+const year = new Date().getFullYear()
+
 const mapConfig = {
   inline: false,
   annotation: true,
@@ -13,7 +16,16 @@ module.exports = context => {
       autoprefixer: {
         cascade: false
       },
-      rtlcss: context.env === 'RTL'
+      rtlcss: context.env === 'RTL',
+      'postcss-banner': {
+        important: true,
+        banner: context.file.basename.includes('bootstrap') ?
+          `${pkg.name} ${context.file.basename.split('-').length > 1 ? `${context.file.basename.split('-')[1].split('.')[0]} ` : ''}v${pkg.version} (${pkg.homepage})
+Copyright 2011-${year} ${pkg.author}
+Copyright 2011-${year} ${pkg.contributors[0]}
+Licensed under ${pkg.license} (https://github.com/twbs/bootstrap/blob/main/LICENSE)` :
+          ''
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "nodemon": "^2.0.20",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.19",
+        "postcss-banner": "^4.0.1",
         "postcss-cli": "^10.0.0",
         "rollup": "^3.3.0",
         "rollup-plugin-istanbul": "^4.0.0",
@@ -8032,6 +8033,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-banner": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-banner/-/postcss-banner-4.0.1.tgz",
+      "integrity": "sha512-vpxkcADfBp28r50HH3HPVBoQxE2u0IF5WG9qTQMdYJWqk7VsFBWPAnVkDMGZwvBiJFU7B9HYos6o/fz++PVTgQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-cli": {
@@ -16432,6 +16442,15 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-banner": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-banner/-/postcss-banner-4.0.1.tgz",
+      "integrity": "sha512-vpxkcADfBp28r50HH3HPVBoQxE2u0IF5WG9qTQMdYJWqk7VsFBWPAnVkDMGZwvBiJFU7B9HYos6o/fz++PVTgQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^8.2.2"
       }
     },
     "postcss-cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,8 +56,8 @@
         "nodemon": "^2.0.20",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.19",
-        "postcss-banner": "^4.0.1",
         "postcss-cli": "^10.0.0",
+        "postcss-header": "^3.0.3",
         "rollup": "^3.3.0",
         "rollup-plugin-istanbul": "^4.0.0",
         "rtlcss": "^4.0.0",
@@ -8035,15 +8035,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-banner": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-banner/-/postcss-banner-4.0.1.tgz",
-      "integrity": "sha512-vpxkcADfBp28r50HH3HPVBoQxE2u0IF5WG9qTQMdYJWqk7VsFBWPAnVkDMGZwvBiJFU7B9HYos6o/fz++PVTgQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
     "node_modules/postcss-cli": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-10.0.0.tgz",
@@ -8143,6 +8134,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/postcss-header": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-header/-/postcss-header-3.0.3.tgz",
+      "integrity": "sha512-bmm/qVdphnJcHHLyL2efiPUaLRR6y0iMRYKWl06cfdvNEoXlPUBENL1vqBBn2uTnxYTYvWoec7o+bYnPRJAmMA==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-load-config": {
@@ -16444,15 +16444,6 @@
         "source-map-js": "^1.0.2"
       }
     },
-    "postcss-banner": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-banner/-/postcss-banner-4.0.1.tgz",
-      "integrity": "sha512-vpxkcADfBp28r50HH3HPVBoQxE2u0IF5WG9qTQMdYJWqk7VsFBWPAnVkDMGZwvBiJFU7B9HYos6o/fz++PVTgQ==",
-      "dev": true,
-      "requires": {
-        "postcss": "^8.2.2"
-      }
-    },
     "postcss-cli": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-10.0.0.tgz",
@@ -16525,6 +16516,13 @@
           "dev": true
         }
       }
+    },
+    "postcss-header": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-header/-/postcss-header-3.0.3.tgz",
+      "integrity": "sha512-bmm/qVdphnJcHHLyL2efiPUaLRR6y0iMRYKWl06cfdvNEoXlPUBENL1vqBBn2uTnxYTYvWoec7o+bYnPRJAmMA==",
+      "dev": true,
+      "requires": {}
     },
     "postcss-load-config": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
   "version": "5.2.3",
   "config": {
-    "version_short": "5.2"
+    "version_short": "5.2",
+    "license": "MIT",
+    "homepage": "https://getbootstrap.com/",
+    "author": "The Bootstrap Authors (https://github.com/twbs/bootstrap/graphs/contributors)"
   },
   "keywords": [
     "css",
@@ -65,9 +68,9 @@
     "js-compile-plugins": "node build/build-plugins.js",
     "js-lint": "eslint --cache --cache-location .cache/.eslintcache --report-unused-disable-directives --ext .html,.js .",
     "js-minify": "npm-run-all --aggregate-output --parallel js-minify-*",
-    "js-minify-standalone": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
-    "js-minify-standalone-esm": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.esm.js.map,includeSources,url=bootstrap.esm.min.js.map\" --output dist/js/bootstrap.esm.min.js dist/js/bootstrap.esm.js",
-    "js-minify-bundle": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.bundle.js.map,includeSources,url=bootstrap.bundle.min.js.map\" --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js",
+    "js-minify-standalone": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
+    "js-minify-standalone-esm": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.esm.js.map,includeSources,url=bootstrap.esm.min.js.map\" --output dist/js/bootstrap.esm.min.js dist/js/bootstrap.esm.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
+    "js-minify-bundle": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.bundle.js.map,includeSources,url=bootstrap.bundle.min.js.map\" --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
     "js-test": "npm-run-all --aggregate-output --parallel js-test-karma js-test-jquery js-test-integration-*",
     "js-debug": "cross-env DEBUG=true npm run js-test-karma",
     "js-test-karma": "karma start js/tests/karma.conf.js",
@@ -141,6 +144,7 @@
     "nodemon": "^2.0.20",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.19",
+    "postcss-banner": "^4.0.1",
     "postcss-cli": "^10.0.0",
     "rollup": "^3.3.0",
     "rollup-plugin-istanbul": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
   "version": "5.2.3",
   "config": {
-    "version_short": "5.2",
-    "license": "MIT",
-    "homepage": "https://getbootstrap.com/",
-    "author": "The Bootstrap Authors (https://github.com/twbs/bootstrap/graphs/contributors)"
+    "version_short": "5.2"
   },
   "keywords": [
     "css",
@@ -68,9 +65,9 @@
     "js-compile-plugins": "node build/build-plugins.js",
     "js-lint": "eslint --cache --cache-location .cache/.eslintcache --report-unused-disable-directives --ext .html,.js .",
     "js-minify": "npm-run-all --aggregate-output --parallel js-minify-*",
-    "js-minify-standalone": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
-    "js-minify-standalone-esm": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.esm.js.map,includeSources,url=bootstrap.esm.min.js.map\" --output dist/js/bootstrap.esm.min.js dist/js/bootstrap.esm.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
-    "js-minify-bundle": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.bundle.js.map,includeSources,url=bootstrap.bundle.min.js.map\" --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js --format \"preamble='/*!\\n  * Bootstrap v$npm_package_version ($npm_package_config_homepage)\\n  * Copyright 2011-`date +%Y` $npm_package_config_author\\n  * Licensed under $npm_package_config_license (https://github.com/twbs/bootstrap/blob/main/LICENSE)\\n  */'\"",
+    "js-minify-standalone": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.js.map,includeSources,url=bootstrap.min.js.map\" --output dist/js/bootstrap.min.js dist/js/bootstrap.js",
+    "js-minify-standalone-esm": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.esm.js.map,includeSources,url=bootstrap.esm.min.js.map\" --output dist/js/bootstrap.esm.min.js dist/js/bootstrap.esm.js",
+    "js-minify-bundle": "terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=dist/js/bootstrap.bundle.js.map,includeSources,url=bootstrap.bundle.min.js.map\" --output dist/js/bootstrap.bundle.min.js dist/js/bootstrap.bundle.js",
     "js-test": "npm-run-all --aggregate-output --parallel js-test-karma js-test-jquery js-test-integration-*",
     "js-debug": "cross-env DEBUG=true npm run js-test-karma",
     "js-test-karma": "karma start js/tests/karma.conf.js",
@@ -144,7 +141,7 @@
     "nodemon": "^2.0.20",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.19",
-    "postcss-banner": "^4.0.1",
+    "postcss-header": "^3.0.3",
     "postcss-cli": "^10.0.0",
     "rollup": "^3.3.0",
     "rollup-plugin-istanbul": "^4.0.0",

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -1,6 +1,3 @@
-@import "mixins/banner";
-@include bsBanner(Grid);
-
 $include-column-box-sizing: true !default;
 
 @import "functions";

--- a/scss/bootstrap-reboot.scss
+++ b/scss/bootstrap-reboot.scss
@@ -1,6 +1,3 @@
-@import "mixins/banner";
-@include bsBanner(Reboot);
-
 @import "functions";
 @import "variables";
 @import "maps";

--- a/scss/bootstrap-utilities.scss
+++ b/scss/bootstrap-utilities.scss
@@ -1,6 +1,3 @@
-@import "mixins/banner";
-@include bsBanner(Utilities);
-
 // Configuration
 @import "functions";
 @import "variables";

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,7 +1,3 @@
-@import "mixins/banner";
-@include bsBanner("");
-
-
 // scss-docs-start import-stack
 // Configuration
 @import "functions";

--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,9 +1,0 @@
-@mixin bsBanner($file) {
-  /*!
-   * Bootstrap #{$file} v5.2.3 (https://getbootstrap.com/)
-   * Copyright 2011-2022 The Bootstrap Authors
-   * Copyright 2011-2022 Twitter, Inc.
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
-   */
-}
-


### PR DESCRIPTION
#37494 replacement POC, adresses #35010 in another way: update banner in dist files  when compiling them, respectively using terser and PostCSS.

A few quirks and drawbacks that need a bit more work:

- I used as much data from `package.json` as I could (even added some in the `config` entry) as it was done in `build/banner.js` but that may be overthought: most of them could be hardcoded I think.
- one of the drawbacks is that a few words should be capitalized, which will need some work—or we hardcode them :innocent: 

Regarding JavaScript components, they're built using Rollup: terser doesn't run on those files, so my current changes only works on `dist/js/` files. I didn't try anything for now since my initial idea was missing the fact that banner are already in our sources, not only in dist files.

So IMHO this is not meant to be merged but only to show a few more possibilities regarding banners.

@GeoSot if you have any idea to push further or want me to dig deeper, I could try :)

