### PR TITLE
Icon link: envariable + enhance the documentation

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -459,6 +459,15 @@ $link-hover-decoration:                   null !default;
 $stretched-link-pseudo-element:           after !default;
 $stretched-link-z-index:                  1 !default;
 
+// Icon links
+// scss-docs-start icon-link-variables
+$icon-link-gap:               .375rem !default;
+$icon-link-underline-offset:  .25em !default;
+$icon-link-icon-size:         1em !default;
+$icon-link-icon-transition:   .2s ease-in-out transform !default;
+$icon-link-icon-transform:    translate3d(.25em, 0, 0) !default;
+// scss-docs-end icon-link-variables
+
 // Paragraphs
 //
 // Style p element.

--- a/scss/helpers/_icon-link.scss
+++ b/scss/helpers/_icon-link.scss
@@ -10,6 +10,7 @@
     flex-shrink: 0;
     width: $icon-link-icon-size;
     height: $icon-link-icon-size;
+    fill: currentcolor;
     @include transition($icon-link-icon-transition);
   }
 }

--- a/scss/helpers/_icon-link.scss
+++ b/scss/helpers/_icon-link.scss
@@ -1,16 +1,16 @@
 .icon-link {
   display: inline-flex;
-  gap: .375rem;
+  gap: $icon-link-gap;
   align-items: center;
   text-decoration-color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, .5));
-  text-underline-offset: .25em;
+  text-underline-offset: $icon-link-underline-offset;
   backface-visibility: hidden;
 
   > .bi {
     flex-shrink: 0;
-    width: 1em;
-    height: 1em;
-    @include transition(.2s ease-in-out transform);
+    width: $icon-link-icon-size;
+    height: $icon-link-icon-size;
+    @include transition($icon-link-icon-transition);
   }
 }
 
@@ -18,7 +18,7 @@
   &:hover,
   &:focus-visible {
     > .bi {
-      transform: var(--#{$prefix}icon-link-transform, translate3d(.25em, 0, 0));
+      transform: var(--#{$prefix}icon-link-transform, $icon-link-icon-transform);
     }
   }
 }

--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -65,9 +65,9 @@ Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS
 Customize the color by overriding the `--bs-link-*` CSS variable:
 
 {{< example >}}
-<a class="icon-link icon-link-hover link-warning" style="--bs-link-hover-color-rgb: 139,185,354;" href="#">
-  <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
+<a class="icon-link icon-link-hover" style="--bs-link-hover-color-rgb: 25, 135, 84;" href="#">
   Icon link
+  <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>
 </a>
 {{< /example >}}
 

--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -45,6 +45,14 @@ Add `.icon-link-hover` to move the icon to the right on hover.
 </a>
 {{< /example >}}
 
+## Customize
+
+Modify the styling of an icon link with our link CSS variables, Sass variables, utilities, or custom styles.
+
+### CSS variables
+
+Modify the `--bs-link-*` and `--bs-icon-link-*` CSS variables as needed to change the default appearance.
+
 Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS variable:
 
 {{< example >}}
@@ -54,7 +62,22 @@ Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS
 </a>
 {{< /example >}}
 
-## Pairs with link utilities
+Customize the color by overriding the `--bs-link-*` CSS variable:
+
+{{< example >}}
+<a class="icon-link icon-link-hover link-warning" style="--bs-link-hover-color-rgb: 139,185,354;" href="#">
+  <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
+  Icon link
+</a>
+{{< /example >}}
+
+### Sass
+
+Customize the icon link Sass variables to modify all icon link styles across your Bootstrap-powered project.
+
+{{< scss-docs name="icon-link-variables" file="scss/_variables.scss" >}}
+
+### Utilities
 
 Modify icon links with any of [our link utilities]({{< docsref "/utilities/link/" >}}) for modifying underline color and offset.
 


### PR DESCRIPTION
### Description

Introduce some Sass variables to better handle the default `.icon-link`.
Adding some docs about this variables and display some ways to custom those links.
Add `fill: currentcolor` for icons.

### Motivation & Context

Better customization for end users.
Adding some CSS that comes from the docs CSS atm.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38130--twbs-bootstrap.netlify.app/docs/5.3/helpers/icon-link#customize>

### Related issues

NA
