### PR TITLE
Selector Engine: fix multiple IDs

### DIFF
--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -29,7 +29,7 @@ const getSelector = element => {
     selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
   }
 
-  return selector?.split(',').map(sel => parseSelector(sel)).join(',')
+  return selector ? selector.split(',').map(sel => parseSelector(sel)).join(',') : null
 }
 
 const SelectorEngine = {

--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -26,10 +26,10 @@ const getSelector = element => {
       hrefAttribute = `#${hrefAttribute.split('#')[1]}`
     }
 
-    selector = hrefAttribute && hrefAttribute !== '#' ? parseSelector(hrefAttribute.trim()) : null
+    selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
   }
-
-  return selector
+  
+  return selector.split(',').map(sel=>parseSelector(sel)).join(',')
 }
 
 const SelectorEngine = {

--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -28,8 +28,8 @@ const getSelector = element => {
 
     selector = hrefAttribute && hrefAttribute !== '#' ? hrefAttribute.trim() : null
   }
-  
-  return selector.split(',').map(sel=>parseSelector(sel)).join(',')
+
+  return selector?.split(',').map(sel => parseSelector(sel)).join(',')
 }
 
 const SelectorEngine = {

--- a/js/tests/unit/dom/selector-engine.spec.js
+++ b/js/tests/unit/dom/selector-engine.spec.js
@@ -371,6 +371,18 @@ describe('SelectorEngine', () => {
       expect(SelectorEngine.getMultipleElementsFromSelector(testEl)).toEqual(Array.from(fixtureEl.querySelectorAll('.target')))
     })
 
+    it('should get elements if several ids with special chars are given', () => {
+      fixtureEl.innerHTML = [
+        '<div id="test" data-bs-target="#j_id11:exampleModal,#j_id22:exampleModal"></div>',
+        '<div class="target" id="j_id11:exampleModal"></div>',
+        '<div class="target" id="j_id22:exampleModal"></div>'
+      ].join('')
+
+      const testEl = fixtureEl.querySelector('#test')
+
+      expect(SelectorEngine.getMultipleElementsFromSelector(testEl)).toEqual(Array.from(fixtureEl.querySelectorAll('.target')))
+    })
+
     it('should get elements in array, from href if no data-bs-target set', () => {
       fixtureEl.innerHTML = [
         '<a id="test" href=".target"></a>',

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -991,6 +991,36 @@ describe('Modal', () => {
         trigger.click()
       })
     })
+
+    it('should open modal, having special characters in its id', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+        '<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#j_id22:exampleModal">',
+        '   Launch demo modal',
+        '</button>',
+        '<div class="modal fade" id="j_id22:exampleModal" aria-labelledby="exampleModalLabel" aria-hidden="true">',
+        '  <div class="modal-dialog">',
+        '    <div class="modal-content">',
+        '      <div class="modal-body">',
+        '        <p>modal body</p>',
+        '      </div>',
+        '    </div>',
+        '  </div>',
+        '</div>',
+        ].join('')
+
+        const modalEl = fixtureEl.querySelector('.modal')
+        const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
+
+
+        modalEl.addEventListener('shown.bs.modal', () => {
+          resolve()
+        })
+
+        trigger.click()
+      })
+    })
+
     it('should not prevent default when a click occurred on data-bs-dismiss="modal" where tagName is DIFFERENT than <a> or <area>', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -995,23 +995,22 @@ describe('Modal', () => {
     it('should open modal, having special characters in its id', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
-        '<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#j_id22:exampleModal">',
-        '   Launch demo modal',
-        '</button>',
-        '<div class="modal fade" id="j_id22:exampleModal" aria-labelledby="exampleModalLabel" aria-hidden="true">',
-        '  <div class="modal-dialog">',
-        '    <div class="modal-content">',
-        '      <div class="modal-body">',
-        '        <p>modal body</p>',
-        '      </div>',
-        '    </div>',
-        '  </div>',
-        '</div>',
+          '<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#j_id22:exampleModal">',
+          '   Launch demo modal',
+          '</button>',
+          '<div class="modal fade" id="j_id22:exampleModal" aria-labelledby="exampleModalLabel" aria-hidden="true">',
+          '  <div class="modal-dialog">',
+          '    <div class="modal-content">',
+          '      <div class="modal-body">',
+          '        <p>modal body</p>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
         ].join('')
 
         const modalEl = fixtureEl.querySelector('.modal')
         const trigger = fixtureEl.querySelector('[data-bs-toggle="modal"]')
-
 
         modalEl.addEventListener('shown.bs.modal', () => {
           resolve()


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

### Motivation & Context

A draft solution, which supports multiple ids, and usage off CSS.escape at the same time

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-39201--twbs-bootstrap.netlify.app/>

### Related issues

Ref: #38989 , #339198

closes: #39189 

<!-- Please link any related issues here. -->
