### PR TITLE
Modal: fix `dispose` function

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -139,13 +139,17 @@ class Modal extends BaseComponent {
   }
 
   dispose() {
-    EventHandler.off(window, EVENT_KEY)
-    EventHandler.off(this._dialog, EVENT_KEY)
+    this._element.addEventListener(EVENT_HIDDEN, () => {
+      EventHandler.off(window, EVENT_KEY)
+      EventHandler.off(this._dialog, EVENT_KEY)
 
-    this._backdrop.dispose()
-    this._focustrap.deactivate()
+      this._backdrop.dispose()
+      this._focustrap.deactivate()
 
-    super.dispose()
+      super.dispose()
+    })
+
+    this._hideModal()
   }
 
   handleUpdate() {

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -139,11 +139,11 @@ class Modal extends BaseComponent {
   }
 
   dispose() {
-    this._element.addEventListener(EVENT_HIDDEN, () => {
+    EventHandler.on(this._element, EVENT_HIDDEN, () => {
       EventHandler.off(window, EVENT_KEY)
       EventHandler.off(this._dialog, EVENT_KEY)
 
-      this._backdrop.dispose()
+      this._backdrop?.dispose()
       this._focustrap.deactivate()
 
       super.dispose()

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -1,3 +1,4 @@
+import BaseComponent from '../../src/base-component.js'
 import EventHandler from '../../src/dom/event-handler.js'
 import Modal from '../../src/modal.js'
 import ScrollBarHelper from '../../src/util/scrollbar.js'
@@ -846,18 +847,48 @@ describe('Modal', () => {
 
       const modalEl = fixtureEl.querySelector('.modal')
       const modal = new Modal(modalEl)
-      const focustrap = modal._focustrap
-      const spyDeactivate = spyOn(focustrap, 'deactivate').and.callThrough()
-
-      expect(Modal.getInstance(modalEl)).toEqual(modal)
-
+      const spyHideModal = spyOn(modal, '_hideModal').and.callThrough()
+      const spyDeactivate = spyOn(modal._focustrap, 'deactivate')
+      const spyBackdropDispose = spyOn(modal._backdrop, 'dispose')
+      const spySuperDispose = spyOn(BaseComponent.prototype, 'dispose')
       const spyOff = spyOn(EventHandler, 'off')
 
       modal.dispose()
 
-      expect(Modal.getInstance(modalEl)).toBeNull()
-      expect(spyOff).toHaveBeenCalledTimes(3)
+      expect(spyHideModal).toHaveBeenCalled()
+      expect(spyOff).toHaveBeenCalledTimes(2)
       expect(spyDeactivate).toHaveBeenCalled()
+      expect(spyBackdropDispose).toHaveBeenCalled()
+      expect(spySuperDispose).toHaveBeenCalled()
+    })
+
+    it('should dispose a shown modal', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div id="exampleModal" class="modal"><div class="modal-dialog"></div></div>'
+
+        const modalEl = fixtureEl.querySelector('.modal')
+        const modal = new Modal(modalEl)
+
+        modal.show()
+
+        const spyHideModal = spyOn(modal, '_hideModal').and.callThrough()
+        const spyDeactivate = spyOn(modal._focustrap, 'deactivate')
+        const spyBackdropDispose = spyOn(modal._backdrop, 'dispose')
+        const spySuperDispose = spyOn(BaseComponent.prototype, 'dispose')
+        const spyOff = spyOn(EventHandler, 'off')
+
+        modal.dispose()
+
+        expect(spyHideModal).toHaveBeenCalled()
+
+        setTimeout(() => {
+          expect(spyOff).toHaveBeenCalledTimes(2)
+          expect(spyDeactivate).toHaveBeenCalled()
+          expect(spyBackdropDispose).toHaveBeenCalled()
+          expect(spySuperDispose).toHaveBeenCalled()
+          resolve()
+        }, 20)
+      })
     })
   })
 


### PR DESCRIPTION
### Description

Call a function that removes all body attributes before disposing the modal itself.

However, I'm not quite sure about my comprehension of our doc explanation about the dispose function. Shall it remove the modal element from the DOM or shall it just remove the modal object instance ? both ?

### Motivation & Context

Fix the dispose call when a modal is shown.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (NA) My change introduces changes to the documentation
- (NA) I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38857--twbs-bootstrap.netlify.app/docs/5.3/components/modal>

### Related issues

Closes #35934.
