### PR TITLE
optimized horizontal card documentation example

### DIFF
--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -395,10 +395,10 @@ Note that content should not be larger than the height of the image. If content 
 Using a combination of grid and utility classes, cards can be made horizontal in a mobile-friendly and responsive way. In the example below, we remove the grid gutters with `.g-0` and use `.col-md-*` classes to make the card horizontal at the `md` breakpoint. Further adjustments may be needed depending on your card content.
 
 {{< example >}}
-<div class="card mb-3" style="max-width: 540px;">
+<div class="card mb-3" style="max-width: 540px; overflow: hidden;">
   <div class="row g-0">
     <div class="col-md-4">
-      {{< placeholder width="100%" height="250" text="Image" class="img-fluid rounded-start" >}}
+      {{< placeholder width="100%" height="250" text="Image" class="img-fluid" >}}
     </div>
     <div class="col-md-8">
       <div class="card-body">

--- a/site/content/docs/5.3/components/card.md
+++ b/site/content/docs/5.3/components/card.md
@@ -395,7 +395,7 @@ Note that content should not be larger than the height of the image. If content 
 Using a combination of grid and utility classes, cards can be made horizontal in a mobile-friendly and responsive way. In the example below, we remove the grid gutters with `.g-0` and use `.col-md-*` classes to make the card horizontal at the `md` breakpoint. Further adjustments may be needed depending on your card content.
 
 {{< example >}}
-<div class="card mb-3" style="max-width: 540px; overflow: hidden;">
+<div class="card mb-3 overflow-hidden" style="max-width: 540px;">
   <div class="row g-0">
     <div class="col-md-4">
       {{< placeholder width="100%" height="250" text="Image" class="img-fluid" >}}


### PR DESCRIPTION
### Description

Edited the documentation of the horizontal card.
Removed the class rounded-start from card, instead added a hidden overflow

### Motivation & Context

The horizontal card had rounded corners in the front, even if the card was sized that the text was under the image.
The rounded corners of the card and the image are not the same radius.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- https://deploy-preview-38845--twbs-bootstrap.netlify.app/docs/5.3/components/card/#horizontal

##### Before Commit
![Before change](https://github.com/twbs/bootstrap/assets/54738102/3a62ae13-180e-408d-856b-89c6a50ee533)
##### After Commit
![After change](https://github.com/twbs/bootstrap/assets/54738102/c132fed7-9a12-4ad3-a994-2ec3984e0a5e)

### Related issues

none
