### PR TITLE
fix(examples): access to the examples page by removing duplicate `indexPath`

### DIFF
--- a/site/data/examples.yml
+++ b/site/data/examples.yml
@@ -21,7 +21,6 @@
       description: "Import and bundle Bootstrap's source Sass and JavaScript via Parcel."
       url: /examples/tree/main/parcel
       indexPath: src/index.html
-      indexPath: src/index.html
     - name: React
       description: "Import and bundle Bootstrap's source Sass and JavaScript with React, Next.js, and React Bootstrap."
       url: /examples/tree/main/react-nextjs


### PR DESCRIPTION
### Description

Simple PR that allows to access to the "Examples" pages when running `npm run astro-dev` locally to avoid the `Failed to load data from ./site/data/examples.yml` error in the browser.