### PR TITLE
Fix some typos in Customize > Sass doc

### DIFF
--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -14,12 +14,12 @@ Whenever possible, avoid modifying Bootstrap's core files. For Sass, that means 
 
 ```text
 your-project/
-├── scss
+├── scss/
 │   └── custom.scss
 └── node_modules/
-│   └── bootstrap
-│       ├── js
-│       └── scss
+│   └── bootstrap/
+│       ├── js/
+│       └── scss/
 └── index.html
 ```
 
@@ -27,11 +27,11 @@ If you've downloaded our source files and aren't using a package manager, you'll
 
 ```text
 your-project/
-├── scss
+├── scss/
 │   └── custom.scss
 ├── bootstrap/
-│   ├── js
-│   └── scss
+│   ├── js/
+│   └── scss/
 └── index.html
 ```
 
@@ -104,7 +104,7 @@ sass --watch ./scss/custom.scss ./css/custom.css
 Learn more about your options at [sass-lang.com/install](https://sass-lang.com/install) and [compiling with VS Code](https://code.visualstudio.com/docs/languages/css#_transpiling-sass-and-less-into-css).
 
 {{< callout info >}}
-**Using Bootstrap with another build tool?** Consider reading our guides for compiling with [WebPack]({{< docsref "/getting-started/webpack" >}}), [Parcel]({{< docsref "/getting-started/parcel" >}}), or [Vite]({{< docsref "/getting-started/vite" >}}). We also have production-ready demos in [our examples repository on GitHub](https://github.com/twbs/examples).
+**Using Bootstrap with another build tool?** Consider reading our guides for compiling with [Webpack]({{< docsref "/getting-started/webpack" >}}), [Parcel]({{< docsref "/getting-started/parcel" >}}), or [Vite]({{< docsref "/getting-started/vite" >}}). We also have production-ready demos in [our examples repository on GitHub](https://github.com/twbs/examples).
 {{< /callout >}}
 
 ## Including


### PR DESCRIPTION
### Description

This PR fixes some typos in [Customize > Sass doc](https://twbs-bootstrap.netlify.app/docs/5.3/customize/sass/):
- "WebPack" → "Webpack" like everywhere
- Add a trailing slash to directories like it's done in other docs pages

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-38948--twbs-bootstrap.netlify.app/docs/5.3/customize/sass/#file-structure
- https://deploy-preview-38948--twbs-bootstrap.netlify.app/docs/5.3/customize/sass/#compiling
