### PR TITLE
Add `media-query` color mode Sass test

### DIFF
--- a/scss/tests/mixins/_media-query-color-mode-full.test.scss
+++ b/scss/tests/mixins/_media-query-color-mode-full.test.scss
@@ -3,6 +3,6 @@ $color-mode-type: media-query;
 @import "../../bootstrap";
 
 @include describe("global $color-mode-type: media-query") {
-  @include it("compiles entirely Bootstrap CSS with media-query color mode") {
+  @include it("compiles entirely Bootstrap CSS with media-query color mode") { // stylelint-disable-line block-no-empty
   }
 }

--- a/scss/tests/mixins/_media-query-color-mode-full.test.scss
+++ b/scss/tests/mixins/_media-query-color-mode-full.test.scss
@@ -1,0 +1,8 @@
+$color-mode-type: media-query;
+
+@import "../../bootstrap";
+
+@include describe("global $color-mode-type: media-query") {
+  @include it("compiles entirely Bootstrap CSS with media-query color mode") {
+  }
+}


### PR DESCRIPTION
### Description

Related to https://github.com/twbs/bootstrap/issues/38322, this PR suggests adding an automatic test to build Bootstrap with `$color-mode: "media-query"` enabled since we released a version with errors for this use case.

IDK if a kind of "assert true" is mandatory here.

/cc @mdo and @romaricpascal for thoughts

### Motivation & Context

Not releasing again a version with errors with `$color-mode: "media-query"`.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

https://github.com/twbs/bootstrap/issues/38322
