### PR TITLE
Start compatibility work on SASS 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rollup": "^4.21.2",
         "rollup-plugin-istanbul": "^5.0.0",
         "rtlcss": "^4.3.0",
-        "sass": "^1.77.8",
+        "sass": "^1.79.3",
         "sass-true": "^8.0.0",
         "shelljs": "^0.8.5",
         "stylelint": "^16.8.1",
@@ -10803,13 +10803,13 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
+        "chokidar": "^4.0.0",
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
@@ -10833,6 +10833,36 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
+      "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/search-insights": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rollup": "^4.21.2",
     "rollup-plugin-istanbul": "^5.0.0",
     "rtlcss": "^4.3.0",
-    "sass": "^1.77.8",
+    "sass": "^1.79.3",
     "sass-true": "^8.0.0",
     "shelljs": "^0.8.5",
     "stylelint": "^16.8.1",

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -2,6 +2,9 @@
 //
 // Utility mixins and functions for evaluating source code across our variables, maps, and mixins.
 
+@use "sass:color";
+@use "sass:math";
+
 // Ascending
 // Used to evaluate Sass maps like our grid breakpoints.
 @mixin _assert-ascending($map, $map-name) {
@@ -34,7 +37,12 @@
 
 // Colors
 @function to-rgb($value) {
-  @return red($value), green($value), blue($value);
+  $red: math.round(color.channel($value, "red", rgb));
+  $green: math.round(color.channel($value, "green", rgb));
+  $blue: math.round(color.channel($value, "blue", rgb));
+
+  @return $red, $green, $blue;
+
 }
 
 // stylelint-disable scss/dollar-variable-pattern
@@ -182,9 +190,9 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 // See https://www.w3.org/TR/WCAG/#dfn-contrast-ratio
 @function luminance($color) {
   $rgb: (
-    "r": red($color),
-    "g": green($color),
-    "b": blue($color)
+    "r": math.round(color.channel($color, "red", rgb)),
+    "g": math.round(color.channel($color, "green", rgb)),
+    "b": math.round(color.channel($color, "blue", rgb))
   );
 
   @each $name, $value in $rgb {


### PR DESCRIPTION
### Description
Fixes deprecation warnings starting in SASS 1.79 and fixes #40849

### Motivation & Context

Plone is using Twitter Bootstrap with it's default theme. When doing JavaScript work, webpack presents a big warning and breaks execution of any other code.
We will silence the warnings as described in https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#silencing-warnings but for progressing, this issue needs to be fixed anyways.

### Type of changes

It changes the usage of the deprecated `red`, `green` and `blue` converter functions.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

Tests do not pass. Therefore this PR is in draft mode. Help wanted.

#### Live previews

There are no documentation changes.
Here is a Preview to the SASS playground where I tested my changes:

https://sass-lang.com/playground/#eJyVj0EKwyAQRfeeYpAEFCQYSheNm1xF46ALqzDW+1fTRbPNapjPf4+Zdd1bReDV1rodJRXihl2it/3EnrCJ0G8wtoVKy16c3eWINmdMItYkXtpjgIee4alnqYB3hCug4KQ0bAqEmO8qTugicanhXcdg/gq2e3QtwHhIwe+qPkfJfAFc21KF

### Related issues

https://github.com/twbs/bootstrap/issues/40849