### PR TITLE
Ensure element exists before accessing dropdown

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -418,6 +418,9 @@ class Dropdown extends BaseComponent {
       (SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0] ||
         SelectorEngine.next(this, SELECTOR_DATA_TOGGLE)[0] ||
         SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, event.delegateTarget.parentNode))
+    if (!getToggleButton) {
+        return
+    }
 
     const instance = Dropdown.getOrCreateInstance(getToggleButton)
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

Minor check if the toggle element can be found, before using it to get or create the dropdown instance.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
We're using dropdowns in our main menu which slightly differs from the expectedBootstrap markup.
When closing the dropdown via Escape key, that triggers a JavaScript error as the element Bootstrap is looking for is not present in our code.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
