### PR TITLE
fixed Please adjust default table-striped color when dark mode is active  Fixes

### DIFF
--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -51,14 +51,19 @@ Use contextual classes to color tables, table rows or individual cells.
 </div>
 
 {{< highlight html >}}
+
 <!-- On tables -->{{< table.inline >}}
+
 {{- range (index $.Site.Data "theme-colors") }}
+
 <table class="table-{{ .name }}">...</table>
 {{- end -}}
 {{< /table.inline >}}
 
 <!-- On rows -->{{< table.inline >}}
+
 {{- range (index $.Site.Data "theme-colors") }}
+
 <tr class="table-{{ .name }}">...</tr>
 {{- end -}}
 {{< /table.inline >}}
@@ -82,13 +87,13 @@ Use contextual classes to color tables, table rows or individual cells.
 
 Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
 
-{{< table class="table table-striped" >}}
+{{< table class="table table-dark table-striped" >}}
 
 ### Striped columns
 
 Use `.table-striped-columns` to add zebra-striping to any table column.
 
-{{< table class="table table-striped-columns" >}}
+{{< table class="table table-dark table-striped-columns" >}}
 
 These classes can also be added to table variants:
 
@@ -104,20 +109,20 @@ These classes can also be added to table variants:
 
 Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
 
-{{< table class="table table-hover" >}}
-
 {{< table class="table table-dark table-hover" >}}
+
+{{< table class="table table-dark table-dark table-hover" >}}
 
 These hoverable rows can also be combined with the striped rows variant:
 
-{{< table class="table table-striped table-hover" >}}
+{{< table class="table table-dark table-striped table-hover" >}}
 
 ### Active tables
 
 Highlight a table row or cell by adding a `.table-active` class.
 
 <div class="bd-example">
-  <table class="table">
+  <table class="table table-dark">
     <thead>
       <tr>
         <th scope="col">#</th>
@@ -149,7 +154,7 @@ Highlight a table row or cell by adding a `.table-active` class.
 </div>
 
 ```html
-<table class="table">
+<table class="table table-dark">
   <thead>
     ...
   </thead>
@@ -242,17 +247,17 @@ Behind the scenes it looks like this:
 
 Add `.table-bordered` for borders on all sides of the table and cells.
 
-{{< table class="table table-bordered" >}}
+{{< table class="table table-dark table-bordered" >}}
 
 [Border color utilities]({{< docsref "/utilities/borders#border-color" >}}) can be added to change colors:
 
-{{< table class="table table-bordered border-primary" >}}
+{{< table class="table table-dark table-bordered border-primary" >}}
 
 ### Tables without borders
 
 Add `.table-borderless` for a table without borders.
 
-{{< table class="table table-borderless" >}}
+{{< table class="table table-dark table-borderless" >}}
 
 {{< table class="table table-dark table-borderless" >}}
 
@@ -260,7 +265,7 @@ Add `.table-borderless` for a table without borders.
 
 Add `.table-sm` to make any `.table` more compact by cutting all cell `padding` in half.
 
-{{< table class="table table-sm" >}}
+{{< table class="table table-dark table-sm" >}}
 
 {{< table class="table table-dark table-sm" >}}
 
@@ -269,7 +274,8 @@ Add `.table-sm` to make any `.table` more compact by cutting all cell `padding` 
 Add a thicker border, darker between table groups—`<thead>`, `<tbody>`, and `<tfoot>`—with `.table-group-divider`. Customize the color by changing the `border-top-color` (which we don't currently provide a utility class for at this time).
 
 {{< example >}}
-<table class="table">
+
+<table class="table table-dark">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -370,7 +376,7 @@ Table cells of `<thead>` are always vertical aligned to the bottom. Table cells 
 Border styles, active styles, and table variants are not inherited by nested tables.
 
 <div class="bd-example">
-<table class="table table-striped table-bordered">
+<table class="table table-dark table-striped table-bordered">
   <thead>
     <tr>
       <th scope="col">#</th>
@@ -427,7 +433,7 @@ Border styles, active styles, and table variants are not inherited by nested tab
 </div>
 
 ```html
-<table class="table table-striped table-bordered">
+<table class="table table-dark table-striped table-bordered">
   <thead>
     ...
   </thead>
@@ -607,15 +613,17 @@ Similar to tables and dark tables, use the modifier classes `.table-light` or `.
 A `<caption>` functions like a heading for a table. It helps users with screen readers to find a table and understand what it's about and decide if they want to read it.
 
 <div class="bd-example">
-  <table class="table">
+  <table class="table table-dark">
     <caption>List of users</caption>
     {{< partial "table-content" >}}
   </table>
 </div>
 
 ```html
-<table class="table table-sm">
-  <caption>List of users</caption>
+<table class="table table-dark table-sm">
+  <caption>
+    List of users
+  </caption>
   <thead>
     ...
   </thead>
@@ -628,7 +636,8 @@ A `<caption>` functions like a heading for a table. It helps users with screen r
 You can also put the `<caption>` on the top of the table with `.caption-top`.
 
 {{< example >}}
-<table class="table caption-top">
+
+<table class="table table-dark caption-top">
   <caption>List of users</caption>
   <thead>
     <tr>
@@ -666,6 +675,7 @@ You can also put the `<caption>` on the top of the table with `.caption-top`.
 Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl|-xxl}`.
 
 {{< callout warning >}}
+
 ##### Vertical clipping/truncation
 
 Responsive tables make use of `overflow-y: hidden`, which clips off any content that goes beyond the bottom or top edges of the table. In particular, this can clip off dropdown menus and other third-party widgets.
@@ -751,6 +761,7 @@ Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tab
 {{< tables.inline >}}
 {{ range $.Site.Data.breakpoints }}
 {{ if not (eq . "xs") }}
+
 <div class="bd-example">
   <div class="table-responsive{{ .abbr }}">
     <table class="table">
@@ -813,6 +824,7 @@ Use `.table-responsive{-sm|-md|-lg|-xl|-xxl}` as needed to create responsive tab
 {{< tables.inline >}}
 {{- range $.Site.Data.breakpoints -}}
 {{- if not (eq . "xs") }}
+
 <div class="table-responsive{{ .abbr }}">
   <table class="table">
     ...


### PR DESCRIPTION
 Fixes #39029
### Description
<!-- Describe your changes in detail -->
The comment suggests that there was a problem related to readability in the Dark mode of a table. In Dark mode, the background might have been too dark, making it difficult for users to distinguish the table text from the background. This lack of contrast can lead to an uncomfortable user experience and hinder accessibility.
**so, I have added the table-dark to tables.**

<!-- Why is this change required? What problem does it solve? -->
By incorporating the table-dark class, developers aim to enhance the user experience, especially when the application is being used in Dark mode. This change promotes accessibility and ensures that users can easily read and interact with the table's content, regardless of the chosen color scheme.

Before:
![image](https://github.com/twbs/bootstrap/assets/73093527/23adea6a-9d5b-4cf3-b467-9f5961a536ff)
After:-
![image](https://github.com/twbs/bootstrap/assets/73093527/3a2f44e3-5236-478c-bcd9-005a9b61c62f)
 
