### PR TITLE
Docs: drop useless `.justify-content-start` class in homepage

### DIFF
--- a/site/layouts/partials/home/components-utilities.html
+++ b/site/layouts/partials/home/components-utilities.html
@@ -52,7 +52,7 @@
   </li>
 </ul>
 `) "html" "" }}
-      <p class="d-flex justify-content-start mb-md-0">
+      <p class="d-flex mb-md-0">
         <a href="/docs/{{ .Site.Params.docs_version }}/examples/#snippets" class="icon-link icon-link-hover fw-semibold">
           Explore customized components
           <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>
@@ -77,7 +77,7 @@ $utilities: map-merge(
 );
 `) "scss" "" }}
 
-      <p class="d-flex justify-content-start mb-md-0">
+      <p class="d-flex mb-md-0">
         <a href="/docs/{{ .Site.Params.docs_version }}/utilities/api/" class="icon-link icon-link-hover fw-semibold mb-3">
           Explore the utility API
           <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/home/css-variables.html
+++ b/site/layouts/partials/home/css-variables.html
@@ -7,7 +7,7 @@
     <p class="lead fw-normal">
       Bootstrap 5 is evolving with each release to better utilize CSS variables for global theme styles, individual components, and even utilities. We provide dozens of variables for colors, font styles, and more at a <code>:root</code> level for use anywhere. On components and utilities, CSS variables are scoped to the relevant class and can easily be modified.
     </p>
-    <p class="d-flex align-items-start flex-column lead fw-normal mb-0">
+    <p class="d-flex flex-column lead fw-normal mb-0">
       <a href="/docs/{{ .Site.Params.docs_version }}/customize/css-variables/" class="icon-link icon-link-hover fw-semibold mb-3">
         Learn more about CSS variables
         <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/home/customize.html
+++ b/site/layouts/partials/home/customize.html
@@ -6,7 +6,7 @@
   <p class="lead fw-normal">
     Bootstrap utilizes Sass for a modular and customizable architecture. Import only the components you need, enable global options like gradients and shadows, and write your own CSS with our variables, maps, functions, and mixins.
   </p>
-  <p class="d-flex justify-content-start lead fw-normal">
+  <p class="d-flex lead fw-normal">
     <a href="/docs/{{ .Site.Params.docs_version }}/customize/overview/" class="icon-link icon-link-hover fw-semibold">
       Learn more about customizing
       <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/home/icons.html
+++ b/site/layouts/partials/home/icons.html
@@ -7,7 +7,7 @@
     <p class="lead fw-normal">
       <a href="{{ .Site.Params.icons }}">Bootstrap Icons</a> is an open source SVG icon library featuring over 1,800 glyphs, with more added every release. They're designed to work in any project, whether you use Bootstrap itself or not. Use them as SVGs or icon fonts—both options give you vector scaling and easy customization via CSS.
     </p>
-    <p class="d-flex justify-content-start lead fw-normal mb-md-0">
+    <p class="d-flex lead fw-normal mb-md-0">
       <a href="{{ .Site.Params.icons }}" class="icon-link icon-link-hover fw-semibold">
         Get Bootstrap Icons
         <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/home/plugins.html
+++ b/site/layouts/partials/home/plugins.html
@@ -7,7 +7,7 @@
     <p class="lead fw-normal">
       Add toggleable hidden elements, modals and offcanvas menus, popovers and tooltips, and so much more—all without jQuery. Bootstrap's JavaScript is HTML-first, meaning most plugins are added with <code>data</code> attributes in your HTML. Need more control? Include individual plugins programmatically.
     </p>
-    <p class="d-flex justify-content-start lead fw-normal mb-md-0">
+    <p class="d-flex lead fw-normal mb-md-0">
       <a href="/docs/{{ .Site.Params.docs_version }}/getting-started/javascript/" class="icon-link icon-link-hover fw-semibold">
         Learn more about Bootstrap JavaScript
         <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>

--- a/site/layouts/partials/home/themes.html
+++ b/site/layouts/partials/home/themes.html
@@ -7,7 +7,7 @@
     <p class="lead fw-normal">
       Take Bootstrap to the next level with premium themes from the <a href="{{ .Site.Params.themes }}">official Bootstrap Themes marketplace</a>. Themes are built on Bootstrap as their own extended frameworks, rich with new components and plugins, documentation, and powerful build tools.
     </p>
-    <p class="d-flex justify-content-start lead fw-normal mb-md-0">
+    <p class="d-flex lead fw-normal mb-md-0">
       <a href="{{ .Site.Params.themes }}" class="icon-link icon-link-hover fw-semibold">
         Browse Bootstrap Themes
         <svg class="bi" aria-hidden="true"><use xlink:href="#arrow-right"></use></svg>


### PR DESCRIPTION
### Description

Following up https://github.com/twbs/bootstrap/pull/40900, this PR drops `.justify-content-start` (and `.align-items-start` in another case) class in the homepage as it's redundant and useless since it's the default behavior.

If you think it's safer to keep `.justify-content-start`, then I'll modify this PR to bring some consistency whenever it's not present.

### Type of changes

- [x] Refactoring (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-40914--twbs-bootstrap.netlify.app/>