### PR TITLE
Customize the cursor of clear button shown on non-empty search inputs

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -534,6 +534,12 @@ legend {
 [type="search"] {
   -webkit-appearance: textfield; // 1
   outline-offset: -2px; // 2
+
+  @if $enable-search-clear-pointer {
+    &[type="search"]::-webkit-search-cancel-button {
+      cursor: pointer;
+    }
+  }
 }
 
 // 1. A few input types should stay LTR

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -378,6 +378,7 @@ $enable-grid-classes:         true !default;
 $enable-container-classes:    true !default;
 $enable-cssgrid:              false !default;
 $enable-button-pointers:      true !default;
+$enable-search-clear-pointer: false !default;
 $enable-rfs:                  true !default;
 $enable-validation-icons:     true !default;
 $enable-negative-margins:     false !default;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -30,6 +30,13 @@
     }
   }
 
+  // WebKit/Blink only: Add pointer cursor to the native search cancel button.
+  &[type="search"] {
+    &::-webkit-search-cancel-button {
+      cursor: pointer;
+    }
+  }
+
   // Customize the `:focus` state to imitate native WebKit styles.
   &:focus {
     color: $input-focus-color;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -30,11 +30,9 @@
     }
   }
 
-  // WebKit/Blink only: Add pointer cursor to the native search cancel button.
-  &[type="search"] {
-    &::-webkit-search-cancel-button {
-      cursor: pointer;
-    }
+  // Customize the cursor of clear button shown on non-empty search inputs
+  &[type="search"]::-webkit-search-cancel-button {
+    cursor: pointer;
   }
 
   // Customize the `:focus` state to imitate native WebKit styles.

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -30,11 +30,6 @@
     }
   }
 
-  // Customize the cursor of clear button shown on non-empty search inputs
-  &[type="search"]::-webkit-search-cancel-button {
-    cursor: pointer;
-  }
-
   // Customize the `:focus` state to imitate native WebKit styles.
   &:focus {
     color: $input-focus-color;


### PR DESCRIPTION
This change adds the `cursor: pointer` style to the native `::-webkit-search-cancel-button` pseudo-element to improve user experience on WebKit/Blink-based browsers.

Closes: #39114

### Description

This change introduces a CSS rule to apply `cursor: pointer` to the native clear button (`::-webkit-search-cancel-button`) found in `<input type="search">` elements. A comment has been added to clarify that this enhancement only affects WebKit/Blink-based browsers and does not apply to Firefox (Gecko).

### Motivation & Context

Currently, the native clear button in search inputs lacks a pointer cursor, which can make it feel less interactive than other clickable elements on a page. This change improves user experience by providing standard visual feedback that the element is clickable, aligning its behavior with that of other buttons and links. This resolves the issue described in #39114.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- https://deploy-preview-41577--twbs-bootstrap.netlify.app/docs/5.3/components/navbar/#supported-content

### Related issues

None.