### PR TITLE
fix(modal): prevent focus on modal container with negative tabindex

### DIFF
--- a/js/src/util/focustrap.js
+++ b/js/src/util/focustrap.js
@@ -95,7 +95,11 @@ class FocusTrap extends Config {
     const elements = SelectorEngine.focusableChildren(trapElement)
 
     if (elements.length === 0) {
-      trapElement.focus()
+      // Don't focus the trapElement if it has a negative tabindex
+      // as this creates an unwanted focus stop for keyboard users
+      if (trapElement.tabIndex >= 0) {
+        trapElement.focus()
+      }
     } else if (this._lastTabNavDirection === TAB_NAV_BACKWARD) {
       elements[elements.length - 1].focus()
     } else {

--- a/js/tests/unit/util/focustrap.spec.js
+++ b/js/tests/unit/util/focustrap.spec.js
@@ -155,7 +155,7 @@ describe('FocusTrap', () => {
       })
     })
 
-    it('should force focus on itself if there is no focusable content', () => {
+    it('should not force focus on element with negative tabindex if there is no focusable content', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<a href="#" id="outside">outside</a>',
@@ -167,7 +167,7 @@ describe('FocusTrap', () => {
         focustrap.activate()
 
         const focusInListener = () => {
-          expect(spy).toHaveBeenCalled()
+          expect(spy).not.toHaveBeenCalled()
           document.removeEventListener('focusin', focusInListener)
           resolve()
         }


### PR DESCRIPTION
Fixes #41606 - Extra focus stop on hidden element at end of modal

When a modal has no focusable children, the FocusTrap was focusing the modal container element (which has tabindex="-1"). This created an unwanted focus stop for keyboard users navigating with Tab.

The fix prevents focusing elements with negative tabindex values, which are not meant to be part of the normal tab sequence.

- Modified FocusTrap._handleFocusin to check tabIndex >= 0 before focusing trap element
- Updated test to expect the new behavior (no focus on negative tabindex elements)

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [bootstrap@5.3.7 lint ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41607--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
