### PR TITLE
Build(deps-dev): Bump stylelint-config-twbs-bootstrap from 16.0.0 to 16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "sass-true": "^8.1.0",
         "shelljs": "^0.10.0",
         "stylelint": "^16.20.0",
-        "stylelint-config-twbs-bootstrap": "^16.0.0",
+        "stylelint-config-twbs-bootstrap": "^16.1.0",
         "terser": "^5.42.0",
         "unist-util-visit": "^5.0.0",
         "vnu-jar": "24.10.17",
@@ -17262,9 +17262,9 @@
       }
     },
     "node_modules/stylelint-config-twbs-bootstrap": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.0.0.tgz",
-      "integrity": "sha512-MgFiCiqCZVUZ8Rt417lTPBnpgDgFsnZK1sy56UFL+niVLptO0kviKyzZB6b6yEU5bnlWRusau9/FgXiJOi2pJA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.1.0.tgz",
+      "integrity": "sha512-jp+/lHxOo5r21g05+qC/nbFueb7OH5Pub5SdWeBj7T0HVGuHDjB4NoNlWklmz1GsqNhAtFms6ZCnJsAgc8XOmQ==",
       "dev": true,
       "funding": [
         {
@@ -17283,7 +17283,7 @@
         "stylelint-config-recess-order": "^5.1.1",
         "stylelint-config-standard": "^36.0.1",
         "stylelint-config-standard-scss": "^14.0.0",
-        "stylelint-scss": "^6.11.1"
+        "stylelint-scss": "^6.12.1"
       },
       "engines": {
         "node": ">=18.12.0"

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "sass-true": "^8.1.0",
     "shelljs": "^0.10.0",
     "stylelint": "^16.20.0",
-    "stylelint-config-twbs-bootstrap": "^16.0.0",
+    "stylelint-config-twbs-bootstrap": "^16.1.0",
     "terser": "^5.42.0",
     "unist-util-visit": "^5.0.0",
     "vnu-jar": "24.10.17",


### PR DESCRIPTION
### `stylelint-config-twbs-bootstrap@16.1.0`

[Release note](https://github.com/twbs/stylelint-config-twbs-bootstrap/releases/tag/v16.1.0)

No impact on our side based on these deps bumps and [`stylelint-scss@v6.12.1`](https://github.com/stylelint-scss/stylelint-scss/releases/tag/v6.12.1).