### PR TITLE
Change diff file path in Webpack guide

### DIFF
--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -303,8 +303,8 @@ Then instantiate and use the plugin in the Webpack configuration:
 After running `npm run build` again, there will be a new file `dist/main.css`, which will contain all of the CSS imported by `src/js/main.js`. If you view `dist/index.html` in your browser now, the style will be missing, as it is now in `dist/main.css`. You can include the generated CSS in `dist/index.html` like this:
 
 ```diff
---- a/webpack/dist/index.html
-+++ b/webpack/dist/index.html
+--- a/dist/index.html
++++ b/dist/index.html
 @@ -3,6 +3,7 @@
    <head>
      <meta charset="utf-8">
@@ -322,8 +322,8 @@ Bootstrap's CSS includes multiple references to SVG files via inline `data:` URI
 Configure Webpack to extract inline SVG files like this:
 
 ```diff
---- a/webpack/webpack.config.js
-+++ b/webpack/webpack.config.js
+--- a/webpack.config.js
++++ b/webpack.config.js
 @@ -23,6 +23,14 @@ module.exports = {
    },
    module: {


### PR DESCRIPTION
### Description

This PR contains a small fix to use the same reference for the diff in the Webpack guide.
When we follow the tutorial, we are in the `my-project` directory, so when we are doing the diffs, it is in this directory and not in a `webpack` directory (as in twbs/examples).

There are no diffs in Parcel and Vite guides so this is the only place where a modification is needed.

### Motivation & Context

Consistency between diffs in this guide.

### Type of changes

- [x] Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38339--twbs-bootstrap.netlify.app/docs/5.3/getting-started/webpack/#extracting-css
- https://deploy-preview-38339--twbs-bootstrap.netlify.app/docs/5.3/getting-started/webpack/#extracting-svg-files
