### PR TITLE
Docs: add missing comma in native font stack code source in Content > Reboot

### DIFF
--- a/site/content/docs/5.3/content/reboot.md
+++ b/site/content/docs/5.3/content/reboot.md
@@ -64,7 +64,7 @@ $font-family-sans-serif:
   // Android
   Roboto,
   // older macOS and iOS
-  "Helvetica Neue"
+  "Helvetica Neue",
   // Linux
   "Noto Sans",
   "Liberation Sans",


### PR DESCRIPTION
### Description

Simple typo fix.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39617--twbs-bootstrap.netlify.app/docs/5.3/content/reboot/#native-font-stack

### Related issues

Fixes #39616