### PR TITLE
Docs: improve progress bar labels markup and explanations for accessibility

### DIFF
--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -80,7 +80,7 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
 Note that by default, the content inside the `.progress-bar` is controlled with `overflow: hidden`, so it doesn't bleed out of the bar. If your progress bar is shorter than its label, the content will be capped and may become unreadable. To change this behavior, you can use `.overflow-visible` from the [overflow utilities]({{< docsref "/utilities/overflow" >}}).
 
 {{< callout warning >}}
-**Accessibility warning:** Long labels may not be fully accessible with this method. As it relies on the text color having the right contrast ratio with both the `.progress` and `.progress-bar` background colors, your color palette could be incompatible with this approach.
+Labels longer than the progress bar within may not be fully accessible using this method because it relies on the text color having the correct contrast ratio with both the `.progress` and `.progress-bar` background colors. Use caution when implementing this example.
 
 If the text can overlap the progress bar, we often recommend displaying the label outside of the progress bar for better accessibility.
 {{< /callout >}}

--- a/site/content/docs/5.3/components/progress.md
+++ b/site/content/docs/5.3/components/progress.md
@@ -75,13 +75,15 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
 </div>
 {{< /example >}}
 
-Note that by default, the content inside the `.progress-bar` is controlled with `overflow: hidden`, so it doesn't bleed out of the bar. If your progress bar is shorter than its label, the content will be capped and may become unreadable. To change this behavior, you can use `.overflow-visible` from the [overflow utilities]({{< docsref "/utilities/overflow" >}}), but make sure to also define an explicit [text color]({{< docsref "/utilities/colors#colors" >}}) so the text remains readable. Be aware though that currently this approach does not take into account [color modes]({{< docsref "/customize/color-modes" >}}).
+### Long labels
 
-{{< example >}}
-<div class="progress" role="progressbar" aria-label="Example with label" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar overflow-visible text-dark" style="width: 10%">Long label text for the progress bar, set to a dark color</div>
-</div>
-{{< /example >}}
+Note that by default, the content inside the `.progress-bar` is controlled with `overflow: hidden`, so it doesn't bleed out of the bar. If your progress bar is shorter than its label, the content will be capped and may become unreadable. To change this behavior, you can use `.overflow-visible` from the [overflow utilities]({{< docsref "/utilities/overflow" >}}).
+
+{{< callout warning >}}
+**Accessibility warning:** Long labels may not be fully accessible with this method. As it relies on the text color having the right contrast ratio with both the `.progress` and `.progress-bar` background colors, your color palette could be incompatible with this approach.
+
+If the text can overlap the progress bar, we often recommend displaying the label outside of the progress bar for better accessibility.
+{{< /callout >}}
 
 ## Backgrounds
 
@@ -106,28 +108,20 @@ Use background utility classes to change the appearance of individual progress b
 {{< partial "callouts/warning-color-assistive-technologies.md" >}}
 {{< /callout >}}
 
-If you're adding labels to progress bars with a custom background color, make sure to also set an appropriate [text color]({{< docsref "/utilities/colors#colors" >}}), so the labels remain readable and have sufficient contrast.
+If you're adding labels to progress bars with a custom background color, make sure to also set an appropriate [text color]({{< docsref "/utilities/colors#colors" >}}), so the labels remain readable and have sufficient contrast. We recommend using the [color and background]({{< docsref "/helpers/color-background" >}}) helper classes.
 
 {{< example >}}
 <div class="progress" role="progressbar" aria-label="Success example" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar bg-success" style="width: 25%">25%</div>
+  <div class="progress-bar text-bg-success" style="width: 25%">25%</div>
 </div>
 <div class="progress" role="progressbar" aria-label="Info example" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar bg-info text-dark" style="width: 50%">50%</div>
+  <div class="progress-bar text-bg-info" style="width: 50%">50%</div>
 </div>
-<div class="progress" role="progressbar" aria-label="Warning example" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar bg-warning text-dark" style="width: 75%">75%</div>
-</div>
-<div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
-  <div class="progress-bar bg-danger" style="width: 100%">100%</div>
-</div>
-{{< /example >}}
-
-Alternatively, you can use the new combined [color and background]({{< docsref "/helpers/color-background" >}}) helper classes.
-
-{{< example >}}
 <div class="progress" role="progressbar" aria-label="Warning example" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">
   <div class="progress-bar text-bg-warning" style="width: 75%">75%</div>
+</div>
+<div class="progress" role="progressbar" aria-label="Danger example" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+  <div class="progress-bar text-bg-danger" style="width: 100%">100%</div>
 </div>
 {{< /example >}}
 


### PR DESCRIPTION
### Description

#### Usage of color and background helper classes

In the current [Progress > Backgrounds documentation](https://twbs-bootstrap.netlify.app/docs/5.3/components/progress/#backgrounds), we say the following:

> Alternatively, you can use the new combined [color and background](https://twbs-bootstrap.netlify.app/docs/5.3/helpers/color-background/) helper classes.”

In the same spirit as what we've done in https://github.com/twbs/bootstrap/pull/39214, this PR suggests always using `.text-bg-{color}` when a label is used within the progress component. If one changes the colors between the light and the dark mode (contrary to Bootstrap), you'd like the text color to adapt automatically in light and dark mode to have sufficient contrast. And it can't be done with `.text-dark` or other utilities.

The idea here is to:
* keep the examples without labels with `.bg-{color}`
* change the label examples to use `.text-bg-{color}`
* modify the documentation explanation to always suggest the use of `.text-bg-{color}`

_Note: we talked about it internally and @mdo seemed to agree with this option_

#### Long labels

The second part of the current [Progress > Labels](https://twbs-bootstrap.netlify.app/docs/5.3/components/progress/#labels) mentions something to handle the long labels. It's already mentioned that _“Be aware though that currently this approach does not take into account [color modes](https://getbootstrap.com/docs/5.3/customize/color-modes/).”_

However, I don't think there's anything we can provide that will make it work all the time.

Right now, we use .text-dark which obviously doesn’t work in dark mode as mentioned.
Based on my previous proposal, we should rather use `.text-bg-primary` which works well in dark mode and half-works in light mode (only on the blue color):

![Screenshot 2023-11-03 at 08 18 06](https://github.com/twbs/bootstrap/assets/17381666/f48b28fe-caa6-4940-9271-c11f29aae876)

The issue here is that we will never find anything that can work for both colors with the actual color palette. It can only work if the color palette is compatible and that `.progress` and `.progress-bar` have the same tint. Said differently, that they are both using light colors or dark colors so that the text color has sufficient contrast.

Since we don't know how the color palettes of projects will be built, I suggest that we don't show this example anymore in our documentation but still explain that it's possible, but with a big warning regarding accessibility and contrast ratio, and that we rather recommend most of the time to display the label outside the progress bar.

_Note: we talked about it internally and @mdo seemed to agree with this option_

Friendly ping for @mdo and @patrickhlauke for wording and double-checking the explanation. We might want to show how to display the label outside of the progress bar and keep it accessible.

Please also note that I haven't changed the Cheatsheet example since the values fit within the progress bar and don't have any contrast ratio issues.

#### Target version

IMO this is non-breaking for users so it could be embedded directly into the v5.3.x. Thoughts?

### Type of changes

- [x] Documentation (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39364--twbs-bootstrap.netlify.app/docs/5.3/components/progress/#labels
- https://deploy-preview-39364--twbs-bootstrap.netlify.app/docs/5.3/components/progress/#backgrounds
- https://deploy-preview-39364--twbs-bootstrap.netlify.app/docs/5.3/examples/cheatsheet/#progress (stays the same)
