### PR TITLE
Reverse spinners modifier class

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -83,3 +83,30 @@
     }
   }
 }
+
+//
+// reverse modifier class
+//
+
+.reverse {
+  &.spinner-border {
+    animation: var(--#{$prefix}spinner-animation-speed) linear infinite reverse-spinner-border;
+  }
+  &.spinner-grow {
+    animation: reverse-spinner-grow var(--#{$prefix}spinner-animation-speed) linear infinite;
+  }
+}
+
+@keyframes reverse-spinner-border {
+  from { transform: rotate(360deg) /* rtl:ignore */; }
+}
+
+@keyframes reverse-spinner-grow {
+  100% {
+    transform: scale(0);
+  }
+  50% {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -145,6 +145,19 @@ Or, use custom CSS or inline styles to change the dimensions as needed.
 </div>
 {{< /example >}}
 
+## Reverse modifier class
+
+Add `.reverse` to any spinner to reverse its behavior. The spinner-border will rotate in the opposite direction, and the spinner-grow will shrink instead of growing
+
+{{< example >}}
+<div class="spinner-border reverse" role="status">
+  <span class="visually-hidden">Loading...</span>
+</div>
+<div class="spinner-grow reverse" role="status">
+  <span class="visually-hidden">Loading...</span>
+</div>
+{{< /example >}}
+
 ## Buttons
 
 Use spinners within buttons to indicate an action is currently processing or taking place. You may also swap the text out of the spinner element and utilize button text as needed.

--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -205,7 +205,7 @@ Use the `<kbd>` to indicate input that is typically entered via keyboard.
 
 {{< example >}}
 To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
-To edit settings, press <kbd><kbd>Ctrl</kbd> + <kbd>,</kbd></kbd>
+To edit settings, press <kbd>Ctrl</kbd> + <kbd>,</kbd>
 {{< /example >}}
 
 ## Sample output

--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -205,7 +205,7 @@ Use the `<kbd>` to indicate input that is typically entered via keyboard.
 
 {{< example >}}
 To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
-To edit settings, press <kbd>Ctrl</kbd> + <kbd>,</kbd>
+To edit settings, press <kbd><kbd>Ctrl</kbd> + <kbd>,</kbd></kbd>
 {{< /example >}}
 
 ## Sample output


### PR DESCRIPTION
### Description

modifier class to reverse the behaviour of all spinners

### Motivation & Context

This pull request responds to the issue https://github.com/twbs/bootstrap/issues/38053 introducing a modifier class "reverse" that reverses the behavior of the spinner (regardless of its color or size).
With the introduction of this class, the spinner-border will simply rotate in the opposite direction, while the spinner-grow will shrink instead of grow.

### Type of changes
A new feature, along with an update for the documentation.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [X] My change introduces changes to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

You can check an example in the updated section of the documentation in the live preview:
- <https://deploy-preview-38054--twbs-bootstrap.netlify.app/docs/5.3/components/spinners/#reverse-modifier-class/>

### Related issues

Closes https://github.com/twbs/bootstrap/issues/38053
The related issue also refers to another closed issue: https://github.com/twbs/bootstrap/issues/37989 with a referring closed pull request: https://github.com/twbs/bootstrap/pull/37990
