### PR TITLE
Docs: enhance callouts links on dark mode

### DIFF
--- a/site/assets/scss/_callouts.scss
+++ b/site/assets/scss/_callouts.scss
@@ -3,7 +3,7 @@
 //
 
 .bd-callout {
-  --#{$prefix}link-color-rgb: #{to-rgb($blue-600)};
+  --#{$prefix}link-color-rgb: var(--bd-callout-link);
 
   padding: 1.25rem;
   margin-top: 1.25rem;

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -21,6 +21,7 @@ $bd-callout-variants: info, warning, danger !default;
   --bd-violet-bg: var(--bd-violet);
   --bd-toc-color: var(--bd-violet);
   --bd-sidebar-link-bg: rgba(var(--bd-violet-rgb), .1);
+  --bd-callout-link: #{to-rgb($blue-600)};
 }
 
 @include color-mode(dark, true) {
@@ -28,4 +29,5 @@ $bd-callout-variants: info, warning, danger !default;
   --bd-violet-bg: #{$bd-violet};
   --bd-toc-color: var(--#{$prefix}emphasis-color);
   --bd-sidebar-link-bg: rgba(#{to-rgb(mix($bd-violet, $black, 75%))}, .5);
+  --bd-callout-link: #{to-rgb($blue-300)};
 }


### PR DESCRIPTION
Following up https://github.com/twbs/bootstrap/pull/37759/files.

This PR suggests to handle different colors for the links within the callouts based on light/dark mode to avoid the following use cases.

### Before

![Screenshot 2022-12-29 at 21 35 54](https://user-images.githubusercontent.com/17381666/210008985-ed3450dc-b19b-4a1c-8e1c-5471d9c1f229.png)
![Screenshot 2022-12-29 at 21 35 48](https://user-images.githubusercontent.com/17381666/210008986-2089a2a5-81c3-4405-b2cc-555c5500bd04.png)
![Screenshot 2022-12-29 at 21 35 08](https://user-images.githubusercontent.com/17381666/210008989-62ef4e22-321e-4cb6-88cf-d9c06e3031ec.png)
![Screenshot 2022-12-29 at 21 34 57](https://user-images.githubusercontent.com/17381666/210008994-4cd7915d-030f-4223-8cb8-456533236db0.png)

### Now

#### Warning callout
![Screenshot 2022-12-29 at 21 37 23](https://user-images.githubusercontent.com/17381666/210008983-8f1f7e72-a345-44e6-88e5-5b87eb425778.png)
![Screenshot 2022-12-29 at 21 37 16](https://user-images.githubusercontent.com/17381666/210008984-94e81e68-9b2a-469c-b683-2554126f8cec.png)

#### Info callout

* https://deploy-preview-37761--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/
