### PR TITLE
Tests: update navbar in visual modal test

### DIFF
--- a/js/tests/visual/modal.html
+++ b/js/tests/visual/modal.html
@@ -13,21 +13,25 @@
     </style>
   </head>
   <body>
-    <nav class="navbar navbar-full navbar-dark bg-dark">
-      <button class="navbar-toggler hidden-lg-up" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-      <div class="collapse navbar-expand-md" id="navbarResponsive">
-        <a class="navbar-brand" href="#">This shouldn't jump!</a>
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link active" href="#" aria-current="page">Home</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Link</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Link</a>
-          </li>
-        </ul>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container-fluid">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarResponsive">
+          <a class="navbar-brand" href="#">This shouldn't jump!</a>
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link active" href="#" aria-current="page">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Link</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#">Link</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </nav>
 


### PR DESCRIPTION
### Description

This PR updates the navbar used in our modal visual test which still use old `.navbar-full` and `.hidden-lg-up` classes, and so never render the content of the navbar.

For context, `.hidden-lg-up` and `.navbar-full` were removed after v4.0.0 alpha versions.

Their usage was the following:

> The `.hidden-*-up` classes hide the element when the viewport is at the given breakpoint or wider. For example, `.hidden-md-up` hides an element on medium, large, and extra-large viewports.

Corresponding code in `bootstrap.css` in v4.0.0-alpha.5

```css
@media (min-width: 992px) {
  .hidden-lg-up {
    display: none !important;
  }
}
```

that I've changed to our `.navbar-expand-lg` which does the same thing:

```css
@media (min-width: 992px) {
.navbar-expand-lg .navbar-toggler {
    display: none;
  }
}
```

Regarding `.navbar-full`, IMO we can just drop it as it's already handled by our `.navbar-*` classes:

```css
.navbar-full {
  z-index: 1000;
}

@media (min-width: 576px) {
  .navbar-full {
    border-radius: 0;
  }
}
```

The global modification of the navbar follows our current navbar documentation and usage.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

### Live preview

- **Locally**: http://localhost:8008/js/tests/visual/modal.html