### PR TITLE
Provided style table-striped-inverse which make uses striped color in the even rows instead of odd.

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -110,7 +110,13 @@
 
 // For rows
 .table-striped {
-  > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
+  > tbody > tr:nth-of-type(odd) > * {
+    --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
+    --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+  }
+}
+.table-striped-inverse {
+  > tbody > tr:nth-of-type(even) > * {
     --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
     --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
   }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -110,13 +110,7 @@
 
 // For rows
 .table-striped {
-  > tbody > tr:nth-of-type(odd) > * {
-    --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
-    --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
-  }
-}
-.table-striped-inverse {
-  > tbody > tr:nth-of-type(even) > * {
+  > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
     --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
     --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
   }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -109,8 +109,17 @@
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 
 // For rows
+// odd
 .table-striped {
-  > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
+  > tbody > tr:nth-of-type(odd) > * {
+    --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
+    --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
+  }
+}
+
+// even
+.table-striped-inverse {
+  > tbody > tr:nth-of-type(even) > * {
     --#{$prefix}table-color-type: var(--#{$prefix}table-striped-color);
     --#{$prefix}table-bg-type: var(--#{$prefix}table-striped-bg);
   }


### PR DESCRIPTION
### Description

Provide style table-striped-inverse which make uses striped color in the even rows instead of odd.

### Motivation & Context

make uses striped color in the even rows instead of odd.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

https://github.com/twbs/bootstrap/issues/38617#issue-1715027674
