### PR TITLE
Docs: make all headings use `var(--bs-emphasis-color)`

### DIFF
--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -10,6 +10,7 @@
   // stylelint-enable
 
   h1 {
+    --bs-heading-color: var(--bs-emphasis-color);
     @include font-size(4rem);
   }
 
@@ -64,6 +65,12 @@
 }
 
 .masthead-followup {
+  h2,
+  h3,
+  h4 {
+    --bs-heading-color: var(--bs-emphasis-color);
+  }
+
   .lead {
     @include font-size(1rem);
   }


### PR DESCRIPTION
### Description

In the _main_ branch, headings of the homepage are all grays:

![Screenshot 2023-03-17 at 14 31 41](https://user-images.githubusercontent.com/17381666/225919158-a9fc83db-559f-4ca1-ae5d-5237b21b3854.png)

But this is not the case for the `/docs` and `/examples` pages.

This PR suggests using `var(--bs-emphasis-color)` in .bd-masthead and .masthead-followup headings.

Note: no change of color for the footer headings.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38262--twbs-bootstrap.netlify.app/>

