### PR TITLE
Bug fix: #39862

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -169,38 +169,41 @@ class Modal extends BaseComponent {
   }
 
   _showElement(relatedTarget) {
-    // try to append dynamic modal
     if (!document.body.contains(this._element)) {
-      document.body.append(this._element)
+      document.body.append(this._element);
     }
 
-    this._element.style.display = 'block'
-    this._element.removeAttribute('aria-hidden')
-    this._element.setAttribute('aria-modal', true)
-    this._element.setAttribute('role', 'dialog')
-    this._element.scrollTop = 0
+    const scrollPosition = window.scrollY || document.documentElement.scrollTop;
 
-    const modalBody = SelectorEngine.findOne(SELECTOR_MODAL_BODY, this._dialog)
+    this._element.style.display = "block";
+    this._element.removeAttribute("aria-hidden");
+    this._element.setAttribute("aria-modal", "true");
+    this._element.setAttribute("role", "dialog");
+    this._element.scrollTop = 0;
+
+    const modalBody = SelectorEngine.findOne(SELECTOR_MODAL_BODY, this._dialog);
     if (modalBody) {
-      modalBody.scrollTop = 0
+      modalBody.scrollTop = 0;
     }
 
-    reflow(this._element)
+    reflow(this._element);
 
-    this._element.classList.add(CLASS_NAME_SHOW)
+    this._element.classList.add(CLASS_NAME_SHOW);
+
+    if (this._config.focus) {
+      this._focustrap.activate();
+    }
+
+    window.scrollTo(0, scrollPosition);
 
     const transitionComplete = () => {
-      if (this._config.focus) {
-        this._focustrap.activate()
-      }
-
-      this._isTransitioning = false
+      this._isTransitioning = false;
       EventHandler.trigger(this._element, EVENT_SHOWN, {
-        relatedTarget
-      })
-    }
+        relatedTarget,
+      });
+    };
 
-    this._queueCallback(transitionComplete, this._dialog, this._isAnimated())
+    this._queueCallback(transitionComplete, this._dialog, this._isAnimated());
   }
 
   _addEventListeners() {


### PR DESCRIPTION
### Description
When you tab through an open modal, one complete cycle so that the focus goes from the last element on the modal back to the X [close] button, it causes the page to scroll where ever the modal is in the DOM order. This behavior is present in the current bootstrap site as well.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-39927--twbs-bootstrap.netlify.app/docs/5.3/components/modal/#live-demo

### Related issues

Closes #39862
