### PR TITLE
Fix typos and code indentation in Forms > Checks and radios

### DIFF
--- a/site/src/content/docs/forms/checks-radios.mdx
+++ b/site/src/content/docs/forms/checks-radios.mdx
@@ -9,7 +9,7 @@ toc: true
 
 Browser default checkboxes and radios are replaced with the help of `.form-check`, a series of classes for both input types that improves the layout and behavior of their HTML elements, that provide greater customization and cross browser consistency. Checkboxes are for selecting one or several options in a list, while radios are for selecting one option from many.
 
-Structurally, our `<input>`s and `<label>`s are sibling elements as opposed to an `<input>` within a `<label>`. This is slightly more verbose as you must specify `id` and `for` attributes to relate the `<input>` and `<label>`. We use the sibling selector (`~`) for all our `<input>` states, like `:checked` or `:disabled`. When combined with the `.form-check-label` class, we can easily style the text for each item based on the `<input>`'s state.
+Structurally, our `<input>`s and `<label>`s are sibling elements as opposed to an `<input>` within a `<label>`. This is slightly more verbose as you must specify `id` and `for` attributes to relate the `<input>` and `<label>`. We use the sibling selector (`~`) for all our `<input>` states, like `:checked` or `:disabled`. When combined with the `.form-check-label` class, we can easily style the text for each item based on the `<input>`’s state.
 
 Our checks use custom Bootstrap icons to indicate checked or indeterminate states.
 
@@ -41,7 +41,7 @@ Checkboxes can utilize the `:indeterminate` pseudo class when manually set via J
 
 ### Disabled
 
-Add the `disabled` attribute and the associated `<label>`s are automatically styled to match with a lighter color to help indicate the input's state.
+Add the `disabled` attribute and the associated `<label>`s are automatically styled to match with a lighter color to help indicate the input’s state.
 
 <Example addStackblitzJs class="bd-example-indeterminate" code={`<div class="form-check">
     <input class="form-check-input" type="checkbox" value="" id="checkIndeterminateDisabled" disabled>
@@ -79,7 +79,7 @@ Add the `disabled` attribute and the associated `<label>`s are automatically sty
 
 ### Disabled
 
-Add the `disabled` attribute and the associated `<label>`s are automatically styled to match with a lighter color to help indicate the input's state.
+Add the `disabled` attribute and the associated `<label>`s are automatically styled to match with a lighter color to help indicate the input’s state.
 
 <Example code={`<div class="form-check">
     <input class="form-check-input" type="radio" name="radioDisabled" id="radioDisabled" disabled>
@@ -120,11 +120,11 @@ A switch has the markup of a custom checkbox but uses the `.form-switch` class t
 Progressively enhance your switches for mobile Safari (iOS 17.4+) by adding a `switch` attribute to your input to enable haptic feedback when toggling switches, just like native iOS switches. There are no style changes attached to using this attribute in Bootstrap as all our switches use custom styles.
 
 <Example code={`<div class="form-check form-switch">
-  <input class="form-check-input" type="checkbox" value="" id="checkNativeSwitch" switch>
-  <label class="form-check-label" for="checkNativeSwitch">
-    Native switch haptics
-  </label>
-</div>`} />
+    <input class="form-check-input" type="checkbox" value="" id="checkNativeSwitch" switch>
+    <label class="form-check-label" for="checkNativeSwitch">
+      Native switch haptics
+    </label>
+  </div>`} />
 
 Be sure to read more about [the switch attribute on the WebKit blog](https://webkit.org/blog/15054/an-html-switch-control/). Safari 17.4+ on macOS and iOS both have native-style switches in HTML while other browsers simply fall back to the standard checkbox appearance. Applying the attribute to a non-Bootstrap checkbox in more recent versions of Safari will render a native switch.
 
@@ -253,7 +253,7 @@ Create button-like checkboxes and radio buttons by using `.btn` styles rather th
 <label class="btn" for="btn-check-6">Disabled</label>`} />
 
 <Callout>
-Visually, these checkbox toggle buttons are identical to the [button plugin toggle buttons]([[docsref:/components/buttons#button-plugin]]). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as "checked"/"not checked" (since, despite their appearance, they are fundamentally still checkboxes), whereas the button plugin toggle buttons will be announced as "button"/"button pressed". The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
+Visually, these checkbox toggle buttons are identical to the [button plugin toggle buttons]([[docsref:/components/buttons#button-plugin]]). However, they are conveyed differently by assistive technologies: the checkbox toggles will be announced by screen readers as “checked“/“not checked“ (since, despite their appearance, they are fundamentally still checkboxes), whereas the button plugin toggle buttons will be announced as “button“/“button pressed“. The choice between these two approaches will depend on the type of toggle you are creating, and whether or not the toggle will make sense to users when announced as a checkbox or as an actual button.
 </Callout>
 
 ### Radio toggle buttons


### PR DESCRIPTION
### Description

This PR fixes some typos related to quotes/double quotes, and code indentation, after https://github.com/twbs/bootstrap/commit/dd4e14499fd48e697a1a98ed3e94bcb872669436 (after the Astro migration and rebase process).

#### Live previews

- https://deploy-preview-41399--twbs-bootstrap.netlify.app/docs/5.3/forms/checks-radios
