### PR TITLE
Form Validation: Increase `$form-feedback-font-size` to make `.invalid-feedback` larger

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1085,7 +1085,7 @@ $form-floating-transition:              opacity .1s ease-in-out, transform .1s e
 
 // scss-docs-start form-feedback-variables
 $form-feedback-margin-top:          $form-text-margin-top !default;
-$form-feedback-font-size:           $form-text-font-size !default;
+$form-feedback-font-size:           $font-size-base !default;
 $form-feedback-font-style:          $form-text-font-style !default;
 $form-feedback-valid-color:         $success !default;
 $form-feedback-invalid-color:       $danger !default;


### PR DESCRIPTION
### Description

Increase the `font-size` of `.invalid-feedback` to the regular body font size (which I guess is `$font-size-base`).

### Motivation & Context

Although common, it's actually weird to display error messages in smaller font size, cause:
* **When an error message is present, this is the most important text on the entire page** In this case, visual appeal is less important than a legible message informing the user what actually is wrong with their input.
* Most of the time the error message isn't shown at all (especially when initially loading the page), so it doesn't hinder the page's overall appeal.

I'm aware that this also affects `.valid-feedback`. This is OK for me (positive feedback should be legible as well), but maybe it would be better to introduce separate font size variables for `.valid` and `.invalid`.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [ ] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

https://deploy-preview-41488--twbs-bootstrap.netlify.app/docs/5.3/forms/validation/#server-side