### PR TITLE
Fix product example mobile navbar toggler

### DIFF
--- a/site/content/docs/5.3/examples/product/index.html
+++ b/site/content/docs/5.3/examples/product/index.html
@@ -24,12 +24,12 @@ extra_css:
       <svg class="bi" width="24" height="24"><use xlink:href="#aperture"/></svg>
       Aperture
     </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas" aria-controls="#offcanvas" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas" aria-controls="offcanvas" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="offcanvas offcanvas-end" tabindex="-1" id="#offcanvas" aria-labelledby="#offcanvasLabel">
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas" aria-labelledby="offcanvasLabel">
       <div class="offcanvas-header">
-        <h5 class="offcanvas-title" id="#offcanvasLabel">Aperture</h5>
+        <h5 class="offcanvas-title" id="offcanvasLabel">Aperture</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
       </div>
       <div class="offcanvas-body">


### PR DESCRIPTION
### Description

This PR fixes the second issue described in #39656:

> "Product example": when screen is small (mobile for example), menu does not work. I click the button but nothing happens.

Indeed, the IDs started with a "#" which caused an issue when referenced by `data-bs-toggle`.
Other references starting with a "#" were also wrong in this same document and have been fixed.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39657--twbs-bootstrap.netlify.app/docs/5.3/examples/product/ (please check the mobile mode and the offcanvas)

### Related issues

Closes #39656
