### PR TITLE
unify `offcanvas` `keydown` event logic with `modal`

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -208,7 +208,6 @@ class Modal extends BaseComponent {
       }
 
       if (this._config.keyboard) {
-        event.preventDefault()
         this.hide()
         return
       }

--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -198,12 +198,12 @@ class Offcanvas extends BaseComponent {
         return
       }
 
-      if (!this._config.keyboard) {
-        EventHandler.trigger(this._element, EVENT_HIDE_PREVENTED)
+      if (this._config.keyboard) {
+        this.hide()
         return
       }
 
-      this.hide()
+      EventHandler.trigger(this._element, EVENT_HIDE_PREVENTED)
     })
   }
 


### PR DESCRIPTION
### Description

Since the `offcanvas` `keydown` event listener behaves like the `modal` `keydown` listener, the former was refactored like the `modal`. Making it more readable by using positive conditions instead of negative ones.

### Motivation & Context

To make refactor and bugfix separated, a new PR was opened as discussed [in this comment](https://github.com/twbs/bootstrap/pull/37968#discussion_r1097420274).

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

#### Live previews

N/A

### Related issues

Splited from #37968