### PR TITLE
Add docs search to homepage

### DIFF
--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -8,7 +8,7 @@
       </button>
     </div>
     {{- else }}
-      <div class="d-lg-none" style="width: 1.5rem;"></div>
+      <div class="d-lg-none" style="width: 4.25rem;"></div>
     {{- end }}
 
     <a class="navbar-brand p-0 me-0 me-lg-2" href="/" aria-label="Bootstrap">

--- a/site/layouts/partials/docs-navbar.html
+++ b/site/layouts/partials/docs-navbar.html
@@ -16,9 +16,7 @@
     </a>
 
     <div class="d-flex">
-      {{ if eq .Layout "docs" }}
-        <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
-      {{ end }}
+      <div class="bd-search" id="docsearch" data-bd-docs-version="{{ .Site.Params.docs_version }}"></div>
 
       <button class="navbar-toggler d-flex d-lg-none order-3 p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#bdNavbar" aria-controls="bdNavbar" aria-label="Toggle navigation">
         <svg class="bi" aria-hidden="true"><use xlink:href="#three-dots"></use></svg>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -11,9 +11,7 @@
 
 <link rel="canonical" href="{{ .Permalink }}">
 
-{{- if eq .Page.Layout "docs" -}}
 <link rel="preconnect" href="https://AK7KMZKZHQ-dsn.algolia.net" crossorigin>
-{{- end }}
 
 {{ with .Params.robots -}}
 <meta name="robots" content="{{ . }}">

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -4,8 +4,9 @@
   <script src="/docs/{{ .Site.Params.docs_version }}/dist/js/bootstrap.bundle.js"></script>
 {{- end }}
 
-{{ if eq .Page.Layout "docs" -}}
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+
+{{ if eq .Page.Layout "docs" -}}
 <script src="https://cdn.jsdelivr.net/npm/@stackblitz/sdk@1/bundles/sdk.umd.js"></script>
 {{- end }}
 

--- a/site/layouts/partials/stylesheet.html
+++ b/site/layouts/partials/stylesheet.html
@@ -1,6 +1,4 @@
-{{ if eq .Page.Layout "docs" -}}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3">
-{{- end }}
 
 {{ if eq hugo.Environment "production" -}}
 {{ if eq .Page.Params.direction "rtl" -}}


### PR DESCRIPTION
### Description

Make the search form available on all pages.

### Motivation & Context

Repeated components must be at the **same place on each page** of the site in order to allow users to predict where they can find things on each page. This helps users with cognitive limitations, users with low vision, users with intellectual disabilities, and also those who are blind (according to **Criterion 3.2.3 Consistent Navigation**, see below).

That's why the search field must be at the same place on every page in a site so users can quickly locate the search function.

**Compliance to Success Criterion 3.2.3 Consistent Navigation (Level AA):**
Navigational mechanisms that are repeated on multiple Web pages within a set of Web pages occur in the same relative order each time they are repeated, unless a change is initiated by the user.
 
 https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (na) My change introduces changes to the documentation
- (na) I have updated the documentation accordingly
- (na) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-38850--twbs-bootstrap.netlify.app/>

