### PR TITLE
carousel: Allow selecting a slide when none is active

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -274,8 +274,10 @@ class Carousel extends BaseComponent {
 
     const activeIndicator = SelectorEngine.findOne(SELECTOR_ACTIVE, this._indicatorsElement)
 
-    activeIndicator.classList.remove(CLASS_NAME_ACTIVE)
-    activeIndicator.removeAttribute('aria-current')
+    if (activeIndicator) {
+      activeIndicator.classList.remove(CLASS_NAME_ACTIVE)
+      activeIndicator.removeAttribute('aria-current')
+    }
 
     const newActiveIndicator = SelectorEngine.findOne(`[data-bs-slide-to="${index}"]`, this._indicatorsElement)
 

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1187,6 +1187,39 @@ describe('Carousel', () => {
         })
       })
     })
+
+    it('should update the active element if none is active', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div id="myCarousel" class="carousel slide">',
+          '  <div class="carousel-indicators">',
+          '    <button type="button" data-bs-target="myCarousel" data-bs-slide-to="0" aria-label="Slide 1"></button>',
+          '    <button type="button" data-bs-target="myCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>',
+          '    <button type="button" data-bs-target="myCarousel" data-bs-slide-to="2" aria-label="Slide 3" id="thirdIndicator"></button>',
+          '  </div>',
+          '  <div class="carousel-inner">',
+          '    <div id="item1" class="carousel-item active">item 1</div>',
+          '    <div class="carousel-item">item 2</div>',
+          '    <div id="item3" class="carousel-item">item 3</div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const carouselEl = fixtureEl.querySelector('#myCarousel')
+        const thirdIndicator = fixtureEl.querySelector('#thirdIndicator')
+        const thirdItem = fixtureEl.querySelector('#item3')
+        const carousel = new Carousel(carouselEl, {})
+
+        carousel.to(2)
+
+        carouselEl.addEventListener('slid.bs.carousel', () => {
+          expect(thirdItem).toHaveClass('active')
+          expect(thirdIndicator).toHaveClass('active')
+          expect(thirdIndicator.getAttribute('aria-current')).toEqual('true')
+          resolve()
+        })
+      })
+    })
   })
 
   describe('rtl function', () => {


### PR DESCRIPTION
### Description

Check that an active carousel indicator actually exists before trying to remove its `active` class

### Motivation & Context

In the current implementation, if no indicator has the `active` class, selecting an indicator will throw an exception instead of selecting the desired one.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed


