### PR TITLE
Fixed form switch when `enable-rounded` is `false`

### DIFF
--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -63,11 +63,7 @@ $form-select-indicator-color-dark:  $body-color-dark !default;
 $form-select-indicator-dark:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color-dark}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
 $form-switch-color-dark:            rgba($white, .25) !default;
-@if $enable-rounded {
-  $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
-} @else {
-  $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color-dark}'/></svg>") !default;
-}
+$form-switch-bg-image-dark:         if($enable-rounded, url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>"), url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color-dark}'/></svg>")) !default;
 
 // scss-docs-start form-validation-colors-dark
 $form-valid-color-dark:             $green-300 !default;

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -63,7 +63,11 @@ $form-select-indicator-color-dark:  $body-color-dark !default;
 $form-select-indicator-dark:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color-dark}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
 $form-switch-color-dark:            rgba($white, .25) !default;
-$form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
+@if $enable-rounded {
+  $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color-dark}'/></svg>") !default;
+} @else {
+  $form-switch-bg-image-dark:         url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color-dark}'/></svg>") !default;
+}
 
 // scss-docs-start form-validation-colors-dark
 $form-valid-color-dark:             $green-300 !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -969,27 +969,16 @@ $form-check-inline-margin-end:    1rem !default;
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
 $form-switch-padding-start:       $form-switch-width + .5em !default;
-@if $enable-rounded {
-  $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
-} @else {
-  $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color}'/></svg>") !default;
-}
+
+$form-switch-bg-image:            if(enable-rounded, url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>"), url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color}'/></svg>")) !default;
 $form-switch-border-radius:       $form-switch-width !default;
 $form-switch-transition:          background-position .15s ease-in-out !default;
 
 $form-switch-focus-color:         $input-focus-border-color !default;
-@if $enable-rounded {
-  $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
-} @else {
-  $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-focus-color}'/></svg>") !default;
-}
+$form-switch-focus-bg-image:      if(enable-rounded, url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>"), url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-focus-color}'/></svg>")) !default;
 
 $form-switch-checked-color:       $component-active-color !default;
-@if $enable-rounded {
-  $form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
-} @else {
-  $form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-checked-color}'/></svg>") !default;
-}
+$form-switch-checked-bg-image:    if(enable-rounded, url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>"), url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-checked-color}'/></svg>")) !default;
 $form-switch-checked-bg-position: right center !default;
 // scss-docs-end form-switch-variables
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -969,15 +969,27 @@ $form-check-inline-margin-end:    1rem !default;
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
 $form-switch-padding-start:       $form-switch-width + .5em !default;
-$form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
+@if $enable-rounded {
+  $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
+} @else {
+  $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-color}'/></svg>") !default;
+}
 $form-switch-border-radius:       $form-switch-width !default;
 $form-switch-transition:          background-position .15s ease-in-out !default;
 
 $form-switch-focus-color:         $input-focus-border-color !default;
-$form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
+@if $enable-rounded {
+  $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-focus-color}'/></svg>") !default;
+} @else {
+  $form-switch-focus-bg-image:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-focus-color}'/></svg>") !default;
+}
 
 $form-switch-checked-color:       $component-active-color !default;
-$form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
+@if $enable-rounded {
+  $form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-checked-color}'/></svg>") !default;
+} @else {
+  $form-switch-checked-bg-image:    url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><rect x='-3' y='-3' width='6' height='6' fill='#{$form-switch-checked-color}'/></svg>") !default;
+}
 $form-switch-checked-bg-position: right center !default;
 // scss-docs-end form-switch-variables
 


### PR DESCRIPTION
### Description

Different approach to #38109. When `enable-rounded` is set to `false` switch indicator shouldn't be rounded.

### Motivation & Context

When `enable-rounded` is set to `false` form switch component takes the form of a retangle with rounded corners removed. However the switch indicator is still a circle, which is not consistent.

![obraz](https://user-images.githubusercontent.com/8281509/226167328-d39b120a-4d13-473a-82a5-7db65dcac35b.png)

After the fix the switch indicator will be a rectangle.

![obraz](https://user-images.githubusercontent.com/8281509/226167144-8eeed73f-935b-4423-902c-8f9bcc01a228.png)

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

### Related issues

#38109
