### PR TITLE
Docs: handle light/dark mode in Algolia search modal

### DIFF
--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -1,5 +1,34 @@
 // stylelint-disable selector-class-pattern
 
+:root,
+[data-bs-theme="light"] {
+  --docsearch-primary-color: var(--bd-violet);
+  --docsearch-logo-color: var(--bd-violet);
+}
+
+@include color-mode(dark, true) {
+  --docsearch-primary-color: var(--bd-violet);
+  --docsearch-logo-color: var(--bd-violet);
+
+  // From here, the values are copied from https://cdn.jsdelivr.net/npm/@docsearch/css@3
+  // in html[data-theme="dark"] selector
+  // and are slightly modified for formatting purpose
+  --docsearch-text-color: #f5f6f7;
+  --docsearch-container-background: rgba(9, 10, 17, .8);
+  --docsearch-modal-background: #15172a;
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309;
+  --docsearch-searchbox-background: #090a11;
+  --docsearch-searchbox-focus-background: #000;
+  --docsearch-hit-color: #bec3c9;
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: #090a11;
+  --docsearch-key-gradient: linear-gradient(-26.5deg, #565872, #31355b);
+  --docsearch-key-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d, 0 2px 2px 0 rgba(3, 4, 9, .3);
+  --docsearch-footer-background: #1e2136;
+  --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, .5), 0 -4px 8px 0 rgba(0, 0, 0, .2);
+  --docsearch-muted-color: #7f8497;
+}
+
 .bd-search {
   position: relative;
 
@@ -138,4 +167,10 @@
 .DocSearch-Hit-icon {
   display: flex;
   align-items: center;
+}
+
+// Fix --docsearch-logo-color that doesn't do anything
+.DocSearch-Logo svg .cls-1,
+.DocSearch-Logo svg .cls-2 {
+  fill: var(--docsearch-logo-color);
 }

--- a/site/assets/scss/_search.scss
+++ b/site/assets/scss/_search.scss
@@ -1,15 +1,11 @@
 // stylelint-disable selector-class-pattern
 
-:root,
-[data-bs-theme="light"] {
+:root {
   --docsearch-primary-color: var(--bd-violet);
   --docsearch-logo-color: var(--bd-violet);
 }
 
 @include color-mode(dark, true) {
-  --docsearch-primary-color: var(--bd-violet);
-  --docsearch-logo-color: var(--bd-violet);
-
   // From here, the values are copied from https://cdn.jsdelivr.net/npm/@docsearch/css@3
   // in html[data-theme="dark"] selector
   // and are slightly modified for formatting purpose

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -18,8 +18,6 @@ $bd-callout-variants: info, warning, danger !default;
   --bd-accent-rgb: #{to-rgb($bd-accent)};
   --bd-pink-rgb: #{to-rgb($pink-500)};
   --bd-teal-rgb: #{to-rgb($teal-500)};
-  --docsearch-primary-color: var(--bd-violet);
-  --docsearch-logo-color: var(--bd-violet);
 
   --bd-violet-bg: var(--bd-violet);
   --bd-sidebar-link-bg: rgba(var(--bd-violet-rgb), .1);


### PR DESCRIPTION
### Description

This PR suggests some modifications to handle the dark mode in Algolia modal based on the values available in their CSS file.

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot 2022-12-27 at 22 52 03](https://user-images.githubusercontent.com/17381666/209725612-1aff2d94-c3a8-491f-8461-b966c6a59027.png) | ![Screenshot 2022-12-27 at 22 51 54](https://user-images.githubusercontent.com/17381666/209725616-efc14d46-897b-4800-8f9b-0a7544c84ae6.png) |

I preferred to avoid adding a `data-theme="dark"` to our `<html>` in the docs and rather copied the content of their CSS file in ours.

Also moved some `--docsearch-*` definitions in our `_search.scss` file to gather together this management in a single file.

Finally, had to add a patch because `--docsearch-logo-color` doesn't seem to work well in our case. Sounds like a bug (see https://github.com/algolia/docsearch/issues/1695 where I've added a lil' comment)

⚠️ This PR doesn't tackle the visible focus (keyboard focus). We should create a dedicated issue/PR for that since it already doesn't work even in light mode.

 
![2022-12-27 22 49 46](https://user-images.githubusercontent.com/17381666/209725484-851f0884-4f46-4401-9629-5c4e8ca8d05a.gif)


### Motivation & Context

Simple motivation: having a light/dark mode for this modal as well.

### Type of changes

- Enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37738--twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/

### Related issues

Linked to a sub-task in #37549
