### PR TITLE
Align floating labels with form-select sizes

### DIFF
--- a/js/tests/visual/floating-label.html
+++ b/js/tests/visual/floating-label.html
@@ -167,6 +167,34 @@
         <input type="email" readonly class="form-control-plaintext" id="floatingPlaintextInput1" placeholder="name@example.com" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum mattis mi at lobortis rutrum. Phasellus varius a risus non lobortis. Ut id congue enim. Quisque facilisis elit ac elit dapibus aliquet nec sit amet arcu. Morbi vitae ultricies eros. Proin varius augue in tristique pretium. Morbi at ullamcorper elit, at ullamcorper massa. Vivamus suscipit quam quis viverra eleifend.">
         <label for="floatingPlaintextInput1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum mattis mi at lobortis rutrum. Phasellus varius a risus non lobortis. Ut id congue enim. Quisque facilisis elit ac elit dapibus aliquet nec sit amet arcu. Morbi vitae ultricies eros. Proin varius augue in tristique pretium. Morbi at ullamcorper elit, at ullamcorper massa. Vivamus suscipit quam quis viverra eleifend.</label>
       </div>
+      <!--Compare form-select rendering depending on the size-->
+      <div class="form-floating">
+        <select class="form-select" id="floatingSelect" aria-label="Floating label select example">
+          <option selected="">Open this select menu</option>
+          <option value="1">One</option>
+          <option value="2">Two</option>
+          <option value="3">Three</option>
+        </select>
+        <label for="floatingSelect">Works with selects</label>
+      </div>
+      <div class="form-floating">
+        <select class="form-select form-select-sm" id="floatingSelectSM" aria-label="Floating label select example">
+          <option selected="">Open this select menu</option>
+          <option value="1">One</option>
+          <option value="2">Two</option>
+          <option value="3">Three</option>
+        </select>
+        <label for="floatingSelectSM">Works with selects</label>
+      </div>
+      <div class="form-floating">
+        <select class="form-select form-select-lg" id="floatingSelectLG" aria-label="Floating label select example">
+          <option selected="">Open this select menu</option>
+          <option value="1">One</option>
+          <option value="2">Two</option>
+          <option value="3">Three</option>
+        </select>
+        <label for="floatingSelectLG">Works with selects</label>
+      </div>
     </div>
     
     <div class="container-fluid bg-body" data-bs-theme="dark">
@@ -328,6 +356,34 @@
         <div class="form-floating mb-3">
           <input type="email" readonly class="form-control-plaintext" id="floatingPlaintextInput3" placeholder="name@example.com" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum mattis mi at lobortis rutrum. Phasellus varius a risus non lobortis. Ut id congue enim. Quisque facilisis elit ac elit dapibus aliquet nec sit amet arcu. Morbi vitae ultricies eros. Proin varius augue in tristique pretium. Morbi at ullamcorper elit, at ullamcorper massa. Vivamus suscipit quam quis viverra eleifend.">
           <label for="floatingPlaintextInput3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum mattis mi at lobortis rutrum. Phasellus varius a risus non lobortis. Ut id congue enim. Quisque facilisis elit ac elit dapibus aliquet nec sit amet arcu. Morbi vitae ultricies eros. Proin varius augue in tristique pretium. Morbi at ullamcorper elit, at ullamcorper massa. Vivamus suscipit quam quis viverra eleifend.</label>
+        </div>
+        <!--Compare form-select rendering depending on the size-->
+        <div class="form-floating">
+          <select class="form-select" id="floatingSelect" aria-label="Floating label select example">
+            <option selected="">Open this select menu</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+          </select>
+          <label for="floatingSelect">Works with selects</label>
+        </div>
+        <div class="form-floating">
+          <select class="form-select form-select-sm" id="floatingSelectSM" aria-label="Floating label select example">
+            <option selected="">Open this select menu</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+          </select>
+          <label for="floatingSelectSM">Works with selects</label>
+        </div>
+        <div class="form-floating">
+          <select class="form-select form-select-lg" id="floatingSelectLG" aria-label="Floating label select example">
+            <option selected="">Open this select menu</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+          </select>
+          <label for="floatingSelectLG">Works with selects</label>
         </div>
       </div>
     </div>

--- a/js/tests/visual/floating-label.html
+++ b/js/tests/visual/floating-label.html
@@ -169,31 +169,31 @@
       </div>
       <!--Compare form-select rendering depending on the size-->
       <div class="form-floating">
-        <select class="form-select" id="floatingSelect" aria-label="Floating label select example">
+        <select class="form-select" id="floatingSelectRegular" aria-label="Floating label select example">
           <option selected="">Open this select menu</option>
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <label for="floatingSelect">Works with selects</label>
+        <label for="floatingSelectRegular">Works with selects</label>
       </div>
       <div class="form-floating">
-        <select class="form-select form-select-sm" id="floatingSelectSM" aria-label="Floating label select example">
+        <select class="form-select form-select-sm" id="floatingSelectSmall" aria-label="Floating label select example">
           <option selected="">Open this select menu</option>
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <label for="floatingSelectSM">Works with selects</label>
+        <label for="floatingSelectSmall">Works with selects</label>
       </div>
       <div class="form-floating">
-        <select class="form-select form-select-lg" id="floatingSelectLG" aria-label="Floating label select example">
+        <select class="form-select form-select-lg" id="floatingSelectLarge" aria-label="Floating label select example">
           <option selected="">Open this select menu</option>
           <option value="1">One</option>
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <label for="floatingSelectLG">Works with selects</label>
+        <label for="floatingSelectLarge">Works with selects</label>
       </div>
     </div>
     
@@ -359,31 +359,31 @@
         </div>
         <!--Compare form-select rendering depending on the size-->
         <div class="form-floating">
-          <select class="form-select" id="floatingSelect" aria-label="Floating label select example">
+          <select class="form-select" id="floatingSelectRegularDark" aria-label="Floating label select example">
             <option selected="">Open this select menu</option>
             <option value="1">One</option>
             <option value="2">Two</option>
             <option value="3">Three</option>
           </select>
-          <label for="floatingSelect">Works with selects</label>
+          <label for="floatingSelectRegularDark">Works with selects</label>
         </div>
         <div class="form-floating">
-          <select class="form-select form-select-sm" id="floatingSelectSM" aria-label="Floating label select example">
+          <select class="form-select form-select-sm" id="floatingSelectSmallDark" aria-label="Floating label select example">
             <option selected="">Open this select menu</option>
             <option value="1">One</option>
             <option value="2">Two</option>
             <option value="3">Three</option>
           </select>
-          <label for="floatingSelectSM">Works with selects</label>
+          <label for="floatingSelectSmallDark">Works with selects</label>
         </div>
         <div class="form-floating">
-          <select class="form-select form-select-lg" id="floatingSelectLG" aria-label="Floating label select example">
+          <select class="form-select form-select-lg" id="floatingSelectLargeDark" aria-label="Floating label select example">
             <option selected="">Open this select menu</option>
             <option value="1">One</option>
             <option value="2">Two</option>
             <option value="3">Three</option>
           </select>
-          <label for="floatingSelectLG">Works with selects</label>
+          <label for="floatingSelectLargeDark">Works with selects</label>
         </div>
       </div>
     </div>

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -51,6 +51,7 @@
   > .form-select {
     padding-top: $form-floating-input-padding-t;
     padding-bottom: $form-floating-input-padding-b;
+    padding-left: $form-floating-padding-x;
   }
 
   > .form-control:focus,


### PR DESCRIPTION
### Description

This pull request addresses an alignment issue with Bootstrap’s floating labels when using the small `form-select-sm` element. The problem occurs because the selected value is misaligned with the floating label due to reduced padding applied to the small select. By adjusting the `padding-left` property to match the floating label's padding, this PR ensures the selected value aligns properly with the label.

### Motivation & Context

The change is required to fix the visual misalignment of the `form-select-sm` element when used with floating labels, as reported in [GitHub Issue #41008](https://github.com/twbs/bootstrap/issues/41008). This fix ensures a consistent and visually correct layout for the small select element when used with floating labels.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

#### Live previews

You can see the changes in the live preview, when adding the form-select-sm class:

- [<https://deploy-preview-41013--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels/#selects>](https://deploy-preview-41013--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels/#selects)

### Related issues

- Closes [#41008](https://github.com/twbs/bootstrap/issues/41008)