### PR TITLE
Add CSS breakpoint for modal.

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -32,6 +32,13 @@
   --#{$prefix}modal-footer-border-width: #{$modal-footer-border-width};
   // scss-docs-end modal-css-vars
 
+  // Modal width breakpoints
+  // These can be customized using CSS variables
+  --#{$prefix}modal-sm-width: #{$modal-sm};
+  --#{$prefix}modal-md-width: #{$modal-md};
+  --#{$prefix}modal-lg-width: #{$modal-lg};
+  --#{$prefix}modal-xl-width: #{$modal-xl};
+
   position: fixed;
   top: 0;
   left: 0;
@@ -201,6 +208,32 @@
 @include media-breakpoint-up(xl) {
   .modal-xl {
     --#{$prefix}modal-width: #{$modal-xl};
+  }
+}
+
+// Media Queries for new CSS Breakpoints
+@include media-breakpoint-up(sm) {
+  .modal-dialog {
+    max-width: var(--#{$prefix}modal-md-width);
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .modal-sm {
+    max-width: var(--#{$prefix}modal-sm-width);
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  .modal-lg,
+  .modal-xl {
+    max-width: var(--#{$prefix}modal-lg-width);
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .modal-xl {
+    max-width: var(--#{$prefix}modal-xl-width);
   }
 }
 

--- a/site/content/docs/5.3/components/modal.md
+++ b/site/content/docs/5.3/components/modal.md
@@ -869,3 +869,71 @@ myModalEl.addEventListener('hidden.bs.modal', event => {
   // do something...
 })
 ```
+
+## New Custom Modal Width Breakpoints
+
+You can now set custom width breakpoints for modals using CSS variables. This allows you to define different modal sizes for different screen widths, directly in your CSS.
+
+### Custom Properties for Modal Sizes
+
+Here are the available CSS custom properties for modals:
+
+- `--bs-modal-sm-width`: Custom width for small modals (default `300px`).
+- `--bs-modal-md-width`: Custom width for medium modals (default `500px`).
+- `--bs-modal-lg-width`: Custom width for large modals (default `800px`).
+- `--bs-modal-xl-width`: Custom width for extra-large modals (default `1140px`).
+
+#### Example Usage:
+
+In your custom CSS:
+
+```css
+:root {
+  --bs-modal-sm-width: 400px;
+  --bs-modal-md-width: 600px;
+  --bs-modal-lg-width: 900px;
+  --bs-modal-xl-width: 1200px;
+}
+```
+The Example of the Modal:
+
+<div class="bd-example">
+  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#smallModal">
+    Small Modal
+  </button>
+</div>
+
+
+```html
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#smallModal">
+  Small Modal
+</button>
+
+<div class="modal fade" id="smallModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Small Modal</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>This is a small modal example.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+```
+<div class="modal fade" id="smallModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Small Modal</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>This is a small modal example.</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### Description

Added CSS variables for modal width breakpoints and refactored the modal-test.html file to demonstrate different modal sizes.

### Motivation & Context

This change allows users to set different breakpoints for different modals using CSS variables, rather than just globally with SCSS variables. It provides more flexibility in customizing modal sizes across different use cases.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-40787--twbs-bootstrap.netlify.app/>
- https://deploy-preview-40787--twbs-bootstrap.netlify.app/docs/5.3/components/modal/#custom-properties-for-modal-sizes

