### PR TITLE
Fix floating labels rendering on Firefox

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -9,3 +9,4 @@ Firefox ESR
 iOS >= 12
 Safari >= 12
 not Explorer <= 11
+not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)


### PR DESCRIPTION
Fixes https://github.com/twbs/bootstrap/issues/41342

This PR addresses the floating label rendering issue in Firefox, based on the discussion and analysis at https://github.com/twbs/bootstrap/issues/41342#issuecomment-2777697596.

We considered three possible solutions:
1. Pin `autoprefixer` to the previous release. However, it's unclear how the issue will be handled upstream.
2. Add `not kaios <= 2.5` to our `.browserlistrc` which appears to resolve the problem in Firefox. This is the solution implemented in this PR. Note: if `autoprefixer` provides an upstream fix, we’ll likely need to revisit and remove this workaround.
3. Identify a more robust fix by adjusting our floating label implementation or refining our use of pseudo-elements.

We chose the second option as a temporary, pragmatic fix, for a quick v5.3.5. A more permanent solution may involve revisiting our use of pseudo-elements once we better understand the root cause or once an upstream fix is released.

Live preview available at https://deploy-preview-41347--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels/

Rendering:
- ✅ Firefox 137.0 - macOS 15.3.2
- ✅ Chrome 134.0.6998.166 (Official Build) (arm64) - macOS 15.3.2
- ✅ Safari 18.3.1 (20620.2.4.11.6) - macOS 15.3.2
- ✅ Edge 134.0.3124.95 (Official build) (arm64) - macOS 15.3.2
- ✅ Firefox 117.0 - Ubuntu 22.04