### PR TITLE
Fix reference to twbs/examples/icons-font + fine-tune index.html SB location target

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -108,6 +108,7 @@
     "unstyled",
     "Uppercased",
     "urlize",
+    "urlquery",
     "vbtn",
     "viewports",
     "Vite",

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -32,11 +32,11 @@ aliases: "/examples/"
             </h3>
             <p class="text-body-secondary">{{ $example.description }}</p>
             <p>
-              {{ $htmlIndexLocation := "index.html" }}
-              {{ if $example.htmlIndexLocation }}
-                {{ $htmlIndexLocation = printf "%s/index.html" $example.htmlIndexLocation }}
-              {{ end }}
-              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ $htmlIndexLocation | urlquery }}" target="_blank">
+              {{- $htmlIndexLocation := "index.html" -}}
+              {{- if $example.htmlIndexLocation -}}
+                {{- $htmlIndexLocation = printf "%s/index.html" $example.htmlIndexLocation -}}
+              {{- end }}
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ $htmlIndexLocation | urlquery }}" target="_blank" rel="noopener">
                 <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
                 Edit in StackBlitz
               </a>

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -32,7 +32,7 @@ aliases: "/examples/"
             </h3>
             <p class="text-body-secondary">{{ $example.description }}</p>
             <p>
-              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ with $example.htmlIndexLocation }}{{ . }}/{{ end }}index.html" target="_blank">
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ with $example.htmlIndexLocation }}{{ . }}%2F{{ end }}index.html" target="_blank">
                 <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
                 Edit in StackBlitz
               </a>

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -32,7 +32,11 @@ aliases: "/examples/"
             </h3>
             <p class="text-body-secondary">{{ $example.description }}</p>
             <p>
-              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ with $example.htmlIndexLocation }}{{ . }}%2F{{ end }}index.html" target="_blank">
+              {{ $htmlIndexLocation := "index.html" }}
+              {{ if $example.htmlIndexLocation }}
+                {{ $htmlIndexLocation = printf "%s/index.html" $example.htmlIndexLocation }}
+              {{ end }}
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ $htmlIndexLocation | urlquery }}" target="_blank">
                 <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
                 Edit in StackBlitz
               </a>

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -32,7 +32,7 @@ aliases: "/examples/"
             </h3>
             <p class="text-body-secondary">{{ $example.description }}</p>
             <p>
-              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file=index.html" target="_blank">
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ with $example.htmlIndexLocation }}{{ . }}/{{ end }}index.html" target="_blank">
                 <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
                 Edit in StackBlitz
               </a>

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -26,7 +26,7 @@ aliases: "/examples/"
           <svg class="bi fs-5 flex-shrink-0 mt-1"><use xlink:href="#box-seam"></use></svg>
           <div>
             <h3 class="h5 mb-1">
-              <a class="d-block link-offset-1" href="{{ $.Site.Params.github_org }}{{ $example.url }}/" target="_blank">
+              <a class="d-block link-offset-1" href="{{ $.Site.Params.github_org }}{{ $example.url }}/" target="_blank" rel="noopener">
                 {{ $example.name }}
               </a>
             </h3>

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -14,15 +14,18 @@
     - name: Webpack
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
       url: /examples/tree/main/webpack
+      htmlIndexLocation: src
     - name: Parcel
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
+      htmlIndexLocation: src
     - name: Vite
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
       url: /examples/tree/main/vite
+      htmlIndexLocation: src
     - name: Bootstrap Icons
       description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
-      url: /examples/tree/main/bootstrap-icons
+      url: /examples/tree/main/icons-font
 
 - category: Snippets
   description: "Common patterns for building sites and apps that build on existing components and utilities with custom CSS and more."


### PR DESCRIPTION
### Description

Some links in https://twbs-bootstrap.netlify.app/docs/5.3/examples/ redirect to the right StackBlitz environment, but not always directly to the `index.html` which can be in `src` directory.

![Screenshot 2023-03-23 at 15 55 33](https://user-images.githubusercontent.com/17381666/227244411-ee038a4b-0f20-4c8d-a5f8-5326eaa04647.png)


This PR shows a way to fix it. It might over-complexify the algorithm.
3 possibilities:
- this PR is OK
- we don't care and keep the current situation not perfect
- we choose to link to `/` instead of `/index.html` which will point out to the `README.md` and it would be valid for each environment.

⚠️ This PR also fixes the link to the "Bootstrap Icons" correct StackBlitz environment. It might be treated in another PR if needed.

/cc @XhmikosR 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38310--twbs-bootstrap.netlify.app/docs/5.3/examples/>
