### PR TITLE
Docs: minor modifications in our migration guide for the v5.3.0-alpha2

### DIFF
--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -69,7 +69,7 @@ If you're migrating from our previous alpha release of v5.3.0, please reviewing 
 
 ### Docs
 
-- Examples are now displayed with the appropriate light or dark color mode as dictated by the setting in our docs. However, they lack an individual color mode picker for the time being.
+- Examples are now displayed with the appropriate light or dark color mode as dictated by the setting in our docs. Each example has an individual color mode picker.
 
 - Improved included JavaScript for live Toast demo.
 
@@ -150,7 +150,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
 #### Dropdowns
 
-- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.dropdown-menu-dark` class has been deprecated and replaced with `data-bs-theme="dark"` on the close button or any parent element. [See the docs for an example.]({{< docsref "/components/dropdowns#dark-dropdowns" >}})
+- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.dropdown-menu-dark` class has been deprecated and replaced with `data-bs-theme="dark"` on the dropdown or any parent element. [See the docs for an example.]({{< docsref "/components/dropdowns#dark-dropdowns" >}})
 
 #### Close button
 


### PR DESCRIPTION
This fixes some minor things in our migration guide for v5.3.0-alpha2:
- typo in our migration guide around `.dropdown-menu-dark` found by @crdo in https://github.com/twbs/bootstrap/commit/c735b2e196544b3bba25d645f4d725e8667b106c#r99475857.
- changed the sentence regarding the color picker in our examples since it now has been developed and merged