### PR TITLE
Fix form switch glitch

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -969,15 +969,16 @@ $form-check-inline-margin-end:    1rem !default;
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
 $form-switch-padding-start:       $form-switch-width + .5em !default;
-$form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
+$form-switch-bg-shape:            if($enable-rounded, "circle r='3'", "rect x='-3' y='-3' width='6' height='6'") !default;
+$form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><#{$form-switch-bg-shape} fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius:       $form-switch-width !default;
 $form-switch-transition:          background-position .15s ease-in-out !default;
 
 $form-switch-focus-color:         $input-focus-border-color !default;
-$form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
+$form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><#{$form-switch-bg-shape} fill='#{$form-switch-focus-color}'/></svg>") !default;
 
 $form-switch-checked-color:       $component-active-color !default;
-$form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
+$form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><#{$form-switch-bg-shape} fill='#{$form-switch-checked-color}'/></svg>") !default;
 $form-switch-checked-bg-position: right center !default;
 // scss-docs-end form-switch-variables
 


### PR DESCRIPTION
### Description

The form switch or toggle component is in limbo state when `$enable-rounded: false`. The box is rectangular while the toggle is round. Just like this:

<img width="253" alt="image" src="https://user-images.githubusercontent.com/988276/221163771-5ce32964-7004-4137-80a8-3edb317cbc73.png">


### Motivation & Context

This change fixes the bug where a form switch is displayed as rectangle with a round toggle image.

<img width="176" alt="image" src="https://user-images.githubusercontent.com/988276/226212464-6f98594a-fd0a-4375-8e4c-e5989cf5c38b.png">

Please see also https://gregorw.github.io/bootstrap-switch-bugfix/.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- https://gregorw.github.io/bootstrap-switch-bugfix/
- https://deploy-preview-38109--twbs-bootstrap.netlify.app/docs/5.3/forms/checks-radios/#switches

### Related issues

<!-- Please link any related issues here. -->
