### PR TITLE
code-examples.js: switch to `firstElementChild`

### DIFF
--- a/site/assets/js/code-examples.js
+++ b/site/assets/js/code-examples.js
@@ -56,7 +56,7 @@
   })
 
   clipboard.on('success', event => {
-    const iconFirstChild = event.trigger.querySelector('.bi').firstChild
+    const iconFirstChild = event.trigger.querySelector('.bi').firstElementChild
     const tooltipBtn = bootstrap.Tooltip.getInstance(event.trigger)
     const namespace = 'http://www.w3.org/1999/xlink'
     const originalXhref = iconFirstChild.getAttributeNS(namespace, 'href')


### PR DESCRIPTION
Spotted on https://github.com/twbs/blog/pull/330