### PR TITLE
Added closing tag to search bar in navbar documentation

### DIFF
--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -67,7 +67,7 @@ Here's an example of all the sub-components included in a responsive light-theme
         </li>
       </ul>
       <form class="d-flex" role="search">
-        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
         <button class="btn btn-outline-success" type="submit">Search</button>
       </form>
     </div>


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

### Motivation & Context

I was trying out the documentation for the [navbar](https://getbootstrap.com/docs/5.3/components/navbar/) and I noticed that the search bar input box was missing a closing tag and as this was in the official documentation I came here to correct the issue

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

Without this change some people could be confused by the documentation as the code provided in the example is not correct

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
