### PR TITLE
docs: remove trailing newline when copying snippets

### DIFF
--- a/site/assets/js/code-examples.js
+++ b/site/assets/js/code-examples.js
@@ -13,6 +13,7 @@
 
 (() => {
   'use strict'
+
   // Insert copy to clipboard button before .highlight
   const btnTitle = 'Copy to clipboard'
   const btnEdit = 'Edit on StackBlitz'
@@ -27,7 +28,7 @@
     '</div>'
   ].join('')
 
-  // wrap programmatically code blocks and add copy btn.
+  // Wrap programmatically code blocks and add copy btn.
   document.querySelectorAll('.highlight')
     .forEach(element => {
       if (!element.closest('.bd-example-snippet')) { // Ignore examples made be shortcode
@@ -51,7 +52,8 @@
   snippetButtonTooltip('.btn-edit', btnEdit)
 
   const clipboard = new ClipboardJS('.btn-clipboard', {
-    target: trigger => trigger.closest('.bd-code-snippet').querySelector('.highlight')
+    target: trigger => trigger.closest('.bd-code-snippet').querySelector('.highlight'),
+    text: trigger => trigger.parentNode.nextElementSibling.textContent.trimEnd()
   })
 
   clipboard.on('success', event => {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38321--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
