### PR TITLE
Docs: fix highlight border radius

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -380,7 +380,6 @@
 
   .highlight {
     margin-bottom: 0;
-    @include border-top-radius(0);
   }
 
   .bd-example {
@@ -391,7 +390,7 @@
   @include media-breakpoint-up(md) {
     margin-right: 0;
     margin-left: 0;
-    @include border-radius($border-radius);
+    @include border-radius(calc(var(--bs-border-radius) + 1px));
   }
 }
 
@@ -401,7 +400,7 @@
 
 .bd-scss-docs {
   .highlight-toolbar {
-    @include border-top-radius(calc(var(--bs-border-radius) + 1px));
+    @include border-top-radius(calc(var(--bs-border-radius) - 1px));
   }
 }
 


### PR DESCRIPTION
### Description

This PR tries to fix the highlight border radius in our docs coming from https://github.com/twbs/bootstrap/commit/20ab8219a0caca784483e93083cde269055d0f3a.

⚠️ But maybe there is a smarter/better way to do it. IMO the rendering in this PR is better but the values are not exactly the same depending on the cases; sometimes 7px, sometimes 8px.

#### Issues

(_Shoutout to @Hideoo for catching it_)

Upper border radius of the "simple" highlight is straight in our _main_ branch contrary to the live site.

![Screenshot 2023-02-25 at 08 31 00](https://user-images.githubusercontent.com/17381666/221344932-126349d3-dbf4-40f0-9fc0-6ec510d03cb0.png)

![Screenshot 2023-02-25 at 08 32 08](https://user-images.githubusercontent.com/17381666/221344961-1b72f4b8-2569-4e73-abee-8fbfbe610c59.png)

But in some cases with more complex rendering, it was OK like in https://twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#example

OK but still with a small issue (in https://twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#flush for example):

![Screenshot 2023-02-25 at 08 33 16](https://user-images.githubusercontent.com/17381666/221345030-0039b58d-96d8-4b31-a894-1540dbe49818.png)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38114--twbs-bootstrap.netlify.app/

Plus examples or more complex use cases in:

- https://deploy-preview-38114--twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/
- https://deploy-preview-38114--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#example
- https://deploy-preview-38114--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#flush

