### PR TITLE
fix undefined is not an object (evaluating 'this._config.backdrop')

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -64,6 +64,10 @@ const DefaultType = {
 class Modal extends BaseComponent {
   constructor(element, config) {
     super(element, config)
+    
+    if (!this._element) { 
+      return 
+    } 
 
     this._dialog = SelectorEngine.findOne(SELECTOR_DIALOG, this._element)
     this._backdrop = this._initializeBackDrop()


### PR DESCRIPTION
### Description

if the element failed to initialize (this._element never being set), proceeding with constructor will result in errors, the first one being undefined is not an object (evaluating 'this._config.backdrop') in _initializeBackDrop .

### Motivation & Context

i have issues in my bug tracker :-)

see https://github.com/twbs/bootstrap/issues/37305 for context

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

i didn't run the unit tests because i made the edit live on github, but if you consider the change, i'd be happy to run them since in quite sure it doesn't break anything :-)

#### Live previews

not necessary
