### PR TITLE
Docs: remove `.btn-*-dark` from Button group docs to avoid issues in dark mode

### DIFF
--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -145,21 +145,21 @@ Instead of applying button sizing classes to every button in a group, just add `
 
 {{< example >}}
 <div class="btn-group btn-group-lg" role="group" aria-label="Large button group">
-  <button type="button" class="btn btn-outline-dark">Left</button>
-  <button type="button" class="btn btn-outline-dark">Middle</button>
-  <button type="button" class="btn btn-outline-dark">Right</button>
+  <button type="button" class="btn btn-outline-primary">Left</button>
+  <button type="button" class="btn btn-outline-primary">Middle</button>
+  <button type="button" class="btn btn-outline-primary">Right</button>
 </div>
 <br>
 <div class="btn-group" role="group" aria-label="Default button group">
-  <button type="button" class="btn btn-outline-dark">Left</button>
-  <button type="button" class="btn btn-outline-dark">Middle</button>
-  <button type="button" class="btn btn-outline-dark">Right</button>
+  <button type="button" class="btn btn-outline-primary">Left</button>
+  <button type="button" class="btn btn-outline-primary">Middle</button>
+  <button type="button" class="btn btn-outline-primary">Right</button>
 </div>
 <br>
 <div class="btn-group btn-group-sm" role="group" aria-label="Small button group">
-  <button type="button" class="btn btn-outline-dark">Left</button>
-  <button type="button" class="btn btn-outline-dark">Middle</button>
-  <button type="button" class="btn btn-outline-dark">Right</button>
+  <button type="button" class="btn btn-outline-primary">Left</button>
+  <button type="button" class="btn btn-outline-primary">Middle</button>
+  <button type="button" class="btn btn-outline-primary">Right</button>
 </div>
 {{< /example >}}
 
@@ -190,12 +190,12 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
 
 {{< example >}}
 <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
-  <button type="button" class="btn btn-dark">Button</button>
-  <button type="button" class="btn btn-dark">Button</button>
-  <button type="button" class="btn btn-dark">Button</button>
-  <button type="button" class="btn btn-dark">Button</button>
-  <button type="button" class="btn btn-dark">Button</button>
-  <button type="button" class="btn btn-dark">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
+  <button type="button" class="btn btn-primary">Button</button>
 </div>
 {{< /example >}}
 


### PR DESCRIPTION
### Description

This PR suggests to replace the use of `.btn-*-dark` with `.btn-*-primary` so that the dark mode renders correctly the examples.

I don't think that the colors were that important before so I chose to use primary color. Can be something else of course if we want to add some variety of colors in the page.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37757--twbs-bootstrap.netlify.app/docs/5.3/components/button-group/#sizing
- https://deploy-preview-37757--twbs-bootstrap.netlify.app/docs/5.3/components/button-group/#vertical-variation (1st example)

### Related issues

Closes #37753
