### PR TITLE
Update selectors for carousel media query color mode option

### DIFF
--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -230,9 +230,15 @@
 
 @if $enable-dark-mode {
   @include color-mode(dark) {
-    .carousel,
-    &.carousel {
-      @include carousel-dark();
+    @if $color-mode-type == "media-query" {
+      .carousel {
+        @include carousel-dark();
+      }
+    } @else {
+      .carousel,
+      &.carousel {
+        @include carousel-dark();
+      }
     }
   }
 }


### PR DESCRIPTION
Complementary fix to go with #38326.

This adds a check on the `$color-mode-type` to our carousel dark mode selector to ensure we're not sending a root level `&` selector.

/cc @julien-deramond 