### PR TITLE
Fade disabled buttons into luminance-gray color of current plane background

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -18,6 +18,7 @@
   --#{$prefix}btn-hover-border-color: transparent;
   --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
   --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
+  --#{$prefix}btn-disabled-fade-percentage: #{$btn-disabled-fade-percentage};
   --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), .5);
   // scss-docs-end btn-css-vars
 
@@ -112,13 +113,38 @@
   &:disabled,
   &.disabled,
   fieldset:disabled & {
-    color: var(--#{$prefix}btn-disabled-color);
+    --#{$prefix}btn-parent-bg-luminance-gray: lab(from var(--#{$prefix}current-plane-bg) l 0 0);
+
+    color:
+      color-mix(
+        in srgb,
+        var(--#{$prefix}btn-parent-bg-luminance-gray) var(--#{$prefix}btn-disabled-fade-percentage),
+        var(--#{$prefix}btn-disabled-color)
+      );
     pointer-events: none;
-    background-color: var(--#{$prefix}btn-disabled-bg);
+    background-color:
+      color-mix(
+        in srgb,
+        var(--#{$prefix}btn-parent-bg-luminance-gray) var(--#{$prefix}btn-disabled-fade-percentage),
+        var(--#{$prefix}btn-disabled-bg)
+      );
     background-image: if($enable-gradients, none, null);
-    border-color: var(--#{$prefix}btn-disabled-border-color);
-    opacity: var(--#{$prefix}btn-disabled-opacity);
     @include box-shadow(none);
+    border-color:
+      color-mix(
+        in srgb,
+        var(--#{$prefix}btn-parent-bg-luminance-gray) var(--#{$prefix}btn-disabled-fade-percentage),
+        var(--#{$prefix}btn-disabled-border-color)
+      );
+
+    &.btn-link {
+      border-color: var(--#{$prefix}btn-disabled-border-color);
+    }
+
+    > * {
+      color: var(--#{$prefix}btn-disabled-color);
+      opacity: var(--#{$prefix}btn-disabled-opacity);
+    }
   }
 }
 

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -48,6 +48,16 @@
   }
 }
 
+@function color-css-var($identifier, $target) {
+  @if $identifier == "body" and $target == "bg" {
+    @return var(--#{$prefix}#{$identifier}-bg);
+  } @if $identifier == "body" and $target == "text" {
+    @return var(--#{$prefix}#{$identifier}-color);
+  } @else {
+    @return var(--#{$prefix}#{$identifier});
+  }
+}
+
 @function map-loop($map, $func, $args...) {
   $_map: ();
 

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -101,6 +101,7 @@
   color: var(--#{$prefix}modal-color);
   pointer-events: auto;
   background-color: var(--#{$prefix}modal-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}modal-bg);
   background-clip: padding-box;
   border: var(--#{$prefix}modal-border-width) solid var(--#{$prefix}modal-border-color);
   @include border-radius(var(--#{$prefix}modal-border-radius));
@@ -161,6 +162,7 @@
   justify-content: flex-end; // Right align buttons with flex property because text-align doesn't work on flex items
   padding: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * .5);
   background-color: var(--#{$prefix}modal-footer-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}modal-footer-bg);
   border-top: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
   @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));
 

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -32,6 +32,7 @@
   // Allow breaking very long words so they don't overflow the popover's bounds
   word-wrap: break-word;
   background-color: var(--#{$prefix}popover-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}popover-bg);
   background-clip: padding-box;
   border: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
   @include border-radius(var(--#{$prefix}popover-border-radius));
@@ -182,6 +183,7 @@
   @include font-size(var(--#{$prefix}popover-header-font-size));
   color: var(--#{$prefix}popover-header-color);
   background-color: var(--#{$prefix}popover-header-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}popover-header-bg);
   border-bottom: var(--#{$prefix}popover-border-width) solid var(--#{$prefix}popover-border-color);
   @include border-top-radius(var(--#{$prefix}popover-inner-border-radius));
 

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -55,6 +55,7 @@ body {
   color: var(--#{$prefix}body-color);
   text-align: var(--#{$prefix}body-text-align);
   background-color: var(--#{$prefix}body-bg); // 2
+  --#{$prefix}current-plane-bg: var(--#{$prefix}body-bg);
   -webkit-text-size-adjust: 100%; // 3
   -webkit-tap-highlight-color: rgba($black, 0); // 4
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -35,6 +35,7 @@
     // Following the precept of cascades: https://codepen.io/miriamsuzanne/full/vYNgodb
     color: var(--#{$prefix}table-color-state, var(--#{$prefix}table-color-type, var(--#{$prefix}table-color)));
     background-color: var(--#{$prefix}table-bg);
+    --#{$prefix}current-plane-bg: var(--#{$prefix}table-bg);
     border-bottom-width: $table-border-width;
     box-shadow: inset 0 0 0 9999px var(--#{$prefix}table-bg-state, var(--#{$prefix}table-bg-type, var(--#{$prefix}table-accent-bg)));
   }

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -23,6 +23,7 @@
   color: var(--#{$prefix}toast-color);
   pointer-events: auto;
   background-color: var(--#{$prefix}toast-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}toast-bg);
   background-clip: padding-box;
   border: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-border-color);
   box-shadow: var(--#{$prefix}toast-box-shadow);
@@ -57,6 +58,7 @@
   padding: var(--#{$prefix}toast-padding-y) var(--#{$prefix}toast-padding-x);
   color: var(--#{$prefix}toast-header-color);
   background-color: var(--#{$prefix}toast-header-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}toast-header-bg);
   background-clip: padding-box;
   border-bottom: var(--#{$prefix}toast-border-width) solid var(--#{$prefix}toast-header-border-color);
   @include border-top-radius(calc(var(--#{$prefix}toast-border-radius) - var(--#{$prefix}toast-border-width)));

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -115,5 +115,6 @@
   color: var(--#{$prefix}tooltip-color);
   text-align: center;
   background-color: var(--#{$prefix}tooltip-bg);
+  --#{$prefix}current-plane-bg: var(--#{$prefix}tooltip-bg);
   @include border-radius(var(--#{$prefix}tooltip-border-radius));
 }

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -674,6 +674,18 @@ $utilities: map-merge(
         )
       )
     ),
+    "background-color-inherit": (
+      css-var: true,
+      css-variable-name: current-plane-bg,
+      class: bg,
+      values: map-merge(
+        map-loop($utilities-bg, color-css-var, "$key", "bg"),
+        (
+          "body-secondary": var(--#{$prefix}secondary-bg),
+          "body-tertiary": var(--#{$prefix}tertiary-bg),
+        )
+      )
+    ),
     "bg-opacity": (
       css-var: true,
       class: bg-opacity,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -838,6 +838,7 @@ $btn-box-shadow:              inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($b
 $btn-focus-width:             $input-btn-focus-width !default;
 $btn-focus-box-shadow:        $input-btn-focus-box-shadow !default;
 $btn-disabled-opacity:        .65 !default;
+$btn-disabled-fade-percentage: 35% !default;
 $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 
 $btn-link-color:              var(--#{$prefix}link-color) !default;


### PR DESCRIPTION
### Description

Fade disabled buttons into luminance-gray color of current plane background.

Disabled buttons color is mixed with a gray having the identical luminance as the background-color. This results in the following color change of disabled buttons.

Before             |  New
:-------------------------:|:-------------------------:
Bootstrap CSS @5.3.3<br>https://codepen.io/rr-it/pen/LYoOKrx  |  Bootstrap CSS @deploy-preview-40559<br>https://codepen.io/rr-it/pen/jOoYVMm
![bootstrap-disabled-buttons-before](https://github.com/twbs/bootstrap/assets/29690343/27d6acde-a640-4975-8509-d02ab8f9f1be)  |  ![bootstrap-disabled-buttons-after](https://github.com/twbs/bootstrap/assets/29690343/90226423-c31b-4aa7-b839-c7f8d8d2090d)

#### Lightness:

Lightened on light background and darkened on dark background.

In comparison:
Identical behaviour as before. Buttons lightness is slightly (`fade-percentage`) fading into the background.

#### Saturation:

Slightly desaturated.

In comparison:
On black/white gray background: Identical behaviour as before.
On colorful background: Before there was an unintentional mix between bg-color and button-color saturation. Now the button is simply slightly (`fade-percentage`) desaturated.

#### Hue:
Stays identical.

In comparison:
On black/white gray background: Identical behaviour as before.
On colorful background: Before there was an unintentional  cross-fading between bg-color and button-color resulting in unfortunate dyeing of the  button. Now the button keeps its color hue.

#### Introduction of new css-var `--bs-current-plane-bg` 

This introduces the css-var `--bs-current-plane-bg` to hold a reference to the bg-color of the current plane.

Motivation: `inherit` is currently not usable inside CSS functions. See https://github.com/w3c/csswg-drafts/issues/9757

This css-var is set in
* `body`-tag
* `.bg-<COLOR>` classes
* elements which serve as plane and set their own background-color

This css-var should also be set for custom elements that set their own background-color.

```css
body {
  --bs-current-plane-bg: var(--bs-body-bg);
}

.bg-primary {
  --bs-current-plane-bg: var(--bs-primary);
}

.bg-secondary {
  --bs-current-plane-bg: var(--bs-secondary);
}

.bg-success {
  --bs-current-plane-bg: var(--bs-success);
}

[…]
```

### Motivation & Context

Before disabled buttons simply used `opacity` and color-cross-fading happened.
E.g. a disabled red button on a blue plane became purple.

#### More real world example:

Gray disabled button in a button-group on selected row with blue background:
![grafik](https://github.com/twbs/bootstrap/assets/29690343/0c83b23b-3c3c-45f3-8058-3800b5a458f7)

This 'disabled' button has a blueish look and thereby looks somehow activated.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-40559--twbs-bootstrap.netlify.app/>
- New: <https://codepen.io/rr-it/pen/jOoYVMm> (Bootstrap CSS `@deploy-preview-40559`)
- Before: <https://codepen.io/rr-it/pen/LYoOKrx> (Bootstrap CSS `@5.3.3`)

### Related issues

Resolves https://github.com/twbs/bootstrap/issues/40557
