### PR TITLE
docs: add Sass deprecations notice in docs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -87,6 +87,7 @@
     "roboto",
     "RTLCSS",
     "ruleset",
+    "sassrc",
     "screenreaders",
     "scrollbars",
     "scrollspy",

--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -8,6 +8,10 @@ toc: true
 
 Utilize our source Sass files to take advantage of variables, maps, mixins, and more.
 
+{{< callout warning >}}
+**Sass deprecation warnings** are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962) but in the meantime these deprecation notices can be ignored.
+{{< /callout >}}
+
 ## File structure
 
 Whenever possible, avoid modifying Bootstrap's core files. For Sass, that means creating your own stylesheet that imports Bootstrap so you can modify and extend it. Assuming you're using a package manager like npm, you'll have a file structure that looks like this:

--- a/site/content/docs/5.3/customize/sass.md
+++ b/site/content/docs/5.3/customize/sass.md
@@ -9,9 +9,8 @@ toc: true
 Utilize our source Sass files to take advantage of variables, maps, mixins, and more.
 
 {{< callout warning >}}
-**Sass deprecation warnings** are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962) but in the meantime these deprecation notices can be ignored.
+Sass deprecation warnings are shown when compiling source Sass files with the latest versions of Dart Sass. This does not prevent compilation or usage of Bootstrap. We're [working on a long-term fix]({{< param repo >}}/issues/40962), but in the meantime these deprecation notices can be ignored.
 {{< /callout >}}
-
 ## File structure
 
 Whenever possible, avoid modifying Bootstrap's core files. For Sass, that means creating your own stylesheet that imports Bootstrap so you can modify and extend it. Assuming you're using a package manager like npm, you'll have a file structure that looks like this:

--- a/site/content/docs/5.3/getting-started/parcel.md
+++ b/site/content/docs/5.3/getting-started/parcel.md
@@ -109,7 +109,16 @@ With dependencies installed and our project folder ready for us to start coding,
    }
    ```
 
-3. **And finally, we can start Parcel.** From the `my-project` folder in your terminal, run that newly added npm script:
+
+3. ***Optional:***  Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime you can silence these warning by adding the following configuration in a `.sassrc.js` file in the root folder.
+
+   ```js
+   module.exports = {
+     silenceDeprecations: ['import', 'mixed-decls', 'color-functions', 'global-builtin']
+   }
+   ```
+
+4. **And finally, we can start Parcel.** From the `my-project` folder in your terminal, run that newly added npm script:
 
    ```sh
    npm start

--- a/site/content/docs/5.3/getting-started/parcel.md
+++ b/site/content/docs/5.3/getting-started/parcel.md
@@ -110,7 +110,7 @@ With dependencies installed and our project folder ready for us to start coding,
    ```
 
 
-3. ***Optional:***  Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime you can silence these warning by adding the following configuration in a `.sassrc.js` file in the root folder.
+3. **Optional:** You may see Sass deprecation warnings with the latest versions of Dart Sass. These can silenced by adding the following configuration in a `.sassrc.js` file in the root folder with the following:
 
    ```js
    module.exports = {

--- a/site/content/docs/5.3/getting-started/parcel.md
+++ b/site/content/docs/5.3/getting-started/parcel.md
@@ -109,16 +109,7 @@ With dependencies installed and our project folder ready for us to start coding,
    }
    ```
 
-
-3. **Optional:** You may see Sass deprecation warnings with the latest versions of Dart Sass. These can silenced by adding the following configuration in a `.sassrc.js` file in the root folder with the following:
-
-   ```js
-   module.exports = {
-     silenceDeprecations: ['import', 'mixed-decls', 'color-functions', 'global-builtin']
-   }
-   ```
-
-4. **And finally, we can start Parcel.** From the `my-project` folder in your terminal, run that newly added npm script:
+3. **And finally, we can start Parcel.** From the `my-project` folder in your terminal, run that newly added npm script:
 
    ```sh
    npm start
@@ -140,6 +131,14 @@ Importing Bootstrap into Parcel requires two imports, one into our `styles.scss`
    ```
 
    *You can also import our stylesheets individually if you want. [Read our Sass import docs]({{< docsref "/customize/sass#importing" >}}) for details.*
+
+   **Optional:** You may see Sass deprecation warnings with the latest versions of Dart Sass. These can silenced by adding the following configuration in a `.sassrc.js` file in the root folder with the following:
+
+   ```js
+   module.exports = {
+     silenceDeprecations: ['import', 'mixed-decls', 'color-functions', 'global-builtin']
+   }
+   ```
 
 2. **Import Bootstrap's JS.** Add the following to `src/js/main.js` to import all of Bootstrap's JS. Popper will be imported automatically through Bootstrap.
 

--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -94,9 +94,25 @@ With dependencies installed and our project folder ready for us to start coding,
      },
      server: {
        port: 8080
-     }
+     },
+     // silencing Sass deprecation warnings, see note below
+     css: {
+        preprocessorOptions: {
+           scss: {
+             silenceDeprecations: [
+               'import',
+               'mixed-decls',
+               'color-functions',
+               'global-builtin',
+             ],
+           },
+        },
+     },
    }
    ```
+
+   ***Note:*** *Sass deprecation warnings are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
+
 
 2. **Next we fill in `src/index.html`.** This is the HTML page Vite will load in the browser to utilize the bundled CSS and JS we'll add to it in later steps.
 

--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -95,7 +95,7 @@ With dependencies installed and our project folder ready for us to start coding,
      server: {
        port: 8080
      },
-     // silencing Sass deprecation warnings, see note below
+     // optional: silencing Sass deprecation warnings, see note below
      css: {
         preprocessorOptions: {
            scss: {
@@ -111,7 +111,7 @@ With dependencies installed and our project folder ready for us to start coding,
    }
    ```
 
-   ***Note:*** *Sass deprecation warnings are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
+   ***Note:*** *Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
 
 
 2. **Next we fill in `src/index.html`.** This is the HTML page Vite will load in the browser to utilize the bundled CSS and JS we'll add to it in later steps.

--- a/site/content/docs/5.3/getting-started/vite.md
+++ b/site/content/docs/5.3/getting-started/vite.md
@@ -95,7 +95,7 @@ With dependencies installed and our project folder ready for us to start coding,
      server: {
        port: 8080
      },
-     // optional: silencing Sass deprecation warnings, see note below
+     // Optional: Silence Sass deprecation warnings. See note below.
      css: {
         preprocessorOptions: {
            scss: {
@@ -111,8 +111,7 @@ With dependencies installed and our project folder ready for us to start coding,
    }
    ```
 
-   ***Note:*** *Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
-
+   **Note:** Sass deprecation warnings are shown when compiling source Sass files with the latest versions of Dart Sass. This does not prevent compilation or usage of Bootstrap. We're [working on a long-term fix]({{< param repo >}}/issues/40962), but in the meantime these deprecation notices can be ignored.
 
 2. **Next we fill in `src/index.html`.** This is the HTML page Vite will load in the browser to utilize the bundled CSS and JS we'll add to it in later steps.
 

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -206,7 +206,7 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
                loader: 'sass-loader',
                options: {
                  sassOptions: {
-                   // silencing Sass deprecation warnings, see note below
+                   // optional: silencing Sass deprecation warnings, see note below
                    silenceDeprecations: [
                      'mixed-decls',
                      'color-functions',
@@ -225,7 +225,7 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
 
    Here's a recap of why we need all these loaders. `style-loader` injects the CSS into a `<style>` element in the `<head>` of the HTML page, `css-loader` helps with using `@import` and `url()`, `postcss-loader` is required for Autoprefixer, and `sass-loader` allows us to use Sass.
 
-   ***Note:*** *Sass deprecation warnings are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
+   ***Note:*** *Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
 
 2. **Now, let's import Bootstrap's CSS.** Add the following to `src/scss/styles.scss` to import all of Bootstrap's source Sass.
 

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -203,7 +203,18 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
              },
              {
                // Loads a SASS/SCSS file and compiles it to CSS
-               loader: 'sass-loader'
+               loader: 'sass-loader',
+               options: {
+                 sassOptions: {
+                   // silencing Sass deprecation warnings, see note below
+                   silenceDeprecations: [
+                     'mixed-decls',
+                     'color-functions',
+                     'global-builtin',
+                     'import'
+                   ]
+                 }
+               }
              }
            ]
          }
@@ -213,6 +224,8 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
    ```
 
    Here's a recap of why we need all these loaders. `style-loader` injects the CSS into a `<style>` element in the `<head>` of the HTML page, `css-loader` helps with using `@import` and `url()`, `postcss-loader` is required for Autoprefixer, and `sass-loader` allows us to use Sass.
+
+   ***Note:*** *Sass deprecation warnings are shown when compiling source sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
 
 2. **Now, let's import Bootstrap's CSS.** Add the following to `src/scss/styles.scss` to import all of Bootstrap's source Sass.
 

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -225,7 +225,7 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
 
    Here's a recap of why we need all these loaders. `style-loader` injects the CSS into a `<style>` element in the `<head>` of the HTML page, `css-loader` helps with using `@import` and `url()`, `postcss-loader` is required for Autoprefixer, and `sass-loader` allows us to use Sass.
 
-   ***Note:*** *Sass deprecation warnings are shown when compiling source Sass files with the last versions of Dart Sass. This does not prevent compilation or usage. We are [working on a long-term fix]({{< param repo >}}/issues/40962), in the meantime the above config will suppress these warnings.*
+   **Note:** Sass deprecation warnings are shown when compiling source Sass files with the latest versions of Dart Sass. This does not prevent compilation or usage of Bootstrap. We're [working on a long-term fix]({{< param repo >}}/issues/40962), but in the meantime these deprecation notices can be ignored.
 
 2. **Now, let's import Bootstrap's CSS.** Add the following to `src/scss/styles.scss` to import all of Bootstrap's source Sass.
 

--- a/site/content/docs/5.3/getting-started/webpack.md
+++ b/site/content/docs/5.3/getting-started/webpack.md
@@ -206,7 +206,7 @@ Importing Bootstrap into Webpack requires the loaders we installed in the first 
                loader: 'sass-loader',
                options: {
                  sassOptions: {
-                   // optional: silencing Sass deprecation warnings, see note below
+                   // Optional: Silence Sass deprecation warnings. See note below.
                    silenceDeprecations: [
                      'mixed-decls',
                      'color-functions',


### PR DESCRIPTION
### Description

This PR will add a callout in the docs to explain and provide links to potential resolution regarding Sass depreciation. Also it modifies `Vite`, `Parcel` and `Webpack` configs to silence the deprecations warnings from Dart Sass.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Many issues are opened regarding the Sass deprecation notices (see #40962) and users must search the web to pinpoint the problem and potential workarounds, adding a callout directly in the docs while the core team is working on `node Sass` exit would be helpful for users and would limit erroneous new issues opening about these deprecations.
We have the same problems with our company's fork's users who must search the web for information about these issues but we figured it could be an improvement on Bootstrap docs directly.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41283--twbs-bootstrap.netlify.app/docs/5.3/customize/sass/>
- <https://deploy-preview-41283--twbs-bootstrap.netlify.app/docs/5.3/getting-started/webpack/>
- <https://deploy-preview-41283--twbs-bootstrap.netlify.app/docs/5.3/getting-started/vite/>

### Related issues

#40962 
