### PR TITLE
Another pass at fixing floating labels disabled colors

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1068,7 +1068,7 @@ $form-floating-padding-x:               $input-padding-x !default;
 $form-floating-padding-y:               1rem !default;
 $form-floating-input-padding-t:         1.625rem !default;
 $form-floating-input-padding-b:         .625rem !default;
-$form-floating-label-height:            1.875em !default;
+$form-floating-label-height:            1.5em !default;
 $form-floating-label-opacity:           .65 !default;
 $form-floating-label-transform:         scale(.85) translateY(-.5rem) translateX(.15rem) !default;
 $form-floating-label-disabled-color:    $gray-600 !default;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,16 +1,16 @@
 .form-floating {
   position: relative;
 
-  &:not(.form-control:disabled)::before {
-    position: absolute;
-    top: $input-border-width;
-    left: $input-border-width;
-    width: subtract(100%, add($input-height-inner-quarter, $input-height-inner-half));
-    height: $form-floating-label-height;
-    content: "";
-    background-color: $input-bg;
-    @include border-radius($input-border-radius);
-  }
+  // &:not(.form-control:disabled)::before {
+  //   position: absolute;
+  //   top: $input-border-width;
+  //   left: $input-border-width;
+  //   width: subtract(100%, add($input-height-inner-quarter, $input-height-inner-half));
+  //   height: $form-floating-label-height;
+  //   content: "";
+  //   background-color: $input-bg;
+  //   @include border-radius($input-border-radius);
+  // }
 
   > .form-control,
   > .form-control-plaintext,
@@ -23,6 +23,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 2;
     width: 100%;
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
@@ -66,14 +67,23 @@
   > .form-control-plaintext,
   > .form-select {
     ~ label {
-      opacity: $form-floating-label-opacity;
+      color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
       transform: $form-floating-label-transform;
+
+      &::after {
+        position: absolute;
+        inset: $form-floating-padding-y ($form-floating-padding-x * .5);
+        z-index: -1;
+        content: "";
+        background-color: $input-bg;
+        @include border-radius($input-border-radius);
+      }
     }
   }
   // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
   > .form-control:-webkit-autofill {
     ~ label {
-      opacity: $form-floating-label-opacity;
+      color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
       transform: $form-floating-label-transform;
     }
   }

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -13,7 +13,6 @@
     top: 0;
     left: 0;
     z-index: 2;
-    width: 100%;
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -84,7 +84,11 @@
     }
   }
 
-  > .form-control:disabled ~ label {
+  > :disabled ~ label {
     color: $form-floating-label-disabled-color;
+
+    &::after {
+      background-color: $input-disabled-bg;
+    }
   }
 }

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,17 +1,6 @@
 .form-floating {
   position: relative;
 
-  // &:not(.form-control:disabled)::before {
-  //   position: absolute;
-  //   top: $input-border-width;
-  //   left: $input-border-width;
-  //   width: subtract(100%, add($input-height-inner-quarter, $input-height-inner-half));
-  //   height: $form-floating-label-height;
-  //   content: "";
-  //   background-color: $input-bg;
-  //   @include border-radius($input-border-radius);
-  // }
-
   > .form-control,
   > .form-control-plaintext,
   > .form-select {
@@ -74,6 +63,7 @@
         position: absolute;
         inset: $form-floating-padding-y ($form-floating-padding-x * .5);
         z-index: -1;
+        height: $form-floating-label-height;
         content: "";
         background-color: $input-bg;
         @include border-radius($input-border-radius);


### PR DESCRIPTION
Alternate fix to #38159.

Will need to deprecate the `$form-floating-label-height` variable with this solution, or use it some other way, but it works without using the `:has()` selector. Approach here remaps the `opacity` value to an `rgba()` alpha channel, so we can just style based on background or a generated element. With this we could probably simplify more, but open to ideas.