### PR TITLE
Docs: enhance Focus ring example section desc

### DIFF
--- a/site/content/docs/5.3/helpers/focus-ring.md
+++ b/site/content/docs/5.3/helpers/focus-ring.md
@@ -11,7 +11,7 @@ The `.focus-ring` helper removes the default `outline` on `:focus`, replacing it
 
 ## Example
 
-Click into the example below and press <kbd>Tab</kbd> to see the focus ring in action.
+Click directly on the link below to see the focus ring in action, or into the example below and then press <kbd>Tab</kbd>.
 
 {{< example >}}
 <a href="#" class="d-inline-flex focus-ring py-1 px-2 text-decoration-none border rounded-2">


### PR DESCRIPTION
### Description

This PR suggests to add a precision in "Helpers > Focus ring > Example" description so that it is easier to see the rendering. IMO `:focus` is way easier to test out with a simple click instead of having to click on the area and then press "Tab".

I tried a sentence that combines both ideas but feel free to modify it or close the PR if you're not convinced.

### Type of changes

- [x] Doc enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37772--twbs-bootstrap.netlify.app/docs/5.3/helpers/focus-ring/#example>