### PR TITLE
added table-striped-inverse

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -1896,7 +1896,7 @@ progress {
 }
 .table-bordered > :not(caption) > * > * {
   border-width: 0 var(--bs-border-width);
-}
+} 
 
 .table-borderless > :not(caption) > * > * {
   border-bottom-width: 0;
@@ -1906,6 +1906,11 @@ progress {
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) > * {
+  --bs-table-accent-bg: var(--bs-table-striped-bg);
+  color: var(--bs-table-striped-color);
+}
+
+.table-striped-inverse > tbody > tr:nth-of-type(even) > * {
   --bs-table-accent-bg: var(--bs-table-striped-bg);
   color: var(--bs-table-striped-color);
 }

--- a/dist/css/bootstrap.rtl.css
+++ b/dist/css/bootstrap.rtl.css
@@ -1908,6 +1908,11 @@ progress {
   color: var(--bs-table-striped-color);
 }
 
+.table-striped-inverse > tbody > tr:nth-of-type(even) > * {
+  --bs-table-accent-bg: var(--bs-table-striped-bg);
+  color: var(--bs-table-striped-color);
+}
+
 .table-striped-columns > :not(caption) > tr > :nth-child(even) {
   --bs-table-accent-bg: var(--bs-table-striped-bg);
   color: var(--bs-table-striped-color);


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

Provide style table-striped-inverse which make uses striped color in the even rows instead of odd.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
uses striped color in the even rows instead of odd.

### Type of changes
added
 .table-striped-inverse > tbody > tr:nth-of-type(even) > * {
  --bs-table-accent-bg: var(--bs-table-striped-bg);
  color: var(--bs-table-striped-color);
}

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

bootstrap/dist/css/bootstrap.css
bootstrap/dist/css/bootstrap.rtl.css


- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

Closes https://github.com/twbs/bootstrap/issues/38617
