### PR TITLE
Resolve inconsistent behavior in 'show' and 'hide' methods

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -60,6 +60,7 @@ class Collapse extends BaseComponent {
   constructor(element, config) {
     super(element, config)
 
+    this._isShown = element.classList.contains('show')
     this._isTransitioning = false
     this._triggerArray = []
 
@@ -146,6 +147,7 @@ class Collapse extends BaseComponent {
     this._isTransitioning = true
 
     const complete = () => {
+      this._isShown = true
       this._isTransitioning = false
 
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
@@ -193,6 +195,7 @@ class Collapse extends BaseComponent {
     this._isTransitioning = true
 
     const complete = () => {
+      this._isShown = false
       this._isTransitioning = false
       this._element.classList.remove(CLASS_NAME_COLLAPSING)
       this._element.classList.add(CLASS_NAME_COLLAPSE)


### PR DESCRIPTION
### Description

Currently the `_isShown` property is being checked in the 'show' and 'hide' methods, but the `_isShown` property is never changed, causing it to stay false no matter the component's state. This behavior is inconsistent with the behavior of other components, and can cause undesired behavior when the same method is called multiple times in succession.

This PR introduces code in the constructor to set the `_isShown` property based on the current classes of the component (in accordance with the documentation), and to update the `_isShown` property in the 'show' and 'hide' methods.

### Motivation & Context

Currently the 'show' and 'hide' methods of the collapse component act like its 'toggle' method, ignoring whether the component is actually shown or hidden.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
