### PR TITLE
Keep context when navigating from v5.0/v5.1 to v5.2

### DIFF
--- a/docs/5.0/about/brand/index.html
+++ b/docs/5.0/about/brand/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/brand/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/about/brand/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/about/brand/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/about/license/index.html
+++ b/docs/5.0/about/license/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/license/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/about/license/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/about/license/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/about/overview/index.html
+++ b/docs/5.0/about/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/about/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/about/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/about/team/index.html
+++ b/docs/5.0/about/team/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/team/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/about/team/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/about/team/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/about/translations/index.html
+++ b/docs/5.0/about/translations/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/translations/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/about/translations/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/about/translations/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/accordion/index.html
+++ b/docs/5.0/components/accordion/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/accordion/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/accordion/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/accordion/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/alerts/index.html
+++ b/docs/5.0/components/alerts/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/alerts/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/alerts/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/alerts/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/badge/index.html
+++ b/docs/5.0/components/badge/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/badge/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/badge/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/badge/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/breadcrumb/index.html
+++ b/docs/5.0/components/breadcrumb/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/breadcrumb/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/breadcrumb/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/breadcrumb/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/button-group/index.html
+++ b/docs/5.0/components/button-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/button-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/button-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/button-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/buttons/index.html
+++ b/docs/5.0/components/buttons/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/buttons/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/buttons/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/buttons/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/card/index.html
+++ b/docs/5.0/components/card/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/card/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/card/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/card/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/carousel/index.html
+++ b/docs/5.0/components/carousel/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/carousel/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/carousel/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/carousel/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/close-button/index.html
+++ b/docs/5.0/components/close-button/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/close-button/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/close-button/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/close-button/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/collapse/index.html
+++ b/docs/5.0/components/collapse/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/collapse/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/collapse/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/collapse/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/dropdowns/index.html
+++ b/docs/5.0/components/dropdowns/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/dropdowns/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/dropdowns/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/dropdowns/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/list-group/index.html
+++ b/docs/5.0/components/list-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/list-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/list-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/list-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/modal/index.html
+++ b/docs/5.0/components/modal/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/modal/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/modal/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/modal/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/navbar/index.html
+++ b/docs/5.0/components/navbar/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/navbar/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/navbar/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/navbar/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/navs-tabs/index.html
+++ b/docs/5.0/components/navs-tabs/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/navs-tabs/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/navs-tabs/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/navs-tabs/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/offcanvas/index.html
+++ b/docs/5.0/components/offcanvas/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/offcanvas/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/offcanvas/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/offcanvas/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/pagination/index.html
+++ b/docs/5.0/components/pagination/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/pagination/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/pagination/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/pagination/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/popovers/index.html
+++ b/docs/5.0/components/popovers/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/popovers/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/popovers/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/popovers/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/progress/index.html
+++ b/docs/5.0/components/progress/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/progress/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/progress/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/progress/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/scrollspy/index.html
+++ b/docs/5.0/components/scrollspy/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/scrollspy/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/scrollspy/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/scrollspy/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/spinners/index.html
+++ b/docs/5.0/components/spinners/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/spinners/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/spinners/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/spinners/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/toasts/index.html
+++ b/docs/5.0/components/toasts/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/toasts/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/toasts/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/toasts/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/components/tooltips/index.html
+++ b/docs/5.0/components/tooltips/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/tooltips/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/components/tooltips/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/components/tooltips/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/content/figures/index.html
+++ b/docs/5.0/content/figures/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/figures/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/content/figures/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/content/figures/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/content/images/index.html
+++ b/docs/5.0/content/images/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/images/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/content/images/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/content/images/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/content/reboot/index.html
+++ b/docs/5.0/content/reboot/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/reboot/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/content/reboot/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/content/reboot/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/content/tables/index.html
+++ b/docs/5.0/content/tables/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/tables/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/content/tables/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/content/tables/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/content/typography/index.html
+++ b/docs/5.0/content/typography/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/typography/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/content/typography/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/content/typography/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/color/index.html
+++ b/docs/5.0/customize/color/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/color/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/color/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/color/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/components/index.html
+++ b/docs/5.0/customize/components/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/components/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/components/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/components/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/css-variables/index.html
+++ b/docs/5.0/customize/css-variables/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/css-variables/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/css-variables/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/css-variables/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/optimize/index.html
+++ b/docs/5.0/customize/optimize/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/optimize/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/optimize/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/optimize/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/options/index.html
+++ b/docs/5.0/customize/options/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/options/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/options/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/options/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/overview/index.html
+++ b/docs/5.0/customize/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/customize/sass/index.html
+++ b/docs/5.0/customize/sass/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/sass/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/customize/sass/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/customize/sass/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/extend/approach/index.html
+++ b/docs/5.0/extend/approach/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/extend/approach/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/extend/approach/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/extend/approach/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/extend/icons/index.html
+++ b/docs/5.0/extend/icons/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/extend/icons/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/extend/icons/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/extend/icons/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/checks-radios/index.html
+++ b/docs/5.0/forms/checks-radios/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/checks-radios/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/checks-radios/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/checks-radios/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/floating-labels/index.html
+++ b/docs/5.0/forms/floating-labels/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/floating-labels/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/floating-labels/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/floating-labels/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/form-control/index.html
+++ b/docs/5.0/forms/form-control/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/form-control/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/form-control/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/form-control/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/input-group/index.html
+++ b/docs/5.0/forms/input-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/input-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/input-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/input-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/layout/index.html
+++ b/docs/5.0/forms/layout/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/layout/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/layout/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/layout/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/overview/index.html
+++ b/docs/5.0/forms/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/range/index.html
+++ b/docs/5.0/forms/range/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/range/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/range/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/range/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/select/index.html
+++ b/docs/5.0/forms/select/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/select/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/select/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/select/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/forms/validation/index.html
+++ b/docs/5.0/forms/validation/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/validation/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/forms/validation/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/forms/validation/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/accessibility/index.html
+++ b/docs/5.0/getting-started/accessibility/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/accessibility/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/accessibility/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/accessibility/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/best-practices/index.html
+++ b/docs/5.0/getting-started/best-practices/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/best-practices/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/best-practices/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/best-practices/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/browsers-devices/index.html
+++ b/docs/5.0/getting-started/browsers-devices/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/browsers-devices/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/build-tools/index.html
+++ b/docs/5.0/getting-started/build-tools/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/build-tools/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/build-tools/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/build-tools/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/contents/index.html
+++ b/docs/5.0/getting-started/contents/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/contents/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/contents/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/contents/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/download/index.html
+++ b/docs/5.0/getting-started/download/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/download/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/download/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/download/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/introduction/index.html
+++ b/docs/5.0/getting-started/introduction/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/introduction/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/introduction/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/introduction/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/javascript/index.html
+++ b/docs/5.0/getting-started/javascript/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/javascript/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/javascript/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/javascript/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/parcel/index.html
+++ b/docs/5.0/getting-started/parcel/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/parcel/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/parcel/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/parcel/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/rfs/index.html
+++ b/docs/5.0/getting-started/rfs/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/rfs/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/rfs/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/rfs/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/rtl/index.html
+++ b/docs/5.0/getting-started/rtl/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/rtl/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/rtl/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/rtl/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/getting-started/webpack/index.html
+++ b/docs/5.0/getting-started/webpack/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/webpack/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/getting-started/webpack/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/getting-started/webpack/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/clearfix/index.html
+++ b/docs/5.0/helpers/clearfix/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/clearfix/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/clearfix/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/clearfix/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/colored-links/index.html
+++ b/docs/5.0/helpers/colored-links/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/colored-links/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/colored-links/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/colored-links/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/position/index.html
+++ b/docs/5.0/helpers/position/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/position/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/position/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/position/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/ratio/index.html
+++ b/docs/5.0/helpers/ratio/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/ratio/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/ratio/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/ratio/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/stretched-link/index.html
+++ b/docs/5.0/helpers/stretched-link/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/stretched-link/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/stretched-link/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/stretched-link/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/text-truncation/index.html
+++ b/docs/5.0/helpers/text-truncation/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/text-truncation/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/text-truncation/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/text-truncation/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/helpers/visually-hidden/index.html
+++ b/docs/5.0/helpers/visually-hidden/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/visually-hidden/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/helpers/visually-hidden/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/helpers/visually-hidden/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/breakpoints/index.html
+++ b/docs/5.0/layout/breakpoints/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/breakpoints/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/breakpoints/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/breakpoints/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/columns/index.html
+++ b/docs/5.0/layout/columns/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/columns/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/columns/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/columns/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/containers/index.html
+++ b/docs/5.0/layout/containers/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/containers/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/containers/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/containers/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/grid/index.html
+++ b/docs/5.0/layout/grid/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/grid/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/grid/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/grid/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/gutters/index.html
+++ b/docs/5.0/layout/gutters/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/gutters/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/gutters/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/gutters/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/utilities/index.html
+++ b/docs/5.0/layout/utilities/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/utilities/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/utilities/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/utilities/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/layout/z-index/index.html
+++ b/docs/5.0/layout/z-index/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/z-index/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/layout/z-index/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/layout/z-index/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/migration/index.html
+++ b/docs/5.0/migration/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/migration/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/migration/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/migration/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/api/index.html
+++ b/docs/5.0/utilities/api/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/api/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/api/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/api/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/background/index.html
+++ b/docs/5.0/utilities/background/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/background/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/background/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/background/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/borders/index.html
+++ b/docs/5.0/utilities/borders/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/borders/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/borders/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/borders/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/colors/index.html
+++ b/docs/5.0/utilities/colors/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/colors/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/colors/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/colors/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/display/index.html
+++ b/docs/5.0/utilities/display/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/display/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/display/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/display/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/flex/index.html
+++ b/docs/5.0/utilities/flex/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/flex/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/flex/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/flex/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/float/index.html
+++ b/docs/5.0/utilities/float/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/float/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/float/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/float/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/interactions/index.html
+++ b/docs/5.0/utilities/interactions/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/interactions/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/interactions/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/interactions/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/overflow/index.html
+++ b/docs/5.0/utilities/overflow/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/overflow/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/overflow/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/overflow/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/position/index.html
+++ b/docs/5.0/utilities/position/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/position/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/position/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/position/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/shadows/index.html
+++ b/docs/5.0/utilities/shadows/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/shadows/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/shadows/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/shadows/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/sizing/index.html
+++ b/docs/5.0/utilities/sizing/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/sizing/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/sizing/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/sizing/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/spacing/index.html
+++ b/docs/5.0/utilities/spacing/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/spacing/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/spacing/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/spacing/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/text/index.html
+++ b/docs/5.0/utilities/text/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/text/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/text/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/text/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/vertical-align/index.html
+++ b/docs/5.0/utilities/vertical-align/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/vertical-align/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/vertical-align/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/vertical-align/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.0/utilities/visibility/index.html
+++ b/docs/5.0/utilities/visibility/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/visibility/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/utilities/visibility/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.0/utilities/visibility/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/about/brand/index.html
+++ b/docs/5.1/about/brand/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/brand/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/about/brand/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/about/brand/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/about/license/index.html
+++ b/docs/5.1/about/license/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/license/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/about/license/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/about/license/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/about/overview/index.html
+++ b/docs/5.1/about/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/about/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/about/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/about/team/index.html
+++ b/docs/5.1/about/team/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/team/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/about/team/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/about/team/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/about/translations/index.html
+++ b/docs/5.1/about/translations/index.html
@@ -145,15 +145,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/about/translations/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/about/translations/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/about/translations/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/accordion/index.html
+++ b/docs/5.1/components/accordion/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/accordion/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/accordion/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/accordion/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/alerts/index.html
+++ b/docs/5.1/components/alerts/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/alerts/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/alerts/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/alerts/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/badge/index.html
+++ b/docs/5.1/components/badge/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/badge/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/badge/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/badge/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/breadcrumb/index.html
+++ b/docs/5.1/components/breadcrumb/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/breadcrumb/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/breadcrumb/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/breadcrumb/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/button-group/index.html
+++ b/docs/5.1/components/button-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/button-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/button-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/button-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/buttons/index.html
+++ b/docs/5.1/components/buttons/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/buttons/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/buttons/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/buttons/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/card/index.html
+++ b/docs/5.1/components/card/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/card/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/card/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/card/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/carousel/index.html
+++ b/docs/5.1/components/carousel/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/carousel/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/carousel/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/carousel/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/close-button/index.html
+++ b/docs/5.1/components/close-button/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/close-button/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/close-button/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/close-button/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/collapse/index.html
+++ b/docs/5.1/components/collapse/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/collapse/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/collapse/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/collapse/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/dropdowns/index.html
+++ b/docs/5.1/components/dropdowns/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/dropdowns/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/dropdowns/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/dropdowns/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/list-group/index.html
+++ b/docs/5.1/components/list-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/list-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/list-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/list-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/modal/index.html
+++ b/docs/5.1/components/modal/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/modal/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/modal/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/modal/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/navbar/index.html
+++ b/docs/5.1/components/navbar/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/navbar/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/navbar/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/navbar/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/navs-tabs/index.html
+++ b/docs/5.1/components/navs-tabs/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/navs-tabs/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/navs-tabs/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/navs-tabs/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/offcanvas/index.html
+++ b/docs/5.1/components/offcanvas/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/offcanvas/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/offcanvas/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/offcanvas/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/pagination/index.html
+++ b/docs/5.1/components/pagination/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/pagination/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/pagination/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/pagination/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/placeholders/index.html
+++ b/docs/5.1/components/placeholders/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/placeholders/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/placeholders/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/placeholders/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/popovers/index.html
+++ b/docs/5.1/components/popovers/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/popovers/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/popovers/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/popovers/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/progress/index.html
+++ b/docs/5.1/components/progress/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/progress/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/progress/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/progress/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/scrollspy/index.html
+++ b/docs/5.1/components/scrollspy/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/scrollspy/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/scrollspy/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/scrollspy/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/spinners/index.html
+++ b/docs/5.1/components/spinners/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/spinners/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/spinners/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/spinners/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/toasts/index.html
+++ b/docs/5.1/components/toasts/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/toasts/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/toasts/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/toasts/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/components/tooltips/index.html
+++ b/docs/5.1/components/tooltips/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/components/tooltips/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/components/tooltips/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/components/tooltips/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/content/figures/index.html
+++ b/docs/5.1/content/figures/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/figures/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/content/figures/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/content/figures/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/content/images/index.html
+++ b/docs/5.1/content/images/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/images/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/content/images/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/content/images/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/content/reboot/index.html
+++ b/docs/5.1/content/reboot/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/reboot/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/content/reboot/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/content/reboot/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/content/tables/index.html
+++ b/docs/5.1/content/tables/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/tables/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/content/tables/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/content/tables/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/content/typography/index.html
+++ b/docs/5.1/content/typography/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/content/typography/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/content/typography/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/content/typography/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/color/index.html
+++ b/docs/5.1/customize/color/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/color/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/color/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/color/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/components/index.html
+++ b/docs/5.1/customize/components/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/components/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/components/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/components/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/css-variables/index.html
+++ b/docs/5.1/customize/css-variables/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/css-variables/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/css-variables/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/css-variables/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/optimize/index.html
+++ b/docs/5.1/customize/optimize/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/optimize/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/optimize/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/optimize/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/options/index.html
+++ b/docs/5.1/customize/options/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/options/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/options/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/options/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/overview/index.html
+++ b/docs/5.1/customize/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/customize/sass/index.html
+++ b/docs/5.1/customize/sass/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/customize/sass/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/customize/sass/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/customize/sass/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/extend/approach/index.html
+++ b/docs/5.1/extend/approach/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/extend/approach/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/extend/approach/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/extend/approach/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/extend/icons/index.html
+++ b/docs/5.1/extend/icons/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/extend/icons/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/extend/icons/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/extend/icons/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/checks-radios/index.html
+++ b/docs/5.1/forms/checks-radios/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/checks-radios/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/checks-radios/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/checks-radios/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/floating-labels/index.html
+++ b/docs/5.1/forms/floating-labels/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/floating-labels/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/floating-labels/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/floating-labels/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/form-control/index.html
+++ b/docs/5.1/forms/form-control/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/form-control/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/form-control/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/form-control/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/input-group/index.html
+++ b/docs/5.1/forms/input-group/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/input-group/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/input-group/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/input-group/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/layout/index.html
+++ b/docs/5.1/forms/layout/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/layout/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/layout/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/layout/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/overview/index.html
+++ b/docs/5.1/forms/overview/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/overview/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/overview/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/overview/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/range/index.html
+++ b/docs/5.1/forms/range/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/range/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/range/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/range/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/select/index.html
+++ b/docs/5.1/forms/select/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/select/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/select/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/select/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/forms/validation/index.html
+++ b/docs/5.1/forms/validation/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/forms/validation/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/forms/validation/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/forms/validation/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/accessibility/index.html
+++ b/docs/5.1/getting-started/accessibility/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/accessibility/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/accessibility/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/accessibility/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/best-practices/index.html
+++ b/docs/5.1/getting-started/best-practices/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/best-practices/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/best-practices/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/best-practices/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/browsers-devices/index.html
+++ b/docs/5.1/getting-started/browsers-devices/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/browsers-devices/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/browsers-devices/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/browsers-devices/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/contents/index.html
+++ b/docs/5.1/getting-started/contents/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/contents/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/contents/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/contents/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/contribute/index.html
+++ b/docs/5.1/getting-started/contribute/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/contribute/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/contribute/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/contribute/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/download/index.html
+++ b/docs/5.1/getting-started/download/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/download/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/download/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/download/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/introduction/index.html
+++ b/docs/5.1/getting-started/introduction/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/introduction/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/introduction/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/introduction/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/javascript/index.html
+++ b/docs/5.1/getting-started/javascript/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/javascript/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/javascript/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/javascript/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/parcel/index.html
+++ b/docs/5.1/getting-started/parcel/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/parcel/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/parcel/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/parcel/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/rfs/index.html
+++ b/docs/5.1/getting-started/rfs/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/rfs/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/rfs/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/rfs/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/rtl/index.html
+++ b/docs/5.1/getting-started/rtl/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/rtl/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/rtl/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/rtl/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/getting-started/webpack/index.html
+++ b/docs/5.1/getting-started/webpack/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/getting-started/webpack/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/getting-started/webpack/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/getting-started/webpack/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/clearfix/index.html
+++ b/docs/5.1/helpers/clearfix/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/clearfix/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/clearfix/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/clearfix/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/colored-links/index.html
+++ b/docs/5.1/helpers/colored-links/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/colored-links/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/colored-links/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/colored-links/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/position/index.html
+++ b/docs/5.1/helpers/position/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/position/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/position/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/position/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/ratio/index.html
+++ b/docs/5.1/helpers/ratio/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/ratio/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/ratio/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/ratio/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/stacks/index.html
+++ b/docs/5.1/helpers/stacks/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/stacks/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/stacks/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/stacks/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/stretched-link/index.html
+++ b/docs/5.1/helpers/stretched-link/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/stretched-link/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/stretched-link/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/stretched-link/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/text-truncation/index.html
+++ b/docs/5.1/helpers/text-truncation/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/text-truncation/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/text-truncation/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/text-truncation/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/vertical-rule/index.html
+++ b/docs/5.1/helpers/vertical-rule/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/vertical-rule/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/vertical-rule/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/vertical-rule/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/helpers/visually-hidden/index.html
+++ b/docs/5.1/helpers/visually-hidden/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/helpers/visually-hidden/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/helpers/visually-hidden/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/helpers/visually-hidden/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/breakpoints/index.html
+++ b/docs/5.1/layout/breakpoints/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/breakpoints/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/breakpoints/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/breakpoints/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/columns/index.html
+++ b/docs/5.1/layout/columns/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/columns/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/columns/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/columns/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/containers/index.html
+++ b/docs/5.1/layout/containers/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/containers/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/containers/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/containers/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/css-grid/index.html
+++ b/docs/5.1/layout/css-grid/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/css-grid/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/css-grid/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/css-grid/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/grid/index.html
+++ b/docs/5.1/layout/grid/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/grid/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/grid/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/grid/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/gutters/index.html
+++ b/docs/5.1/layout/gutters/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/gutters/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/gutters/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/gutters/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/utilities/index.html
+++ b/docs/5.1/layout/utilities/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/utilities/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/utilities/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/utilities/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/layout/z-index/index.html
+++ b/docs/5.1/layout/z-index/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/layout/z-index/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/layout/z-index/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/layout/z-index/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/migration/index.html
+++ b/docs/5.1/migration/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/migration/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/migration/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/migration/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/api/index.html
+++ b/docs/5.1/utilities/api/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/api/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/api/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/api/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/background/index.html
+++ b/docs/5.1/utilities/background/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/background/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/background/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/background/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/borders/index.html
+++ b/docs/5.1/utilities/borders/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/borders/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/borders/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/borders/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/colors/index.html
+++ b/docs/5.1/utilities/colors/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/colors/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/colors/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/colors/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/display/index.html
+++ b/docs/5.1/utilities/display/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/display/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/display/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/display/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/flex/index.html
+++ b/docs/5.1/utilities/flex/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/flex/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/flex/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/flex/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/float/index.html
+++ b/docs/5.1/utilities/float/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/float/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/float/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/float/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/interactions/index.html
+++ b/docs/5.1/utilities/interactions/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/interactions/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/interactions/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/interactions/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/opacity/index.html
+++ b/docs/5.1/utilities/opacity/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/opacity/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/opacity/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/opacity/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/overflow/index.html
+++ b/docs/5.1/utilities/overflow/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/overflow/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/overflow/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/overflow/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/position/index.html
+++ b/docs/5.1/utilities/position/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/position/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/position/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/position/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/shadows/index.html
+++ b/docs/5.1/utilities/shadows/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/shadows/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/shadows/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/shadows/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/sizing/index.html
+++ b/docs/5.1/utilities/sizing/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/sizing/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/sizing/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/sizing/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/spacing/index.html
+++ b/docs/5.1/utilities/spacing/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/spacing/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/spacing/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/spacing/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/text/index.html
+++ b/docs/5.1/utilities/text/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/text/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/text/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/text/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/vertical-align/index.html
+++ b/docs/5.1/utilities/vertical-align/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/vertical-align/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/vertical-align/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/vertical-align/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>

--- a/docs/5.1/utilities/visibility/index.html
+++ b/docs/5.1/utilities/visibility/index.html
@@ -146,15 +146,15 @@
   <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-versions">
     <li><h6 class="dropdown-header">v5 releases</h6></li>
     <li>
-      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/">
+      <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/utilities/visibility/">
         Latest (5.2.x)
       </a>
     </li>
     <li>
-        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/">v5.1.x</a>
+        <a class="dropdown-item current" aria-current="true" href="/docs/5.1/utilities/visibility/">v5.1.3</a>
     </li>
     <li>
-        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/">v5.0.x</a>
+        <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/utilities/visibility/">v5.0.2</a>
     </li>
     <li><hr class="dropdown-divider"></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>


### PR DESCRIPTION
### Related issues

Closes #37643

### Description

This PR suggests to modify `docs/v5.0` and `docs/v5.1` to keep the context of navigation when going from v5.0/v5.1 to v5.2. Going from v5.2 to v5.1/v5.2 is already in place.

Used the following script to modify everything (not a good quality one but worked pretty well). Put it here, can be useful for future selves.

```sh
#!/bin/bash

echo "toto"

for file in `find docs/5.0 -name "index.html" -type f`
do
  # echo $file

  # Get path (e.g. /about/brand)
  test=`echo $file | tail -c +9`
  path=`echo $test | rev | cut -c 11- | rev`

  # Filter the files we want to modify
  toto=`cat $file | grep "<a class=\"dropdown-item\" href=\"https://getbootstrap.com/docs/5.2/\">"`
  if [[ $toto ]]
  then
    ttt=`echo $path | sed 's/\//\\\\\//g'`
    echo $ttt

    # First modification
    sed 's/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.2\/">/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.2'${ttt}'">/g' $file > $file.out
    mv $file.out $file

    # Second modification
    sed 's/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.1\/">v5.1.x<\/a>/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.1'${ttt}'">v5.1.3<\/a>/g' $file > $file.out
    mv $file.out $file

    # Third modification
    sed 's/<a class="dropdown-item current" aria-current="true" href="\/docs\/5.0\/">v5.0.x<\/a>/<a class="dropdown-item current" aria-current="true" href="\/docs\/5.0'${ttt}'">v5.0.2<\/a>/g' $file > $file.out
    mv $file.out $file
  fi
done

for file in `find docs/5.1 -name "index.html" -type f`
do
  # echo $file

  # Get path /about/brand for example
  test=`echo $file | tail -c +9`
  path=`echo $test | rev | cut -c 11- | rev`

  # Filter the files we want to modify
  toto=`cat $file | grep "<a class=\"dropdown-item\" href=\"https://getbootstrap.com/docs/5.2/\">"`
  if [[ $toto ]]
  then
    ttt=`echo $path | sed 's/\//\\\\\//g'`
    echo $ttt

    # First modification
    sed 's/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.2\/">/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.2'${ttt}'">/g' $file > $file.out
    mv $file.out $file

    # Second modification
    sed 's/<a class="dropdown-item current" aria-current="true" href="\/docs\/5.1\/">v5.1.x<\/a>/<a class="dropdown-item current" aria-current="true" href="\/docs\/5.1'${ttt}'">v5.1.3<\/a>/g' $file > $file.out
    mv $file.out $file

    # Third modification
    sed 's/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.0\/">v5.0.x<\/a>/<a class="dropdown-item" href="https:\/\/getbootstrap.com\/docs\/5.0'${ttt}'">v5.0.2<\/a>/g' $file > $file.out
    mv $file.out $file
  fi
done
```

### Motivation & Context

This modification could be very helpful for folks arriving from search engines results where, we know it, Bootstrap is not always referenced with the latest version (more details in the issue).

### Type of changes

- [x] Enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed


