### PR TITLE
Docs: add ngx-bootstrap to JavaScript frameworks list

### DIFF
--- a/site/content/docs/5.3/getting-started/javascript.md
+++ b/site/content/docs/5.3/getting-started/javascript.md
@@ -24,7 +24,7 @@ A better alternative for those using this type of frameworks is to use a framewo
   {{< /callout >}}
 - Vue: [BootstrapVue](https://bootstrap-vue.org/) (Bootstrap 4)
 - Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5, currently in alpha)
-- Angular: [ng-bootstrap](https://ng-bootstrap.github.io/)
+- Angular: [ng-bootstrap](https://ng-bootstrap.github.io/) or [ngx-bootstrap](https://valor-software.com/ngx-bootstrap)
 
 ## Using Bootstrap as a module
 


### PR DESCRIPTION
### Description

This PR adds ngx-bootstrap to our JavaScript frameworks list. It works well with Bootstrap 5, as an equivalent number of stars compared to ng-bootstrap, and is widely used by the Bootstrap community.

### Type of changes

- [x] Docs enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-40932--twbs-bootstrap.netlify.app/docs/5.3/getting-started/javascript/#usage-with-javascript-frameworks

### Related issues

Closes #40921
