### PR TITLE
Added 'clip' value for 'overflow' property

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -52,15 +52,15 @@ $utilities: map-merge(
     // scss-docs-start utils-overflow
     "overflow": (
       property: overflow,
-      values: auto hidden visible scroll,
+      values: auto hidden visible scroll clip,
     ),
     "overflow-x": (
       property: overflow-x,
-      values: auto hidden visible scroll,
+      values: auto hidden visible scroll clip,
     ),
     "overflow-y": (
       property: overflow-y,
-      values: auto hidden visible scroll,
+      values: auto hidden visible scroll clip,
     ),
     // scss-docs-end utils-overflow
     // scss-docs-start utils-display

--- a/site/content/docs/5.3/utilities/overflow.md
+++ b/site/content/docs/5.3/utilities/overflow.md
@@ -23,6 +23,9 @@ Adjust the `overflow` property on the fly with four default values and classes. 
   <div class="overflow-scroll p-3 bg-body-tertiary" style="max-width: 260px; max-height: 100px;">
     This is an example of using <code>.overflow-scroll</code> on an element with set width and height dimensions.
   </div>
+  <div class="overflow-clip p-3 bg-body-tertiary" style="max-width: 260px; max-height: 100px;">
+    This is an example of using <code>.overflow-clip</code> on an element with set width and height dimensions.
+  </div>
 </div>
 
 ```html
@@ -30,6 +33,7 @@ Adjust the `overflow` property on the fly with four default values and classes. 
 <div class="overflow-hidden">...</div>
 <div class="overflow-visible">...</div>
 <div class="overflow-scroll">...</div>
+<div class="overflow-clip">...</div>
 ```
 
 ### `overflow-x`
@@ -53,6 +57,10 @@ Adjust the `overflow-x` property to affect the overflow of content horizontally.
     <div><code>.overflow-x-scroll</code> example on an element</div>
     <div> with set width and height dimensions.</div>
   </div>
+  <div class="overflow-x-clip p-3 bg-body-tertiary w-100" style="max-width: 200px; max-height: 100px;white-space: nowrap;">
+    <div><code>.overflow-x-clip</code> example on an element</div>
+    <div> with set width and height dimensions.</div>
+  </div>
 </div>
 
 ```html
@@ -60,6 +68,7 @@ Adjust the `overflow-x` property to affect the overflow of content horizontally.
 <div class="overflow-x-hidden">...</div>
 <div class="overflow-x-visible">...</div>
 <div class="overflow-x-scroll">...</div>
+<div class="overflow-x-clip">...</div>
 ```
 
 ### `overflow-y`
@@ -79,6 +88,9 @@ Adjust the `overflow-y` property to affect the overflow of content vertically.
   <div class="overflow-y-scroll p-3 bg-body-tertiary w-100" style="max-width: 200px; max-height: 100px;">
     <code>.overflow-y-scroll</code> example on an element with set width and height dimensions.
   </div>
+  <div class="overflow-y-clip p-3 bg-body-tertiary w-100" style="max-width: 200px; max-height: 100px;">
+    <code>.overflow-y-clip</code> example on an element with set width and height dimensions.
+  </div>
 </div>
 
 ```html
@@ -86,6 +98,7 @@ Adjust the `overflow-y` property to affect the overflow of content vertically.
 <div class="overflow-y-hidden">...</div>
 <div class="overflow-y-visible">...</div>
 <div class="overflow-y-scroll">...</div>
+<div class="overflow-y-clip">...</div>
 ```
 
 Using Sass variables, you may customize the overflow utilities by changing the `$overflows` variable in `_variables.scss`.


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

The 'clip' value was not present in bootstrap for 'overflow' property. The changes in this PR builds three new classes viz. 'overflow-clip' 'overflow-x-clip' and 'overflow-y-clip' with value 'clip' set for 'overflow', 'overflow-x' and 'overflow-y' respectively.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

I ran into a situation where `overflow: clip` was required for an HTML element and I discovered `overflow-clip` class is not present in Bootstrap. So I added it.
- Learn more about the 'overflow: clip': https://www.w3.org/TR/css-overflow-3/#overflow-properties

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-39686--twbs-bootstrap.netlify.app/docs/5.3/utilities/overflow/>

### Related issues

<!-- Please link any related issues here. -->
