### PR TITLE
Fix missing active state for outline buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -159,11 +159,13 @@
     @if $color == "light" {
       @include button-outline-variant(
         $value,
+        $hover-background: shade-color($value, $btn-hover-bg-shade-amount),
         $active-background: shade-color($value, $btn-active-bg-shade-amount)
       );
     } @else if $color == "dark" {
       @include button-outline-variant(
         $value,
+        $hover-background: tint-color($value, $btn-hover-bg-tint-amount),
         $active-background: tint-color($value, $btn-active-bg-tint-amount)
       );
     } @else {

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -156,7 +156,19 @@
 
 @each $color, $value in $theme-colors {
   .btn-outline-#{$color} {
-    @include button-outline-variant($value);
+    @if $color == "light" {
+      @include button-outline-variant(
+        $value,
+        $active-background: shade-color($value, $btn-active-bg-shade-amount)
+      );
+    } @else if $color == "dark" {
+      @include button-outline-variant(
+        $value,
+        $active-background: tint-color($value, $btn-active-bg-tint-amount)
+      );
+    } @else {
+      @include button-outline-variant($value);
+    }
   }
 }
 // scss-docs-end btn-variant-loops

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -38,16 +38,19 @@
 // scss-docs-start btn-outline-variant-mixin
 @mixin button-outline-variant(
   $color,
-  $color-hover: color-contrast($color),
-  $active-background: if($color-hover == $color-contrast-light, shade-color($color, $btn-active-bg-shade-amount), tint-color($color, $btn-active-bg-tint-amount)),
+  $color-contrast: color-contrast($color),
+  $hover-background: if($color-contrast == $color-contrast-light, shade-color($color, $btn-hover-bg-shade-amount), tint-color($color, $btn-hover-bg-tint-amount)),
+  $hover-border: $hover-background,
+  $hover-color: color-contrast($hover-background),
+  $active-background: if($color-contrast == $color-contrast-light, shade-color($color, $btn-active-bg-shade-amount), tint-color($color, $btn-active-bg-tint-amount)),
   $active-border: $active-background,
   $active-color: color-contrast($active-background)
 ) {
   --#{$prefix}btn-color: #{$color};
   --#{$prefix}btn-border-color: #{$color};
-  --#{$prefix}btn-hover-color: #{$color-hover};
-  --#{$prefix}btn-hover-bg: #{$color};
-  --#{$prefix}btn-hover-border-color: #{$color};
+  --#{$prefix}btn-hover-color: #{$hover-color};
+  --#{$prefix}btn-hover-bg: #{$hover-background};
+  --#{$prefix}btn-hover-border-color: #{$hover-border};
   --#{$prefix}btn-focus-shadow-rgb: #{to-rgb($color)};
   --#{$prefix}btn-active-color: #{$active-color};
   --#{$prefix}btn-active-bg: #{$active-background};

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -39,15 +39,15 @@
 @mixin button-outline-variant(
   $color,
   $color-hover: color-contrast($color),
-  $active-background: $color,
-  $active-border: $color,
+  $active-background: if($color-hover == $color-contrast-light, shade-color($color, $btn-active-bg-shade-amount), tint-color($color, $btn-active-bg-tint-amount)),
+  $active-border: $active-background,
   $active-color: color-contrast($active-background)
 ) {
   --#{$prefix}btn-color: #{$color};
   --#{$prefix}btn-border-color: #{$color};
   --#{$prefix}btn-hover-color: #{$color-hover};
-  --#{$prefix}btn-hover-bg: #{$active-background};
-  --#{$prefix}btn-hover-border-color: #{$active-border};
+  --#{$prefix}btn-hover-bg: #{$color};
+  --#{$prefix}btn-hover-border-color: #{$color};
   --#{$prefix}btn-focus-shadow-rgb: #{to-rgb($color)};
   --#{$prefix}btn-active-color: #{$active-color};
   --#{$prefix}btn-active-bg: #{$active-background};


### PR DESCRIPTION
### Description

Previously there was no visual feedback when clicking an outline button, which made them feel somewhat buggy/broken. This pull request adds an active state to outline buttons so they respond similarly to other buttons when selected.

It also updates the hover state for outline buttons to match that of regular buttons. Previously if an outline button was next to a regular button, when hovered it looked the same as the non-hovered regular button which could cause confusion.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have added tests to cover my changes
- [x] All existing tests passed

#### Live previews

- <https://deploy-preview-39099--twbs-bootstrap.netlify.app/docs/5.3/components/buttons/#outline-buttons>

### Related issues

Resolves #39085