### PR TITLE
Docs: fix example hiding element except on medium and large devices in 'Utilities > Display > Hiding elements'

### DIFF
--- a/site/content/docs/5.3/utilities/display.md
+++ b/site/content/docs/5.3/utilities/display.md
@@ -55,7 +55,7 @@ For faster mobile-friendly development, use responsive display classes for showi
 
 To hide elements simply use the `.d-none` class or one of the `.d-{sm,md,lg,xl,xxl}-none` classes for any responsive screen variation.
 
-To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none .d-xxl-none` will hide the element for all screen sizes except on medium and large devices.
+To show an element only on a given interval of screen sizes you can combine one `.d-*-none` class with a `.d-*-*` class, for example `.d-none .d-md-block .d-xl-none` will hide the element for all screen sizes except on medium and large devices.
 
 {{< bs-table >}}
 | Screen size | Class |


### PR DESCRIPTION
### Description

This PR fixes a description in [Utilities > Display > Hiding elements](https://getbootstrap.com/docs/5.3/utilities/display/#hiding-elements) that says:

> [...] for example `.d-none .d-md-block .d-xl-none .d-xxl-none` will hide the element for all screen sizes except on medium and large devices.

This is true, but `.d-xxl-none` is useless as `.d-xl-none` will already do the job.
You can check the behavior at https://codepen.io/julien-deramond/pen/gOVWgNN.

### Type of changes

- [x] Documentation fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-40951--twbs-bootstrap.netlify.app/docs/5.3/utilities/display/#hiding-elements>
