### PR TITLE
Remove duplicate `$alert-*-scale` Sass vars

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1543,9 +1543,6 @@ $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        $font-weight-bold !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
-$alert-bg-scale:                -80% !default;
-$alert-border-scale:            -70% !default;
-$alert-color-scale:             40% !default;
 $alert-dismissible-padding-r:   $alert-padding-x * 3 !default; // 3x covers width of x plus default padding on either side
 // scss-docs-end alert-variables
 


### PR DESCRIPTION
### Description

This PR removes duplicate `$alert-bg-scale`, `$alert-border-scale` and `$alert-color-scale` definitions in `_variables.scss`.

### Motivation & Context

Even if it will be removed in v6, let's avoid duplication right now.

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38674--twbs-bootstrap.netlify.app/docs/5.3/components/alerts/

### Related issues

Closes #38672
