### PR TITLE
Drop `.table-light` from table foot example

### DIFF
--- a/site/content/docs/5.3/content/tables.md
+++ b/site/content/docs/5.3/content/tables.md
@@ -549,7 +549,7 @@ Similar to tables and dark tables, use the modifier classes `.table-light` or `.
 
 <div class="bd-example">
 <table class="table">
-  <thead class="table-light">
+  <thead>
     <tr>
       <th scope="col">#</th>
       <th scope="col">First</th>


### PR DESCRIPTION
### Description

As mentioned in #39319, users could expect to see `.table-light` in the code part. Since this part is rather to show the table foot, I've dropped the `.table-light` class from the rendering part. It makes it consistent with the other examples and doesn't "pollute" the code part with an extra class.

### Type of changes

- [x] Doc enhancement (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39320--twbs-bootstrap.netlify.app/docs/5.3/content/tables/#table-foot

### Related issues

Closes #39319
