### PR TITLE
fix: remove overflow:hidden from progressbar (issue: 37821)

### DIFF
--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -34,7 +34,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  overflow: hidden;
   color: var(--#{$prefix}progress-bar-color);
   text-align: center;
   white-space: nowrap;


### PR DESCRIPTION
### Description

This PR reverts changes made with https://github.com/twbs/bootstrap/pull/29629 for IE (with v5 we dropped the support). If percentage of progressbar is low (ie: 0%), the progressbar do not show labels (or cut it), therefore i have removed the overflow:hidden.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

Closes https://github.com/twbs/bootstrap/issues/37821
