### PR TITLE
Docs: missing deprecated callout for `list-group-item-variant()` mixin

### DIFF
--- a/scss/mixins/_list-group.scss
+++ b/scss/mixins/_list-group.scss
@@ -1,6 +1,5 @@
 @include deprecate("`list-group-item-variant()`", "v5.3.0", "v6.0.0");
 
-
 // List Groups
 
 // scss-docs-start list-group-mixin

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -319,6 +319,8 @@ As part of Bootstrap's evolving CSS variables approach, list groups now use loca
 
 ### Sass mixins
 
+{{< deprecated-in "5.3.0" >}}
+
 Used in combination with `$theme-colors` to generate the [contextual variant classes](#variants) for `.list-group-item`s.
 
 {{< scss-docs name="list-group-mixin" file="scss/mixins/_list-group.scss" >}}


### PR DESCRIPTION
### Description

This PR suggests to add a deprecate callout in the [List group > Sass mixins](https://getbootstrap.com/docs/5.3/components/list-group/#sass-mixins) section for consistency with what's done in [Alerts > Sass mixins](https://getbootstrap.com/docs/5.3/components/alerts/#sass-mixin) section.

Indeed `alert-variant()` deprecated mixin got this callout and it's missing for `list-group-item-variant()` deprecated mixin.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37829--twbs-bootstrap.netlify.app/docs/5.3/components/list-group/#sass-mixins>

