### PR TITLE
Sivasish48: Issue #39287  Replacing the "show" method with a modified and  Introduced a small delay before triggering the 'Offcanvas'

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -102,7 +102,11 @@ class Offcanvas extends BaseComponent {
     }
 
     this._isShown = true
-    this._backdrop.show()
+    this._element.classList.add("offcanvas-end") // Adding the class 'offcanvas-end' here
+
+    const showOffcanvas = ()=>{
+            this._backdrop.show()
+    
 
     if (!this._config.scroll) {
       new ScrollBarHelper().hide()
@@ -123,8 +127,12 @@ class Offcanvas extends BaseComponent {
     }
 
     this._queueCallback(completeCallBack, this._element, true)
+  
   }
 
+  // calling a setTimeout to introduce a small delay triggering Offcanvas
+   setTimeout(showOffcanvas,50) // Adjust the delay as needed
+}
   hide() {
     if (!this._isShown) {
       return


### PR DESCRIPTION

### Description

Modifying the 'show' method with the 'Offcanvas' class and creating a small delay with 'setTimeOut' before triggering the Offcanvas

### Motivation & Context
 These changes are intended to make the transition work more reliably in various browsers, including Chrome.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
