### PR TITLE
Fix missing modifications when `--bs-{color}-text` was changed to `--bs-{color}-text-emphasis`

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1374,7 +1374,7 @@ $accordion-button-color:                  var(--#{$prefix}body-color) !default;
 $accordion-button-bg:                     var(--#{$prefix}accordion-bg) !default;
 $accordion-transition:                    $btn-transition, border-radius .15s ease !default;
 $accordion-button-active-bg:              var(--#{$prefix}primary-bg-subtle) !default;
-$accordion-button-active-color:           var(--#{$prefix}primary-text) !default;
+$accordion-button-active-color:           var(--#{$prefix}primary-text-emphasis) !default;
 
 $accordion-button-focus-border-color:     $input-focus-border-color !default;
 $accordion-button-focus-box-shadow:       $btn-focus-box-shadow !default;

--- a/scss/tests/mixins/_color-modes.test.scss
+++ b/scss/tests/mixins/_color-modes.test.scss
@@ -12,7 +12,7 @@
       @include output() {
         @include color-mode(dark) {
           .element {
-            color: var(--bs-primary-text);
+            color: var(--bs-primary-text-emphasis);
             background-color: var(--bs-primary-bg-subtle);
           }
         }
@@ -22,7 +22,7 @@
       }
       @include expect() {
         [data-bs-theme=dark] .element {
-          color: var(--bs-primary-text);
+          color: var(--bs-primary-text-emphasis);
           background-color: var(--bs-primary-bg-subtle);
         }
         [data-bs-theme=dark] {
@@ -41,7 +41,7 @@
       @include output() {
         @include color-mode(dark) {
           .element {
-            color: var(--bs-primary-text);
+            color: var(--bs-primary-text-emphasis);
             background-color: var(--bs-primary-bg-subtle);
           }
         }
@@ -52,7 +52,7 @@
       @include expect() {
         @media (prefers-color-scheme: dark) {
           .element {
-            color: var(--bs-primary-text);
+            color: var(--bs-primary-text-emphasis);
             background-color: var(--bs-primary-bg-subtle);
           }
         }


### PR DESCRIPTION
### Description

https://github.com/twbs/bootstrap/commit/15744ee1d04bcca03155c3bb37ee7e65a7b011c6 introduced the following change: `bs-{color}-text` → `bs-{color}-text-emphasis`

This PR fixes some missing modifications in:
* `scss/tests/mixins/_color-modes.test.scss`
* `scss/_variables.scss` that fixes the rendering of the active text color in both light and dark modes

Please double-check that we haven't forgotten other things with different combinations of `--bs-{color}-text` and/or `--#{$prefix}{color}-text`.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38176--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/#example

