### PR TITLE
Fix broken `View on GitHub` url

### DIFF
--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -65,7 +65,7 @@ if (frontmatter.toc) {
             }
             <a
               class="btn btn-sm btn-bd-light rounded-2"
-              href={`${getConfig().repo}/blob/v${getConfig().current_version}/site/src/content/${id}`}
+              href={`${getConfig().repo}/blob/v${getConfig().current_version}/site/src/content/docs/${id}`}
               title="View and edit this file on GitHub"
               target="_blank"
               rel="noopener"


### PR DESCRIPTION
### Description
Fixes the issue of `View on GitHub` opening incorrect files.

### Type of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
