### PR TITLE
Docs: Remove unnecessary `href` and `tabindex="-1"`

### DIFF
--- a/site/content/docs/5.3/components/placeholders.md
+++ b/site/content/docs/5.3/components/placeholders.md
@@ -38,7 +38,7 @@ In the example below, we take a typical card component and recreate it with plac
       <span class="placeholder col-6"></span>
       <span class="placeholder col-8"></span>
     </p>
-    <a href="#" tabindex="-1" class="btn btn-primary disabled placeholder col-6"></a>
+    <a class="btn btn-primary disabled placeholder col-6"></a>
   </div>
 </div>
 </div>
@@ -67,7 +67,7 @@ In the example below, we take a typical card component and recreate it with plac
       <span class="placeholder col-6"></span>
       <span class="placeholder col-8"></span>
     </p>
-    <a href="#" tabindex="-1" class="btn btn-primary disabled placeholder col-6"></a>
+    <a class="btn btn-primary disabled placeholder col-6"></a>
   </div>
 </div>
 ```
@@ -83,7 +83,7 @@ We apply additional styling to `.btn`s via `::before` to ensure the `height` is 
   <span class="placeholder col-6"></span>
 </p>
 
-<a href="#" tabindex="-1" class="btn btn-primary disabled placeholder col-4" aria-hidden="true"></a>
+<a class="btn btn-primary disabled placeholder col-4" aria-hidden="true"></a>
 {{< /example >}}
 
 {{< callout info >}}

--- a/site/content/docs/5.3/components/placeholders.md
+++ b/site/content/docs/5.3/components/placeholders.md
@@ -83,7 +83,7 @@ We apply additional styling to `.btn`s via `::before` to ensure the `height` is 
   <span class="placeholder col-6"></span>
 </p>
 
-<a class="btn btn-primary disabled placeholder col-4" aria-hidden="true"></a>
+<a class="btn btn-primary disabled placeholder col-4"></a>
 {{< /example >}}
 
 {{< callout info >}}


### PR DESCRIPTION
### Description

Remove unnecessary `href` and `tabindex="-1"`. The ones remaining in the [buttons](https://main--twbs-bootstrap.netlify.app/docs/5.3/components/buttons/#link-functionality-caveat) and in the [interactions](https://main--twbs-bootstrap.netlify.app/docs/5.3/utilities/interactions/#pointer-events) seem pretty legit for me.

### Motivation & Context

Coherence inside the doc.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38196--twbs-bootstrap.netlify.app/docs/5.3/components/placeholders#example>

### Related issues

NA
