### PR TITLE
Build(deps-dev): Bump the development-dependencies group with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/mime": "^4.0.0",
         "@types/prismjs": "^1.26.5",
-        "astro": "^5.9.2",
+        "astro": "^5.9.3",
         "astro-auto-import": "^0.4.4",
         "autoprefixer": "^10.4.21",
         "bundlewatch": "^0.4.1",
@@ -91,7 +91,7 @@
         "terser": "^5.42.0",
         "unist-util-visit": "^5.0.0",
         "vnu-jar": "24.10.17",
-        "zod": "^3.25.62"
+        "zod": "^3.25.64"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
@@ -4899,9 +4899,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.2.tgz",
-      "integrity": "sha512-K/zZlQOWMpamfLDOls5jvG7lrsjH1gkk3ESRZyZDCkVBtKHMF4LbjwCicm/iBb3mX3V/PerqRYzLbOy3/4JLCQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.9.3.tgz",
+      "integrity": "sha512-VReZrpUa/3rfeiVvsQ1A2M3ujDPI+pDGIYOMtXPEZwut8tZoEyealXXLjitgCsJ+3dunKGZbg4Eak6i+r0vniw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5661,9 +5661,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001722",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
-      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
+      "version": "1.0.30001723",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
       "dev": true,
       "funding": [
         {
@@ -6902,9 +6902,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.166",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
-      "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
+      "version": "1.5.167",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
+      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -19533,9 +19533,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.62",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.62.tgz",
-      "integrity": "sha512-YCxsr4DmhPcrKPC9R1oBHQNlQzlJEyPAId//qTau/vBee9uO8K6prmRq4eMkOyxvBfH4wDPIPdLx9HVMWIY3xA==",
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/mime": "^4.0.0",
     "@types/prismjs": "^1.26.5",
-    "astro": "^5.9.2",
+    "astro": "^5.9.3",
     "astro-auto-import": "^0.4.4",
     "autoprefixer": "^10.4.21",
     "bundlewatch": "^0.4.1",
@@ -180,7 +180,7 @@
     "terser": "^5.42.0",
     "unist-util-visit": "^5.0.0",
     "vnu-jar": "24.10.17",
-    "zod": "^3.25.62"
+    "zod": "^3.25.64"
   },
   "files": [
     "dist/{css,js}/*.{css,js,map}",


### PR DESCRIPTION
### `astro@5.9.3`

[Release note](https://github.com/withastro/astro/releases/tag/astro%405.9.3)

- The breaking change is related to the CSP experimental feature that we don't use
- The other fix bugs are not related to any direct usages on our side

---

### `zod@3.25.64`

Docs compilation is OK.