### PR TITLE
Docs: vertically align starters images in example page

### DIFF
--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -23,7 +23,7 @@ aliases: "/examples/"
     {{ if (eq $i 0) }}<div class="row">{{ end }}
       {{ if $entry.external }}
         <div class="col-md-6 col-lg-4 mb-3 d-flex gap-3">
-          <svg class="bi fs-5 flex-shrink-0"><use xlink:href="#box-seam"></use></svg>
+          <svg class="bi fs-5 flex-shrink-0 mt-1"><use xlink:href="#box-seam"></use></svg>
           <div>
             <h3 class="h5 mb-1">
               <a class="d-block link-offset-1" href="{{ $.Site.Params.github_org }}{{ $example.url }}/" target="_blank">


### PR DESCRIPTION
### Description

This PR suggests to slightly change the vertical alignment of the images in "Examples > Starters" section. This is done with a simple `.mt-1` but could be done in CSS if not precise enough.

#### [Before](https://twbs-bootstrap.netlify.app/docs/5.3/examples/)

<img width="426" alt="Screenshot 2023-03-06 at 22 45 17" src="https://user-images.githubusercontent.com/17381666/223240766-e6f58c2c-03f6-4310-82e2-0ed9a1b2d2ef.png">

#### [Now](https://deploy-preview-38179--twbs-bootstrap.netlify.app//docs/5.3/examples/)

<img width="430" alt="Screenshot 2023-03-06 at 22 46 33" src="https://user-images.githubusercontent.com/17381666/223241436-e1097809-0948-44bc-95f7-a09414873938.png">

### Type of changes

-  Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews


- https://deploy-preview-38179--twbs-bootstrap.netlify.app//docs/5.3/examples/

