### PR TITLE
docs: add BootstrapVueNext to docs

### DIFF
--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -23,7 +23,7 @@ A better alternative for those using this type of frameworks is to use a framewo
   **Try it yourself!** Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/react-nextjs). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx).
   {{< /callout >}}
 - Vue: [BootstrapVue](https://bootstrap-vue.org/) (Bootstrap 4)
-- Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5) **ALPHA**
+- Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5, currently in alpha)
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
 
 ## Using Bootstrap as a module

--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -22,7 +22,8 @@ A better alternative for those using this type of frameworks is to use a framewo
   {{< callout >}}
   **Try it yourself!** Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/react-nextjs). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx).
   {{< /callout >}}
-- Vue: [BootstrapVue](https://bootstrap-vue.org/) (currently only supports Vue 2 and Bootstrap 4)
+- Vue: [BootstrapVue](https://bootstrap-vue.org/) (Bootstrap 4)
+- Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5) **ALPHA**
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
 
 ## Using Bootstrap as a module


### PR DESCRIPTION
_Same as https://github.com/twbs/bootstrap/pull/38969 but correct this time (Probably)_

### Description

Add in BootstrapVueNext onto the Bootstrap docs

### Motivation & Context

BootstrapVue is a separate repository, it is mostly unmaintained

### [Live preview](https://deploy-preview-38970--twbs-bootstrap.netlify.app/docs/5.3/getting-started/javascript/#usage-with-javascript-frameworks)