### PR TITLE
Update bootstrap.css

### DIFF
--- a/dist/css/bootstrap.css
+++ b/dist/css/bootstrap.css
@@ -7728,6 +7728,18 @@ textarea.form-control-lg {
   min-height: 100vh !important;
 }
 
+.min-vh-75 {
+  min-height: 75vh !important;
+}
+
+.min-vh-50 {
+  min-height: 50vh !important;
+}
+
+.min-vh-25 {
+  min-height: 25vh !important;
+}
+
 .flex-fill {
   flex: 1 1 auto !important;
 }


### PR DESCRIPTION
### Description

Solves #40567 .
Increases the scope of class `min-vh-*`. From only having `min-vh-100`, it now also includes-

- `min-vh-75`
- `min-vh-50`
- `min-vh-25`

Documentation has not been updated as it is not necessary.
### Motivation & Context

The inadequacy of the `min-vh-*` class is reflected in this Stack Overflow question-https://stackoverflow.com/questions/78636386/min-vh-50-is-not-behaving-as-expected-in-bootstrap-css
Ultimately the answer was given in the comments which concluded that Bootstrap doesn't define `min-vh-50`.

The motivation behind this change is to avoid the alignment problems and confusion that can occur without these classes as demonstrated above.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

None as a documentation update was not required

### Related issues

#40567 