### PR TITLE
Dropdowns: Modified Dropdown's _parent to use a new method called 'cl…

### DIFF
--- a/js/src/dom/selector-engine.js
+++ b/js/src/dom/selector-engine.js
@@ -57,6 +57,10 @@ const SelectorEngine = {
     return parents
   },
 
+  closest(element, selector) {
+    return Element.prototype.closest.call(element, selector)
+  },
+
   prev(element, selector) {
     let previous = element.previousElementSibling
 

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -95,7 +95,8 @@ class Dropdown extends BaseComponent {
     super(element, config)
 
     this._popper = null
-    this._parent = this._element.parentNode // dropdown wrapper
+    const wrapperSelector = `:has(${SELECTOR_MENU})`
+    this._parent = SelectorEngine.closest(element, wrapperSelector) // dropdown wrapper
     // TODO: v6 revert #37011 & change markup https://getbootstrap.com/docs/5.3/forms/input-group/
     this._menu = SelectorEngine.next(this._element, SELECTOR_MENU)[0] ||
       SelectorEngine.prev(this._element, SELECTOR_MENU)[0] ||

--- a/js/tests/unit/dom/selector-engine.spec.js
+++ b/js/tests/unit/dom/selector-engine.spec.js
@@ -81,6 +81,28 @@ describe('SelectorEngine', () => {
     })
   })
 
+  describe('closest', () => {
+    it('should return one element when element with selector is the direct parent', () => {
+      const testId = 'test'
+      fixtureEl.innerHTML = `<div id="${testId}"><div id="element"></div></div>`
+
+      const element = fixtureEl.querySelector('#element')
+      const parent = fixtureEl.querySelector(`#${testId}`)
+
+      expect(SelectorEngine.closest(element, `#${testId}`)).toEqual(parent)
+    })
+
+    it('should return one element when element with selector is an ancestor', () => {
+      const testId = 'test'
+      fixtureEl.innerHTML = `<div id="${testId}"><div><div id="element"></div></div></div>`
+
+      const element = fixtureEl.querySelector('#element')
+      const ancestor = fixtureEl.querySelector(`#${testId}`)
+
+      expect(SelectorEngine.closest(element, `#${testId}`)).toEqual(ancestor)
+    })
+  })
+
   describe('prev', () => {
     it('should return previous element', () => {
       fixtureEl.innerHTML = '<div class="test"></div><button class="btn"></button>'


### PR DESCRIPTION
Dropdowns: Modified Dropdown's _parent to use a new method called 'closest', to allow dropdown menus to not necessarily be the sibling of the trigger button element. So instead of trying to use dropdown wrapper as the direct parent, it can be an ancestor.

### Description

This is a non-breaking improvement change to the Dropdown and Selector Engine JS files. More in the Motivation or context. But the long story short is that inside the dropdown's ```constructor```, instead of setting ```this._parent``` to the direct parent element, this change will use a new method for the selector engine called ```closest``` which will find the closest ancestor that contains the ```dropdown menu element```. This will then allow a not-so restrictive DOM structure. All existing behaviour as per Bootstrap documentation remains the same.

### Motivation & Context

Currently, I'm trying to create web components that use Bootstrap's dropdowns as the main mechanism for our dropdowns in our design system. Currently based on  the ```Dropdown```'s ```constructor```, ```this._parent``` is set to only use the ```this._element```'s  direct parent. So as per documentation, it allows usages like this:
```
<div class="dropdown">
  <a class="btn btn-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
    Dropdown link
  </a>

  <ul class="dropdown-menu">
    <li><a class="dropdown-item" href="#">Action</a></li>
    <li><a class="dropdown-item" href="#">Another action</a></li>
    <li><a class="dropdown-item" href="#">Something else here</a></li>
  </ul>
</div>
```

Which is fine for most use cases. However, in our use case, since it is a design system, we also create web components for things such as buttons like this:
```
<design-system-dropdown>
    <design-system-button>Trigger Dropdown</design-system-button>
    <design-system-dropdown-menu>
        <design-system-dropdown-item>
            <a href="https://google.com" target="_blank">Go to Google</a>
        </design-system-dropdown-item>
    </design-system-dropdown-menu>
</design-system-dropdown>
```

On render, the HTML would look something typical to this:
```
<design-system-dropdown class="dropdown">
    <design-system-button>
        <button class="btn btn-primary dropdown-trigger" data-bs-toggle="dropdown">Trigger Dropdown</button>
    </design-system-button>
    <design-system-dropdown-menu class class="dropdown-menu">
        <design-system-dropdown-item>
            <a href="https://google.com" class="dropdown-item" target="_blank">Go to Google</a>
        </design-system-dropdown-item>
    </design-system-dropdown-menu>
</design-system-dropdown>
```
As you can see in the above, the ```button``` with the ```data-bs-toggle``` which is the ```element``` in the dropdown constructor is **not** a sibling of the ```.dropdown-menu``` element, so when the dropdown open is called, the code is stuck because of the restrictive HTML structure.

The proposed changes will address the issue whilst maintaining the original intent of the HTML structure of these elements, and works for the current HTML structure. I have tested this with all of the combinations within the Bootstrap documentation including dropdowns inside navbars, split dropdown and standard default use cases.

In terms of documentation, I don't feel a change is required on that front since all of the use cases in the documentation have not changed.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed


