### PR TITLE
Docs: change vite config path import in vite guide

### DIFF
--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -78,10 +78,10 @@ With dependencies installed and our project folder ready for us to start coding,
 
    <!-- eslint-skip -->
    ```js
-   const path = require('path')
+   import { resolve } from 'path'
 
    export default {
-     root: path.resolve(__dirname, 'src'),
+     root: resolve(__dirname, 'src'),
      build: {
        outDir: '../dist'
      },


### PR DESCRIPTION
### Description

This PR changes the way we import `resolve` from `path` in the Vite config.
The full explanation is in https://github.com/twbs/examples/pull/332 where the enhancement has been done in the first place in our examples.
This PR just reports this enhancement in our Vite guide.

### Type of changes

- [x] Documentation enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39418--twbs-bootstrap.netlify.app/docs/5.3/getting-started/vite/#configure-vite
