### PR TITLE
Fix bundlewatch values

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "23.15 kB"
+      "maxSize": "23.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.esm.js",


### PR DESCRIPTION
### Description

This PR fixes one of the values not respecting the global rule.

Feel free to close it if the rule has changed or if it is an exception to check something specific.

### Motivation & Context

To my knowledge, the rule until then was to have the following decimal values: `.0`, `.25`, `.5`, `.75`.
