### PR TITLE
Docs: fix StackBlitz examples needing icons

### DIFF
--- a/site/content/docs/5.3/helpers/icon-link.md
+++ b/site/content/docs/5.3/helpers/icon-link.md
@@ -19,14 +19,14 @@ When icons are purely decorative, they should be hidden from assistive technolog
 
 Take a regular `<a>` element, add `.icon-link`, and insert an icon on either the left or right of your link text. The icon is automatically sized, placed, and colored.
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link" href="#">
   <svg class="bi" aria-hidden="true"><use xlink:href="#box-seam"></use></svg>
   Icon link
 </a>
 {{< /example >}}
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link" href="#">
   Icon link
   <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>
@@ -37,7 +37,7 @@ Take a regular `<a>` element, add `.icon-link`, and insert an icon on either the
 
 Add `.icon-link-hover` to move the icon to the right on hover.
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link icon-link-hover" href="#">
   Icon link
   <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>
@@ -54,7 +54,7 @@ Modify the `--bs-link-*` and `--bs-icon-link-*` CSS variables as needed to chang
 
 Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS variable:
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link icon-link-hover" style="--bs-icon-link-transform: translate3d(0, -.125rem, 0);" href="#">
   <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
   Icon link
@@ -63,7 +63,7 @@ Customize the hover `transform` by overriding the `--bs-icon-link-transform` CSS
 
 Customize the color by overriding the `--bs-link-*` CSS variable:
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link icon-link-hover" style="--bs-link-hover-color-rgb: 25, 135, 84;" href="#">
   Icon link
   <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>
@@ -80,7 +80,7 @@ Customize the icon link Sass variables to modify all icon link styles across you
 
 Modify icon links with any of [our link utilities]({{< docsref "/utilities/link/" >}}) for modifying underline color and offset.
 
-{{< example >}}
+{{< example stackblitz_add_icons="true" >}}
 <a class="icon-link icon-link-hover link-success link-underline-success link-underline-opacity-25" href="#">
   Icon link
   <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/scripts.html
+++ b/site/layouts/partials/scripts.html
@@ -32,11 +32,13 @@
       const classes = Array.from(event.target.closest('.bd-code-snippet').querySelector('.bd-example').classList).join(' ')
 
       const jsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-sb-js-snippet')
-      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet, classes)
+      const iconsSnippet = event.target.closest('.bd-code-snippet').querySelector('.btn-edit').getAttribute('data-sb-icons-snippet')
+      StackBlitzSDK.openBootstrapSnippet(htmlSnippet, jsSnippet, iconsSnippet, classes)
     })
   })
 
-  StackBlitzSDK.openBootstrapSnippet = (htmlSnippet, jsSnippet, classes) => {
+  StackBlitzSDK.openBootstrapSnippet = (htmlSnippet, jsSnippet, iconsSnippet, classes) => {
+    const icons = iconsSnippet ? `{{ os.ReadFile "site/layouts/partials/icons.html" }}` : ""
     const markup = `<!doctype html>
 <html lang="en">
   <head>
@@ -48,7 +50,7 @@
     <${'script'} src="{{ .Site.Params.cdn.js_bundle }}"></${'script'}>
   </head>
   <body class="p-3 m-0 border-0 ${classes}">
-
+${icons.replace(/^/gm, '    ')}
     <!-- Example Code -->
 ${htmlSnippet.replace(/^/gm, '    ')}
     <!-- End Example Code -->

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -7,12 +7,14 @@
     * lang: language used to display the code - default: "html"
     * show_markup: if the markup should be output in the HTML - default: `true`
     * show_preview: if the preview should be output in the HTML - default: `true`
+    * stackblitz_add_icons: if extra icons should be added to StackBlitz - default: `false`
     * stackblitz_add_js: if extra JS snippet should be added to StackBlitz - default: `false`
 */ -}}
 
 {{- $id := .Get "id" -}}
 {{- $class := .Get "class" -}}
 {{- $lang := .Get "lang" | default "html" -}}
+{{- $stackblitz_add_icons := .Get "stackblitz_add_icons" | default false -}}
 {{- $stackblitz_add_js := .Get "stackblitz_add_js" | default false -}}
 {{- $show_markup := .Get "show_markup" | default true -}}
 {{- $show_preview := .Get "show_preview" | default true -}}
@@ -31,7 +33,7 @@
       <div class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">
         <small class="font-monospace text-body-secondary text-uppercase">{{- $lang -}}</small>
         <div class="d-flex ms-auto">
-          <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }} title="Try it on StackBlitz">
+          <button type="button" class="btn-edit text-nowrap"{{ with $stackblitz_add_js }} data-sb-js-snippet="{{ $stackblitz_add_js }}"{{ end }}{{ with $stackblitz_add_icons }} data-sb-icons-snippet="{{ $stackblitz_add_icons }}"{{ end }} title="Try it on StackBlitz">
             <svg class="bi" aria-hidden="true"><use xlink:href="#lightning-charge-fill"/></svg>
           </button>
           <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">


### PR DESCRIPTION
### Description

This PR takes into account the issue reported in https://github.com/twbs/bootstrap/issues/39499 (the issue has been closed by OP but is still there in our documentation).

As explained in https://github.com/twbs/bootstrap/issues/39499#issuecomment-1858783774, the problem is that we don't embed the icons in these cases that come from `site/layouts/partials/icons.html`.

The idea of this PR is to add a parameter to handle this specific use case like it's done for the optional JavaScript snippet.
Whenever an `{{ example }}` needs the icons, we only need to use the new `stackblitz_add_icons` parameter and set it to `true` like this: `{{< example stackblitz_add_icons="true" >}}`.

Note: I haven't checked the whole documentation to add this parameter, only the `icon-link` page.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39505--twbs-bootstrap.netlify.app/docs/5.3/helpers/icon-link/
- https://deploy-preview-39505--twbs-bootstrap.netlify.app/docs/5.3/components/accordion/ (for non-regression testing: the `<svg>` containing the icons shouldn't be in StackBlitz)

### Related issues

Closes #39499
