### PR TITLE
Docs: remove moot `hot` option from Vite guide

### DIFF
--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -86,8 +86,7 @@ With dependencies installed and our project folder ready for us to start coding,
        outDir: '../dist'
      },
      server: {
-       port: 8080,
-       hot: true
+       port: 8080
      }
    }
    ```


### PR DESCRIPTION
### Description

This PR removes the moot `hot` option from the Vite config example in the docs.

### Motivation & Context

Vite config example must be updated after https://github.com/twbs/examples/pull/157.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38405--twbs-bootstrap.netlify.app/docs/5.3/getting-started/vite/#configure-vite
