### PR TITLE
Fix cards color for contextual color mode

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -30,6 +30,7 @@
   flex-direction: column;
   min-width: 0; // See https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
   height: var(--#{$prefix}card-height);
+  color: var(--#{$prefix}body-color);
   word-wrap: break-word;
   background-color: var(--#{$prefix}card-bg);
   background-clip: border-box;


### PR DESCRIPTION
### Description

This PR adds a default color for `.card` so that it gets inherited in all `.card-*` classes that have corresponding `$card-*-color` set to `null`.

In order to test this modification, please double-check that the rendering is not broken:
* in light mode in the docs
* in dark mode in the docs
* with contextual `data-bs-theme="dark"` for each card example in the docs when displayed in light mode
* with contextual `data-bs-theme="light"` for each card example in the docs when displayed in dark mode

**Note:** I'll add a task into our tracking issue for color modes to check all the components with contextual light/dark mode as well.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (NA) My change introduces changes to the documentation
- (NA) I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37777--twbs-bootstrap.netlify.app/docs/5.3/components/card/>

### Related issues

Fixes #37765
