### PR TITLE
Fix color schemes description in Sass customization documentation

### DIFF
--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -338,18 +338,18 @@ Our `scss/mixins/` directory has a ton of mixins that power parts of Bootstrap a
 
 ### Color schemes
 
-A shorthand mixin for the `prefers-color-scheme` media query is available with support for `light`, `dark`, and custom color schemes. See [the color modes documentation]({{< docsref "/customize/color-modes" >}}) for information on our color mode mixin.
+A shorthand mixin for the `prefers-color-scheme` media query is available with support for `light` and `dark` color schemes. See [the color modes documentation]({{< docsref "/customize/color-modes" >}}) for information on our color mode mixin.
 
 {{< scss-docs name="mixin-color-scheme" file="scss/mixins/_color-scheme.scss" >}}
 
 ```scss
 .custom-element {
-  @include color-scheme(dark) {
-    // Insert dark mode styles here
+  @include color-scheme(light) {
+    // Insert light mode styles here
   }
 
-  @include color-scheme(custom-named-scheme) {
-    // Insert custom color scheme styles here
+  @include color-scheme(dark) {
+    // Insert dark mode styles here
   }
 }
 ```


### PR DESCRIPTION
### Description

This PR fixes the description of the "Color schemes" contained in "Customize > Sass" documentation page.
As mentioned in the issue's discussion, [Media Queries Level 5 spec](https://www.w3.org/TR/mediaqueries-5/#prefers-color-scheme) mentions that the only values of `prefers-color-scheme` are `light` and `dark`. So talking about custom values is wrong.

I chose to avoid mentioning the fact that the spec says that the values might be expanded in the future:

> The values for this feature might be expanded in the future (to express a more active preference for light color schemes, or preferences for other types of color schemes like "sepia").

### Type of changes

- [x] Documentation bug fix

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- (N/A) My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- (N/A) All new and existing tests passed

#### Live previews

- https://deploy-preview-39417--twbs-bootstrap.netlify.app/docs/5.3/customize/sass/#color-schemes

### Related issues

Closes #39410
