### PR TITLE
Reboot: change `kbd` markup

### DIFF
--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -205,7 +205,7 @@ Use the `<kbd>` to indicate input that is typically entered via keyboard.
 
 {{< example >}}
 To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
-To edit settings, press <kbd><kbd>Ctrl</kbd> + <kbd>,</kbd></kbd>
+To edit settings, press <kbd>Ctrl</kbd> + <kbd>,</kbd>
 {{< /example >}}
 
 ## Sample output


### PR DESCRIPTION
### Description

Fix a typo in Reboot.md, change from <kbd>CTRL + ,</kbd> to <kbd>CTRL</kbd> + <kbd> ,</kbd>

### Motivation & Context

As mentioned in the related issue, <kbd>CTRL + ,</kbd> is a little confusing since it shows "+" as if it was part of the key input. However, it is not, and I believe it is better if we kept it outside the kbd tag.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

https://deploy-preview-38001--twbs-bootstrap.netlify.app/docs/5.3/content/reboot/#user-input

The updated section should look like this:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/76244671/216765431-9e223976-0afe-4212-9b89-1c2f7677a7c9.png">


### Related issues

Closes #38000
