### PR TITLE
Set focus style for contenteditable elements

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -375,6 +375,14 @@ th {
   border-width: 0;
 }
 
+// Contenteditable
+//
+// Handle focus states for elements with contenteditable set to true or plaintext-only
+
+[contenteditable]:not([contenteditable="false"]):focus {
+  outline: 0;
+  box-shadow: $input-focus-box-shadow;
+}
 
 // Forms
 //

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -380,6 +380,7 @@ th {
 // Handle focus states for elements with contenteditable set to true or plaintext-only
 
 [contenteditable]:not([contenteditable="false"]):focus {
+  @include border-radius(inherit);
   outline: 0;
   box-shadow: $input-focus-box-shadow;
 }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -380,7 +380,6 @@ th {
 // Handle focus states for elements with contenteditable set to true or plaintext-only
 
 [contenteditable]:not([contenteditable="false"]):focus {
-  @include border-radius(inherit);
   outline: 0;
   box-shadow: $input-focus-box-shadow;
 }


### PR DESCRIPTION
### Description
It's important to make sure `contenteditable` elements also have a focus style, just like other interactive elements. Some elements, like buttons, don’t get a focus style when they’re made `contenteditable`, which can hurt the user experience. Now, all `contenteditable` elements will behave the same way and get a focus style, just like other elements that can be focused. Since `contenteditable` acts like an input field, it makes sense to give it a focus style too.

Some Examples:

**Button Component**
Before:
![chrome_QDUqyMOYFZ](https://github.com/user-attachments/assets/3670df57-35c7-4f45-a290-f7ec98bc0b26)

After:
![chrome_IiwCYTqF9s](https://github.com/user-attachments/assets/736ec4bf-6db7-410f-8843-797ea5b97aee)

**Card Component**
Before:
![chrome_FyR4Jw46KY](https://github.com/user-attachments/assets/a27ae95a-7e41-4f92-8750-73eb48a3c439)

After:
![chrome_T9cwcBUGro](https://github.com/user-attachments/assets/36da2b69-5530-4647-8fa3-0d1053ea29cc)






<!-- Describe your changes in detail -->

### Motivation & Context
To improve consistency, ensuring that all contenteditable elements receive a focus style enhances the user experience across the site

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41200--twbs-bootstrap.netlify.app/docs/5.3/components/card/#about>
 To test the functionality, add the contenteditable attribute to the element you want to make editable, e.g., from the DevTools.

