### PR TITLE
Fix insufficient contrast on borders

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -539,7 +539,7 @@ $border-widths: (
   5: 5px
 ) !default;
 $border-style:                solid !default;
-$border-color:                $gray-300 !default;
+$border-color:                $gray-600 !default;
 $border-color-translucent:    rgba($black, .175) !default;
 // scss-docs-end border-variables
 


### PR DESCRIPTION
### Description

Use $gray-600 for border color in light mode.
This has a contrast of 4.69 to white, which should be good

### Motivation & Context

This solves the insufficient contrast on borders when on light mode. Issue opened here: #38480 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-40949--twbs-bootstrap.netlify.app/>

### Related issues

No related issues.
