### PR TITLE
Bug Fix #39851

### DIFF
--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -4,12 +4,20 @@
 // elements cannot be mixed. As such, there are no shared styles for focus or
 // active states on prefixed selectors.
 
+@import "../variables";
+
 .form-range {
   width: 100%;
   height: add($form-range-thumb-height, $form-range-thumb-focus-box-shadow-width * 2);
   padding: 0; // Need to reset padding
   appearance: none;
   background-color: transparent;
+
+  &::-moz-range-thumb, &::-webkit-slider-thumb {
+    @if $enable-radius == false {
+      border-radius: 0; // Explicitly set to 0 when border radius is disabled
+    }
+  }
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
### Description

When customizing bootstrap and setting $enable-radius to false, there is still a border radius on .form-range::-moz-range-thumb, .form-range::-webkit-slider-thumb

It seems the browser has a default border radius for the thumb, and you have to explicitly set it to 0

You could pass a fallback value of 0 to the border-radius mixin, and it should correct the issue

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
