### PR TITLE
Bump `image-size` from 1.0.2 to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "globby": "^14.1.0",
         "hammer-simulator": "0.0.1",
         "htmlparser2": "^10.0.0",
-        "image-size": "^1.0.2",
+        "image-size": "^2.0.2",
         "ip": "^2.0.1",
         "jasmine": "^5.6.0",
         "jquery": "^3.7.1",
@@ -9450,14 +9450,11 @@
       "license": "ISC"
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -14947,16 +14944,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "globby": "^14.1.0",
     "hammer-simulator": "0.0.1",
     "htmlparser2": "^10.0.0",
-    "image-size": "^1.0.2",
+    "image-size": "^2.0.2",
     "ip": "^2.0.1",
     "jasmine": "^5.6.0",
     "jquery": "^3.7.1",

--- a/site/src/components/head/Social.astro
+++ b/site/src/components/head/Social.astro
@@ -14,7 +14,7 @@ interface Props {
 const { description, layout, thumbnail, title } = Astro.props
 
 const socialImageUrl = new URL(getVersionedDocsPath(`assets/${thumbnail}`), Astro.site)
-const socialImageSize = getStaticImageSize(`/docs/[version]/assets/${thumbnail}`)
+const socialImageSize = await getStaticImageSize(`/docs/[version]/assets/${thumbnail}`)
 ---
 
 <meta name="twitter:card" content="summary_large_image" />

--- a/site/src/libs/image.ts
+++ b/site/src/libs/image.ts
@@ -1,11 +1,14 @@
 import path from 'node:path'
+import { promises as fs } from 'node:fs'
 import sizeOf from 'image-size'
 import { getDocsStaticFsPath } from './path'
 
-export function getStaticImageSize(imagePath: string) {
-  const size = sizeOf(path.join(getDocsStaticFsPath(), imagePath))
+export async function getStaticImageSize(imagePath: string) {
+  const fullPath = path.join(getDocsStaticFsPath(), imagePath)
+  const buffer = await fs.readFile(fullPath)
+  const size = await sizeOf(buffer)
 
-  if (!size.height || !size.width) {
+  if (!size?.height || !size?.width) {
     throw new Error(`Failed to get size of static image at '${imagePath}'.`)
   }
 


### PR DESCRIPTION
This PR bumps `image-size` from version 1.0.2 to 2.0.2 and updates the code to ensure the documentation builds successfully.

As shown in the deployed Netlify preview, the meta information is correctly generated:

```html
<meta property="og:image:width" content="2000" />
<meta property="og:image:height" content="1000" />
```