### PR TITLE
generate-sri.js: use destructuring

### DIFF
--- a/build/generate-sri.js
+++ b/build/generate-sri.js
@@ -46,8 +46,8 @@ const files = [
   }
 ]
 
-for (const file of files) {
-  fs.readFile(file.file, 'utf8', (error, data) => {
+for (const { file, configPropertyName } of files) {
+  fs.readFile(file, 'utf8', (error, data) => {
     if (error) {
       throw error
     }
@@ -56,8 +56,8 @@ for (const file of files) {
     const hash = crypto.createHash(algo).update(data, 'utf8').digest('base64')
     const integrity = `${algo}-${hash}`
 
-    console.log(`${file.configPropertyName}: ${integrity}`)
+    console.log(`${configPropertyName}: ${integrity}`)
 
-    sh.sed('-i', new RegExp(`^(\\s+${file.configPropertyName}:\\s+["'])\\S*(["'])`), `$1${integrity}$2`, configFile)
+    sh.sed('-i', new RegExp(`^(\\s+${configPropertyName}:\\s+["'])\\S*(["'])`), `$1${integrity}$2`, configFile)
   })
 }


### PR DESCRIPTION
Would be nice if we could remove shelljs and just use the `fs` methods.

Any help is welcome!

/CC @GeoSot 