### PR TITLE
Docs: add scroll-margin-top for keyboard navigation

### DIFF
--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -1,0 +1,5 @@
+// When navigating with the keyboard, prevent focus from landing behind the sticky header
+
+main *:focus {
+  scroll-margin-top: 100px;
+}

--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -52,6 +52,7 @@ $enable-cssgrid: true; // stylelint-disable-line scss/dollar-variable-default
 @import "colors";
 @import "clipboard-js";
 @import "placeholder-img";
+@import "scrolling";
 
 // Load docs dependencies
 @import "syntax";


### PR DESCRIPTION
### Description

Adds `scroll-margin-top` to the documentation styles https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top

### Motivation & Context

When navigating with the keyboard, if you scroll down a documentation page and then navigate in reverse (`Shift+Tab`), keyboard focus can land _behind_ the sticky header. This small CSS addition prevents this from happening.

With a hat-tip to @joelamyman for the inspiration.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Video

Screen recording showing the reverse keyboard navigation before (with me jiggling the mouse at the top whenever keyboard focus is obscured by the sticky header) and after this addition.

https://user-images.githubusercontent.com/895831/213894362-fd4a659e-9e36-460a-87af-cbbc8636f8f9.mp4

Note that code blocks still seem to have a funky behaviour, but this looks more like a browser bug/shortcoming.

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

https://deploy-preview-37926--twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/#community

Scroll down/jump to "Community", then navigate in reverse using `Shift+Tab`