### PR TITLE
Docs: remove v4 reference on homepage

### DIFF
--- a/site/layouts/partials/home/masthead.html
+++ b/site/layouts/partials/home/masthead.html
@@ -24,8 +24,6 @@
         <span class="px-1">&middot;</span>
         <a href="/docs/{{ .Site.Params.docs_version }}/getting-started/download/" class="link-secondary">Download</a>
         <span class="px-1">&middot;</span>
-        <a href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" class="link-secondary text-nowrap">v4.6.x docs</a>
-        <span class="px-1">&middot;</span>
         <a href="/docs/versions/" class="link-secondary text-nowrap">All releases</a>
       </p>
       {{ partial "ads" . }}


### PR DESCRIPTION
### Description

This PR removes the v4 reference on the homepage.

Before:
<img width="483" alt="Screenshot 2023-07-21 at 08 49 54" src="https://github.com/twbs/bootstrap/assets/17381666/82c9fa35-7071-4bc0-a9dd-91d385081e4d">


In this PR:
<img width="353" alt="Screenshot 2023-07-21 at 08 49 45" src="https://github.com/twbs/bootstrap/assets/17381666/2fdf96aa-1186-4e95-aff6-8c9e59fe286f">


### Motivation & Context

v4 is now deprecated/not supported so having it on the homepage IMO is a bit weird since it's not to be used anymore.

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38946--twbs-bootstrap.netlify.app/
