### PR TITLE
change-version.js: handle rubygems specific version number

### DIFF
--- a/build/change-version.js
+++ b/build/change-version.js
@@ -35,8 +35,13 @@ function regExpQuoteReplacement(string) {
 
 async function replaceRecursively(file, oldVersion, newVersion) {
   const originalString = await fs.readFile(file, 'utf8')
-  const newString = originalString.replace(
+  var newString = originalString.replace(
     new RegExp(regExpQuote(oldVersion), 'g'), regExpQuoteReplacement(newVersion)
+  )
+
+  // Also replace the version used by Ruby sometimes in this case: '5.3.0.alpha3' which is different from '5.3.0-alpha3'
+  newString = newString.replace(
+    new RegExp(regExpQuote(oldVersion.replace(/-/g,'.')), 'g'), regExpQuoteReplacement(newVersion)
   )
 
   // No need to move any further if the strings are identical

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -66,7 +66,7 @@ async function replaceRecursively(file, oldVersion, newVersion) {
 async function main(args) {
   let [oldVersion, newVersion] = args
 
-  if (!oldVersion || !newVersion) {
+  if (!oldVersion || !newVersion || (oldVersion === newVersion)) {
     console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
     console.error('Got arguments:', args)
     process.exit(1)

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -63,6 +63,12 @@ async function replaceRecursively(file, oldVersion, newVersion) {
   await fs.writeFile(file, newString, 'utf8')
 }
 
+function showUsage(args) {
+  console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
+  console.error('Got arguments:', args)
+  process.exit(1)
+}
+
 async function main(args) {
   let [oldVersion, newVersion] = args
 
@@ -90,12 +96,6 @@ async function main(args) {
     console.error(error)
     process.exit(1)
   }
-}
-
-function showUsage(args) {
-  console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
-  console.error('Got arguments:', args)
-  process.exit(1)
 }
 
 main(process.argv.slice(2))

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -66,25 +66,36 @@ async function replaceRecursively(file, oldVersion, newVersion) {
 async function main(args) {
   let [oldVersion, newVersion] = args
 
-  if (!oldVersion || !newVersion || (oldVersion === newVersion)) {
-    console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
-    console.error('Got arguments:', args)
-    process.exit(1)
+  if (!oldVersion || !newVersion) {
+    showUsage()
   }
 
-  // Strip any leading `v` from arguments because otherwise we will end up with duplicate `v`s
+  // Strip any leading `v` from arguments because
+  // otherwise we will end up with duplicate `v`s
   [oldVersion, newVersion] = [oldVersion, newVersion].map(arg => {
     return arg.startsWith('v') ? arg.slice(1) : arg
   })
 
+  if (oldVersion === newVersion) {
+    showUsage()
+  }
+
   try {
     const files = await globby(GLOB, GLOBBY_OPTIONS)
 
-    await Promise.all(files.map(file => replaceRecursively(file, oldVersion, newVersion)))
+    await Promise.all(
+      files.map(file => replaceRecursively(file, oldVersion, newVersion))
+    )
   } catch (error) {
     console.error(error)
     process.exit(1)
   }
+}
+
+function showUsage() {
+    console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
+    console.error('Got arguments:', args)
+    process.exit(1)
 }
 
 main(process.argv.slice(2))

--- a/build/change-version.js
+++ b/build/change-version.js
@@ -67,7 +67,7 @@ async function main(args) {
   let [oldVersion, newVersion] = args
 
   if (!oldVersion || !newVersion) {
-    showUsage()
+    showUsage(args)
   }
 
   // Strip any leading `v` from arguments because
@@ -77,7 +77,7 @@ async function main(args) {
   })
 
   if (oldVersion === newVersion) {
-    showUsage()
+    showUsage(args)
   }
 
   try {
@@ -92,10 +92,10 @@ async function main(args) {
   }
 }
 
-function showUsage() {
-    console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
-    console.error('Got arguments:', args)
-    process.exit(1)
+function showUsage(args) {
+  console.error('USAGE: change-version old_version new_version [--verbose] [--dry[-run]]')
+  console.error('Got arguments:', args)
+  process.exit(1)
 }
 
 main(process.argv.slice(2))


### PR DESCRIPTION
### Description

In https://github.com/twbs/bootstrap/commit/fe0c7432af53adebc1144ead0ff0ff7889873e77, we are changing the `current_ruby_version` value to `"5.3.0.alpha3"`.

When we will run `npm run release-version 5.3.0-alpha3 5.3.0`, `config.yml` won't be modified for `current_ruby_version` because it won't match `5.3.0-alpha3`.

This PR is a very naive approach to handling this specific use case.
It is probably more a ping for you @XhmikosR than a real solution.
Feel free to change it or close it if not necessary.