### PR TITLE
Docs: correct example formatting in 'Utilities > API' for linting compliance

### DIFF
--- a/site/content/docs/5.3/utilities/api.md
+++ b/site/content/docs/5.3/utilities/api.md
@@ -452,7 +452,8 @@ You can enable responsive classes for an existing set of utilities that are not 
 @import "bootstrap/scss/utilities";
 
 $utilities: map-merge(
-  $utilities, (
+  $utilities,
+  (
     "border": map-merge(
       map-get($utilities, "border"),
       ( responsive: true ),
@@ -508,7 +509,8 @@ Missing v4 utilities, or used to another naming convention? The utilities API ca
 @import "bootstrap/scss/utilities";
 
 $utilities: map-merge(
-  $utilities, (
+  $utilities,
+  (
     "margin-start": map-merge(
       map-get($utilities, "margin-start"),
       ( class: ml ),
@@ -574,13 +576,11 @@ $utilities: map-merge(
   (
     // Remove the `width` utility
     "width": null,
-
     // Make an existing utility responsive
     "border": map-merge(
       map-get($utilities, "border"),
       ( responsive: true ),
     ),
-
     // Add new utilities
     "cursor": (
       property: cursor,


### PR DESCRIPTION
### Description

Whenever one copies some Sass code from the "Utility > API" page, if they use the same linter rules, they would have some issues. This PR suggests some tiny fixes to have a consistent approach in terms of linting, even when the code is copied from the docs.

### Type of changes

- [x] Documentation enhancement (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-40973--twbs-bootstrap.netlify.app/docs/5.3/utilities/api/