### PR TITLE
Change stylelint `property-blacklist` to `property-disallowed-list`

### DIFF
--- a/scss/vendor/_rfs.scss
+++ b/scss/vendor/_rfs.scss
@@ -1,4 +1,4 @@
-// stylelint-disable property-blacklist, scss/dollar-variable-default
+// stylelint-disable property-disallowed-list, scss/dollar-variable-default
 
 // SCSS RFS mixin
 //


### PR DESCRIPTION
### Description

Change stylelint `property-blacklist` to `property-disallowed-list` (as the former has been deprecated)

### Motivation & Context

see https://github.com/twbs/bootstrap/pull/31066#issuecomment-1369405723 / https://github.com/stylelint/stylelint/releases/tag/13.7.0

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Related issues

Follow-up to #31066
