### PR TITLE
Docs: consistent deprecation messages in Close Button dark variant

### DIFF
--- a/site/content/docs/5.3/components/close-button.md
+++ b/site/content/docs/5.3/components/close-button.md
@@ -24,7 +24,9 @@ Disabled close buttons change their `opacity`. We've also applied `pointer-event
 
 ## Dark variant
 
-{{< callout info >}}
+{{< deprecated-in "5.3.0" >}}
+
+{{< callout warning >}}
 **Heads up!** As of v5.3.0, the `.btn-close-white` class is deprecated. Instead, use `data-bs-theme="dark"` to change the color mode of the close button.
 {{< /callout >}}
 


### PR DESCRIPTION
### Description

Several dark variants of components are deprecated in v5.3.0.
Close button message regarding this deprecation is not correctly aligned with the one from the dark carousels for example (see https://twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#dark-variant).

This PR suggests to:
* add the `deprecated-in` shortcode
* change the level of the "Heads up!" message from `info` to `warning`

### Motivation & Context

Consistency in the doc.

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38247--twbs-bootstrap.netlify.app/docs/5.3/components/close-button/#dark-variant

