### PR TITLE
Add text-wrap balance and pretty to complement existing white-space utils

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -565,6 +565,14 @@ $utilities: map-merge(
         nowrap: nowrap,
       )
     ),
+    "text-wrap": (
+      property: text-wrap,
+      class: text,
+      values: (
+        balance: balance,
+        pretty: pretty,
+      )
+    ),
     "word-wrap": (
       property: word-wrap word-break,
       class: text,

--- a/site/src/content/docs/utilities/text.mdx
+++ b/site/src/content/docs/utilities/text.mdx
@@ -26,14 +26,26 @@ Note that we don’t provide utility classes for justified text. While, aestheti
 
 Wrap text with a `.text-wrap` class.
 
-<Example code={`<div class="badge text-bg-primary text-wrap" style="width: 6rem;">
-    This text should wrap.
+<Example code={`<div class="text-wrap bg-body-secondary border" style="width: 8rem;">
+    This snippet of text should wrap.
   </div>`} />
 
 Prevent text from wrapping with a `.text-nowrap` class.
 
 <Example code={`<div class="text-nowrap bg-body-secondary border" style="width: 8rem;">
     This text should overflow the parent.
+  </div>`} />
+
+Use `.text-balance` to balance evenly distribute text across multiple lines. This is computationally expensive and is thus limited by the Chromium to six lines and by Firefox to ten lines.
+
+<Example code={`<div class="text-balance mx-auto" style="width: 20rem;">
+    This text should be balanced. Here we’re writing a longer snippet of text to form a paragraph and demonstrate how the text wraps.
+  </div>`} />
+
+Use `.text-pretty` to prevent single words their own line (orphans). **Pretty text wrapping is not fully supported in Safari and Firefox at the moment.**
+
+<Example code={`<div class="text-pretty mx-auto" style="width: 20rem;">
+    This text should be pretty. Here we’re writing a longer snippet of text to form a paragraph and demonstrate how the text wraps.
   </div>`} />
 
 ## Word break


### PR DESCRIPTION
Fixes #41389 for v5. Complemented by #41490 for v6, which replaces the `white-space` utilities with all `text-wrap`.