### PR TITLE
Fix border shortcomings: Add separate border utilities for bb-2, bt-2, by-2,etc (#41371)

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -477,6 +477,61 @@ $utilities: map-merge(
       class: ps,
       values: $spacers
     ),
+    // Border Width Utilities
+    "border": (
+      responsive: true,
+      property: border-width,
+      class: b,
+      values: $border-widths
+    ),
+    "border-top": (
+      responsive: true,
+      property: border-top-width,
+      class: bt,
+      values: $border-widths
+    ),
+    "border-bottom": (
+      responsive: true,
+      property: border-bottom-width,
+      class: bb,
+      values: $border-widths
+    ),
+    "border-left": (
+      responsive: true,
+      property: border-left-width,
+      class: bl,
+      values: $border-widths
+    ),
+    "border-right": (
+      responsive: true,
+      property: border-right-width,
+      class: br,
+      values: $border-widths
+    ),
+    "border-start": (
+      responsive: true,
+      property: border-inline-start-width,
+      class: bs,
+      values: $border-widths
+    ),
+    "border-end": (
+      responsive: true,
+      property: border-inline-end-width,
+      class: be,
+      values: $border-widths
+    ),
+    "border-x": (
+      responsive: true,
+      property: border-left-width border-right-width,
+      class: bx,
+      values: $border-widths
+    ),
+    "border-y": (
+      responsive: true,
+      property: border-top-width border-bottom-width,
+      class: by,
+      values: $border-widths
+    ),
     // Gap utility
     "gap": (
       responsive: true,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -478,55 +478,55 @@ $utilities: map-merge(
       values: $spacers
     ),
     // Border Width Utilities
-    "border": (
+    "border-width": (
       responsive: true,
       property: border-width,
       class: b,
       values: $border-widths
     ),
-    "border-top": (
+    "border-top-width": (
       responsive: true,
       property: border-top-width,
       class: bt,
       values: $border-widths
     ),
-    "border-bottom": (
+    "border-bottom-width": (
       responsive: true,
       property: border-bottom-width,
       class: bb,
       values: $border-widths
     ),
-    "border-left": (
+    "border-left-width": (
       responsive: true,
       property: border-left-width,
       class: bl,
       values: $border-widths
     ),
-    "border-right": (
+    "border-right-width": (
       responsive: true,
       property: border-right-width,
       class: br,
       values: $border-widths
     ),
-    "border-start": (
+    "border-start-width": (
       responsive: true,
       property: border-inline-start-width,
       class: bs,
       values: $border-widths
     ),
-    "border-end": (
+    "border-end-width": (
       responsive: true,
       property: border-inline-end-width,
       class: be,
       values: $border-widths
     ),
-    "border-x": (
+    "border-x-width": (
       responsive: true,
       property: border-left-width border-right-width,
       class: bx,
       values: $border-widths
     ),
-    "border-y": (
+    "border-y-width": (
       responsive: true,
       property: border-top-width border-bottom-width,
       class: by,

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -478,7 +478,7 @@ $utilities: map-merge(
       values: $spacers
     ),
     // Border Width Utilities
-    "border-width": (
+    "border-thickness": (
       responsive: true,
       property: border-width,
       class: b,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -418,6 +418,24 @@ $spacers: (
 ) !default;
 // scss-docs-end spacer-variables-maps
 
+// scss-docs-start border-width-variables-maps
+// Border Widths
+//
+// Define custom border width sizes that can be used with the border utilities.
+// This map controls the width of borders that are applied via Bootstrap's
+// border-width utilities (e.g., .bt-1, .bb-2, .bs-3, etc.).
+
+// Default border-width value is 1px, but can be customized.
+$border-widths: (
+  0: 0,               // No border width
+  1: 1px,             // Thin border
+  2: 2px,             // Medium border
+  3: 3px,             // Thick border
+  4: 4px,             // Extra thick border
+  5: 5px              // Maximum border width
+) !default;
+// scss-docs-end border-width-variables-maps
+
 // Position
 //
 // Define the edge positioning anchors of the position utilities.


### PR DESCRIPTION
### Description

This PR adds utility classes for setting individual border widths (top, bottom, left, right, start, end, x, y) using concise class names such as .bt-2, .bb-1, .bs-3, etc. These follow the pattern and spirit of existing spacing utilities (mt-2, mb-4, etc.), but for border thickness.

### Motivation & Context

Currently, Bootstrap does not provide utility classes for customizing individual border widths beyond the default border shorthand classes. This makes it inconvenient to adjust specific borders (e.g., only the bottom) with different widths. This PR fixes that gap by allowing consistent and granular border width utilities—similar to how margin/padding work.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41377--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
Fixes #41371
