### PR TITLE
Should show anchor color over header color

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -87,37 +87,42 @@ hr {
   font-style: $headings-font-style;
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;
-  color: var(--#{$prefix}heading-color);
 }
 
 h1 {
   @extend %heading;
   @include font-size($h1-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 h2 {
   @extend %heading;
   @include font-size($h2-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 h3 {
   @extend %heading;
   @include font-size($h3-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 h4 {
   @extend %heading;
   @include font-size($h4-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 h5 {
   @extend %heading;
   @include font-size($h5-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 h6 {
   @extend %heading;
   @include font-size($h6-font-size);
+  color: var(--#{$prefix}heading-color);
 }
 
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -1,28 +1,15 @@
 //
 // Headings
 //
-.h1 {
-  @extend h1;
-}
+@each $key, $value in $font-sizes {
+  .h#{$key} {
+    @extend %heading;
+    @include font-size($value);
 
-.h2 {
-  @extend h2;
-}
-
-.h3 {
-  @extend h3;
-}
-
-.h4 {
-  @extend h4;
-}
-
-.h5 {
-  @extend h5;
-}
-
-.h6 {
-  @extend h6;
+    :not(a) {
+      color: $value;
+    }
+  }
 }
 
 

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -6,8 +6,8 @@
     @extend %heading;
     @include font-size($value);
 
-    :not(a) {
-      color: $value;
+    &:not(a) {
+      color: var(--#{$prefix}heading-color);
     }
   }
 }


### PR DESCRIPTION
### Description

Fix changes introduced with header coloring via css variables.
Header variable coloring should not overwrite anchor colors

<!-- Describe your changes in detail -->

Header classes now extend `%headings` instead of extending relevant header, this was required due to needed specific control over non header anchors to set color variable
Added new rule to header classes not set on an anchor to use css variable

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Please see issue #36365 and respective regression #39023

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
