### PR TITLE
Build(deps-dev): Bump the development-dependencies group with 4 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@astrojs/markdown-remark": "^6.3.2",
         "@astrojs/mdx": "^4.3.0",
         "@astrojs/prism": "^3.3.0",
-        "@astrojs/sitemap": "^3.4.0",
+        "@astrojs/sitemap": "^3.4.1",
         "@babel/cli": "^7.27.2",
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
@@ -37,7 +37,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/mime": "^4.0.0",
         "@types/prismjs": "^1.26.5",
-        "astro": "^5.8.1",
+        "astro": "^5.9.0",
         "astro-auto-import": "^0.4.4",
         "autoprefixer": "^10.4.21",
         "bundlewatch": "^0.4.1",
@@ -88,10 +88,10 @@
         "shelljs": "^0.10.0",
         "stylelint": "^16.20.0",
         "stylelint-config-twbs-bootstrap": "^16.0.0",
-        "terser": "^5.40.0",
+        "terser": "^5.41.0",
         "unist-util-visit": "^5.0.0",
         "vnu-jar": "24.10.17",
-        "zod": "^3.25.50"
+        "zod": "^3.25.51"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
@@ -154,41 +154,41 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.25.0.tgz",
-      "integrity": "sha512-1pfQulNUYNf1Tk/svbfjfkLBS36zsuph6m+B6gDkPEivFmso/XnRgwDvjAx80WNtiHnmeNjIXdF7Gos8+OLHqQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.27.0.tgz",
+      "integrity": "sha512-SITU5umoknxETtw67TxJu9njyMkWiH8pM+Bvw4dzfuIrIAT6Y1rmwV4y0A0didWoT+6xVuammIykbtBMolBcmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.25.0.tgz",
-      "integrity": "sha512-AFbG6VDJX/o2vDd9hqncj1B6B4Tulk61mY0pzTtzKClyTDlNP0xaUiEKhl6E7KO9I/x0FJF5tDCm0Hn6v5x18A==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.27.0.tgz",
+      "integrity": "sha512-go1b9qIZK5vYEQ7jD2bsfhhhVsoh9cFxQ5xF8TzTsg2WOCZR3O92oXCkq15SOK0ngJfqDU6a/k0oZ4KuEnih1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.25.0.tgz",
-      "integrity": "sha512-il1zS/+Rc6la6RaCdSZ2YbJnkQC6W1wiBO8+SH+DE6CPMWBU6iDVzH0sCKSAtMWl9WBxoN6MhNjGBnCv9Yy2bA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.27.0.tgz",
+      "integrity": "sha512-tnFOzdNuMzsz93kOClj3fKfuYoF3oYaEB5bggULSj075GJ7HUNedBEm7a6ScrjtnOaOtipbnT7veUpHA4o4wEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -196,151 +196,151 @@
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.25.0.tgz",
-      "integrity": "sha512-blbjrUH1siZNfyCGeq0iLQu00w3a4fBXm0WRIM0V8alcAPo7rWjLbMJMrfBtzL9X5ic6wgxVpDADXduGtdrnkw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.27.0.tgz",
+      "integrity": "sha512-y1qgw39qZijjQBXrqZTiwK1cWgWGRiLpJNWBv9w36nVMKfl9kInrfsYmdBAfmlhVgF/+Woe0y1jQ7pa4HyShAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.25.0.tgz",
-      "integrity": "sha512-aywoEuu1NxChBcHZ1pWaat0Plw7A8jDMwjgRJ00Mcl7wGlwuPt5dJ/LTNcg3McsEUbs2MBNmw0ignXBw9Tbgow==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.27.0.tgz",
+      "integrity": "sha512-XluG9qPZKEbiLoIfXTKbABsWDNOMPx0t6T2ImJTTeuX+U/zBdmfcqqgcgkqXp+vbXof/XX/4of9Eqo1JaqEmKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.25.0.tgz",
-      "integrity": "sha512-a/W2z6XWKjKjIW1QQQV8PTTj1TXtaKx79uR3NGBdBdGvVdt24KzGAaN7sCr5oP8DW4D3cJt44wp2OY/fZcPAVA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.27.0.tgz",
+      "integrity": "sha512-V8/To+SsAl2sdw2AAjeLJuCW1L+xpz+LAGerJK7HKqHzE5yQhWmIWZTzqYQcojkii4iBMYn0y3+uReWqT8XVSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.25.0.tgz",
-      "integrity": "sha512-9rUYcMIBOrCtYiLX49djyzxqdK9Dya/6Z/8sebPn94BekT+KLOpaZCuc6s0Fpfq7nx5J6YY5LIVFQrtioK9u0g==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.27.0.tgz",
+      "integrity": "sha512-EJJ7WmvmUXZdchueKFCK8UZFyLqy4Hz64snNp0cTc7c0MKaSeDGYEDxVsIJKp15r7ORaoGxSyS4y6BGZMXYuCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.25.0.tgz",
-      "integrity": "sha512-jJeH/Hk+k17Vkokf02lkfYE4A+EJX+UgnMhTLR/Mb+d1ya5WhE+po8p5a/Nxb6lo9OLCRl6w3Hmk1TX1e9gVbQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.27.0.tgz",
+      "integrity": "sha512-xNCyWeqpmEo4EdmpG57Fs1fJIQcPwt5NnJ6MBdXnUdMVXF4f5PHgza+HQWQQcYpCsune96jfmR0v7us6gRIlCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.25.0.tgz",
-      "integrity": "sha512-Ls3i1AehJ0C6xaHe7kK9vPmzImOn5zBg7Kzj8tRYIcmCWVyuuFwCIsbuIIz/qzUf1FPSWmw0TZrGeTumk2fqXg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.27.0.tgz",
+      "integrity": "sha512-P0NDiEFyt9UYQLBI0IQocIT7xHpjMpoFN3UDeerbztlkH9HdqT0GGh1SHYmNWpbMWIGWhSJTtz6kSIWvFu4+pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.25.0.tgz",
-      "integrity": "sha512-79sMdHpiRLXVxSjgw7Pt4R1aNUHxFLHiaTDnN2MQjHwJ1+o3wSseb55T9VXU4kqy3m7TUme3pyRhLk5ip/S4Mw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.27.0.tgz",
+      "integrity": "sha512-cqfTMF1d1cc7hg0vITNAFxJZas7MJ4Obc36WwkKpY23NOtGb+4tH9X7UKlQa2PmTgbXIANoJ/DAQTeiVlD2I4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-common": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.25.0.tgz",
-      "integrity": "sha512-JLaF23p1SOPBmfEqozUAgKHQrGl3z/Z5RHbggBu6s07QqXXcazEsub5VLonCxGVqTv6a61AAPr8J1G5HgGGjEw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.27.0.tgz",
+      "integrity": "sha512-ErenYTcXl16wYXtf0pxLl9KLVxIztuehqXHfW9nNsD8mz9OX42HbXuPzT7y6JcPiWJpc/UU/LY5wBTB65vsEUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.25.0.tgz",
-      "integrity": "sha512-rtzXwqzFi1edkOF6sXxq+HhmRKDy7tz84u0o5t1fXwz0cwx+cjpmxu/6OQKTdOJFS92JUYHsG51Iunie7xbqfQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.27.0.tgz",
+      "integrity": "sha512-CNOvmXsVi+IvT7z1d+6X7FveVkgEQwTNgipjQCHTIbF9KSMfZR7tUsJC+NpELrm10ALdOMauah84ybs9rw1cKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.25.0.tgz",
-      "integrity": "sha512-ZO0UKvDyEFvyeJQX0gmZDQEvhLZ2X10K+ps6hViMo1HgE2V8em00SwNsQ+7E/52a+YiBkVWX61pJJJE44juDMQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.27.0.tgz",
+      "integrity": "sha512-Nx9EdLYZDsaYFTthqmc0XcVvsx6jqeEX8fNiYOB5i2HboQwl8pJPj1jFhGqoGd0KG7KFR+sdPO5/e0EDDAru2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.25.0"
+        "@algolia/client-common": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -507,9 +507,9 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.4.0.tgz",
-      "integrity": "sha512-C5m/xsKvRSILKM3hy47n5wKtTQtJXn8epoYuUmCCstaE9XBt20yInym3Bz2uNbEiNfv11bokoW0MqeXPIvjFIQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.4.1.tgz",
+      "integrity": "sha512-VjZvr1e4FH6NHyyHXOiQgLiw94LnCVY4v06wN/D0gZKchTMkg71GrAHJz81/huafcmavtLkIv26HnpfDq6/h/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -702,13 +702,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.3",
+        "@babel/parser": "^7.27.5",
         "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -970,23 +970,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
-      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.4.tgz",
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.3.tgz",
-      "integrity": "sha512-+F8CnfhuLhwUACIJMLWnjz6zvzYM2r0yeIHKlbgfw7ml8rOMJsXNXV/hyRcb3nb493gRs4WvYpQAndWj/qQmkQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
+      "integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.4.tgz",
-      "integrity": "sha512-Glp/0n8xuj+E1588otw5rjJkTXfzW7FjH3IIUrfqiZOPQCd2vbg8e+DQE8jK9g4V5/zrxFW+D9WM9gboRPELpQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
+      "integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4036,65 +4036,65 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-AG8vnSi1W2pbgR2B911EfGqtLE9c4hQBYkv/x7Z+Kt0VxhgQKcW7UNDVYsu9YxwV6u+OJrvdJrMq6DNWoBjihQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.5.0.tgz",
+      "integrity": "sha512-iycvvnVG7MWZHRNuoqpYkV3Qc8DNLU74Lxh/roDwUqJJoXRnCTbbVJGfSWAdBslUgJMsjSHwFL42i55voavDDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.2.tgz",
-      "integrity": "sha512-1/adJbSMBOkpScCE/SB6XkjJU17ANln3Wky7lOmrnpl+zBdQ1qXUJg2GXTYVHRq+2j3hd1DesmElTXYDgtfSOQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.5.0.tgz",
+      "integrity": "sha512-3MhSnVHEdGb4L4FS/HAPc7WtPmIfHjRZraObf6tKxQaGuQGZfBsoLVCGuoGfiqt/zy0MKpll3oiZiQ/maT/wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
-      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.5.0.tgz",
+      "integrity": "sha512-DLM1VL+WvWFHQlikP8MTc8T2MdEGAOJhAi9+48wkQ7kO7c/99h4ALK0b0CPQBCeLMp37raoM1Ucuo3OTSjtUxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.5.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
-      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.5.0.tgz",
+      "integrity": "sha512-kBJhmj0ZkULbf3O+Asr8Xs7hcFtQdPnqIld2kKrG9WhDpIvqMRWSj3L9LECi2TH7vV6ROrvJ78/1yEASL0d00w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.5.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
-      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.5.0.tgz",
+      "integrity": "sha512-xr4bPmAORm2fhfVeaCDfRXiq0rxAxPRR0Bhiw+EaofgJ79Jj61fnVZDF40nJKvmMoKnC60TqCTpbr15ToTgTOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.5.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-VvqGHhS8BWClF7eVnEJLe0nAhQw/1L+xC5mp6uj+tVr3tjD2ASx2Mx9M9l7tZQO++1qwZeIIusvSRhz4aKODFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4605,25 +4605,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.25.0.tgz",
-      "integrity": "sha512-n73BVorL4HIwKlfJKb4SEzAYkR3Buwfwbh+MYxg2mloFph2fFGV58E90QTzdbfzWrLn4HE5Czx/WTjI8fcHaMg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.27.0.tgz",
+      "integrity": "sha512-2PvAgvxxJzA3+dB+ERfS2JPdvUsxNf89Cc2GF5iCcFupTULOwmbfinvqrC4Qj9nHJJDNf494NqEN/1f9177ZTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-abtesting": "5.25.0",
-        "@algolia/client-analytics": "5.25.0",
-        "@algolia/client-common": "5.25.0",
-        "@algolia/client-insights": "5.25.0",
-        "@algolia/client-personalization": "5.25.0",
-        "@algolia/client-query-suggestions": "5.25.0",
-        "@algolia/client-search": "5.25.0",
-        "@algolia/ingestion": "1.25.0",
-        "@algolia/monitoring": "1.25.0",
-        "@algolia/recommend": "5.25.0",
-        "@algolia/requester-browser-xhr": "5.25.0",
-        "@algolia/requester-fetch": "5.25.0",
-        "@algolia/requester-node-http": "5.25.0"
+        "@algolia/client-abtesting": "5.27.0",
+        "@algolia/client-analytics": "5.27.0",
+        "@algolia/client-common": "5.27.0",
+        "@algolia/client-insights": "5.27.0",
+        "@algolia/client-personalization": "5.27.0",
+        "@algolia/client-query-suggestions": "5.27.0",
+        "@algolia/client-search": "5.27.0",
+        "@algolia/ingestion": "1.27.0",
+        "@algolia/monitoring": "1.27.0",
+        "@algolia/recommend": "5.27.0",
+        "@algolia/requester-browser-xhr": "5.27.0",
+        "@algolia/requester-fetch": "5.27.0",
+        "@algolia/requester-node-http": "5.27.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -4899,13 +4899,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.8.1.tgz",
-      "integrity": "sha512-lkBg1smMRFW+FQ6i92SgEN53o4+ItRjlRt6Ck+rEjmTcb57Bid7faTNKUQNYuNnxiesTWw3NJDyVPQPbfKDyfw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.0.tgz",
+      "integrity": "sha512-AHF7oZDBQRwggHUG0bwBhRQjrDD+vJpCtPd0/GVxDB1hGRV0SQuFWS0UHX5bYczIqFcao1z9o9o0r2rQtHrTMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.11.0",
+        "@astrojs/compiler": "^2.12.0",
         "@astrojs/internal-helpers": "0.6.1",
         "@astrojs/markdown-remark": "6.3.2",
         "@astrojs/telemetry": "3.3.0",
@@ -5661,9 +5661,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "dev": true,
       "funding": [
         {
@@ -6902,9 +6902,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.161",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.161.tgz",
-      "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
+      "version": "1.5.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
+      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true,
       "license": "ISC"
     },
@@ -8293,15 +8293,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -16304,18 +16305,18 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.2.tgz",
-      "integrity": "sha512-wuxzZzQG8kvZndD7nustrNFIKYJ1jJoWIPaBpVe2+KHSvtzMi4SBjOxrigs8qeqce/l3U0cwiC+VAkLKSunHQQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.5.0.tgz",
+      "integrity": "sha512-1lyPuqIPPAlmR1BKtDkxiuoZTB2IKSyr+GeHXu4ReOyHoEMhCnUoGZDUv4SJRH0Bi4QmsEPsrkQCRSOgnVRC+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.2",
-        "@shikijs/engine-javascript": "3.4.2",
-        "@shikijs/engine-oniguruma": "3.4.2",
-        "@shikijs/langs": "3.4.2",
-        "@shikijs/themes": "3.4.2",
-        "@shikijs/types": "3.4.2",
+        "@shikijs/core": "3.5.0",
+        "@shikijs/engine-javascript": "3.5.0",
+        "@shikijs/engine-oniguruma": "3.5.0",
+        "@shikijs/langs": "3.5.0",
+        "@shikijs/themes": "3.5.0",
+        "@shikijs/types": "3.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -17563,9 +17564,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
-      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
+      "integrity": "sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -19525,9 +19526,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.50",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.50.tgz",
-      "integrity": "sha512-VstOnRxf4tlSq0raIwbn0n+LA34SxVoZ8r3pkwSUM0jqNiA/HCMQEVjTuS5FZmHsge+9MDGTiAuHyml5T0um6A==",
+      "version": "3.25.51",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@astrojs/markdown-remark": "^6.3.2",
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/prism": "^3.3.0",
-    "@astrojs/sitemap": "^3.4.0",
+    "@astrojs/sitemap": "^3.4.1",
     "@babel/cli": "^7.27.2",
     "@babel/core": "^7.27.4",
     "@babel/preset-env": "^7.27.2",
@@ -126,7 +126,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/mime": "^4.0.0",
     "@types/prismjs": "^1.26.5",
-    "astro": "^5.8.1",
+    "astro": "^5.9.0",
     "astro-auto-import": "^0.4.4",
     "autoprefixer": "^10.4.21",
     "bundlewatch": "^0.4.1",
@@ -177,10 +177,10 @@
     "shelljs": "^0.10.0",
     "stylelint": "^16.20.0",
     "stylelint-config-twbs-bootstrap": "^16.0.0",
-    "terser": "^5.40.0",
+    "terser": "^5.41.0",
     "unist-util-visit": "^5.0.0",
     "vnu-jar": "24.10.17",
-    "zod": "^3.25.50"
+    "zod": "^3.25.51"
   },
   "files": [
     "dist/{css,js}/*.{css,js,map}",


### PR DESCRIPTION
## `@astrojs/sitemap`    ^3.4.0  →    ^3.4.1

[@astrojs/sitemap](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fsitemap%403.4.1)

We're not impacted by the initial issue.

---

## `astro`                        ^5.8.1  →    ^5.9.0

[astro@5.9.0](https://github.com/withastro/astro/releases/tag/astro%405.9.0)

There's no need for us to use the new Markdown renderer to content loaders, and we don't use the `supportedAstroFeatures`.

### New experimental CSP flag experimentation

I quickly tried out the new [experimental CSP flag](https://docs.astro.build/en/reference/experimental-flags/csp/) just out of curiosity.

For instance, the generated 404.html page would be:

```diff
<   <meta name="generator" content="Astro v5.8.1">
---
>   <meta name="generator" content="Astro v5.9.0">
40a41,42
>   <meta http-equiv="content-security-policy"
>     content=" style-src 'self' 'sha256-GbquMC32s3w1n7n35GTnFvRivAu9h3ewYsKDcJSoOyw=' 'sha256-vv9IoKo7BSLbWcUHr3tNmfNVmm5L/9Cfn2H6LMk7/ow='; script-src 'self' 'sha256-uofanfzmv4RYtykfO1L3dkyOe0EWPKUgyZ2zSL3qsGw=' 'sha256-BF0290pkb3jxQsE7z00xR8Imp8X34FLC88L0lkMnrGw=' 'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c=' 'sha256-0chmwFk0zaA528yFfGV7J9ppIpdfTPPULncDF3WG7Zs=' 'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc=' 'sha256-Q2BPg90ZMplYY+FSdApNErhpWafg2hcRRbndmvxuL/Q=' 'sha256-U7a72oKuFFz8D7GUHLA1NZ0ciymHmDOc9T9aVDg2rWU=' 'sha256-p9VbHs/ClkQc+x63XdUjvCAgeWxA4ZGvpebJtMn9jbs=';">
```

Without modifications, this is the rendering we get while running `npm run start`:

![Screenshot 2025-06-05 at 20 55 04](https://github.com/user-attachments/assets/21da6375-0db9-48d2-ab76-b851e075b90f)

So it would need more modifications if we're willing to put that in place. Postponing for when it's going to be no more experimental.

---

## `terser`                    ^5.40.0  →   ^5.41.0

[terser@5.41.0](https://github.com/terser/terser/compare/v5.40.0...v5.41.0)

There's no diff between `dist` directories from this branch generated by `npm run dist` and the `main` branch.

---

## `zod`                     ^3.25.50  →  ^3.25.51

[zod@3.25.51](https://github.com/colinhacks/zod/releases/tag/v3.25.51)

No impact as the docs compile.