### PR TITLE
Docs: uniformize disabled nav links for underline nav

### DIFF
--- a/site/content/docs/5.3/components/navs-tabs.md
+++ b/site/content/docs/5.3/components/navs-tabs.md
@@ -183,7 +183,7 @@ Take that same HTML, but use `.nav-underline` instead:
     <a class="nav-link" href="#">Link</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
+    <a class="nav-link disabled">Disabled</a>
   </li>
 </ul>
 {{< /example >}}


### PR DESCRIPTION
### Description

This PR suggests to uniformize the markup of the disabled `.nav-link` within `.nav-underline` with all the other disabled `.nav-link`s in this page (and more globally in our docs).

We use everywhere `<a class="nav-link disabled">Disabled</a>` and `<a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>` was introduced only in this example.

### Motivation & Context

Consistency 📐 

### Type of changes

- [x] Enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38040--twbs-bootstrap.netlify.app/docs/5.3/components/navs-tabs/#underline
