### PR TITLE
Fix heading colors in dark mode

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -190,7 +190,9 @@
     --#{$prefix}light-border-subtle: #{$light-border-subtle-dark};
     --#{$prefix}dark-border-subtle: #{$dark-border-subtle-dark};
 
-    --#{$prefix}heading-color: #{$headings-color-dark};
+    @if $headings-color-dark != null {
+      --#{$prefix}heading-color: #{$headings-color-dark};
+    }
 
     --#{$prefix}link-color: #{$link-color-dark};
     --#{$prefix}link-hover-color: #{$link-hover-color-dark};

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -44,7 +44,7 @@ $body-tertiary-bg-dark:             mix($gray-800, $gray-900, 50%) !default;
 $emphasis-color-dark:               $white !default;
 $border-color-dark:                 $gray-700 !default;
 $border-color-translucent-dark:     rgba($white, .15) !default;
-$headings-color-dark:               #fff !default;
+$headings-color-dark:               null !default;
 $link-color-dark:                   $blue-300 !default;
 $link-hover-color-dark:             $blue-200 !default;
 $code-color-dark:                   $pink-300 !default;

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -9,6 +9,12 @@
     margin-top: -5rem;
   }
 
+  > h2,
+  > h3,
+  > h4 {
+    --#{$prefix}heading-color: #fff;
+  }
+
   > h2:not(:first-child) {
     margin-top: 3rem;
   }
@@ -102,6 +108,7 @@
 }
 
 .bd-title {
+  --#{$prefix}heading-color: #fff;
   @include font-size(3rem);
 }
 


### PR DESCRIPTION
- Removes dark mode `--bs-heading-color` value
- Set the `$headings-color-dark` Sass variable to `null` and add a null check to the root variable
- Adds custom styles for the docs dark mode headings

Closes #37797, fixes #37799, fixes #37795.
