### PR TITLE
Add missing is-invalid class to example code

### DIFF
--- a/site/content/docs/4.6/components/forms.md
+++ b/site/content/docs/4.6/components/forms.md
@@ -1119,7 +1119,7 @@ To detect what elements need rounded corners inside an input group with validati
   <div class="input-group-prepend">
     <span class="input-group-text">@</span>
   </div>
-  <input type="text" class="form-control" required>
+  <input type="text" class="form-control is-invalid" required>
   <div class="invalid-feedback">
     Please choose a username.
   </div>


### PR DESCRIPTION
### Description

Input group validation example code was missing the is-invalid class.

### Motivation & Context

Fixing docs.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-37603--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
