### PR TITLE
Fix floating label text cut off in select elements

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1069,11 +1069,13 @@ $form-file-button-hover-bg:       var(--#{$prefix}secondary-bg) !default;
 
 // scss-docs-start form-floating-variables
 $form-floating-height:                  add(3.5rem, $input-height-border) !default;
-$form-floating-line-height:             1.25 !default;
+$form-floating-line-height:             1.375 !default;
 $form-floating-padding-x:               $input-padding-x !default;
 $form-floating-padding-y:               1rem !default;
 $form-floating-input-padding-t:         1.625rem !default;
 $form-floating-input-padding-b:         .625rem !default;
+$form-floating-select-padding-t:        1.25rem !default;
+$form-floating-select-padding-b:        .25rem !default;
 $form-floating-label-height:            1.5em !default;
 $form-floating-label-opacity:           .65 !default;
 $form-floating-label-transform:         scale(.85) translateY(-.5rem) translateX(.15rem) !default;

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -49,8 +49,8 @@
   }
 
   > .form-select {
-    padding-top: $form-floating-input-padding-t;
-    padding-bottom: $form-floating-input-padding-b;
+    padding-top: $form-floating-select-padding-t;
+    padding-bottom: $form-floating-select-padding-b;
     padding-left: $form-floating-padding-x;
   }
 


### PR DESCRIPTION
### Description

Tweaks line height and padding so that letters with descenders will not be cut off when using a floating label on a `<select>` element.

### Motivation & Context

In Bootstrap 5.3.3 floating labels cause the bottom of some letters like j, g, p, and y to be cut off. This occurs with normal `form-select` dropdowns in Firefox and Chrome/Edge, and the problem gets significantly worse when using `form-select-lg`, such that this class is unusable with floating labels in all browsers (including Safari).

- Demo: https://stackblitz.com/edit/bs-select-floating-label?file=index.html
- Screenshot:
![Edge screenshot of BS floating label bug](https://github.com/twbs/bootstrap/assets/3053271/b777ba29-81f3-4b9c-be7b-dd0b5bef7358)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation

#### Live previews

- <https://deploy-preview-39483--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels/#selects>

### Related issues

Fixes #33711, fixes #34147