### PR TITLE
Remove `-moz-padding-start` from `.form-select`

### DIFF
--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -9,7 +9,6 @@
   display: block;
   width: 100%;
   padding: $form-select-padding-y $form-select-indicator-padding $form-select-padding-y $form-select-padding-x;
-  -moz-padding-start: subtract($form-select-padding-x, 3px); // See https://github.com/twbs/bootstrap/issues/32636
   font-family: $form-select-font-family;
   @include font-size($form-select-font-size);
   font-weight: $form-select-font-weight;


### PR DESCRIPTION
Fixes #37748. Previously reported in #32636.

Firefox appears to have fixed the issue, so removing this fixes the new bug.