### PR TITLE
Simplify link styling using :is(), to avoid additional rule with :not().

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -241,26 +241,16 @@ sup { top: -.5em; }
 
 // Links
 
-a {
+// Do not target named anchors. See #19402.
+// Do target links with classes, as these could be buttons. See #30726.
+// Use `:is()` to avoid an increased specificity.
+a:is([href],[class]) {
   color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
   text-decoration: $link-decoration;
 
   &:hover {
     --#{$prefix}link-color-rgb: var(--#{$prefix}link-hover-color-rgb);
     text-decoration: $link-hover-decoration;
-  }
-}
-
-// And undo these styles for placeholder links/named anchors (without href).
-// It would be more straightforward to just use a[href] in previous block, but that
-// causes specificity issues in many other styles that are too complex to fix.
-// See https://github.com/twbs/bootstrap/issues/19402
-
-a:not([href]):not([class]) {
-  &,
-  &:hover {
-    color: inherit;
-    text-decoration: none;
   }
 }
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -243,8 +243,10 @@ sup { top: -.5em; }
 
 // Do not target named anchors. See #19402.
 // Do target links with classes, as these could be buttons. See #30726.
-// Use `:is()` to avoid an increased specificity.
-a:is([href],[class]) {
+// Use `:not(:not())` to avoid an increased specificity.
+// Unfortunately, `:is()` would not work with some browsers that are still
+// supported in this version of bootstrap.
+a:not(:not([href],[class])) {
   color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
   text-decoration: $link-decoration;
 


### PR DESCRIPTION
### Description

Use a single rule with `a:is(...) {` instead of `a {` + `a:not(...)` for link styling.

### Motivation & Context

In `_reboot.scss` we have link styling that is immediately countered by a more specific rule to undo the styling on named anchors. The `:not()` part was introduced in #19402 and refined in #30726.

This is awkward and can be simplified.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

(I shall review the points later)

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-40439--twbs-bootstrap.netlify.app/>

### Related issues

- #19402
- #30726
