### PR TITLE
Increase contrast in dark-mode (#38525)

### DIFF
--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -40,7 +40,7 @@ $light-border-subtle-dark:          $gray-700 !default;
 $dark-border-subtle-dark:           $gray-800 !default;
 // scss-docs-end theme-border-subtle-dark-variables
 
-$body-color-dark:                   $gray-500 !default;
+$body-color-dark:                   $gray-300 !default;
 $body-bg-dark:                      $gray-900 !default;
 $body-secondary-color-dark:         rgba($body-color-dark, .75) !default;
 $body-secondary-bg-dark:            $gray-800 !default;


### PR DESCRIPTION
### Description

This increases the default brightness for the body text-color in dark mode, which inceases readability a bit.

It was also suggested to darken the background a bit, but we unfortunately don't have a darker gray in our color palette. So for now, let's increase the text-color by two notches, and leave the background color as-is instead.

### Motivation & Context

See issue #38525

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [ ] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

(not really sure any of the above applies here)

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38815--twbs-bootstrap.netlify.app/>

### Related issues

#38525