### PR TITLE
Remove useless comment from `scss/_utilities.scss`

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -634,7 +634,6 @@ $utilities: map-merge(
       )
     ),
     "link-underline": (
-      // css-var: true,
       property: text-decoration-color,
       class: link-underline,
       local-vars: (


### PR DESCRIPTION
A minor modification that removes a useless comment from `scss/_utilities.scss`.