### PR TITLE
docs: improve social image partial

### DIFF
--- a/site/layouts/partials/social.html
+++ b/site/layouts/partials/social.html
@@ -1,15 +1,23 @@
+{{ $socialImagePath := printf "/docs/%s/assets" .Site.Params.docs_version -}}
+
+{{- if .Page.Params.thumbnail -}}
+  {{- $socialImagePath = path.Join $socialImagePath "img/" .Page.Params.thumbnail -}}
+{{- else -}}
+  {{- $socialImagePath = path.Join $socialImagePath "brand/bootstrap-social.png" -}}
+{{- end -}}
+
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
 <meta name="twitter:creator" content="@{{ .Site.Params.twitter }}">
 <meta name="twitter:title" content="{{ .Title | markdownify }}">
 <meta name="twitter:description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
-<meta name="twitter:image" content="/docs/{{ .Site.Params.docs_version }}/assets/{{ if .Page.Params.thumbnail }}img/{{ .Page.Params.thumbnail }}{{else}}brand/bootstrap-social.png{{end}}">
+<meta name="twitter:image" content="{{ $socialImagePath | absURL }}">
 
 <meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:title" content="{{ .Title | markdownify }}">
 <meta property="og:description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+<meta property="og:image" content="{{ $socialImagePath | absURL }}">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1000">
 <meta property="og:image:height" content="500">
-<meta property="og:image" content="/docs/{{ .Site.Params.docs_version }}/assets/{{ if .Page.Params.thumbnail }}img/{{ .Page.Params.thumbnail }}{{else}}brand/bootstrap-social.png{{end}}">

--- a/site/layouts/partials/social.html
+++ b/site/layouts/partials/social.html
@@ -1,4 +1,6 @@
-{{ $socialImagePath := printf "/docs/%s/assets" .Site.Params.docs_version -}}
+{{- $pageTitle := .Title | markdownify -}}
+{{- $pageDescription := .Page.Params.description | default .Site.Params.description | markdownify -}}
+{{- $socialImagePath := printf "/docs/%s/assets" .Site.Params.docs_version -}}
 
 {{- if .Page.Params.thumbnail -}}
   {{- $socialImagePath = path.Join $socialImagePath "img/" .Page.Params.thumbnail -}}
@@ -9,13 +11,13 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
 <meta name="twitter:creator" content="@{{ .Site.Params.twitter }}">
-<meta name="twitter:title" content="{{ .Title | markdownify }}">
-<meta name="twitter:description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
+<meta name="twitter:title" content="{{ $pageTitle }}">
+<meta name="twitter:description" content="{{ $pageDescription }}">
 <meta name="twitter:image" content="{{ $socialImagePath | absURL }}">
 
 <meta property="og:url" content="{{ .Permalink }}">
-<meta property="og:title" content="{{ .Title | markdownify }}">
-<meta property="og:description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
+<meta property="og:title" content="{{ $pageTitle }}">
+<meta property="og:description" content="{{ $pageDescription }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 <meta property="og:image" content="{{ $socialImagePath | absURL }}">
 <meta property="og:image:type" content="image/png">

--- a/site/layouts/partials/social.html
+++ b/site/layouts/partials/social.html
@@ -21,5 +21,7 @@
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 <meta property="og:image" content="{{ $socialImagePath | absURL }}">
 <meta property="og:image:type" content="image/png">
-<meta property="og:image:width" content="1000">
-<meta property="og:image:height" content="500">
+{{ with (imageConfig (path.Join "site/static" $socialImagePath)) -}}
+<meta property="og:image:width" content="{{ .Width }}">
+<meta property="og:image:height" content="{{ .Height }}">
+{{- end }}


### PR DESCRIPTION
Fixes #37716 

**TODO for later**: see if we can just do what we do in blog <https://github.com/twbs/blog/blob/main/src/layouts/partials/social.html>. Note that the `twitter:creator` tag is currently broken in blog for pages.

Also, we should switch to `params.images` and do it like we do it in blog.