### PR TITLE
Fix list group colors by using `*-text-emphasis` CSS vars in Sass loop

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -182,7 +182,7 @@
 
 @each $state in map-keys($theme-colors) {
   .list-group-item-#{$state} {
-    --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text);
+    --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text-emphasis);
     --#{$prefix}list-group-bg: var(--#{$prefix}#{$state}-bg-subtle);
     --#{$prefix}list-group-border-color: var(--#{$prefix}#{$state}-border-subtle);
     --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
@@ -190,8 +190,8 @@
     --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);
     --#{$prefix}list-group-action-active-bg: var(--#{$prefix}#{$state}-border-subtle);
     --#{$prefix}list-group-active-color: var(--#{$prefix}#{$state}-bg-subtle);
-    --#{$prefix}list-group-active-bg: var(--#{$prefix}#{$state}-text);
-    --#{$prefix}list-group-active-border-color: var(--#{$prefix}#{$state}-text);
+    --#{$prefix}list-group-active-bg: var(--#{$prefix}#{$state}-text-emphasis);
+    --#{$prefix}list-group-active-border-color: var(--#{$prefix}#{$state}-text-emphasis);
   }
 }
 // scss-docs-end list-group-modifiers


### PR DESCRIPTION
### Description

Change the list group text color to `*-text-emphasis` to fix variant colors not applied.

### Motivation & Context

List group text colors need the same update as in https://github.com/twbs/bootstrap/pull/38003 for the same reason as it can be seen in https://twbs-bootstrap.netlify.app/docs/5.3/components/list-group/#variants.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38008--twbs-bootstrap.netlify.app/docs/5.3/components/list-group/#variants>