### PR TITLE
Fixed minor typo in Sass documentation

### DIFF
--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -89,7 +89,7 @@ With that setup in place, you can begin to modify any of the Sass variables and 
 
 ## Compiling
 
-In order to use your custom Sass code as CSS in the browser, you need a Sass compiler. Sass ships as a CLI package, but you can also compile it with other build tools like [Gulp](https://gulpjs.com/) or [Webpack](https://webpack.js.org/), or with a GUI applications. Some IDEs also have Sass compilers built in or as downloadable extensions.
+In order to use your custom Sass code as CSS in the browser, you need a Sass compiler. Sass ships as a CLI package, but you can also compile it with other build tools like [Gulp](https://gulpjs.com/) or [Webpack](https://webpack.js.org/), or with a GUI application. Some IDEs also have Sass compilers built in or as downloadable extensions.
 
 We like to use the CLI to compile our Sass, but you can use whichever method you prefer. From the command line, run the following:
 

--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -89,7 +89,7 @@ With that setup in place, you can begin to modify any of the Sass variables and 
 
 ## Compiling
 
-In order to use your custom Sass code as CSS in the browser, you need a Sass compiler. Sass ships as a CLI package, but you can also compile it with other build tools like [Gulp](https://gulpjs.com/) or [Webpack](https://webpack.js.org/), or with a GUI application. Some IDEs also have Sass compilers built in or as downloadable extensions.
+In order to use your custom Sass code as CSS in the browser, you need a Sass compiler. Sass ships as a CLI package, but you can also compile it with other build tools like [Gulp](https://gulpjs.com/) or [Webpack](https://webpack.js.org/), or with GUI applications. Some IDEs also have Sass compilers built in or as downloadable extensions.
 
 We like to use the CLI to compile our Sass, but you can use whichever method you prefer. From the command line, run the following:
 


### PR DESCRIPTION
### Description

In the [Customize &rarr; Sass](https://getbootstrap.com/docs/5.3/customize/sass/) documentation, there is this phrase:

> [...] or with a GUI applications

That looks like a typo. Either "applications" should be "application", or "a" should be removed. I went with the first option.

### Motivation & Context

Spelling.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

None

### Related issues

None
