### PR TITLE
Fix modal backdrop overlap in sticky container

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1129,7 +1129,7 @@ $zindex-sticky:                     1020 !default;
 $zindex-fixed:                      1030 !default;
 $zindex-offcanvas-backdrop:         1040 !default;
 $zindex-offcanvas:                  1045 !default;
-$zindex-modal-backdrop:             1050 !default;
+$zindex-modal-backdrop:             1019 !default;
 $zindex-modal:                      1055 !default;
 $zindex-popover:                    1070 !default;
 $zindex-tooltip:                    1080 !default;


### PR DESCRIPTION
### Description

There was a reported issue [here](https://github.com/twbs/bootstrap/issues/38561) that the modal backdrop overlaps the modal when it's used in a sticky container.  

### Motivation & Context

The issue mentioned renders the modal completely non-interactive once launched; The user cannot interact or even dismiss the modal

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38564--twbs-bootstrap.netlify.app/docs/5.3/components/modal/>

### Related issues

Closes https://github.com/twbs/bootstrap/issues/38561
