### PR TITLE
Docs: restore local dev port to 9001

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,4 +47,4 @@ jobs:
           paths: _site
           recurse: true
           verbosity: error
-          skip: "^(?!http://localhost)"
+          skip: "^(?!http://localhost(:\\d+)?/)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,4 +47,4 @@ jobs:
           paths: _site
           recurse: true
           verbosity: error
-          skip: "^(?!http://localhost(:\\d+)?/)"
+          skip: "^http://localhost"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Documentation search is powered by [Algolia's DocSearch](https://docsearch.algol
 1. Run `npm install` to install the Node.js dependencies, including Astro (the site builder).
 2. Run `npm run test` (or a specific npm script) to rebuild distributed CSS and JavaScript files, as well as our docs assets.
 3. From the root `/bootstrap` directory, run `npm run docs-serve` in the command line.
-4. Open <http://localhost:4321> in your browser, and voilà.
+4. Open <http://localhost:9001> in your browser, and voilà.
 
 Learn more about using Astro by reading its [documentation](https://docs.astro.build/en/getting-started/).
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Documentation search is powered by [Algolia's DocSearch](https://docsearch.algol
 1. Run `npm install` to install the Node.js dependencies, including Astro (the site builder).
 2. Run `npm run test` (or a specific npm script) to rebuild distributed CSS and JavaScript files, as well as our docs assets.
 3. From the root `/bootstrap` directory, run `npm run docs-serve` in the command line.
-4. Open `http://localhost:9001/` in your browser, and voilà.
+4. Open <http://localhost:4321> in your browser, and voilà.
 
 Learn more about using Astro by reading its [documentation](https://docs.astro.build/en/getting-started/).
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "docs-lint": "npm-run-all docs-prettier-check docs-vnu",
     "docs-prettier-check": "prettier --config site/.prettierrc.json -c --cache site",
     "docs-prettier-format": "prettier --config site/.prettierrc.json --write --cache site",
-    "docs-serve": "npm run astro-dev",
+    "docs-serve": "npm run astro-dev -- --port 9001",
     "docs-serve-only": "npx sirv-cli _site --port 9001",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",
     "update-deps": "ncu -u -x eslint,eslint-config-xo,eslint-plugin-unicorn,karma-browserstack-launcher,karma-rollup-preprocessor,sass",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "docs-lint": "npm-run-all docs-prettier-check docs-vnu",
     "docs-prettier-check": "prettier --config site/.prettierrc.json -c --cache site",
     "docs-prettier-format": "prettier --config site/.prettierrc.json --write --cache site",
-    "docs-serve": "npm run astro-dev -- --port 9001",
+    "docs-serve": "npm run astro-dev",
     "docs-serve-only": "npx sirv-cli _site --port 9001",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",
     "update-deps": "ncu -u -x eslint,eslint-config-xo,eslint-plugin-unicorn,karma-browserstack-launcher,karma-rollup-preprocessor,sass",
@@ -100,9 +100,9 @@
     "watch-css-test": "nodemon --watch scss/ --ext scss,js --exec \"npm run css-test\"",
     "watch-js-main": "nodemon --watch js/src/ --ext js --exec \"npm-run-all js-lint js-compile\"",
     "watch-js-docs": "nodemon --watch site/src/assets/ --ext js --exec \"npm run js-lint\"",
-    "astro-dev": "astro dev --root site",
+    "astro-dev": "astro dev --root site --port 9001",
     "astro-build": "astro build --root site && rm -rf _site && cp -r site/dist _site",
-    "astro-preview": "astro preview --root site"
+    "astro-preview": "astro preview --root site --port 9001"
   },
   "peerDependencies": {
     "@popperjs/core": "^2.11.8"

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -9,7 +9,7 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const site = isDev
   ? // In development mode, use the local dev server.
-    'http://localhost:4321'
+    'http://localhost:9001'
   : process.env.DEPLOY_PRIME_URL !== undefined
     ? // If deploying on Netlify, use the `DEPLOY_PRIME_URL` environment variable.
       process.env.DEPLOY_PRIME_URL

--- a/site/src/content/docs/getting-started/contribute.mdx
+++ b/site/src/content/docs/getting-started/contribute.mdx
@@ -56,7 +56,7 @@ Running our documentation locally requires the use of Astro. Astro is a modern s
 
 1. Run through the [tooling setup](#tooling-setup) above to install all dependencies.
 2. From the root `/bootstrap` directory, run `npm run docs-serve` in the command line.
-3. Open `http://localhost:4321/` in your browser, and voilà.
+3. Open `http://localhost:9001/` in your browser, and voilà.
 
 Learn more about using Astro by reading its [documentation](https://docs.astro.build/en/getting-started/).
 

--- a/site/src/content/docs/getting-started/contribute.mdx
+++ b/site/src/content/docs/getting-started/contribute.mdx
@@ -56,7 +56,7 @@ Running our documentation locally requires the use of Astro. Astro is a modern s
 
 1. Run through the [tooling setup](#tooling-setup) above to install all dependencies.
 2. From the root `/bootstrap` directory, run `npm run docs-serve` in the command line.
-3. Open `http://localhost:9001/` in your browser, and voilà.
+3. Open http://localhost:9001 in your browser, and voilà.
 
 Learn more about using Astro by reading its [documentation](https://docs.astro.build/en/getting-started/).
 


### PR DESCRIPTION
Since the migration to Astro, the localhost port is now 4321. This PR updates the README's "Running documentation locally" to reflect this change.