### PR TITLE
Remove unused npm watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "watch-css-docs": "nodemon --watch site/src/scss/ --ext scss --exec \"npm run css-lint\"",
     "watch-css-test": "nodemon --watch scss/ --ext scss,js --exec \"npm run css-test\"",
     "watch-js-main": "nodemon --watch js/src/ --ext js --exec \"npm-run-all js-lint js-compile\"",
-    "watch-js-docs": "nodemon --watch site/src/assets/ --ext js --exec \"npm run js-lint\"",
     "astro-dev": "astro dev --root site --port 9001",
     "astro-build": "astro build --root site && rm -rf _site && cp -r site/dist _site",
     "astro-preview": "astro preview --root site --port 9001"


### PR DESCRIPTION
> [!WARNING]  
> Heavily draft

This PR follows up on [#41574](https://github.com/twbs/bootstrap/pull/41574), which introduced automatic Sass recompilation for Astro.

The goal is to identify and remove `watch*` npm scripts that are no longer necessary.

Currently, these scripts are only triggered through the main `watch` script, which runs when executing `npm run start`. There are no known use cases where the `watch-*` scripts are run directly.

We'll evaluate them one by one.

---

## 🟢  `watch-js-docs`

**Steps:**

1. Remove the `watch-js-docs` npm script.
2. Run `npm run start`.
3. Edit `site/src/assets/stackblitz.js` (e.g., change a comment in the HTML).
4. Confirm that Astro detects the change and recompiles automatically.
5. Click the “Try it on Stackblitz” button — the updated comment appears as expected.

**Conclusion:** `watch-js-docs` is no longer needed and can safely be removed.

## 🔴 `watch-css-docs`

Astro can recompile files like `site/src/scss/_variables.scss` on the fly (e.g., to update the `$bd-purple` Sass variable), but it doesn’t trigger the linter. That’s why we keep `watch-css-docs` running to execute `npm run lint` in real time.

---

TODO

- [ ] `watch-css-main`
- [ ] `watch-css-dist`
- [ ] `watch-css-test`
- [ ] `watch-js-main`
- [ ] `watch` → `watch-*`
- [ ] `start` → `watch`

<!--
"watch-css-main": "nodemon --watch scss/ --ext scss --exec \"npm-run-all css-lint css-compile css-prefix\"",
"watch-css-dist": "nodemon --watch dist/css/ --ext css --ignore \"dist/css/*.rtl.*\" --exec \"npm run css-rtl\"",
"watch-css-test": "nodemon --watch scss/ --ext scss,js --exec \"npm run css-test\"",
"watch-js-main": "nodemon --watch js/src/ --ext js --exec \"npm-run-all js-lint js-compile\"",
"watch": "npm-run-all --parallel watch-*",
"start": "npm-run-all --parallel watch docs-serve",
-->