### PR TITLE
Docs: fix desc around deprecated Sass mixins for alerts and list groups

### DIFF
--- a/site/content/docs/5.3/components/alerts.md
+++ b/site/content/docs/5.3/components/alerts.md
@@ -162,13 +162,11 @@ As part of Bootstrap's evolving CSS variables approach, alerts now use local CSS
 
 {{< deprecated-in "5.3.0" >}}
 
-Used in combination with `$theme-colors` to create contextual modifier classes for our alerts.
-
 {{< scss-docs name="alert-variant-mixin" file="scss/mixins/_alert.scss" >}}
 
 ### Sass loops
 
-Loop that generates the modifier classes with the `alert-variant()` mixin.
+Loop that generates the modifier classes with an overriding of CSS variables.
 
 {{< scss-docs name="alert-modifiers" file="scss/_alert.scss" >}}
 

--- a/site/content/docs/5.3/components/list-group.md
+++ b/site/content/docs/5.3/components/list-group.md
@@ -321,8 +321,6 @@ As part of Bootstrap's evolving CSS variables approach, list groups now use loca
 
 {{< deprecated-in "5.3.0" >}}
 
-Used in combination with `$theme-colors` to generate the [contextual variant classes](#variants) for `.list-group-item`s.
-
 {{< scss-docs name="list-group-mixin" file="scss/mixins/_list-group.scss" >}}
 
 ### Sass loops

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -152,13 +152,13 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
 - Alert variants are now styled via CSS variables.
 
-- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.alert-variant()` mixin is now deprecated. We now [use a Sass loop]({{< docsref "/components/alerts#sass-loops" >}}) directly to modify the component's default CSS variables for each variant.
+- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `alert-variant()` mixin is now deprecated. We now [use a Sass loop]({{< docsref "/components/alerts#sass-loops" >}}) directly to modify the component's default CSS variables for each variant.
 
 #### List group
 
 - List group item variants are now styled via CSS variables.
 
-- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `.list-group-variant()` mixin is now deprecated. We now [use a Sass loop]({{< docsref "/components/list-group#sass-loops" >}}) directly to modify the component's default CSS variables for each variant.
+- <span class="badge text-warning-emphasis bg-warning-subtle">Deprecated</span> The `list-group-item-variant()` mixin is now deprecated. We now [use a Sass loop]({{< docsref "/components/list-group#sass-loops" >}}) directly to modify the component's default CSS variables for each variant.
 
 #### Dropdowns
 


### PR DESCRIPTION
### Description

This PR fixes the Alerts and List group documentation pages based on the deprecation of their respective `alert-variant()` and `list-group-item-variant()` mixins:
- in the Sass loops section, don't mention anymore the mixin but the override of CSS variables
- in the Sass mixins section, drop entirely the sentence that isn't true anymore

This PR also fixes some minor issues in the migration guide:
- Drop the dot prefixing the name of the mixins
- Use the right name for the deprecated list group mixin

### Type of changes

- [x] Documentation fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39537--twbs-bootstrap.netlify.app/docs/5.3/components/alerts/#sass-mixins
- https://deploy-preview-39537--twbs-bootstrap.netlify.app/docs/5.3/components/alerts/#sass-loops
- https://deploy-preview-39537--twbs-bootstrap.netlify.app/docs/5.3/components/list-group/#sass-mixins
- https://deploy-preview-39537--twbs-bootstrap.netlify.app/docs/5.3/migration/