### PR TITLE
Docs: Added form validation feedback example

### DIFF
--- a/site/src/content/docs/forms/validation.mdx
+++ b/site/src/content/docs/forms/validation.mdx
@@ -32,8 +32,6 @@ Here’s how form validation works with Bootstrap:
 - To ensure accessibility, use the `aria-describedby` attribute on the form control and reference the IDs of your feedback elements. Example: `aria-describedby="inputValidFeedback inputInvalidFeedback"`.
 - When `.was-validated` is added to the form, Bootstrap will show `.invalid-feedback` if the field is invalid, and `.valid-feedback` if the field is valid. Without `.was-validated`, feedback messages remain hidden.
 
-#### Example
-
 ```html
 <form class="was-validated">
   <div class="mb-3">
@@ -54,7 +52,6 @@ Here’s how form validation works with Bootstrap:
 - For server-side validation, set `.is-valid` or `.is-invalid` classes on the form control based on the server response. This will show the appropriate feedback message without needing `.was-validated`.
 - You can also use JavaScript’s `setCustomValidity()` to set a custom error message. This will make the field invalid and show the `.invalid-feedback` message after validation is triggered.
 
-With these guidelines, you can display clear and accessible feedback messages in your Bootstrap forms.
 ## Custom styles
 
 For custom Bootstrap form validation messages, you’ll need to add the `novalidate` boolean attribute to your `<form>`. This disables the browser default feedback tooltips, but still provides access to the form validation APIs in JavaScript. Try to submit the form below; our JavaScript will intercept the submit button and relay feedback to you. When attempting to submit, you’ll see the `:invalid` and `:valid` styles applied to your form controls.

--- a/site/src/content/docs/forms/validation.mdx
+++ b/site/src/content/docs/forms/validation.mdx
@@ -47,11 +47,6 @@ Here’s how form validation works with Bootstrap:
 </form>
 ```
 
-### Server-side Validation
-
-- For server-side validation, set `.is-valid` or `.is-invalid` classes on the form control based on the server response. This will show the appropriate feedback message without needing `.was-validated`.
-- You can also use JavaScript’s `setCustomValidity()` to set a custom error message. This will make the field invalid and show the `.invalid-feedback` message after validation is triggered.
-
 ## Custom styles
 
 For custom Bootstrap form validation messages, you’ll need to add the `novalidate` boolean attribute to your `<form>`. This disables the browser default feedback tooltips, but still provides access to the form validation APIs in JavaScript. Try to submit the form below; our JavaScript will intercept the submit button and relay feedback to you. When attempting to submit, you’ll see the `:invalid` and `:valid` styles applied to your form controls.

--- a/site/src/content/docs/forms/validation.mdx
+++ b/site/src/content/docs/forms/validation.mdx
@@ -18,16 +18,43 @@ We are aware that currently the client-side custom validation styles and tooltip
 Here’s how form validation works with Bootstrap:
 
 - HTML form validation is applied via CSS’s two pseudo-classes, `:invalid` and `:valid`. It applies to `<input>`, `<select>`, and `<textarea>` elements.
-- Bootstrap scopes the `:invalid` and `:valid` styles to parent `.was-validated` class, usually applied to the `<form>`. Otherwise, any required field without a value shows up as invalid on page load. This way, you may choose when to activate them (typically after form submission is attempted).
-- To reset the appearance of the form (for instance, in the case of dynamic form submissions using Ajax), remove the `.was-validated` class from the `<form>` again after submission.
-- As a fallback, `.is-invalid` and `.is-valid` classes may be used instead of the pseudo-classes for [server-side validation](#server-side). They do not require a `.was-validated` parent class.
-- Due to constraints in how CSS works, we cannot (at present) apply styles to a `<label>` that comes before a form control in the DOM without the help of custom JavaScript.
-- All modern browsers support the [constraint validation API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api), a series of JavaScript methods for validating form controls.
-- Feedback messages may utilize the [browser defaults](#browser-defaults) (different for each browser, and unstylable via CSS) or our custom feedback styles with additional HTML and CSS.
-- You may provide custom validity messages with `setCustomValidity` in JavaScript.
+- Bootstrap scopes the `:invalid` and `:valid` styles to a parent `.was-validated` class, usually applied to the `<form>`. This prevents required fields from showing as invalid on page load. Add `.was-validated` to the form when you want to show validation feedback (typically after submission is attempted).
+- To reset the form appearance (for example, after dynamic submissions using Ajax), remove the `.was-validated` class from the `<form>`.
+- As a fallback, `.is-invalid` and `.is-valid` classes can be used directly on form controls for [server-side validation](#server-side). These do not require a `.was-validated` parent class.
+- Due to CSS limitations, you cannot style a `<label>` that comes before a form control in the DOM without custom JavaScript.
+- All modern browsers support the [constraint validation API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api), a set of JavaScript methods for validating form controls.
+- Feedback messages can use browser defaults (which are different for each browser and cannot be styled) or Bootstrap’s custom feedback styles with additional HTML and CSS.
+- You can provide custom validity messages with `setCustomValidity` in JavaScript.
 
-With that in mind, consider the following demos for our custom form validation styles, optional server-side classes, and browser defaults.
+### Showing Feedback Messages
 
+- Use `.valid-feedback` and `.invalid-feedback` elements after your form control to show feedback messages. Only one will be visible at a time, depending on the field’s validity.
+- To ensure accessibility, use the `aria-describedby` attribute on the form control and reference the IDs of your feedback elements. Example: `aria-describedby="inputValidFeedback inputInvalidFeedback"`.
+- When `.was-validated` is added to the form, Bootstrap will show `.invalid-feedback` if the field is invalid, and `.valid-feedback` if the field is valid. Without `.was-validated`, feedback messages remain hidden.
+
+#### Example
+
+```html
+<form class="was-validated">
+  <div class="mb-3">
+    <label for="input1" class="form-label">Email address</label>
+    <input type="email" class="form-control" id="input1" required aria-describedby="input1Valid input1Invalid">
+    <div id="input1Valid" class="valid-feedback">
+      Looks good!
+    </div>
+    <div id="input1Invalid" class="invalid-feedback">
+      Please enter a valid email.
+    </div>
+  </div>
+</form>
+```
+
+### Server-side Validation
+
+- For server-side validation, set `.is-valid` or `.is-invalid` classes on the form control based on the server response. This will show the appropriate feedback message without needing `.was-validated`.
+- You can also use JavaScript’s `setCustomValidity()` to set a custom error message. This will make the field invalid and show the `.invalid-feedback` message after validation is triggered.
+
+With these guidelines, you can display clear and accessible feedback messages in your Bootstrap forms.
 ## Custom styles
 
 For custom Bootstrap form validation messages, you’ll need to add the `novalidate` boolean attribute to your `<form>`. This disables the browser default feedback tooltips, but still provides access to the form validation APIs in JavaScript. Try to submit the form below; our JavaScript will intercept the submit button and relay feedback to you. When attempting to submit, you’ll see the `:invalid` and `:valid` styles applied to your form controls.


### PR DESCRIPTION
### Description

Clarified how `.valid-feedback` and `.invalid-feedback` are to be used including an example.

### Motivation & Context

Closes #40769

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews
- https://deploy-preview-41605--twbs-bootstrap.netlify.app/docs/5.3/forms/validation/

### Related issues

Related to issue #40769
