### PR TITLE
package.json: exclude scss test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
     "dist/{css,js}/*.{css,js,map}",
     "js/{src,dist}/**/*.{js,map}",
     "js/index.{esm,umd}.js",
-    "scss/**/*.scss"
+    "scss/**/*.scss",
+    "!scss/tests/**"
   ],
   "hugo-bin": {
     "buildTags": "extended"


### PR DESCRIPTION
Before:

```
npm notice === Tarball Details ===
npm notice name:          bootstrap
npm notice version:       5.3.0-alpha1
npm notice filename:      bootstrap-5.3.0-alpha1.tgz
npm notice package size:  1.7 MB
npm notice unpacked size: 9.5 MB
npm notice shasum:        265605a00a28462aafce59c52082f346efe9df31
npm notice integrity:     sha512-pLr+LPytfJGYz[...]zc5oDOZQzzczg==
npm notice total files:   220
```

After:

```
npm notice === Tarball Details ===
npm notice name:          bootstrap
npm notice version:       5.3.0-alpha1
npm notice filename:      bootstrap-5.3.0-alpha1.tgz
npm notice package size:  1.7 MB
npm notice unpacked size: 9.5 MB
npm notice shasum:        6e5f759a822cad4910658db5569607c3fb091e51
npm notice integrity:     sha512-zuPZDyx6SsYdL[...]YOOsT2hww25kA==
npm notice total files:   217
```

Fixup after #36029 