### PR TITLE
Docs: add focus visible outline to navbar's nav links and toggler

### DIFF
--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -58,7 +58,9 @@
     }
 
     &:focus-visible {
-      outline: auto;
+      outline: #fff auto 1px;
+      outline: -webkit-focus-ring-color auto 1px;
+      box-shadow: none;
     }
 
     &.active {

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -58,7 +58,7 @@
     }
 
     &:focus-visible {
-      outline: #fff auto 1px;
+      outline: $white auto 1px;
       outline: -webkit-focus-ring-color auto 1px;
       box-shadow: none;
     }

--- a/site/assets/scss/_navbar.scss
+++ b/site/assets/scss/_navbar.scss
@@ -57,6 +57,10 @@
       color: $white;
     }
 
+    &:focus-visible {
+      outline: auto;
+    }
+
     &.active {
       font-weight: 600;
       color: $white;


### PR DESCRIPTION
### Description

This PR adds a focus visible outline to navbar's nav links and toggler. The outline is the same as the one used when focusing the navbar brand logo for consistency.

Thix fix only works for Chrome and Firefox. Safari's navbar brand and skip links focus visible already have a contrast issue in the main branch; the outline rules not being handled the same way by the browser.

![2024-03-22 08 24 43](https://github.com/twbs/bootstrap/assets/17381666/808f0259-5b35-459b-9a2e-b30bbaed19ed)

### Motivation & Context

In our current documentation, it's almost impossible to see the focused items in the navbar when navigating with the keyboard.

**Before:**

![2024-03-22 08 24 13](https://github.com/twbs/bootstrap/assets/17381666/b2a1d205-7b79-498b-bd13-e4fe48bfa68a)

### Type of changes

- [x] Enhancement (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-39825--twbs-bootstrap.netlify.app/>
