### PR TITLE
Tweak `.visually-hidden` to use `display:inline-block` instead of absolute positioning

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "./dist/css/bootstrap-utilities.min.css",
-      "maxSize": "10.75 kB"
+      "maxSize": "11 kB"
     },
     {
       "path": "./dist/css/bootstrap.css",

--- a/scss/mixins/_visually-hidden.scss
+++ b/scss/mixins/_visually-hidden.scss
@@ -6,6 +6,7 @@
 // See: https://kittygiraudel.com/2016/10/13/css-hide-and-seek/
 
 @mixin visually-hidden() {
+  display: inline-block !important; // using this rather than position:absolute to allow for width/height/clip to work without causing undue spacing (e.g. in responsive tables)
   width: 1px !important;
   height: 1px !important;
   padding: 0 !important;
@@ -14,11 +15,6 @@
   clip: rect(0, 0, 0, 0) !important;
   white-space: nowrap !important;
   border: 0 !important;
-
-  // Fix for positioned table caption that could become anonymous cells
-  &:not(caption) {
-    position: absolute !important;
-  }
 
   // Fix to prevent overflowing children to become focusable
   * {

--- a/scss/mixins/_visually-hidden.scss
+++ b/scss/mixins/_visually-hidden.scss
@@ -7,12 +7,14 @@
 
 @mixin visually-hidden() {
   display: inline-block !important; // using this rather than position:absolute to allow for width/height/clip to work without causing undue spacing (e.g. in responsive tables)
+  flex: none !important;
   width: 1px !important;
   height: 1px !important;
   padding: 0 !important;
   margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
   overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  contain: strict !important;
   white-space: nowrap !important;
   border: 0 !important;
 


### PR DESCRIPTION
### Description

Use `display:inline-block` instead of `position:absolute` for `.visually-hidden`

### Motivation & Context

While tried and tested, the regular `.visually-hidden` styles have unintended consequences in certain scenarios, such as inside responsive tables - see https://github.com/twbs/bootstrap/issues/31885

As the `position:absolute` is used essentially to force the element to accept explicit `width`/`height`/`clip` even when it's currently inline, this new approach should have the same end result, but without causing any more accidental spacing.

---

See the redone example from #31885 (replacing the old `.sr-only` with `.visually-hidden`), with overrides that mimic the end result of this PR: https://codepen.io/team/bootstrap/pen/azzxqBZ (removing the overrides in the Pen's CSS shows the current broken behaviour: make the viewport/browser window narrow, and notice how - just like in the original #31885 issue - the visually hidden content in the last cell of the first row leads to whitespace to the right of the table that then results in a page-level horizontal scrollbar)

---

Suggest extensive testing of this, to make sure the change doesn't now cause *other* unintended consequences elsewhere. Suggest also testing on devices that are notoriously flaky ... like "does it work as expected on iOS/Safari with/without VoiceOver running".

**Marking as a breaking change because it has the *potential* to break things if an author did heavily rely on the old styles for some reason.**

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41474--twbs-bootstrap.netlify.app/>

### Related issues

https://github.com/twbs/bootstrap/issues/31885
