### PR TITLE
button-group: Fix `btn-group-vertical` by using same rules as `btn-group`

### DIFF
--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -131,7 +131,6 @@
 
   // Reset rounded corners
   > .btn:not(:last-child):not(.dropdown-toggle),
-  > .btn.dropdown-toggle-split:first-child,
   > .btn-group:not(:last-child) > .btn {
     @include border-bottom-radius(0);
   }

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -131,12 +131,18 @@
 
   // Reset rounded corners
   > .btn:not(:last-child):not(.dropdown-toggle),
+  > .btn.dropdown-toggle-split:first-child,
   > .btn-group:not(:last-child) > .btn {
     @include border-bottom-radius(0);
   }
 
-  > .btn ~ .btn,
+  // The top radius should be 0 if the button is:
+  // - the "third or more" child
+  // - the second child and the previous element isn't `.btn-check` (making it the first child visually)
+  // - part of a btn-group which isn't the first child
+  > .btn:nth-child(n + 3),
+  > :not(.btn-check) + .btn,
   > .btn-group:not(:first-child) > .btn {
-    @include border-top-radius(0);
+    @include border-start-radius(0);
   }
 }

--- a/scss/_button-group.scss
+++ b/scss/_button-group.scss
@@ -143,6 +143,6 @@
   > .btn:nth-child(n + 3),
   > :not(.btn-check) + .btn,
   > .btn-group:not(:first-child) > .btn {
-    @include border-start-radius(0);
+    @include border-top-radius(0);
   }
 }

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -195,6 +195,15 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
 
 {{< example >}}
 <div class="btn-group-vertical" role="group" aria-label="Vertical button group">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+      Dropdown
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
+      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
+    </ul>
+  </div>
   <button type="button" class="btn btn-primary">Button</button>
   <button type="button" class="btn btn-primary">Button</button>
   <div class="btn-group" role="group">
@@ -207,15 +216,6 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
     </ul>
   </div>
   <div class="btn-group dropstart" role="group">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-      Dropdown
-    </button>
-    <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-    </ul>
-  </div>
-  <div class="btn-group dropend" role="group">
     <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
       Dropdown
     </button>

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -224,6 +224,15 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
       <li><a class="dropdown-item" href="#">Dropdown link</a></li>
     </ul>
   </div>
+  <div class="btn-group dropend" role="group">
+    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+      Dropdown
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
+      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
+    </ul>
+  </div>
   <div class="btn-group dropup" role="group">
     <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
       Dropdown

--- a/site/content/docs/5.3/components/button-group.md
+++ b/site/content/docs/5.3/components/button-group.md
@@ -206,15 +206,6 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
   </div>
   <button type="button" class="btn btn-primary">Button</button>
   <button type="button" class="btn btn-primary">Button</button>
-  <div class="btn-group" role="group">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-      Dropdown
-    </button>
-    <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-      <li><a class="dropdown-item" href="#">Dropdown link</a></li>
-    </ul>
-  </div>
   <div class="btn-group dropstart" role="group">
     <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
       Dropdown


### PR DESCRIPTION
### Description

The CSS conditions for vertical button groups was different from the regular button group.

When using the same conditions for the regular groups for the vertical group, the bug is fixed.

**Current CSS:**

See the `.btn-group>:not(.btn-check)+.btn` on the right

> <img width="1399" alt="Bildschirmfoto 2024-05-25 um 07 06 39" src="https://github.com/twbs/bootstrap/assets/111561/1d5c8e2b-3e22-4d9f-b021-32a35a660c2c">

**Modified CSS:**

> <img width="1385" alt="Bildschirmfoto 2024-05-25 um 07 08 03" src="https://github.com/twbs/bootstrap/assets/111561/567f3a15-646f-45f8-864f-796d602126ca">

I am assuming the css for the regular button group was improved at some point but not applied to the vertical button group at this point.

~The second change is to add `> .btn.dropdown-toggle-split:first-child` to the `Reset rounded corners` section which is also copied down from the regular button group. I am not sure what that does but I think the same logic applies to assume that both button groups should behave the same.~ – Update: I removed this again because the docs state that the split buttons are not supported for vertical button groups.

I have modified the docs page of the second example on https://getbootstrap.com/docs/5.2/components/button-group/#vertical-variation to have a button group in the first position.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Refactoring (non-breaking change)~
- [ ] ~Breaking change (fix or feature that would change existing functionality)~

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] ~I have updated the documentation accordingly~
- [ ] ~I have added tests to cover my changes~
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-40488--twbs-bootstrap.netlify.app/docs/5.3/components/button-group

### Related issues

- Closes https://github.com/twbs/bootstrap/issues/40487