### PR TITLE
Docs: use 'i.e.' instead of 'e.g.' in Floating Labels example description

### DIFF
--- a/site/content/docs/5.3/forms/floating-labels.md
+++ b/site/content/docs/5.3/forms/floating-labels.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Example
 
-Wrap a pair of `<input class="form-control">` and `<label>` elements in `.form-floating` to enable floating labels with Bootstrap's textual form fields. A `placeholder` is required on each `<input>` as our method of CSS-only floating labels uses the `:placeholder-shown` pseudo-element. Also note that the `<input>` must come first so we can utilize a sibling selector (e.g., `~`).
+Wrap a pair of `<input class="form-control">` and `<label>` elements in `.form-floating` to enable floating labels with Bootstrap's textual form fields. A `placeholder` is required on each `<input>` as our method of CSS-only floating labels uses the `:placeholder-shown` pseudo-element. Also note that the `<input>` must come first so we can utilize a sibling selector (i.e., `~`).
 
 {{< example >}}
 <div class="form-floating mb-3">


### PR DESCRIPTION
### Description

Simple modification after the feedback from https://github.com/twbs/bootstrap/issues/41362. Indeed, "i.e." is to be used in that context.