### PR TITLE
Fix: make theme selector tick icon visible when active in examples layout

### DIFF
--- a/site/layouts/_default/examples.html
+++ b/site/layouts/_default/examples.html
@@ -89,8 +89,13 @@
         --bs-btn-active-bg: #5a23c8;
         --bs-btn-active-border-color: #5a23c8;
       }
+
       .bd-mode-toggle {
         z-index: 1500;
+      }
+
+      .bd-mode-toggle .dropdown-menu .active .bi {
+        display: block !important;
       }
     </style>
 


### PR DESCRIPTION
### Description

This PR uses the existing `.bd-mode-toggle` selector to force-switch the `display` value of the icon when active directly in the style of the layout of the examples. It's done based on the same principle as the following in `site/assets/_navbar.scss`:

```css
.bd-navbar .dropdown-menu .active .bi {
  display: block !important;
}
```

I'm not a big fan of the current solution (even for the navbar) but this fix stays in the same spirit.

#### New rendering

![Screenshot 2023-09-13 at 23 14 49](https://github.com/twbs/bootstrap/assets/17381666/b4628541-c0f4-44f5-9bb1-6cd4620a4fb9)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39177--twbs-bootstrap.netlify.app/docs/5.3/examples/features/ (for instance)

### Related issues

Closes #39175
