### PR TITLE
Fix duplicate `--bs-emphasis-color` set value

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -58,8 +58,8 @@
   --#{$prefix}body-line-height: #{$line-height-base};
   --#{$prefix}body-color: #{$body-color};
 
-  --#{$prefix}emphasis-color: #{$body-emphasis-color};
-  --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color)};
+  --#{$prefix}emphasis-color: #{$emphasis-color};
+  --#{$prefix}emphasis-color-rgb: #{to-rgb($emphasis-color)};
 
   --#{$prefix}secondary-color: #{$body-secondary-color};
   --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color)};
@@ -115,8 +115,6 @@
   --#{$prefix}box-shadow-lg: #{$box-shadow-lg};
   --#{$prefix}box-shadow-inset: #{$box-shadow-inset};
 
-  --#{$prefix}emphasis-color: #{$emphasis-color};
-
   // scss-docs-start form-control-vars
   --#{$prefix}form-control-bg: var(--#{$prefix}body-bg);
   --#{$prefix}form-control-disabled-bg: var(--#{$prefix}secondary-bg);
@@ -146,8 +144,8 @@
     --#{$prefix}body-bg: #{$body-bg-dark};
     --#{$prefix}body-bg-rgb: #{to-rgb($body-bg-dark)};
 
-    --#{$prefix}emphasis-color: #{$body-emphasis-color-dark};
-    --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color-dark)};
+    --#{$prefix}emphasis-color: #{$emphasis-color-dark};
+    --#{$prefix}emphasis-color-rgb: #{to-rgb($emphasis-color-dark)};
 
     --#{$prefix}secondary-color: #{$body-secondary-color-dark};
     --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color-dark)};
@@ -158,8 +156,6 @@
     --#{$prefix}tertiary-color-rgb: #{to-rgb($body-tertiary-color-dark)};
     --#{$prefix}tertiary-bg: #{$body-tertiary-bg-dark};
     --#{$prefix}tertiary-bg-rgb: #{to-rgb($body-tertiary-bg-dark)};
-
-    --#{$prefix}emphasis-color: #{$emphasis-color-dark};
 
     --#{$prefix}primary-text: #{$primary-text-dark};
     --#{$prefix}secondary-text: #{$secondary-text-dark};

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -58,8 +58,8 @@
   --#{$prefix}body-line-height: #{$line-height-base};
   --#{$prefix}body-color: #{$body-color};
 
-  --#{$prefix}emphasis-color: #{$emphasis-color};
-  --#{$prefix}emphasis-color-rgb: #{to-rgb($emphasis-color)};
+  --#{$prefix}emphasis-color: #{$body-emphasis-color};
+  --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color)};
 
   --#{$prefix}secondary-color: #{$body-secondary-color};
   --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color)};
@@ -144,8 +144,8 @@
     --#{$prefix}body-bg: #{$body-bg-dark};
     --#{$prefix}body-bg-rgb: #{to-rgb($body-bg-dark)};
 
-    --#{$prefix}emphasis-color: #{$emphasis-color-dark};
-    --#{$prefix}emphasis-color-rgb: #{to-rgb($emphasis-color-dark)};
+    --#{$prefix}emphasis-color: #{$body-emphasis-color-dark};
+    --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color-dark)};
 
     --#{$prefix}secondary-color: #{$body-secondary-color-dark};
     --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color-dark)};

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -36,7 +36,6 @@ $dark-border-subtle-dark:           $gray-800 !default;
 
 $body-color-dark:                   $gray-500 !default;
 $body-bg-dark:                      $gray-900 !default;
-$body-emphasis-color-dark:          $gray-100 !default;
 $body-secondary-color-dark:         rgba($body-color-dark, .75) !default;
 $body-secondary-bg-dark:            $gray-800 !default;
 $body-tertiary-color-dark:          rgba($body-color-dark, .5) !default;

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -40,7 +40,7 @@ $body-secondary-color-dark:         rgba($body-color-dark, .75) !default;
 $body-secondary-bg-dark:            $gray-800 !default;
 $body-tertiary-color-dark:          rgba($body-color-dark, .5) !default;
 $body-tertiary-bg-dark:             mix($gray-800, $gray-900, 50%) !default;
-$emphasis-color-dark:               $white !default;
+$body-emphasis-color-dark:          $white !default;
 $border-color-dark:                 $gray-700 !default;
 $border-color-translucent-dark:     rgba($white, .15) !default;
 $headings-color-dark:               null !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -438,7 +438,7 @@ $body-secondary-bg:         $gray-200 !default;
 $body-tertiary-color:       rgba($body-color, .5) !default;
 $body-tertiary-bg:          $gray-100 !default;
 
-$emphasis-color:            $black !default;
+$body-emphasis-color:       $black !default;
 
 // Links
 //

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -432,8 +432,6 @@ $body-text-align:           null !default;
 $body-color:                $gray-900 !default;
 $body-bg:                   $white !default;
 
-$body-emphasis-color:       $black !default;
-
 $body-secondary-color:      rgba($body-color, .75) !default;
 $body-secondary-bg:         $gray-200 !default;
 


### PR DESCRIPTION
### Description

`--bs-emphasis-color` is set 2 times in `scss/_root.scss`; 1 time with `$body-emphasis-color` and 1 time with `$emphasis-color`.

I supposed that the last is the right one based on what we fixed recently on dark mode (having a white color instead of `$gray-100`) so this PR suggests to have `--bs-emphasis-color` based on `$emphasis-color` on light mode and `$emphasis-color-dark` in dark mode.

It means that `$body-emphasis-color` and `$body-emphasis-color-dark` become useless and can be dropped.

@mdo I let you double-check if the rendering is not broken and if this is the way you thought the Sass/CSS vars. We can keep `$body-emphasis-color*` and remove `$emphasis-color*` if that makes more sense to you. 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (NA) My change introduces changes to the documentation
- (NA) I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37809--twbs-bootstrap.netlify.app/>
