### PR TITLE
Remove `outline: 0` from modals

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -41,9 +41,6 @@
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  // Prevent Chrome on Windows from adding a focus outline. For details, see
-  // https://github.com/twbs/bootstrap/pull/10951.
-  outline: 0;
   // We deliberately don't use `-webkit-overflow-scrolling: touch;` due to a
   // gnarly iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
   // See also https://github.com/twbs/bootstrap/issues/17695


### PR DESCRIPTION
### Description

This was [added about 12 years ago](https://github.com/twbs/bootstrap/pull/10951) and is no longer needed from what I can tell.

I've tested with Chrome 133 and Edge 122 on Windows 11. The modal itself is never focused anyway, when the modal opens the focus is only within the modal.

### Motivation & Context

No longer needed. Removing it saves a few bytes. :-)

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41269--twbs-bootstrap.netlify.app/docs/5.3/components/modal/>

### Related issues

<!-- Please link any related issues here. -->
