### PR TITLE
Docs: fix text rendering of navbar external content

### DIFF
--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -655,9 +655,9 @@ With a toggler on the left and brand name on the right:
 Sometimes you want to use the collapse plugin to trigger a container element for content that structurally sits outside of the `.navbar` . Because our plugin works on the `id` and `data-bs-target` matching, that's easily done!
 
 {{< example >}}
-<div class="collapse" id="navbarToggleExternalContent">
+<div class="collapse" id="navbarToggleExternalContent" data-bs-theme="dark">
   <div class="bg-dark p-4">
-    <h5 class="text-white h4">Collapsed content</h5>
+    <h5 class="text-body-emphasis h4">Collapsed content</h5>
     <span class="text-body-secondary">Toggleable via the navbar brand.</span>
   </div>
 </div>


### PR DESCRIPTION
### Description

Reference: https://github.com/twbs/bootstrap/issues/38430#issuecomment-1501193732

Before this PR, in https://twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#external-content, when you click on the toggle button, "Toggleable via the navbar brand." is not visible because written with the same color as the background.

<img width="773" alt="Screenshot 2023-04-10 at 09 04 23" src="https://user-images.githubusercontent.com/17381666/230846587-2255696a-62d9-4941-965a-9a891ed3cc15.png">

This is due to the fact that `.text-muted` is deprecated and has been changed by `.text-body-emphasis`.
In light mode, `.text-body-emphasis` will have the same color as `.bg-dark`.
Based on what's explained in https://twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#color-schemes, we can simply use `data-bs-theme="dark"` combined with the `.bg-dark` to keep using `.text-body-emphasis`. But we should also rather use `.text-body-emphasis` for the white color.

Another possibility to fix this issue would be to avoid using a dark navbar here since the content is not linked to this specific color, we could have a light background to explain this feature.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38431--twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#external-content>

### Related issues

#38430
