### PR TITLE
Include `twbs/examples` repo examples in the Examples page

### DIFF
--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -7,26 +7,41 @@ aliases: "/examples/"
 
 {{< list-examples.inline >}}
 {{ range $entry := $.Site.Data.examples -}}
-<div class="row g-lg-5 mb-5">
-  <div class="bd-content col-lg-3">
-    <h2 id="{{ $entry.category | urlize }}">{{ $entry.category }}</h2>
-    <p>{{ $entry.description }}</p>
-    {{ if eq $entry.category "RTL" -}}
-      <div class="bd-callout bd-callout-warning small">
-        <p>
-          <strong>RTL is still experimental</strong> and will evolve with feedback. Spotted something or have an improvement to suggest?
-        </p>
-        <p><a href="{{ $.Site.Params.repo }}/issues/new/choose">Please open an issue.</a></p>
-      </div>
-    {{ end -}}
-  </div>
-
-  <div class="col-lg-9">
-    {{ range $i, $example := $entry.examples -}}
-      {{- $len := len $entry.examples -}}
-      {{ if (eq $i 0) }}<div class="row">{{ end }}
-        <div class="col-sm-6 col-md-4 mb-3">
-          <a class="d-block" href="/docs/{{ $.Site.Params.docs_version }}/examples/{{ $example.name | urlize }}/"{{ if in $example.name "RTL" }} hreflang="ar"{{ end }}>
+<div class="bd-content">
+  <h2 id="{{ $entry.category | urlize }}">{{ $entry.category }}</h2>
+  <p>{{ $entry.description }}</p>
+  {{ if eq $entry.category "RTL" -}}
+    <div class="bd-callout bd-callout-warning small">
+      <p>
+        <strong>RTL is still experimental</strong> and will evolve with feedback. Spotted something or have an improvement to suggest?
+      </p>
+      <p><a href="{{ $.Site.Params.repo }}/issues/new/choose">Please open an issue.</a></p>
+    </div>
+  {{ end -}}
+  {{ range $i, $example := $entry.examples -}}
+    {{- $len := len $entry.examples -}}
+    {{ if (eq $i 0) }}<div class="row">{{ end }}
+      {{ if $entry.external }}
+        <div class="col-md-6 col-lg-4 mb-3 d-flex gap-3">
+          <svg class="bi fs-5 flex-shrink-0"><use xlink:href="#box-seam"></use></svg>
+          <div>
+            <h3 class="h5 mb-1">
+              <a class="d-block link-offset-1" href="{{ $.Site.Params.github_org }}{{ $example.url }}/" target="_blank">
+                {{ $example.name }}
+              </a>
+            </h3>
+            <p class="text-muted">{{ $example.description }}</p>
+            <p>
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file=index.html" target="_blank">
+                <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
+                Edit in StackBlitz
+              </a>
+            </p>
+          </div>
+        </div>
+      {{ else }}
+        <div class="col-sm-6 col-md-3 mb-3">
+          <a class="d-block link-offset-1" href="/docs/{{ $.Site.Params.docs_version }}/examples/{{ $example.name | urlize }}/"{{ if in $example.name "RTL" }} hreflang="ar"{{ end }}>
             <img class="img-thumbnail mb-3" srcset="/docs/{{ $.Site.Params.docs_version }}/assets/img/examples/{{ $example.name | urlize }}.png,
                                                     /docs/{{ $.Site.Params.docs_version }}/assets/img/examples/{{ $example.name | urlize }}@2x.png 2x"
                                             src="/docs/{{ $.Site.Params.docs_version }}/assets/img/examples/{{ $example.name | urlize }}.png"
@@ -39,9 +54,9 @@ aliases: "/examples/"
           </a>
           <p class="text-muted">{{ $example.description }}</p>
         </div>
-      {{ if (eq (add $i 1) $len) }}</div>{{ end }}
-    {{ end -}}
-  </div>
+      {{ end }}
+    {{ if (eq (add $i 1) $len) }}</div>{{ end }}
+  {{ end -}}
 </div>
 {{ end -}}
 {{< /list-examples.inline >}}

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -1,3 +1,29 @@
+- category: Starters
+  external: true
+  description: "Functional examples of using Bootstrap in common JS frameworks like Webpack, Parcel, Vite, and more you can edit in StackBlitz."
+  examples:
+    - name: CDN starter
+      description: "Instantly include Bootstrap's compiled CSS and JavaScript via the jsDelivr CDN."
+      url: /examples/tree/main/starter
+    - name: Sass & JS
+      description: "Use npm to import and compile Bootstrap's Sass with Autoprefixer and Stylelint, plus our bundled JavaScript."
+      url: /examples/tree/main/sass-js
+    - name: Sass & ESM JS
+      description: "Import and compile Bootstrap's Sass with Autoprefixer and Stylelint, and compile our source JavaScript with an ESM shim."
+      url: /examples/tree/main/sass-js-esm
+    - name: Webpack
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
+      url: /examples/tree/main/webpack
+    - name: Parcel
+      description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
+      url: /examples/tree/main/parcel
+    - name: Vite
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
+      url: /examples/tree/main/vite
+    - name: Bootstrap Icons
+      description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
+      url: /examples/tree/main/bootstrap-icons
+
 - category: Snippets
   description: "Common patterns for building sites and apps that build on existing components and utilities with custom CSS and more."
   examples:


### PR DESCRIPTION
Depends on the changes coming from the link helpers and utilities in #37762.

**Preview:** https://deploy-preview-37763--twbs-bootstrap.netlify.app/docs/5.3/examples/