### PR TITLE
Add keydown listener to `backdrop` to enable static `offcanvas` to close on `Esc`

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "43.0 kB"
+      "maxSize": "43.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -174,6 +174,12 @@ class Offcanvas extends BaseComponent {
       this.hide()
     }
 
+    const keydownCallback = event => {
+      if (event.key === ESCAPE_KEY) {
+        this.hide()
+      }
+    }
+
     // 'static' option will be translated to true, and booleans will keep their value
     const isVisible = Boolean(this._config.backdrop)
 
@@ -182,7 +188,8 @@ class Offcanvas extends BaseComponent {
       isVisible,
       isAnimated: true,
       rootElement: this._element.parentNode,
-      clickCallback: isVisible ? clickCallback : null
+      clickCallback: isVisible ? clickCallback : null,
+      keydownCallback: this._config.keyboard ? keydownCallback : null
     })
   }
 

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -17,8 +17,8 @@ const NAME = 'backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
 const EVENT_KEY = `.bs.${NAME}`
-const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 const EVENT_KEYDOWN = `keydown.bs.${NAME}`
+const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
 
 const Default = {
   className: 'modal-backdrop',

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -16,13 +16,16 @@ import Config from './config.js'
 const NAME = 'backdrop'
 const CLASS_NAME_FADE = 'fade'
 const CLASS_NAME_SHOW = 'show'
+const EVENT_KEY = `.bs.${NAME}`
 const EVENT_MOUSEDOWN = `mousedown.bs.${NAME}`
+const EVENT_KEYDOWN = `keydown.bs.${NAME}`
 
 const Default = {
   className: 'modal-backdrop',
   clickCallback: null,
   isAnimated: false,
   isVisible: true, // if false, we use the backdrop helper without adding any element to the dom
+  keydownCallback: null,
   rootElement: 'body' // give the choice to place backdrop under different elements
 }
 
@@ -31,6 +34,7 @@ const DefaultType = {
   clickCallback: '(function|null)',
   isAnimated: 'boolean',
   isVisible: 'boolean',
+  keydownCallback: '(function|null)',
   rootElement: '(element|string)'
 }
 
@@ -99,7 +103,7 @@ class Backdrop extends Config {
       return
     }
 
-    EventHandler.off(this._element, EVENT_MOUSEDOWN)
+    EventHandler.off(this._element, EVENT_KEY)
 
     this._element.remove()
     this._isAppended = false
@@ -137,6 +141,12 @@ class Backdrop extends Config {
     EventHandler.on(element, EVENT_MOUSEDOWN, () => {
       execute(this._config.clickCallback)
     })
+
+    if (this._config.keydownCallback) {
+      EventHandler.on(document, EVENT_KEYDOWN, event => {
+        execute(this._config.keydownCallback, [event])
+      })
+    }
 
     this._isAppended = true
   }

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -156,6 +156,74 @@ describe('Offcanvas', () => {
       })
     })
 
+    it('should hide if backdrop is static and esc key is pressed on document', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('div')
+        const offCanvas = new Offcanvas(offCanvasEl, { backdrop: 'static' })
+
+        const keydownEscEvent = createEvent('keydown')
+        keydownEscEvent.key = 'Escape'
+
+        const spyHide = spyOn(offCanvas, 'hide')
+
+        offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+          document.dispatchEvent(keydownEscEvent)
+          expect(spyHide).toHaveBeenCalled()
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
+
+    it('should not hide if backdrop is static and esc key is pressed on document but keyboard = false', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('div')
+        const offCanvas = new Offcanvas(offCanvasEl, { backdrop: 'static', keyboard: false })
+
+        const keydownEscEvent = createEvent('keydown')
+        keydownEscEvent.key = 'Escape'
+
+        const spyHide = spyOn(offCanvas, 'hide')
+
+        offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+          expect(offCanvas._config.keyboard).toBeFalse()
+
+          document.dispatchEvent(keydownEscEvent)
+          expect(spyHide).not.toHaveBeenCalled()
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
+
+    it('should not hide if backdrop is static but key other than esc is pressed on document', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('div')
+        const offCanvas = new Offcanvas(offCanvasEl, { backdrop: 'static' })
+
+        const keydownEvent = createEvent('keydown')
+        keydownEvent.key = 'Tab'
+
+        const spyHide = spyOn(offCanvas, 'hide')
+
+        offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+          document.dispatchEvent(keydownEvent)
+          expect(spyHide).not.toHaveBeenCalled()
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
+
     it('should call `hide` on resize, if element\'s position is not fixed any more', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="offcanvas-lg"></div>'

--- a/js/tests/unit/util/backdrop.spec.js
+++ b/js/tests/unit/util/backdrop.spec.js
@@ -191,6 +191,32 @@ describe('Backdrop', () => {
       })
     })
 
+    describe('keydown callback', () => {
+      it('should execute keydown callback on keydown event', () => {
+        return new Promise(resolve => {
+          const spy = jasmine.createSpy('spy')
+
+          const instance = new Backdrop({
+            isVisible: true,
+            isAnimated: false,
+            keydownCallback: () => spy()
+          })
+          const endTest = () => {
+            setTimeout(() => {
+              expect(spy).toHaveBeenCalled()
+              resolve()
+            }, 10)
+          }
+
+          instance.show(() => {
+            const keydownEvent = new Event('keydown', { bubbles: true, cancelable: true })
+            document.querySelector(CLASS_BACKDROP).dispatchEvent(keydownEvent)
+            endTest()
+          })
+        })
+      })
+    })
+
     describe('animation callbacks', () => {
       it('should show and hide backdrop after counting transition duration if it is animated', () => {
         return new Promise(resolve => {


### PR DESCRIPTION
### Description
Added keydown event listener to `backdrop`.
Updated static `offcanvas` to close on `esc` when ``data-bs-keyboard = true``, which is also the current default setting for this attribute. 
If ``data-bs-keyboard = false`` the `offcanvas` will not close on any `esc` press.

### Motivation & Context
This is a bug fix and provides `offcanvas` with similar behavior on `esc` keydown to `modal`, `esc` pressed on either `static offcanvas` or its `backdrop` will close it.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

#### Live previews
Change can be verified using this code snippet (showcases all scenarios): 


```html
<!--Static offcanvs with data-bs-keyboard=true closes on esc-->
    <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#staticBackdrop"
        aria-controls="staticBackdrop">
        static offcanvas closes on esc
    </button>
    <div class="offcanvas offcanvas-start" data-bs-backdrop="static" data-bs-keyboard="true" tabindex="-1"
        id="staticBackdrop" aria-labelledby="staticBackdropLabel">
        <div class="offcanvas-header">
            <h5 class="offcanvas-title" id="staticBackdropLabel">Offcanvas</h5>
            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
        </div>
        <div class="offcanvas-body">
            <div>
                I will not close if you click outside of me, but will close on esc
            </div>
        </div>
    </div>

    <!--Static offcanvs with data-bs-keyboard=false attribute dosen't close on esc-->
    <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-keyboard="false"
        data-bs-target="#staticBackdropNoKeyboard" aria-controls="staticBackdrop">
        static offcanvas closes on esc
    </button>
    <div class="offcanvas offcanvas-start" data-bs-backdrop="static" tabindex="-1" id="staticBackdropNoKeyboard"
        aria-labelledby="staticBackdropLabel">
        <div class="offcanvas-header">
            <h5 class="offcanvas-title" id="staticBackdropLabel">Offcanvas</h5>
            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
        </div>
        <div class="offcanvas-body">
            <div>I will not close if you click on press esc outside of me.</div>
        </div>
    </div>

    <!--Non-static offcanvs behavior not changed-->
    <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#nonStaticBackdrop"
        aria-controls="staticBackdrop">
        non-static offcanvas
    </button>
    <div class="offcanvas offcanvas-start" tabindex="-1" id="nonStaticBackdrop" aria-labelledby="staticBackdropLabel">
        <div class="offcanvas-header">
            <h5 class="offcanvas-title" id="staticBackdropLabel">Offcanvas</h5>
            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
        </div>
        <div class="offcanvas-body">
            <div>I will close if you click outside of me.</div>
        </div>
    </div>
```

### Related issues
Closes #37155
<!-- Please link any related issues here. -->
