### PR TITLE
feat: add reset button for toast placement

### DIFF
--- a/site/assets/js/partials/snippets.js
+++ b/site/assets/js/partials/snippets.js
@@ -38,12 +38,23 @@ export default () => {
   // Used by 'Placement' example in docs or StackBlitz
   const toastPlacement = document.getElementById('toastPlacement')
   if (toastPlacement) {
-    document.getElementById('selectToastPlacement').addEventListener('change', function () {
+    const selectToastPlacement = document.getElementById('selectToastPlacement')
+    const toastPlacementResetBtn = document.getElementById('toastPlacementResetBtn')
+    const defaultSelectionIndex = 0
+
+    selectToastPlacement.addEventListener('change', function () {
       if (!toastPlacement.dataset.originalClass) {
         toastPlacement.dataset.originalClass = toastPlacement.className
       }
 
       toastPlacement.className = `${toastPlacement.dataset.originalClass} ${this.value}`
+    })
+
+    toastPlacementResetBtn.addEventListener('click', event => {
+      event.preventDefault()
+
+      selectToastPlacement.selectedIndex = defaultSelectionIndex
+      selectToastPlacement.dispatchEvent(new Event('change'))
     })
   }
 

--- a/site/content/docs/5.3/components/toasts.md
+++ b/site/content/docs/5.3/components/toasts.md
@@ -190,7 +190,11 @@ Place toasts with custom CSS as you need them. The top right is often used for n
 {{< example stackblitz_add_js="true" >}}
 <form>
   <div class="mb-3">
-    <label for="selectToastPlacement">Toast placement</label>
+    <div class="d-flex justify-content-between align-items-center">
+     <label for="selectToastPlacement">Toast placement</label>
+     <button class="btn btn-primary btn-sm" id="toastPlacementResetBtn" 
+      aria-label="Reset toast placement">Reset</button>
+    </div>
     <select class="form-select mt-2" id="selectToastPlacement">
       <option value="" selected>Select a position...</option>
       <option value="top-0 start-0">Top left</option>


### PR DESCRIPTION
### Description
Added a reset button to set the toast placement back to the default.

<!-- Describe your changes in detail -->

### Motivation & Context
This improves user experience by allowing users to quickly reset the toast placement without manually selecting it again.

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41172--twbs-bootstrap.netlify.app/docs/5.3/components/toasts/#placement>
