### PR TITLE
Fix keyboard navigation for contenteditable elements

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -398,12 +398,13 @@ class Dropdown extends BaseComponent {
     const isInput = /input|textarea/i.test(event.target.tagName)
     const isEscapeEvent = event.key === ESCAPE_KEY
     const isUpOrDownEvent = [ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)
+    const isContentEditable = event.target.closest('[contenteditable]') !== null
 
     if (!isUpOrDownEvent && !isEscapeEvent) {
       return
     }
 
-    if (isInput && !isEscapeEvent) {
+    if ((isInput || isContentEditable) && !isEscapeEvent) {
       return
     }
 


### PR DESCRIPTION
### Description
If the target is a contenteditable element, then there's no need to process the next steps like for input and textarea elements because it won't work correctly.And also event.preventDefault() will prevent moving up or down inside the editable content.

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

### Related issues


<!-- Please link any related issues here. -->
Closes [Dropdown prevents default actions for contenteditable elements on Up/Down arrow keys](https://github.com/twbs/bootstrap/issues/41021) #41021 
