### PR TITLE
Docs: fix typo on Masonry example

### DIFF
--- a/site/src/assets/examples/masonry/index.astro
+++ b/site/src/assets/examples/masonry/index.astro
@@ -18,7 +18,7 @@ import Placeholder from "@shortcodes/Placeholder.astro"
 &lt;script src=&quot;https://cdn.jsdelivr.net/npm/masonry-layout@4.2.2/dist/masonry.pkgd.min.js&quot; integrity=&quot;sha384-GNFwBvfVxBkLMJpYMOABq3c+d3KnQxudP/mGPkzpZSTYykLBNsZEnG2D9G/X/+7D&quot; crossorigin=&quot;anonymous&quot; async&gt;&lt;/script&gt;
   </code></pre>
 
-  <p>By adding <code>data-masonry='&rcub;"percentPosition": true &rcub;'</code> to the <code>.row</code> wrapper, we can combine the powers of Bootstrap's responsive grid and Masonry's positioning.</p>
+  <p>By adding <code>data-masonry='&lcub;"percentPosition": true &rcub;'</code> to the <code>.row</code> wrapper, we can combine the powers of Bootstrap's responsive grid and Masonry's positioning.</p>
 
   <hr class="my-5">
 


### PR DESCRIPTION
### Description

Fixing a typo on Masonry example page

### Motivation & Context

Text was `data-masonry='}"percentPosition": true }'` instead of `data-masonry='{"percentPosition": true }'`

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41486--twbs-bootstrap.netlify.app/docs/5.3/examples/masonry/>

