### PR TITLE
Fix docs-versions.html

### DIFF
--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -10,9 +10,9 @@
   {{- $versions_link = printf "%s/" $page_slug -}}
 {{- end }}
 
-{{- $added_in_51 := eq (string .Page.Params.added.version) "5.1" -}}
-{{- $added_in_52 := eq (string .Page.Params.added.version) "5.2" -}}
-{{- $added_in_53 := eq (string .Page.Params.added.version) "5.3" -}}
+{{- $added_in_51 := eq (string .Page.Params.added) "5.1" -}}
+{{- $added_in_52 := eq (string .Page.Params.added) "5.2" -}}
+{{- $added_in_53 := eq (string .Page.Params.added) "5.3" -}}
 
 <li class="nav-item dropdown">
   <button type="button" class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -10,6 +10,10 @@
   {{- $versions_link = printf "%s/" $page_slug -}}
 {{- end }}
 
+{{- $added_in_51 := eq (string .Page.Params.added.version) "5.1" -}}
+{{- $added_in_52 := eq (string .Page.Params.added.version) "5.2" -}}
+{{- $added_in_53 := eq (string .Page.Params.added.version) "5.3" -}}
+
 <li class="nav-item dropdown">
   <button type="button" class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-bs-display="static">
     <span class="d-lg-none" aria-hidden="true">Bootstrap</span><span class="visually-hidden">Bootstrap&nbsp;</span> v{{ .Site.Params.docs_version }} <span class="visually-hidden">(switch to other versions)</span>
@@ -23,21 +27,21 @@
       </a>
     </li>
     <li>
-      {{- if (eq (string .Page.Params.added) "5.3") }}
+      {{- if ($added_in_53) }}
         <div class="dropdown-item disabled">v5.2.3</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/{{ $versions_link }}">v5.2.3</a>
       {{- end }}
     </li>
     <li>
-      {{- if or (eq (string .Page.Params.added) "5.2") (eq (string .Page.Params.added) "5.3") }}
+      {{- if (or $added_in_52 $added_in_53) }}
         <div class="dropdown-item disabled">v5.1.3</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ $versions_link }}">v5.1.3</a>
       {{- end }}
     </li>
     <li>
-      {{- if or (eq (string .Page.Params.added) "5.1") (eq (string .Page.Params.added) "5.2") (eq (string .Page.Params.added) "5.3") }}
+      {{- if (or $added_in_51 $added_in_52 $added_in_53) }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ $versions_link }}">v5.0.2</a>

--- a/site/layouts/partials/docs-versions.html
+++ b/site/layouts/partials/docs-versions.html
@@ -23,21 +23,21 @@
       </a>
     </li>
     <li>
-      {{- if (eq .Page.Params.added "5.3") }}
+      {{- if (eq (string .Page.Params.added) "5.3") }}
         <div class="dropdown-item disabled">v5.2.3</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.2/{{ $versions_link }}">v5.2.3</a>
       {{- end }}
     </li>
     <li>
-      {{- if or (eq .Page.Params.added "5.2") (eq .Page.Params.added "5.3") }}
+      {{- if or (eq (string .Page.Params.added) "5.2") (eq (string .Page.Params.added) "5.3") }}
         <div class="dropdown-item disabled">v5.1.3</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.1/{{ $versions_link }}">v5.1.3</a>
       {{- end }}
     </li>
     <li>
-      {{- if or (eq .Page.Params.added "5.1") (eq .Page.Params.added "5.2") (eq .Page.Params.added "5.3") }}
+      {{- if or (eq (string .Page.Params.added) "5.1") (eq (string .Page.Params.added) "5.2") (eq (string .Page.Params.added) "5.3") }}
         <div class="dropdown-item disabled">v5.0.2</div>
       {{- else }}
         <a class="dropdown-item" href="https://getbootstrap.com/docs/5.0/{{ $versions_link }}">v5.0.2</a>


### PR DESCRIPTION
Cast to string when comparing the versions, otherwise we were comparing numbers with strings.

Also, move checks to variables.

Fixes 404 errors in the version picker.

---

Alternatively, we could just make sure we are using quoted strings in front matter, but this should work in both cases.

(check the version picker)
main: <https://twbs-bootstrap.netlify.app/docs/5.3/helpers/icon-link/>
Preview: <https://deploy-preview-39738--twbs-bootstrap.netlify.app/docs/5.3/helpers/icon-link/>

Split from #39724
