### PR TITLE
Docs: Doc Scrollspy correction

### DIFF
--- a/site/layouts/_default/docs.html
+++ b/site/layouts/_default/docs.html
@@ -1,4 +1,4 @@
-{{ define "body_override" }}<body data-bs-spy="scroll" tabindex="0" data-bs-target="#TableOfContents">{{ end }}
+{{ define "body_override" }}<body tabindex="0"{{ if (eq .Page.Params.toc true) }} data-bs-spy="scroll" data-bs-target="#TableOfContents"{{ end }}>{{ end }}
 {{ define "main" }}
   <div class="container-xxl bd-gutter mt-3 my-md-4 bd-layout">
     <aside class="bd-sidebar">


### PR DESCRIPTION
### Description

Make the doc scrollspy appear only when needed.

### Motivation & Context

Every page that had no table of content (aka .Page.Params.toc = false) had its active link removed in the left sidebar, for example : [Interactions](https://main--twbs-bootstrap.netlify.app/docs/5.3/utilities/interactions/), [Visually hidden](https://main--twbs-bootstrap.netlify.app/docs/5.3/helpers/visually-hidden/).

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-37898--twbs-bootstrap.netlify.app/docs/5.3/utilities/interactions/>
- <https://deploy-preview-37898--twbs-bootstrap.netlify.app/docs/5.3/helpers/visually-hidden/>

### Related issues

NA
