### PR TITLE
Visually-hidden: Remove `position: absolute` for captions

### DIFF
--- a/scss/mixins/_visually-hidden.scss
+++ b/scss/mixins/_visually-hidden.scss
@@ -6,7 +6,6 @@
 // See: https://kittygiraudel.com/2016/10/13/css-hide-and-seek/
 
 @mixin visually-hidden() {
-  position: absolute !important;
   width: 1px !important;
   height: 1px !important;
   padding: 0 !important;
@@ -15,6 +14,11 @@
   clip: rect(0, 0, 0, 0) !important;
   white-space: nowrap !important;
   border: 0 !important;
+
+  // Fix for positioned table caption that could become anonymous cells
+  &:not(caption) {
+    position: absolute !important;
+  }
 }
 
 // Use to only display content when it's focused, or one of its child elements is focused


### PR DESCRIPTION
### Description

Remove the `position: absolute;` from the visually hidden caption, tried to group it with all `.visually-hidden`. There's maybe a better way ?

### Motivation & Context

Main issue: a positioned (or floating) table caption is understood as an anonymous cell of a table. This behavior leads to have an undeclared cell between the `thead` and the `tbody`. This leads to the issue: It removes the `border-collapse: collapse;` effect. More explanations [here](https://stackoverflow.com/questions/31057955/why-are-table-borders-not-collapsing-when-caption-is-positioned/32063028#32063028).

<details>
<summary>Visual issue</summary>

Bordered modifier without `.visually-hidden`:
![image](https://user-images.githubusercontent.com/91960143/203295575-e30bd1bd-cd0c-453a-8653-673d5054df9a.png)

Bordered modifier with `.visually-hidden`:
![image](https://user-images.githubusercontent.com/91960143/203295493-1767e3df-49cc-4d76-9708-3ee504e1f53a.png)

Table divider modifier without `.visually-hidden`:
![image](https://user-images.githubusercontent.com/91960143/203295700-2352dad7-54e3-4e58-b321-ad2c3f3ac90c.png)

Table divider modifier with `.visually-hidden`:
![image](https://user-images.githubusercontent.com/91960143/203295633-b7bc722a-907f-4fd6-a263-4d22c88100fa.png)
</details>

Here is the minimum code:
```html
<table class="table table-bordered">
  <caption class="visually-hidden">Text</caption>
  <thead>
    <tr>
      <th scope="col">#</th>
      <th scope="col">First</th>
      <th scope="col">Last</th>
      <th scope="col">Handle</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th scope="row">1</th>
      <td>Mark</td>
      <td>Otto</td>
      <td>@mdo</td>
    </tr>
  </tbody>
</table>
```

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37533--twbs-bootstrap.netlify.app/docs/5.2/content/tables/>

### Related issues

NA
