### PR TITLE
Fix stack examples

### DIFF
--- a/site/content/docs/5.3/helpers/stacks.md
+++ b/site/content/docs/5.3/helpers/stacks.md
@@ -42,7 +42,7 @@ Using horizontal margin utilities like `.ms-auto` as spacers:
 {{< example class="bd-example-flex" >}}
 <div class="hstack gap-3">
   <div class="p-2">First item</div>
-  <div class="p-2">Second item</div>
+  <div class="p-2 ms-auto">Second item</div>
   <div class="p-2">Third item</div>
 </div>
 {{< /example >}}
@@ -52,7 +52,7 @@ And with [vertical rules]({{< docsref "/helpers/vertical-rule" >}}):
 {{< example class="bd-example-flex" >}}
 <div class="hstack gap-3">
   <div class="p-2">First item</div>
-  <div class="p-2">Second item</div>
+  <div class="p-2 ms-auto">Second item</div>
   <div class="vr"></div>
   <div class="p-2">Third item</div>
 </div>


### PR DESCRIPTION
### Description

I was going over the stack docs and noticed that the first two horizontal stack examples were the same.  I think the `.ms-auto` class was accidentally removed in https://github.com/twbs/bootstrap/pull/37900/files

### Motivation & Context

Fixes examples so it matches wording.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38745--twbs-bootstrap.netlify.app/docs/5.3/helpers/stacks/#horizontal>

### Related issues

<!-- Please link any related issues here. -->
