### PR TITLE
Prevent scrolling upon focusing modal-trigger when modal is hidden

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -350,7 +350,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
     EventHandler.one(target, EVENT_HIDDEN, () => {
       if (isVisible(this)) {
-        this.focus()
+        this.focus({ preventScroll: true })
       }
     })
   })

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -838,6 +838,40 @@ describe('Modal', () => {
         modal.show()
       })
     })
+
+    it('should prevent scrolling upon focusing modal triggering element when modal is hidden', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<button type="button" id="btn-1" data-bs-toggle="modal" data-bs-target="#exampleModal"></button>',
+          '<div style={height: 1000px}></div>',
+          '<div class="modal" id="exampleModal"><div class="modal-dialog"></div></div>',
+          '<button type="button" id="btn-2"></button>'
+        ].join('')
+
+        const scrollY = window.scrollY
+
+        const modalEl = fixtureEl.querySelector('.modal')
+        const button1El = fixtureEl.querySelector('#btn-1')
+        const button2El = fixtureEl.querySelector('#btn-2')
+        const modal = new Modal(modalEl)
+
+        button2El.addEventListener('click', () => {
+          button1El.focus()
+          expect(window.scrollY).toEqual(scrollY)
+        })
+
+        modalEl.addEventListener('shown.bs.modal', () => {
+          modal.hide()
+        })
+
+        modalEl.addEventListener('hidden.bs.modal', () => {
+          button2El.click()
+          resolve()
+        })
+
+        modal.show()
+      })
+    })
   })
 
   describe('dispose', () => {


### PR DESCRIPTION
### Description
Add `{preventScroll: true}` to `model.js` in `EVENT_HIDDEN.` Preventing unintended scrolling when focusing a model triggering element (i.e. button) is focused when the model is hidden.
<!-- Describe your changes in detail -->

### Motivation & Context
This is an attempt to follow up #35393 and to address #35391
<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

### Related issues
#35391
<!-- Please link any related issues here. -->
