### PR TITLE
Fix var `--bs-body-font-family`. Keep quotes in the font stack.

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -39,7 +39,7 @@
   @if $font-size-root != null {
     --#{$prefix}root-font-size: #{$font-size-root};
   }
-  --#{$prefix}body-font-family: #{$font-family-base};
+  --#{$prefix}body-font-family: #{inspect($font-family-base)};
   @include rfs($font-size-base, --#{$prefix}body-font-size);
   --#{$prefix}body-font-weight: #{$font-weight-base};
   --#{$prefix}body-line-height: #{$line-height-base};


### PR DESCRIPTION
### Description

Quotes in var `--bs-body-font-family` are removed.

### Motivation & Context

When using something like `$font-family-base: "Helvetica Neue", Arial` the quotes are removed, so you will get this:

    :root {
        --bs-body-font-family: Helvetica Neue, Arial;
    }

Expected behaviour would be:

    :root {
        --bs-body-font-family: "Helvetica Neue", Arial;
    }


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

