### PR TITLE
Fix Rubygems link to README.md

### DIFF
--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -96,7 +96,7 @@ Alternatively, if you're not using Bundler, you can install the gem by running t
 gem install bootstrap -v {{< param current_ruby_version >}}
 ```
 
-[See the gem's README](https://github.com/twbs/bootstrap-rubygem/blob/master/README.md) for further details.
+[See the gem's README](https://github.com/twbs/bootstrap-rubygem/blob/main/README.md) for further details.
 
 ### Composer
 


### PR DESCRIPTION
This is already in #38458 which I plan to merge to gh-pages where I noticed it.