### PR TITLE
Fix comment position in `assets/scss/_content.scss`

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -3,13 +3,13 @@
 //
 
 .bd-content {
-  // Offset content from fixed navbar when jumping to headings
   > h2,
   > h3,
   > h4 {
     --bs-heading-color: var(--bs-emphasis-color);
   }
 
+  // Offset content from fixed navbar when jumping to headings
   > h2:not(:first-child) {
     margin-top: 3rem;
   }


### PR DESCRIPTION
Minor fix to move the comment near the rules about offsets.