### PR TITLE
Docs: ensure `stackblitz.js` loads conditionally as intended

### DIFF
--- a/site/src/components/DocsScripts.astro
+++ b/site/src/components/DocsScripts.astro
@@ -1,5 +1,4 @@
 ---
-
 ---
 
 <script src="../assets/stackblitz.js"></script>

--- a/site/src/components/DocsScripts.astro
+++ b/site/src/components/DocsScripts.astro
@@ -1,0 +1,5 @@
+---
+
+---
+
+<script src="../assets/stackblitz.js"></script>

--- a/site/src/components/Scripts.astro
+++ b/site/src/components/Scripts.astro
@@ -1,6 +1,7 @@
 ---
 import { getVersionedBsJsProps } from '@libs/bootstrap'
 import type { Layout } from '@libs/layout'
+import DocsScripts from './DocsScripts.astro'
 
 interface Props {
   layout: Layout
@@ -14,4 +15,4 @@ const { layout } = Astro.props
 <script src="../assets/application.js"></script>
 <script src="../assets/search.js"></script>
 
-{layout === 'docs' && <script src="../assets/stackblitz.js" />}
+{layout === 'docs' && <DocsScripts />}


### PR DESCRIPTION
### Description & Motivation & Context

During backporting the Astro commit to our doc, there was an issue regarding the Scripts bundled by Astro. I couldn't spot it on Bootstrap side but on our side. The `stackblitz.js` is loaded on the landing page (main branch) and not the `application.js` contrary at what is specified in `Scripts.astro`.

Special thanks to @vprothais !

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-41482--twbs-bootstrap.netlify.app/>

### Related issues

NA
