### PR TITLE
Remove outline on focus for consistent link and button styling

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -184,6 +184,7 @@
   white-space: nowrap; // prevent links from randomly breaking onto new lines
   background-color: transparent; // For `<button>`s
   border: 0; // For `<button>`s
+  outline: 0; // For `<button>`s
   @include border-radius(var(--#{$prefix}dropdown-item-border-radius, 0));
 
   &:hover,


### PR DESCRIPTION
### Description
I removed the outline from buttons when focused via keyboard navigation, causing a white border to appear around buttons while links remain without a border.

Please let me know if I missed anything! 😊


Before 🤔:
![chrome_fiYIotJpOv](https://github.com/user-attachments/assets/4e435d6f-94b0-4ebf-a8db-67de83f756d1)

After 😊:
![chrome_qROkcSSgxo](https://github.com/user-attachments/assets/010e6b36-863f-4d3b-8ddd-8a4225e09805)



<!-- Describe your changes in detail -->

### Motivation & Context
Links and buttons will now have the same style when navigating with the keyboard

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41194--twbs-bootstrap.netlify.app/>
