### PR TITLE
Fix Missing Classes with Quotation Marks on map-get and map-has-key

### DIFF
--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -1,7 +1,7 @@
 // Utility generator
 // Used to generate utilities & print utilities
 @mixin generate-utility($utility, $infix: "", $is-rfs-media-query: false) {
-  $values: map-get($utility, values);
+  $values: map-get($utility, "values");
 
   // If the values are a list or string, convert it into a map
   @if type-of($values) == "string" or type-of(nth($values, 1)) != "list" {
@@ -9,7 +9,7 @@
   }
 
   @each $key, $value in $values {
-    $properties: map-get($utility, property);
+    $properties: map-get($utility, "property");
 
     // Multiple properties are possible, for example with vertical or horizontal margins or paddings
     @if type-of($properties) == "string" {
@@ -17,21 +17,21 @@
     }
 
     // Use custom class if present
-    $property-class: if(map-has-key($utility, class), map-get($utility, class), nth($properties, 1));
+    $property-class: if(map-has-key($utility, "class"), map-get($utility, "class"), nth($properties, 1));
     $property-class: if($property-class == null, "", $property-class);
 
     // Use custom CSS variable name if present, otherwise default to `class`
-    $css-variable-name: if(map-has-key($utility, css-variable-name), map-get($utility, css-variable-name), map-get($utility, class));
+    $css-variable-name: if(map-has-key($utility, "css-variable-name"), map-get($utility, "css-variable-name"), map-get($utility, "class"));
 
     // State params to generate pseudo-classes
-    $state: if(map-has-key($utility, state), map-get($utility, state), ());
+    $state: if(map-has-key($utility, "state"), map-get($utility, "state"), ());
 
     $infix: if($property-class == "" and str-slice($infix, 1, 1) == "-", str-slice($infix, 2), $infix);
 
     // Don't prefix if value key is null (e.g. with shadow class)
     $property-class-modifier: if($key, if($property-class == "" and $infix == "", "", "-") + $key, "");
 
-    @if map-get($utility, rfs) {
+    @if map-get($utility, "rfs") {
       // Inside the media query
       @if $is-rfs-media-query {
         $val: rfs-value($value);
@@ -44,9 +44,9 @@
       }
     }
 
-    $is-css-var: map-get($utility, css-var);
-    $is-local-vars: map-get($utility, local-vars);
-    $is-rtl: map-get($utility, rtl);
+    $is-css-var: map-get($utility, "css-var");
+    $is-local-vars: map-get($utility, "local-vars");
+    $is-rtl: map-get($utility, "rtl");
 
     @if $value != null {
       @if $is-rtl == false {

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -9,7 +9,7 @@
     @each $key, $utility in $utilities {
       // The utility can be disabled with `false`, thus check if the utility is a map first
       // Only proceed if responsive media queries are enabled or if it's the base media query
-      @if type-of($utility) == "map" and (map-get($utility, responsive) or $infix == "") {
+      @if type-of($utility) == "map" and (map-get($utility, "responsive") or $infix == "") {
         @include generate-utility($utility, $infix);
       }
     }
@@ -26,7 +26,7 @@
       @each $key, $utility in $utilities {
         // The utility can be disabled with `false`, thus check if the utility is a map first
         // Only proceed if responsive media queries are enabled or if it's the base media query
-        @if type-of($utility) == "map" and map-get($utility, rfs) and (map-get($utility, responsive) or $infix == "") {
+        @if type-of($utility) == "map" and map-get($utility, "rfs") and (map-get($utility, "responsive") or $infix == "") {
           @include generate-utility($utility, $infix, true);
         }
       }
@@ -40,7 +40,7 @@
   @each $key, $utility in $utilities {
     // The utility can be disabled with `false`, thus check if the utility is a map first
     // Then check if the utility needs print styles
-    @if type-of($utility) == "map" and map-get($utility, print) == true {
+    @if type-of($utility) == "map" and map-get($utility, "print") == true {
       @include generate-utility($utility, "-print");
     }
   }


### PR DESCRIPTION
### Description

I noticed that classes like `flex-sm-row` were missing despite being recognized in the docs. This change causes them to be properly generated.

I kindly request a patch release rather quickly after merging this; at least with the default SASS compiler in Rails, these classes are missing without this patch.

### Motivation & Context

Classes referenced in docs missing in generated CSS due to non-erroring syntax typo.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

N/A

### Related issues

- #28445
- #32397
