### PR TITLE
Docs: add warning callout for Yarn Berry

### DIFF
--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -100,6 +100,17 @@ Install Bootstrap in your Node.js powered apps with [the yarn package](https://y
 yarn add bootstrap@{{< param "current_version" >}}
 ```
 
+{{< callout warning >}}
+**Yarn 2+ (aka Yarn Berry) doesn't support the `node_modules` directory by default**: using our [Sass & JS example](https://github.com/twbs/examples/tree/main/sass-js) needs some adjustments:
+
+```sh
+yarn config set nodeLinker node-modules # Use the node_modules linker
+touch yarn.lock # Create an empty yarn.lock file
+yarn install # Install the dependencies
+yarn start # Start the project
+```
+{{< /callout >}}
+
 ### RubyGems
 
 Install Bootstrap in your Ruby apps using [Bundler](https://bundler.io/) (**recommended**) and [RubyGems](https://rubygems.org/) by adding the following line to your [`Gemfile`](https://bundler.io/guides/gemfile.html):


### PR DESCRIPTION
### Description

Based on the discussion in https://github.com/twbs/bootstrap/issues/40933 and the solution brought to build our [Sass & JS example](https://github.com/twbs/examples/tree/main/sass-js) in https://github.com/twbs/bootstrap/issues/40933#issuecomment-2480946630, this PR suggests a small enhancement to at leasts mention this "trick".

The approach is that we consider that most folks are still on Yarn (Classic), but we mention a way to make our examples work with Yarn Berry too to unblock some others.

Another approach would be to create a dedicated example in `twbs/examples` and link to it. But, TBH, I don't have time for it, and I'm not sure whether it's needed for now.

### Type of changes

- [x] Docs enhancement

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-41036--twbs-bootstrap.netlify.app/docs/5.3/getting-started/download/#yarn
