### PR TITLE
Fix navbar-nav link styling

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -100,9 +100,11 @@
   margin-bottom: 0;
   list-style: none;
 
-  .show > .nav-link,
-  .nav-link.active {
-    color: var(--#{$prefix}navbar-active-color);
+  .nav-link {
+    &.active,
+    &.show {
+      color: var(--#{$prefix}navbar-active-color);
+    }
   }
 
   .dropdown-menu {


### PR DESCRIPTION
The `.show` class is generated on the link itself, not on its parent.