### PR TITLE
JS/SCSS shortcodes: Add new feature to remove nested calls inside.

### DIFF
--- a/site/layouts/shortcodes/js-docs.html
+++ b/site/layouts/shortcodes/js-docs.html
@@ -13,8 +13,9 @@
   {{- errorf "%s: %q: Missing required parameters! Got: name=%q file=%q!" .Position .Name $name $file -}}
 {{- else -}}
   {{- $capture_start := printf "// js-docs-start %s\n" $name -}}
-  {{- $capture_end := printf "// js-docs-end %s" $name -}}
+  {{- $capture_end := printf "// js-docs-end %s\n" $name -}}
   {{- $regex := printf `%s((?:.|\n)*)%s` $capture_start $capture_end -}}
+  {{- $regex_nested := printf `// js-docs-.*\n` -}}
 
   {{- $match := findRE $regex (readFile $file) -}}
   {{- $match = index $match 0 -}}
@@ -25,6 +26,11 @@
 
   {{- $match = replace $match $capture_start "" -}}
   {{- $match = replace $match $capture_end "" -}}
+
+  {{- $match_nested := findRE $regex_nested $match -}}
+  {{- range $to_remove := $match_nested -}}
+    {{- $match = replace $match $to_remove "" -}}
+  {{- end -}}
 
   <div class="bd-example-snippet bd-code-snippet bd-file-ref">
     <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">

--- a/site/layouts/shortcodes/scss-docs.html
+++ b/site/layouts/shortcodes/scss-docs.html
@@ -17,8 +17,9 @@
   {{- errorf "%s: %q: Missing required parameters! Got: name=%q file=%q!" .Position .Name $name $file -}}
 {{- else -}}
   {{- $capture_start := printf "// scss-docs-start %s\n" $name -}}
-  {{- $capture_end := printf "// scss-docs-end %s" $name -}}
+  {{- $capture_end := printf "// scss-docs-end %s\n" $name -}}
   {{- $regex := printf `%s((?:.|\n)*)%s` $capture_start $capture_end -}}
+  {{- $regex_nested := printf `// scss-docs-.*\n` -}}
 
   {{- /*
     TODO: figure out why we can't do the following and get the first group (the only capturing one)...
@@ -34,6 +35,11 @@
 
   {{- $match = replace $match $capture_start "" -}}
   {{- $match = replace $match $capture_end "" -}}
+
+  {{- $match_nested := findRE $regex_nested $match -}}
+  {{- range $to_remove := $match_nested -}}
+    {{- $match = replace $match $to_remove "" -}}
+  {{- end -}}
 
   {{- if (ne $strip_default "false") -}}
     {{- $match = replace $match " !default" "" -}}


### PR DESCRIPTION
### Description

Remove nested calls to shortcodes. I had to face this issue in my project, so updating it here if it can help. Changed the js shortcode as well.

### Motivation & Context

Nested calls to shortcodes. For instance:

```scss
// scss-docs-start accordion-variables
...
// scss-docs-start random-variables-that-I-needed
...
// scss-docs-end accordion-variables
...
// scss-docs-end random-variables-that-I-needed
```
I didn't want to have the `// scss-docs-start random-variables-that-I-needed` inside my accordion documentation.

Moreover, adding this, had a weird behavior: It renders twice.

```scss
// scss-docs-start accordion-variables
...
// scss-docs-end accordion-variables
...
// scss-docs-start accordion-variables-xxl
...
// scss-docs-end accordion-variables-xxl
```

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (NA) My change introduces changes to the documentation
- (NA) I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- (NA) All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

NA since it's defensive code.

### Related issues

NA
