### PR TITLE
 Added support for clearing floats in the Float utility class-> Issue number - #39610 

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -805,6 +805,7 @@ $utilities: map-merge(
   $utilities
 );
 
+//Added
 // .float-clear class
 .float-clear::after {
   content: "";

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -804,3 +804,24 @@ $utilities: map-merge(
   ),
   $utilities
 );
+
+// .float-clear class
+.float-clear::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+// .float-clear-start class
+.float-clear-start::after {
+  content: "";
+  display: table;
+  clear: left;
+}
+
+// .float-clear-end class
+.float-clear-end::after {
+  content: "";
+  display: table;
+  clear: right;
+}


### PR DESCRIPTION
### Description

Added support for clearing floats in the Float utility class. Implemented `.float-clear`, `.float-clear-start`, and `.float-clear-end` classes to apply `clear: both`, `clear: left`, and `clear: right` CSS properties respectively, providing a convenient way to manage floated elements and prevent unwanted wrapping.

### Motivation & Context

Previously, Bootstrap lacked explicit support for clearing floats within its Float utility classes. This enhancement addresses the need for a clear and standardized approach to handle floated elements, improving layout consistency and flexibility in various scenarios where floats are utilized.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Related issues

Fixes #39610
