### PR TITLE
Docs: `.text-body-secondary` appears two times in Utilities > Colors

### DIFF
--- a/site/content/docs/5.3/utilities/colors.md
+++ b/site/content/docs/5.3/utilities/colors.md
@@ -25,9 +25,8 @@ Color utilities like `.text-*` that generated from our original `$theme-colors` 
 <p class="text-{{ .name }}-emphasis">.text-{{ .name }}-emphasis</p>
 {{- end -}}
 {{< /colors.inline >}}
-<p class="text-body">.text-body</p>
-<p class="text-body-secondary">.text-body-secondary</p>
 
+<p class="text-body">.text-body</p>
 <p class="text-body-emphasis">.text-body-emphasis</p>
 <p class="text-body-secondary">.text-body-secondary</p>
 <p class="text-body-tertiary">.text-body-tertiary</p>


### PR DESCRIPTION
### Description

On our _main_ branch, `.text-body-secondary` is mentioned two times with the [Utilities > Colors](https://twbs-bootstrap.netlify.app/docs/5.3/utilities/colors/#colors) section.

This PR:
- removes one occurrence of `.text-body-secondary`
- gather all `.text-body-*`s in a "group" separated by break lines to keep consistency with what's been done before after the `{{< colors.inline >}}` block

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- (N/A) My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38153--twbs-bootstrap.netlify.app/docs/5.3/utilities/colors/#colors>
