### PR TITLE
Fix postcss plugin options

### DIFF
--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -191,7 +191,7 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
                loader: 'postcss-loader',
                options: {
                  postcssOptions: {
-                   plugins: () => [
+                   plugins: [
                      autoprefixer
                    ]
                  }


### PR DESCRIPTION
### Description
The current configuration doesn't work. If you check the output, the vendor prefixes aren't there.

I had to change the syntax a bit. It's a tiny fix.

You can see an example of the correct syntax [here](https://github.com/postcss/autoprefixer/tree/10.4.14#webpack) and [here](https://github.com/webpack-contrib/postcss-loader/tree/v7.3.3#getting-started).

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed


### Related issues

<!-- Please link any related issues here. -->
