### PR TITLE
Docs: Add missing form elements in focusable elements

### DIFF
--- a/site/assets/scss/_scrolling.scss
+++ b/site/assets/scss/_scrolling.scss
@@ -3,6 +3,9 @@
 main {
   a,
   button,
+  input,
+  select,
+  textarea,
   h2,
   h3,
   h4,


### PR DESCRIPTION
### Description

Add `input`, `select` and `textarea` to `_scrolling.scss`

### Motivation & Context

Not the same behavior for this one compared to the other elements in the doc.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-38977--twbs-bootstrap.netlify.app/docs/5.3/forms/form-control>
- <https://deploy-preview-38977--twbs-bootstrap.netlify.app/docs/5.3/forms/select>

### Related issues

NA
