### PR TITLE
Docs: add missing `twbs/examples` and change sorting

### DIFF
--- a/site/content/docs/5.3/customize/color-modes.md
+++ b/site/content/docs/5.3/customize/color-modes.md
@@ -7,6 +7,10 @@ toc: true
 added: "5.3"
 ---
 
+{{< callout >}}
+**Try it yourself!** Download the source code and working demo for using Bootstrap with Stylelint, and the color modes from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/color-modes). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/color-modes?file=index.html).
+{{< /callout >}}
+
 ## Dark mode
 
 **Bootstrap now supports color modes, starting with dark mode!** With v5.3.0 you can implement your own color mode toggler (see below for an example from Bootstrap's docs) and apply the different color modes as you see fit. We support a light mode (default) and now dark mode. Color modes can be toggled globally on the `<html>` element, or on specific components and elements, thanks to the `data-bs-theme` attribute.

--- a/site/content/docs/5.3/examples/_index.md
+++ b/site/content/docs/5.3/examples/_index.md
@@ -32,11 +32,11 @@ aliases: "/examples/"
             </h3>
             <p class="text-body-secondary">{{ $example.description }}</p>
             <p>
-              {{- $htmlIndexLocation := "index.html" -}}
-              {{- if $example.htmlIndexLocation -}}
-                {{- $htmlIndexLocation = printf "%s/index.html" $example.htmlIndexLocation -}}
+              {{- $indexPath := "index.html" -}}
+              {{- if $example.indexPath -}}
+                {{- $indexPath = $example.indexPath -}}
               {{- end }}
-              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ $htmlIndexLocation | urlquery }}" target="_blank" rel="noopener">
+              <a class="icon-link small link-secondary link-offset-1" href="https://stackblitz.com/github/twbs{{ $example.url }}?file={{ $indexPath | urlquery }}" target="_blank" rel="noopener">
                 <svg class="bi flex-shrink-0"><use xlink:href="#lightning-charge-fill"></use></svg>
                 Edit in StackBlitz
               </a>

--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -19,8 +19,14 @@ While the Bootstrap CSS can be used with any framework, **the Bootstrap JavaScri
 A better alternative for those using this type of frameworks is to use a framework-specific package **instead of** the Bootstrap JavaScript. Here are some of the most popular options:
 
 - React: [React Bootstrap](https://react-bootstrap.github.io/)
+  {{< callout >}}
+  **Try it yourself!** Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/react-nextjs). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx).
+  {{< /callout >}}
 - Vue: [BootstrapVue](https://bootstrap-vue.org/) (currently only supports Vue 2 and Bootstrap 4)
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
+
+
+
 
 ## Using Bootstrap as a module
 

--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -25,9 +25,6 @@ A better alternative for those using this type of frameworks is to use a framewo
 - Vue: [BootstrapVue](https://bootstrap-vue.org/) (currently only supports Vue 2 and Bootstrap 4)
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
 
-
-
-
 ## Using Bootstrap as a module
 
 {{< callout >}}

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -14,18 +14,29 @@
     - name: Webpack
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
       url: /examples/tree/main/webpack
-      htmlIndexLocation: src
+      indexPath: src/index.html
     - name: Parcel
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
-      htmlIndexLocation: src
+      indexPath: src/index.html
     - name: Vite
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
       url: /examples/tree/main/vite
-      htmlIndexLocation: src
+      indexPath: src/index.html
     - name: Bootstrap Icons
       description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
       url: /examples/tree/main/icons-font
+    - name: Bootstrap color modes
+      description: "Import and compile Bootstrap's Sass with Stylelint, and the Bootstrap color modes."
+      url: /examples/tree/main/color-modes
+    - name: Bootstrap with React
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
+      url: /examples/tree/main/react-nextjs
+      indexPath: src/pages/index.tsx
+    - name: Bootstrap with Vue
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with Vue and Vite."
+      url: /examples/tree/main/vue
+
 
 - category: Snippets
   description: "Common patterns for building sites and apps that build on existing components and utilities with custom CSS and more."

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -17,7 +17,7 @@
     - name: Bootstrap Icons
       description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
       url: /examples/tree/main/icons-font
-    - name: Parcel
+    - name: Bootstrap with Parcel
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
       indexPath: src/index.html
@@ -26,7 +26,7 @@
       description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
       url: /examples/tree/main/react-nextjs
       indexPath: src/pages/index.tsx
-    - name: Vite
+    - name: Bootstrap with Vite
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
       url: /examples/tree/main/vite
     - name: Bootstrap with Vue

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -5,15 +5,15 @@
     - name: CDN starter
       description: "Instantly include Bootstrap's compiled CSS and JavaScript via the jsDelivr CDN."
       url: /examples/tree/main/starter
-    - name: Bootstrap color modes
-      description: "Import and compile Bootstrap's Sass with Stylelint, and the Bootstrap color modes."
-      url: /examples/tree/main/color-modes
     - name: Sass & JS
       description: "Use npm to import and compile Bootstrap's Sass with Autoprefixer and Stylelint, plus our bundled JavaScript."
       url: /examples/tree/main/sass-js
     - name: Sass & ESM JS
       description: "Import and compile Bootstrap's Sass with Autoprefixer and Stylelint, and compile our source JavaScript with an ESM shim."
       url: /examples/tree/main/sass-js-esm
+    - name: Bootstrap color modes
+      description: "Import and compile Bootstrap's Sass with Stylelint, and the Bootstrap color modes."
+      url: /examples/tree/main/color-modes
     - name: Bootstrap Icons
       description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
       url: /examples/tree/main/icons-font

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -5,37 +5,37 @@
     - name: CDN starter
       description: "Instantly include Bootstrap's compiled CSS and JavaScript via the jsDelivr CDN."
       url: /examples/tree/main/starter
+    - name: Bootstrap color modes
+      description: "Import and compile Bootstrap's Sass with Stylelint, and the Bootstrap color modes."
+      url: /examples/tree/main/color-modes
     - name: Sass & JS
       description: "Use npm to import and compile Bootstrap's Sass with Autoprefixer and Stylelint, plus our bundled JavaScript."
       url: /examples/tree/main/sass-js
     - name: Sass & ESM JS
       description: "Import and compile Bootstrap's Sass with Autoprefixer and Stylelint, and compile our source JavaScript with an ESM shim."
       url: /examples/tree/main/sass-js-esm
-    - name: Webpack
-      description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
-      url: /examples/tree/main/webpack
-      indexPath: src/index.html
+    - name: Bootstrap Icons
+      description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
+      url: /examples/tree/main/icons-font
     - name: Parcel
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
       indexPath: src/index.html
-    - name: Vite
-      description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
-      url: /examples/tree/main/vite
       indexPath: src/index.html
-    - name: Bootstrap Icons
-      description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
-      url: /examples/tree/main/icons-font
-    - name: Bootstrap color modes
-      description: "Import and compile Bootstrap's Sass with Stylelint, and the Bootstrap color modes."
-      url: /examples/tree/main/color-modes
     - name: Bootstrap with React
       description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
       url: /examples/tree/main/react-nextjs
       indexPath: src/pages/index.tsx
+    - name: Vite
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
+      url: /examples/tree/main/vite
     - name: Bootstrap with Vue
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vue and Vite."
       url: /examples/tree/main/vue
+    - name: Bootstrap with Webpack
+      description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
+      url: /examples/tree/main/webpack
+      indexPath: src/index.html
 
 - category: Snippets
   description: "Common patterns for building sites and apps that build on existing components and utilities with custom CSS and more."

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -37,7 +37,6 @@
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vue and Vite."
       url: /examples/tree/main/vue
 
-
 - category: Snippets
   description: "Common patterns for building sites and apps that build on existing components and utilities with custom CSS and more."
   examples:

--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -17,22 +17,22 @@
     - name: Bootstrap Icons
       description: "Import and compile Bootstrap's Sass with Stylelint, PurgeCSS, and the Bootstrap Icons web font."
       url: /examples/tree/main/icons-font
-    - name: Bootstrap with Parcel
+    - name: Parcel
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
       indexPath: src/index.html
       indexPath: src/index.html
-    - name: Bootstrap with React
+    - name: React
       description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
       url: /examples/tree/main/react-nextjs
       indexPath: src/pages/index.tsx
-    - name: Bootstrap with Vite
+    - name: Vite
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vite."
       url: /examples/tree/main/vite
-    - name: Bootstrap with Vue
+    - name: Vue
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Vue and Vite."
       url: /examples/tree/main/vue
-    - name: Bootstrap with Webpack
+    - name: Webpack
       description: "Import and bundle Bootstrap's source Sass and JavaScript with Webpack."
       url: /examples/tree/main/webpack
       indexPath: src/index.html


### PR DESCRIPTION
### Description

This PR adds missing [twbs/examples](https://github.com/twbs/examples) in our /examples page.

In order to do that, because of the `src/pages/index.tsx` main file, I've modified the `/examples/_index.md` file to directly set the index path from `site/data/examples.yml` file.

It also adds some callouts:
- First one is on the top of the color modes page, to let users know that we have a dedicated example for that.
- Second one is within the list of JS frameworks in JavaScript documentation page, to let users know that we have a dedicated example for React and React Bootstrap.

### Motivation & Context

Let the users know that we have a lot of examples.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38407--twbs-bootstrap.netlify.app/docs/5.3/examples/
- https://deploy-preview-38407--twbs-bootstrap.netlify.app/docs/5.3/getting-started/javascript/#usage-with-javascript-frameworks
- https://deploy-preview-38407--twbs-bootstrap.netlify.app/docs/5.3/customize/color-modes/

### Related issues

Closes #38370
