### PR TITLE
Fix selector for form floating background

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,12 +1,13 @@
 .form-floating {
   position: relative;
 
-  &:not(.form-control:disabled)::before {
+  &:has(.form-control:not(:disabled))::before {
     position: absolute;
     top: $input-border-width;
     left: $input-border-width;
     width: subtract(100%, add($input-height-inner-quarter, $input-height-inner-half));
     height: $form-floating-label-height;
+    pointer-events: none;
     content: "";
     background-color: $input-bg;
     @include border-radius($input-border-radius);


### PR DESCRIPTION
This rewrites the selector to use `:has()` because `.form-floating` is a parent container, which has no `:disabled` state. The `:disabled` is handled on the individual form element.

That said, it'd be really cool if adding a `disabled` attribute on a parent element would disabled all the elements within—right now only fieldsets do that. And I genuinely just stumbled back into thinking about this... so what if we used fieldsets here in v6? Something to think about.

Anyway, the downside of using the `:has()` selector is browser compatibility right now. I'm not super worried about that as this could be seen as a progressive enhancement, but it's worth calling out. With the new selector, nothing is generated for disabled fields, so we avoid that problem entirely.

/cc @julien-deramond @louismaximepiton @jonnysp 