### PR TITLE
Fix dropdown toggle visible focus in headers example

### DIFF
--- a/site/content/docs/5.3/examples/headers/headers.css
+++ b/site/content/docs/5.3/examples/headers/headers.css
@@ -10,6 +10,6 @@
   font-size: 85%;
 }
 
-.dropdown-toggle {
+.dropdown-toggle:not(:focus) {
   outline: 0;
 }


### PR DESCRIPTION
### Description

In [our headers example](https://getbootstrap.com/docs/5.3/examples/headers/), visible focus while navigating with the keyboard is not visible for dropdown toggles. This is the last element in the following .gif:

![2023-02-27 08 14 00](https://user-images.githubusercontent.com/17381666/221498323-8e540b75-b05e-4ee7-a77a-c9572218ef1d.gif)

This PR suggests making the rule removing the outline more specific to let the focus state be handled normally.

### Motivation & Context

Accessibility

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38123--twbs-bootstrap.netlify.app/docs/5.3/examples/headers/
