### PR TITLE
Docs: add warning callout to add a workaround when jsDelivr is not available

### DIFF
--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -50,15 +50,13 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 <script src="{{< param "cdn.js" >}}" integrity="{{< param "cdn.js_hash" >}}" crossorigin="anonymous"></script>
 ```
 
-{{< callout warning >}}
-**Heads up!** We use and advise to use [jsDelivr](https://www.jsdelivr.com/) in our documentation. However, in some cases, like in some specific countries or environments, you might need to use other CDN providers, such as [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
+### Alternative CDNs
 
-You'll find the same files on these CDN providers, albeit with different URLs.
+We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-While changing the URLs, you'll also need to update the `integrity` attribute. Tools like [SRI Hash Generator](https://www.srihash.org/) can help you generate the correct values.
+You'll find the same files on these CDN providers, albeit with different URLs. When changing the URLs, you'll also need to update the `integrity` attribute. Tools like [SRI Hash Generator](https://www.srihash.org/) can help you generate the correct values.
 
-Easier, this [cdnjs Bootstrap direct link](https://cdnjs.com/libraries/bootstrap) provides a ready-to-use HTML snippet for each version of Bootstrap where you can just copy and paste the script tag.
-{{< /callout >}}
+With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 
 ## Package managers
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -51,9 +51,13 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 ```
 
 {{< callout warning >}}
-**Heads up!** We use and advise to use [jsDelivr](https://www.jsdelivr.com/) in our documentation. However, in some cases, like in some specific countries or environments, you might need to use other CDN providers, such as [unpkg](https://unpkg.com/).
+**Heads up!** We use and advise to use [jsDelivr](https://www.jsdelivr.com/) in our documentation. However, in some cases, like in some specific countries or environments, you might need to use other CDN providers, such as [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-In this case, you can replace `https://cdn.jsdelivr.net/npm/` with `https://unpkg.com/`.
+You'll find the same files on these CDN providers, albeit with different URLs.
+
+While changing the URLs, you'll also need to update the `integrity` attribute. Tools like [SRI Hash Generator](https://www.srihash.org/) can help you generate the correct values.
+
+Easier, this [cdnjs Bootstrap direct link](https://cdnjs.com/libraries/bootstrap) provides a ready-to-use HTML snippet for each version of Bootstrap where you can just copy and paste the script tag.
 {{< /callout >}}
 
 ## Package managers

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -50,6 +50,12 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 <script src="{{< param "cdn.js" >}}" integrity="{{< param "cdn.js_hash" >}}" crossorigin="anonymous"></script>
 ```
 
+{{< callout warning >}}
+**Heads up!** We use and advise to use [jsDelivr](https://www.jsdelivr.com/) in our documentation. However, in some cases, like in some specific countries or environments, you might need to use other CDN providers, such as [unpkg](https://unpkg.com/).
+
+In this case, you can replace `https://cdn.jsdelivr.net/npm/` with `https://unpkg.com/`.
+{{< /callout >}}
+
 ## Package managers
 
 Pull in Bootstrap's **source files** into nearly any project with some of the most popular package managers. No matter the package manager, Bootstrap will **require a [Sass compiler]({{< docsref "/getting-started/contribute#sass" >}}) and [Autoprefixer](https://github.com/postcss/autoprefixer)** for a setup that matches our official compiled versions.


### PR DESCRIPTION
### Description

We use (and advise to use) jsDelivr when using the CDN version of Bootstrap.

However, recently, in https://github.com/orgs/twbs/discussions/39143 or https://github.com/orgs/twbs/discussions/38782 (if I remember well, other discussions exist as well), it seems like jsDelivr is not available in some countries (might be blocked).

So this PR suggests adding a warning callout to explain it and provides a workaround with [cdnjs](https://cdnjs.com) pr [unpkg](https://unpkg.com/) which seem to be reliable resources as well.

As mentioned in the comments, [cdnjs Bootstrap page](https://cdnjs.com/libraries/bootstrap) provides a ready-to-use snippet that can be really a handful for folks.

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39145--twbs-bootstrap.netlify.app/docs/5.3/getting-started/download/#cdn-via-jsdelivr

### Related discussions

- https://github.com/orgs/twbs/discussions/39143
- https://github.com/orgs/twbs/discussions/38782
