### PR TITLE
Fix carousel caption heading colors

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -211,6 +211,8 @@
 // Dark mode carousel
 
 @mixin carousel-dark() {
+  --#{$prefix}heading-color: $black;
+
   .carousel-control-prev-icon,
   .carousel-control-next-icon {
     filter: $carousel-dark-control-icon-filter;

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -44,7 +44,7 @@ $body-tertiary-bg-dark:             mix($gray-800, $gray-900, 50%) !default;
 $emphasis-color-dark:               $white !default;
 $border-color-dark:                 $gray-700 !default;
 $border-color-translucent-dark:     rgba($white, .15) !default;
-$headings-color-dark:               #fff !default;
+$headings-color-dark:               $white !default;
 $link-color-dark:                   $blue-300 !default;
 $link-hover-color-dark:             $blue-200 !default;
 $code-color-dark:                   $pink-300 !default;


### PR DESCRIPTION
### Description

This PR suggests to set `--bs-heading-color` to black in dark mode or when `.carousel-dark` is used.
TBH I'm not a big fan of this modification so far but headers have a color set by `--bs-heading-color` which has a bigger priority compared to `.carousel-caption` color. So I haven't found a more elegant way of doing it for now. Thoughts to improve this PR?

### Motivation & Context

Color consistency between header and text colors within `.carousel-caption`.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

Please check the following URLs in light and dark modes:

- <https://deploy-preview-37797--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#captions>
- <https://deploy-preview-37797--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#dark-variant>

### Related issues

Closes #37795
