### PR TITLE
Floating labels: fix disabled with text inside

### DIFF
--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -84,7 +84,8 @@
     }
   }
 
-  > :disabled ~ label {
+  > :disabled ~ label,
+  > .form-control:disabled ~ label { // Required for `.form-control`s because of specificity
     color: $form-floating-label-disabled-color;
 
     &::after {

--- a/site/content/docs/5.3/forms/floating-labels.md
+++ b/site/content/docs/5.3/forms/floating-labels.md
@@ -89,7 +89,7 @@ Add the `disabled` boolean attribute on an input, a textarea or a select to give
   <label for="floatingTextareaDisabled">Comments</label>
 </div>
 <div class="form-floating mb-3">
-  <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2Disabled" style="height: 100px" disabled></textarea>
+  <textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea2Disabled" style="height: 100px" disabled>Disabled textarea with some text inside</textarea>
   <label for="floatingTextarea2Disabled">Comments</label>
 </div>
 <div class="form-floating">


### PR DESCRIPTION
### Description

Add a rule to add more specifity on disabled rule.
Add some text inside one of our exemple since it doesn't overlap anything and help for the support.

### Motivation & Context

Asked by community

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (NA) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38913--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels>

### Related issues

Fixes #38731.
