### PR TITLE
Update gutters docs

### DIFF
--- a/site/content/docs/5.3/layout/gutters.md
+++ b/site/content/docs/5.3/layout/gutters.md
@@ -71,7 +71,7 @@ An alternative solution is to add a wrapper around the `.row` with the `.overflo
 
 ## Horizontal & vertical gutters
 
-`.g-*` classes can be used to control the horizontal gutter widths, for the following example we use a smaller gutter width, so there won't be a need to add the `.overflow-hidden` wrapper class.
+`.g-*` classes can be used to control the horizontal and vertical gutter widths, for the following example we use a smaller gutter width, so there won't be a need to add the `.overflow-hidden` wrapper class.
 
 {{< example class="bd-example-cols" >}}
 <div class="container text-center">

--- a/site/content/docs/5.3/layout/gutters.md
+++ b/site/content/docs/5.3/layout/gutters.md
@@ -71,7 +71,7 @@ An alternative solution is to add a wrapper around the `.row` with the `.overflo
 
 ## Horizontal & vertical gutters
 
-`.g-*` classes can be used to control the horizontal and vertical gutter widths, for the following example we use a smaller gutter width, so there won't be a need to add the `.overflow-hidden` wrapper class.
+Use `.g-*` classes to control the horizontal and vertical grid gutters. In the example below, we use a smaller gutter width, so there isn't a need for the `.overflow-hidden` wrapper class.
 
 {{< example class="bd-example-cols" >}}
 <div class="container text-center">


### PR DESCRIPTION
### Description

In Bootstrap documentation, in Layout => Gutters. In the Horizontal & vertical gutters section, I changed the description from ".g-* classes can be used to control the horizontal gutter widths" to ".g-* classes can be used to control the horizontal and vertical gutter widths".

### Motivation & Context

The documentation was misleading. In fact, the classes in question are used to modify horizontal and vertical gutters. However, it indicates that they only change the horizontal section. This might lead users, especially new ones, to confuse the classes  "g-*" with "gx-*"

I thought of introducing these changes after checking issue #37914 opened by marcomarsala.

### Type of changes

Documentation update

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Live preview:
https://deploy-preview-37918--twbs-bootstrap.netlify.app/docs/5.3/layout/gutters/

### Checklist

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [X] My change introduces changes to the documentation
- [X] I have updated the documentation accordingly

### Related issues

https://github.com/twbs/bootstrap/issues/37914
