### PR TITLE
fix: SASS deprecated lighten, darken and color methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rollup": "^4.21.2",
         "rollup-plugin-istanbul": "^5.0.0",
         "rtlcss": "^4.3.0",
-        "sass": "^1.77.8",
+        "sass": "^1.79.3",
         "sass-true": "^8.0.0",
         "shelljs": "^0.8.5",
         "stylelint": "^16.8.1",
@@ -10803,13 +10803,12 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
+        "chokidar": "^4.0.0",
         "immutable": "^4.0.0",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
@@ -10833,6 +10832,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
+      "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/search-insights": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rollup": "^4.21.2",
     "rollup-plugin-istanbul": "^5.0.0",
     "rtlcss": "^4.3.0",
-    "sass": "^1.77.8",
+    "sass": "^1.79.3",
     "sass-true": "^8.0.0",
     "shelljs": "^0.8.5",
     "stylelint": "^16.8.1",

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 // Bootstrap functions
 //
 // Utility mixins and functions for evaluating source code across our variables, maps, and mixins.
@@ -34,7 +35,7 @@
 
 // Colors
 @function to-rgb($value) {
-  @return red($value), green($value), blue($value);
+  @return color.channel($value, "red", $space: rgb), color.channel($value, "green", $space: rgb), color.channel($value, "blue", $space: rgb);
 }
 
 // stylelint-disable scss/dollar-variable-pattern
@@ -182,9 +183,9 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 // See https://www.w3.org/TR/WCAG/#dfn-contrast-ratio
 @function luminance($color) {
   $rgb: (
-    "r": red($color),
-    "g": green($color),
-    "b": blue($color)
+    "r": color.channel($color, "red", $space: rgb),
+    "g": color.channel($color, "green", $space: rgb),
+    "b": color.channel($color, "blue", $space: rgb)
   );
 
   @each $name, $value in $rgb {

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -1,4 +1,4 @@
-@use 'sass:color';
+@use "sass:color";
 // Bootstrap functions
 //
 // Utility mixins and functions for evaluating source code across our variables, maps, and mixins.
@@ -182,6 +182,7 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 // See https://www.w3.org/TR/WCAG/#dfn-relative-luminance
 // See https://www.w3.org/TR/WCAG/#dfn-contrast-ratio
 @function luminance($color) {
+  // stylelint-disable scss/at-function-named-arguments
   $rgb: (
     "r": color.channel($color, "red", $space: rgb),
     "g": color.channel($color, "green", $space: rgb),

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 //
 // Bootstrap docs content theming
 //
@@ -151,9 +152,9 @@
   .btn-secondary {
     --bs-btn-bg: #{mix($gray-600, $blue-400, .5)};
     --bs-btn-border-color: #{rgba($white, .25)};
-    --bs-btn-hover-bg: #{darken(mix($gray-600, $blue-400, .5), 5%)};
+    --bs-btn-hover-bg: #{color.adjust(mix($gray-600, $blue-400, .5), $lightness: -5%)};
     --bs-btn-hover-border-color: #{rgba($white, .25)};
-    --bs-btn-active-bg: #{darken(mix($gray-600, $blue-400, .5), 10%)};
+    --bs-btn-active-bg: #{color.adjust(mix($gray-600, $blue-400, .5), $lightness: -10%)};
     --bs-btn-active-border-color: #{rgba($white, .5)};
     --bs-btn-focus-border-color: #{rgba($white, .5)};
     --bs-btn-focus-box-shadow: 0 0 0 .25rem rgba(255, 255, 255, .2);

--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -1,4 +1,4 @@
-@use 'sass:color';
+@use "sass:color";
 //
 // Bootstrap docs content theming
 //
@@ -149,6 +149,7 @@
     --bs-dropdown-link-active-bg: #{$blue-700};
   }
 
+  // stylelint-disable scss/at-function-named-arguments
   .btn-secondary {
     --bs-btn-bg: #{mix($gray-600, $blue-400, .5)};
     --bs-btn-border-color: #{rgba($white, .25)};

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -1,7 +1,8 @@
+@use 'sass:color';
 // Local docs variables
 $bd-purple:        #4c0bce;
-$bd-violet:        lighten(saturate($bd-purple, 5%), 15%); // stylelint-disable-line function-disallowed-list
-$bd-purple-light:  lighten(saturate($bd-purple, 5%), 45%); // stylelint-disable-line function-disallowed-list
+$bd-violet:        color.adjust(saturate($bd-purple, 5%), $lightness: 15%); // stylelint-disable-line function-disallowed-list
+$bd-purple-light:  color.adjust(saturate($bd-purple, 5%), $lightness: 45%); // stylelint-disable-line function-disallowed-list
 $bd-accent:        #ffe484;
 
 $bd-gutter-x: 3rem;

--- a/site/assets/scss/_variables.scss
+++ b/site/assets/scss/_variables.scss
@@ -1,6 +1,7 @@
-@use 'sass:color';
+@use "sass:color";
 // Local docs variables
 $bd-purple:        #4c0bce;
+// stylelint-disable scss/at-function-named-arguments
 $bd-violet:        color.adjust(saturate($bd-purple, 5%), $lightness: 15%); // stylelint-disable-line function-disallowed-list
 $bd-purple-light:  color.adjust(saturate($bd-purple, 5%), $lightness: 45%); // stylelint-disable-line function-disallowed-list
 $bd-accent:        #ffe484;


### PR DESCRIPTION
### Description

fixes issue #40849
- another deprecation from SASS which is again displaying a load of console warnings
- more info on SASS website: https://sass-lang.com/documentation/breaking-changes/color-functions/

### Motivation & Context

latest SASS version v1.79.x and higher are now showing a bunch of deprecation warnings as shown below.

![image](https://github.com/user-attachments/assets/08c692f8-bc2d-41ea-b093-5013f7b6dde5)


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
