### PR TITLE
Resolve warnings with Sass 1.59.3

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -204,12 +204,12 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 // scss-docs-start color-functions
 // Tint a color: mix a color with white
 @function tint-color($color, $weight) {
-  @return mix(white, $color, $weight);
+  @return mix(white, $color, $weight * 1%);
 }
 
 // Shade a color: mix a color with black
 @function shade-color($color, $weight) {
-  @return mix(black, $color, $weight);
+  @return mix(black, $color, $weight * 1%);
 }
 
 // Shade the color if the weight is positive, else tint it


### PR DESCRIPTION
Resolve warnings in `tint-color` and `shade-color`.

### Description

When using `tint-color` or `shade-color` triggers the following warning:
```
    ╷
212 │   @return mix(black, $color, $weight);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 212:11  shade-color()
    src/style/index.scss 90:37                          root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (20) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units
```
The issue stems from newer sass versions deprecating variable passing without a unit and this PR just adds units.

### Motivation & Context
Every time I build a project I get a several warnings if I have used `tint-color` or `shade-color`.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues
Same root cause as https://github.com/twbs/bootstrap/pull/37425

