### PR TITLE
Remove `debug` references from DocSearch v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Have a bug or a feature request? Please first read the [issue guidelines](https:
 
 Bootstrap's documentation, included in this repo in the root directory, is built with [Hugo](https://gohugo.io/) and publicly hosted on GitHub Pages at <https://getbootstrap.com/>. The docs may also be run locally.
 
-Documentation search is powered by [Algolia's DocSearch](https://docsearch.algolia.com/). Working on our search? Be sure to set `debug: true` in `site/assets/js/search.js`.
+Documentation search is powered by [Algolia's DocSearch](https://docsearch.algolia.com/).
 
 ### Running documentation locally
 

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -40,8 +40,6 @@
 
         return item
       })
-    },
-    // Set debug to `true` if you want to inspect the dropdown
-    debug: false
+    }
   })
 })()


### PR DESCRIPTION
### Description

This PR removes any references to `debug` from DocSearch v2.
In v3, this configuration param doesn't exist anymore.

Sources:
* [v3 API documentation](https://docsearch.algolia.com/docs/api)
* [v2 API documentation](https://docsearch.algolia.com/docs/legacy/dropdown) (legacy doc)

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38032--twbs-bootstrap.netlify.app/docs/5.3/>
