### PR TITLE
Docs: fix local assets path handling for Windows compatibility

### DIFF
--- a/site/src/libs/examples.ts
+++ b/site/src/libs/examples.ts
@@ -58,13 +58,13 @@ function getExamplesAssetsRecursively(source: string, assets: string[] = []) {
 }
 
 function sanitizeAssetPath(assetPath: string) {
-  const matches = assetPath.match(/([^\/]+\/[^\/]+\.\w+)$/)
+  const matches = assetPath.match(/([^\/\\]+[\/\\][^\/\\]+\.\w+)$/)
 
   if (!matches || !matches[1]) {
     throw new Error(`Failed to get example asset path from path: '${assetPath}'.`)
   }
 
-  return matches[1]
+  return matches[1].replaceAll('\\', '/')
 }
 
 function isAliasedAstroInstance(page: AstroInstance): page is AliasedAstroInstance {

--- a/site/src/libs/path.ts
+++ b/site/src/libs/path.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { getConfig } from './config'
+import { fileURLToPath } from 'node:url';
 
 // The docs directory path relative to the root of the project.
 export const docsDirectory = getConfig().docsDir
@@ -32,7 +33,7 @@ export function validateVersionedDocsPaths(distUrl: URL) {
 
   for (const docsPath of generatedVersionedDocsPaths) {
     const sanitizedDocsPath = sanitizeVersionedDocsPathForValidation(docsPath)
-    const absoluteDocsPath = path.join(distUrl.pathname, 'docs', docs_version, sanitizedDocsPath)
+    const absoluteDocsPath = fileURLToPath(new URL(path.join( './docs', docs_version, sanitizedDocsPath), distUrl));
 
     const docsPathExists = fs.existsSync(absoluteDocsPath)
 


### PR DESCRIPTION
### Description & Motivation & Context

On Windows, I had some troubles having the examples working with extraCss or extraJs working on local. The solution was to add some `\` in the path regex and it works fine on my side now.

Here is the rendering I have on main when I want to acces to the grid example:
![image](https://github.com/user-attachments/assets/e3e067dd-e3fd-420a-92e4-85fc14bc1860)

Here is the trace I have in the terminal:
```sh
09:49:31 [ERROR] Failed to get example asset path from path: '**\bootstrap\site\src\assets\examples\badges\badges.css'.
  Stack trace:
    at sanitizeAssetPath (**\bootstrap\site\src\libs\examples.ts:64:11)
    at getExamplesAssetsRecursively (**\bootstrap\site\src\libs\examples.ts:53:7)
    at Module.getStaticPaths (**\bootstrap\site\src\pages\docs\[version]\examples\[...asset].ts:10:26)
    [...] See full stack trace in the browser, or rerun with --verbose.
```

with the change, it behaves correctly.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41485--twbs-bootstrap.netlify.app/>

### Related issues

NA
