### PR TITLE
Fix sizing on masthead npm i snippet

### DIFF
--- a/site/assets/scss/_masthead.scss
+++ b/site/assets/scss/_masthead.scss
@@ -42,8 +42,7 @@
 
     pre {
       padding: 0;
-      margin-top: .625rem;
-      margin-bottom: .625rem;
+      margin: .625rem 0;
       overflow: hidden;
     }
   }


### PR DESCRIPTION
Quick little fix to keep the element sized right.