### PR TITLE
Build(deps-dev): Bump the development-dependencies group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/mime": "^4.0.0",
         "@types/prismjs": "^1.26.5",
-        "astro": "^5.9.1",
+        "astro": "^5.9.2",
         "astro-auto-import": "^0.4.4",
         "autoprefixer": "^10.4.21",
         "bundlewatch": "^0.4.1",
@@ -88,7 +88,7 @@
         "shelljs": "^0.10.0",
         "stylelint": "^16.20.0",
         "stylelint-config-twbs-bootstrap": "^16.0.0",
-        "terser": "^5.41.0",
+        "terser": "^5.42.0",
         "unist-util-visit": "^5.0.0",
         "vnu-jar": "24.10.17",
         "zod": "^3.25.56"
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.1.tgz",
-      "integrity": "sha512-WDSyVIiz7sNcJcCJxJFITu6XjfGhJ50Z0auyaWsrM+xb07IlhBLFtQuDkNy0caVHWNcKTM2LISAaHhgkRqGAVg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
+      "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4552,9 +4552,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4899,13 +4899,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.1.tgz",
-      "integrity": "sha512-wxoJcTbuDZNFSv6EaL0PAlrp0Wx6VnOAULCXvy0scsV70oWMeUkdxuBxfO54JxO5Qgyvwj9h99y6E0elqOpGtA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.2.tgz",
+      "integrity": "sha512-K/zZlQOWMpamfLDOls5jvG7lrsjH1gkk3ESRZyZDCkVBtKHMF4LbjwCicm/iBb3mX3V/PerqRYzLbOy3/4JLCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.12.1",
+        "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
         "@astrojs/markdown-remark": "6.3.2",
         "@astrojs/telemetry": "3.3.0",
@@ -5567,9 +5567,9 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.9.0.tgz",
-      "integrity": "sha512-8D5htMCxPDUULux9gFzv30f04Xo3wCnik0oOxKoRTPIBoqA7HtOcJ87uBhQTs3jCfZZTrUBGsYIZOgE0ZRgMAg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.0.tgz",
+      "integrity": "sha512-SSgQTAnhd7WlJXnGlIi4jJJOiHzgnM5wRMEPaXAU4kECTAMpBoYKoZ9i5zHmclIEZbxcu3j7yY/CF8DTmwIsHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6251,13 +6251,13 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
+      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6902,9 +6902,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
+      "version": "1.5.166",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
+      "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
       "dev": true,
       "license": "ISC"
     },
@@ -7018,9 +7018,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -17351,25 +17351,25 @@
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.0.tgz",
-      "integrity": "sha512-Et/ex6smi3wOOB+n5mek+Grf7P2AxZR5ueqRUvAAn4qkyatXi3cUC1cuQXVkX0VlzBVsN4BkWJFmY/fYiRTdww==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
+      "integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.9"
+        "flat-cache": "^6.1.10"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.9.tgz",
-      "integrity": "sha512-DUqiKkTlAfhtl7g78IuwqYM+YqvT+as0mY+EVk6mfimy19U79pJCzDZQsnqk3Ou/T6hFXWLGbwbADzD/c8Tydg==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.10.tgz",
+      "integrity": "sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.9.0",
+        "cacheable": "^1.10.0",
         "flatted": "^3.3.3",
-        "hookified": "^1.8.2"
+        "hookified": "^1.9.1"
       }
     },
     "node_modules/stylelint/node_modules/globby": {
@@ -17571,9 +17571,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
-      "integrity": "sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
+      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/mime": "^4.0.0",
     "@types/prismjs": "^1.26.5",
-    "astro": "^5.9.1",
+    "astro": "^5.9.2",
     "astro-auto-import": "^0.4.4",
     "autoprefixer": "^10.4.21",
     "bundlewatch": "^0.4.1",
@@ -177,7 +177,7 @@
     "shelljs": "^0.10.0",
     "stylelint": "^16.20.0",
     "stylelint-config-twbs-bootstrap": "^16.0.0",
-    "terser": "^5.41.0",
+    "terser": "^5.42.0",
     "unist-util-visit": "^5.0.0",
     "vnu-jar": "24.10.17",
     "zod": "^3.25.56"


### PR DESCRIPTION
### `astro@5.9.2`

[Release link](https://github.com/withastro/astro/releases/tag/astro%405.9.2).

We haven't integrated the experimental CSP option, so nothing impacts us in this patch release.

---

### `terser@5.42.0`

[Changelog link](https://github.com/terser/terser/blob/v5.42.0/CHANGELOG.md#v5420)

Tested it in the `v537` branch, and it generated exactly the same files.