### PR TITLE
Add `color-modes.js` to `bootstrap-x.y.z-examples.zip`

### DIFF
--- a/build/zip-examples.js
+++ b/build/zip-examples.js
@@ -34,6 +34,9 @@ const imgFiles = [
   'bootstrap-logo.svg',
   'bootstrap-logo-white.svg'
 ]
+const staticJsFiles = [
+  'color-modes.js'
+]
 
 sh.config.fatal = true
 
@@ -52,7 +55,8 @@ sh.mkdir('-p', [
   distFolder,
   `${distFolder}/assets/brand/`,
   `${distFolder}/assets/dist/css/`,
-  `${distFolder}/assets/dist/js/`
+  `${distFolder}/assets/dist/js/`,
+  `${distFolder}/assets/js/`
 ])
 
 sh.cp('-Rf', `${docsDir}/examples/*`, distFolder)
@@ -67,6 +71,10 @@ for (const file of jsFiles) {
 
 for (const file of imgFiles) {
   sh.cp('-f', `${docsDir}/assets/brand/${file}`, `${distFolder}/assets/brand/`)
+}
+
+for (const file of staticJsFiles) {
+  sh.cp('-f', `${docsDir}/assets/js/${file}`, `${distFolder}/assets/js/`)
 }
 
 sh.rm(`${distFolder}/index.html`)


### PR DESCRIPTION
### Description

As described in #38746, new `color-modes.js` asset was not including in `bootstrap-x.y.z-examples.zip`.
This PR modifies `build/zip-examples.js` which is used to create the corresponding directory.

/cc @XhmikosR for a possible v5.3.1

### How to test

Locally:
```
$ npm run release
$ unzip bootstrap-5.3.0-examples.zip
$ php -S localhost:800 # Or run another local server
```

Then go to http://localhost:8008/album and change the color mode

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_

### Related issues

Closes #38746
