### PR TITLE
Added blur and grayscale to modal backdrop

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -235,3 +235,13 @@
   }
 }
 // scss-docs-end modal-fullscreen-loop
+
+// modal-blur-background
+body.modal-open > :not(.modal) {
+  -webkit-filter: grayscale($modal-backdrop-grayscale) blur($modal-backdrop-blur);
+  -moz-filter: grayscale($modal-backdrop-grayscale) blur($modal-backdrop-blur);
+  -o-filter: grayscale($modal-backdrop-grayscale) blur($modal-backdrop-blur);
+  -ms-filter: grayscale($modal-backdrop-grayscale) blur($modal-backdrop-blur);
+  filter: grayscale($modal-backdrop-grayscale) blur($modal-backdrop-blur);
+}
+// scss-docs-end modal-fullscreen-loop

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1469,6 +1469,8 @@ $modal-content-box-shadow-sm-up:    $box-shadow !default;
 
 $modal-backdrop-bg:                 $black !default;
 $modal-backdrop-opacity:            .5 !default;
+$modal-backdrop-blur:               4px !default;
+$modal-backdrop-grayscale:          0 !default;
 
 $modal-header-border-color:         var(--#{$prefix}border-color) !default;
 $modal-header-border-width:         $modal-content-border-width !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1469,7 +1469,7 @@ $modal-content-box-shadow-sm-up:    $box-shadow !default;
 
 $modal-backdrop-bg:                 $black !default;
 $modal-backdrop-opacity:            .5 !default;
-$modal-backdrop-blur:               4px !default;
+$modal-backdrop-blur:               1px !default;
 $modal-backdrop-grayscale:          0 !default;
 
 $modal-header-border-color:         var(--#{$prefix}border-color) !default;


### PR DESCRIPTION
### Description

I added the ability to include and adjust the blur and grayscale of the modal backdrop. The change is done only in the _variables.scss and _modal.scss files. 

### Motivation & Context

It was a needed requirement for one of my projects and believed others will need it as well. 

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

N/A

### Related issues

N/A
