### PR TITLE
Update form validation styles to use new CSS variables for `color` and `border-color`

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -123,6 +123,11 @@
   // By default, there is no `--bs-focus-ring-x`, `--bs-focus-ring-y`, or `--bs-focus-ring-blur`, but we provide CSS variables with fallbacks to initial `0` values
   --#{$prefix}focus-ring-box-shadow: var(--#{$prefix}focus-ring-x, 0) var(--#{$prefix}focus-ring-y, 0) var(--#{$prefix}focus-ring-blur, 0) var(--#{$prefix}focus-ring-width) var(--#{$prefix}focus-ring-color);
   // scss-docs-end root-focus-variables
+
+  --#{$prefix}form-valid-color: #{$green-500};
+  --#{$prefix}form-valid-border-color: #{$green-500};
+  --#{$prefix}form-invalid-color: #{$red-500};
+  --#{$prefix}form-invalid-border-color: #{$red-500};
 }
 
 @if $enable-dark-mode {
@@ -173,6 +178,11 @@
 
     --#{$prefix}border-color: #{$border-color-dark};
     --#{$prefix}border-color-translucent: #{$border-color-translucent-dark};
+
+    --#{$prefix}form-valid-color: #{$green-300};
+    --#{$prefix}form-valid-border-color: #{$green-300};
+    --#{$prefix}form-invalid-color: #{$red-300};
+    --#{$prefix}form-invalid-border-color: #{$red-300};
     // scss-docs-end root-dark-mode-vars
   }
 }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -124,10 +124,12 @@
   --#{$prefix}focus-ring-box-shadow: var(--#{$prefix}focus-ring-x, 0) var(--#{$prefix}focus-ring-y, 0) var(--#{$prefix}focus-ring-blur, 0) var(--#{$prefix}focus-ring-width) var(--#{$prefix}focus-ring-color);
   // scss-docs-end root-focus-variables
 
-  --#{$prefix}form-valid-color: #{$green-500};
-  --#{$prefix}form-valid-border-color: #{$green-500};
-  --#{$prefix}form-invalid-color: #{$red-500};
-  --#{$prefix}form-invalid-border-color: #{$red-500};
+  // scss-docs-start root-form-validation-variables
+  --#{$prefix}form-valid-color: #{$form-valid-color};
+  --#{$prefix}form-valid-border-color: #{$form-valid-border-color};
+  --#{$prefix}form-invalid-color: #{$form-invalid-color};
+  --#{$prefix}form-invalid-border-color: #{$form-invalid-border-color};
+  // scss-docs-end root-form-validation-variables
 }
 
 @if $enable-dark-mode {
@@ -179,10 +181,10 @@
     --#{$prefix}border-color: #{$border-color-dark};
     --#{$prefix}border-color-translucent: #{$border-color-translucent-dark};
 
-    --#{$prefix}form-valid-color: #{$green-300};
-    --#{$prefix}form-valid-border-color: #{$green-300};
-    --#{$prefix}form-invalid-color: #{$red-300};
-    --#{$prefix}form-invalid-border-color: #{$red-300};
+    --#{$prefix}form-valid-color: #{$form-valid-color-dark};
+    --#{$prefix}form-valid-border-color: #{$form-valid-border-color-dark};
+    --#{$prefix}form-invalid-color: #{$form-invalid-color-dark};
+    --#{$prefix}form-invalid-border-color: #{$form-invalid-border-color-dark};
     // scss-docs-end root-dark-mode-vars
   }
 }

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -65,6 +65,13 @@ $form-select-indicator-dark:        url("data:image/svg+xml,<svg xmlns='http://w
 $form-switch-color-dark:            rgba($white, .25) !default;
 $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
 
+// scss-docs-start form-validation-colors-dark
+$form-valid-color-dark:             $green-300 !default;
+$form-valid-border-color-dark:      $green-300 !default;
+$form-invalid-color-dark:           $red-300 !default;
+$form-invalid-border-color-dark:    $red-300 !default;
+// scss-docs-end form-validation-colors-dark
+
 
 //
 // Accordion

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1080,6 +1080,13 @@ $form-feedback-icon-invalid-color:  $form-feedback-invalid-color !default;
 $form-feedback-icon-invalid:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>") !default;
 // scss-docs-end form-feedback-variables
 
+// scss-docs-start form-validation-colors
+$form-valid-color:                  $form-feedback-valid-color !default;
+$form-valid-border-color:           $form-feedback-valid-color !default;
+$form-invalid-color:                $form-feedback-invalid-color !default;
+$form-invalid-border-color:         $form-feedback-invalid-color !default;
+// scss-docs-end form-validation-colors
+
 // scss-docs-start form-validation-states
 $form-validation-states: (
   "valid": (

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1083,20 +1083,20 @@ $form-feedback-icon-invalid:        url("data:image/svg+xml,<svg xmlns='http://w
 // scss-docs-start form-validation-states
 $form-validation-states: (
   "valid": (
-    "color": var(--#{$prefix}success-text),
+    "color": var(--#{$prefix}form-valid-color),
     "icon": $form-feedback-icon-valid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}success),
     "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}success-rgb), $input-btn-focus-color-opacity),
-    "border-color": var(--#{$prefix}success),
+    "border-color": var(--#{$prefix}form-valid-border-color),
   ),
   "invalid": (
-    "color": var(--#{$prefix}danger-text),
+    "color": var(--#{$prefix}form-invalid-color),
     "icon": $form-feedback-icon-invalid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}danger),
     "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}danger-rgb), $input-btn-focus-color-opacity),
-    "border-color": var(--#{$prefix}danger),
+    "border-color": var(--#{$prefix}form-invalid-border-color),
   )
 ) !default;
 // scss-docs-end form-validation-states

--- a/site/content/docs/5.3/forms/validation.md
+++ b/site/content/docs/5.3/forms/validation.md
@@ -351,9 +351,23 @@ If your form layout allows it, you can swap the `.{valid|invalid}-feedback` clas
 
 ## CSS
 
+### Variables
+
+{{< added-in "5.3.0" >}}
+
+As part of Bootstrap's evolving CSS variables approach, forms now use local CSS variables for validation for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+
+{{< scss-docs name="root-form-validation-variables" file="scss/_root.scss" >}}
+
+These variables are also color mode adaptive, meaning they change color while in dark mode.
+
 ### Sass variables
 
 {{< scss-docs name="form-feedback-variables" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="form-validation-colors" file="scss/_variables.scss" >}}
+
+{{< scss-docs name="form-validation-colors-dark" file="scss/_variables-dark.scss" >}}
 
 ### Sass mixins
 


### PR DESCRIPTION
Linked to #38041.

This is an alternate fix that includes some new CSS variables dedicated to form validation `valid` and `invalid` colors. This approach _should_ suffice for a number of customization options while also solving our color contrast and color mode issues.

- We're not programmatically generating the CSS variables for form validation states (e.g., if folks move from valid/invalid to custom ones like warning/error), but that's okay I think. Maybe something to tackle in v6 if possible.
- This means folks can customize via Sass only (the validation map, Sass variables, and Sass mixin), or via CSS variables, depending on their needs.

What this doesn't, and can't, resolve is the icon color since we're embedding SVGs. I don't think the path of duplicating the SVG as embedded in our CSS is a good option either since that adds a good chunk of file size.