### PR TITLE
Add new docsref page, fix docs border-radius issues

### DIFF
--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -14,9 +14,10 @@
 
   // Scroll the active sidebar link into view
   const sidenav = document.querySelector('.bd-sidebar')
-  if (sidenav) {
+  const sidenavActiveLink = document.querySelector('.bd-links-nav .active')
+
+  if (sidenav && sidenavActiveLink) {
     const sidenavHeight = sidenav.clientHeight
-    const sidenavActiveLink = document.querySelector('.bd-links-nav .active')
     const sidenavActiveLinkTop = sidenavActiveLink.offsetTop
     const sidenavActiveLinkHeight = sidenavActiveLink.clientHeight
     const viewportTop = sidenavActiveLinkTop

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -3,6 +3,8 @@
 //
 
 .bd-code-snippet {
+  margin-right: ($bd-gutter-x * -.5);
+  margin-left: ($bd-gutter-x * -.5);
   border: solid var(--bs-border-color);
   border-width: 1px 0;
 
@@ -17,7 +19,9 @@
 
   position: relative;
   padding: var(--bd-example-padding);
-  margin: 0 ($bd-gutter-x * -.5);
+  margin: 0 ($bd-gutter-x * -.5) 1rem;
+  border: solid var(--bs-border-color);
+  border-width: 1px 0;
   @include clearfix();
 
   @include media-breakpoint-up(md) {
@@ -26,6 +30,7 @@
     margin-right: 0;
     margin-left: 0;
     border-width: 1px;
+    @include border-radius(var(--bs-border-radius));
   }
 
   + p {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -342,7 +342,6 @@
 .highlight {
   position: relative;
   padding: .75rem ($bd-gutter-x * .5);
-  // margin-bottom: 1rem;
   background-color: var(--bd-pre-bg);
 
   @include media-breakpoint-up(md) {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -2,12 +2,13 @@
 // Docs examples
 //
 
-.bd-example-snippet {
+.bd-code-snippet {
   border: solid var(--bs-border-color);
   border-width: 1px 0;
 
   @include media-breakpoint-up(md) {
     border-width: 1px;
+    @include border-radius(var(--bs-border-radius));
   }
 }
 
@@ -17,8 +18,6 @@
   position: relative;
   padding: var(--bd-example-padding);
   margin: 0 ($bd-gutter-x * -.5);
-  border: solid var(--bs-border-color);
-  border-width: 1px 0;
   @include clearfix();
 
   @include media-breakpoint-up(md) {
@@ -27,13 +26,6 @@
     margin-right: 0;
     margin-left: 0;
     border-width: 1px;
-    @include border-top-radius(var(--bs-border-radius));
-  }
-
-  + .bd-code-snippet {
-    @include border-top-radius(0);
-    border: solid var(--bs-border-color);
-    border-width: 0 1px 1px;
   }
 
   + p {
@@ -350,12 +342,12 @@
 .highlight {
   position: relative;
   padding: .75rem ($bd-gutter-x * .5);
-  margin-bottom: 1rem;
+  // margin-bottom: 1rem;
   background-color: var(--bd-pre-bg);
 
   @include media-breakpoint-up(md) {
     padding: .75rem 1.25rem;
-    @include border-radius(var(--bs-border-radius));
+    @include border-radius(calc(var(--bs-border-radius) - 1px));
   }
 
   pre {
@@ -376,32 +368,22 @@
   }
 }
 
-.bd-code-snippet {
-  margin: 0 ($bd-gutter-x * -.5) $spacer;
-
-  .highlight {
-    margin-bottom: 0;
-    @include border-top-radius(0);
-  }
-
-  .bd-example {
-    margin: 0;
-    border: 0;
-  }
-
-  @include media-breakpoint-up(md) {
-    margin-right: 0;
-    margin-left: 0;
-    @include border-radius($border-radius);
-  }
-}
-
 .highlight-toolbar {
   background-color: var(--bd-pre-bg);
+
+  + .highlight {
+    @include border-top-radius(0);
+  }
 }
 
-.bd-scss-docs {
+.bd-file-ref {
   .highlight-toolbar {
-    @include border-top-radius(calc(var(--bs-border-radius) + 1px));
+    @include media-breakpoint-up(md) {
+      @include border-top-radius(calc(var(--bs-border-radius) - 1px));
+    }
   }
+}
+
+.bd-content .bd-code-snippet {
+  margin-bottom: 1rem;
 }

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -3,12 +3,13 @@
 //
 
 .bd-code-snippet {
-  margin-right: ($bd-gutter-x * -.5);
-  margin-left: ($bd-gutter-x * -.5);
+  margin: 0 ($bd-gutter-x * -.5) 1rem;
   border: solid var(--bs-border-color);
   border-width: 1px 0;
 
   @include media-breakpoint-up(md) {
+    margin-right: 0;
+    margin-left: 0;
     border-width: 1px;
     @include border-radius(var(--bs-border-radius));
   }
@@ -354,10 +355,15 @@
     @include border-radius(calc(var(--bs-border-radius) - 1px));
   }
 
+  @include media-breakpoint-up(lg) {
+    pre {
+      margin-right: 1.875rem;
+    }
+  }
+
   pre {
     padding: .25rem 0 .875rem;
     margin-top: .8125rem;
-    margin-right: 1.875rem;
     margin-bottom: 0;
     overflow: overlay;
     white-space: pre;

--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -22,7 +22,7 @@
 
   .bd-code-snippet {
     margin: 0;
-    @include border-radius(.5rem);
+    border-color: var(--bs-border-color-translucent);
   }
 
   .highlight {
@@ -32,7 +32,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     background-color: rgba(var(--bs-body-color-rgb), .075);
-    @include border-radius(.5rem);
 
     @include media-breakpoint-up(lg) {
       padding-right: 4rem;

--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -76,10 +76,6 @@
     @include font-size(1rem);
   }
 
-  .highlight {
-    @include border-radius(.5rem);
-  }
-
   @include media-breakpoint-up(md) {
     .lead {
       @include font-size(1.25rem);

--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -23,6 +23,8 @@
   .bd-code-snippet {
     margin: 0;
     border-color: var(--bs-border-color-translucent);
+    border-width: 1px;
+    @include border-radius(.5rem);
   }
 
   .highlight {
@@ -32,6 +34,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     background-color: rgba(var(--bs-body-color-rgb), .075);
+    @include border-radius(calc(.5rem - 1px));
 
     @include media-breakpoint-up(lg) {
       padding-right: 4rem;
@@ -40,7 +43,6 @@
     pre {
       padding: 0;
       margin-top: .625rem;
-      margin-right: 1.875rem;
       margin-bottom: .625rem;
       overflow: hidden;
     }

--- a/site/content/docs/5.3/docsref.md
+++ b/site/content/docs/5.3/docsref.md
@@ -34,6 +34,10 @@ toc: true
 }
 ```
 
+<div class="bd-example">
+  The <abbr title="HyperText Markup Language">HTML</abbr> abbreviation element.
+</div>
+
 {{< example >}}
 <div class="test">This is a test.</div>
 {{< /example >}}

--- a/site/content/docs/5.3/docsref.md
+++ b/site/content/docs/5.3/docsref.md
@@ -4,6 +4,8 @@ title: Docs reference
 description: Examples of Bootstrap's documentation-specific components and styles.
 aliases: "/docsref/"
 toc: true
+robots: noindex,follow
+sitemap_exclude: true
 ---
 
 ## Buttons

--- a/site/content/docs/5.3/docsref.md
+++ b/site/content/docs/5.3/docsref.md
@@ -26,7 +26,7 @@ toc: true
   Danger callout
 {{< /callout >}}
 
-## Code
+## Code example
 
 ```scss
 .test {

--- a/site/content/docs/5.3/docsref.md
+++ b/site/content/docs/5.3/docsref.md
@@ -1,0 +1,43 @@
+---
+layout: docs
+title: Docs reference
+description: Examples of Bootstrap's documentation-specific components and styles.
+aliases: "/docsref/"
+toc: true
+---
+
+## Buttons
+
+<button class="btn btn-bd-primary">Primary button</button>
+<button class="btn btn-bd-accent">Accent button</button>
+<button class="btn btn-bd-light">Light button</button>
+
+## Callouts
+
+{{< callout >}}
+  Default callout
+{{< /callout >}}
+
+{{< callout warning >}}
+  Warning callout
+{{< /callout >}}
+
+{{< callout danger >}}
+  Danger callout
+{{< /callout >}}
+
+## Code
+
+```scss
+.test {
+  --color: blue;
+}
+```
+
+{{< example >}}
+<div class="test">This is a test.</div>
+{{< /example >}}
+
+{{< scss-docs name="variable-gradient" file="scss/_variables.scss" >}}
+
+{{< js-docs name="live-toast" file="site/assets/js/snippets.js" >}}

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -21,7 +21,7 @@
 
 <div class="bd-example-snippet bd-code-snippet">
   {{- if eq $show_preview true -}}
-  <div{{ with $id }} id="{{ . }}"{{ end }} class="bd-example{{ with $class }} {{ . }}{{ end }}">
+  <div{{ with $id }} id="{{ . }}"{{ end }} class="bd-example m-0 border-0{{ with $class }} {{ . }}{{ end }}">
     {{- $input -}}
   </div>
   {{- end -}}

--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -26,12 +26,18 @@
   {{- $match = replace $match $capture_start "" -}}
   {{- $match = replace $match $capture_end "" -}}
 
-  <div class="bd-example-snippet bd-code-snippet">
-    <div class="bd-clipboard">
-      <button type="button" class="btn-clipboard" title="Copy to clipboard">
-        <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
-      </button>
+  <div class="bd-example-snippet bd-code-snippet bd-file-ref">
+    <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
+      <a class="font-monospace link-secondary link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
+        {{- $file -}}
+      </a>
+      <div class="d-flex ms-auto">
+        <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">
+          <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"/></svg>
+        </button>
+      </div>
     </div>
+
     {{- $unindent := 0 -}}
     {{- $found := false -}}
     {{- $first_line:= index (split $match "\n") 0 -}}

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -39,7 +39,7 @@
     {{- $match = replace $match " !default" "" -}}
   {{- end -}}
 
-  <div class="bd-example-snippet bd-code-snippet bd-scss-docs">
+  <div class="bd-example-snippet bd-code-snippet bd-file-ref">
     <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
       <a class="font-monospace link-secondary link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small" href="{{ .Site.Params.repo }}/blob/v{{ .Site.Params.current_version }}/{{ $file | replaceRE `\\` "/" }}">
         {{- $file -}}


### PR DESCRIPTION
Alternate fix for #38114.

This refactors things a smidge to give us consistent borders and border-radius values around all our code snippets and examples in our docs. I started by removing all borders and rounded corners, and then slowly restoring them. This feels cleaner and leaner to me, but I wasn't sure about use cases. So I built a new `/docsref` page, which serves as a docs kitchen sink of sorts for our docs-specific components. Let me know if I'm missing anything else here, goal is to give us a quick way to test rendering just like any other component.

One thing I'm not 100% sure on is if I can remove all `.bd-example-snippet` instances and change our one JS selector looking for that to `.bd-code-snippet`. Will dive back into that later.

Because I'm choosing not to render the new `/docsref` page in the sidebar, I've also added a check in the sidebar navigation for existence of `sidenavActiveLink`.