### PR TITLE
Move _isShown() method to private section

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -204,11 +204,11 @@ class Collapse extends BaseComponent {
     this._queueCallback(complete, this._element, true)
   }
 
+  // Private
   _isShown(element = this._element) {
     return element.classList.contains(CLASS_NAME_SHOW)
   }
 
-  // Private
   _configAfterMerge(config) {
     config.toggle = Boolean(config.toggle) // Coerce string values
     config.parent = getElement(config.parent)


### PR DESCRIPTION
### Description
I’m not sure if this is an oversight or on purpose, but I think the _isShown() method should be moved to the private section since it’s marked as private, especially since in [js/src/dropdown.js](https://github.com/twbs/bootstrap/blob/c5be828d99a43e871572e205d41badeac1d1f70f/js/src/dropdown.js#L244C1-L246C4) it’s correctly placed under the private section. Please let me know if I missed anything. I’d appreciate your feedback!

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
