### PR TITLE
docs: add note about integrity attribute when using local Bootstrap files

### DIFF
--- a/build/gen-integrity.js
+++ b/build/gen-integrity.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+
+function generateIntegrity(filePath) {
+  const fileBuffer = fs.readFileSync(filePath);
+  const hash = crypto.createHash('sha384').update(fileBuffer).digest('base64');
+  console.log(`${path.basename(filePath)}:\nsha384-${hash}`);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error("Usage: node build/gen-integrity.js <file>");
+  process.exit(1);
+}
+
+args.forEach(generateIntegrity);

--- a/site/src/content/docs/getting-started/introduction.mdx
+++ b/site/src/content/docs/getting-started/introduction.mdx
@@ -152,3 +152,15 @@ Stay up-to-date on the development of Bootstrap and reach out to the community w
 - Developers should use the keyword `bootstrap` on packages that modify or add to the functionality of Bootstrap when distributing through [npm](https://www.npmjs.com/search?q=keywords:bootstrap) or similar delivery mechanisms for maximum discoverability.
 
 You can also follow [@getbootstrap on X](https://x.com/[[config:x]]) for the latest gossip and awesome music videos.
+
+
+###  Troubleshooting: Integrity Attribute with Local Files
+
+When using Bootstrap **locally** (from your own files instead of a CDN), avoid using the `integrity` attribute in `<script>` or `<link>` tags.
+
+The `integrity` attribute is intended for CDN use only, and can prevent locally hosted files from loading due to hash mismatches.
+
+Recommended:
+<script src="js/bootstrap.bundle.min.js"></script>
+ Avoid:
+<script src="js/bootstrap.bundle.min.js" integrity="..." crossorigin="anonymous"></script>

--- a/site/src/content/docs/getting-started/introduction.mdx
+++ b/site/src/content/docs/getting-started/introduction.mdx
@@ -154,13 +154,12 @@ Stay up-to-date on the development of Bootstrap and reach out to the community w
 You can also follow [@getbootstrap on X](https://x.com/[[config:x]]) for the latest gossip and awesome music videos.
 
 
-###  Troubleshooting: Integrity Attribute with Local Files
+> **Note:** If you're using Bootstrap from local files, the `integrity` attribute may cause files not to load due to hash mismatches. This is because the integrity hash is meant for CDN-hosted files and won’t match local copies unless generated manually.
 
-When using Bootstrap **locally** (from your own files instead of a CDN), avoid using the `integrity` attribute in `<script>` or `<link>` tags.
+You have two options:
 
-The `integrity` attribute is intended for CDN use only, and can prevent locally hosted files from loading due to hash mismatches.
+- **Remove the `integrity` attribute** — this is only safe if your local files are fully trusted.
+- **Generate a matching hash** using this command:
 
-Recommended:
-<script src="js/bootstrap.bundle.min.js"></script>
- Avoid:
-<script src="js/bootstrap.bundle.min.js" integrity="..." crossorigin="anonymous"></script>
+  ```bash
+  openssl dgst -sha384 -binary path/to/file.js | openssl base64 -A


### PR DESCRIPTION
This PR adds a small documentation section about troubleshooting issues with the `integrity` attribute when using Bootstrap locally.

When loading Bootstrap from local files, using the `integrity` attribute may cause files not to load due to hash mismatches. This update explains the issue and provides a recommended solution for local development.

The note was added to `introduction.mdx` under the "Getting Started" section.

Fixes #41388
