### PR TITLE
Sass warning: Handle the error directly in the function

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -260,9 +260,11 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 }
 
 @function divide($dividend, $divisor, $precision: 10) {
+  $dividend-unit: unit($dividend);
+  $divisor-unit: unit($divisor);
   $sign: if($dividend > 0 and $divisor > 0 or $dividend < 0 and $divisor < 0, 1, -1);
-  $dividend: abs($dividend);
-  $divisor: abs($divisor);
+  $dividend: if($dividend-unit == "%", abs(calc($dividend / 1%)), abs($dividend));
+  $divisor: if($divisor-unit == "%", abs(calc($divisor / 1%)), abs($divisor));
   @if $dividend == 0 {
     @return 0;
   }
@@ -287,8 +289,6 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
     }
   }
   $result: $result * $factor * $sign;
-  $dividend-unit: unit($dividend);
-  $divisor-unit: unit($divisor);
   $unit-map: (
     "px": 1px,
     "rem": 1rem,

--- a/scss/vendor/_rfs.scss
+++ b/scss/vendor/_rfs.scss
@@ -53,9 +53,11 @@ $enable-rfs: true !default;
 $rfs-base-value-unit: unit($rfs-base-value);
 
 @function divide($dividend, $divisor, $precision: 10) {
+  $dividend-unit: unit($dividend);
+  $divisor-unit: unit($divisor);
   $sign: if($dividend > 0 and $divisor > 0 or $dividend < 0 and $divisor < 0, 1, -1);
-  $dividend: abs($dividend);
-  $divisor: abs($divisor);
+  $dividend: if($dividend-unit == "%", abs(calc($dividend / 1%)), abs($dividend));
+  $divisor: if($divisor-unit == "%", abs(calc($divisor / 1%)), abs($divisor));
   @if $dividend == 0 {
     @return 0;
   }
@@ -80,8 +82,6 @@ $rfs-base-value-unit: unit($rfs-base-value);
     }
   }
   $result: $result * $factor * $sign;
-  $dividend-unit: unit($dividend);
-  $divisor-unit: unit($divisor);
   $unit-map: (
     "px": 1px,
     "rem": 1rem,


### PR DESCRIPTION
### Description

Add a check for percentage values directly in the function so people using this function won't have any change to do.
Changed the rfs vendor as well, but it might be done on rfs side directly and backported in Bootstrap.

### Motivation & Context

Deprecation warning while using percentage values in `abs()` function.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

Fixes #39028.
Might superseed #39030.
