### PR TITLE
Added `user-select-text` class

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -699,7 +699,7 @@ $utilities: map-merge(
     // scss-docs-start utils-interaction
     "user-select": (
       property: user-select,
-      values: all auto none
+      values: all auto text none
     ),
     "pointer-events": (
       property: pointer-events,

--- a/site/content/docs/5.3/utilities/interactions.md
+++ b/site/content/docs/5.3/utilities/interactions.md
@@ -13,6 +13,7 @@ Change the way in which the content is selected when the user interacts with it.
 {{< example >}}
 <p class="user-select-all">This paragraph will be entirely selected when clicked by the user.</p>
 <p class="user-select-auto">This paragraph has default select behavior.</p>
+<p class="user-select-text">This paragraph text will be selectable.</p>
 <p class="user-select-none">This paragraph will not be selectable when clicked by the user.</p>
 {{< /example >}}
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->
Added missing `user-select-text` class to implement the text selection behaviour as documented: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Bootstrap does not implement the `text` selection as a class. When we set `user-select-none` to a container element, we cannot use `user-select-auto` to be able to select on a children element, we need `user-select: text`.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
