### PR TITLE
Fix display issues of close button in contextual light and dark modes

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -12,7 +12,6 @@
   --#{$prefix}btn-close-focus-shadow: #{$btn-close-focus-shadow};
   --#{$prefix}btn-close-focus-opacity: #{$btn-close-focus-opacity};
   --#{$prefix}btn-close-disabled-opacity: #{$btn-close-disabled-opacity};
-  --#{$prefix}btn-close-white-filter: #{$btn-close-white-filter};
   // scss-docs-end close-css-vars
 
   box-sizing: content-box;
@@ -21,6 +20,7 @@
   padding: $btn-close-padding-y $btn-close-padding-x;
   color: var(--#{$prefix}btn-close-color);
   background: transparent var(--#{$prefix}btn-close-bg) center / $btn-close-width auto no-repeat; // include transparent for button elements
+  filter: var(--#{$prefix}btn-close-filter);
   border: 0; // for button elements
   @include border-radius();
   opacity: var(--#{$prefix}btn-close-opacity);
@@ -47,17 +47,20 @@
 }
 
 @mixin btn-close-white() {
-  filter: var(--#{$prefix}btn-close-white-filter);
+  --#{$prefix}btn-close-filter: #{$btn-close-filter-dark};
 }
 
 .btn-close-white {
   @include btn-close-white();
 }
 
+:root,
+[data-bs-theme="light"] {
+  --#{$prefix}btn-close-filter: #{$btn-close-filter};
+}
+
 @if $enable-dark-mode {
-  @include color-mode(dark) {
-    .btn-close {
-      @include btn-close-white();
-    }
+  @include color-mode(dark, true) {
+    @include btn-close-white();
   }
 }

--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -94,3 +94,9 @@ $accordion-button-active-icon-dark:  url("data:image/svg+xml,<svg xmlns='http://
 $carousel-indicator-active-bg-dark:   $carousel-dark-indicator-active-bg !default;
 $carousel-caption-color-dark:         $carousel-dark-caption-color !default;
 $carousel-control-icon-filter-dark:   $carousel-dark-control-icon-filter !default;
+
+//
+// Close button
+//
+
+$btn-close-filter-dark:             $btn-close-white-filter !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1713,7 +1713,8 @@ $btn-close-opacity:          .5 !default;
 $btn-close-hover-opacity:    .75 !default;
 $btn-close-focus-opacity:    1 !default;
 $btn-close-disabled-opacity: .25 !default;
-$btn-close-white-filter:     invert(1) grayscale(100%) brightness(200%) !default;
+$btn-close-filter:           null !default;
+$btn-close-white-filter:     invert(1) grayscale(100%) brightness(200%) !default; // Deprecated in v5.3.4
 // scss-docs-end close-variables
 
 

--- a/site/content/docs/5.3/components/close-button.md
+++ b/site/content/docs/5.3/components/close-button.md
@@ -6,49 +6,52 @@ group: components
 toc: true
 ---
 
-## Example
-
-Provide an option to dismiss or close a component with `.btn-close`. Default styling is limited, but highly customizable. Modify the Sass variables to replace the default `background-image`. **Be sure to include text for screen readers**, as we've done with `aria-label`.
+## Basic Close Button
 
 {{< example >}}
 <button type="button" class="btn-close" aria-label="Close"></button>
 {{< /example >}}
 
-## Disabled state
-
-Disabled close buttons change their `opacity`. We've also applied `pointer-events: none` and `user-select: none` to preventing hover and active states from triggering.
+## Dark Close Button
 
 {{< example >}}
-<button type="button" class="btn-close" disabled aria-label="Close"></button>
-{{< /example >}}
-
-## Dark variant
-
-{{< deprecated-in "5.3.0" >}}
-
-{{< callout warning >}}
-**Heads up!** As of v5.3.0, the `.btn-close-white` class is deprecated. Instead, use `data-bs-theme="dark"` to change the color mode of the close button.
-{{< /callout >}}
-
-Add `data-bs-theme="dark"` to the `.btn-close`, or to its parent element, to invert the close button. This uses the `filter` property to invert the `background-image` without overriding its value.
-
-{{< example class="bg-dark" >}}
-<div data-bs-theme="dark">
-  <button type="button" class="btn-close" aria-label="Close"></button>
-  <button type="button" class="btn-close" disabled aria-label="Close"></button>
+<div class="bg-dark p-2">
+  <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>
 </div>
 {{< /example >}}
 
-## CSS
+## Dark
 
-### Variables
+{{< example >}}
+<div data-bs-theme="dark" class="bg-body p-2">
+  <button type="button" class="btn-close" aria-label="Close"></button>
+</div>
+{{< /example >}}
 
-{{< added-in "5.3.0" >}}
+## Light
 
-As part of Bootstrap's evolving CSS variables approach, close button now uses local CSS variables on `.btn-close` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
+{{< example >}}
+<div data-bs-theme="light" class="bg-body p-2">
+  <button type="button" class="btn-close" aria-label="Close"></button>
+</div>
+{{< /example >}}
 
-{{< scss-docs name="close-css-vars" file="scss/_close.scss" >}}
+## Light in dark
 
-### Sass variables
+{{< example >}}
+<div data-bs-theme="dark" class="bg-body p-2">
+  <div data-bs-theme="light" class="bg-body p-2">
+    <button type="button" class="btn-close" aria-label="Close"></button>
+  </div>
+</div>
+{{< /example >}}
 
-{{< scss-docs name="close-variables" file="scss/_variables.scss" >}}
+## Dark in light
+
+{{< example >}}
+<div data-bs-theme="light" class="bg-body p-2">
+  <div data-bs-theme="dark" class="bg-body p-2">
+    <button type="button" class="btn-close" aria-label="Close"></button>
+  </div>
+</div>
+{{< /example >}}

--- a/site/content/docs/5.3/components/close-button.md
+++ b/site/content/docs/5.3/components/close-button.md
@@ -12,7 +12,7 @@ toc: true
 <button type="button" class="btn-close" aria-label="Close"></button>
 {{< /example >}}
 
-## Dark Close Button
+## Dark Variant
 
 {{< example >}}
 <div class="bg-dark p-2">
@@ -52,6 +52,24 @@ toc: true
 <div data-bs-theme="light" class="bg-body p-2">
   <div data-bs-theme="dark" class="bg-body p-2">
     <button type="button" class="btn-close" aria-label="Close"></button>
+  </div>
+</div>
+{{< /example >}}
+
+## Toast and Close Button issue
+
+Forcing `data-bs-theme="light"` didn't work in dark mode. Now, the cross button is always dark.
+
+{{< example >}}
+<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+  <div class="toast-header bg-warning" data-bs-theme="light">
+    <img src="..." class="rounded me-2" alt="...">
+    <strong class="me-auto">Warning!</strong>
+    <small>11 mins ago</small>
+    <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+  </div>
+  <div class="toast-body">
+    This is a warning message.
   </div>
 </div>
 {{< /example >}}

--- a/site/content/docs/5.3/components/close-button.md
+++ b/site/content/docs/5.3/components/close-button.md
@@ -6,70 +6,49 @@ group: components
 toc: true
 ---
 
-## Basic Close Button
+## Example
+
+Provide an option to dismiss or close a component with `.btn-close`. Default styling is limited, but highly customizable. Modify the Sass variables to replace the default `background-image`. **Be sure to include text for screen readers**, as we've done with `aria-label`.
 
 {{< example >}}
 <button type="button" class="btn-close" aria-label="Close"></button>
 {{< /example >}}
 
-## Dark Variant
+## Disabled state
+
+Disabled close buttons change their `opacity`. We've also applied `pointer-events: none` and `user-select: none` to preventing hover and active states from triggering.
 
 {{< example >}}
-<div class="bg-dark p-2">
-  <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>
-</div>
+<button type="button" class="btn-close" disabled aria-label="Close"></button>
 {{< /example >}}
 
-## Dark
+## Dark variant
 
-{{< example >}}
-<div data-bs-theme="dark" class="bg-body p-2">
+{{< deprecated-in "5.3.0" >}}
+
+{{< callout warning >}}
+**Heads up!** As of v5.3.0, the `.btn-close-white` class is deprecated. Instead, use `data-bs-theme="dark"` to change the color mode of the close button.
+{{< /callout >}}
+
+Add `data-bs-theme="dark"` to the `.btn-close`, or to its parent element, to invert the close button. This uses the `filter` property to invert the `background-image` without overriding its value.
+
+{{< example class="bg-dark" >}}
+<div data-bs-theme="dark">
   <button type="button" class="btn-close" aria-label="Close"></button>
+  <button type="button" class="btn-close" disabled aria-label="Close"></button>
 </div>
 {{< /example >}}
 
-## Light
+## CSS
 
-{{< example >}}
-<div data-bs-theme="light" class="bg-body p-2">
-  <button type="button" class="btn-close" aria-label="Close"></button>
-</div>
-{{< /example >}}
+### Variables
 
-## Light in dark
+{{< added-in "5.3.0" >}}
 
-{{< example >}}
-<div data-bs-theme="dark" class="bg-body p-2">
-  <div data-bs-theme="light" class="bg-body p-2">
-    <button type="button" class="btn-close" aria-label="Close"></button>
-  </div>
-</div>
-{{< /example >}}
+As part of Bootstrap's evolving CSS variables approach, close button now uses local CSS variables on `.btn-close` for enhanced real-time customization. Values for the CSS variables are set via Sass, so Sass customization is still supported, too.
 
-## Dark in light
+{{< scss-docs name="close-css-vars" file="scss/_close.scss" >}}
 
-{{< example >}}
-<div data-bs-theme="light" class="bg-body p-2">
-  <div data-bs-theme="dark" class="bg-body p-2">
-    <button type="button" class="btn-close" aria-label="Close"></button>
-  </div>
-</div>
-{{< /example >}}
+### Sass variables
 
-## Toast and Close Button issue
-
-Forcing `data-bs-theme="light"` didn't work in dark mode. Now, the cross button is always dark.
-
-{{< example >}}
-<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-  <div class="toast-header bg-warning" data-bs-theme="light">
-    <img src="..." class="rounded me-2" alt="...">
-    <strong class="me-auto">Warning!</strong>
-    <small>11 mins ago</small>
-    <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-  </div>
-  <div class="toast-body">
-    This is a warning message.
-  </div>
-</div>
-{{< /example >}}
+{{< scss-docs name="close-variables" file="scss/_variables.scss" >}}


### PR DESCRIPTION
> [!CAUTION]
> Before merging, `close-button.md` modifications must be reverted

### Description

Following up the PR for the carousel display issues in contextual light and dark modes at https://github.com/twbs/bootstrap/pull/40695, this PR also fixes the same kind of `filter` issue.

This PR will close https://github.com/twbs/bootstrap/issues/39765.

The light in dark mode doesn't work in the _main_ branch:

![Screenshot 2024-12-29 at 21 31 26](https://github.com/user-attachments/assets/e529c46d-45e6-407b-89ac-639fff45ce68)

The idea is to rely on custom properties so that there's never a specificity issue when nesting color modes (light mode in dark mode, and dark mode in light mode) (see more info in https://github.com/twbs/bootstrap/pull/40695)

/cc @louismaximepiton 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-41126--twbs-bootstrap.netlify.app/docs/5.3/components/close-button/

### Related issues

Closes #39765
