### PR TITLE
Force color-mode mixins to prepend selectors instead of append

### DIFF
--- a/scss/mixins/_color-mode.scss
+++ b/scss/mixins/_color-mode.scss
@@ -13,7 +13,8 @@
       }
     }
   } @else {
-    [data-bs-theme="#{$mode}"] {
+    $parent-selector: &;
+    @at-root [data-bs-theme="#{$mode}"] #{$parent-selector} {
       @content;
     }
   }

--- a/scss/tests/mixins/_color-modes.test.scss
+++ b/scss/tests/mixins/_color-modes.test.scss
@@ -30,6 +30,30 @@
         }
       }
     }
+    @include assert() {
+      @include output() {
+        .parent {
+          @include color-mode(dark) {
+            .element {
+              color: var(--bs-primary-text-emphasis);
+              background-color: var(--bs-primary-bg-subtle);
+            }
+          }
+          @include color-mode(dark, true) {
+            --custom-color: #{mix($indigo, $blue, 50%)};
+          }
+        }
+      }
+      @include expect() {
+        [data-bs-theme=dark] .parent .element {
+          color: var(--bs-primary-text-emphasis);
+          background-color: var(--bs-primary-bg-subtle);
+        }
+        [data-bs-theme=dark] .parent {
+          --custom-color: #3a3ff8;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description

`color-mode` mixins on `$color-mode-type=data` appends `[data-bs-theme="#{$mode}"]` instead of prepend the selectors from the parent. This PR will update the behavior of `color-mode` mixins on `$color-mode-type=data` so that we can use this mixins deep inside other selector/rule blocks.

### Motivation & Context

Before this PR, using the `color-mode` mixins inside a rule block will just append `[data-bs-theme="#{$mode}"]` selector to the parent selector.

SCSS:

```scss
.parent {
  @include color-mode(dark, true) {
    .element {
      color: var(--bs-primary-text-emphasis);
      background-color: var(--bs-primary-bg-subtle);
    }
  }
  @include color-mode(dark, true) {
    --custom-color: #{mix($indigo, $blue, 50%)};
  }
}
```

Output:

```css
.parent [data-bs-theme=dark] .element {
  color: var(--bs-primary-text-emphasis);
  background-color: var(--bs-primary-bg-subtle);
}
.parent [data-bs-theme=dark] {
  --custom-color: #3a3ff8;
}
```

This is problematic, because if `[data-bs-theme=dark]` are set on `<html>`tag, the selector will not match. So this PR update the said SCSS code to following CSS:

```css
[data-bs-theme=dark] .parent .element {
  color: var(--bs-primary-text-emphasis);
  background-color: var(--bs-primary-bg-subtle);
}
[data-bs-theme=dark] .parent {
  --custom-color: #3a3ff8;
}
```

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-39194--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
