### PR TITLE
Remove duplicate definition of `--bs-highlight-bg` in `scss/_root.scss`

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -122,8 +122,6 @@
   --#{$prefix}form-control-disabled-bg: var(--#{$prefix}secondary-bg);
   // scss-docs-end form-control-vars
 
-  --#{$prefix}highlight-bg: #{$mark-bg};
-
   @each $name, $value in $grid-breakpoints {
     --#{$prefix}breakpoint-#{$name}: #{$value};
   }


### PR DESCRIPTION
### Description

This PR removes a duplicate definition of `--bs-highlight-bg` in `scss/_root.scss` which was defined 2 times with the same value:

https://github.com/twbs/bootstrap/blob/8a3540803015cf9e1a9406ad7ffbfb264ac72ec9/scss/_root.scss#L97

https://github.com/twbs/bootstrap/blob/8a3540803015cf9e1a9406ad7ffbfb264ac72ec9/scss/_root.scss#L125

### Type of changes

- Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed

#### Live previews

For non-regression:

- https://deploy-preview-37820--twbs-bootstrap.netlify.app/docs/5.3/content/typography/#inline-text-elements
