### PR TITLE
Generalize disabled nav links CSS rules

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -44,7 +44,8 @@
   }
 
   // Disabled state lightens text
-  &.disabled {
+  &.disabled,
+  &:disabled {
     color: var(--#{$prefix}nav-link-disabled-color);
     pointer-events: none;
     cursor: default;
@@ -79,13 +80,6 @@
       isolation: isolate;
       border-color: var(--#{$prefix}nav-tabs-link-hover-border-color);
     }
-
-    &.disabled,
-    &:disabled {
-      color: var(--#{$prefix}nav-link-disabled-color);
-      background-color: transparent;
-      border-color: transparent;
-    }
   }
 
   .nav-link.active,
@@ -117,12 +111,6 @@
 
   .nav-link {
     @include border-radius(var(--#{$prefix}nav-pills-border-radius));
-
-    &:disabled {
-      color: var(--#{$prefix}nav-link-disabled-color);
-      background-color: transparent;
-      border-color: transparent;
-    }
   }
 
   .nav-link.active,


### PR DESCRIPTION
### Description

Most of the time, our `.nav-link`s are really links and don't need `:disabled` rules. However, we provide JavaScript examples (e.g. with `.nav-tabs`) where we use `<button>`s that can need `:disabled` rules.

This PR suggest a kind of defensive approach where the disabled state is defined globally for all `.nav-link`s using `.disabled` and `:disabled` selectors.

It allows us to remove the other rules defining the colors.

⚠️ Rules defining transparent "color" to background and border were also removed because I couldn't notice use cases where it was actually changing anything. I haven't found anything in the history, but it can be put back if you are aware about any use cases where it's mandatory.

Please double-check different complex use cases to avoid any regressions since the documentation does not reflect all possibilities.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38774--twbs-bootstrap.netlify.app/docs/5.3/components/navs-tabs/

### Related issues

Linked to #38765 but doesn't take into account https://github.com/twbs/bootstrap/issues/38765#issuecomment-1592395961
