### PR TITLE
Docs: update Webpack guide

### DIFF
--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -128,7 +128,7 @@ With dependencies installed and our project folder ready for us to start coding,
      // ...
      "scripts": {
        "start": "webpack serve",
-       "build": "webpack build",
+       "build": "webpack build --mode=production",
        "test": "echo \"Error: no test specified\" && exit 1"
      },
      // ...

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -115,7 +115,6 @@ With dependencies installed and our project folder ready for us to start coding,
          <h1>Hello, Bootstrap and Webpack!</h1>
          <button class="btn btn-primary">Primary button</button>
        </div>
-       <script src="./main.js"></script>
      </body>
    </html>
    ```


### PR DESCRIPTION
### Description

* https://github.com/twbs/examples/pull/136/files introduced the removal of `<script src="./main.js"></script>` since Webpack handles it on its own. So this PR updates the Webpack guide to remove this `<script>` part as well.

* https://github.com/twbs/examples/pull/138/files introduced a new way to build the Webpack tutorial with the `--mode=production`. So this PR updates the Webpack guide to introduce it as well.

### Motivation & Context

Consistency between the docs and the `twbs/examples` repository.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38345--twbs-bootstrap.netlify.app/docs/5.3/getting-started/webpack/#configure-webpack
