### PR TITLE
Remove obsolete comment from `_variables.scss`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1334,7 +1334,7 @@ $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-start accordion-variables
 $accordion-padding-y:                     1rem !default;
 $accordion-padding-x:                     1.25rem !default;
-$accordion-color:                         var(--#{$prefix}body-color) !default; // Sass variable because of $accordion-button-icon
+$accordion-color:                         var(--#{$prefix}body-color) !default;
 $accordion-bg:                            var(--#{$prefix}body-bg) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;


### PR DESCRIPTION
Just removing an obsolete comment from `_variables.scss` since we don't use anymore a Sass var but a custom property and also because `$accordion-button-icon` uses `$accordion-icon-color` and not `$accordion-color`.