### PR TITLE
Fix focus box-shadow for validation stated form-controls

### DIFF
--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -69,7 +69,12 @@
 
       &:focus {
         border-color: $border-color;
-        box-shadow: $focus-box-shadow;
+        @if $enable-shadows {
+          @include box-shadow($input-box-shadow, $focus-box-shadow);
+        } @else {
+          // Avoid using mixin so we can pass custom focus shadow properly
+          box-shadow: $focus-box-shadow;
+        }
       }
     }
   }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -105,7 +105,12 @@
 
       &:focus {
         border-color: $border-color;
-        box-shadow: $focus-box-shadow;
+        @if $enable-shadows {
+          @include box-shadow($form-select-box-shadow, $focus-box-shadow);
+        } @else {
+          // Avoid using mixin so we can pass custom focus shadow properly
+          box-shadow: $focus-box-shadow;
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

Fix focus box-shadow for validation stated form-controls.

### Motivation & Context

I use styles with custom build bootstrap with option `$enable-shadows: true;`. Found a few issues in `.form-control` styling with classes `.is-invalid` and `.is-valid`. In particular, the shadow override for such elements, when in focus, does not use standard wrap that I have used in this PR. Without it, for such elements, in the state of focus, only the outer shadow is exposed. 
1. That is, the first problem is the loss of the inner shadow. 
2. The second problem is the lack of animation, since the transition property only works if number of shadows between states matches.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38719--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
Not found.
