### PR TITLE
Update a point in the RTL documentation

### DIFF
--- a/site/content/docs/5.3/getting-started/rtl.md
+++ b/site/content/docs/5.3/getting-started/rtl.md
@@ -175,7 +175,7 @@ Do you want to automate this process and address several edge cases involving bo
 
 1. It is recommended that you add the `dir` attribute to the `html` element. This way, the entire page will be affected when you change the direction. Also, make sure you add the `lang` attribute accordingly.
 2. Having a single bundle with both directions will increase the size of the final stylesheet (on average, by 20%-30%): consider some [optimization]({{< docsref "/customize/optimize" >}}).
-3. Take into account that PostCSS RTLCSS is not compatible with `/* rtl:remove */` directives because it doesn't remove any CSS rule. You should replace your `/* rtl:remove */`, `/* rtl:begin:remove */` and `/* rtl:end:remove */` directives with `/* rtl:ignore */`, `/* rtl:begin:ignore */` and `/* rtl:end:ignore */` directives respectively. These directives will ignore the rule and will not create an RTL counterpart (same result as the `remove` ones in RTLCSS).
+3. Take into account that PostCSS RTLCSS is not compatible with `/* rtl:remove */` directives because it doesn't remove any CSS rule. You should replace your `/* rtl:remove */`, `/* rtl:begin:remove */` and `/* rtl:end:remove */` directives with `/* rtl:freeze */`, `/* rtl:begin:freeze */` and `/* rtl:end:freeze */` directives respectively. These directives will prefix the targeted rules or declarations with the current direction but will not create an RTL counterpart (same result as the `remove` ones in RTLCSS).
 {{< /callout >}}
 
 ## The breadcrumb case


### PR DESCRIPTION
### Description

This is a follow up of [this pull request](https://github.com/twbs/bootstrap/pull/39863) in which a small section was added to the RTL documentation. [PostCSS RTLCSS](https://github.com/elchininet/postcss-rtlcss) has a new directive that is more aligned with the `/*rtl:remove*/` directives of `RTLCSS`.

### Motivation & Context

Previous recommendation was to use the `/*rtl:ignore*/`, `/*rtl:begin:ignore*/` and `/*rtl:end:ignore*/` directives, stating that as these directives do not create an RTL counterpart, the result will be the same as using the `remove` ones in `RTLCSS`.

The previous statement is not completely true. It is true that the `ignore` directives of `PostCSS RTLCCS` do not create a RTL counterpart, but this will not achieve the same result as removing the rule/declaration from the `rtl.css` bundle.

For example, having the next input:

```css
.example-1 {
  text-align: left;
}

/*rtl:ignore*/
.example-2 {
  padding-left: 10px;
}
```

The resulted output will be:

```css
[dir="ltr"] .example-1 {
  text-align: left;
}

[dir="rtl"] .example-1 {
  text-align: right;
}

.example-2 {
  padding-left: 10px;
}
```

It is true, that `.example-2` has not been processed and no RTL rule has been created for it. But this means that those users in RTL will still have that `padding-left` affecting the elements with the class `example-2`. `RTLCSS` (using the `remove` directive) would have generated a bundle file without the `.example-2` rule, so users in RTL will not have the `padding-left`.

`PostCSS RTLCSS` has a new directive that will achieve the same as `RTLCCS` with the `remove` directives. Consider the next input:

```css
.example-1 {
  text-align: left;
}

/*rtl:freeze*/
.example-2 {
  padding-left: 10px;
}
```

The resulted output [will be](https://elchininet.github.io/postcss-rtlcss/#675c9601e4423):

```css
[dir="ltr"] .example-1 {
  text-align: left;
}

[dir="rtl"] .example-1 {
  text-align: right;
}

[dir="ltr"] .example-2 {
  padding-left: 10px;
}
```

Now the `padding-left` will only affect to users in LTR and users in RTL will not have it.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- https://deploy-preview-41098--twbs-bootstrap.netlify.app/docs/5.3/getting-started/rtl/#ltr-and-rtl-at-the-same-time

### Related issues

https://github.com/twbs/bootstrap/pull/39863
