### PR TITLE
Docs: consistency between custom buttons, popovers and tooltips

### DIFF
--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -220,15 +220,16 @@
 
 // scss-docs-start custom-tooltip
 .custom-tooltip {
-  --bs-tooltip-bg: var(--bs-primary);
+  --bs-tooltip-bg: var(--bd-violet-bg);
+  --bs-tooltip-color: var(--bs-white);
 }
 // scss-docs-end custom-tooltip
 
 // scss-docs-start custom-popovers
 .custom-popover {
   --bs-popover-max-width: 200px;
-  --bs-popover-border-color: var(--bs-primary);
-  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-border-color: var(--bd-violet-bg);
+  --bs-popover-header-bg: var(--bd-violet-bg);
   --bs-popover-header-color: var(--bs-white);
   --bs-popover-body-padding-x: 1rem;
   --bs-popover-body-padding-y: .5rem;


### PR DESCRIPTION
### Description

This PR updates `_component-examples.scss` for `.custom-tooltip` and `.custom-popover`.

Custom tooltip background color is set to violet and the color is forced to white to avoid contrast issues (in the actual _main_ branch, on dark mode, the text color is not accessible).

Custom popover background and border colors are set to violet.

### Motivation & Context

IMO this change can enhance the comprehension of our custom examples in the documentation by using a color absent from our default theme colors. It enforces the consistency with the custom buttons in https://twbs-bootstrap.netlify.app/docs/5.3/components/buttons/#variables which is better, still IMO, compared to the corresponding popovers and tooltips examples.

### Type of changes

- [x] Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- Reference: https://deploy-preview-38681--twbs-bootstrap.netlify.app/docs/5.3/components/buttons/#variables
- https://deploy-preview-38681--twbs-bootstrap.netlify.app/docs/5.3/components/tooltips/#custom-tooltips
- https://deploy-preview-38681--twbs-bootstrap.netlify.app/docs/5.3/components/popovers/#custom-popovers