### PR TITLE
Make form range track background more contrasted

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1042,7 +1042,7 @@ $form-select-transition:          $input-transition !default;
 $form-range-track-width:          100% !default;
 $form-range-track-height:         .5rem !default;
 $form-range-track-cursor:         pointer !default;
-$form-range-track-bg:             var(--#{$prefix}tertiary-bg) !default;
+$form-range-track-bg:             var(--#{$prefix}secondary-bg) !default;
 $form-range-track-border-radius:  1rem !default;
 $form-range-track-box-shadow:     var(--#{$prefix}box-shadow-inset) !default;
 


### PR DESCRIPTION
### Description

This PR makes the form range track background color more contrasted for a11y reasons. The previous color wasn't enough contrasted, especially in light mode. I chose the secondary color instead of the tertiary color so that it works automatically in both light and dark modes.

#### Before

![Screenshot 2023-08-23 at 07 43 19](https://github.com/twbs/bootstrap/assets/17381666/e7ffe844-cbc8-458e-9acb-b523c9a46d49)
![Screenshot 2023-08-23 at 07 43 05](https://github.com/twbs/bootstrap/assets/17381666/a96f5bab-07bd-46bd-bf91-b5b3375195e1)

#### Now

![Screenshot 2023-08-23 at 07 44 43](https://github.com/twbs/bootstrap/assets/17381666/da63f6e4-c114-495f-99bb-e7a90561a932)
![Screenshot 2023-08-23 at 07 44 33](https://github.com/twbs/bootstrap/assets/17381666/51018a90-7f74-4fab-9b40-e2c429f5b825)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-39095--twbs-bootstrap.netlify.app/docs/5.3/forms/range/>

### Related issues

Closes #38999 
