### PR TITLE
ScrollSpy: improve active feedback

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -125,9 +125,7 @@ class ScrollSpy extends BaseComponent {
   }
 
   _maybeEnableSmoothScroll() {
-    if (!this._config.smoothScroll) {
-      return
-    }
+    const scrollBehavior = this._config.smoothScroll ? 'smooth' : 'auto'
 
     // unregister any previous listeners
     EventHandler.off(this._config.target, EVENT_CLICK)
@@ -139,7 +137,7 @@ class ScrollSpy extends BaseComponent {
         const root = this._rootElement || window
         const height = observableSection.offsetTop - this._element.offsetTop
         if (root.scrollTo) {
-          root.scrollTo({ top: height, behavior: 'smooth' })
+          root.scrollTo({ top: height, behavior: scrollBehavior })
           return
         }
 

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -69,6 +69,9 @@ class ScrollSpy extends BaseComponent {
     this._rootElement = getComputedStyle(this._element).overflowY === 'visible' ? null : this._element
     this._activeTarget = null
     this._observer = null
+    // Sometimes scrolling to the section isn't enough to trigger a observation callback.
+    // Scroll to up to 2px to make sure it triggers.
+    this._scrollOffset = 2
     this.refresh() // initialize
   }
 
@@ -132,7 +135,8 @@ class ScrollSpy extends BaseComponent {
       if (observableSection) {
         event.preventDefault()
         const root = this._rootElement || window
-        const height = observableSection.offsetTop - this._element.offsetTop
+
+        const height = observableSection.offsetTop - this._element.offsetTop - this._scrollOffset
         if (root.scrollTo) {
           root.scrollTo({ top: height, behavior: scrollBehavior })
           return

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -842,37 +842,54 @@ describe('ScrollSpy', () => {
   })
 
   describe('SmoothScroll', () => {
-    it('should not enable smoothScroll', () => {
+    it('should not enable smoothScroll', done => {
       fixtureEl.innerHTML = getDummyFixture()
-      const offSpy = spyOn(EventHandler, 'off').and.callThrough()
-      const onSpy = spyOn(EventHandler, 'on').and.callThrough()
 
       const div = fixtureEl.querySelector('.content')
-      const target = fixtureEl.querySelector('#navBar')
-      // eslint-disable-next-line no-new
-      new ScrollSpy(div, {
-        offset: 1
+      const link = fixtureEl.querySelector('[href="#div-jsm-1"]')
+      const observable = fixtureEl.querySelector('#div-jsm-1')
+      const clickSpy = getElementScrollSpy(div)
+
+      const scrollSpy = new ScrollSpy(div, {
+        offset: 1,
+        smoothScroll: false
       })
 
-      expect(offSpy).not.toHaveBeenCalledWith(target, 'click.bs.scrollspy')
-      expect(onSpy).not.toHaveBeenCalledWith(target, 'click.bs.scrollspy')
+      setTimeout(() => {
+        if (div.scrollTo) {
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'auto' })
+        } else {
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+        }
+
+        done()
+      }, 100)
+      link.click()
     })
 
-    it('should enable smoothScroll', () => {
+    it('should enable smoothScroll', done => {
       fixtureEl.innerHTML = getDummyFixture()
-      const offSpy = spyOn(EventHandler, 'off').and.callThrough()
-      const onSpy = spyOn(EventHandler, 'on').and.callThrough()
 
       const div = fixtureEl.querySelector('.content')
-      const target = fixtureEl.querySelector('#navBar')
-      // eslint-disable-next-line no-new
-      new ScrollSpy(div, {
+      const link = fixtureEl.querySelector('[href="#div-jsm-1"]')
+      const observable = fixtureEl.querySelector('#div-jsm-1')
+      const clickSpy = getElementScrollSpy(div)
+
+      const scrollSpy = new ScrollSpy(div, {
         offset: 1,
         smoothScroll: true
       })
 
-      expect(offSpy).toHaveBeenCalledWith(target, 'click.bs.scrollspy')
-      expect(onSpy).toHaveBeenCalledWith(target, 'click.bs.scrollspy', '[href]', jasmine.any(Function))
+      setTimeout(() => {
+        if (div.scrollTo) {
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'smooth' })
+        } else {
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+        }
+
+        done()
+      }, 100)
+      link.click()
     })
 
     it('should not smoothScroll to element if it not handles a scrollspy section', () => {

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -451,7 +451,7 @@ describe('ScrollSpy', () => {
       })
     })
 
-    it('should clear selection if above the first section', () => {
+    it('should remember previous selection', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<div id="header" style="height: 500px;"></div>',
@@ -483,9 +483,10 @@ describe('ScrollSpy', () => {
           expect(spy).toHaveBeenCalled()
 
           expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
-          expect(active().getAttribute('id')).toEqual('two-link')
+          expect(active().getAttribute('id')).toEqual('one-link')
           onScrollStop(() => {
-            expect(active()).toBeNull()
+            expect(fixtureEl.querySelectorAll('.active')).toHaveSize(1)
+            expect(active().getAttribute('id')).toEqual('one-link')
             resolve()
           }, contentEl)
           scrollTo(contentEl, 0)

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -858,9 +858,9 @@ describe('ScrollSpy', () => {
 
       setTimeout(() => {
         if (div.scrollTo) {
-          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'auto' })
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset, behavior: 'auto' })
         } else {
-          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset)
         }
 
         done()
@@ -883,9 +883,9 @@ describe('ScrollSpy', () => {
 
       setTimeout(() => {
         if (div.scrollTo) {
-          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'smooth' })
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset, behavior: 'smooth' })
         } else {
-          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset)
         }
 
         done()
@@ -943,17 +943,17 @@ describe('ScrollSpy', () => {
       const link = fixtureEl.querySelector('[href="#div-jsm-1"]')
       const observable = fixtureEl.querySelector('#div-jsm-1')
       const clickSpy = getElementScrollSpy(div)
-      // eslint-disable-next-line no-new
-      new ScrollSpy(div, {
+
+      const scrollSpy = new ScrollSpy(div, {
         offset: 1,
         smoothScroll: true
       })
 
       setTimeout(() => {
         if (div.scrollTo) {
-          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'smooth' })
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset, behavior: 'smooth' })
         } else {
-          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset)
         }
 
         done()
@@ -977,17 +977,17 @@ describe('ScrollSpy', () => {
       const link = fixtureEl.querySelector('[href="#présentation"]')
       const observable = fixtureEl.querySelector('#présentation')
       const clickSpy = getElementScrollSpy(div)
-      // eslint-disable-next-line no-new
-      new ScrollSpy(div, {
+
+      const scrollSpy = new ScrollSpy(div, {
         offset: 1,
         smoothScroll: true
       })
 
       setTimeout(() => {
         if (div.scrollTo) {
-          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop, behavior: 'smooth' })
+          expect(clickSpy).toHaveBeenCalledWith({ top: observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset, behavior: 'smooth' })
         } else {
-          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop)
+          expect(clickSpy).toHaveBeenCalledWith(observable.offsetTop - div.offsetTop - scrollSpy._scrollOffset)
         }
 
         done()


### PR DESCRIPTION
### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Current ScrollSpy behavior had some shortcomings when it comes to detecting the correct active class. 
- Sometimes none of the classes are active
- After clicking to go to a section, it immediately shows as non active

### Solution

~~To fix this I simplified the current logic, by adding an active state for all sections and keeping track of the previous highlighted section. The current rational is to highlight the first section that is intersecting at all times.~~

Different logic for scrolling up or down ~~and custom thresholds are~~ **is** removed due to not being needed anymore.

**Edit**: My previous implementation only considered header elements, which are small due to not wrapping the text in their section. However, when using entire div elements, it became impossible to activate the next element because, in many cases, two elements would be visible simultaneously. To address this, I now activate the element with the larger intersection ratio. To achieve this, I keep track of each element's intersection ratio and have increased the thresholds to recalculate the intersection ratios at every 10% increment.

### Changes
#### Scroll Behaviour:
- Before ( Note that sometimes the active class disappears and other times it jumps to early ):

https://github.com/user-attachments/assets/6db60726-699f-43fa-847b-52e28d59acc2

- After:

https://github.com/user-attachments/assets/3c060388-9749-457d-971d-05b6e8b7cedd

#### Click Behaviour:
- Before (Note the section clicked isn't active after auto scroll)

https://github.com/user-attachments/assets/ca1f2586-3c90-4e03-8955-c2ed4badcdf3

- After

https://github.com/user-attachments/assets/78e22712-3a31-4188-b53d-08851885e5c4

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Live Previews

https://deploy-preview-41016--twbs-bootstrap.netlify.app/docs/5.3/getting-started/introduction/
