### PR TITLE
Docs: Use ESM Popper CDN reference in 'Using Bootstrap as a module'

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -82,6 +82,7 @@ params:
     js_bundle_hash:   "sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
     popper:           "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
     popper_hash:      "sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
+    popper_esm:       "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/esm/popper.min.js"
 
   anchors:
     min: 2

--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -71,7 +71,7 @@ To fix this, you can use an `importmap` to resolve the arbitrary module names to
     <script type="importmap">
     {
       "imports": {
-        "@popperjs/core": "{{< param "cdn.popper" >}}",
+        "@popperjs/core": "{{< param "cdn.popper_esm" >}}",
         "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@{{< param "current_version" >}}/dist/js/bootstrap.esm.min.js"
       }
     }


### PR DESCRIPTION
### Description

This PR adds a new `cdn.popper_esm` config element used in "Using Bootstrap as a module" page to make this example works and consistent with https://github.com/twbs/examples/blob/main/sass-js-esm/index.html.

Another way would be to keep `cdn.popper` and to replace `umd` by `esm` on the fly thanks to a Hugo pipe or something.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38006--twbs-bootstrap.netlify.app/docs/5.3/getting-started/javascript/#using-bootstrap-as-a-module>

### Related issues

Closes #37978
