### PR TITLE
Remove unused comment in `scss/_maps.scss`

### DIFF
--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -92,7 +92,6 @@ $utilities-bg-subtle: (
   "light-subtle": var(--#{$prefix}light-bg-subtle),
   "dark-subtle": var(--#{$prefix}dark-bg-subtle)
 ) !default;
-// $utilities-bg-subtle-colors: map-loop($utilities-bg-subtle, rgba-css-var, "$key", "bg") !default;
 // scss-docs-end utilities-bg-colors
 
 // scss-docs-start utilities-border-colors


### PR DESCRIPTION
Just removing an unused comment in `scss/_maps.scss` we forgot to remove while developing colors mode.