### PR TITLE
Docs: fix headings color in light/dark mode

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -12,7 +12,7 @@
   > h2,
   > h3,
   > h4 {
-    --#{$prefix}heading-color: #fff;
+    --bs-heading-color: var(--bs-emphasis-color);
   }
 
   > h2:not(:first-child) {
@@ -108,7 +108,7 @@
 }
 
 .bd-title {
-  --#{$prefix}heading-color: #fff;
+  --bs-heading-color: var(--bs-emphasis-color);
   @include font-size(3rem);
 }
 


### PR DESCRIPTION
### Description

/cc @mdo 

https://github.com/twbs/bootstrap/pull/37800/files introduced a regression of headings color in our docs; we can't see anymore the headings in light mode.

You can check this regression live in https://twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/:

![Screenshot 2023-01-04 at 10 29 36](https://user-images.githubusercontent.com/17381666/210524804-c1840784-d97a-4137-8930-7ca008b663e2.png)

This PR suggests to use a custom property allowing to switch between black and white in light/dark mode and replaces `--#{$prefix}` by `--bs`. 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37802--twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/ (in both light/dark mode)
- https://deploy-preview-37802--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#captions (in both light/dark mode)
- https://deploy-preview-37802--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#dark-variant (in both light/dark mode)