### PR TITLE
Fix `--bs-form-check-bg` definition

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -27,7 +27,7 @@
 }
 
 .form-check-input {
-  --#{$prefix}form-check-bg: #{escape-svg($form-check-input-bg)};
+  --#{$prefix}form-check-bg: #{$form-check-input-bg};
 
   width: $form-check-input-width;
   height: $form-check-input-width;


### PR DESCRIPTION
### Related issues

Closes #37620

### Description

Customizing `$input-bg`  change `$*-input-bg` values.
The problematic one was `$form-check-input-bg` that tried to apply `escape-svg()` on it.
This PR suggests to simply remove unnecessary call to `escape-svg()` since we're handling colors and not images in this case.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed

#### Testing

* All use cases depending on `$form-check-input-bg` still work correctly
* Modifying `$input-bg` to `#fd0` (for example) doesn't cause anymore any compilation issues




