### PR TITLE
Change dropdown arrow orientation on click

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -9,10 +9,18 @@
 }
 
 .dropdown-toggle {
+  --#{$prefix}dropdown-btn-icon-transform: #{$dropdown-icon-transform};
+
   white-space: nowrap;
 
   // Generate the caret automatically
   @include caret();
+
+  &.show {
+    &::after {
+      transform: var(--#{$prefix}dropdown-btn-icon-transform);
+    }
+  }
 }
 
 // The dropdown menu

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1233,6 +1233,8 @@ $dropdown-item-padding-x:           $spacer !default;
 $dropdown-header-color:             $gray-600 !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $dropdown-padding-y !default;
+
+$dropdown-icon-transform:           rotate(-180deg) !default;
 // fusv-disable
 $dropdown-header-padding:           $dropdown-header-padding-y $dropdown-header-padding-x !default; // Deprecated in v5.2.0
 // fusv-enable


### PR DESCRIPTION
### Description

Allow arrows in dropdown’s toggle to change orientation on click.

### Motivation & Context

Ensure that the arrow markers behave similarly in the accordions and dropdown menus.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- [https://deploy-preview-37792--twbs-bootstrap.netlify.app/docs/5.3/components/dropdowns/#examples](https://deploy-preview-37792--twbs-bootstrap.netlify.app/docs/5.3/components/dropdowns/#examples)

