### PR TITLE
dropdown.spec.js: expect nothing in constructor

### DIFF
--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -75,6 +75,7 @@ describe('Dropdown', () => {
           resolve()
         })
 
+        expect().nothing()
         dropdown.show()
       })
     })


### PR DESCRIPTION
The related jasmine warnings seem to be gone with this change.

The failures are the known "unknown" ones for now...