### PR TITLE
Simpler tooltip initialization

### DIFF
--- a/site/content/docs/5.3/components/tooltips.md
+++ b/site/content/docs/5.3/components/tooltips.md
@@ -37,7 +37,7 @@ Got all that? Great, let's see how they work with some examples.
 As mentioned above, you must initialize tooltips before they can be used. One way to initialize all tooltips on a page would be to select them by their `data-bs-toggle` attribute, like so:
 
 ```js
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el))
 ```
 
 ### Tooltips on links

--- a/site/content/docs/5.3/components/tooltips.md
+++ b/site/content/docs/5.3/components/tooltips.md
@@ -37,8 +37,7 @@ Got all that? Great, let's see how they work with some examples.
 As mentioned above, you must initialize tooltips before they can be used. One way to initialize all tooltips on a page would be to select them by their `data-bs-toggle` attribute, like so:
 
 ```js
-const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
 ```
 
 ### Tooltips on links


### PR DESCRIPTION
### Description

Simpler way to initialize tooltips

### Motivation & Context

This is boilerplate code I use on every page everywhere. A little golfing may be in order :-)

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews


- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

n/a

---

Previously we were targeting browsers that do not support `NodeList.prototype.forEach.

Now all our supported browsers do. Source: https://caniuse.com/mdn-api_nodelist_foreach