### PR TITLE
Add data attr selector for dark mode navbars

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -266,7 +266,8 @@
   @include deprecate("`.navbar-light`", "v5.2.0", "v6.0.0", true);
 }
 
-.navbar-dark {
+.navbar-dark,
+.navbar[data-bs-theme="dark"] {
   // scss-docs-start navbar-dark-css-vars
   --#{$prefix}navbar-color: #{$navbar-dark-color};
   --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color};

--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -328,10 +328,10 @@ Mix and match with other components and utilities as needed.
 **New in v5.2.0  —** Navbar theming is now powered by CSS variables and `.navbar-light` has been deprecated. CSS variables are applied to `.navbar`, defaulting to the "light" appearance, and can be overridden with `.navbar-dark`.
 {{< /callout >}}
 
-Navbar themes are easier than ever thanks to Bootstrap's combination of Sass and CSS variables. The default is our "light navbar" for use with light background colors, but you can also apply `data-bs-theme="dark"` to the `.navbar` parent for dark background colors. Then, customize with `.bg-*` utilities.
+Navbar themes are easier than ever thanks to Bootstrap's combination of Sass and CSS variables. The default is our "light navbar" for use with light background colors, but you can also apply `data-bs-theme="dark"` to the `.navbar` parent for dark background colors. Then, customize with `.bg-*` and additional utilities.
 
 <div class="bd-example">
-  <nav class="navbar navbar-expand-lg bg-body-secondary" data-bs-theme="dark">
+  <nav class="navbar navbar-expand-lg bg-dark border-bottom border-bottom-dark" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Navbar</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
@@ -420,7 +420,7 @@ Navbar themes are easier than ever thanks to Bootstrap's combination of Sass and
 </div>
 
 ```html
-<nav class="navbar bg-dark" data-bs-theme="dark">
+<nav class="navbar bg-dark border-bottom border-bottom-dark" data-bs-theme="dark">
   <!-- Navbar content -->
 </nav>
 


### PR DESCRIPTION
Fixes #38363, I think. We advise folks to use the `data-bs-theme` selectors for toggling dark mode on some components, but when using the `media-query` type for color modes, the selectors aren't available. So we need to include something like this branch proposes.

/cc @julien-deramond for ideas on if there's a better approach here.