### PR TITLE
Switch from none keyword value to a fake shadow for btn-link

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -169,7 +169,7 @@
   --#{$prefix}btn-active-border-color: transparent;
   --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
   --#{$prefix}btn-disabled-border-color: transparent;
-  --#{$prefix}btn-box-shadow: none;
+  --#{$prefix}btn-box-shadow: 0 0 0 #000; // Can't use `none` as keyword negates all values when used with multiple shadows
   --#{$prefix}btn-focus-shadow-rgb: #{to-rgb(mix(color-contrast($primary), $primary, 15%))};
 
   text-decoration: $link-decoration;


### PR DESCRIPTION
It seems that any instance of `none` nullifies the other shadows, so this changes to a "false" shadow with no distance or blur. Unsure if there's a perf hit here, but since nothing renders, maybe not?

Fixes #37810.