### PR TITLE
Doc: add expanded accordion explanation

### DIFF
--- a/site/content/docs/5.3/components/accordion.md
+++ b/site/content/docs/5.3/components/accordion.md
@@ -23,7 +23,7 @@ Click the accordions below to expand/collapse the accordion content.
 
 To render an accordion that's expanded by default:
 - add the `.show` class on the `.accordion-collapse` element.
-- drop the `collapse` class from the `.accordion-button` element and set its `aria-expanded` to `true`.
+- drop the `.collapsed` class from the `.accordion-button` element and set its `aria-expanded` attribute to `true`.
 
 {{< example >}}
 <div class="accordion" id="accordionExample">

--- a/site/content/docs/5.3/components/accordion.md
+++ b/site/content/docs/5.3/components/accordion.md
@@ -11,7 +11,7 @@ toc: true
 
 ## How it works
 
-The accordion uses [collapse]({{< docsref "/components/collapse" >}}) internally to make it collapsible. To render an accordion that's expanded, add the `.open` class on the `.accordion`.
+The accordion uses [collapse]({{< docsref "/components/collapse" >}}) internally to make it collapsible.
 
 {{< callout info >}}
 {{< partial "callouts/info-prefersreducedmotion.md" >}}
@@ -20,6 +20,10 @@ The accordion uses [collapse]({{< docsref "/components/collapse" >}}) internally
 ## Example
 
 Click the accordions below to expand/collapse the accordion content.
+
+To render an accordion that's expanded by default:
+- add the `.show` class on the `.accordion-collapse` element.
+- drop the `collapse` class from the `.accordion-button` element and set its `aria-expanded` to `true`.
 
 {{< example >}}
 <div class="accordion" id="accordionExample">


### PR DESCRIPTION
### Description

This PR suggests fixing the accordion's documentation about how to render it when expanded.

The original sentence was in fact not correct from the beginning as there was no `.open` class used for the accordions. The correct class is `.show`, but is not enough to make the accordion expand. The `.collapsed` class needs to be removed and the `aria-expanded` attribute needs to be set to `true`.

This description has been updated to reflect the changes and moved to the "Example" section.

Feel free to enhance this fix directly if you have any suggestions.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39304--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/

### Related issues

Closes #39303
