### PR TITLE
refactor css: modal and offcanvas header spacing

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -126,7 +126,6 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  justify-content: space-between; // Put modal header elements (title and dismiss) on opposite ends
   padding: var(--#{$prefix}modal-header-padding);
   border-bottom: var(--#{$prefix}modal-header-border-width) solid var(--#{$prefix}modal-header-border-color);
   @include border-top-radius(var(--#{$prefix}modal-inner-border-radius));

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -123,14 +123,11 @@
 .offcanvas-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: var(--#{$prefix}offcanvas-padding-y) var(--#{$prefix}offcanvas-padding-x);
 
   .btn-close {
     padding: calc(var(--#{$prefix}offcanvas-padding-y) * .5) calc(var(--#{$prefix}offcanvas-padding-x) * .5);
-    margin-top: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
-    margin-right: calc(-.5 * var(--#{$prefix}offcanvas-padding-x));
-    margin-bottom: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
+    margin: calc(-.5 * var(--#{$prefix}offcanvas-padding-y)) calc(-.5 * var(--#{$prefix}offcanvas-padding-x)) calc(-.5 * var(--#{$prefix}offcanvas-padding-y)) auto;
   }
 }
 


### PR DESCRIPTION
### Description

PR regarding the discussion https://github.com/orgs/twbs/discussions/39370 about the spacing in the modal (plus offcanvas) header. The _space-between_ is not used anymore as the position of the btn-close is based on the margin now.

### Motivation & Context

If the btn-close is removed the content is distributed evenly (space-between behavior), so the wide modals have scattered title if the header is composite (e.g. icon plus text). It is logical to put it to the default setting, which is justify-content: start.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would change existing functionality)

(not sure whether it is breaking change, but might be, please correct me if I am wrong)
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39373--twbs-bootstrap.netlify.app/docs/5.3/components/modal/
- https://deploy-preview-39373--twbs-bootstrap.netlify.app/docs/5.3/components/offcanvas/

### Related GH discussion

https://github.com/orgs/twbs/discussions/39370
