### PR TITLE
Fix HTML `<head>` content built from 'Download examples' button

### DIFF
--- a/build/zip-examples.mjs
+++ b/build/zip-examples.mjs
@@ -88,9 +88,9 @@ for (const file of sh.find(`${distFolder}/**/*.html`)) {
     .toString()
     .replace(new RegExp(`"/docs/${versionShort}/`, 'g'), '"../')
     .replace(/"..\/dist\//g, '"../assets/dist/')
-    .replace(/(<link href="\.\.\/.*) integrity=".*>/g, '$1>')
-    .replace(/(<script src="\.\.\/.*) integrity=".*>/g, '$1></script>')
-    .replace(/( +)<!-- favicons(.|\n)+<style>/i, '    <style>')
+    .replace(/(<link href="\.\.\/[^"]*"[^>]*) integrity="[^"]*"/g, '$1')
+    .replace(/<link[^>]*href="\.\.\/assets\/img\/favicons\/[^"]*"[^>]*>/g, '')
+    .replace(/(<script src="\.\.\/[^"]*"[^>]*) integrity="[^"]*"/g, '$1')
   new sh.ShellString(fileContents).to(file)
 }
 


### PR DESCRIPTION
### Description

This PR fixes the issue mentioned at https://github.com/orgs/twbs/discussions/41437#discussioncomment-13066048.

When clicking on 'Download examples' in the documentation, HTML `<head>` content is broken; e.g. in `bootstrap-5.3.6-examples/navbars/index.html`:

```html
<link rel="canonical" href="https://getbootstrap.com/docs/5.3/examples/navbars/">
<script src="../assets/js/color-modes.js"></script>
<link href="../assets/dist/css/bootstrap.min.css" rel="stylesheet">
.bd-placeholder-img{font-size:1.125rem;text-anchor:middle;-webkit-user-select:none;-moz-user-select:none;user-select:none}@media
(min-width:
768px){.bd-placeholder-img-lg{font-size:3.5rem}}.b-example-divider{width:100%;height:3rem;background-color:#0000001a;border:solid
rgba(0,0,0,.15);border-width:1px 0;box-shadow:inset 0 .5em 1.5em #0000001a,inset 0 .125em .5em
#00000026}.b-example-vr{flex-shrink:0;width:1.5rem;height:100vh}.bi{vertical-align:-.125em;fill:currentColor}.nav-scroller{position:relative;z-index:2;height:2.75rem;overflow-y:hidden}.nav-scroller
.nav{display:flex;flex-wrap:nowrap;padding-bottom:1rem;margin-top:-1px;overflow-x:auto;text-align:center;white-space:nowrap;-webkit-overflow-scrolling:touch}.btn-bd-primary{--bd-violet-bg:
#712cf9;--bd-violet-rgb: 112.520718, 44.062154, 249.437846;--bs-btn-font-weight: 600;--bs-btn-color:
var(--bs-white);--bs-btn-bg: var(--bd-violet-bg);--bs-btn-border-color: var(--bd-violet-bg);--bs-btn-hover-color:
var(--bs-white);--bs-btn-hover-bg: #6528e0;--bs-btn-hover-border-color: #6528e0;--bs-btn-focus-shadow-rgb:
var(--bd-violet-rgb);--bs-btn-active-color: var(--bs-btn-hover-color);--bs-btn-active-bg:
#5a23c8;--bs-btn-active-border-color: #5a23c8}.bd-mode-toggle{z-index:1500}.bd-mode-toggle
.bi{width:1em;height:1em}.bd-mode-toggle .dropdown-menu .active .bi{display:block!important}
</style>
```

### How to test

```
npm run release-zip-examples
unzip bootstrap-5.3.6-examples.zip
cd bootstrap-5.3.6-examples
http-server
```

Go to http://127.0.0.1:8080/album, http://127.0.0.1:8080/badges, etc.

- [x] Check the rendering of all examples

### Comparison with v5.2.3

In v5.2.3:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="description" content="">
    <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
    <meta name="generator" content="Hugo 0.104.2">
    <title>Album example · Bootstrap v5.2</title>

    <link rel="canonical" href="https://getbootstrap.com/docs/5.2/examples/album/">

    

    

<link href="../assets/dist/css/bootstrap.min.css" rel="stylesheet">

    <style>
      .bd-placeholder-img {
```

In this branch:

```html
<!DOCTYPE html>
<html lang="en" data-bs-theme="auto">

<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <meta name="description" content="">
  <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
  <meta name="generator" content="Astro v5.7.12">
  <title>Album example · Bootstrap v5.3</title>
  <link rel="canonical" href="https://getbootstrap.com/docs/5.3/examples/album/">
  <script src="../assets/js/color-modes.js"></script>
  <link href="../assets/dist/css/bootstrap.min.css" rel="stylesheet">
  <meta name="theme-color" content="#712cf9">
  <style>
    .bd-placeholder-img {
```

- [x] Get rid of the `<link>`s with the favicons
- [x] ~~Get rid of the `<meta name="theme-color">` one?~~ Let's keep it as it doesn't cause any issues.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed