### PR TITLE
Docs: fix carousel carousel colors of carousel examples in dark mode

### DIFF
--- a/site/content/docs/5.3/examples/carousel-rtl/index.html
+++ b/site/content/docs/5.3/examples/carousel-rtl/index.html
@@ -36,7 +36,7 @@ extra_css:
 
 <main>
 
-  <div id="myCarousel" class="carousel slide mb-6" data-bs-ride="carousel" data-bs-theme="light">
+  <div id="myCarousel" class="carousel slide mb-6" data-bs-ride="carousel">
     <div class="carousel-indicators">
       <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
       <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>

--- a/site/content/docs/5.3/examples/carousel/index.html
+++ b/site/content/docs/5.3/examples/carousel/index.html
@@ -35,7 +35,7 @@ extra_css:
 
 <main>
 
-  <div id="myCarousel" class="carousel slide mb-6" data-bs-ride="carousel" data-bs-theme="light">
+  <div id="myCarousel" class="carousel slide mb-6" data-bs-ride="carousel">
     <div class="carousel-indicators">
       <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
       <button type="button" data-bs-target="#myCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>


### PR DESCRIPTION
### Description

This PR removes the unnecessary `data-bs-theme="light"` from the carousel markup in both the LTR and RTL carousel examples.

### Motivation & Context

The rendering in dark mode was not working properly because of the `data-bs-theme="light"` attribute:
- https://twbs-bootstrap.netlify.app/docs/5.3/examples/carousel/
- https://twbs-bootstrap.netlify.app/docs/5.3/examples/carousel-rtl/

![Screenshot 2023-06-27 at 21 29 37](https://github.com/twbs/bootstrap/assets/17381666/bb73b7ba-ac82-476a-8b20-b8a3acba4012)

Please double-check that the rendering in dark mode is considered as fitting the global design.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews


Please test these URLs in light and dark mode:
- https://deploy-preview-38840--twbs-bootstrap.netlify.app/docs/5.3/examples/carousel/
- https://deploy-preview-38840--twbs-bootstrap.netlify.app/docs/5.3/examples/carousel-rtl/
