### PR TITLE
Allow fewer breakpoints for navbars

### DIFF
--- a/scss/_maps.scss
+++ b/scss/_maps.scss
@@ -172,3 +172,8 @@ $utilities-links-underline: map-loop($utilities-colors, rgba-css-var, "$key", "l
 $negative-spacers: if($enable-negative-margins, negativify-map($spacers), null) !default;
 
 $gutters: $spacers !default;
+
+// scss-docs-start navbar-breakpoints
+$navbar-breakpoints: $grid-breakpoints !default;
+// scss-docs-end navbar-breakpoints
+

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -190,9 +190,9 @@
 // Generate series of `.navbar-expand-*` responsive classes for configuring
 // where your navbar collapses.
 .navbar-expand {
-  @each $breakpoint in map-keys($grid-breakpoints) {
-    $next: breakpoint-next($breakpoint, $grid-breakpoints);
-    $infix: breakpoint-infix($next, $grid-breakpoints);
+  @each $breakpoint in map-keys($navbar-breakpoints) {
+    $next: breakpoint-next($breakpoint, $navbar-breakpoints);
+    $infix: breakpoint-infix($next, $navbar-breakpoints);
 
     // stylelint-disable-next-line scss/selector-no-union-class-name
     &#{$infix} {

--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -223,6 +223,34 @@ $theme-colors: map-remove($theme-colors, "info", "light", "dark");
 // etc
 ```
 
+To remove breakpoints from `$navbar-breakpoints`, use `map-remove` on `$navbar-breakpoints` or `$grid-breakpoints`. Be aware that the initial breakpoint is always skipped by the `navbar-expand-` class generation loop:
+
+```scss
+// Required
+@import "../node_modules/bootstrap/scss/functions";
+@import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/variables-dark";
+
+// $navbar-breakpoints MUST be a sub-map of $grid-breakpoints and it is defined
+// equal to it by default.
+// The following $navbar-breakpoints will be: sm, md, lg.
+// Since the first breakpoint is regarded as the base collapsed mode it will be
+// skipped and the resulting navbar classes will be:
+// - navbar-expand-md
+// - navbar-expand-lg
+// - navbar-expand
+$navbar-breakpoints: map-remove($navbar-breakpoints, "xs", "xl", "xxl");
+
+@import "../node_modules/bootstrap/scss/maps";
+@import "../node_modules/bootstrap/scss/mixins";
+@import "../node_modules/bootstrap/scss/root";
+
+// Optional
+@import "../node_modules/bootstrap/scss/reboot";
+@import "../node_modules/bootstrap/scss/type";
+// etc
+```
+
 ## Required keys
 
 Bootstrap assumes the presence of some specific keys within Sass maps as we used and extend these ourselves. As you customize the included maps, you may encounter errors where a specific Sass map's key is being used.

--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -223,7 +223,7 @@ $theme-colors: map-remove($theme-colors, "info", "light", "dark");
 // etc
 ```
 
-To remove breakpoints from `$navbar-breakpoints`, use `map-remove` on `$navbar-breakpoints` or `$grid-breakpoints`. Be aware that the initial breakpoint is always skipped by the `navbar-expand-` class generation loop:
+To remove breakpoints from `$navbar-breakpoints`, use `map-remove` on `$grid-breakpoints` before importing the `maps` file. Be aware that the initial breakpoint is always skipped by the `navbar-expand-` class generation loop:
 
 ```scss
 // Required


### PR DESCRIPTION
### Description

Add the ability to remove navbar breakpoints

(Rebased PR replacing https://github.com/twbs/bootstrap/pull/36521)

### Motivation & Context

We usually do not need so many breakpoints for navbars as for grids: see https://github.com/twbs/bootstrap/issues/36517 for feature description.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ X] All existing tests passed

### Related issues

[Related issue/discussion](https://github.com/twbs/bootstrap/issues/36517)
