### PR TITLE
Docs: remove some CSS from `.highlight-toolbar` def

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -389,13 +389,6 @@
 
 .highlight-toolbar {
   background-color: var(--bd-pre-bg);
-  border: solid var(--bs-border-color);
-  border-width: 1px 0;
-
-  .btn-clipboard {
-    margin-top: 0;
-    margin-right: 0;
-  }
 }
 
 .focused {

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -28,7 +28,7 @@
 
   {{- if eq $show_markup true -}}
     {{- if eq $show_preview true -}}
-      <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1">
+      <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">
         <small class="font-monospace text-muted text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
           <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }} title="Try it on StackBlitz">


### PR DESCRIPTION
### Description

This PR removes some CSS code used to define `.highlight-toolbar`:
* `border: solid var(--bs-border-color);` can be dropped safely since it's the default border color
* `border-width: 1px 0;` is replaced by `border-0 border-top border-bottom`
* `.btn-clipboard { margin-top: 0; margin-right: 0 }` is useless because we already use utilities in this case

https://github.com/twbs/bootstrap/blob/8a3540803015cf9e1a9406ad7ffbfb264ac72ec9/site/layouts/shortcodes/example.html#L37

### Motivation & Context

Less CSS and more utilities

### Type of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37817--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#example (for example) in light/dark mode for non-regression