### PR TITLE
Allow abbr styling with tooltip, fixes #39026

### DIFF
--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -117,3 +117,12 @@
   background-color: var(--#{$prefix}tooltip-bg);
   @include border-radius(var(--#{$prefix}tooltip-border-radius));
 }
+
+// Workaround for abbr when tooltip substitutes title for data-bs-original-title
+//
+// This matches the abbr styling in _reboot.scss
+abbr[data-bs-original-title] {
+  text-decoration: underline dotted;
+  cursor: help;
+  text-decoration-skip-ink: none;
+}


### PR DESCRIPTION
### Description

This allows the `abbr` element to retain styling if you are using tooltips.

The tooltips feature will remove the `title` attribute, so the original `abbr[title]` rule no longer applies.

### Motivation & Context

Closes https://github.com/twbs/bootstrap/issues/39026

To allow the usage:

```html
<abbr title="Bootstrap">BS</abbr> is awesome
```

and allow people to hover that text to show the full title.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

Here is the test case before this change.

https://stackblitz.com/edit/github-rpfnqj-hsmnpo?file=index.html

<mark>I need help to edit this to use the new built change after this PR.</mark>

- <https://deploy-preview-41421--twbs-bootstrap.netlify.app/>

### Related issues

- https://github.com/twbs/bootstrap/issues/39026