### PR TITLE
Python wrapper package for precompiled Bootstrap assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.vi
 *.zip
 *~
+*.pyc
 
 # OS or Editor folders
 ._*
@@ -41,3 +42,5 @@ Thumbs.db
 /dist-sass/
 /js/coverage/
 /node_modules/
+build/lib/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dist *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bootstrap"
+dynamic = ["version"]
+description = "A wrapper to distribute Bootstrap via a python package"
+readme = "README.md"
+requires-python = ">=3.7"
+license = { text = "MIT" }
+authors = [
+    { name = "Mark Otto", email = "markdotto@gmail.com" },
+    { name = "Jacob Thornton", email = "jacobthornton@gmail.com" }
+]
+
+[tool.setuptools.dynamic]
+version = { attr = "bootstrap.__version__" }
+
+[project.urls]
+Homepage = "https://github.com/twbs/bootstrap"
+
+[tool.setuptools]
+packages = ["bootstrap", "bootstrap.dist"]
+package-dir = { "bootstrap" = "python", "bootstrap.dist" = "dist" }
+include-package-data = true

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+from importlib import resources
+
+try:
+    # Loading package.json
+    package_json_path = Path(__file__).parent.parent / "package.json"
+    with package_json_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    
+    # to get current version
+    __version__ = data["version"]
+except Exception as e:
+    __version__ = "0.0.0"

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,14 +1,17 @@
+"""
+Load the package.json to get the current version of the package for the installer
+"""
+
 import json
 from pathlib import Path
-from importlib import resources
 
 try:
     # Loading package.json
     package_json_path = Path(__file__).parent.parent / "package.json"
     with package_json_path.open(encoding="utf-8") as f:
         data = json.load(f)
-    
+
     # to get current version
     __version__ = data["version"]
-except Exception as e:
+except Exception as e: # pylint: disable=broad-exception-caught
     __version__ = "0.0.0"

--- a/site/content/docs/5.3/getting-started/download.md
+++ b/site/content/docs/5.3/getting-started/download.md
@@ -146,3 +146,32 @@ Install-Package bootstrap
 ```powershell
 Install-Package bootstrap.sass
 ```
+
+### Python
+
+Bootstrap is now installable as a Python package, allowing you to integrate the compiled Bootstrap assets directly into your Python projects. Installation via pip is now supported:
+
+```sh
+pip install git+https://github.com/twbs/bootstrap.git
+```
+
+After installation, the Bootstrap assets (CSS and JS files) are embedded as package data and can be served directly in your Python web application. For example, in a FastAPI app you can serve these static assets under the `/bootstrap` URL path:
+
+```python
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+import importlib.metadata
+
+app = FastAPI()
+
+# Retrieve the distribution information for the 'bootstrap' package.
+dist = importlib.metadata.distribution("bootstrap")
+
+# Locate the static assets installed as package data.
+static_path = Path(dist.locate_file("bootstrap/dist"))
+
+app.mount("/bootstrap", StaticFiles(directory=str(static_path)), name="bootstrap")
+```
+
+In this configuration, you can access Bootstrap's CSS at `/bootstrap/css/bootstrap.min.css` and JavaScript at `/bootstrap/js/bootstrap.bundle.min.js` in your application.


### PR DESCRIPTION
### Description
A trivial change to make the precompiled CSS and JS files available for Python projects.

### Motivation & Context

The motivation behind this change is to avoid having to manually update the assets (CSS + JS) in my FastAPI application. By integrating these assets as a dependency, users will always have access to the latest version automatically.


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

```sh
pip install git+https://github.com/MaximilianClemens/bootstrap.git
( pip install git+https://github.com/twbs/bootstrap.git ) # when accepted
```


```python
from fastapi import FastAPI
from fastapi.staticfiles import StaticFiles
from pathlib import Path
import importlib.metadata

app = FastAPI()

# Retrieve the distribution information for the 'bootstrap' package.
dist = importlib.metadata.distribution("bootstrap")

# Locate the static assets installed as package data.
static_path = Path(dist.locate_file("bootstrap/dist"))

app.mount("/bootstrap", StaticFiles(directory=str(static_path)), name="bootstrap")
```

### Related issues

<!-- Please link any related issues here. -->
