### PR TITLE
fix: add navbar hover bg variables (#41316)

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1208,6 +1208,7 @@ $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
 
 $navbar-light-color:                rgba(var(--#{$prefix}emphasis-color-rgb), .65) !default;
 $navbar-light-hover-color:          rgba(var(--#{$prefix}emphasis-color-rgb), .8) !default;
+$navbar-light-hover-bg:             rgba(var(--#{$prefix}secondary-bg-rgb), 0.1) !default;
 $navbar-light-active-color:         rgba(var(--#{$prefix}emphasis-color-rgb), 1) !default;
 $navbar-light-disabled-color:       rgba(var(--#{$prefix}emphasis-color-rgb), .3) !default;
 $navbar-light-icon-color:           rgba($body-color, .75) !default;
@@ -1220,6 +1221,7 @@ $navbar-light-brand-hover-color:    $navbar-light-active-color !default;
 // scss-docs-start navbar-dark-variables
 $navbar-dark-color:                 rgba($white, .55) !default;
 $navbar-dark-hover-color:           rgba($white, .75) !default;
+$navbar-dark-hover-bg:              rgba(var(--#{$prefix}secondary-bg-rgb), 0.2) !default;
 $navbar-dark-active-color:          $white !default;
 $navbar-dark-disabled-color:        rgba($white, .25) !default;
 $navbar-dark-icon-color:            $navbar-dark-color !default;


### PR DESCRIPTION
### Description

This PR adds two missing SCSS variables for navbar link background colors on hover:

- `$navbar-light-hover-bg`
- `$navbar-dark-hover-bg`

These variables allow theme authors to customize the background color on hover for light and dark navbars, similar to the already-existing `*-hover-color` variables.

### Motivation & Context

Currently, Bootstrap provides `navbar-light-hover-color` and `navbar-dark-hover-color` but lacks corresponding background color variables. This limits customization options and makes it difficult to apply consistent theming via variables. This PR resolves issue #41316.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41372--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->

Closes #41316
