### PR TITLE
Made dropdown in navbar-expand absolute and assigned min width

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -253,6 +253,14 @@
           }
         }
       }
+
+      @include media-breakpoint-between(md, lg) {
+        .dropdown-menu {
+          position: absolute;
+          top: 100%;
+          min-width: 200px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

I have this set to only apply to medium to large (in between) screen sizes. Added absolute, forced 200px minimum, limited application to md-lg screens because that's where the problem really exists.

### Motivation & Context

The dropdown previously was taking over tablet screens. Simply was inefficient use of screen space. I understand the collapse navbar and it's great, but the dropdown forcing the navbar even lower than necessary for nav items was difficult especially as pages get larger. This way the navbar stays somewhat minimal. I didn't think the visual needed to change for small screens, but in hind sight it might look better to use this update on small screens as well. This could mean there is an easier way to implement this.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed 

#### Live previews

- <https://deploy-preview-41081--twbs-bootstrap.netlify.app/>

### Related issues

Closes #41049
