### PR TITLE
CSS: Prevent spinner distortion in flex containers with multiline content

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -5,6 +5,7 @@
 .spinner-grow,
 .spinner-border {
   display: inline-block;
+  flex-shrink: 0;
   width: var(--#{$prefix}spinner-width);
   height: var(--#{$prefix}spinner-height);
   vertical-align: var(--#{$prefix}spinner-vertical-align);


### PR DESCRIPTION
### Description

This PR fixes #41578 by using the method suggested by @mdo at https://github.com/twbs/bootstrap/issues/41578#issuecomment-3042820979, instead of updating the documentation to use our `.flex-shrink-0` utility as proposed at https://github.com/twbs/bootstrap/issues/41578#issuecomment-3020486355.

It can be tested directly in the docs with the following code:

```mdx
<div class="d-flex align-items-center" style={{ width: '30px' }}>
  <strong>A long string of text that will wrap to the next line...</strong>
  <div class="spinner-border ms-auto" aria-hidden="true"></div>
</div>
```

We already used this kind of defensive CSS approach with this same `flex-shrink: 0` CSS rule in https://github.com/twbs/bootstrap/pull/38955.

It can possibly be released in v5.3.8 as it should be non-breaking.

### Type of changes

-  Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- (N/A) My change introduces changes to the documentation
- (N/A) I have updated the documentation accordingly
- (N/A) I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

For non-regression visual testing:

- https://deploy-preview-41654--twbs-bootstrap.netlify.app/docs/5.3/components/spinners/
- https://deploy-preview-41654--twbs-bootstrap.netlify.app/docs/5.3/examples/buttons/
- https://deploy-preview-41654--twbs-bootstrap.netlify.app/docs/5.3/examples/cheatsheet/#spinners
- https://deploy-preview-41654--twbs-bootstrap.netlify.app/docs/5.3/examples/cheatsheet-rtl/#spinners

### Related issues

Closes #41578
