### PR TITLE
Build(deps-dev): Bump sass-true from 6.1.0 to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "rollup-plugin-istanbul": "^4.0.0",
         "rtlcss": "^4.0.0",
         "sass": "^1.57.1",
-        "sass-true": "^6.1.0",
+        "sass-true": "^7.0.0",
         "shelljs": "^0.8.5",
         "stylelint": "^14.16.0",
         "stylelint-config-twbs-bootstrap": "^7.0.0",
@@ -1834,6 +1834,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.24.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -2115,6 +2127,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.7.0",
@@ -3942,12 +3960,12 @@
       "dev": true
     },
     "node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
+      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -6594,18 +6612,18 @@
       "dev": true
     },
     "node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.3.1.tgz",
+      "integrity": "sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "diff-sequences": "^29.3.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.3.1"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
@@ -6679,12 +6697,12 @@
       }
     },
     "node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true,
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jquery": {
@@ -8537,17 +8555,17 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
+      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.0.0",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -8716,9 +8734,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "node_modules/read-cache": {
@@ -9300,18 +9318,21 @@
       }
     },
     "node_modules/sass-true": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-6.1.0.tgz",
-      "integrity": "sha512-Qt6TpPe8Ogr8g9FvBSwXvzfrkbtHD7rej0X3lzyoiZ+I0kKV9NFeefcF560uMn5NFCA7g5rcVKxc9UHrrMcDrw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-7.0.0.tgz",
+      "integrity": "sha512-sRdXX7MrrYdg+lPRm+/vIr8wVvDrNtWj3ttOVyIMHZQ8vNoV67+YjZKTsY9+B4Ecee+/U3ryXKJLi1YcMEkaJQ==",
       "dev": true,
       "dependencies": {
         "@types/css": "^0.0.33",
         "css": "^3.0.0",
-        "jest-diff": "^27.5.1",
+        "jest-diff": "^29.3.1",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "sass": ">=1.45.0"
       }
     },
     "node_modules/seek-bzip": {
@@ -12114,6 +12135,15 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jest/schemas": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.24.1"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -12305,6 +12335,12 @@
         "estree-walker": "^2.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -13686,9 +13722,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
+      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
       "dev": true
     },
     "dir-glob": {
@@ -15676,15 +15712,15 @@
       "dev": true
     },
     "jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.3.1.tgz",
+      "integrity": "sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
+        "diff-sequences": "^29.3.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15739,9 +15775,9 @@
       }
     },
     "jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true
     },
     "jquery": {
@@ -17075,14 +17111,14 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
+      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.0.0",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17202,9 +17238,9 @@
       }
     },
     "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "read-cache": {
@@ -17634,14 +17670,14 @@
       }
     },
     "sass-true": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-6.1.0.tgz",
-      "integrity": "sha512-Qt6TpPe8Ogr8g9FvBSwXvzfrkbtHD7rej0X3lzyoiZ+I0kKV9NFeefcF560uMn5NFCA7g5rcVKxc9UHrrMcDrw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-7.0.0.tgz",
+      "integrity": "sha512-sRdXX7MrrYdg+lPRm+/vIr8wVvDrNtWj3ttOVyIMHZQ8vNoV67+YjZKTsY9+B4Ecee+/U3ryXKJLi1YcMEkaJQ==",
       "dev": true,
       "requires": {
         "@types/css": "^0.0.33",
         "css": "^3.0.0",
-        "jest-diff": "^27.5.1",
+        "jest-diff": "^29.3.1",
         "lodash": "^4.17.21"
       }
     },

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rollup-plugin-istanbul": "^4.0.0",
     "rtlcss": "^4.0.0",
     "sass": "^1.57.1",
-    "sass-true": "^6.1.0",
+    "sass-true": "^7.0.0",
     "shelljs": "^0.8.5",
     "stylelint": "^14.16.0",
     "stylelint-config-twbs-bootstrap": "^7.0.0",

--- a/scss/tests/sass-true/runner.js
+++ b/scss/tests/sass-true/runner.js
@@ -9,9 +9,11 @@ const path = require('node:path')
 module.exports = (filename, { describe, it }) => {
   const data = fs.readFileSync(filename, 'utf8')
   const TRUE_SETUP = '$true-terminal-output: false; @import "true";'
+  const sassString = TRUE_SETUP + data
 
-  runSass({
-    data: TRUE_SETUP + data,
-    includePaths: [path.dirname(filename)]
-  }, { describe, it })
+  runSass(
+    { describe, it, sourceType: 'string' },
+    sassString,
+    { loadPaths: [path.dirname(filename)] }
+  )
 }


### PR DESCRIPTION
This PR is based on https://github.com/twbs/bootstrap/pull/37730. It fixes `runner.js` by following migration guide described in [v7.0.0 Migrating from v6](https://github.com/oddbird/true/releases/tag/v7.0.0) + some search into `sass-true` repo to handle `includePaths` -> `loadPaths` (created [an issue upstream](https://github.com/oddbird/true/issues/247) to help improving the migration guide).

/cc @XhmikosR 