### PR TITLE
Add color-scheme to light root selector

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -2,6 +2,8 @@
 [data-bs-theme="light"] {
   // Note: Custom variable values only support SassScript inside `#{}`.
 
+  color-scheme: light;
+
   // Colors
   //
   // Generate palettes for full colors, grays, and theme colors.


### PR DESCRIPTION
Fixup for #37734

If `[data-bs-theme="light"]` is nested within `[data-bs-theme="dark"]`, `color-scheme` should be reset to `light`.