### PR TITLE
Set floating-labels default color equal to the input placeholder color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1075,6 +1075,7 @@ $form-floating-input-padding-b:         .625rem !default;
 $form-floating-label-height:            1.5em !default;
 $form-floating-label-opacity:           .65 !default;
 $form-floating-label-transform:         scale(.85) translateY(-.5rem) translateX(.15rem) !default;
+$form-floating-label-color:             $input-placeholder-color !default; // When the label is acting as a placeholder
 $form-floating-label-disabled-color:    $gray-600 !default;
 $form-floating-transition:              opacity .1s ease-in-out, transform .1s ease-in-out !default;
 // scss-docs-end form-floating-variables

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -17,7 +17,7 @@
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
-    color: $input-placeholder-color;
+    color: $form-floating-label-color;
     text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -17,6 +17,7 @@
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
+    color: $input-placeholder-color;
     text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
### Motivation & Context

Floating labels (after  not focused  inputs and not plaintext form-control) are used as input placeholders, so they should have the same styling (read `$input-placeholder-color`) of actual input-placeholders.

(edit)
Added (and used) new var: 
```scss
$form-floating-label-color:             $input-placeholder-color !default;
```
to allow easier extra customization