### PR TITLE
Add new team member to the Teams page

### DIFF
--- a/site/data/core-team.yml
+++ b/site/data/core-team.yml
@@ -30,3 +30,6 @@
 
 - name: Gleb Mazovetskiy
   user: glebm
+
+- name: Julien Déramond
+  user: julien-deramond

--- a/site/data/core-team.yml
+++ b/site/data/core-team.yml
@@ -10,17 +10,20 @@
 - name: GeoSot
   user: geosot
 
+- name: Patrick H. Lauke
+  user: patrickhlauke
+
+- name: Julien Déramond
+  user: julien-deramond
+
+- name: Gaël Poupard
+  user: ffoodd
+
 - name: Rohit Sharma
   user: rohit2sharma95
 
 - name: alpadev
   user: alpadev
-
-- name: Gaël Poupard
-  user: ffoodd
-
-- name: Patrick H. Lauke
-  user: patrickhlauke
 
 - name: Martijn Cuppens
   user: martijncuppens
@@ -30,6 +33,3 @@
 
 - name: Gleb Mazovetskiy
   user: glebm
-
-- name: Julien Déramond
-  user: julien-deramond


### PR DESCRIPTION
Found out that our Teams page hadn't been updated for a while while working on the sponsors page

### [Live preview](https://deploy-preview-37615--twbs-bootstrap.netlify.app/docs/5.2/about/team/)

