### PR TITLE
Remove color picker borders on Chromium based browsers

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -205,6 +205,7 @@ textarea {
   }
 
   &::-webkit-color-swatch {
+    border: 0 !important; // stylelint-disable-line declaration-no-important
     @include border-radius($input-border-radius);
   }
 


### PR DESCRIPTION
### Description

The PR [Update .form-control-color sizing and styles #36156](https://github.com/twbs/bootstrap/pull/36156) removes the Firefox-specific border on the swatch of the color picker:
```css
  &::-moz-color-swatch {
    border: 0 !important; // stylelint-disable-line declaration-no-important
    @include border-radius($input-border-radius);
  }
```

But nothing was made for Chromium based browsers and I don't see why the visual rendering of the color picker should be different on Firefox only.

### Motivation & Context

Keep the code consistent between all browsers.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

[https://deploy-preview-37936--twbs-bootstrap.netlify.app/docs/5.3/forms/form-control/#color](https://deploy-preview-37936--twbs-bootstrap.netlify.app/docs/5.3/forms/form-control/#color)

