### PR TITLE
Add no-spinners utility to remove input spinners

### DIFF
--- a/site/content/docs/5.3/utilities/no-spinners.md
+++ b/site/content/docs/5.3/utilities/no-spinners.md
@@ -1,0 +1,6 @@
+### No Spinners
+
+The `.no-spinners` utility removes the spinner arrows from `<input type="number">` and similar elements across supported browsers (WebKit and Firefox).
+
+```html
+<input type="number" class="form-control no-spinners" value="42">

--- a/tests/visual/no-spinners.html
+++ b/tests/visual/no-spinners.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bootstrap Visual Test: No Spinners Utility</title>
+  <link rel="stylesheet" href="/dist/css/bootstrap.css">
+</head>
+<body>
+  <div class="container py-5">
+    <h1>No Spinners Utility Test</h1>
+    <p>Inputs below should not display spinners in supported browsers.</p>
+
+    <h2>Default Number Input (with spinners)</h2>
+    <input type="number" class="form-control" value="42">
+
+    <h2>Number Input with .no-spinners</h2>
+    <input type="number" class="form-control no-spinners" value="42">
+
+    <h2>Time Input with .no-spinners</h2>
+    <input type="time" class="form-control no-spinners" value="13:37">
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Adds a new utility class .no-spinners to remove spinners
from number inputs. Includes visual test in tests/visual/no-spinners.html
and documentation in docs/5.3/utilities/misc.md. Implemented via
a separate _no-spinners.scss file due to utilities API limitations
with pseudo-elements like ::-webkit-inner-spin-button.

### Description
This pull request introduces a new utility class, .no-spinners, to the
Bootstrap framework. The purpose of this utility is to remove the spinner
arrows (increment/decrement controls) from <input type="number">
elements and similar input types across supported browsers, providing a
cleaner visual appearance while preserving the input's numeric functionality.

### Motivation & Context
This change is required to address a common customization need in web
development: removing the spinner arrows (increment/decrement controls)
from <input type="number"> elements and similar input types. Bootstrap
currently lacks a built-in utility to control this aspect of form inputs, leaving
developers to implement custom CSS outside the framework. By adding the
.no-spinners utility, Bootstrap provides a standardized, reusable solution that
aligns with its philosophy of offering flexible, ready-to-use utilities for
common styling tasks. This enhances the framework’s utility suite, reduces
the need for external overrides, and ensures consistency across projects that
rely on Bootstrap.
The .no-spinners utility solves several problems faced by developers:
* Inconsistent default behavior across browsers;
* Aesthetic and usability customization;
* Lack of native Bootstrap support; and,
* Community Demand

### Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews
- 

### Related issues
This pull request addresses a recurring need in the Bootstrap community for controlling the appearance of spinner arrows in `<input type="number">` elements. Below are some related issues and discussions from the Bootstrap GitHub repository:

- **Issue #8350: `input[type="number"]` not displaying properly in Chrome** (Opened June 29, 2013)  
  - Link: https://github.com/twbs/bootstrap/issues/8350  
  - Description: Users reported inconsistencies with `<input type="number">` rendering, including spinner visibility issues in Chrome. A suggested fix involved CSS targeting `::-webkit-outer-spin-button` and `::-webkit-inner-spin-button`, similar to this PR’s approach.

- **Issue #28600: Spinner inside input** (Opened April 1, 2019)  
  - Link: https://github.com/twbs/bootstrap/issues/28600  
  - Description: A feature request to embed loading spinners inside inputs. This reflects broader interest in input customization, including spinner control.

- **General Community Feedback**: Frequent discussions on Stack Overflow and forums highlight the need for spinner removal, often using custom CSS. This PR formalizes that solution within Bootstrap.
