### PR TITLE
Docs: enhance floating labels `placeholder` usage description

### DIFF
--- a/site/src/content/docs/forms/floating-labels.mdx
+++ b/site/src/content/docs/forms/floating-labels.mdx
@@ -6,7 +6,11 @@ toc: true
 
 ## Example
 
-Wrap a pair of `<input class="form-control">` and `<label>` elements in `.form-floating` to enable floating labels with Bootstrap’s textual form fields. A `placeholder` is required on each `<input>` as our method of CSS-only floating labels uses the `:placeholder-shown` pseudo-element. Also note that the `<input>` must come first so we can utilize a sibling selector (i.e., `~`).
+Wrap a pair of `<input class="form-control">` and `<label>` elements in `.form-floating` to enable floating labels with Bootstrap’s textual form fields.
+
+A non-empty `placeholder` attribute is required on each `<input>` as our CSS-only floating label implementation relies on the `:placeholder-shown` pseudo-element to detect when the input is empty. The placeholder text itself is not visible; only the `<label>` is shown to users.
+
+Also note that the `<input>` must come first so we can utilize a sibling selector (i.e., `~`).
 
 <Example code={`<div class="form-floating mb-3">
     <input type="email" class="form-control" id="floatingInput" placeholder="name@example.com">


### PR DESCRIPTION
### Description

Related to https://github.com/twbs/bootstrap/issues/41521.

This PR suggests precising a little bit more the floating labels' `placeholder` usage; that it's not visible and used only for technical purpose; while this is the `<label>` that is visible.

#### Live previews

- <https://deploy-preview-41526--twbs-bootstrap.netlify.app/docs/5.3/forms/floating-labels/#example>
