### PR TITLE
Add `.spinner-reverse` modifier

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -83,3 +83,11 @@
     }
   }
 }
+
+//
+// Modifiers
+//
+
+.spinner-reverse {
+  animation-direction: reverse;
+}

--- a/site/content/docs/5.3/components/spinners.md
+++ b/site/content/docs/5.3/components/spinners.md
@@ -145,6 +145,19 @@ Or, use custom CSS or inline styles to change the dimensions as needed.
 </div>
 {{< /example >}}
 
+## Reverse
+
+Add `.spinner-reverse` to any spinner to reverse its animation.
+
+{{< example >}}
+<div class="spinner-border spinner-reverse" role="status">
+  <span class="visually-hidden">Loading...</span>
+</div>
+<div class="spinner-grow spinner-reverse" role="status">
+  <span class="visually-hidden">Loading...</span>
+</div>
+{{< /example >}}
+
 ## Buttons
 
 Use spinners within buttons to indicate an action is currently processing or taking place. You may also swap the text out of the spinner element and utilize button text as needed.


### PR DESCRIPTION
### Description

⚠️ Alternate proposal to https://github.com/twbs/bootstrap/pull/38054 to fix #38053 to lighten the CSS bundle.

This PR suggests adding a `.spinner-reverse` modifier to reverse the animation of the border and grow spinners.

RTL behavior is not impacted by this new modifier: the orientation remains the same in LTR and RTL.

Browser support is very good (see https://caniuse.com/mdn-css_properties_animation-direction_reverse). Tested it with old OSs/browsers combinations and works well.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38081--twbs-bootstrap.netlify.app/docs/5.3/components/spinners/#reverse

### Related issues

#38053
