### PR TITLE
download: Reword CDN paragraph

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -40,6 +40,7 @@
     "dropright",
     "dropstart",
     "dropup",
+    "dgst",
     "errorf",
     "favicon",
     "favicons",

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -54,7 +54,7 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-You'll find the same files on these CDN providers, albeit with different URLs.
+You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
 
 With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -57,7 +57,7 @@ We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our d
 With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 
 You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
-Note that you should compare same length hashes, e.g. sha-384 with sha-384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file. Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
+Note that you should compare same length hashes, e.g. sha384 with sha384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file. Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
 
 ```sh
 openssl dgst -sha384 -binary bootstrap.min.js | openssl base64 -A

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -54,10 +54,14 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
-Note that you should compare same length hashes, e.g. sha-384 with sha-384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file.
-
 With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
+
+You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
+Note that you should compare same length hashes, e.g. sha-384 with sha-384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file. Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
+
+```sh
+openssl dgst -sha384 -binary bootstrap.min.js | openssl base64 -A
+```
 
 ## Package managers
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -54,10 +54,12 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
+You'll find the same files on these CDN providers, albeit with different URLs. With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 
-You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
-Note that you should compare same length hashes, e.g. sha384 with sha384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file. Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
+**If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
+Note that you should compare same length hashes, e.g. `sha384` with `sha384`, otherwise it's expected for them to be different.
+As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file.
+Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
 
 ```sh
 openssl dgst -sha384 -binary bootstrap.min.js | openssl base64 -A

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -54,7 +54,7 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
-You'll find the same files on these CDN providers, albeit with different URLs. When changing the URLs, you'll also need to update the `integrity` attribute. Tools like [SRI Hash Generator](https://www.srihash.org/) can help you generate the correct values.
+You'll find the same files on these CDN providers, albeit with different URLs.
 
 With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -55,6 +55,7 @@ If you're using our compiled JavaScript and prefer to include Popper separately,
 We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our documentation. However, in some cases—like in some specific countries or environments—you may need to use other CDN providers like [cdnjs](https://cdnjs.com/) or [unpkg](https://unpkg.com/).
 
 You'll find the same files on these CDN providers, albeit with different URLs. **If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
+Note that you should compare same length hashes, e.g. sha-384 with sha-384, otherwise it's expected for them to be different. As such, you can use [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file.
 
 With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -56,7 +56,10 @@ We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our d
 
 You'll find the same files on these CDN providers, albeit with different URLs. With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 
-**If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone.**
+{{< callout warning>}}
+**If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone else.**
+{{< /callout >}}
+
 Note that you should compare same length hashes, e.g. `sha384` with `sha384`, otherwise it's expected for them to be different.
 As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file.
 Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -57,12 +57,12 @@ We recommend [jsDelivr](https://www.jsdelivr.com/) and use it ourselves in our d
 You'll find the same files on these CDN providers, albeit with different URLs. With cdnjs, you can [use this direct Bootstrap package link](https://cdnjs.com/libraries/bootstrap) to copy and paste ready-to-use HTML snippets for each dist file from any version of Bootstrap.
 
 {{< callout warning>}}
-**If the SRI hashes differ, you shouldn't use the files from that CDN, because it means that the file was modified by someone else.**
+**If the SRI hashes differ for a given file, you shouldn't use the files from that CDN, because it means that the file was modified by someone else.**
 {{< /callout >}}
 
 Note that you should compare same length hashes, e.g. `sha384` with `sha384`, otherwise it's expected for them to be different.
-As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure the hashes are the same for a given file.
-Alternatively, you can achieve the same from the CLI assuming you have OpenSSL installed, for example:
+As such, you can use an online tool like [SRI Hash Generator](https://www.srihash.org/) to make sure that the hashes are the same for a given file.
+Alternatively, assuming you have OpenSSL installed, you can achieve the same from the CLI, for example:
 
 ```sh
 openssl dgst -sha384 -binary bootstrap.min.js | openssl base64 -A


### PR DESCRIPTION
The hashes do not differ for the same files. If they do, someone is modifying our files and as such the users should be cautious if that's the case.

https://deploy-preview-39179--twbs-bootstrap.netlify.app/docs/5.3/getting-started/download/#alternative-cdns