### PR TITLE
Docs: fix `.order` values in the migration guide

### DIFF
--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -445,7 +445,7 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 
 - Columns no longer have `position: relative` applied, so you may have to add `.position-relative` to some elements to restore that behavior.
 
-- <span class="badge text-bg-danger">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-1` to `.order-5` out of the box.
+- <span class="badge text-bg-danger">Breaking</span> Dropped several `.order-*` classes that often went unused. We now only provide `.order-0` to `.order-5` out of the box.
 
 - <span class="badge text-bg-danger">Breaking</span> Dropped the `.media` component as it can be easily replicated with utilities. [See #28265](https://github.com/twbs/bootstrap/pull/28265) and the [flex utilities page for an example]({{< docsref "/utilities/flex#media-object" >}}).
 


### PR DESCRIPTION
### Description

While answering to https://github.com/twbs/bootstrap/issues/41029, I spotted a tiny error in our migration guide.

We also have `.order-0`: https://github.com/twbs/bootstrap/blob/cbbb567b637e24882fd0fad62bca49e248afb9a4/dist/css/bootstrap.css#L7871-L7901

And it was already the case in Bootstrap v5.0.0 (source: https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.css)

### Type of changes

- [x] Docs fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-41030--twbs-bootstrap.netlify.app/docs/5.3/migration/
