### PR TITLE
This fixes #40923

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -38,7 +38,6 @@
         <h5>Projects</h5>
         <ul class="list-unstyled">
           <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap" target="_blank" rel="noopener">Bootstrap 5</a></li>
-          <li class="mb-2"><a href="{{ .Site.Params.github_org }}/bootstrap/tree/v4-dev" target="_blank" rel="noopener">Bootstrap 4</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.github_org }}/icons" target="_blank" rel="noopener">Icons</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.github_org }}/rfs" target="_blank" rel="noopener">RFS</a></li>
           <li class="mb-2"><a href="{{ .Site.Params.github_org }}/examples" target="_blank" rel="noopener">Examples repo</a></li>


### PR DESCRIPTION
### Description

I have done #40923 issue

### Motivation & Context

It's been almost 2 years since Bootstrap v4 reached EOL, so we should remove the link. Keeping it might give the wrong impression that it's still supported. Removing it could also help boost Bootstrap v5's visibility in search results, as v4 pages still rank higher for some queries.