### PR TITLE
Docs: Remove unneeded Twitter/X metatags (as it uses Open Graph for title/description and image)

### DIFF
--- a/site/src/components/head/Social.astro
+++ b/site/src/components/head/Social.astro
@@ -20,9 +20,6 @@ const socialImageSize = await getStaticImageSize(`/docs/[version]/assets/${thumb
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content=`@${getConfig().x}` />
 <meta name="twitter:creator" content=`@${getConfig().x}` />
-<meta name="twitter:title" content={title} />
-<meta name="twitter:description" content={description} />
-<meta name="twitter:image" content={socialImageUrl} />
 
 <meta property="og:url" content={new URL(Astro.url.pathname, Astro.site)} />
 <meta property="og:title" content={title} />


### PR DESCRIPTION
### Description

No need to define description, title and image twitter cards since it'll use Open Graph ones anyway (which are identical).

For reference see bottom section at: https://developer.x.com/en/docs/x-for-websites/cards/guides/getting-started#twitter-cards-and-open-graph

### Motivation & Context

Removing this will save some bytes on every page. :-)

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41408--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
