### PR TITLE
docs: update readme to include bun install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Several quick start options are available:
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
 - Install with [npm](https://www.npmjs.com/): `npm install bootstrap@v5.3.5`
 - Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@v5.3.5`
+- Install with [Bun](https://bun.sh/): `bun add bootstrap@v5.3.5`
 - Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:5.3.5`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap` Sass: `Install-Package bootstrap.sass`
 

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -111,6 +111,14 @@ yarn start # Start the project
 ```
 {{< /callout >}}
 
+### Bun
+
+Install Bootstrap in your Bun or Node.js powered apps with [the bun CLI](https://bun.sh/):
+
+```sh
+bun add bootstrap@{{< param "current_version" >}}
+```
+
 ### RubyGems
 
 Install Bootstrap in your Ruby apps using [Bundler](https://bundler.io/) (**recommended**) and [RubyGems](https://rubygems.org/) by adding the following line to your [`Gemfile`](https://bundler.io/guides/gemfile.html):

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -113,7 +113,7 @@ yarn start # Start the project
 
 ### Bun
 
-Install Bootstrap in your Bun or Node.js powered apps with [the bun CLI](https://bun.sh/):
+Install Bootstrap in your Bun or Node.js powered apps with [the Bun CLI](https://bun.sh/):
 
 ```sh
 bun add bootstrap@{{< param "current_version" >}}


### PR DESCRIPTION
### Description

Adds `bun add bootstrap` as an installation option, alongside npm and yarn.

### Motivation & Context

Bun is a popular package manager, which is compatible with npm/yarn.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

Screenshot of the `README.md` rendered on GitHub:

<img width="575" alt="Screenshot 2025-03-06 at 3 56 19 PM" src="https://github.com/user-attachments/assets/90778fb3-8694-45eb-95d3-e9779e0cf752" />

### Related issues
