### PR TITLE
Feature: Add default border-bottom to dropdown-item in dropdown menu

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -79,6 +79,24 @@
     }
 
   }
+
+  //Add default border-bottom to dropdown-item
+  > .dropdown-item:not(:last-child),
+  > li:not(:last-child) .dropdown-item {
+    border-bottom: var(--#{$prefix}dropdown-border-width) solid
+      var(--#{$prefix}dropdown-border-color);
+
+    &:hover,
+    &:focus {
+      border-bottom-color: var(--#{$prefix}dropdown-link-hover-bg);
+    }
+
+    &:active,
+    &:active {
+      border-bottom-color: var(--#{$prefix}dropdown-link-active-bg);
+    }
+  }
+
 }
 
 // scss-docs-start responsive-breakpoints


### PR DESCRIPTION
### Description

Adds a default border-bottom to the items in the dropdown menu.

### Motivation & Context

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

### Related issues

Solves issue #38272 
