### PR TITLE
Add `color-scheme` to dark root selector

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -131,6 +131,8 @@
 
 @if $enable-dark-mode {
   @include color-mode(dark, true) {
+    color-scheme: dark;
+
     // scss-docs-start root-dark-mode-vars
     --#{$prefix}body-color: #{$body-color-dark};
     --#{$prefix}body-color-rgb: #{to-rgb($body-color-dark)};


### PR DESCRIPTION
Unfortunately, I don't see any difference in setting this on macOS at least (Safari and Chrome). Select elements and scroll bars don't update until I change the OS level color mode.

Fixes #37710.