### PR TITLE
Docs: Update float responsive examples

### DIFF
--- a/site/content/docs/5.3/utilities/float.md
+++ b/site/content/docs/5.3/utilities/float.md
@@ -23,10 +23,11 @@ Use the [clearfix helper]({{< docsref "/helpers/clearfix" >}}) on a parent eleme
 Responsive variations also exist for each `float` value.
 
 {{< example >}}
-<div class="float-sm-start">Float start on viewports sized SM (small) or wider</div><br>
-<div class="float-md-start">Float start on viewports sized MD (medium) or wider</div><br>
-<div class="float-lg-start">Float start on viewports sized LG (large) or wider</div><br>
-<div class="float-xl-start">Float start on viewports sized XL (extra-large) or wider</div><br>
+<div class="float-sm-end">Float end on viewports sized SM (small) or wider</div><br>
+<div class="float-md-end">Float end on viewports sized MD (medium) or wider</div><br>
+<div class="float-lg-end">Float end on viewports sized LG (large) or wider</div><br>
+<div class="float-xl-end">Float end on viewports sized XL (extra large) or wider</div><br>
+<div class="float-xxl-end">Float end on viewports sized XXL (extra extra large) or wider</div><br>
 {{< /example >}}
 
 Here are all the support classes:


### PR DESCRIPTION
### Description

Switch example to use `float-end` rather than `float-start`, so it's possible to see/test how they work by resizing the browser window. Right now they are always left-aligned.

Also adds missing xxl variant example.

### Motivation & Context

to show users all variants and how they work.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38885--twbs-bootstrap.netlify.app/docs/5.3/utilities/float/#responsive>

### Related issues

<!-- Please link any related issues here. -->
