### PR TITLE
Docs: fix `.btn-clipboard` and `.btn-edit` link hover color

### DIFF
--- a/site/assets/scss/_clipboard-js.scss
+++ b/site/assets/scss/_clipboard-js.scss
@@ -28,7 +28,7 @@
   @include border-radius(.25rem);
 
   &:hover {
-    color: var(--bs-link-color);
+    color: var(--bs-link-hover-color);
   }
 
   &:focus {


### PR DESCRIPTION
### Description

This PR fixes the color used to display link hover color for `.btn-clipboard` and `.btn-edit` in the documentation.
`--bs-link-color` and `--bs-link-hover-color` are very close in Bootstrap so we almost can't see the difference but conceptually, this is an error.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-37823--twbs-bootstrap.netlify.app/
