### PR TITLE
Dropdown Header font size now references a css variable

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -42,7 +42,7 @@
   --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x};
   --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y};
   --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
-  --#{$prefix}dropdown-header-font-size: #{$font-size-sm};
+  --#{$prefix}dropdown-header-font-size: #{$dropdown-header-font-size};
   --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x};
   --#{$prefix}dropdown-header-padding-y: #{$dropdown-header-padding-y};
   // scss-docs-end dropdown-css-vars

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -41,8 +41,8 @@
   --#{$prefix}dropdown-link-disabled-color: #{$dropdown-link-disabled-color};
   --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x};
   --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y};
-  --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
   --#{$prefix}dropdown-header-font-size: #{$dropdown-header-font-size};
+  --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
   --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x};
   --#{$prefix}dropdown-header-padding-y: #{$dropdown-header-padding-y};
   // scss-docs-end dropdown-css-vars

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -42,6 +42,7 @@
   --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x};
   --#{$prefix}dropdown-item-padding-y: #{$dropdown-item-padding-y};
   --#{$prefix}dropdown-header-color: #{$dropdown-header-color};
+  --#{$prefix}dropdown-header-font-size: #{$font-size-sm};
   --#{$prefix}dropdown-header-padding-x: #{$dropdown-header-padding-x};
   --#{$prefix}dropdown-header-padding-y: #{$dropdown-header-padding-y};
   // scss-docs-end dropdown-css-vars
@@ -219,7 +220,7 @@
   display: block;
   padding: var(--#{$prefix}dropdown-header-padding-y) var(--#{$prefix}dropdown-header-padding-x);
   margin-bottom: 0; // for use with heading elements
-  @include font-size($font-size-sm);
+  @include font-size(var(--#{$prefix}dropdown-header-font-size));
   color: var(--#{$prefix}dropdown-header-color);
   white-space: nowrap; // as with > li > a
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1262,8 +1262,8 @@ $dropdown-link-disabled-color:      var(--#{$prefix}tertiary-color) !default;
 $dropdown-item-padding-y:           $spacer * .25 !default;
 $dropdown-item-padding-x:           $spacer !default;
 
-$dropdown-header-color:             $gray-600 !default;
 $dropdown-header-font-size:         $font-size-sm !default;
+$dropdown-header-color:             $gray-600 !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $dropdown-padding-y !default;
 // fusv-disable

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1263,6 +1263,7 @@ $dropdown-item-padding-y:           $spacer * .25 !default;
 $dropdown-item-padding-x:           $spacer !default;
 
 $dropdown-header-color:             $gray-600 !default;
+$dropdown-header-font-size:         $font-size-sm !default;
 $dropdown-header-padding-x:         $dropdown-item-padding-x !default;
 $dropdown-header-padding-y:         $dropdown-padding-y !default;
 // fusv-disable


### PR DESCRIPTION
### Description

Dropdown Header Font Size now references a css variable which can be overridden

### Motivation & Context

Previously the font-size referenced a SASS variable which can only be overridden by recompiling the library using SASS.

By using a css variable, users won't need to override the SASS variable, but rather the CSS variable.

With this change, both methods can still be used to override the value, i.e. using SASS or using CSS

### Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist
- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

#### Live previews
n/a

However this resulting css may be of help

Before
```css
.dropdown-header {
  display: block;
  padding: var(--bs-dropdown-header-padding-y) var(--bs-dropdown-header-padding-x);
  margin-bottom: 0;
  font-size:.875rem;
  color: var(--bs-dropdown-header-color);
  white-space: nowrap
}
```

After
```css
.dropdown-header {
  display: block;
  padding: var(--bs-dropdown-header-padding-y) var(--bs-dropdown-header-padding-x);
  margin-bottom: 0;
  font-size: var(--bs-dropdown-header-font-size); // <-------------
  color: var(--bs-dropdown-header-color);
  white-space: nowrap
}
```

### Related issues
Searched for dropdown header related issues, none were found.