### PR TITLE
Fix `$grid-breakpoints` SCSS unit tests init

### DIFF
--- a/scss/tests/utilities/_api.test.scss
+++ b/scss/tests/utilities/_api.test.scss
@@ -27,10 +27,9 @@ $utilities: ();
 
     $grid-breakpoints: (
       xs: 0,
-      sm: 576px,
-      md: 768px
-    );
-
+      sm: 333px,
+      md: 666px
+    ) !global;
 
     @include assert() {
       @include output() {
@@ -52,13 +51,13 @@ $utilities: ();
           font-size: 1.25rem !important;
         }
 
-        @media (min-width: 576px) {
+        @media (min-width: 333px) {
           .padding-sm-1rem {
             padding: 1rem !important;
           }
         }
 
-        @media (min-width: 768px) {
+        @media (min-width: 666px) {
           .padding-md-1rem {
             padding: 1rem !important;
           }


### PR DESCRIPTION
### Description

This PR changes the values of `$grid-breakpoints` in `scss/tests/utilities/_api.test.scss` to be sure that this value is well overriden. Since it was not the case, also added a `!global`.

If you need to manually test this modification, you can remove the `!global` and you'll see that even if we expect to change the small and medium values respectively to 333 and 666, the test still passes.

### Motivation & Context

Unit test worked because `$grid-breakpoints` contained the same values for small and medium breakpoints so we didn't detect that the overriden value didn't work.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
