### PR TITLE
update deprecated unit measure for alpha values from decimal to perce…

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -150,14 +150,14 @@
   }
 
   .btn-secondary {
-    --bs-btn-bg: #{mix($gray-600, $blue-400, .5)};
-    --bs-btn-border-color: #{rgba($white, .25)};
-    --bs-btn-hover-bg: #{darken(mix($gray-600, $blue-400, .5), 5%)};
-    --bs-btn-hover-border-color: #{rgba($white, .25)};
-    --bs-btn-active-bg: #{darken(mix($gray-600, $blue-400, .5), 10%)};
-    --bs-btn-active-border-color: #{rgba($white, .5)};
-    --bs-btn-focus-border-color: #{rgba($white, .5)};
-    --bs-btn-focus-box-shadow: 0 0 0 .25rem rgba(255, 255, 255, .2);
+    --bs-btn-bg: #{mix($gray-600, $blue-400, 50%)};
+    --bs-btn-border-color: #{rgba($white, 25%)};
+    --bs-btn-hover-bg: #{darken(mix($gray-600, $blue-400, 50%), 5%)};
+    --bs-btn-hover-border-color: #{rgba($white, 25%)};
+    --bs-btn-active-bg: #{darken(mix($gray-600, $blue-400, 50%), 10%)};
+    --bs-btn-active-border-color: #{rgba($white, 50%)};
+    --bs-btn-focus-border-color: #{rgba($white, 50%)};
+    --bs-btn-focus-box-shadow: 0 0 0 .25rem rgba(255, 255, 255, 20%);
   }
 }
 // scss-docs-end custom-color-mode


### PR DESCRIPTION
…ntage

### Description

Updated deprecated unit values in /bootstrap/site/assets/scss/_content.scss from decimal value (e.g. .2, deprecated) to percentage (e.g. 50%, new standard)

### Motivation & Context

Update according to SASS' new standard guidelines:
https://sass-lang.com/documentation/breaking-changes/function-units/

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
