### PR TITLE
Build(deps-dev): Bump the development-dependencies group with 3 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/mime": "^4.0.0",
         "@types/prismjs": "^1.26.5",
-        "astro": "^5.9.0",
+        "astro": "^5.9.1",
         "astro-auto-import": "^0.4.4",
         "autoprefixer": "^10.4.21",
         "bundlewatch": "^0.4.1",
@@ -57,7 +57,7 @@
         "htmlparser2": "^10.0.0",
         "image-size": "^2.0.2",
         "ip": "^2.0.1",
-        "jasmine": "^5.7.1",
+        "jasmine": "^5.8.0",
         "jquery": "^3.7.1",
         "js-yaml": "^4.1.0",
         "karma": "^6.4.4",
@@ -91,7 +91,7 @@
         "terser": "^5.41.0",
         "unist-util-visit": "^5.0.0",
         "vnu-jar": "24.10.17",
-        "zod": "^3.25.55"
+        "zod": "^3.25.56"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
-      "integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.1.tgz",
+      "integrity": "sha512-WDSyVIiz7sNcJcCJxJFITu6XjfGhJ50Z0auyaWsrM+xb07IlhBLFtQuDkNy0caVHWNcKTM2LISAaHhgkRqGAVg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/@types/cors": {
-      "version": "2.8.18",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.18.tgz",
-      "integrity": "sha512-nX3d0sxJW41CqQvfOzVG1NCTXfFDrDWIghCZncpHeWlVFd81zxB/DLhg7avFg6eHLCRX7ckBmoIIcqa++upvJA==",
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4899,13 +4899,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.0.tgz",
-      "integrity": "sha512-AHF7oZDBQRwggHUG0bwBhRQjrDD+vJpCtPd0/GVxDB1hGRV0SQuFWS0UHX5bYczIqFcao1z9o9o0r2rQtHrTMg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.1.tgz",
+      "integrity": "sha512-wxoJcTbuDZNFSv6EaL0PAlrp0Wx6VnOAULCXvy0scsV70oWMeUkdxuBxfO54JxO5Qgyvwj9h99y6E0elqOpGtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.12.0",
+        "@astrojs/compiler": "^2.12.1",
         "@astrojs/internal-helpers": "0.6.1",
         "@astrojs/markdown-remark": "6.3.2",
         "@astrojs/telemetry": "3.3.0",
@@ -10291,23 +10291,23 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.7.1.tgz",
-      "integrity": "sha512-E/4fkRNy/9ALz6z3Z3/tYXFAohoznVy7In9FWutG2fqBSkILJHFzbgZtHJUw5UrL3jgUQ4sdGYOVZ5KpSXYjGw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.8.0.tgz",
+      "integrity": "sha512-1V6HGa0+TMoMY20+/vp++RqLlL1noupV8awzV6CiPuICC0g7iKZ9z87zV2KyelRyoig0G1lHn7ueElXVMGVagg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.2.2",
-        "jasmine-core": "~5.7.0"
+        "jasmine-core": "~5.8.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.7.1.tgz",
-      "integrity": "sha512-QnurrtpKsPoixxG2R3d1xP0St/2kcX5oTZyDyQJMY+Vzi/HUlu1kGm+2V8Tz+9lV991leB1l0xcsyz40s9xOOw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.8.0.tgz",
+      "integrity": "sha512-Q9dqmpUAfptwyueW3+HqBOkSuYd9I/clZSSfN97wXE/Nr2ROFNCwIBEC1F6kb3QXS9Fcz0LjFYSDQT+BiwjuhA==",
       "dev": true,
       "license": "MIT"
     },
@@ -19533,9 +19533,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.55",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.55.tgz",
-      "integrity": "sha512-219huNnkSLQnLsQ3uaRjXsxMrVm5C9W3OOpEVt2k5tvMKuA8nBSu38e0B//a+he9Iq2dvmk2VyYVlHqiHa4YBA==",
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/mime": "^4.0.0",
     "@types/prismjs": "^1.26.5",
-    "astro": "^5.9.0",
+    "astro": "^5.9.1",
     "astro-auto-import": "^0.4.4",
     "autoprefixer": "^10.4.21",
     "bundlewatch": "^0.4.1",
@@ -146,7 +146,7 @@
     "htmlparser2": "^10.0.0",
     "image-size": "^2.0.2",
     "ip": "^2.0.1",
-    "jasmine": "^5.7.1",
+    "jasmine": "^5.8.0",
     "jquery": "^3.7.1",
     "js-yaml": "^4.1.0",
     "karma": "^6.4.4",
@@ -180,7 +180,7 @@
     "terser": "^5.41.0",
     "unist-util-visit": "^5.0.0",
     "vnu-jar": "24.10.17",
-    "zod": "^3.25.55"
+    "zod": "^3.25.56"
   },
   "files": [
     "dist/{css,js}/*.{css,js,map}",


### PR DESCRIPTION
### `astro@5.9.1`

[Changelog](https://github.com/withastro/astro/releases/tag/astro%405.9.1).

The documentation build completes successfully. As this is a patch release, no action is required.

---

### `jasmine@5.8.0`

[Release note](https://github.com/jasmine/jasmine/blob/main/release_notes/5.8.0.md)

The `saveArgumentsByValue` feature is not used in our codebase. Other changes appear to be internal improvements and do not require any modifications on our end.

The JS tests are OK.

---

### `zod@3.25.56`

The documentation build is successful. No action needed, as this is a patch release.