### PR TITLE
changed border-color variable from #dee2e6 to #888

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -539,7 +539,7 @@ $border-widths: (
   5: 5px
 ) !default;
 $border-style:                solid !default;
-$border-color:                $gray-300 !default;
+$border-color:                #888 !default;
 $border-color-translucent:    rgba($black, .175) !default;
 // scss-docs-end border-variables
 


### PR DESCRIPTION
### Description

Made changes in the  _variables.scss file where I changed the value of border-color from #dee2e6 to #888 that would resolve the issue #38480.


fixes #38480 

### Motivation & Context
The border of some elements , specially in input form like checkboxes had very low contrast that made them slightly invisible

<!-- Why is this change required? What problem does it solve? -->
This change solves the border color invisibility for the elements like checkboxes , form inputs  , etc.
### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- N/A New feature (non-breaking change which adds functionality)
- N/A Refactoring (non-breaking change)
- N/A Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- N/A My change introduces changes to the documentation
- N/A I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38489--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
