### PR TITLE
Fix popover doesn't show if its content or title is set dynamically after init

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -186,14 +186,13 @@ class Tooltip extends BaseComponent {
       throw new Error('Please use show on visible elements')
     }
 
-    if (!((this._isWithContent() || this._newContent != null) && this._isEnabled)) {
+    if (!((this._isWithContent() || this._newContent !== null) && this._isEnabled)) {
       return
     }
 
     const showEvent = EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SHOW))
     const shadowRoot = findShadowRoot(this._element)
     const isInTheDom = (shadowRoot || this._element.ownerDocument.documentElement).contains(this._element)
-    
     if (showEvent.defaultPrevented || !isInTheDom) {
       return
     }

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -186,14 +186,14 @@ class Tooltip extends BaseComponent {
       throw new Error('Please use show on visible elements')
     }
 
-    if (!(this._isWithContent() && this._isEnabled)) {
+    if (!((this._isWithContent() || this._newContent != null) && this._isEnabled)) {
       return
     }
 
     const showEvent = EventHandler.trigger(this._element, this.constructor.eventName(EVENT_SHOW))
     const shadowRoot = findShadowRoot(this._element)
     const isInTheDom = (shadowRoot || this._element.ownerDocument.documentElement).contains(this._element)
-
+    
     if (showEvent.defaultPrevented || !isInTheDom) {
       return
     }

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -56,6 +56,26 @@ describe('Popover', () => {
   })
 
   describe('show', () => {
+    fit('should show a popover with no content after setContent', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<a href="#">BS twitter</a>'
+
+        const popoverEl = fixtureEl.querySelector('a')
+        const popover = Popover.getOrCreateInstance(popoverEl)
+
+        popoverEl.addEventListener('shown.bs.popover', () => {
+          expect(document.querySelector('.popover')).not.toBeNull()
+          resolve()
+        })
+
+        popover.setContent({
+          '.popover-body': 'some content'
+        })
+
+        popover.show()
+      })
+    })
+
     it('should toggle a popover after show', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#" title="Popover" data-bs-content="https://twitter.com/getbootstrap">BS twitter</a>'

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -56,7 +56,7 @@ describe('Popover', () => {
   })
 
   describe('show', () => {
-    fit('should show a popover with no content after setContent', () => {
+    it('should show a popover with no content after setContent', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<a href="#">BS twitter</a>'
 


### PR DESCRIPTION
### Description
Fixes #40525 
<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-40851--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
