### PR TITLE
Remove autofocus on theme switch when page is loaded

### DIFF
--- a/site/static/docs/5.3/assets/js/color-modes.js
+++ b/site/static/docs/5.3/assets/js/color-modes.js
@@ -27,7 +27,7 @@
 
   setTheme(getPreferredTheme())
 
-  const showActiveTheme = theme => {
+  const showActiveTheme = (theme, focus = false) => {
     const themeSwitcher = document.querySelector('#bd-theme')
     const themeSwitcherText = document.querySelector('#bd-theme-text')
     const activeThemeIcon = document.querySelector('.theme-icon-active use')
@@ -44,7 +44,10 @@
     activeThemeIcon.setAttribute('href', svgOfActiveBtn)
     const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
     themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
-    themeSwitcher.focus()
+
+    if (focus) {
+      themeSwitcher.focus()
+    }
   }
 
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -62,7 +65,7 @@
           const theme = toggle.getAttribute('data-bs-theme-value')
           localStorage.setItem('theme', theme)
           setTheme(theme)
-          showActiveTheme(theme)
+          showActiveTheme(theme, true)
         })
       })
   })


### PR DESCRIPTION
### Description

From https://github.com/twbs/bootstrap/pull/37780, when our docs website is loaded, the theme switch gets automatically the focus which causes an issue of a11y since we can't go directly on the skip links.

I suppose that this modification was rather made to only give back the focus to the dropdown when a change is made and not during the init phase.

In order to understand what I'm saying, simply load https://twbs-bootstrap.netlify.app/. The focus (blue outline difficult to see) is automatically on the dropdown, then press <kbd>Tab</kbd>; "New in v5.3" will be focused instead of the skip links.

I tried to isolate the init phase in the script to force the focus only after. Please double-check that the a11y modifications made in the previous PR are still OK but it seems so.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37836--twbs-bootstrap.netlify.app/>
