### PR TITLE
Fix code indentation in homepage JavaScript plugins section

### DIFF
--- a/site/layouts/partials/home/plugins.html
+++ b/site/layouts/partials/home/plugins.html
@@ -32,14 +32,14 @@
       </div>
 
       {{ highlight (printf `<div class="dropdown">
-<button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-  Dropdown
-</button>
-<ul class="dropdown-menu">
-  <li><button class="dropdown-item" type="button">Dropdown item</button></li>
-  <li><button class="dropdown-item" type="button">Dropdown item</button></li>
-  <li><button class="dropdown-item" type="button">Dropdown item</button></li>
-</ul>
+  <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+    Dropdown
+  </button>
+  <ul class="dropdown-menu">
+    <li><button class="dropdown-item" type="button">Dropdown item</button></li>
+    <li><button class="dropdown-item" type="button">Dropdown item</button></li>
+    <li><button class="dropdown-item" type="button">Dropdown item</button></li>
+  </ul>
 </div>
 `) "html" "" }}
       <p>Learn more about <a href="/docs/{{ .Site.Params.docs_version }}/getting-started/javascript/#using-bootstrap-as-a-module">our JavaScript as modules</a> and <a href="/docs/{{ .Site.Params.docs_version }}/getting-started/javascript/#programmatic-api">using the programmatic API</a>.</p>


### PR DESCRIPTION
### Description

This PR slightly changes the code indentation in the "Powerful JavaScript plugins without jQuery" homepage section.
_Good catch @HiDeoo_

#### Before

(https://twbs-bootstrap.netlify.app/)

![Screenshot 2023-02-24 at 16 00 32](https://user-images.githubusercontent.com/17381666/221211174-89ff45d5-c043-48ca-8f76-583ba65729fe.png)

#### Now

(https://deploy-preview-38112--twbs-bootstrap.netlify.app/)

![Screenshot 2023-02-24 at 16 01 19](https://user-images.githubusercontent.com/17381666/221211347-04f25408-07f1-42c5-9f69-5ef86e7b8cba.png)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38112--twbs-bootstrap.netlify.app/