### PR TITLE
Fix `.form-control` in dark mode

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -115,11 +115,6 @@
   --#{$prefix}box-shadow-lg: #{$box-shadow-lg};
   --#{$prefix}box-shadow-inset: #{$box-shadow-inset};
 
-  // scss-docs-start form-control-vars
-  --#{$prefix}form-control-bg: var(--#{$prefix}body-bg);
-  --#{$prefix}form-control-disabled-bg: var(--#{$prefix}secondary-bg);
-  // scss-docs-end form-control-vars
-
   // Focus styles
   // scss-docs-start root-focus-variables
   --#{$prefix}focus-ring-width: #{$focus-ring-width};

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -873,9 +873,9 @@ $input-padding-y-lg:                    $input-btn-padding-y-lg !default;
 $input-padding-x-lg:                    $input-btn-padding-x-lg !default;
 $input-font-size-lg:                    $input-btn-font-size-lg !default;
 
-$input-bg:                              var(--#{$prefix}form-control-bg) !default;
+$input-bg:                              var(--#{$prefix}body-bg) !default;
 $input-disabled-color:                  null !default;
-$input-disabled-bg:                     var(--#{$prefix}form-control-disabled-bg) !default;
+$input-disabled-bg:                     var(--#{$prefix}secondary-bg) !default;
 $input-disabled-border-color:           null !default;
 
 $input-color:                           var(--#{$prefix}body-color) !default;

--- a/site/content/docs/5.3/forms/form-control.md
+++ b/site/content/docs/5.3/forms/form-control.md
@@ -173,12 +173,6 @@ Learn more about [support for datalist elements](https://caniuse.com/datalist).
 
 ## CSS
 
-### Variables
-
-Form controls make use of a small amount of CSS variables to support custom styling across color modes.
-
-{{< scss-docs name="form-control-vars" file="scss/_root.scss" >}}
-
 ### Sass variables
 
 `$input-*` are shared across most of our form controls (and not buttons).


### PR DESCRIPTION
Removes the CSS variables for `.form-control`. The problem here is we're reassigning an earlier custom property `--bs-body-bg` with a new custom property `--bs-form-control-bg`, but the value of that original one stays computed to the first instance. Only two ways to combat this is to redeclare the variable for dark mode (adds file size), or to remove the extra custom variable. Chose to do the latter as this matches our other form controls.

Fixes #37891.

**Before and after:**

![CleanShot 2023-01-16 at 15 36 51@2x](https://user-images.githubusercontent.com/98681/212780745-c95929d9-00a6-403a-b8c3-5f431c00acc8.png)

![CleanShot 2023-01-16 at 15 35 06@2x](https://user-images.githubusercontent.com/98681/212780741-bdb6a5c6-89d4-4244-bd48-032cb9cbcd10.png)