### PR TITLE
New `$grid-breakpoint-max-offset` Sass variable

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -480,6 +480,8 @@ $paragraph-margin-bottom:   1rem !default;
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.
 
+$grid-breakpoint-max-offset:     .02 !default;
+
 // scss-docs-start grid-breakpoints
 $grid-breakpoints: (
   xs: 0,

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -32,8 +32,9 @@
 }
 
 // Maximum breakpoint width.
-// The maximum value is reduced by 0.02px to work around the limitations of
-// `min-` and `max-` prefixes and viewports with fractional widths.
+// The maximum value is reduced by `$grid-breakpoint-max-offset` (0.02px)
+// to work around the limitations of `min-` and `max-` prefixes and viewports
+// with fractional widths.
 // See https://www.w3.org/TR/mediaqueries-4/#mq-min-max
 // Uses 0.02px rather than 0.01px to work around a current rounding bug in Safari.
 // See https://bugs.webkit.org/show_bug.cgi?id=178261
@@ -42,7 +43,7 @@
 //    767.98px
 @function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
   $max: map-get($breakpoints, $name);
-  @return if($max and $max > 0, $max - .02, null);
+  @return if($max and $max > 0, $max - $grid-breakpoint-max-offset, null);
 }
 
 // Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.


### PR DESCRIPTION
### Description

This PR addresses the use case mentioned in [#41192](https://github.com/twbs/bootstrap/issues/41192) by defining the .02 value as a Sass variable, making it customizable externally.

I don’t believe this change necessarily needs to be documented as it's rather an edge case of customization.

The corresponding issue is for now linked to the v5.4.0 project as it's kind of a new feature, but could be merged in a v5.3.x as non-breaking.

### Motivation & Context

Allow users to customize this value.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

N/A

### Related issues

Closes #41192
