### PR TITLE
Force left auto margin to be applied for modal and offcanvas header close buttons

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -132,7 +132,12 @@
 
   .btn-close {
     padding: calc(var(--#{$prefix}modal-header-padding-y) * .5) calc(var(--#{$prefix}modal-header-padding-x) * .5);
-    margin: calc(-.5 * var(--#{$prefix}modal-header-padding-y)) calc(-.5 * var(--#{$prefix}modal-header-padding-x)) calc(-.5 * var(--#{$prefix}modal-header-padding-y)) auto;
+
+    // An equivalent `margin` shorthand is not used to ensure that the `auto` left margin is applied correctly
+    margin-top: calc(-.5 * var(--#{$prefix}modal-header-padding-y));
+    margin-right: calc(-.5 * var(--#{$prefix}modal-header-padding-x));
+    margin-bottom: calc(-.5 * var(--#{$prefix}modal-header-padding-y));
+    margin-left: auto;
   }
 }
 

--- a/scss/_offcanvas.scss
+++ b/scss/_offcanvas.scss
@@ -127,7 +127,12 @@
 
   .btn-close {
     padding: calc(var(--#{$prefix}offcanvas-padding-y) * .5) calc(var(--#{$prefix}offcanvas-padding-x) * .5);
-    margin: calc(-.5 * var(--#{$prefix}offcanvas-padding-y)) calc(-.5 * var(--#{$prefix}offcanvas-padding-x)) calc(-.5 * var(--#{$prefix}offcanvas-padding-y)) auto;
+
+    // An equivalent `margin` shorthand is not used to ensure that the `auto` left margin is applied correctly
+    margin-top: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
+    margin-right: calc(-.5 * var(--#{$prefix}offcanvas-padding-x));
+    margin-bottom: calc(-.5 * var(--#{$prefix}offcanvas-padding-y));
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
### Description

This PR fixes the use case described in https://github.com/twbs/bootstrap/issues/39798#issuecomment-2040301613 after a modification done in https://github.com/twbs/bootstrap/pull/39373.

IMHO, we don't need to reintroduce `justify-content: space-between`. Without `justify-content: space-between`, it offers more possibilities in terms of compositions for the modals and offcanvases headers. The issue seems to be limited to the special use case described in https://github.com/twbs/bootstrap/issues/39798#issuecomment-2040301613.

Whenever `$modal-inner-padding` is set to `0` (or `$modal-header-padding-y` and `$modal-header-padding-x` are set to 0), the following shorthand margin rule doesn't apply the auto margin left rule:

```scss
margin: calc(-.5* var(--bs-modal-header-padding-y)) calc(-.5* var(--bs-modal-header-padding-x)) calc(-.5* var(--bs-modal-header-padding-y)) auto;
```

It works manually when doing:

```scss
margin: 0 0 0 auto;
```

I suspect an issue with the combination of `calc` and the actual values of the custom properties that could lead maybe to something kind of undefined or invalid. All the intermediate values in the shorthand rule are maybe undefined or invalid, making the entire rule invalid or equal to `0`; `auto` not being applied for the left-margin. It is evaluated as something like `margin: 0;` in the end.

When replacing the shorthand rule by the longhand rule, it seems now to work with the special case setting a 0 value.

Still based on my suspicion, even if the `calc` rules (when setting a value to 0) are undefined or invalid, the longhand version allows having the right value for each `margin-*` rules:

```scss
// An equivalent `margin` shorthand is not used to ensure that the `auto` left margin is applied correctly
margin-top: calc(-.5 * var(--#{$prefix}modal-header-padding-y)); // Even if it's undefined or invalid, the browser is probably understanding that as `0`
margin-right: calc(-.5 * var(--#{$prefix}modal-header-padding-x)); // Even if it's undefined or invalid, the browser is probably understanding that as `0`
margin-bottom: calc(-.5 * var(--#{$prefix}modal-header-padding-y)); // Even if it's undefined or invalid, the browser is probably understanding that as `0`
margin-left: auto; // `auto` is always applied
```

/cc @twbs/css-review for other ideas or a better technical analysis

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- N/A My change introduces changes to the documentation
- N/A I have updated the documentation accordingly
- N/A I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39873--twbs-bootstrap.netlify.app/docs/5.3/components/offcanvas/
- https://deploy-preview-39873--twbs-bootstrap.netlify.app/docs/5.3/components/modal/

#### Testing

- Reproduce locally https://github.com/twbs/bootstrap/issues/39798#issuecomment-2040301613 use case
- Play with all modal/offcanvas header Sass variables and CSS variables to double-check that every use case works as expected

### Related issues

Closes #39798
