### PR TITLE
node-sass workflow: improve error message when Sass vars are found

### DIFF
--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Check built CSS files
         shell: bash
         run: |
-          SASS_VARS_FOUND=`find dist-sass/css/ -name "*.css" | xargs grep -F "\$"`
-
+          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" | xargs grep -F "\$")
           if [ -z "$SASS_VARS_FOUND" ]; then
             echo "All good, no Sass variables found"
             exit 0

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check built CSS files
         shell: bash
         run: |
-          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" | xargs grep -F "\$")
+          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" -print0 | xargs -0 grep -F "\$")
           if [ -z "$SASS_VARS_FOUND" ]; then
             echo "All good, no Sass variables found"
             exit 0

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -39,10 +39,13 @@ jobs:
       - name: Check built CSS files
         shell: bash
         run: |
-          if [[ $(find dist-sass/css/ -name "*.css" | xargs grep -F "\$" | wc -l | bc) -eq 0 ]]; then
+          SASS_VARS_FOUND=`find dist-sass/css/ -name "*.css" | xargs grep -F "\$"`
+
+          if [ -z "$SASS_VARS_FOUND" ]; then
             echo "All good, no Sass variables found"
             exit 0
           else
-            echo "Found Sass variables!"
+            echo "Found $(echo "$SASS_VARS_FOUND" | wc -l | bc) Sass variables:"
+            echo "$SASS_VARS_FOUND"
             exit 1
           fi

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check built CSS files
         shell: bash {0}
         run: |
-          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" | xargs grep -F "\$")
+          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" -print0 | xargs -0 grep -F "\$")
           if [ -z "$SASS_VARS_FOUND" ]; then
             echo "All good, no Sass variables found"
             exit 0

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -35,13 +35,12 @@ jobs:
           npx --package node-sass@latest node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/ -o dist-sass/css/
           ls -Al dist-sass/css
 
-      # Check that there are no Sass variables (`$`)
-      - name: Check built CSS files
-        shell: bash {0}
+      - name: Check built CSS files for Sass variables
+        shell: bash
         run: |
-          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" -print0 | xargs -0 grep -F "\$")
-          if [ -z "$SASS_VARS_FOUND" ]; then
-            echo "All good, no Sass variables found"
+          SASS_VARS_FOUND=$(find "dist-sass/css/" -type f -name "*.css" -print0 | xargs -0 --no-run-if-empty grep -F "\$" || true)
+          if [[ -z "$SASS_VARS_FOUND" ]]; then
+            echo "All good, no Sass variables found!"
             exit 0
           else
             echo "Found $(echo "$SASS_VARS_FOUND" | wc -l | bc) Sass variables:"

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Check that there are no Sass variables (`$`)
       - name: Check built CSS files
-        shell: bash
+        shell: bash {0}
         run: |
           SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" | xargs grep -F "\$")
           if [ -z "$SASS_VARS_FOUND" ]; then

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check built CSS files
         shell: bash
         run: |
-          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" -print0 | xargs -0 grep -F "\$")
+          SASS_VARS_FOUND=$(find dist-sass/css/ -name "*.css" | xargs grep -F "\$")
           if [ -z "$SASS_VARS_FOUND" ]; then
             echo "All good, no Sass variables found"
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ Thumbs.db
 *.komodoproject
 
 # Folders to ignore
+/dist-sass/
 /js/coverage/
 /node_modules/

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -39,7 +39,7 @@
   // Prevent double borders when buttons are next to each other
   > :not(.btn-check:first-child) + .btn,
   > .btn-group:not(:first-child) {
-    margin-left: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners
@@ -126,7 +126,7 @@
 
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) {
-    margin-top: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
+    margin-top: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -39,7 +39,7 @@
   // Prevent double borders when buttons are next to each other
   > :not(.btn-check:first-child) + .btn,
   > .btn-group:not(:first-child) {
-    margin-left: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners
@@ -126,7 +126,7 @@
 
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) {
-    margin-top: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
+    margin-top: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners


### PR DESCRIPTION
### Description

This PR suggests improving the error message of the `node-sass` workflow when we find Sass variables in `dist-sass`.

In the first commit, I voluntarily reverted some changes in our CSS files in https://github.com/twbs/bootstrap/pull/38448/files to show the new error message.
It can be found here: https://github.com/twbs/bootstrap/actions/runs/4679714004/jobs/8290111973?pr=38448.

![Screenshot 2023-04-12 at 16 53 32](https://user-images.githubusercontent.com/17381666/231496932-0ad55827-31c2-44b0-959c-3454448093da.png)

Then, the [second commit](https://github.com/twbs/bootstrap/pull/38448/commits/9c80068042bbb3b6222bc761119ce68b3bd01b5a) rollbacks the wrong changes so that the workflow is green again.

Extra information:  `bash {0}` is used to avoid "Fail-fast behavior" (See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)

### Motivation & Context

When it's not possible to run `npx` locally because of security rules in a company or because you don't remember the command line, it can be really handy to have the list of the errors directly in the logs of the failed workflow.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed
