### PR TITLE
Updated customize instructions

### DIFF
--- a/site/layouts/partials/home/customize.html
+++ b/site/layouts/partials/home/customize.html
@@ -43,10 +43,10 @@ $prefix: "mo-";
 @import "../node_modules/bootstrap/scss/variables";
 @import "../node_modules/bootstrap/scss/maps";
 @import "../node_modules/bootstrap/scss/mixins";
-@import "../node_modules/bootstrap/scss/root";
+@import "../node_modules/bootstrap/scss/utilities";
 
 // Optional components
-@import "../node_modules/bootstrap/scss/utilities";
+@import "../node_modules/bootstrap/scss/root";
 @import "../node_modules/bootstrap/scss/reboot";
 @import "../node_modules/bootstrap/scss/containers";
 @import "../node_modules/bootstrap/scss/grid";


### PR DESCRIPTION
I put utilities before root, like into the original bootstrap scss. Putting root before utilities like it was instructed before, caused navbar fixed-top and sticky-top classes not working

