### PR TITLE
Bump Chart.js from 2.9.4 to 4.2.1 in dashboard examples

### DIFF
--- a/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
@@ -7,8 +7,7 @@
 
   // Graphs
   const ctx = document.getElementById('myChart')
-  // eslint-disable-next-line no-unused-vars
-  const myChart = new Chart(ctx, {
+  new Chart(ctx, {
     type: 'line',
     data: {
       labels: [
@@ -38,15 +37,10 @@
       }]
     },
     options: {
-      scales: {
-        yAxes: [{
-          ticks: {
-            beginAtZero: false
-          }
-        }]
-      },
-      legend: {
-        display: false
+      plugins: {
+        legend: {
+          display: false
+        }
       }
     }
   })

--- a/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
@@ -7,7 +7,8 @@
 
   // Graphs
   const ctx = document.getElementById('myChart')
-  new Chart(ctx, {
+  // eslint-disable-next-line no-unused-vars
+  const myChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels: [

--- a/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard-rtl/dashboard.js
@@ -41,6 +41,9 @@
       plugins: {
         legend: {
           display: false
+        },
+        tooltip: {
+          boxPadding: 3
         }
       }
     }

--- a/site/content/docs/5.3/examples/dashboard-rtl/index.html
+++ b/site/content/docs/5.3/examples/dashboard-rtl/index.html
@@ -7,8 +7,8 @@ extra_css:
 extra_js:
   - src: "https://cdn.jsdelivr.net/npm/feather-icons@4.28.0/dist/feather.min.js"
     integrity: "sha384-uO3SXW5IuS1ZpFPKugNNWqTZRRglnUJK6UAZ/gxOX80nxEkN9NcGZTftn6RzhGWE"
-  - src: "https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"
-    integrity: "sha384-zNy6FEbO50N+Cg5wap8IKA4M/ZnLJgzc6w2NqACZaK0u0FXfOWRRJOnQtpZun8ha"
+  - src: "https://cdn.jsdelivr.net/npm/chart.js@4.2.1/dist/chart.umd.min.js"
+    integrity: "sha384-gdQErvCNWvHQZj6XZM0dNsAoY4v+j5P1XDpNkcM3HJG1Yx04ecqIHk7+4VBOCHOG"
   - src: "dashboard.js"
 ---
 

--- a/site/content/docs/5.3/examples/dashboard/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard/dashboard.js
@@ -7,8 +7,7 @@
 
   // Graphs
   const ctx = document.getElementById('myChart')
-  // eslint-disable-next-line no-unused-vars
-  const myChart = new Chart(ctx, {
+  new Chart(ctx, {
     type: 'line',
     data: {
       labels: [
@@ -38,15 +37,10 @@
       }]
     },
     options: {
-      scales: {
-        yAxes: [{
-          ticks: {
-            beginAtZero: false
-          }
-        }]
-      },
-      legend: {
-        display: false
+      plugins: {
+        legend: {
+          display: false
+        }
       }
     }
   })

--- a/site/content/docs/5.3/examples/dashboard/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard/dashboard.js
@@ -7,7 +7,8 @@
 
   // Graphs
   const ctx = document.getElementById('myChart')
-  new Chart(ctx, {
+  // eslint-disable-next-line no-unused-vars
+  const myChart = new Chart(ctx, {
     type: 'line',
     data: {
       labels: [

--- a/site/content/docs/5.3/examples/dashboard/dashboard.js
+++ b/site/content/docs/5.3/examples/dashboard/dashboard.js
@@ -41,6 +41,9 @@
       plugins: {
         legend: {
           display: false
+        },
+        tooltip: {
+          boxPadding: 3
         }
       }
     }

--- a/site/content/docs/5.3/examples/dashboard/index.html
+++ b/site/content/docs/5.3/examples/dashboard/index.html
@@ -6,8 +6,8 @@ extra_css:
 extra_js:
   - src: "https://cdn.jsdelivr.net/npm/feather-icons@4.28.0/dist/feather.min.js"
     integrity: "sha384-uO3SXW5IuS1ZpFPKugNNWqTZRRglnUJK6UAZ/gxOX80nxEkN9NcGZTftn6RzhGWE"
-  - src: "https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"
-    integrity: "sha384-zNy6FEbO50N+Cg5wap8IKA4M/ZnLJgzc6w2NqACZaK0u0FXfOWRRJOnQtpZun8ha"
+  - src: "https://cdn.jsdelivr.net/npm/chart.js@4.2.1/dist/chart.umd.min.js"
+    integrity: "sha384-gdQErvCNWvHQZj6XZM0dNsAoY4v+j5P1XDpNkcM3HJG1Yx04ecqIHk7+4VBOCHOG"
   - src: "dashboard.js"
 ---
 


### PR DESCRIPTION
### Description

This PR suggests to bump Chart.js version in dashboard and dashboard RTL examples from 2.9.4 to 4.2.1.

The configuration has slightly changed. There's no graphical regression; just a minor change regarding the rendering of numbers on the y-axis.

### Type of changes

- [x] Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38071--twbs-bootstrap.netlify.app/docs/5.3/examples/dashboard/
- https://deploy-preview-38071--twbs-bootstrap.netlify.app/docs/5.3/examples/dashboard-rtl/

