### PR TITLE
docs: add missing `data-bs-theme="light"` in navbars color schemes markup

### DIFF
--- a/site/content/docs/5.3/components/navbar.md
+++ b/site/content/docs/5.3/components/navbar.md
@@ -428,7 +428,7 @@ Navbar themes are easier than ever thanks to Bootstrap's combination of Sass and
   <!-- Navbar content -->
 </nav>
 
-<nav class="navbar" style="background-color: #e3f2fd;">
+<nav class="navbar" style="background-color: #e3f2fd;" data-bs-theme="light">
   <!-- Navbar content -->
 </nav>
 ```


### PR DESCRIPTION
### Description

This PR adds the missing `data-bs-theme="light"` data attribute in the last example of the navbars color schemes at https://getbootstrap.com/docs/5.3/components/navbar/#color-schemes.

The executed code contained it, but not the copyable markup.

### Type of changes

- [x] Documentation fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-40504--twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#color-schemes

#### Related issues

Discussed in https://github.com/twbs/bootstrap/pull/39989#issuecomment-2131005689