### PR TITLE
Generate  classes for responsive screen-reader-only hiding.

### DIFF
--- a/scss/helpers/_visually-hidden.scss
+++ b/scss/helpers/_visually-hidden.scss
@@ -6,3 +6,20 @@
 .visually-hidden-focusable:not(:focus):not(:focus-within) {
   @include visually-hidden();
 }
+
+// Responsive visually hidden utilities
+//
+// Generates `.visually{-breakpoint}-hidden` classes that apply the
+// `visually-hidden` mixin starting at each breakpoint and up,
+// enabling screen-reader-only content that is conditionally hidden
+// based on viewport size.
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+  @include media-breakpoint-up($breakpoint) {
+    .visually#{$infix}-hidden {
+      @include visually-hidden();
+    }
+  }
+}


### PR DESCRIPTION
### Description

Added responsive visually hidden utility classes (e.g., .visually-lg-hidden) that apply the visually-hidden styles starting at each breakpoint and above. This allows easier control over screen-reader-only content visibility based on viewport size.

### Motivation & Context

Bootstrap currently has .visually-hidden and .visually-hidden-focusable utilities, but no responsive variants. These new classes simplify accessibility-focused UI work by enabling developers to conditionally hide content at specific breakpoints without writing custom CSS.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41519--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->

- Closes https://github.com/twbs/bootstrap/issues/40859
