### PR TITLE
Docs: add CSS variables section in close button section

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -4,6 +4,7 @@
 // See https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
 
 .btn-close {
+  // scss-docs-start close-css-vars
   --#{$prefix}btn-close-color: #{$btn-close-color};
   --#{$prefix}btn-close-bg: #{ escape-svg($btn-close-bg) };
   --#{$prefix}btn-close-opacity: #{$btn-close-opacity};
@@ -12,6 +13,7 @@
   --#{$prefix}btn-close-focus-opacity: #{$btn-close-focus-opacity};
   --#{$prefix}btn-close-disabled-opacity: #{$btn-close-disabled-opacity};
   --#{$prefix}btn-close-white-filter: #{$btn-close-white-filter};
+  // scss-docs-end close-css-vars
 
   box-sizing: content-box;
   width: $btn-close-width;

--- a/site/content/docs/5.3/components/close-button.md
+++ b/site/content/docs/5.3/components/close-button.md
@@ -37,8 +37,16 @@ Add `data-bs-theme="dark"` to the `.btn-close`, or to its parent element, to inv
 </div>
 {{< /example >}}
 
-## Sass
+## CSS
 
 ### Variables
+
+{{< added-in "5.3.0" >}}
+
+As part of Bootstrap's evolving CSS variables approach, close button now uses local CSS variables on `.btn-close` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="close-css-vars" file="scss/_close.scss" >}}
+
+### Sass variables
 
 {{< scss-docs name="close-variables" file="scss/_variables.scss" >}}


### PR DESCRIPTION
### Description

This PR adds consistency in the docs by adding in the close button page a CSS var section, as it is done for other components.

This is linked to #36457 which was merged after the release of the 5.2 so the 5.3 added-in shortcode has been added as well.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37782--twbs-bootstrap.netlify.app/docs/5.3/components/close-button/#css>

### Related issues

Related to #36457
