### PR TITLE
Docs: update progress markup in Color modes page

### DIFF
--- a/site/content/docs/5.3/customize/color-modes.md
+++ b/site/content/docs/5.3/customize/color-modes.md
@@ -79,8 +79,8 @@ For example, despite using `data-bs-theme="dark"` on a random `<div>`, the `<div
 
   <p>This should be shown in a <strong>dark</strong> theme at all times.</p>
 
-  <div class="progress mb-4">
-    <div class="progress-bar" role="progressbar" aria-label="Basic example" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress mb-4" role="progressbar" aria-label="Basic example" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+    <div class="progress-bar" style="width: 25%"></div>
   </div>
 
   <div class="dropdown mb-4">
@@ -108,8 +108,8 @@ For example, despite using `data-bs-theme="dark"` on a random `<div>`, the `<div
 
     <p>This should be shown in a <strong>light</strong> theme at all times.</p>
 
-    <div class="progress mb-4">
-      <div class="progress-bar" role="progressbar" aria-label="Basic example" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress mb-4" role="progressbar" aria-label="Basic example" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-bar" style="width: 25%"></div>
     </div>
 
     <div class="dropdown">


### PR DESCRIPTION
### Description

Due to PRs happening at the same time, https://github.com/twbs/bootstrap/pull/36831 was merged after the big color modes one and we forgot to update the markup of the progress component in the "Color modes" page.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-37863--twbs-bootstrap.netlify.app/docs/5.3/customize/color-modes/#nesting-color-modes>