### PR TITLE
WIP: Add loading dots spinner

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "31.25 kB"
+      "maxSize": "31.5 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -83,3 +83,36 @@
     }
   }
 }
+
+//
+// Moving dots
+//
+
+// scss-docs-start spinner-dots-keyframes
+@keyframes spinner-dots {
+  0% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: .3;
+  }
+}
+// scss-docs-end spinner-dots-keyframes
+
+.spinner-dots {
+  user-select: none;
+
+  > circle:first-of-type,
+  > circle:nth-of-type(2),
+  > circle:last-of-type {
+    fill: currentcolor;
+    animation: spinner-dots .75s infinite ease-in-out alternate;
+  }
+  > circle:nth-of-type(2) {
+    animation-delay: .25s;
+  }
+  > circle:last-of-type {
+    animation-delay: .5s;
+  }
+}

--- a/site/content/docs/5.2/components/spinners.md
+++ b/site/content/docs/5.2/components/spinners.md
@@ -66,6 +66,32 @@ Once again, this spinner is built with `currentColor`, so you can easily change 
 {{< /spinner.inline >}}
 {{< /example >}}
 
+## Loading dots spinner
+
+The loading dots spinner is a special spinner that's built using an SVG, making it much easier to work style and animate with CSS. Rather than generate pseudo-elements with `::before` and `::after`, we just have one, tiny HTML element.
+
+{{< callout info >}}
+Loading dots should be named `.loading-dots`, but for consistency's sake, we're using `.spinner-dots`.
+{{< /callout >}}
+
+{{< example >}}
+<svg class="spinner-dots" width="32" height="16" role="status" xmlns="http://www.w3.org/2000/svg">
+  <title>Loading...</title><circle cx="4" cy="8" r="4"/><circle cx="16" cy="8" r="4"/><circle cx="28" cy="8" r="4"/>
+</svg>
+{{< /example >}}
+
+And as usual, this spinner is styled with `currentColor`, so text color utilities can be applied.
+
+{{< example >}}
+{{< spinner.inline >}}
+{{- range (index $.Site.Data "theme-colors") }}
+<svg class="spinner-dots text-{{ .name }}" width="32" height="16" role="status" xmlns="http://www.w3.org/2000/svg">
+  <title>Loading...</title><circle cx="4" cy="8" r="4"/><circle cx="16" cy="8" r="4"/><circle cx="28" cy="8" r="4"/>
+</svg>
+{{- end -}}
+{{< /spinner.inline >}}
+{{< /example >}}
+
 ## Alignment
 
 Spinners in Bootstrap are built with `rem`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.


### PR DESCRIPTION
Got inspired looking at some dots and figured I'd try out using an SVG as a spinner element. This felt easier than animating a single element with pseudo-elements (because of some issues animating colors with CSS variables vs opacity) and just seemed like a fun thing to try.

I wanted to get this to work with a `<symbol>`, but ran into issues where the animation never started for shadow content.

```html
<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
  <symbol id="spinner-dots" class="spinner-dots">
    <title>Loading...</title><circle cx="4" cy="8" r="4"/><circle cx="16" cy="8" r="4"/><circle cx="28" cy="8" r="4"/>
  </symbol>
</svg>
<svg class="text-{{ .name }}" width="32" height="16" role="status"><use xlink:href="#spinner-dots"/></svg>
```

Alas, repeating the SVG manually worked fine. This approach keeps the CSS ridiculously small, but I'd like to keep the HTML small, too, with support for that symbol element. Will come back to this at another time.

_Also, we should probably rename spinners to loaders or something hah._

### [Live preview](https://deploy-preview-37672--twbs-bootstrap.netlify.app/docs/5.2/components/spinners/#loading-dots-spinner)