### PR TITLE
Added listener on escape key to close tooltips

### DIFF
--- a/js/dist/tooltip.js
+++ b/js/dist/tooltip.js
@@ -52,6 +52,7 @@
   const TRIGGER_FOCUS = 'focus';
   const TRIGGER_CLICK = 'click';
   const TRIGGER_MANUAL = 'manual';
+  const ESCAPE_KEY = 'Escape';
   const EVENT_HIDE = 'hide';
   const EVENT_HIDDEN = 'hidden';
   const EVENT_SHOW = 'show';
@@ -62,6 +63,7 @@
   const EVENT_FOCUSOUT = 'focusout';
   const EVENT_MOUSEENTER = 'mouseenter';
   const EVENT_MOUSELEAVE = 'mouseleave';
+  const EVENT_KEYDOWN = 'keydown';
   const AttachmentMap = {
     AUTO: 'auto',
     TOP: 'top',
@@ -115,7 +117,7 @@
   class Tooltip extends BaseComponent {
     constructor(element, config) {
       if (typeof Popper__namespace === 'undefined') {
-        throw new TypeError('Bootstrap\'s tooltips require Popper (https://popper.js.org)');
+        throw new TypeError('Bootstrap\'s tooltips require Popper (https://popper.js.org/docs/v2/)');
       }
       super(element, config);
 
@@ -413,6 +415,11 @@
           });
         }
       }
+      EventHandler.on(document, EVENT_KEYDOWN, this._config.selector, event => {
+        if (event.key === ESCAPE_KEY) {
+          this.hide();
+        }
+      });
       this._hideModalHandler = () => {
         if (this._element) {
           this.hide();

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -48,7 +48,7 @@ const EVENT_FOCUSIN = 'focusin'
 const EVENT_FOCUSOUT = 'focusout'
 const EVENT_MOUSEENTER = 'mouseenter'
 const EVENT_MOUSELEAVE = 'mouseleave'
-const EVENT_KEYUP = 'keyup'
+const EVENT_KEYDOWN = 'keydown'
 
 const AttachmentMap = {
   AUTO: 'auto',
@@ -219,12 +219,6 @@ class Tooltip extends BaseComponent {
     this._popper = this._createPopper(tip)
 
     tip.classList.add(CLASS_NAME_SHOW)
-
-    EventHandler.on(document, EVENT_KEYUP, this._config.selector, event => {
-      if (event.key === ESCAPE_KEY) {
-        this.hide()
-      }
-    })
 
     // If this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;
@@ -482,6 +476,12 @@ class Tooltip extends BaseComponent {
         })
       }
     }
+
+    EventHandler.on(document, EVENT_KEYDOWN, this._config.selector, event => {
+      if (event.key === ESCAPE_KEY) {
+        this.hide()
+      }
+    })
 
     this._hideModalHandler = () => {
       if (this._element) {

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -36,6 +36,8 @@ const TRIGGER_FOCUS = 'focus'
 const TRIGGER_CLICK = 'click'
 const TRIGGER_MANUAL = 'manual'
 
+const ESCAPE_KEY = 'Escape'
+
 const EVENT_HIDE = 'hide'
 const EVENT_HIDDEN = 'hidden'
 const EVENT_SHOW = 'show'
@@ -46,6 +48,7 @@ const EVENT_FOCUSIN = 'focusin'
 const EVENT_FOCUSOUT = 'focusout'
 const EVENT_MOUSEENTER = 'mouseenter'
 const EVENT_MOUSELEAVE = 'mouseleave'
+const EVENT_KEYUP = 'keyup'
 
 const AttachmentMap = {
   AUTO: 'auto',
@@ -216,6 +219,12 @@ class Tooltip extends BaseComponent {
     this._popper = this._createPopper(tip)
 
     tip.classList.add(CLASS_NAME_SHOW)
+
+    EventHandler.on(document, EVENT_KEYUP, this._config.selector, event => {
+      if (event.key === ESCAPE_KEY) {
+        this.hide()
+      }
+    })
 
     // If this is a touch-enabled device we add extra
     // empty mouseover listeners to the body's immediate children;

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -974,6 +974,28 @@ describe('Tooltip', () => {
       })
     })
 
+    it('should hide a tooltip when the escape key is pressed', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'
+
+        const tooltipEl = fixtureEl.querySelector('a')
+        const tooltip = new Tooltip(tooltipEl)
+
+        const keyDownEsc = createEvent('keydown')
+        keyDownEsc.key = 'Escape'
+
+        const spy = spyOn(tooltip, 'hide')
+
+        tooltipEl.addEventListener('shown.bs.tooltip', () => {
+          document.dispatchEvent(keyDownEsc)
+          expect(spy).toHaveBeenCalled()
+          resolve()
+        })
+
+        tooltip.show()
+      })
+    })
+
     it('should hide a tooltip on mobile', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"></a>'


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

As per issue [#39692](https://github.com/twbs/bootstrap/issues/39692) I added a listener for all tooltips to close on keyup event of the escape key

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-39753--twbs-bootstrap.netlify.app/>

### Related issues

Closes #39692
