### PR TITLE
Renamed SCSS variable $headings-color to $heading-color for consistency with CSS variable --heading-color

### DIFF
--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -26,7 +26,7 @@
 
 // Headings for larger alerts
 .alert-heading {
-  // Specified to prevent conflicts of changing $headings-color
+  // Specified to prevent conflicts of changing $heading-color
   color: inherit;
 }
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -77,7 +77,7 @@
   --#{$prefix}tertiary-bg-rgb: #{to-rgb($body-tertiary-bg)};
   // scss-docs-end root-body-variables
 
-  --#{$prefix}heading-color: #{$headings-color};
+  --#{$prefix}heading-color: #{$heading-color};
 
   --#{$prefix}link-color: #{$link-color};
   --#{$prefix}link-color-rgb: #{to-rgb($link-color)};
@@ -164,7 +164,7 @@
       --#{$prefix}#{$color}-border-subtle: #{$value};
     }
 
-    --#{$prefix}heading-color: #{$headings-color-dark};
+    --#{$prefix}heading-color: #{$heading-color-dark};
 
     --#{$prefix}link-color: #{$link-color-dark};
     --#{$prefix}link-hover-color: #{$link-hover-color-dark};

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -49,7 +49,7 @@ $body-tertiary-bg-dark:             mix($gray-800, $gray-900, 50%) !default;
 $body-emphasis-color-dark:          $white !default;
 $border-color-dark:                 $gray-700 !default;
 $border-color-translucent-dark:     rgba($white, .15) !default;
-$headings-color-dark:               inherit !default;
+$heading-color-dark:               inherit !default;
 $link-color-dark:                   tint-color($primary, 40%) !default;
 $link-hover-color-dark:             shift-color($link-color-dark, -$link-shade-percentage) !default;
 $code-color-dark:                   tint-color($code-color, 40%) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -655,7 +655,7 @@ $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
-$headings-color:              inherit !default;
+$heading-color:              inherit !default;
 // scss-docs-end headings-variables
 
 // scss-docs-start display-headings
@@ -1443,7 +1443,7 @@ $popover-box-shadow:                var(--#{$prefix}box-shadow) !default;
 
 $popover-header-font-size:          $font-size-base !default;
 $popover-header-bg:                 var(--#{$prefix}secondary-bg) !default;
-$popover-header-color:              $headings-color !default;
+$popover-header-color:              $heading-color !default;
 $popover-header-padding-y:          .5rem !default;
 $popover-header-padding-x:          $spacer !default;
 

--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -49,7 +49,7 @@ If you're migrating from our previous alpha release of v5.3.0, please review the
 
 ### Typography
 
-- We no longer set a color for `$headings-color-dark` or `--bs-heading-color` for dark mode. To avoid several problems of headings within components appearing the wrong color, we've set the Sass variable to `null` and added a `null` check like we use on the default light mode.
+- We no longer set a color for `$heading-color-dark` or `--bs-heading-color` for dark mode. To avoid several problems of headings within components appearing the wrong color, we've set the Sass variable to `null` and added a `null` check like we use on the default light mode.
 
 ### Components
 
@@ -138,7 +138,7 @@ Learn more by reading the new [color modes documentation]({{< docsref "/customiz
 
 - Adds additional variables for alerts, `.btn-close`, and `.offcanvas`.
 
-- The `--bs-heading-color` variable is back with an update and dark mode support. First, we now check for a `null` value on the associated Sass variable, `$headings-color`, before trying to output the CSS variable, so by default it's not present in our compiled CSS. Second, we use the CSS variable with a fallback value, `inherit`, allowing the original behavior to persist, but also allowing for overrides.
+- The `--bs-heading-color` variable is back with an update and dark mode support. First, we now check for a `null` value on the associated Sass variable, `$heading-color`, before trying to output the CSS variable, so by default it's not present in our compiled CSS. Second, we use the CSS variable with a fallback value, `inherit`, allowing the original behavior to persist, but also allowing for overrides.
 
 - Converts links to use CSS variables for styling `color`, but not `text-decoration`. Colors are now set with `--bs-link-color-rgb` and `--bs-link-opacity` as `rgba()` color, allowing you to customize the translucency with ease. The `a:hover` pseudo-class now overrides `--bs-link-color-rgb` instead of explicitly setting the `color` property.
 


### PR DESCRIPTION
Renamed SCSS variable $headings-color to $heading-color for consistency with CSS variable --heading-color

### Description

This pull request renames the SCSS variable `$headings-color` to `$heading-color` to ensure consistency with the CSS variable `--heading-color`. The updated SCSS variable name aligns with the existing CSS naming convention and improves clarity in the codebase.

### Motivation & Context

The motivation for this change is to bring consistency between SCSS and CSS variable names. Previously, the SCSS variable was named `$headings-color`, which did not match the CSS variable `--heading-color`. This renaming improves code readability and maintains a uniform naming convention across the codebase.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

None
