### PR TITLE
Docs: `js-docs` unindent automatically the code inside shortcode

### DIFF
--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -32,6 +32,27 @@
         <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
       </button>
     </div>
-    {{- highlight $match "js" "" -}}
+    {{- $unindent := 0 -}}
+    {{- $found := false -}}
+    {{- $first_line:= index (split $match "\n") 0 -}}
+    {{- range $char := split $first_line "" -}}
+      {{- if and (eq $char " ") (not $found) -}}
+        {{- $unindent = add $unindent 1 -}}
+      {{- else -}}
+        {{- $found = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $output := "" -}}
+    {{- if (gt $unindent 0) -}}
+      {{- $prefix := (strings.Repeat $unindent " ") -}}
+      {{- range $line := split $match "\n" -}}
+        {{- $line = strings.TrimPrefix $prefix $line -}}
+        {{ $output = printf "%s%s\n" $output $line }}
+      {{- end -}}
+      {{- $output = chomp $output -}}
+    {{- else -}}
+      {{- $output = $match -}}
+    {{- end -}}
+    {{- highlight $output "js" "" -}}
   </div>
 {{- end -}}


### PR DESCRIPTION
### Description

Based on the magical Hugo stuff done by @louismaximepiton from https://github.com/twbs/bootstrap/commit/f8a56da8b04d8d29a8a8f65d50549206c429a621, this PR suggests using the same spell for the new `js-docs` shortcode in order to have the correct indentation.

Before: (e.g. https://twbs-bootstrap.netlify.app/docs/5.3/components/alerts/#live-example)

![Screenshot 2023-03-28 at 11 06 06](https://user-images.githubusercontent.com/17381666/228186851-6cd87910-337b-4194-bfff-910df404528c.png)

Now: (e.g. https://deploy-preview-38349--twbs-bootstrap.netlify.app//docs/5.3/components/alerts/#live-example)

![Screenshot 2023-03-28 at 11 06 36](https://user-images.githubusercontent.com/17381666/228187015-c03c1745-3b7e-451b-b5ba-35bffbc9fcae.png)

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38349--twbs-bootstrap.netlify.app//docs/5.3/components/alerts/#live-example
- https://deploy-preview-38349--twbs-bootstrap.netlify.app/docs/5.3/components/modal/#varying-modal-content
- https://deploy-preview-38349--twbs-bootstrap.netlify.app/docs/5.3/components/toasts/#live-example
- https://deploy-preview-38349--twbs-bootstrap.netlify.app/docs/5.3/getting-started/javascript/#sanitizer

