### PR TITLE
[Draft] Add `$enable-host` to generate a different bootstrap.css for web components

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -2,7 +2,7 @@
 //
 // Rows contain your columns.
 
-:root {
+@include root() {
   @each $name, $value in $grid-breakpoints {
     --#{$prefix}breakpoint-#{$name}: #{$value};
   }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -17,6 +17,7 @@
 @import "mixins/visually-hidden";
 @import "mixins/reset-text";
 @import "mixins/text-truncate";
+@import "mixins/root";
 
 // Utilities
 @import "mixins/utilities";

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -25,7 +25,7 @@
 // Ability to the value of the root font sizes, affecting the value of `rem`.
 // null by default, thus nothing is generated.
 
-:root {
+@include root() {
   @if $font-size-root != null {
     @include font-size(var(--#{$prefix}root-font-size));
   }

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,5 +1,4 @@
-:root,
-[data-bs-theme="light"] {
+@include root('[data-bs-theme="light"]') {
   // Note: Custom variable values only support SassScript inside `#{}`.
 
   // Colors

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -383,6 +383,7 @@ $enable-validation-icons:     true !default;
 $enable-negative-margins:     false !default;
 $enable-deprecation-messages: true !default;
 $enable-important-utilities:  true !default;
+$enable-host:                 false !default;
 
 $enable-dark-mode:            true !default;
 $color-mode-type:             data !default; // `data` or `media-query`

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -13,6 +13,7 @@ $include-column-box-sizing: true !default;
 @import "mixins/container";
 @import "mixins/grid";
 @import "mixins/utilities";
+@import "mixins/root";
 
 @import "vendor/rfs";
 

--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -3,7 +3,7 @@
   @if $color-mode-type == "media-query" {
     @if $root == true {
       @media (prefers-color-scheme: $mode) {
-        :root {
+        @include root() {
           @content;
         }
       }

--- a/scss/mixins/_root.scss
+++ b/scss/mixins/_root.scss
@@ -1,0 +1,7 @@
+@mixin root($extra_selector: "") {
+  $extra_selector: if($enable-host, ":host", ":root") if($extra_selector, ", " + $extra_selector, ""); // stylelint-disable-line scss/dollar-variable-pattern
+
+  #{$extra_selector} {
+    @content;
+  }
+}

--- a/scss/tests/mixins/_root.test.scss
+++ b/scss/tests/mixins/_root.test.scss
@@ -1,0 +1,75 @@
+@import "../../functions";
+@import "../../mixins";
+@import "../../variables";
+
+@include describe("global $enable-host: false") {
+  @include it("generates :root selector for web components") {
+    @include assert() {
+      @include output() {
+        @include root() {
+          --test: 1;
+        }
+      }
+      @include expect() {
+        :root {
+          --test: 1;
+        }
+      }
+    }
+  }
+}
+
+@include describe("global $enable-host: false") {
+  @include it("generates :root, [data-bs-theme=light] selector for web components") {
+    @include assert() {
+      @include output() {
+        @include root("[data-bs-theme=light]") {
+          --test: 1;
+        }
+      }
+      @include expect() {
+        :root,
+        [data-bs-theme="light"] {
+          --test: 1;
+        }
+      }
+    }
+  }
+}
+
+$enable-host: true !global;
+
+@include describe("global $enable-host: true") {
+  @include it("generates :host selector for web components") {
+    @include assert() {
+      @include output() {
+        @include root() {
+          --test: 1;
+        }
+      }
+      @include expect() {
+        :host {
+          --test: 1;
+        }
+      }
+    }
+  }
+}
+
+@include describe("global $enable-host: true") {
+  @include it("generates :root, [data-bs-theme=light] selector for web components") {
+    @include assert() {
+      @include output() {
+        @include root("[data-bs-theme=light]") {
+          --test: 1;
+        }
+      }
+      @include expect() {
+        :host,
+        [data-bs-theme="light"] {
+          --test: 1;
+        }
+      }
+    }
+  }
+}

--- a/site/content/docs/5.3/customize/css-variables.md
+++ b/site/content/docs/5.3/customize/css-variables.md
@@ -18,34 +18,9 @@ Here are the variables we include (note that the `:root` is required) that can b
 
 These CSS variables are available everywhere, regardless of color mode.
 
-```css
-{{< root.inline >}}
-{{- $css := readFile "dist/css/bootstrap.css" -}}
-{{- $match := findRE `:root,\n\[data-bs-theme=light\] {([^}]*)}` $css 1 -}}
-
-{{- if (eq (len $match) 0) -}}
-{{- errorf "Got no matches for :root in %q!" $.Page.Path -}}
-{{- end -}}
-
-{{- index $match 0 -}}
-
-{{< /root.inline >}}
-```
-
 ### Dark mode
 
 These variables are scoped to our built-in dark mode.
-
-```css
-{{< root.inline >}}
-{{- $css := readFile "dist/css/bootstrap.css" -}}
-{{- $match := findRE `\[data-bs-theme=dark\] {([^}]*)}` $css 1 -}}
-{{- if (eq (len $match) 0) -}}
-{{- errorf "Got no matches for [data-bs-theme=dark] in %q!" $.Page.Path -}}
-{{- end -}}
-{{- index $match 0 -}}
-{{< /root.inline >}}
-```
 
 ## Component variables
 


### PR DESCRIPTION
> **Warning**
> Heavily draft

Another possibility to tackle https://github.com/twbs/bootstrap/issues/36688 (Closes #36688)

The principle here is to offer a `$enable-host` Scss var (`false` by default). This var is associated with a `root` mixin allowing to switch between `:root` and `:host`:
* `:root` when `$enable-host` is `false` (default)
* `:host` when `$enable-host` is `true`

I've added some unit tests to check this behavior.

It differs from https://github.com/twbs/bootstrap/pull/37162 which suggests to use `:root, :host` that is not really useful for all folks and projects.

The disadvantage here is that it's only available via Sass compilation. But maybe we can consider that this usage with web components is an "expert mode".
We also talked about a `bootstrap.*.host.*.css` with @vprothais but I'm a bit afraid of what it could imply in combination with the regular `bootstrap.*.css*` files

- [ ] Handle `site/content/docs/5.3/customize/css-variables.md` modifications (if any needed)
- [ ] Test this new file (with `$enable-host` set to `true`) in different use cases amongst https://github.com/twbs/bootstrap/issues/36688#issuecomment-1422236483
- [ ] Add `$enable-host` in the documentation and explain the impacts for web components

Thoughts??