### PR TITLE
Bump copyright year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2023 The Bootstrap Authors
+Copyright (c) 2011-2024 The Bootstrap Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 ## Copyright and license
 
-Code and documentation copyright 2011–2023 the [Bootstrap Authors](https://github.com/twbs/bootstrap/graphs/contributors). Code released under the [MIT License](https://github.com/twbs/bootstrap/blob/main/LICENSE). Docs released under [Creative Commons](https://creativecommons.org/licenses/by/3.0/).
+Code and documentation copyright 2011–2024 the [Bootstrap Authors](https://github.com/twbs/bootstrap/graphs/contributors). Code released under the [MIT License](https://github.com/twbs/bootstrap/blob/main/LICENSE). Docs released under [Creative Commons](https://creativecommons.org/licenses/by/3.0/).

--- a/build/build-plugins.mjs
+++ b/build/build-plugins.mjs
@@ -2,7 +2,7 @@
 
 /*!
  * Script to build our plugins to use them separately.
- * Copyright 2020-2023 The Bootstrap Authors
+ * Copyright 2020-2024 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 

--- a/build/change-version.mjs
+++ b/build/change-version.mjs
@@ -2,7 +2,7 @@
 
 /*!
  * Script to update version number references in the project.
- * Copyright 2017-2023 The Bootstrap Authors
+ * Copyright 2017-2024 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 

--- a/build/generate-sri.mjs
+++ b/build/generate-sri.mjs
@@ -5,7 +5,7 @@
  * Remember to use the same vendor files as the CDN ones,
  * otherwise the hashes won't match!
  *
- * Copyright 2017-2023 The Bootstrap Authors
+ * Copyright 2017-2024 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 

--- a/build/vnu-jar.mjs
+++ b/build/vnu-jar.mjs
@@ -2,7 +2,7 @@
 
 /*!
  * Script to run vnu-jar if Java is available.
- * Copyright 2017-2023 The Bootstrap Authors
+ * Copyright 2017-2024 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 

--- a/build/zip-examples.mjs
+++ b/build/zip-examples.mjs
@@ -3,7 +3,7 @@
 /*!
  * Script to create the built examples zip archive;
  * requires the `zip` command to be present!
- * Copyright 2020-2023 The Bootstrap Authors
+ * Copyright 2020-2024 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -15,7 +15,7 @@
     <repository type="git" url="https://github.com/twbs/bootstrap.git" branch="main" />
     <icon>bootstrap.png</icon>
     <license type="expression">MIT</license>
-    <copyright>Copyright 2011-2023</copyright>
+    <copyright>Copyright 2011-2024</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>css mobile-first responsive front-end framework web</tags>
     <contentFiles>

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -15,7 +15,7 @@
     <repository type="git" url="https://github.com/twbs/bootstrap.git" branch="main" />
     <icon>bootstrap.png</icon>
     <license type="expression">MIT</license>
-    <copyright>Copyright 2011-2023</copyright>
+    <copyright>Copyright 2011-2024</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>css sass mobile-first responsive front-end framework web</tags>
     <contentFiles>

--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,7 +1,7 @@
 @mixin bsBanner($file) {
   /*!
    * Bootstrap #{$file} v5.3.2 (https://getbootstrap.com/)
-   * Copyright 2011-2023 The Bootstrap Authors
+   * Copyright 2011-2024 The Bootstrap Authors
    * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
    */
 }

--- a/site/assets/js/application.js
+++ b/site/assets/js/application.js
@@ -4,7 +4,7 @@
 
 /*!
  * JavaScript for Bootstrap's docs (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
+ * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  * For details, see https://creativecommons.org/licenses/by/3.0/.
  */

--- a/site/assets/js/code-examples.js
+++ b/site/assets/js/code-examples.js
@@ -4,7 +4,7 @@
 
 /*!
  * JavaScript for Bootstrap's docs (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
+ * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  * For details, see https://creativecommons.org/licenses/by/3.0/.
  */

--- a/site/assets/js/snippets.js
+++ b/site/assets/js/snippets.js
@@ -6,7 +6,7 @@
 
 /*!
  * JavaScript for Bootstrap's docs (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
+ * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  * For details, see https://creativecommons.org/licenses/by/3.0/.
  */

--- a/site/assets/scss/docs.scss
+++ b/site/assets/scss/docs.scss
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap Docs (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
+ * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  * For details, see https://creativecommons.org/licenses/by/3.0/.
  */

--- a/site/content/docs/5.3/examples/blog-rtl/index.html
+++ b/site/content/docs/5.3/examples/blog-rtl/index.html
@@ -192,7 +192,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">مثال على عنوان منشور المدونة</h6>
-                  <small class="text-body-secondary">15 يناير 2023</small>
+                  <small class="text-body-secondary">15 يناير 2024</small>
                 </div>
               </a>
             </li>
@@ -201,7 +201,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">هذا عنوان آخر للمدونة</h6>
-                  <small class="text-body-secondary">14 يناير 2023</small>
+                  <small class="text-body-secondary">14 يناير 2024</small>
                 </div>
               </a>
             </li>
@@ -210,7 +210,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">أطول عنوان منشور للمدونة: يحتوي هذا الخط على عدة أسطر!</h6>
-                  <small class="text-body-secondary">13 يناير 2023</small>
+                  <small class="text-body-secondary">13 يناير 2024</small>
                 </div>
               </a>
             </li>

--- a/site/content/docs/5.3/examples/blog/index.html
+++ b/site/content/docs/5.3/examples/blog/index.html
@@ -244,7 +244,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">Example blog post title</h6>
-                  <small class="text-body-secondary">January 15, 2023</small>
+                  <small class="text-body-secondary">January 15, 2024</small>
                 </div>
               </a>
             </li>
@@ -253,7 +253,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">This is another blog post title</h6>
-                  <small class="text-body-secondary">January 14, 2023</small>
+                  <small class="text-body-secondary">January 14, 2024</small>
                 </div>
               </a>
             </li>
@@ -262,7 +262,7 @@ extra_css:
                 {{< placeholder width="100%" height="96" background="#777" color="#777" text="false" title="false" >}}
                 <div class="col-lg-8">
                   <h6 class="mb-0">Longer blog post title: This one has multiple lines!</h6>
-                  <small class="text-body-secondary">January 13, 2023</small>
+                  <small class="text-body-secondary">January 13, 2024</small>
                 </div>
               </a>
             </li>

--- a/site/static/docs/5.3/assets/js/color-modes.js
+++ b/site/static/docs/5.3/assets/js/color-modes.js
@@ -1,6 +1,6 @@
 /*!
  * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
- * Copyright 2011-2023 The Bootstrap Authors
+ * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  */
 


### PR DESCRIPTION
### Description

This PR bumps the copyright year to 2024 so that it can be embedded in the release of v5.3.3.
