### PR TITLE
`calc()` it up — use Sass calculations more

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,7 +13,6 @@
           "outline": "none"
         },
         "function-disallowed-list": [
-          "calc",
           "lighten",
           "darken"
         ],

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -47,7 +47,7 @@
   &:not(.collapsed) {
     color: var(--#{$prefix}accordion-active-color);
     background-color: var(--#{$prefix}accordion-active-bg);
-    box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-border-color); // stylelint-disable-line function-disallowed-list
+    box-shadow: inset 0 calc(-1 * var(--#{$prefix}accordion-border-width)) 0 var(--#{$prefix}accordion-border-color);
 
     &::after {
       background-image: var(--#{$prefix}accordion-btn-active-icon);

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -49,8 +49,8 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: calc($stretched-link-z-index + 1); // stylelint-disable-line function-disallowed-list
-    padding: calc($alert-padding-y * 1.25) $alert-padding-x; // stylelint-disable-line function-disallowed-list
+    z-index: calc($stretched-link-z-index + 1);
+    padding: calc($alert-padding-y * 1.25) $alert-padding-x;
   }
 }
 

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -49,8 +49,8 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: $stretched-link-z-index + 1;
-    padding: $alert-padding-y * 1.25 $alert-padding-x;
+    z-index: calc($stretched-link-z-index + 1); // stylelint-disable-line function-disallowed-list
+    padding: calc($alert-padding-y * 1.25) $alert-padding-x; // stylelint-disable-line function-disallowed-list
   }
 }
 

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -39,7 +39,7 @@
   // Prevent double borders when buttons are next to each other
   > :not(.btn-check:first-child) + .btn,
   > .btn-group:not(:first-child) {
-    margin-left: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($btn-border-width * -1);
   }
 
   // Reset rounded corners
@@ -73,8 +73,8 @@
 //
 
 .dropdown-toggle-split {
-  padding-right: calc($btn-padding-x * .75); // stylelint-disable-line function-disallowed-list
-  padding-left: calc($btn-padding-x * .75); // stylelint-disable-line function-disallowed-list
+  padding-right: calc($btn-padding-x * .75);
+  padding-left: calc($btn-padding-x * .75);
 
   &::after,
   .dropup &::after,
@@ -88,13 +88,13 @@
 }
 
 .btn-sm + .dropdown-toggle-split {
-  padding-right: calc($btn-padding-x-sm * .75); // stylelint-disable-line function-disallowed-list
-  padding-left: calc($btn-padding-x-sm * .75); // stylelint-disable-line function-disallowed-list
+  padding-right: calc($btn-padding-x-sm * .75);
+  padding-left: calc($btn-padding-x-sm * .75);
 }
 
 .btn-lg + .dropdown-toggle-split {
-  padding-right: calc($btn-padding-x-lg * .75); // stylelint-disable-line function-disallowed-list
-  padding-left: calc($btn-padding-x-lg * .75); // stylelint-disable-line function-disallowed-list
+  padding-right: calc($btn-padding-x-lg * .75);
+  padding-left: calc($btn-padding-x-lg * .75);
 }
 
 
@@ -126,7 +126,7 @@
 
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) {
-    margin-top: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
+    margin-top: calc($btn-border-width * -1);
   }
 
   // Reset rounded corners

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -39,7 +39,7 @@
   // Prevent double borders when buttons are next to each other
   > :not(.btn-check:first-child) + .btn,
   > .btn-group:not(:first-child) {
-    margin-left: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners
@@ -73,8 +73,8 @@
 //
 
 .dropdown-toggle-split {
-  padding-right: $btn-padding-x * .75;
-  padding-left: $btn-padding-x * .75;
+  padding-right: calc($btn-padding-x * .75); // stylelint-disable-line function-disallowed-list
+  padding-left: calc($btn-padding-x * .75); // stylelint-disable-line function-disallowed-list
 
   &::after,
   .dropup &::after,
@@ -88,13 +88,13 @@
 }
 
 .btn-sm + .dropdown-toggle-split {
-  padding-right: $btn-padding-x-sm * .75;
-  padding-left: $btn-padding-x-sm * .75;
+  padding-right: calc($btn-padding-x-sm * .75); // stylelint-disable-line function-disallowed-list
+  padding-left: calc($btn-padding-x-sm * .75); // stylelint-disable-line function-disallowed-list
 }
 
 .btn-lg + .dropdown-toggle-split {
-  padding-right: $btn-padding-x-lg * .75;
-  padding-left: $btn-padding-x-lg * .75;
+  padding-right: calc($btn-padding-x-lg * .75); // stylelint-disable-line function-disallowed-list
+  padding-left: calc($btn-padding-x-lg * .75); // stylelint-disable-line function-disallowed-list
 }
 
 
@@ -126,7 +126,7 @@
 
   > .btn:not(:first-child),
   > .btn-group:not(:first-child) {
-    margin-top: calc(#{$btn-border-width} * -1); // stylelint-disable-line function-disallowed-list
+    margin-top: calc($btn-border-width * -1); // stylelint-disable-line function-disallowed-list
   }
 
   // Reset rounded corners

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -80,7 +80,7 @@
 }
 
 .card-subtitle {
-  margin-top: calc(-.5 * var(--#{$prefix}card-title-spacer-y)); // stylelint-disable-line function-disallowed-list
+  margin-top: calc(-.5 * var(--#{$prefix}card-title-spacer-y));
   margin-bottom: 0;
   color: var(--#{$prefix}card-subtitle-color);
 }
@@ -132,9 +132,9 @@
 //
 
 .card-header-tabs {
-  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-  margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
+  margin-bottom: calc(-1 * var(--#{$prefix}card-cap-padding-y));
+  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
   border-bottom: 0;
 
   .nav-link.active {
@@ -144,8 +144,8 @@
 }
 
 .card-header-pills {
-  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x)); // stylelint-disable-line function-disallowed-list
+  margin-right: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
+  margin-left: calc(-.5 * var(--#{$prefix}card-cap-padding-x));
 }
 
 // Card image

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -198,9 +198,9 @@
 
 .carousel-caption {
   position: absolute;
-  right: calc(subtract(100%, $carousel-caption-width) * .5); // stylelint-disable-line function-disallowed-list
+  right: calc((100% - with-unit($carousel-caption-width)) * .5);
   bottom: $carousel-caption-spacer;
-  left: calc(subtract(100%, $carousel-caption-width) * .5); // stylelint-disable-line function-disallowed-list
+  left: calc((100% - with-unit($carousel-caption-width)) * .5);
   padding-top: $carousel-caption-padding-y;
   padding-bottom: $carousel-caption-padding-y;
   color: $carousel-caption-color;

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -198,9 +198,9 @@
 
 .carousel-caption {
   position: absolute;
-  right: (100% - $carousel-caption-width) * .5;
+  right: calc(subtract(100%, $carousel-caption-width) * .5); // stylelint-disable-line function-disallowed-list
   bottom: $carousel-caption-spacer;
-  left: (100% - $carousel-caption-width) * .5;
+  left: calc(subtract(100%, $carousel-caption-width) * .5); // stylelint-disable-line function-disallowed-list
   padding-top: $carousel-caption-padding-y;
   padding-bottom: $carousel-caption-padding-y;
   color: $carousel-caption-color;

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -218,6 +218,18 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 }
 // scss-docs-end color-functions
 
+// Ensure that the value has a unit
+// Useful for `calc()` with addition or subtraction with potentially `null` or unitless values
+@function with-unit($value, $fallback: 1px) {
+  @if $value == null {
+    $value: 0;
+  }
+  @if type-of($value) == number and unitless($value) {
+    $value: calc($value * $fallback);
+  }
+  @return $value;
+}
+
 // Return valid calc
 @function add($value1, $value2, $return-calc: true) {
   @if $value1 == null {

--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: calc($spacer * .5); // stylelint-disable-line function-disallowed-list
+  margin-bottom: calc($spacer * .5);
   line-height: 1;
 }
 

--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: $spacer * .5;
+  margin-bottom: calc($spacer * .5); // stylelint-disable-line function-disallowed-list
   line-height: 1;
 }
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -109,7 +109,7 @@
     border-top-width: 0;
 
     &.active {
-      margin-top: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+      margin-top: calc(-1 * var(--#{$prefix}list-group-border-width));
       border-top-width: var(--#{$prefix}list-group-border-width);
     }
   }
@@ -146,7 +146,7 @@
           border-left-width: 0;
 
           &.active {
-            margin-left: calc(-1 * var(--#{$prefix}list-group-border-width)); // stylelint-disable-line function-disallowed-list
+            margin-left: calc(-1 * var(--#{$prefix}list-group-border-width));
             border-left-width: var(--#{$prefix}list-group-border-width);
           }
         }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,5 +1,3 @@
-// stylelint-disable function-disallowed-list
-
 // .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -70,7 +70,7 @@
   border-bottom: var(--#{$prefix}nav-tabs-border-width) solid var(--#{$prefix}nav-tabs-border-color);
 
   .nav-link {
-    margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+    margin-bottom: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
     border: var(--#{$prefix}nav-tabs-border-width) solid transparent;
     @include border-top-radius(var(--#{$prefix}nav-tabs-border-radius));
 
@@ -91,7 +91,7 @@
 
   .dropdown-menu {
     // Make dropdown border overlap tab border
-    margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width)); // stylelint-disable-line function-disallowed-list
+    margin-top: calc(-1 * var(--#{$prefix}nav-tabs-border-width));
     // Remove the top rounded corners here since there is a hard edge above the menu
     @include border-top-radius(0);
   }

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -1,5 +1,3 @@
-// stylelint-disable function-disallowed-list
-
 %offcanvas-css-vars {
   // scss-docs-start offcanvas-css-vars
   --#{$prefix}offcanvas-zindex: #{$zindex-offcanvas};

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -75,7 +75,7 @@
     margin-left: $pagination-margin-start;
   }
 
-  @if $pagination-margin-start == calc(#{$pagination-border-width} * -1) {
+  @if $pagination-margin-start == calc($pagination-border-width * -1) {
     &:first-child {
       .page-link {
         @include border-start-radius(var(--#{$prefix}pagination-border-radius));

--- a/scss/_placeholders.scss
+++ b/scss/_placeholders.scss
@@ -39,7 +39,7 @@
 }
 
 .placeholder-wave {
-  mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, subtract(1, $placeholder-opacity-min)) 75%, $black 95%);
+  mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, calc(1 - $placeholder-opacity-min)) 75%, $black 95%);
   mask-size: 200% 100%;
   animation: placeholder-wave 2s linear infinite;
 }

--- a/scss/_placeholders.scss
+++ b/scss/_placeholders.scss
@@ -39,7 +39,7 @@
 }
 
 .placeholder-wave {
-  mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, (1 - $placeholder-opacity-min)) 75%, $black 95%);
+  mask-image: linear-gradient(130deg, $black 55%, rgba(0, 0, 0, subtract(1, $placeholder-opacity-min)) 75%, $black 95%);
   mask-size: 200% 100%;
   animation: placeholder-wave 2s linear infinite;
 }

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -56,11 +56,11 @@
 
 .bs-popover-top {
   > .popover-arrow {
-    bottom: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    bottom: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
 
     &::before,
     &::after {
-      border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-width: var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0;
     }
 
     &::before {
@@ -78,13 +78,13 @@
 /* rtl:begin:ignore */
 .bs-popover-end {
   > .popover-arrow {
-    left: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    left: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
     width: var(--#{$prefix}popover-arrow-height);
     height: var(--#{$prefix}popover-arrow-width);
 
     &::before,
     &::after {
-      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height) calc(var(--#{$prefix}popover-arrow-width) * .5) 0;
     }
 
     &::before {
@@ -103,11 +103,11 @@
 
 .bs-popover-bottom {
   > .popover-arrow {
-    top: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    top: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
 
     &::before,
     &::after {
-      border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-width: 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height);
     }
 
     &::before {
@@ -128,7 +128,7 @@
     left: 50%;
     display: block;
     width: var(--#{$prefix}popover-arrow-width);
-    margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width)); // stylelint-disable-line function-disallowed-list
+    margin-left: calc(-.5 * var(--#{$prefix}popover-arrow-width));
     content: "";
     border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-header-bg);
   }
@@ -137,13 +137,13 @@
 /* rtl:begin:ignore */
 .bs-popover-start {
   > .popover-arrow {
-    right: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    right: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width));
     width: var(--#{$prefix}popover-arrow-height);
     height: var(--#{$prefix}popover-arrow-width);
 
     &::before,
     &::after {
-      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height); // stylelint-disable-line function-disallowed-list
+      border-width: calc(var(--#{$prefix}popover-arrow-width) * .5) 0 calc(var(--#{$prefix}popover-arrow-width) * .5) var(--#{$prefix}popover-arrow-height);
     }
 
     &::before {

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -56,7 +56,7 @@
 
 .bs-popover-top {
   > .popover-arrow {
-    bottom: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    bottom: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
 
     &::before,
     &::after {
@@ -78,7 +78,7 @@
 /* rtl:begin:ignore */
 .bs-popover-end {
   > .popover-arrow {
-    left: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    left: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
     width: var(--#{$prefix}popover-arrow-height);
     height: var(--#{$prefix}popover-arrow-width);
 
@@ -103,7 +103,7 @@
 
 .bs-popover-bottom {
   > .popover-arrow {
-    top: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    top: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
 
     &::before,
     &::after {
@@ -137,7 +137,7 @@
 /* rtl:begin:ignore */
 .bs-popover-start {
   > .popover-arrow {
-    right: calc(-1 * (var(--#{$prefix}popover-arrow-height)) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
+    right: calc(-1 * var(--#{$prefix}popover-arrow-height) - var(--#{$prefix}popover-border-width)); // stylelint-disable-line function-disallowed-list
     width: var(--#{$prefix}popover-arrow-height);
     height: var(--#{$prefix}popover-arrow-width);
 

--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -79,7 +79,7 @@
   @media (prefers-reduced-motion: reduce) {
     .spinner-border,
     .spinner-grow {
-      --#{$prefix}spinner-animation-speed: #{$spinner-animation-speed * 2};
+      --#{$prefix}spinner-animation-speed: #{calc($spinner-animation-speed * 2)};
     }
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -49,7 +49,7 @@
 }
 
 .table-group-divider {
-  border-top: calc(#{$table-border-width} * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
+  border-top: calc($table-border-width * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
 }
 
 //

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -49,7 +49,7 @@
 }
 
 .table-group-divider {
-  border-top: calc($table-border-width * 2) solid $table-group-separator-color; // stylelint-disable-line function-disallowed-list
+  border-top: calc($table-border-width * 2) solid $table-group-separator-color;
 }
 
 //

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -62,7 +62,7 @@
   @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));
 
   .btn-close {
-    margin-right: calc(-.5 * var(--#{$prefix}toast-padding-x)); // stylelint-disable-line function-disallowed-list
+    margin-right: calc(-.5 * var(--#{$prefix}toast-padding-x));
     margin-left: var(--#{$prefix}toast-padding-x);
   }
 }

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -44,24 +44,24 @@
 }
 
 .bs-tooltip-top .tooltip-arrow {
-  bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  bottom: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
   &::before {
     top: -1px;
-    border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+    border-width: var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0;
     border-top-color: var(--#{$prefix}tooltip-bg);
   }
 }
 
 /* rtl:begin:ignore */
 .bs-tooltip-end .tooltip-arrow {
-  left: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  left: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
   width: var(--#{$prefix}tooltip-arrow-height);
   height: var(--#{$prefix}tooltip-arrow-width);
 
   &::before {
     right: -1px;
-    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0; // stylelint-disable-line function-disallowed-list
+    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height) calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0;
     border-right-color: var(--#{$prefix}tooltip-bg);
   }
 }
@@ -69,24 +69,24 @@
 /* rtl:end:ignore */
 
 .bs-tooltip-bottom .tooltip-arrow {
-  top: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  top: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
 
   &::before {
     bottom: -1px;
-    border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+    border-width: 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height);
     border-bottom-color: var(--#{$prefix}tooltip-bg);
   }
 }
 
 /* rtl:begin:ignore */
 .bs-tooltip-start .tooltip-arrow {
-  right: calc(-1 * var(--#{$prefix}tooltip-arrow-height)); // stylelint-disable-line function-disallowed-list
+  right: calc(-1 * var(--#{$prefix}tooltip-arrow-height));
   width: var(--#{$prefix}tooltip-arrow-height);
   height: var(--#{$prefix}tooltip-arrow-width);
 
   &::before {
     left: -1px;
-    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height); // stylelint-disable-line function-disallowed-list
+    border-width: calc(var(--#{$prefix}tooltip-arrow-width) * .5) 0 calc(var(--#{$prefix}tooltip-arrow-width) * .5) var(--#{$prefix}tooltip-arrow-height);
     border-left-color: var(--#{$prefix}tooltip-bg);
   }
 }

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -95,7 +95,7 @@
 }
 
 .blockquote-footer {
-  margin-top: -$blockquote-margin-y;
+  margin-top: calc(-1 * $blockquote-margin-y); // stylelint-disable-line function-disallowed-list
   margin-bottom: $blockquote-margin-y;
   @include font-size($blockquote-footer-font-size);
   color: $blockquote-footer-color;

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -95,7 +95,7 @@
 }
 
 .blockquote-footer {
-  margin-top: calc(-1 * $blockquote-margin-y); // stylelint-disable-line function-disallowed-list
+  margin-top: calc(-1 * $blockquote-margin-y);
   margin-bottom: $blockquote-margin-y;
   @include font-size($blockquote-footer-font-size);
   color: $blockquote-footer-color;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -406,17 +406,19 @@ $gradient: linear-gradient(180deg, rgba($white, .15), rgba($white, 0)) !default;
 // variables. Mostly focused on spacing.
 // You can add more entries to the $spacers map, should you need more variation.
 
+// stylelint-disable function-disallowed-list
 // scss-docs-start spacer-variables-maps
 $spacer: 1rem !default;
 $spacers: (
   0: 0,
-  1: $spacer * .25,
-  2: $spacer * .5,
+  1: calc($spacer * .25),
+  2: calc($spacer * .5),
   3: $spacer,
-  4: $spacer * 1.5,
-  5: $spacer * 3,
+  4: calc($spacer * 1.5),
+  5: calc($spacer * 3),
 ) !default;
 // scss-docs-end spacer-variables-maps
+// stylelint-enable function-disallowed-list
 
 // Position
 //
@@ -575,8 +577,8 @@ $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color
 
 // scss-docs-start caret-variables
 $caret-width:                 .3em !default;
-$caret-vertical-align:        $caret-width * .85 !default;
-$caret-spacing:               $caret-width * .85 !default;
+$caret-vertical-align:        calc($caret-width * .85) !default; // stylelint-disable-line function-disallowed-list
+$caret-spacing:               calc($caret-width * .85) !default; // stylelint-disable-line function-disallowed-list
 // scss-docs-end caret-variables
 
 $transition-base:             all .2s ease-in-out !default;
@@ -613,8 +615,8 @@ $font-family-code:            var(--#{$prefix}font-monospace) !default;
 // $font-size-base affects the font size of the body text
 $font-size-root:              null !default;
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-$font-size-sm:                $font-size-base * .875 !default;
-$font-size-lg:                $font-size-base * 1.25 !default;
+$font-size-sm:                calc($font-size-base * .875) !default; // stylelint-disable-line function-disallowed-list
+$font-size-lg:                calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
@@ -630,12 +632,14 @@ $line-height-base:            1.5 !default;
 $line-height-sm:              1.25 !default;
 $line-height-lg:              2 !default;
 
-$h1-font-size:                $font-size-base * 2.5 !default;
-$h2-font-size:                $font-size-base * 2 !default;
-$h3-font-size:                $font-size-base * 1.75 !default;
-$h4-font-size:                $font-size-base * 1.5 !default;
-$h5-font-size:                $font-size-base * 1.25 !default;
+// stylelint-disable function-disallowed-list
+$h1-font-size:                calc($font-size-base * 2.5) !default;
+$h2-font-size:                calc($font-size-base * 2) !default;
+$h3-font-size:                calc($font-size-base * 1.75) !default;
+$h4-font-size:                calc($font-size-base * 1.5) !default;
+$h5-font-size:                calc($font-size-base * 1.25) !default;
 $h6-font-size:                $font-size-base !default;
+// stylelint-enable function-disallowed-list
 // scss-docs-end font-variables
 
 // scss-docs-start font-sizes
@@ -650,7 +654,7 @@ $font-sizes: (
 // scss-docs-end font-sizes
 
 // scss-docs-start headings-variables
-$headings-margin-bottom:      $spacer * .5 !default;
+$headings-margin-bottom:      calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        500 !default;
@@ -675,7 +679,7 @@ $display-line-height: $headings-line-height !default;
 // scss-docs-end display-headings
 
 // scss-docs-start type-variables
-$lead-font-size:              $font-size-base * 1.25 !default;
+$lead-font-size:              calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
 $lead-font-weight:            300 !default;
 
 $small-font-size:             .875em !default;
@@ -689,7 +693,7 @@ $text-muted:                  var(--#{$prefix}secondary-color) !default; // Depr
 $initialism-font-size:        $small-font-size !default;
 
 $blockquote-margin-y:         $spacer !default;
-$blockquote-font-size:        $font-size-base * 1.25 !default;
+$blockquote-font-size:        calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
 $blockquote-footer-color:     $gray-600 !default;
 $blockquote-footer-font-size: $small-font-size !default;
 
@@ -920,15 +924,19 @@ $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
 $input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
 $input-plaintext-color:                 var(--#{$prefix}body-color) !default;
 
-$input-height-border:                   calc(#{$input-border-width} * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-border:                   calc($input-border-width * 2) !default; // stylelint-disable-line function-disallowed-list
 
-$input-height-inner:                    add($input-line-height * 1em, $input-padding-y * 2) !default;
-$input-height-inner-half:               add($input-line-height * .5em, $input-padding-y) !default;
-$input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y * .5) !default;
+// stylelint-disable function-disallowed-list
+$input-height-inner:                    add(calc($input-line-height * 1em), calc($input-padding-y * 2)) !default;
+$input-height-inner-half:               add(calc($input-line-height * .5em), $input-padding-y) !default;
+$input-height-inner-quarter:            add(calc($input-line-height * .25em), calc($input-padding-y * .5)) !default;
+// stylelint-enable function-disallowed-list
 
-$input-height:                          add($input-line-height * 1em, add($input-padding-y * 2, $input-height-border, false)) !default;
-$input-height-sm:                       add($input-line-height * 1em, add($input-padding-y-sm * 2, $input-height-border, false)) !default;
-$input-height-lg:                       add($input-line-height * 1em, add($input-padding-y-lg * 2, $input-height-border, false)) !default;
+// stylelint-disable function-disallowed-list
+$input-height:                          add(calc($input-line-height * 1em), add(calc($input-padding-y * 2), $input-height-border)) !default;
+$input-height-sm:                       add(calc($input-line-height * 1em), add(calc($input-padding-y-sm * 2), $input-height-border)) !default;
+$input-height-lg:                       add(calc($input-line-height * 1em), add(calc($input-padding-y-lg * 2), $input-height-border)) !default;
+// stylelint-enable function-disallowed-list
 
 $input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
@@ -937,8 +945,8 @@ $form-color-width:                      3rem !default;
 
 // scss-docs-start form-check-variables
 $form-check-input-width:                  1em !default;
-$form-check-min-height:                   $font-size-base * $line-height-base !default;
-$form-check-padding-start:                $form-check-input-width + .5em !default;
+$form-check-min-height:                   calc($font-size-base * $line-height-base) !default; // stylelint-disable-line function-disallowed-list
+$form-check-padding-start:                add($form-check-input-width, .5em) !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-label-color:                  null !default;
 $form-check-label-cursor:                 null !default;
@@ -974,7 +982,7 @@ $form-check-inline-margin-end:    1rem !default;
 // scss-docs-start form-switch-variables
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
-$form-switch-padding-start:       $form-switch-width + .5em !default;
+$form-switch-padding-start:       add($form-switch-width, .5em) !default;
 $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius:       $form-switch-width !default;
 $form-switch-transition:          background-position .15s ease-in-out !default;
@@ -1001,7 +1009,8 @@ $form-select-padding-y:             $input-padding-y !default;
 $form-select-padding-x:             $input-padding-x !default;
 $form-select-font-family:           $input-font-family !default;
 $form-select-font-size:             $input-font-size !default;
-$form-select-indicator-padding:     $form-select-padding-x * 3 !default; // Extra padding for background-image
+// Extra padding for background-image
+$form-select-indicator-padding:     calc($form-select-padding-x * 3) !default; // stylelint-disable-line function-disallowed-list
 $form-select-font-weight:           $input-font-weight !default;
 $form-select-line-height:           $input-line-height !default;
 $form-select-color:                 $input-color !default;
@@ -1014,7 +1023,7 @@ $form-select-bg-size:               16px 12px !default; // In pixels because ima
 $form-select-indicator-color:       $gray-800 !default;
 $form-select-indicator:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
-$form-select-feedback-icon-padding-end: $form-select-padding-x * 2.5 + $form-select-indicator-padding !default;
+$form-select-feedback-icon-padding-end: add(calc($form-select-padding-x * 2.5), $form-select-indicator-padding) !default; // stylelint-disable-line function-disallowed-list
 $form-select-feedback-icon-position:    center right $form-select-indicator-padding !default;
 $form-select-feedback-icon-size:        $input-height-inner-half $input-height-inner-half !default;
 
@@ -1187,16 +1196,16 @@ $nav-underline-link-active-color:   var(--#{$prefix}emphasis-color) !default;
 // Navbar
 
 // scss-docs-start navbar-variables
-$navbar-padding-y:                  $spacer * .5 !default;
+$navbar-padding-y:                  calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $navbar-padding-x:                  null !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
 
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   $font-size-base * $line-height-base + $nav-link-padding-y * 2 !default;
-$navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) * .5 !default;
+$nav-link-height:                   add(calc($font-size-base * $line-height-base), calc($nav-link-padding-y * 2)) !default; // stylelint-disable-line function-disallowed-list
+$navbar-brand-height:               calc($navbar-brand-font-size * $line-height-base) !default; // stylelint-disable-line function-disallowed-list
+$navbar-brand-padding-y:            calc(subtract($nav-link-height, $navbar-brand-height) * .5) !default; // stylelint-disable-line function-disallowed-list
 $navbar-brand-margin-end:           1rem !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
@@ -1245,9 +1254,9 @@ $dropdown-bg:                       var(--#{$prefix}body-bg) !default;
 $dropdown-border-color:             var(--#{$prefix}border-color-translucent) !default;
 $dropdown-border-radius:            var(--#{$prefix}border-radius) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
-$dropdown-inner-border-radius:      calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default; // stylelint-disable-line function-disallowed-list
+$dropdown-inner-border-radius:      subtract($dropdown-border-radius, $dropdown-border-width) !default;
 $dropdown-divider-bg:               $dropdown-border-color !default;
-$dropdown-divider-margin-y:         $spacer * .5 !default;
+$dropdown-divider-margin-y:         calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;
 
 $dropdown-link-color:               var(--#{$prefix}body-color) !default;
@@ -1259,7 +1268,7 @@ $dropdown-link-active-bg:           $component-active-bg !default;
 
 $dropdown-link-disabled-color:      var(--#{$prefix}tertiary-color) !default;
 
-$dropdown-item-padding-y:           $spacer * .25 !default;
+$dropdown-item-padding-y:           calc($spacer * .25) !default; // stylelint-disable-line function-disallowed-list
 $dropdown-item-padding-x:           $spacer !default;
 
 $dropdown-header-color:             $gray-600 !default;
@@ -1302,7 +1311,7 @@ $pagination-color:                  var(--#{$prefix}link-color) !default;
 $pagination-bg:                     var(--#{$prefix}body-bg) !default;
 $pagination-border-radius:          var(--#{$prefix}border-radius) !default;
 $pagination-border-width:           var(--#{$prefix}border-width) !default;
-$pagination-margin-start:           calc(#{$pagination-border-width} * -1) !default; // stylelint-disable-line function-disallowed-list
+$pagination-margin-start:           calc($pagination-border-width * -1) !default; // stylelint-disable-line function-disallowed-list
 $pagination-border-color:           var(--#{$prefix}border-color) !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
@@ -1341,7 +1350,7 @@ $placeholder-opacity-min:           .2 !default;
 // scss-docs-start card-variables
 $card-spacer-y:                     $spacer !default;
 $card-spacer-x:                     $spacer !default;
-$card-title-spacer-y:               $spacer * .5 !default;
+$card-title-spacer-y:               calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $card-title-color:                  null !default;
 $card-subtitle-color:               null !default;
 $card-border-width:                 var(--#{$prefix}border-width) !default;
@@ -1349,7 +1358,7 @@ $card-border-color:                 var(--#{$prefix}border-color-translucent) !d
 $card-border-radius:                var(--#{$prefix}border-radius) !default;
 $card-box-shadow:                   null !default;
 $card-inner-border-radius:          subtract($card-border-radius, $card-border-width) !default;
-$card-cap-padding-y:                $card-spacer-y * .5 !default;
+$card-cap-padding-y:                calc($card-spacer-y * .5) !default; // stylelint-disable-line function-disallowed-list
 $card-cap-padding-x:                $card-spacer-x !default;
 $card-cap-bg:                       rgba(var(--#{$prefix}body-color-rgb), .03) !default;
 $card-cap-color:                    null !default;
@@ -1357,7 +1366,7 @@ $card-height:                       null !default;
 $card-color:                        null !default;
 $card-bg:                           var(--#{$prefix}body-bg) !default;
 $card-img-overlay-padding:          $spacer !default;
-$card-group-margin:                 $grid-gutter-width * .5 !default;
+$card-group-margin:                 calc($grid-gutter-width * .5) !default; // stylelint-disable-line function-disallowed-list
 // scss-docs-end card-variables
 
 // Accordion
@@ -1405,8 +1414,8 @@ $tooltip-color:                     var(--#{$prefix}body-bg) !default;
 $tooltip-bg:                        var(--#{$prefix}emphasis-color) !default;
 $tooltip-border-radius:             var(--#{$prefix}border-radius) !default;
 $tooltip-opacity:                   .9 !default;
-$tooltip-padding-y:                 $spacer * .25 !default;
-$tooltip-padding-x:                 $spacer * .5 !default;
+$tooltip-padding-y:                 calc($spacer * .25) !default; // stylelint-disable-line function-disallowed-list
+$tooltip-padding-x:                 calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $tooltip-margin:                    null !default; // TODO: remove this in v6
 
 $tooltip-arrow-width:               .8rem !default;
@@ -1436,7 +1445,7 @@ $popover-max-width:                 276px !default;
 $popover-border-width:              var(--#{$prefix}border-width) !default;
 $popover-border-color:              var(--#{$prefix}border-color-translucent) !default;
 $popover-border-radius:             var(--#{$prefix}border-radius-lg) !default;
-$popover-inner-border-radius:       calc(#{$popover-border-radius} - #{$popover-border-width}) !default; // stylelint-disable-line function-disallowed-list
+$popover-inner-border-radius:       subtract($popover-border-radius, $popover-border-width) !default;
 $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          $font-size-base !default;
@@ -1550,7 +1559,8 @@ $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        $font-weight-bold !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
-$alert-dismissible-padding-r:   $alert-padding-x * 3 !default; // 3x covers width of x plus default padding on either side
+// 3x covers width of x plus default padding on either side
+$alert-dismissible-padding-r:   calc($alert-padding-x * 3) !default; // stylelint-disable-line function-disallowed-list
 // scss-docs-end alert-variables
 
 // fusv-disable
@@ -1563,7 +1573,7 @@ $alert-color-scale:             40% !default; // Deprecated in v5.2.0, to be rem
 
 // scss-docs-start progress-variables
 $progress-height:                   1rem !default;
-$progress-font-size:                $font-size-base * .75 !default;
+$progress-font-size:                calc($font-size-base * .75) !default; // stylelint-disable-line function-disallowed-list
 $progress-bg:                       var(--#{$prefix}secondary-bg) !default;
 $progress-border-radius:            var(--#{$prefix}border-radius) !default;
 $progress-box-shadow:               var(--#{$prefix}box-shadow-inset) !default;
@@ -1583,7 +1593,7 @@ $list-group-border-color:           var(--#{$prefix}border-color) !default;
 $list-group-border-width:           var(--#{$prefix}border-width) !default;
 $list-group-border-radius:          var(--#{$prefix}border-radius) !default;
 
-$list-group-item-padding-y:         $spacer * .5 !default;
+$list-group-item-padding-y:         calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
 $list-group-item-padding-x:         $spacer !default;
 // fusv-disable
 $list-group-item-bg-scale:          -80% !default; // Deprecated in v5.3.0

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -406,7 +406,6 @@ $gradient: linear-gradient(180deg, rgba($white, .15), rgba($white, 0)) !default;
 // variables. Mostly focused on spacing.
 // You can add more entries to the $spacers map, should you need more variation.
 
-// stylelint-disable function-disallowed-list
 // scss-docs-start spacer-variables-maps
 $spacer: 1rem !default;
 $spacers: (
@@ -418,7 +417,6 @@ $spacers: (
   5: calc($spacer * 3),
 ) !default;
 // scss-docs-end spacer-variables-maps
-// stylelint-enable function-disallowed-list
 
 // Position
 //
@@ -577,8 +575,8 @@ $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color
 
 // scss-docs-start caret-variables
 $caret-width:                 .3em !default;
-$caret-vertical-align:        calc($caret-width * .85) !default; // stylelint-disable-line function-disallowed-list
-$caret-spacing:               calc($caret-width * .85) !default; // stylelint-disable-line function-disallowed-list
+$caret-vertical-align:        calc($caret-width * .85) !default;
+$caret-spacing:               calc($caret-width * .85) !default;
 // scss-docs-end caret-variables
 
 $transition-base:             all .2s ease-in-out !default;
@@ -588,7 +586,6 @@ $transition-collapse:         height .35s ease !default;
 $transition-collapse-width:   width .35s ease !default;
 // scss-docs-end collapse-transition
 
-// stylelint-disable function-disallowed-list
 // scss-docs-start aspect-ratios
 $aspect-ratios: (
   "1x1": 100%,
@@ -597,7 +594,6 @@ $aspect-ratios: (
   "21x9": calc(9 / 21 * 100%)
 ) !default;
 // scss-docs-end aspect-ratios
-// stylelint-enable function-disallowed-list
 
 // Typography
 //
@@ -615,8 +611,8 @@ $font-family-code:            var(--#{$prefix}font-monospace) !default;
 // $font-size-base affects the font size of the body text
 $font-size-root:              null !default;
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-$font-size-sm:                calc($font-size-base * .875) !default; // stylelint-disable-line function-disallowed-list
-$font-size-lg:                calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$font-size-sm:                calc($font-size-base * .875) !default;
+$font-size-lg:                calc($font-size-base * 1.25) !default;
 
 $font-weight-lighter:         lighter !default;
 $font-weight-light:           300 !default;
@@ -632,14 +628,12 @@ $line-height-base:            1.5 !default;
 $line-height-sm:              1.25 !default;
 $line-height-lg:              2 !default;
 
-// stylelint-disable function-disallowed-list
 $h1-font-size:                calc($font-size-base * 2.5) !default;
 $h2-font-size:                calc($font-size-base * 2) !default;
 $h3-font-size:                calc($font-size-base * 1.75) !default;
 $h4-font-size:                calc($font-size-base * 1.5) !default;
 $h5-font-size:                calc($font-size-base * 1.25) !default;
 $h6-font-size:                $font-size-base !default;
-// stylelint-enable function-disallowed-list
 // scss-docs-end font-variables
 
 // scss-docs-start font-sizes
@@ -654,7 +648,7 @@ $font-sizes: (
 // scss-docs-end font-sizes
 
 // scss-docs-start headings-variables
-$headings-margin-bottom:      calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$headings-margin-bottom:      calc($spacer * .5) !default;
 $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        500 !default;
@@ -679,7 +673,7 @@ $display-line-height: $headings-line-height !default;
 // scss-docs-end display-headings
 
 // scss-docs-start type-variables
-$lead-font-size:              calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$lead-font-size:              calc($font-size-base * 1.25) !default;
 $lead-font-weight:            300 !default;
 
 $small-font-size:             .875em !default;
@@ -693,7 +687,7 @@ $text-muted:                  var(--#{$prefix}secondary-color) !default; // Depr
 $initialism-font-size:        $small-font-size !default;
 
 $blockquote-margin-y:         $spacer !default;
-$blockquote-font-size:        calc($font-size-base * 1.25) !default; // stylelint-disable-line function-disallowed-list
+$blockquote-font-size:        calc($font-size-base * 1.25) !default;
 $blockquote-footer-color:     $gray-600 !default;
 $blockquote-footer-font-size: $small-font-size !default;
 
@@ -924,19 +918,15 @@ $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
 $input-placeholder-color:               var(--#{$prefix}secondary-color) !default;
 $input-plaintext-color:                 var(--#{$prefix}body-color) !default;
 
-$input-height-border:                   calc($input-border-width * 2) !default; // stylelint-disable-line function-disallowed-list
+$input-height-border:                   calc($input-border-width * 2) !default;
 
-// stylelint-disable function-disallowed-list
-$input-height-inner:                    add(calc($input-line-height * 1em), calc($input-padding-y * 2)) !default;
-$input-height-inner-half:               add(calc($input-line-height * .5em), $input-padding-y) !default;
-$input-height-inner-quarter:            add(calc($input-line-height * .25em), calc($input-padding-y * .5)) !default;
-// stylelint-enable function-disallowed-list
+$input-height-inner:                    calc($input-line-height * 1em + with-unit($input-padding-y) * 2) !default;
+$input-height-inner-half:               calc($input-line-height * .5em + with-unit($input-padding-y)) !default;
+$input-height-inner-quarter:            calc($input-line-height * .25em + with-unit($input-padding-y) * .5) !default;
 
-// stylelint-disable function-disallowed-list
-$input-height:                          add(calc($input-line-height * 1em), add(calc($input-padding-y * 2), $input-height-border)) !default;
-$input-height-sm:                       add(calc($input-line-height * 1em), add(calc($input-padding-y-sm * 2), $input-height-border)) !default;
-$input-height-lg:                       add(calc($input-line-height * 1em), add(calc($input-padding-y-lg * 2), $input-height-border)) !default;
-// stylelint-enable function-disallowed-list
+$input-height:                          calc($input-line-height * 1em + with-unit($input-padding-y) * 2 + with-unit($input-height-border)) !default;
+$input-height-sm:                       calc($input-line-height * 1em + with-unit($input-padding-y-sm) * 2 + with-unit($input-height-border)) !default;
+$input-height-lg:                       calc($input-line-height * 1em + with-unit($input-padding-y-lg) * 2 + with-unit($input-height-border)) !default;
 
 $input-transition:                      border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
@@ -945,8 +935,8 @@ $form-color-width:                      3rem !default;
 
 // scss-docs-start form-check-variables
 $form-check-input-width:                  1em !default;
-$form-check-min-height:                   calc($font-size-base * $line-height-base) !default; // stylelint-disable-line function-disallowed-list
-$form-check-padding-start:                add($form-check-input-width, .5em) !default;
+$form-check-min-height:                   calc($font-size-base * $line-height-base) !default;
+$form-check-padding-start:                calc(with-unit($form-check-input-width) + .5em) !default;
 $form-check-margin-bottom:                .125rem !default;
 $form-check-label-color:                  null !default;
 $form-check-label-cursor:                 null !default;
@@ -982,7 +972,7 @@ $form-check-inline-margin-end:    1rem !default;
 // scss-docs-start form-switch-variables
 $form-switch-color:               rgba($black, .25) !default;
 $form-switch-width:               2em !default;
-$form-switch-padding-start:       add($form-switch-width, .5em) !default;
+$form-switch-padding-start:       calc(with-unit($form-switch-width) + .5em) !default;
 $form-switch-bg-image:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$form-switch-color}'/></svg>") !default;
 $form-switch-border-radius:       $form-switch-width !default;
 $form-switch-transition:          background-position .15s ease-in-out !default;
@@ -1009,8 +999,7 @@ $form-select-padding-y:             $input-padding-y !default;
 $form-select-padding-x:             $input-padding-x !default;
 $form-select-font-family:           $input-font-family !default;
 $form-select-font-size:             $input-font-size !default;
-// Extra padding for background-image
-$form-select-indicator-padding:     calc($form-select-padding-x * 3) !default; // stylelint-disable-line function-disallowed-list
+$form-select-indicator-padding:     calc($form-select-padding-x * 3) !default; // Extra padding for background-image
 $form-select-font-weight:           $input-font-weight !default;
 $form-select-line-height:           $input-line-height !default;
 $form-select-color:                 $input-color !default;
@@ -1023,7 +1012,7 @@ $form-select-bg-size:               16px 12px !default; // In pixels because ima
 $form-select-indicator-color:       $gray-800 !default;
 $form-select-indicator:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
-$form-select-feedback-icon-padding-end: add(calc($form-select-padding-x * 2.5), $form-select-indicator-padding) !default; // stylelint-disable-line function-disallowed-list
+$form-select-feedback-icon-padding-end: calc(with-unit($form-select-padding-x) * 2.5 + with-unit($form-select-indicator-padding)) !default;
 $form-select-feedback-icon-position:    center right $form-select-indicator-padding !default;
 $form-select-feedback-icon-size:        $input-height-inner-half $input-height-inner-half !default;
 
@@ -1077,7 +1066,7 @@ $form-file-button-hover-bg:       var(--#{$prefix}secondary-bg) !default;
 // scss-docs-end form-file-variables
 
 // scss-docs-start form-floating-variables
-$form-floating-height:                  add(3.5rem, $input-height-border) !default;
+$form-floating-height:                  calc(3.5rem + with-unit($input-height-border)) !default;
 $form-floating-line-height:             1.25 !default;
 $form-floating-padding-x:               $input-padding-x !default;
 $form-floating-padding-y:               1rem !default;
@@ -1196,16 +1185,16 @@ $nav-underline-link-active-color:   var(--#{$prefix}emphasis-color) !default;
 // Navbar
 
 // scss-docs-start navbar-variables
-$navbar-padding-y:                  calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$navbar-padding-y:                  calc($spacer * .5) !default;
 $navbar-padding-x:                  null !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
 
 $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
-$nav-link-height:                   add(calc($font-size-base * $line-height-base), calc($nav-link-padding-y * 2)) !default; // stylelint-disable-line function-disallowed-list
-$navbar-brand-height:               calc($navbar-brand-font-size * $line-height-base) !default; // stylelint-disable-line function-disallowed-list
-$navbar-brand-padding-y:            calc(subtract($nav-link-height, $navbar-brand-height) * .5) !default; // stylelint-disable-line function-disallowed-list
+$nav-link-height:                   calc(with-unit($font-size-base) * $line-height-base + with-unit($nav-link-padding-y) * 2) !default;
+$navbar-brand-height:               calc($navbar-brand-font-size * $line-height-base) !default;
+$navbar-brand-padding-y:            calc((with-unit($nav-link-height) - with-unit($navbar-brand-height)) * .5) !default;
 $navbar-brand-margin-end:           1rem !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
@@ -1254,9 +1243,9 @@ $dropdown-bg:                       var(--#{$prefix}body-bg) !default;
 $dropdown-border-color:             var(--#{$prefix}border-color-translucent) !default;
 $dropdown-border-radius:            var(--#{$prefix}border-radius) !default;
 $dropdown-border-width:             var(--#{$prefix}border-width) !default;
-$dropdown-inner-border-radius:      subtract($dropdown-border-radius, $dropdown-border-width) !default;
+$dropdown-inner-border-radius:      calc(with-unit($dropdown-border-radius) - with-unit($dropdown-border-width)) !default;
 $dropdown-divider-bg:               $dropdown-border-color !default;
-$dropdown-divider-margin-y:         calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$dropdown-divider-margin-y:         calc($spacer * .5) !default;
 $dropdown-box-shadow:               var(--#{$prefix}box-shadow) !default;
 
 $dropdown-link-color:               var(--#{$prefix}body-color) !default;
@@ -1268,7 +1257,7 @@ $dropdown-link-active-bg:           $component-active-bg !default;
 
 $dropdown-link-disabled-color:      var(--#{$prefix}tertiary-color) !default;
 
-$dropdown-item-padding-y:           calc($spacer * .25) !default; // stylelint-disable-line function-disallowed-list
+$dropdown-item-padding-y:           calc($spacer * .25) !default;
 $dropdown-item-padding-x:           $spacer !default;
 
 $dropdown-header-color:             $gray-600 !default;
@@ -1311,7 +1300,7 @@ $pagination-color:                  var(--#{$prefix}link-color) !default;
 $pagination-bg:                     var(--#{$prefix}body-bg) !default;
 $pagination-border-radius:          var(--#{$prefix}border-radius) !default;
 $pagination-border-width:           var(--#{$prefix}border-width) !default;
-$pagination-margin-start:           calc($pagination-border-width * -1) !default; // stylelint-disable-line function-disallowed-list
+$pagination-margin-start:           calc($pagination-border-width * -1) !default;
 $pagination-border-color:           var(--#{$prefix}border-color) !default;
 
 $pagination-focus-color:            var(--#{$prefix}link-hover-color) !default;
@@ -1350,15 +1339,15 @@ $placeholder-opacity-min:           .2 !default;
 // scss-docs-start card-variables
 $card-spacer-y:                     $spacer !default;
 $card-spacer-x:                     $spacer !default;
-$card-title-spacer-y:               calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$card-title-spacer-y:               calc($spacer * .5) !default;
 $card-title-color:                  null !default;
 $card-subtitle-color:               null !default;
 $card-border-width:                 var(--#{$prefix}border-width) !default;
 $card-border-color:                 var(--#{$prefix}border-color-translucent) !default;
 $card-border-radius:                var(--#{$prefix}border-radius) !default;
 $card-box-shadow:                   null !default;
-$card-inner-border-radius:          subtract($card-border-radius, $card-border-width) !default;
-$card-cap-padding-y:                calc($card-spacer-y * .5) !default; // stylelint-disable-line function-disallowed-list
+$card-inner-border-radius:          calc(with-unit($card-border-radius) - with-unit($card-border-width)) !default;
+$card-cap-padding-y:                calc($card-spacer-y * .5) !default;
 $card-cap-padding-x:                $card-spacer-x !default;
 $card-cap-bg:                       rgba(var(--#{$prefix}body-color-rgb), .03) !default;
 $card-cap-color:                    null !default;
@@ -1366,7 +1355,7 @@ $card-height:                       null !default;
 $card-color:                        null !default;
 $card-bg:                           var(--#{$prefix}body-bg) !default;
 $card-img-overlay-padding:          $spacer !default;
-$card-group-margin:                 calc($grid-gutter-width * .5) !default; // stylelint-disable-line function-disallowed-list
+$card-group-margin:                 calc($grid-gutter-width * .5) !default;
 // scss-docs-end card-variables
 
 // Accordion
@@ -1379,7 +1368,7 @@ $accordion-bg:                            var(--#{$prefix}body-bg) !default;
 $accordion-border-width:                  var(--#{$prefix}border-width) !default;
 $accordion-border-color:                  var(--#{$prefix}border-color) !default;
 $accordion-border-radius:                 var(--#{$prefix}border-radius) !default;
-$accordion-inner-border-radius:           subtract($accordion-border-radius, $accordion-border-width) !default;
+$accordion-inner-border-radius:           calc(with-unit($accordion-border-radius) - with-unit($accordion-border-width)) !default;
 
 $accordion-body-padding-y:                $accordion-padding-y !default;
 $accordion-body-padding-x:                $accordion-padding-x !default;
@@ -1414,8 +1403,8 @@ $tooltip-color:                     var(--#{$prefix}body-bg) !default;
 $tooltip-bg:                        var(--#{$prefix}emphasis-color) !default;
 $tooltip-border-radius:             var(--#{$prefix}border-radius) !default;
 $tooltip-opacity:                   .9 !default;
-$tooltip-padding-y:                 calc($spacer * .25) !default; // stylelint-disable-line function-disallowed-list
-$tooltip-padding-x:                 calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$tooltip-padding-y:                 calc($spacer * .25) !default;
+$tooltip-padding-x:                 calc($spacer * .5) !default;
 $tooltip-margin:                    null !default; // TODO: remove this in v6
 
 $tooltip-arrow-width:               .8rem !default;
@@ -1445,7 +1434,7 @@ $popover-max-width:                 276px !default;
 $popover-border-width:              var(--#{$prefix}border-width) !default;
 $popover-border-color:              var(--#{$prefix}border-color-translucent) !default;
 $popover-border-radius:             var(--#{$prefix}border-radius-lg) !default;
-$popover-inner-border-radius:       subtract($popover-border-radius, $popover-border-width) !default;
+$popover-inner-border-radius:       calc(with-unit($popover-border-radius) - with-unit($popover-border-width)) !default;
 $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          $font-size-base !default;
@@ -1519,7 +1508,7 @@ $modal-content-bg:                  var(--#{$prefix}body-bg) !default;
 $modal-content-border-color:        var(--#{$prefix}border-color-translucent) !default;
 $modal-content-border-width:        var(--#{$prefix}border-width) !default;
 $modal-content-border-radius:       var(--#{$prefix}border-radius-lg) !default;
-$modal-content-inner-border-radius: subtract($modal-content-border-radius, $modal-content-border-width) !default;
+$modal-content-inner-border-radius: calc(with-unit($modal-content-border-radius) - with-unit($modal-content-border-width)) !default;
 $modal-content-box-shadow-xs:       var(--#{$prefix}box-shadow-sm) !default;
 $modal-content-box-shadow-sm-up:    var(--#{$prefix}box-shadow) !default;
 
@@ -1559,8 +1548,7 @@ $alert-margin-bottom:           1rem !default;
 $alert-border-radius:           var(--#{$prefix}border-radius) !default;
 $alert-link-font-weight:        $font-weight-bold !default;
 $alert-border-width:            var(--#{$prefix}border-width) !default;
-// 3x covers width of x plus default padding on either side
-$alert-dismissible-padding-r:   calc($alert-padding-x * 3) !default; // stylelint-disable-line function-disallowed-list
+$alert-dismissible-padding-r:   calc($alert-padding-x * 3) !default; // 3x covers width of x plus default padding on either side
 // scss-docs-end alert-variables
 
 // fusv-disable
@@ -1573,7 +1561,7 @@ $alert-color-scale:             40% !default; // Deprecated in v5.2.0, to be rem
 
 // scss-docs-start progress-variables
 $progress-height:                   1rem !default;
-$progress-font-size:                calc($font-size-base * .75) !default; // stylelint-disable-line function-disallowed-list
+$progress-font-size:                calc($font-size-base * .75) !default;
 $progress-bg:                       var(--#{$prefix}secondary-bg) !default;
 $progress-border-radius:            var(--#{$prefix}border-radius) !default;
 $progress-box-shadow:               var(--#{$prefix}box-shadow-inset) !default;
@@ -1593,7 +1581,7 @@ $list-group-border-color:           var(--#{$prefix}border-color) !default;
 $list-group-border-width:           var(--#{$prefix}border-width) !default;
 $list-group-border-radius:          var(--#{$prefix}border-radius) !default;
 
-$list-group-item-padding-y:         calc($spacer * .5) !default; // stylelint-disable-line function-disallowed-list
+$list-group-item-padding-y:         calc($spacer * .5) !default;
 $list-group-item-padding-x:         $spacer !default;
 // fusv-disable
 $list-group-item-bg-scale:          -80% !default; // Deprecated in v5.3.0

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -61,7 +61,7 @@
 
       &::after {
         position: absolute;
-        inset: $form-floating-padding-y ($form-floating-padding-x * .5);
+        inset: $form-floating-padding-y calc($form-floating-padding-x * .5); // stylelint-disable-line function-disallowed-list
         z-index: -1;
         height: $form-floating-label-height;
         content: "";

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -61,7 +61,7 @@
 
       &::after {
         position: absolute;
-        inset: $form-floating-padding-y calc($form-floating-padding-x * .5); // stylelint-disable-line function-disallowed-list
+        inset: $form-floating-padding-y calc($form-floating-padding-x * .5);
         z-index: -1;
         height: $form-floating-label-height;
         content: "";

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -10,7 +10,7 @@
 
   .form-check-input {
     float: left;
-    margin-left: $form-check-padding-start * -1;
+    margin-left: calc($form-check-padding-start * -1); // stylelint-disable-line function-disallowed-list
   }
 }
 
@@ -21,7 +21,7 @@
 
   .form-check-input {
     float: right;
-    margin-right: $form-check-padding-start * -1;
+    margin-right: calc($form-check-padding-start * -1); // stylelint-disable-line function-disallowed-list
     margin-left: 0;
   }
 }
@@ -32,7 +32,8 @@
   flex-shrink: 0;
   width: $form-check-input-width;
   height: $form-check-input-width;
-  margin-top: ($line-height-base - $form-check-input-width) * .5; // line-height minus check height
+  // line-height minus check height
+  margin-top: calc(subtract($line-height-base, $form-check-input-width) * .5); // stylelint-disable-line function-disallowed-list
   vertical-align: top;
   appearance: none;
   background-color: var(--#{$prefix}form-check-bg);
@@ -128,7 +129,7 @@
     --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)};
 
     width: $form-switch-width;
-    margin-left: $form-switch-padding-start * -1;
+    margin-left: calc($form-switch-padding-start * -1); // stylelint-disable-line function-disallowed-list
     background-image: var(--#{$prefix}form-switch-bg);
     background-position: left center;
     @include border-radius($form-switch-border-radius, 0);
@@ -154,7 +155,7 @@
     padding-left: 0;
 
     .form-check-input {
-      margin-right: $form-switch-padding-start * -1;
+      margin-right: calc($form-switch-padding-start * -1); // stylelint-disable-line function-disallowed-list
       margin-left: 0;
     }
   }

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -10,7 +10,7 @@
 
   .form-check-input {
     float: left;
-    margin-left: calc($form-check-padding-start * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($form-check-padding-start * -1);
   }
 }
 
@@ -21,7 +21,7 @@
 
   .form-check-input {
     float: right;
-    margin-right: calc($form-check-padding-start * -1); // stylelint-disable-line function-disallowed-list
+    margin-right: calc($form-check-padding-start * -1);
     margin-left: 0;
   }
 }
@@ -32,8 +32,7 @@
   flex-shrink: 0;
   width: $form-check-input-width;
   height: $form-check-input-width;
-  // line-height minus check height
-  margin-top: calc(subtract($line-height-base, $form-check-input-width) * .5); // stylelint-disable-line function-disallowed-list
+  margin-top: calc(($line-height-base * 1em - with-unit($form-check-input-width)) * .5); // line-height minus check height
   vertical-align: top;
   appearance: none;
   background-color: var(--#{$prefix}form-check-bg);
@@ -129,7 +128,7 @@
     --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image)};
 
     width: $form-switch-width;
-    margin-left: calc($form-switch-padding-start * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($form-switch-padding-start * -1);
     background-image: var(--#{$prefix}form-switch-bg);
     background-position: left center;
     @include border-radius($form-switch-border-radius, 0);
@@ -155,7 +154,7 @@
     padding-left: 0;
 
     .form-check-input {
-      margin-right: calc($form-switch-padding-start * -1); // stylelint-disable-line function-disallowed-list
+      margin-right: calc($form-switch-padding-start * -1);
       margin-left: 0;
     }
   }

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -56,7 +56,7 @@
     // https://github.com/twbs/bootstrap/issues/23307
     // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
     // Multiply line-height by 1em if it has no unit
-    height: if(type-of($input-line-height) != number or unit($input-line-height) == "", calc($input-line-height * 1em), $input-line-height); // stylelint-disable-line function-disallowed-list
+    height: if(type-of($input-line-height) != number or unit($input-line-height) == "", calc($input-line-height * 1em), $input-line-height);
 
     // Android Chrome type="date" is taller than the other inputs
     // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
@@ -94,7 +94,7 @@
   // File input buttons theming
   &::file-selector-button {
     padding: $input-padding-y $input-padding-x;
-    margin: calc(-1 * $input-padding-y) calc(-1 * $input-padding-x); // stylelint-disable-line function-disallowed-list
+    margin: calc(-1 * $input-padding-y) calc(-1 * $input-padding-x);
     margin-inline-end: $input-padding-x;
     color: $form-file-button-color;
     @include gradient-bg($form-file-button-bg);
@@ -154,7 +154,7 @@
 
   &::file-selector-button {
     padding: $input-padding-y-sm $input-padding-x-sm;
-    margin: calc(-1 * $input-padding-y-sm) calc(-1 * $input-padding-x-sm); // stylelint-disable-line function-disallowed-list
+    margin: calc(-1 * $input-padding-y-sm) calc(-1 * $input-padding-x-sm);
     margin-inline-end: $input-padding-x-sm;
   }
 }
@@ -167,7 +167,7 @@
 
   &::file-selector-button {
     padding: $input-padding-y-lg $input-padding-x-lg;
-    margin: calc(-1 * $input-padding-y-lg) calc(-1 * $input-padding-x-lg); // stylelint-disable-line function-disallowed-list
+    margin: calc(-1 * $input-padding-y-lg) calc(-1 * $input-padding-x-lg);
     margin-inline-end: $input-padding-x-lg;
   }
 }

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -56,7 +56,7 @@
     // https://github.com/twbs/bootstrap/issues/23307
     // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
     // Multiply line-height by 1em if it has no unit
-    height: if(unit($input-line-height) == "", $input-line-height * 1em, $input-line-height);
+    height: if(type-of($input-line-height) != number or unit($input-line-height) == "", calc($input-line-height * 1em), $input-line-height); // stylelint-disable-line function-disallowed-list
 
     // Android Chrome type="date" is taller than the other inputs
     // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
@@ -94,7 +94,7 @@
   // File input buttons theming
   &::file-selector-button {
     padding: $input-padding-y $input-padding-x;
-    margin: (-$input-padding-y) (-$input-padding-x);
+    margin: calc(-1 * $input-padding-y) calc(-1 * $input-padding-x); // stylelint-disable-line function-disallowed-list
     margin-inline-end: $input-padding-x;
     color: $form-file-button-color;
     @include gradient-bg($form-file-button-bg);
@@ -154,7 +154,7 @@
 
   &::file-selector-button {
     padding: $input-padding-y-sm $input-padding-x-sm;
-    margin: (-$input-padding-y-sm) (-$input-padding-x-sm);
+    margin: calc(-1 * $input-padding-y-sm) calc(-1 * $input-padding-x-sm); // stylelint-disable-line function-disallowed-list
     margin-inline-end: $input-padding-x-sm;
   }
 }
@@ -167,7 +167,7 @@
 
   &::file-selector-button {
     padding: $input-padding-y-lg $input-padding-x-lg;
-    margin: (-$input-padding-y-lg) (-$input-padding-x-lg);
+    margin: calc(-1 * $input-padding-y-lg) calc(-1 * $input-padding-x-lg); // stylelint-disable-line function-disallowed-list
     margin-inline-end: $input-padding-x-lg;
   }
 }

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -6,7 +6,7 @@
 
 .form-range {
   width: 100%;
-  height: add($form-range-thumb-height, $form-range-thumb-focus-box-shadow-width * 2);
+  height: calc(with-unit($form-range-thumb-height) + with-unit($form-range-thumb-focus-box-shadow-width) * 2);
   padding: 0; // Need to reset padding
   appearance: none;
   background-color: transparent;
@@ -27,8 +27,7 @@
   &::-webkit-slider-thumb {
     width: $form-range-thumb-width;
     height: $form-range-thumb-height;
-    // Webkit specific
-    margin-top: calc(subtract($form-range-track-height, $form-range-thumb-height) * .5); // stylelint-disable-line function-disallowed-list
+    margin-top: calc((with-unit($form-range-track-height) - with-unit($form-range-thumb-height)) * .5); // Webkit specific
     appearance: none;
     @include gradient-bg($form-range-thumb-bg);
     border: $form-range-thumb-border;

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -27,7 +27,8 @@
   &::-webkit-slider-thumb {
     width: $form-range-thumb-width;
     height: $form-range-thumb-height;
-    margin-top: ($form-range-track-height - $form-range-thumb-height) * .5; // Webkit specific
+    // Webkit specific
+    margin-top: calc(subtract($form-range-track-height, $form-range-thumb-height) * .5); // stylelint-disable-line function-disallowed-list
     appearance: none;
     @include gradient-bg($form-range-thumb-bg);
     border: $form-range-thumb-border;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -85,7 +85,7 @@
 
 .input-group-lg > .form-select,
 .input-group-sm > .form-select {
-  padding-right: add($form-select-padding-x, $form-select-indicator-padding);
+  padding-right: calc(with-unit($form-select-padding-x) + with-unit($form-select-indicator-padding));
 }
 
 
@@ -121,7 +121,7 @@
   }
 
   > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
-    margin-left: calc($input-border-width * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($input-border-width * -1);
     @include border-start-radius(0);
   }
 

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -85,7 +85,7 @@
 
 .input-group-lg > .form-select,
 .input-group-sm > .form-select {
-  padding-right: $form-select-padding-x + $form-select-indicator-padding;
+  padding-right: add($form-select-padding-x, $form-select-indicator-padding);
 }
 
 
@@ -121,7 +121,7 @@
   }
 
   > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
-    margin-left: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
+    margin-left: calc($input-border-width * -1); // stylelint-disable-line function-disallowed-list
     @include border-start-radius(0);
   }
 

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -13,8 +13,8 @@
 // For use with horizontal and inline forms, when you need the label (or legend)
 // text to align with the form controls.
 .col-form-label {
-  padding-top: add($input-padding-y, $input-border-width);
-  padding-bottom: add($input-padding-y, $input-border-width);
+  padding-top: calc(with-unit($input-padding-y) + with-unit($input-border-width));
+  padding-bottom: calc(with-unit($input-padding-y) + with-unit($input-border-width));
   margin-bottom: 0; // Override the `<legend>` default
   @include font-size(inherit); // Override the `<legend>` default
   font-style: $form-label-font-style;
@@ -24,13 +24,13 @@
 }
 
 .col-form-label-lg {
-  padding-top: add($input-padding-y-lg, $input-border-width);
-  padding-bottom: add($input-padding-y-lg, $input-border-width);
+  padding-top: calc(with-unit($input-padding-y-lg) + with-unit($input-border-width));
+  padding-bottom: calc(with-unit($input-padding-y-lg) + with-unit($input-border-width));
   @include font-size($input-font-size-lg);
 }
 
 .col-form-label-sm {
-  padding-top: add($input-padding-y-sm, $input-border-width);
-  padding-bottom: add($input-padding-y-sm, $input-border-width);
+  padding-top: calc(with-unit($input-padding-y-sm) + with-unit($input-border-width));
+  padding-bottom: calc(with-unit($input-padding-y-sm) + with-unit($input-border-width));
   @include font-size($input-font-size-sm);
 }

--- a/scss/mixins/_container.scss
+++ b/scss/mixins/_container.scss
@@ -4,8 +4,8 @@
   --#{$prefix}gutter-x: #{$gutter};
   --#{$prefix}gutter-y: 0;
   width: 100%;
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-right: calc(var(--#{$prefix}gutter-x) * .5);
+  padding-left: calc(var(--#{$prefix}gutter-x) * .5);
   margin-right: auto;
   margin-left: auto;
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -118,7 +118,7 @@
   .form-control-color {
     @include form-validation-state-selector($state) {
       @if $enable-validation-icons {
-        width: add($form-color-width, $input-height-inner);
+        width: calc(with-unit($form-color-width) + with-unit($input-height-inner));
       }
     }
   }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -8,9 +8,9 @@
   display: flex;
   flex-wrap: wrap;
   // TODO: Revisit calc order after https://github.com/react-bootstrap/react-bootstrap/issues/6039 is fixed
-  margin-top: calc(-1 * var(--#{$prefix}gutter-y)); // stylelint-disable-line function-disallowed-list
-  margin-right: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
-  margin-left: calc(-.5 * var(--#{$prefix}gutter-x)); // stylelint-disable-line function-disallowed-list
+  margin-top: calc(-1 * var(--#{$prefix}gutter-y));
+  margin-right: calc(-.5 * var(--#{$prefix}gutter-x));
+  margin-left: calc(-.5 * var(--#{$prefix}gutter-x));
 }
 
 @mixin make-col-ready() {
@@ -22,8 +22,8 @@
   flex-shrink: 0;
   width: 100%;
   max-width: 100%; // Prevent `.col-auto`, `.col` (& responsive variants) from breaking out the grid
-  padding-right: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
-  padding-left: calc(var(--#{$prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
+  padding-right: calc(var(--#{$prefix}gutter-x) * .5);
+  padding-left: calc(var(--#{$prefix}gutter-x) * .5);
   margin-top: var(--#{$prefix}gutter-y);
 }
 

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -3,7 +3,7 @@
 //
 
 .bd-code-snippet {
-  margin: 0 calc($bd-gutter-x * -.5) 1rem; // stylelint-disable-line function-disallowed-list
+  margin: 0 calc($bd-gutter-x * -.5) 1rem;
   border: solid var(--bs-border-color);
   border-width: 1px 0;
 
@@ -20,7 +20,7 @@
 
   position: relative;
   padding: var(--bd-example-padding);
-  margin: 0 calc($bd-gutter-x * -.5) 1rem; // stylelint-disable-line function-disallowed-list
+  margin: 0 calc($bd-gutter-x * -.5) 1rem;
   border: solid var(--bs-border-color);
   border-width: 1px 0;
   @include clearfix();
@@ -93,13 +93,13 @@
   .fixed-top,
   .sticky-top {
     position: static;
-    margin: calc(var(--bd-example-padding) * -1) calc(var(--bd-example-padding) * -1) var(--bd-example-padding); // stylelint-disable-line function-disallowed-list
+    margin: calc(var(--bd-example-padding) * -1) calc(var(--bd-example-padding) * -1) var(--bd-example-padding);
   }
 
   .fixed-bottom,
   .sticky-bottom {
     position: static;
-    margin: var(--bd-example-padding) calc(var(--bd-example-padding) * -1) calc(var(--bd-example-padding) * -1); // stylelint-disable-line function-disallowed-list
+    margin: var(--bd-example-padding) calc(var(--bd-example-padding) * -1) calc(var(--bd-example-padding) * -1);
 
   }
 
@@ -348,7 +348,7 @@
 
 .highlight {
   position: relative;
-  padding: .75rem calc($bd-gutter-x * .5); // stylelint-disable-line function-disallowed-list
+  padding: .75rem calc($bd-gutter-x * .5);
   background-color: var(--bd-pre-bg);
 
   @include media-breakpoint-up(md) {

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -3,7 +3,7 @@
 //
 
 .bd-code-snippet {
-  margin: 0 ($bd-gutter-x * -.5) 1rem;
+  margin: 0 calc($bd-gutter-x * -.5) 1rem; // stylelint-disable-line function-disallowed-list
   border: solid var(--bs-border-color);
   border-width: 1px 0;
 
@@ -20,7 +20,7 @@
 
   position: relative;
   padding: var(--bd-example-padding);
-  margin: 0 ($bd-gutter-x * -.5) 1rem;
+  margin: 0 calc($bd-gutter-x * -.5) 1rem; // stylelint-disable-line function-disallowed-list
   border: solid var(--bs-border-color);
   border-width: 1px 0;
   @include clearfix();
@@ -348,7 +348,7 @@
 
 .highlight {
   position: relative;
-  padding: .75rem ($bd-gutter-x * .5);
+  padding: .75rem calc($bd-gutter-x * .5); // stylelint-disable-line function-disallowed-list
   background-color: var(--bd-pre-bg);
 
   @include media-breakpoint-up(md) {

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -48,8 +48,8 @@
 
   .navbar-toggler,
   .nav-link {
-    padding-right: $spacer * .25;
-    padding-left: $spacer * .25;
+    padding-right: calc($spacer * .25); // stylelint-disable-line function-disallowed-list
+    padding-left: calc($spacer * .25); // stylelint-disable-line function-disallowed-list
     color: rgba($white, .85);
 
     &:hover,

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -48,8 +48,8 @@
 
   .navbar-toggler,
   .nav-link {
-    padding-right: calc($spacer * .25); // stylelint-disable-line function-disallowed-list
-    padding-left: calc($spacer * .25); // stylelint-disable-line function-disallowed-list
+    padding-right: calc($spacer * .25);
+    padding-left: calc($spacer * .25);
     color: rgba($white, .85);
 
     &:hover,

--- a/site/assets/scss/_sidebar.scss
+++ b/site/assets/scss/_sidebar.scss
@@ -5,7 +5,7 @@
     // Override collapse behaviors
     // stylelint-disable-next-line declaration-no-important
     display: block !important;
-    height: subtract(100vh, 6rem);
+    height: calc(100vh - 6rem);
     // Prevent focus styles to be cut off:
     padding-left: .25rem;
     margin-left: -.25rem;

--- a/site/assets/scss/_toc.scss
+++ b/site/assets/scss/_toc.scss
@@ -6,7 +6,7 @@
     top: 5rem;
     right: 0;
     z-index: 2;
-    height: subtract(100vh, 7rem);
+    height: calc(100vh - 7rem);
     overflow-y: auto;
   }
 


### PR DESCRIPTION
### Description

- I replaced all Sass [`+`, `-`, and `*` math operators](https://sass-lang.com/documentation/operators/numeric/) with Sass [`calc()`ulations](https://sass-lang.com/documentation/values/calculations/)
  - note that the output CSS is simplified at compile time if possible; the **output css is slightly smaller**
- I removed `calc()` from the disallowed functions in stylelint
- I added a `with-value()` function
  - it ensures that the value has a unit, for `calc()` with addition or subtraction with potentially `null` or unitless values like zero
  - it makes some of the source scss more verbose than `add()` and `subtract()` but it is more explicit and the output css is slightly more optimized

### Motivation & Context

I described the full motivation in #39507.

Also, a nice side-effect here is that the code is slightly less tedious to convert to use css variables.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-39606--twbs-bootstrap.netlify.app/>

### Related issues

#39507