### PR TITLE
Remove `files` configuration from `.cspell.json`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -120,9 +120,6 @@
     "zindex"
   ],
   "language": "en-US",
-  "files": [
-    "**/*.md"
-  ],
   "ignorePaths": [
     ".cspell.json",
     "dist/",


### PR DESCRIPTION
### Description

This PR removes the `files` configuration from `.cspell.json` as we never launch locally this check and CSpell GitHub Action is already defining the files to check.

#### Test

I've added https://github.com/twbs/bootstrap/pull/41400/commits/bbcafe12fb148bcd853e903c52f79b97960343cb to check that everything fails for *.md and *.mdx files, and it works even without the `files` configuration within `.cspell.json`. And the job failed:

<img width="661" alt="Screenshot 2025-04-22 at 09 06 46" src="https://github.com/user-attachments/assets/3b614231-3afa-492f-9bd9-6908047b2206" />

