### PR TITLE
Fix console error in examples pages due to no theme switcher

### DIFF
--- a/site/static/docs/5.3/assets/js/color-modes.js
+++ b/site/static/docs/5.3/assets/js/color-modes.js
@@ -29,6 +29,11 @@
 
   const showActiveTheme = (theme, focus = false) => {
     const themeSwitcher = document.querySelector('#bd-theme')
+
+    if (!themeSwitcher) {
+      return
+    }
+
     const themeSwitcherText = document.querySelector('#bd-theme-text')
     const activeThemeIcon = document.querySelector('.theme-icon-active use')
     const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)


### PR DESCRIPTION
### Description

This PR checks in `color-mode.js` that the `themeSwitcher` var is not `null` before continuing the algorithm.

### Motivation & Context

This avoids an error message in the console when one goes to any examples in our doc (e.g. https://twbs-bootstrap.netlify.app/docs/5.3/examples/heroes/) either in light or dark mode:

```
Uncaught TypeError: btnToActive is null
    showActiveTheme https://twbs-bootstrap.netlify.app/docs/5.3/assets/js/color-modes.js:35
    <anonymous> https://twbs-bootstrap.netlify.app/docs/5.3/assets/js/color-modes.js:60
color-modes.js:35:28
```

This is because our examples react to the theme being light or dark via `color-modes.js`, but they don't have any dropdown switcher on the page (like in the header for other pages).

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38074--twbs-bootstrap.netlify.app/docs/5.3/examples/heroes/> (or any other example)

