### PR TITLE
icon-link.md: remove moot aliases

### DIFF
--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -3,7 +3,6 @@ layout: docs
 title: Icon link
 description: Quickly create stylized hyperlinks with Bootstrap Icons or other icons.
 group: helpers
-aliases: "/docs/5.3/icon-link/"
 toc: true
 added: 5.3
 ---


### PR DESCRIPTION
@mdo is this referenced anywhere? It was introduced in #37762 which wasn't deployed AFAICT (it's created after 5.3.0-alpha1 and I couldn't find any reference to it so it might be moot.