### PR TITLE
Updated for issue regarding .form-text inline bug

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -2112,6 +2112,13 @@ progress {
   color: var(--bs-secondary-color);
 }
 
+.inline-form .form-text {
+  display: block; 
+  margin-top: 0.25rem; 
+  font-size: 0.875em;
+  color: var(--bs-secondary-color);
+}
+
 .form-control {
   display: block;
   width: 100%;


### PR DESCRIPTION
### Description

This PR fixes the issue found in #39199 

To fix the bug where using the .form-text class with an inline form breaks the layout, you can override the default behavior of the .form-text class to ensure it works correctly within inline forms.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

### Related issues

<!-- Please link any related issues here. -->

fixes bug #39199 
