### PR TITLE
Docs: fix "Usage -> Enable dark mode" code example

### DIFF
--- a/site/content/docs/5.2/customize/color-modes.md
+++ b/site/content/docs/5.2/customize/color-modes.md
@@ -137,14 +137,14 @@ Enable the built in dark color mode across your entire project by adding the `da
 
 ```html
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
     <link href="{{< param "cdn.css" >}}" rel="stylesheet" integrity="{{< param "cdn.css_hash" >}}" crossorigin="anonymous">
   </head>
-  <body data-bs-theme="dark">
+  <body>
     <h1>Hello, world!</h1>
     <script src="{{< param "cdn.js_bundle" >}}" integrity="{{< param "cdn.js_bundle_hash" >}}" crossorigin="anonymous"></script>
   </body>


### PR DESCRIPTION
### Description

Change 'Usage > Enable dark mode' code example to actually apply `data-bs-theme="dark"` to the `<html>` element and not the `<body>` element.

### Motivation & Context

Coherence between the description, the code example and the actual usage in Bootstrap docs where `data-bs-theme="auto"` is set to the `<html>` element.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37553--twbs-bootstrap.netlify.app/docs/5.2/customize/color-modes/#enable-dark-mode>
