### PR TITLE
v5 Browserslist updates

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,9 +3,10 @@
 >= 0.5%
 last 2 major versions
 not dead
-Chrome >= 105
+Chrome >= 120
 Firefox >= 121
-iOS >= 15.4
-Safari >= 15.4
+iOS >= 15.6
+Safari >= 15.6
 not Explorer <= 11
-not kaios <= 2.5
+Samsung >= 23
+not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,10 +3,9 @@
 >= 0.5%
 last 2 major versions
 not dead
-Chrome >= 60
-Firefox >= 60
-Firefox ESR
-iOS >= 12
-Safari >= 12
+Chrome >= 105
+Firefox >= 121
+iOS >= 15.4
+Safari >= 15.4
 not Explorer <= 11
-not kaios <= 2.5 # fix floating label issues in Firefox (see https://github.com/postcss/autoprefixer/issues/1533)
+not kaios <= 2.5

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -8,11 +8,11 @@
     - title: Introduction
     - title: Download
     - title: Contents
-    - title: Browsers & devices
     - title: JavaScript
     - title: Webpack
     - title: Parcel
     - title: Vite
+    - title: Browsers & devices
     - title: Accessibility
     - title: RFS
     - title: RTL

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -10,7 +10,7 @@ Bootstrap supports the latest, stable releases of all major browsers and platfor
 
 <Code lang="plaintext" filePath=".browserslistrc" />
 
-See the full audience coverage and a more [detailed compatibility report at Browsersl.ist](https://browsersl.ist/#q=%3E%3D+0.5%25%0Alast+2+major+versions%0Anot+dead%0AChrome+%3E%3D+105%0AFirefox+%3E%3D+121%0AiOS+%3E%3D+15.4%0ASafari+%3E%3D+15.4%0Anot+Explorer+%3C%3D+11%0Anot+kaios+%3C%3D+2.5).
+See the full audience coverage and a more [detailed compatibility report on Browserslist](https://browsersl.ist/#q=%3E%3D+0.5%25%0Alast+2+major+versions%0Anot+dead%0AChrome+%3E%3D+105%0AFirefox+%3E%3D+121%0AiOS+%3E%3D+15.4%0ASafari+%3E%3D+15.4%0Anot+Explorer+%3C%3D+11%0Anot+kaios+%3C%3D+2.5).
 
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform’s web view API, are not explicitly supported. However, Bootstrap should (in most cases) display and function correctly in these browsers as well.
 
@@ -44,4 +44,4 @@ Page zooming inevitably presents rendering artifacts in some components, both in
 
 Bootstrap uses some browser-specific selectors to provide progressive enhancements and reset some styles across browsers. These may not always pass CSS validators, but they still have a place in real world applications. These validation warnings don’t matter in practice as they don’t interfere with the proper functioning of our styles, and we deliberately ignore these particular warnings.
 
-Likewise, our HTML has some trivial and inconsequential HTML validation warnings. Some of these are also surpressed by our own local configuration and can be ignored.
+Likewise, our HTML has some trivial and inconsequential HTML validation warnings. Some of these are also supressed by our own local configuration and can be ignored.

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -44,4 +44,4 @@ Page zooming inevitably presents rendering artifacts in some components, both in
 
 Bootstrap uses some browser-specific selectors to provide progressive enhancements and reset some styles across browsers. These may not always pass CSS validators, but they still have a place in real world applications. These validation warnings don’t matter in practice as they don’t interfere with the proper functioning of our styles, and we deliberately ignore these particular warnings.
 
-Likewise, our HTML has some trivial and inconsequential HTML validation warnings. Some of these are also supressed by our own local configuration and can be ignored.
+Likewise, our HTML has some trivial and inconsequential HTML validation warnings. Some of these are also suppressed by our own local configuration and can be ignored.

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -6,45 +6,21 @@ toc: true
 
 ## Supported browsers
 
-Bootstrap supports the **latest, stable releases** of all major browsers and platforms.
-
-Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform’s web view API, are not explicitly supported. However, Bootstrap should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
-
-You can find our supported range of browsers and their versions [in our `.browserslistrc file`]([[config:repo]]/blob/v[[config:current_version]]/.browserslistrc):
+Bootstrap supports the latest, stable releases of all major browsers and platforms. We use a [Browserslist](https://github.com/browserslist/browserslist) configuration file in the root of our project called [`.browserslistrc`]([[config:repo]]/blob/v[[config:current_version]]/.browserslistrc) to explicitly declare our browser and platform compatibility. This combines with [Autoprefixer](https://github.com/postcss/autoprefixer) to generate prefixed CSS properties for browsers as needed.
 
 <Code lang="plaintext" filePath=".browserslistrc" />
 
-We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
+See the full audience coverage and a more [detailed compatibility report at Browsersl.ist](https://browsersl.ist/#q=%3E%3D+0.5%25%0Alast+2+major+versions%0Anot+dead%0AChrome+%3E%3D+105%0AFirefox+%3E%3D+121%0AiOS+%3E%3D+15.4%0ASafari+%3E%3D+15.4%0Anot+Explorer+%3C%3D+11%0Anot+kaios+%3C%3D+2.5).
+
+Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform’s web view API, are not explicitly supported. However, Bootstrap should (in most cases) display and function correctly in these browsers as well.
 
 ### Mobile devices
 
 Generally speaking, Bootstrap supports the latest versions of each major platform’s default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile’s Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
 
-<BsTable class="table">
-| | Chrome | Firefox | Safari | Android Browser &amp; WebView |
-| --- | --- | --- | --- | --- |
-| **Android** | Supported | Supported | <span class="text-body-secondary">&mdash;</span> | v6.0+ |
-| **iOS** | Supported | Supported | Supported | <span class="text-body-secondary">&mdash;</span> |
-</BsTable>
-
 ### Desktop browsers
 
-Similarly, the latest versions of most desktop browsers are supported.
-
-<BsTable class="table">
-| | Chrome | Firefox | Microsoft Edge | Opera | Safari |
-| --- | --- | --- | --- | --- | --- |
-| **Mac** | Supported | Supported | Supported | Supported | Supported |
-| **Windows** | Supported | Supported | Supported | Supported | <span class="text-body-secondary">&mdash;</span> |
-</BsTable>
-
-For Firefox, in addition to the latest normal stable release, we also support the latest [Extended Support Release (ESR)](https://www.mozilla.org/en-US/firefox/enterprise/) version of Firefox.
-
-Unofficially, Bootstrap should look and behave well enough in Chromium and Chrome for Linux, and Firefox for Linux, though they are not officially supported.
-
-## Internet Explorer
-
-Internet Explorer is not supported. **If you require Internet Explorer support, please use Bootstrap v4.**
+Similarly, the latest versions of most desktop browsers are supported. Unofficially, Bootstrap should look and behave well enough in Chromium and Chrome for Linux, and Firefox for Linux, though they are not officially supported. Internet Explorer is not supported.
 
 ## Modals and dropdowns on mobile
 
@@ -66,8 +42,6 @@ Page zooming inevitably presents rendering artifacts in some components, both in
 
 ## Validators
 
-In order to provide the best possible experience to old and buggy browsers, Bootstrap uses [CSS browser hacks](http://browserhacks.com/) in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren’t yet fully standardized, but these are used purely for progressive enhancement.
+Bootstrap uses some browser-specific selectors to provide progressive enhancements and reset some styles across browsers. These may not always pass CSS validators, but they still have a place in real world applications. These validation warnings don’t matter in practice as they don’t interfere with the proper functioning of our styles, and we deliberately ignore these particular warnings.
 
-These validation warnings don’t matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don’t interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.
-
-Our HTML docs likewise have some trivial and inconsequential HTML validation warnings due to our inclusion of a workaround for [a certain Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=654072).
+Likewise, our HTML has some trivial and inconsequential HTML validation warnings. Some of these are also surpressed by our own local configuration and can be ignored.


### PR DESCRIPTION
Fixes #41390.

This implements the suggested Browserslist I put in #41390 and adjusts the **Browsers & Devices** page to simplify and better represent the changes here. I remove all the tables here, they're just not necessary compared to the Browserslist page IMO.  I've also moved that page lower down in the Getting Started docs section as it's really not that important to getting started these days.

/cc @julien-deramond 