### PR TITLE
Docs: improve a11y on section heading anchor links

### DIFF
--- a/site/src/libs/astro.ts
+++ b/site/src/libs/astro.ts
@@ -5,7 +5,7 @@ import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import type { AstroIntegration } from 'astro'
 import autoImport from 'astro-auto-import'
-import type { Element } from 'hast'
+import type { Element, Text } from 'hast'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import { getConfig } from './config'
 import { rehypeBsTable } from './rehype'
@@ -59,7 +59,10 @@ export function bootstrap(): AstroIntegration[] {
                   {
                     behavior: 'append',
                     content: [{ type: 'text', value: ' ' }],
-                    properties: { class: 'anchor-link' },
+                    properties: (element: Element) => ({
+                      class: 'anchor-link',
+                      ariaLabel: `Link to this section: ${(element.children[0] as Text).value}`
+                    }),
                     test: (element: Element) => element.tagName.match(headingsRangeRegex)
                   }
                 ],


### PR DESCRIPTION
### Description

Add content in `anchor-links` in the section headings of the documentation. This is an accessibility improvement to vocalise the actual text of the heading on keyboard navigation. 
I added 2 `span`s, one with `.visually-hidden` the other with `.aria-hidden` to contain the # and deleted the # added in `:after` pseudo-element as it was wrongly vocalized.

### Motivation & Context

At the moment, the # anchor link on each section heading is vocalized as "Number" without any other precision and therefore do not provide any useful information to users of assistive technologies.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-41487--twbs-bootstrap.netlify.app/>
