### PR TITLE
Add 'Issues assignment' section to the Contributing Guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,6 +31,13 @@ restrictions:
   Instead, please email any questions or feedback regarding those themes to `themes AT getbootstrap DOT com`.
 
 
+## Issues assignment
+
+The core team will be looking at the open issues, analyze them, and provide guidance on how to proceed. **Issues won't be assigned to anyone outside the core team.** However, contributors are welcome to participate in the discussion and provide their input on how to best solve the issue, and even submit a PR if they want to. Please wait that the issue is ready to be worked on before submitting a PR, we don't want to waste your time.
+
+Please keep in mind that the core team is small, has limited resources and that we are not always able to respond immediately. We will try to provide feedback as soon as possible, but please be patient. If you don't get a response immediately, it doesn't mean that we are ignoring you or that we don't care about your issue or PR. We will get back to you as soon as we can.
+
+
 ## Issues and labels
 
 Our bug tracker utilizes several labels to help organize and identify issues. Here's what they represent and how we use them:


### PR DESCRIPTION
### Description

This PR suggests adding a new section to our Contributing Guidelines named 'Issues assignment' that explains that we don't assign issues to contributors and why.

### Motivation & Context

As maintainers, we often get asked to assign issues to contributors. We don't do that for several reasons.
IMO it's important to explain why we don't do that in our Contributing Guidelines to avoid frustration and confusion for contributors.
On our side, it will allow us having a link to point to when we get asked to assign issues.

On my side, if it is merged, I'll update my GitHub Saved reply to point to this section that I'll be able to share here as a comment right after if you're interested.
Having the same kind of answers would bring consistency and coherence to our answers.

#### Improvement 1

I wanted to add to this PR a message at the end of all newly created issues (via the issues template) to point to this section but it's not possible to do it. Some sources that confirm it:
- https://github.com/orgs/community/discussions/5631
- https://github.com/orgs/community/discussions/32948
- https://github.com/orgs/community/discussions/5310
- https://github.com/orgs/community/discussions/48397

~~So I'll try to provide a GitHub Action later, as a second step, to add this message to all newly created issues.~~
**Edit**: done via https://github.com/twbs/bootstrap/pull/38622

#### Improvement 2

Still IMHO, at some point, it would be nice to have a kind of "pr welcome" label to add to issues when they are ready to develop for maintainers or contributors, and/or a kind of "core team only" if this can't be treated outside because of the complexity or any other reasons. It would be a good way to help contributors to find issues to work on and would bring some clarity on who can do what to help us.

### Type of changes

- [x] Enhancement (non-breaking change)

### Checklist


- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- (N/A) All new and existing tests passed

#### Live previews

- https://github.com/twbs/bootstrap/blob/e8bed76c5c45917898ef6a936027a38bcca263a9/.github/CONTRIBUTING.md#issues-assignment
