### PR TITLE
Rtl support feature

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -10,3 +10,4 @@
 @import "helpers/stretched-link";
 @import "helpers/text-truncation";
 @import "helpers/vr";
+@import "helpers/rtl";

--- a/scss/helpers/_rtl.scss
+++ b/scss/helpers/_rtl.scss
@@ -1,0 +1,3 @@
+.rtl{
+    direction: rtl !important;
+}

--- a/scss/helpers/_rtl.scss
+++ b/scss/helpers/_rtl.scss
@@ -1,3 +1,3 @@
 .rtl{
-    direction: rtl !important;
+  direction: rtl;
 }

--- a/site/content/docs/5.3/helpers/right-to-left.md
+++ b/site/content/docs/5.3/helpers/right-to-left.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Right to lneft
+title: Right to left
 description: Direct your elements from the right to the left.
 group: helpers
 toc: false

--- a/site/content/docs/5.3/helpers/right-to-left.md
+++ b/site/content/docs/5.3/helpers/right-to-left.md
@@ -1,0 +1,49 @@
+---
+layout: docs
+title: Right to lneft
+description: Direct your elements from the right to the left.
+group: helpers
+toc: false
+---
+
+For content that should be directed from the right to the left instead of from the left to the right, add to it the `.rtl` class.
+
+{{< example >}}
+<!-- navbar -->
+ <nav class="navbar navbar-expand-lg bg-body-tertiary rtl">
+        <div class="container-fluid">
+          <a class="navbar-brand" href="#">Navbar</a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="#">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#">Link</a>
+              </li>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  Dropdown
+                </a>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="#">Action</a></li>
+                  <li><a class="dropdown-item" href="#">Another action</a></li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" href="#">Something else here</a></li>
+                </ul>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link disabled">Disabled</a>
+              </li>
+            </ul>
+            <form class="d-flex" role="search">
+              <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+              <button class="btn btn-outline-success" type="submit">Search</button>
+            </form>
+          </div>
+        </div>
+      </nav>
+{{< /example >}}

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -108,6 +108,7 @@
     - title: Icon link
     - title: Position
     - title: Ratio
+    - title: Right to Left
     - title: Stacks
     - title: Stretched link
     - title: Text truncation


### PR DESCRIPTION
### Description

I tried to add support for RTL. I think RTL support is essential. Especially for websites that use a language written from left to right, such as Arabic. I tried to do so in an easy way where all the user needs to do is to add the class "rtl" and their component will become in the right to left direction.
I also updated the documentation accordingly.

### Motivation & Context

As a web developer, I did feel the need to use the rtl direction on different bootstrap elements, especially the navbar. I then realized that setting a class named "rtl" that updates the direction of any element and sets it to "rtl" is a good option.
The Issue https://github.com/twbs/bootstrap/issues/37938 was opened by [ahmedaabuwarda](https://github.com/ahmedaabuwarda) as a feature request regarding this matter.


### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [X] My change introduces changes to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

I used the rtl mode on the navbar. Here is a preview of the result I got, which is exactly the expected behavior:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/76244671/214941616-48257755-b1aa-41f1-a69c-c3060a6878eb.png">

### Related issues

(https://github.com/twbs/bootstrap/issues/37938)
