### PR TITLE
docs: add iOS-native switch feedback for Safari in Bootstrap docs

### DIFF
--- a/build/vnu-jar.mjs
+++ b/build/vnu-jar.mjs
@@ -31,6 +31,8 @@ execFile('java', ['-version'], (error, stdout, stderr) => {
     // NOT RECOMMENDED, but it's still valid - we explain in the docs that it's not ideal,
     // and offer more robust alternatives, but also need to show a less-than-ideal example
     'An “aria-disabled” attribute whose value is “true” should not be specified on an “a” element that has an “href” attribute.'
+    // Allow `switch` attribute.
+    'Attribute “switch” not allowed on element "input" at this point.'
   ].join('|')
 
   const args = [

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -110,6 +110,24 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 A switch has the markup of a custom checkbox but uses the `.form-switch` class to render a toggle switch. Consider using `role="switch"` to more accurately convey the nature of the control to assistive technologies that support this role. In older assistive technologies, it will simply be announced as a regular checkbox as a fallback. Switches also support the `disabled` attribute.
 
+{{< callout info >}}
+### Safari's Native Switch Support (iOS 17.4+)  
+
+In Safari (iOS 17.4+), you can add the `switch` attribute to checkbox inputs to enable **haptic feedback** when toggling switches, just like native iOS settings.  
+
+**Example:**  
+
+<input class="form-check-input" type="checkbox" switch>
+
+This keeps the styling identical to Bootstrap's default switches but enhances the user experience on iPhones.
+
+For a more iOS/macOS-native look, you can also use:
+-webkit-appearance: auto;
+This ensures compatibility with system accessibility settings like "Differentiate Without Color" and "Prefers Higher Contrast".
+
+[Demo on StackBlitz](https://stackblitz.com/edit/bootstrap-switch-native?file=index.html)
+{{< /callout >}}
+
 {{< example >}}
 <div class="form-check form-switch">
   <input class="form-check-input" type="checkbox" role="switch" id="switchCheckDefault">

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -110,24 +110,6 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 A switch has the markup of a custom checkbox but uses the `.form-switch` class to render a toggle switch. Consider using `role="switch"` to more accurately convey the nature of the control to assistive technologies that support this role. In older assistive technologies, it will simply be announced as a regular checkbox as a fallback. Switches also support the `disabled` attribute.
 
-{{< callout info >}}
-### Safari's Native Switch Support (iOS 17.4+)  
-
-In Safari (iOS 17.4+), you can add the `switch` attribute to checkbox inputs to enable **haptic feedback** when toggling switches, just like native iOS settings.  
-
-**Example:**  
-
-<input class="form-check-input" type="checkbox" switch>
-
-This keeps the styling identical to Bootstrap's default switches but enhances the user experience on iPhones.
-
-For a more iOS/macOS-native look, you can also use:
--webkit-appearance: auto;
-This ensures compatibility with system accessibility settings like "Differentiate Without Color" and "Prefers Higher Contrast".
-
-[Demo on StackBlitz](https://stackblitz.com/edit/bootstrap-switch-native?file=index.html)
-{{< /callout >}}
-
 {{< example >}}
 <div class="form-check form-switch">
   <input class="form-check-input" type="checkbox" role="switch" id="switchCheckDefault">
@@ -146,6 +128,21 @@ This ensures compatibility with system accessibility settings like "Differentiat
   <label class="form-check-label" for="switchCheckCheckedDisabled">Disabled checked switch checkbox input</label>
 </div>
 {{< /example >}}
+
+### Native switches
+
+Progressively enhance your switches for mobile Safari (iOS 17.4+) by adding a `switch` attribute to your input to enable haptic feedback when toggling switches, just like native iOS switches. There are no style changes attached to using this attribute in Bootstrap as all our switches use custom styles.
+
+{{< example >}}
+<div class="form-check form-switch">
+  <input class="form-check-input" type="checkbox" value="" id="checkNativeSwitch" switch>
+  <label class="form-check-label" for="checkNativeSwitch">
+    Native switch haptics
+  </label>
+</div>
+{{< /example >}}
+
+Be sure to read more about [the switch attribute on the WebKit blog](https://webkit.org/blog/15054/an-html-switch-control/). Safari 17.4+ on macOS and iOS both have native-style switches in HTML while other browsers simply fall back to the standard checkbox appearance.
 
 ## Default (stacked)
 

--- a/site/content/docs/5.3/forms/checks-radios.md
+++ b/site/content/docs/5.3/forms/checks-radios.md
@@ -142,7 +142,7 @@ Progressively enhance your switches for mobile Safari (iOS 17.4+) by adding a `s
 </div>
 {{< /example >}}
 
-Be sure to read more about [the switch attribute on the WebKit blog](https://webkit.org/blog/15054/an-html-switch-control/). Safari 17.4+ on macOS and iOS both have native-style switches in HTML while other browsers simply fall back to the standard checkbox appearance.
+Be sure to read more about [the switch attribute on the WebKit blog](https://webkit.org/blog/15054/an-html-switch-control/). Safari 17.4+ on macOS and iOS both have native-style switches in HTML while other browsers simply fall back to the standard checkbox appearance. Applying the attribute to a non-Bootstrap checkbox in more recent versions of Safari will render a native switch.
 
 ## Default (stacked)
 


### PR DESCRIPTION
## Description
Added a note in the Bootstrap documentation about Safari's native switch support on iOS 17.4 and later. This allows users to get haptic feedback when toggling switches in Bootstrap on iPhones, using the new switch attribute. Additionally, a mention of using native switch appearance for a more iOS/macOS-like experience was added, enhancing accessibility with system settings like "Differentiate Without Color" and "Prefers Higher Contrast."

## Motivation & Context
This change provides a minor yet useful enhancement for iOS users, making the Bootstrap switch input behave like native iOS switches with haptic feedback. It adds no functional changes but improves the user experience on iPhones with iOS 17.4+. The change aligns with Bootstrap's goal to ensure cross-browser and cross-device consistency, especially for iOS users.

##Type of changes
 New feature

## Checklist
- I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- My code follows the code style of the project (using npm run lint)
- This contribution introduces changes to the documentation

## Live previews

- https://deploy-preview-41231--twbs-bootstrap.netlify.app/docs/5.3/forms/checks-radios/#switches

## Related issues
Closes #41223
