### PR TITLE
Fix missing `@popperjs/core` 2.11.8 refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "vnu-jar": "23.4.11"
       },
       "peerDependencies": {
-        "@popperjs/core": "^2.11.7"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "watch-js-docs": "nodemon --watch site/assets/js/ --ext js --exec \"npm run js-lint\""
   },
   "peerDependencies": {
-    "@popperjs/core": "^2.11.7"
+    "@popperjs/core": "^2.11.8"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.5",
@@ -178,7 +178,7 @@
     },
     "dependencies": {},
     "peerDependencies": {
-      "@popperjs/core": "^2.11.7"
+      "@popperjs/core": "^2.11.8"
     }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes some remaining `@popperjs/core` 2.11.7 references.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] All new and existing tests passed