### PR TITLE
Fix aspect-ratio

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -589,10 +589,10 @@ $transition-collapse-width:   width .35s ease !default;
 // stylelint-disable function-disallowed-list
 // scss-docs-start aspect-ratios
 $aspect-ratios: (
-  "1x1": 100%,
-  "4x3": calc(3 / 4 * 100%),
-  "16x9": calc(9 / 16 * 100%),
-  "21x9": calc(9 / 21 * 100%)
+  "1x1": 1 / 1,
+  "4x3": 4 / 3,
+  "16x9": 16 / 9,
+  "21x9": 21 / 9
 ) !default;
 // scss-docs-end aspect-ratios
 // stylelint-enable function-disallowed-list


### PR DESCRIPTION
### Description

There are two issues with the current aspect ratios:

1. Aspect ratios must be give in the ratio format `width / height` according to the spec, not in percentage.
2. Width and height values are swapped, leading to incorrect aspect-ratios being applied. According to the spec, the ratio is the ratio of width-to-height.

### Motivation & Context

Incorrect values being applied, in a format not supported by the spec.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41215--twbs-bootstrap.netlify.app/>

### Related issues

