### PR TITLE
(Fixed) Brand icon area too large in third header example #38122

### DIFF
--- a/site/content/docs/5.3/examples/headers/index.html
+++ b/site/content/docs/5.3/examples/headers/index.html
@@ -68,7 +68,7 @@ body_class: ""
 
   <div class="container">
     <header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4 border-bottom">
-      <a href="/" class="d-flex align-items-center col-md-3 mb-2 mb-md-0 link-body-emphasis text-decoration-none">
+      <a href="/" class="d-flex align-items-center my-2 my-lg-0 me-lg-auto link-body-emphasis text-decoration-none">
         <svg class="bi me-2" width="40" height="32" role="img" aria-label="Bootstrap"><use xlink:href="#bootstrap"/></svg>
       </a>
 


### PR DESCRIPTION
Closes #38122

### Description

<!-- Describe your changes in detail -->
The brand icon area was too large in the [third header example](https://getbootstrap.com/docs/5.3/examples/headers/) from 769px breakpoint. After going through the html page, it was found that changing the Bootstrap spacing classes from `col-md-3 mb-2 mb-md-0` to `my-2 my-lg-0 me-lg-auto` solves the issue.

[Reference of the issue](https://github.com/twbs/bootstrap/issues/38122)

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Earlier, a user reading through the docs could accidentally click the Bootstrap icon since the icon area was too large. After this change, such a behavior will no longer happen.
### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
