### PR TITLE
Remove outdated comment from `$input-border-color` variable

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -879,7 +879,7 @@ $input-disabled-bg:                     var(--#{$prefix}form-control-disabled-bg
 $input-disabled-border-color:           null !default;
 
 $input-color:                           var(--#{$prefix}body-color) !default;
-$input-border-color:                    var(--#{$prefix}border-color) !default; //$gray-400
+$input-border-color:                    var(--#{$prefix}border-color) !default;
 $input-border-width:                    $input-btn-border-width !default;
 $input-box-shadow:                      $box-shadow-inset !default;
 


### PR DESCRIPTION
Before fc3f4b67d65c575daa661ecf31cf59b4ff3cced5, `$input-border-color` was set to `$gray-400`. It is now set to `var(--bs-border-color)` instead, which returns `$gray-300`. You can see the slight change by comparing [v5.2 docs](https://getbootstrap.com/docs/5.2/forms/form-control/) to [v5.3 docs](https://getbootstrap.com/docs/5.3/forms/form-control/), or in the following GIF:

![input-border-color](https://user-images.githubusercontent.com/1078430/212177184-7159ad62-90a7-4947-b778-05a2a17fcb35.gif)

I imagine this change was intentional, as #35857 specifically mentions using a global `border-color`. In that case, we should remove the comment, as this PR does, to avoid confusion.

Otherwise, `$input-border-color` should be set to another custom property that translates to `$gray-400` as before.

See also #37835 for a similar, recently merged PR.