### PR TITLE
Avoid inheritance issues on border-width utilities

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -177,8 +177,9 @@ $utilities: map-merge(
       values: $utilities-border-subtle
     ),
     "border-width": (
-      css-var: true,
-      css-variable-name: border-width,
+      property: border-width,
+      // css-var: true,
+      // css-variable-name: border-width,
       class: border,
       values: $border-widths
     ),

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -51,6 +51,8 @@ If you're migrating from our previous alpha release of v5.3.0, please reviewing 
 
 - Added new link utilities for link color opacity, underline offset, underline color, and underline opacity. [Explore the new links utilities.]({{< docsref "/utilities/link" >}})
 
+- CSS variable based `border-width` utilities have been reverted to set their property directly (as was done prior to v5.2.0). This avoids inheritance issues across nested elements, including tables.
+
 ### Docs
 
 - Examples are now displayed with the appropriate light or dark color mode as dictated by the setting in our docs. However, they lack an individual color mode picker for the time being.


### PR DESCRIPTION
Fixes #37963, fixes #37988.

We may have to roll back some other utilities that became CSS variable only depending on how folks feel. In v6, we'll aim to lock this down further I think, too, and have some stronger guidelines around when to use them.