### PR TITLE
Display Range Value Dynamically as Slider Changes

### DIFF
--- a/site/content/docs/5.3/forms/range.md
+++ b/site/content/docs/5.3/forms/range.md
@@ -42,6 +42,32 @@ By default, range inputs "snap" to integer values. To change this, you can speci
 <input type="range" class="form-range" min="0" max="5" step="0.5" id="customRange3">
 {{< /example >}}
 
+# Usability
+
+For improved usability, it is recommended most of the time to display the current selected value in text form
+
+{{< example >}}
+<div class="d-flex w-100 justify-content-between">
+  <label for="customRange4" class="form-label">Example range</label>
+  <output for="customRange4" class="fw-bold" aria-hidden="true"></output>
+</div>
+<input type="range" class="form-range" min="0" max="100" step="1" id="customRange4">
+
+<script>
+  function updateLabelValue() {
+    document.querySelector(`output[for="${this.id}"]`).innerHTML = "Value: " + this.value;
+  }
+  window.addEventListener('load', function () {
+    Array.from(document.getElementsByClassName('form-range')).forEach(function (element) {
+      if (document.querySelector(`output[for="${element.id}"]`)) {
+        element.addEventListener('input', updateLabelValue)
+        updateLabelValue.call(element)
+      }
+    })
+  })
+</script>
+{{< /example >}}
+
 ## CSS
 
 ### Sass variables


### PR DESCRIPTION
### Description

This PR addresses the concerns mentioned in: #41181

it improves the Range component documentation by demonstrating how developers can make their range sliders more accessible and user-friendly. A new example has been added, displaying the range value as text next to the “Example range” header.

This feature is already implemented in the Boosted Orange docs ([Boosted Orange Range Usability](https://boosted.orange.com/docs/5.3/forms/range/#usability)).


### Motivation & Context

This change **enhances accessibility** by helping developers present range values more clearly, improving usability for users who rely on visual or assistive cues.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41196--twbs-bootstrap.netlify.app/docs/5.3/forms/range/#usability/>

### Related issues
Closes: #41181
