### PR TITLE
Enhance popover arrow rendering when popover has a header

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -119,6 +119,12 @@
       top: var(--#{$prefix}popover-border-width);
       border-bottom-color: var(--#{$prefix}popover-bg);
     }
+
+    // `:has` is not yet supported by our `.browserlistrc` but since it adds an extra layer of specificity,
+    // it doesn't hurt the browsers that don't support it.
+    &:has(+ .popover-header)::after {
+      --#{$prefix}popover-bg: var(--#{$prefix}popover-header-bg);
+    }
   }
 
   // This will remove the popover-header's border just below the arrow

--- a/site/content/docs/5.3/components/popovers.md
+++ b/site/content/docs/5.3/components/popovers.md
@@ -51,7 +51,7 @@ We use JavaScript similar to the snippet above to render the following live popo
 {{< /callout >}}
 
 {{< example stackblitz_add_js="true" >}}
-<button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?">Click to toggle popover</button>
+<button type="button" class="btn btn-lg btn-danger" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="And here's some amazing content. It's very engaging. Right?" data-bs-placement="bottom">Click to toggle popover</button>
 {{< /example >}}
 
 ### Four directions


### PR DESCRIPTION
> [!CAUTION]
> Don't merge until https://github.com/twbs/bootstrap/commit/ae129b2c317cb905ae40213ee62495b378dc36b9 is removed

### Description

This PR tries to tackle https://github.com/twbs/bootstrap/issues/40993. The idea would be to change the color of the arrow only when there's a header, and when the popover is opened under the triggering element. That way, both background colors (arrow and headers) would be the same.

Given the order of the HTML elements, I haven't really found a way to do without using `:has`, which is not "authorized" currently in our `.browserslistrc`. However, since it's an extra rule, it wouldn't affect the rendering of browsers not handling `:has`.

What do you think @twbs/css-review?

#### Rendering

By default, with the modified doc commit:

![Screenshot 2024-10-29 at 16 30 00](https://github.com/user-attachments/assets/2c9caa94-00e7-4765-80bd-212a3f31e686)

By default, with the modified doc commit, and scrolling up:

![Screenshot 2024-10-29 at 16 30 07](https://github.com/user-attachments/assets/528d84cb-19bc-4d25-9b8c-a63e4cb380ef)

Basic popovers without headers:

![Screenshot 2024-10-29 at 16 30 14](https://github.com/user-attachments/assets/d453d162-d397-4f6b-9299-674dfa4b898b)

### Type of changes

- [x] Enhancement (non-breaking change that fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-40994--twbs-bootstrap.netlify.app/>

### Related issues

Closes #40993
