### PR TITLE
Improved docs for carousel component

### DIFF
--- a/site/content/docs/5.3/components/carousel.md
+++ b/site/content/docs/5.3/components/carousel.md
@@ -372,6 +372,7 @@ Call carousel manually with:
 ```js
 const carousel = new bootstrap.Carousel('#myCarousel')
 ```
+To obtain a valid reference to the carousel, make sure that it has been loaded by placing the code inside a `$(window).on("load", function()}` rather than a `$(document).ready(function()}`
 
 ### Options
 


### PR DESCRIPTION
### Description
The improvement in the documentation allows a user to know that in order to obtain a valid reference to the carousel, one must wrap the initializer inside a window onload function. This is because carousel reference will be null unless the images have loaded.

### Motivation & Context
This improvement was required as mentioned in issue #35722. 

### Type of changes
- [x] Enhancement (non-breaking change)

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly

#### Live previews
- <https://deploy-preview-38619--twbs-bootstrap.netlify.app/>

### Related issues
This PR fixes #35722
