### PR TITLE
Fixes sass warning on _root.scss:10

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -7,7 +7,7 @@
   // Generate palettes for full colors, grays, and theme colors.
 
   @each $color, $value in $colors {
-    --#{$prefix}#{$color}: #{$value};
+    --#{$prefix}#{"" + $color}: #{$value};
   }
 
   @each $color, $value in $grays {


### PR DESCRIPTION
### Description

When compiling bootstrap with ViteJS (Dart Sass), I get the following warning:

>Warning: You probably don't mean to use the color value white in interpolation here.
It may end up represented as white, which will likely produce invalid CSS.
Always quote color names when using them as strings or map keys (for example, "white").
If you really want to use the color value here, use '"" + $color'.


### Motivation & Context

Fixes a warning during compilation.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38353--twbs-bootstrap.netlify.app/>

### Related issues

https://github.com/twbs/bootstrap/issues/29219 (very outdated)
