### PR TITLE
Change scss form checked variables to css variables for easy overwrite checkbox color

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -126,6 +126,8 @@
   --#{$prefix}form-valid-border-color: #{$form-valid-border-color};
   --#{$prefix}form-invalid-color: #{$form-invalid-color};
   --#{$prefix}form-invalid-border-color: #{$form-invalid-border-color};
+  --#{$prefix}form-check-input-checked-bg-color: #{$form-check-input-checked-bg-color};
+  --#{$prefix}form-check-input-checked-border-color: #{$form-check-input-checked-border-color};
   // scss-docs-end root-form-validation-variables
 }
 

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -64,8 +64,8 @@
   }
 
   &:checked {
-    background-color: $form-check-input-checked-bg-color;
-    border-color: $form-check-input-checked-border-color;
+    background-color: var(--#{$prefix}form-check-input-checked-bg-color);
+    border-color: var(--#{$prefix}form-check-input-checked-border-color);
 
     &[type="checkbox"] {
       @if $enable-gradients {


### PR DESCRIPTION
### Description

Change the values ​​of the form checked variables from $form-check-input-checked-bg-color and $form-check-input-checked-border-color to --#{$prefix}form-check-input-checked -bg-color and --#{$prefix}form-check-input-checked-border-color) by adding these to the _root.scss and _form-check.scss file.

### Motivation & Context

Resolve issue #41137. https://github.com/twbs/bootstrap/issues/41137

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

No live preview

### Related issues

Closes https://github.com/twbs/bootstrap/issues/41137
