### PR TITLE
Add dark theme CSS selector for navbar and dropdown

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -232,7 +232,9 @@
 }
 
 // Dark dropdowns
-.dropdown-menu-dark {
+.dropdown-menu-dark,
+[data-bs-theme="dark"] .dropdown-menu,
+.dropdown-menu[data-bs-theme="dark"] {
   // scss-docs-start dropdown-dark-css-vars
   --#{$prefix}dropdown-color: #{$dropdown-dark-color};
   --#{$prefix}dropdown-bg: #{$dropdown-dark-bg};

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -267,7 +267,8 @@
 }
 
 .navbar-dark,
-.navbar[data-bs-theme="dark"] {
+.navbar[data-bs-theme="dark"],
+[data-bs-theme="dark"] .navbar {
   // scss-docs-start navbar-dark-css-vars
   --#{$prefix}navbar-color: #{$navbar-dark-color};
   --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color};


### PR DESCRIPTION
### Description

Adds `[data-bs-theme="dark"]` selector to `navbar` and `dropdown-menu`, so it's possible to set dark color mode for the components by setting `data-bs-theme="dark"` attribute to `html` element (or any parent element of those components).

### Motivation & Context

The dark theme set on `html` element wasn't applied to navbars and dropdowns. See the #41310.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

#41310 
