### PR TITLE
Docs: mention removal of `util.js` in migration guide

### DIFF
--- a/site/content/docs/5.3/migration.md
+++ b/site/content/docs/5.3/migration.md
@@ -736,3 +736,5 @@ Want more information? [Read the v5.1.0 blog post.](https://blog.getbootstrap.co
 - The default value for the `fallbackPlacements` is changed to `['top', 'right', 'bottom', 'left']` for better placement of Popper elements. **Applies to dropdowns, popovers, and tooltips.**
 
 - Removed underscore from public static methods like `_getInstance()` → `getInstance()`.
+
+- Removed `util.js`, with its functionality now integrated into individual plugins. If you previously included `util.js` manually, you can safely remove it, as it is no longer needed. Each plugin now contains only the utilities it requires, enhancing modularity and reducing dependencies.


### PR DESCRIPTION
### Description

Based on feedback from [this discussion](https://github.com/orgs/twbs/discussions/33152#discussioncomment-11897188) and the entire thread, this PR adds a note about the removal of util.js. I'll leave it to the @twbs/js-review team to decide if this is a worthwhile addition and whether the explanation is accurate.

### Motivation & Context

This addition could help folks migrating from Bootstrap 4 to 5.

### Type of changes

- [x] Docs (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- (N/A) All new and existing tests passed

#### Live previews

- https://deploy-preview-41187--twbs-bootstrap.netlify.app/docs/5.3/migration/