### PR TITLE
Docs: Simplify ids for checks, radios and switches

### DIFF
--- a/site/content/docs/5.3/examples/cheatsheet-rtl/index.html
+++ b/site/content/docs/5.3/examples/cheatsheet-rtl/index.html
@@ -369,8 +369,8 @@ direction: rtl
             <input type="file" class="form-control" id="customFile">
           </div>
           <div class="mb-3 form-check form-switch">
-            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
-            <label class="form-check-label" for="flexSwitchCheckChecked">زر على شكل مفتاح اختيار.</label>
+            <input class="form-check-input" type="checkbox" role="switch" id="switchCheckChecked" checked>
+            <label class="form-check-label" for="switchCheckChecked">زر على شكل مفتاح اختيار.</label>
           </div>
           <div class="mb-3">
             <label for="customRange3" class="form-label">مثال على حقل اختيار نطاقي</label>

--- a/site/content/docs/5.3/examples/cheatsheet/index.html
+++ b/site/content/docs/5.3/examples/cheatsheet/index.html
@@ -368,8 +368,8 @@ body_class: "bg-body-tertiary"
             <input type="file" class="form-control" id="customFile">
           </div>
           <div class="mb-3 form-check form-switch">
-            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
-            <label class="form-check-label" for="flexSwitchCheckChecked">Checked switch checkbox input</label>
+            <input class="form-check-input" type="checkbox" role="switch" id="switchCheckChecked" checked>
+            <label class="form-check-label" for="switchCheckChecked">Checked switch checkbox input</label>
           </div>
           <div class="mb-3">
             <label for="customRange3" class="form-label">Example range</label>

--- a/site/content/docs/5.3/examples/sign-in/index.html
+++ b/site/content/docs/5.3/examples/sign-in/index.html
@@ -21,8 +21,8 @@ body_class: "d-flex align-items-center py-4 bg-body-tertiary"
     </div>
 
     <div class="form-check text-start my-3">
-      <input class="form-check-input" type="checkbox" value="remember-me" id="flexCheckDefault">
-      <label class="form-check-label" for="flexCheckDefault">
+      <input class="form-check-input" type="checkbox" value="remember-me" id="checkDefault">
+      <label class="form-check-label" for="checkDefault">
         Remember me
       </label>
     </div>

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -19,14 +19,14 @@ Our checks use custom Bootstrap icons to indicate checked or indeterminate state
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
-  <label class="form-check-label" for="flexCheckDefault">
+  <input class="form-check-input" type="checkbox" value="" id="CheckDefault">
+  <label class="form-check-label" for="CheckDefault">
     Default checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked" checked>
-  <label class="form-check-label" for="flexCheckChecked">
+  <input class="form-check-input" type="checkbox" value="" id="CheckChecked" checked>
+  <label class="form-check-label" for="CheckChecked">
     Checked checkbox
   </label>
 </div>
@@ -38,8 +38,8 @@ Checkboxes can utilize the `:indeterminate` pseudo class when manually set via J
 
 {{< example class="bd-example-indeterminate" stackblitz_add_js="true" >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckIndeterminate">
-  <label class="form-check-label" for="flexCheckIndeterminate">
+  <input class="form-check-input" type="checkbox" value="" id="CheckIndeterminate">
+  <label class="form-check-label" for="CheckIndeterminate">
     Indeterminate checkbox
   </label>
 </div>
@@ -51,20 +51,20 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example class="bd-example-indeterminate" stackblitz_add_js="true" >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckIndeterminateDisabled" disabled>
-  <label class="form-check-label" for="flexCheckIndeterminateDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="CheckIndeterminateDisabled" disabled>
+  <label class="form-check-label" for="CheckIndeterminateDisabled">
     Disabled indeterminate checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckDisabled" disabled>
-  <label class="form-check-label" for="flexCheckDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="CheckDisabled" disabled>
+  <label class="form-check-label" for="CheckDisabled">
     Disabled checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="flexCheckCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="flexCheckCheckedDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="CheckCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="CheckCheckedDisabled">
     Disabled checked checkbox
   </label>
 </div>
@@ -74,14 +74,14 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="flexRadioDefault" id="flexRadioDefault1">
-  <label class="form-check-label" for="flexRadioDefault1">
+  <input class="form-check-input" type="radio" name="RadioDefault" id="RadioDefault1">
+  <label class="form-check-label" for="RadioDefault1">
     Default radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="flexRadioDefault" id="flexRadioDefault2" checked>
-  <label class="form-check-label" for="flexRadioDefault2">
+  <input class="form-check-input" type="radio" name="RadioDefault" id="RadioDefault2" checked>
+  <label class="form-check-label" for="RadioDefault2">
     Default checked radio
   </label>
 </div>
@@ -93,14 +93,14 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="flexRadioDisabled" id="flexRadioDisabled" disabled>
-  <label class="form-check-label" for="flexRadioDisabled">
+  <input class="form-check-input" type="radio" name="RadioDisabled" id="RadioDisabled" disabled>
+  <label class="form-check-label" for="RadioDisabled">
     Disabled radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="flexRadioDisabled" id="flexRadioCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="flexRadioCheckedDisabled">
+  <input class="form-check-input" type="radio" name="RadioDisabled" id="RadioCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="RadioCheckedDisabled">
     Disabled checked radio
   </label>
 </div>
@@ -112,20 +112,20 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 
 {{< example >}}
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
-  <label class="form-check-label" for="flexSwitchCheckDefault">Default switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckDefault">
+  <label class="form-check-label" for="SwitchCheckDefault">Default switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
-  <label class="form-check-label" for="flexSwitchCheckChecked">Checked switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckChecked" checked>
+  <label class="form-check-label" for="SwitchCheckChecked">Checked switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDisabled" disabled>
-  <label class="form-check-label" for="flexSwitchCheckDisabled">Disabled switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckDisabled" disabled>
+  <label class="form-check-label" for="SwitchCheckDisabled">Disabled switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="flexSwitchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="SwitchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
 </div>
 {{< /example >}}
 
@@ -222,8 +222,8 @@ Put your checkboxes, radios, and switches on the opposite side with the `.form-c
 </div>
 
 <div class="form-check form-switch form-check-reverse">
-  <input class="form-check-input" type="checkbox" id="flexSwitchCheckReverse">
-  <label class="form-check-label" for="flexSwitchCheckReverse">Reverse switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" id="SwitchCheckReverse">
+  <label class="form-check-label" for="SwitchCheckReverse">Reverse switch checkbox input</label>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -112,8 +112,8 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 
 {{< example >}}
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="switchcheckDefault">
-  <label class="form-check-label" for="switchcheckDefault">Default switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="switchCheckDefault">
+  <label class="form-check-label" for="switchCheckDefault">Default switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
   <input class="form-check-input" type="checkbox" role="switch" id="switchCheckChecked" checked>

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -19,14 +19,14 @@ Our checks use custom Bootstrap icons to indicate checked or indeterminate state
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckDefault">
-  <label class="form-check-label" for="CheckDefault">
+  <input class="form-check-input" type="checkbox" value="" id="checkDefault">
+  <label class="form-check-label" for="checkDefault">
     Default checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckChecked" checked>
-  <label class="form-check-label" for="CheckChecked">
+  <input class="form-check-input" type="checkbox" value="" id="checkChecked" checked>
+  <label class="form-check-label" for="checkChecked">
     Checked checkbox
   </label>
 </div>
@@ -38,8 +38,8 @@ Checkboxes can utilize the `:indeterminate` pseudo class when manually set via J
 
 {{< example class="bd-example-indeterminate" stackblitz_add_js="true" >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckIndeterminate">
-  <label class="form-check-label" for="CheckIndeterminate">
+  <input class="form-check-input" type="checkbox" value="" id="checkIndeterminate">
+  <label class="form-check-label" for="checkIndeterminate">
     Indeterminate checkbox
   </label>
 </div>
@@ -51,20 +51,20 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example class="bd-example-indeterminate" stackblitz_add_js="true" >}}
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckIndeterminateDisabled" disabled>
-  <label class="form-check-label" for="CheckIndeterminateDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="checkIndeterminateDisabled" disabled>
+  <label class="form-check-label" for="checkIndeterminateDisabled">
     Disabled indeterminate checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckDisabled" disabled>
-  <label class="form-check-label" for="CheckDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="checkDisabled" disabled>
+  <label class="form-check-label" for="checkDisabled">
     Disabled checkbox
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="checkbox" value="" id="CheckCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="CheckCheckedDisabled">
+  <input class="form-check-input" type="checkbox" value="" id="checkCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="checkCheckedDisabled">
     Disabled checked checkbox
   </label>
 </div>
@@ -112,8 +112,8 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 
 {{< example >}}
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckDefault">
-  <label class="form-check-label" for="SwitchCheckDefault">Default switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="SwitchcheckDefault">
+  <label class="form-check-label" for="SwitchcheckDefault">Default switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
   <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckChecked" checked>

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -74,14 +74,14 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDefault" id="RadioDefault1">
-  <label class="form-check-label" for="RadioDefault1">
+  <input class="form-check-input" type="radio" name="RadioDefault" id="radioDefault1">
+  <label class="form-check-label" for="radioDefault1">
     Default radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDefault" id="RadioDefault2" checked>
-  <label class="form-check-label" for="RadioDefault2">
+  <input class="form-check-input" type="radio" name="RadioDefault" id="radioDefault2" checked>
+  <label class="form-check-label" for="radioDefault2">
     Default checked radio
   </label>
 </div>
@@ -93,14 +93,14 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDisabled" id="RadioDisabled" disabled>
-  <label class="form-check-label" for="RadioDisabled">
+  <input class="form-check-input" type="radio" name="RadioDisabled" id="radioDisabled" disabled>
+  <label class="form-check-label" for="radioDisabled">
     Disabled radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDisabled" id="RadioCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="RadioCheckedDisabled">
+  <input class="form-check-input" type="radio" name="RadioDisabled" id="radioCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="radioCheckedDisabled">
     Disabled checked radio
   </label>
 </div>
@@ -112,20 +112,20 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 
 {{< example >}}
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="SwitchcheckDefault">
-  <label class="form-check-label" for="SwitchcheckDefault">Default switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="switchcheckDefault">
+  <label class="form-check-label" for="switchcheckDefault">Default switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckChecked" checked>
-  <label class="form-check-label" for="SwitchCheckChecked">Checked switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="switchCheckChecked" checked>
+  <label class="form-check-label" for="switchCheckChecked">Checked switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckDisabled" disabled>
-  <label class="form-check-label" for="SwitchCheckDisabled">Disabled switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="switchCheckDisabled" disabled>
+  <label class="form-check-label" for="switchCheckDisabled">Disabled switch checkbox input</label>
 </div>
 <div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" role="switch" id="SwitchCheckCheckedDisabled" checked disabled>
-  <label class="form-check-label" for="SwitchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" role="switch" id="switchCheckCheckedDisabled" checked disabled>
+  <label class="form-check-label" for="switchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
 </div>
 {{< /example >}}
 
@@ -222,8 +222,8 @@ Put your checkboxes, radios, and switches on the opposite side with the `.form-c
 </div>
 
 <div class="form-check form-switch form-check-reverse">
-  <input class="form-check-input" type="checkbox" id="SwitchCheckReverse">
-  <label class="form-check-label" for="SwitchCheckReverse">Reverse switch checkbox input</label>
+  <input class="form-check-input" type="checkbox" id="switchCheckReverse">
+  <label class="form-check-label" for="switchCheckReverse">Reverse switch checkbox input</label>
 </div>
 {{< /example >}}
 

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -74,13 +74,13 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDefault" id="radioDefault1">
+  <input class="form-check-input" type="radio" name="radioDefault" id="radioDefault1">
   <label class="form-check-label" for="radioDefault1">
     Default radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDefault" id="radioDefault2" checked>
+  <input class="form-check-input" type="radio" name="radioDefault" id="radioDefault2" checked>
   <label class="form-check-label" for="radioDefault2">
     Default checked radio
   </label>
@@ -93,13 +93,13 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 {{< example >}}
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDisabled" id="radioDisabled" disabled>
+  <input class="form-check-input" type="radio" name="radioDisabled" id="radioDisabled" disabled>
   <label class="form-check-label" for="radioDisabled">
     Disabled radio
   </label>
 </div>
 <div class="form-check">
-  <input class="form-check-input" type="radio" name="RadioDisabled" id="radioCheckedDisabled" checked disabled>
+  <input class="form-check-input" type="radio" name="radioDisabled" id="radioCheckedDisabled" checked disabled>
   <label class="form-check-label" for="radioCheckedDisabled">
     Disabled checked radio
   </label>


### PR DESCRIPTION
### Description

Minor thing but no need for 'flex' being prefixed in the examples. 

### Motivation & Context

With them being shorter may mean a few examples won't need horizontal scrollbars :-)
keeps things simpler and slightly easier to scan

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41228--twbs-bootstrap.netlify.app/>
