### PR TITLE
docs: add in BootstrapVueNext to getting-started/javascript page, labelled alpha

### DIFF
--- a/docs/5.2/getting-started/javascript/index.html
+++ b/docs/5.2/getting-started/javascript/index.html
@@ -538,9 +538,10 @@
 <p>While the Bootstrap CSS can be used with any framework, <strong>the Bootstrap JavaScript is not fully compatible with JavaScript frameworks like React, Vue, and Angular</strong> which assume full knowledge of the DOM. Both Bootstrap and the framework may attempt to mutate the same DOM element, resulting in bugs like dropdowns that are stuck in the &ldquo;open&rdquo; position.</p>
 <p>A better alternative for those using this type of frameworks is to use a framework-specific package <strong>instead of</strong> the Bootstrap JavaScript. Here are some of the most popular options:</p>
 <ul>
-<li>React: <a href="https://react-bootstrap.github.io/">React Bootstrap</a></li>
-<li>Vue: <a href="https://bootstrap-vue.org/">BootstrapVue</a> (currently only supports Vue 2 and Bootstrap 4)</li>
-<li>Angular: <a href="https://ng-bootstrap.github.io/">ng-bootstrap</a></li>
+  <li>React: <a href="https://react-bootstrap.github.io/" rel="noopener">React Bootstrap</a></li>
+  <li>Vue: <a href="https://bootstrap-vue.org/" rel="noopener">BootstrapVue</a> (Bootstrap 4)</li>
+  <li>Vue 3: <a href="https://bootstrap-vue-next.github.io/bootstrap-vue-next/" rel="noopener">BootstrapVueNext</a> (Bootstrap 5) <b>ALPHA</b></li>
+  <li>Angular: <a href="https://ng-bootstrap.github.io/" rel="noopener">ng-bootstrap</a></li>
 </ul>
 <h2 id="using-bootstrap-as-a-module">Using Bootstrap as a module <a class="anchor-link" href="#using-bootstrap-as-a-module" aria-label="Link to this section: Using Bootstrap as a module"></a></h2>
 <div class="bd-callout bd-callout-info">

--- a/docs/5.3/getting-started/javascript/index.html
+++ b/docs/5.3/getting-started/javascript/index.html
@@ -596,13 +596,14 @@
 <p>While the Bootstrap CSS can be used with any framework, <strong>the Bootstrap JavaScript is not fully compatible with JavaScript frameworks like React, Vue, and Angular</strong> which assume full knowledge of the DOM. Both Bootstrap and the framework may attempt to mutate the same DOM element, resulting in bugs like dropdowns that are stuck in the &ldquo;open&rdquo; position.</p>
 <p>A better alternative for those using this type of frameworks is to use a framework-specific package <strong>instead of</strong> the Bootstrap JavaScript. Here are some of the most popular options:</p>
 <ul>
-<li>React: <a href="https://react-bootstrap.github.io/">React Bootstrap</a>
-<div class="bd-callout bd-callout-info">
-<strong>Try it yourself!</strong> Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the <a href="https://github.com/twbs/examples/tree/main/react-nextjs">twbs/examples repository</a>. You can also <a href="https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx">open the example in StackBlitz</a>.
-</div>
-</li>
-<li>Vue: <a href="https://bootstrap-vue.org/">BootstrapVue</a> (currently only supports Vue 2 and Bootstrap 4)</li>
-<li>Angular: <a href="https://ng-bootstrap.github.io/">ng-bootstrap</a></li>
+  <li>React: <a href="https://react-bootstrap.github.io/" rel="noopener">React Bootstrap</a>
+    <div class="bd-callout bd-callout-info">
+     <strong>Try it yourself!</strong> Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the <a href="https://github.com/twbs/examples/tree/main/react-nextjs">twbs/examples repository</a>. You can also <a href="https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx">open the example in StackBlitz</a>.
+    </div>
+  </li>
+  <li>Vue: <a href="https://bootstrap-vue.org/" rel="noopener">BootstrapVue</a> (Bootstrap 4)</li>
+  <li>Vue 3: <a href="https://bootstrap-vue-next.github.io/bootstrap-vue-next/" rel="noopener">BootstrapVueNext</a> (Bootstrap 5) <b>ALPHA</b></li>
+  <li>Angular: <a href="https://ng-bootstrap.github.io/" rel="noopener">ng-bootstrap</a></li>
 </ul>
 <h2 id="using-bootstrap-as-a-module">Using Bootstrap as a module <a class="anchor-link" href="#using-bootstrap-as-a-module" aria-label="Link to this section: Using Bootstrap as a module"></a></h2>
 <div class="bd-callout bd-callout-info">


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

Add in BootstrapVueNext onto the Bootstrap docs

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
BootstrapVue is a separate repository, it is mostly unmaintained


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
