### PR TITLE
Docs: fix accordion flush description

### DIFF
--- a/site/content/docs/5.3/components/accordion.md
+++ b/site/content/docs/5.3/components/accordion.md
@@ -64,7 +64,7 @@ Click the accordions below to expand/collapse the accordion content.
 
 ### Flush
 
-Add `.accordion-flush` to remove the default `background-color`, some borders, and some rounded corners to render accordions edge-to-edge with their parent container.
+Add `.accordion-flush` to remove some borders and rounded corners to render accordions edge-to-edge with their parent container.
 
 {{< example class="bg-body-secondary" >}}
 <div class="accordion accordion-flush" id="accordionFlushExample">


### PR DESCRIPTION
### Description

Based on the elements from https://github.com/twbs/bootstrap/issues/37776#issuecomment-1369167139, IMO the current background color management is OK since it provides some security regarding a11y and contrast if the accordions (or list groups) are included in another parent container with a different background color.

So this PR suggests to only remove a part of the sentence and to get close to the one in https://getbootstrap.com/docs/5.3/components/list-group/#flush.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-37798--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#flush>

### Related issues

Closes #37776 
