### PR TITLE
Drop unused `.bg-body-emphasis`

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -672,7 +672,6 @@ $utilities: map-merge(
           "transparent": transparent,
           "body-secondary": rgba(var(--#{$prefix}secondary-bg-rgb), var(--#{$prefix}bg-opacity)),
           "body-tertiary": rgba(var(--#{$prefix}tertiary-bg-rgb), var(--#{$prefix}bg-opacity)),
-          "body-emphasis": rgba(var(--#{$prefix}emphasis-bg-rgb), var(--#{$prefix}bg-opacity)),
         )
       )
     ),


### PR DESCRIPTION
### Description

This PR suggests to drop `.bg-body-emphasis` generation since it is not used anywhere and is not even displayed in our [Utilities > Background > Background](https://getbootstrap.com/docs/5.3/utilities/background/#background-color) color documentation.

If we need to still create it for consistency:
* It must be added to [Utilities > Background > Background](https://getbootstrap.com/docs/5.3/utilities/background/#background-color) color documentation
* `--bs-emphasis-bg` and `--bs-emphasis-bg-rgb` must be defined which is not the case right now

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed