### PR TITLE
Fix uncaught TypeError in dropdown.js _completeHide

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -209,7 +209,10 @@ class Dropdown extends BaseComponent {
     EventHandler.trigger(this._element, EVENT_HIDDEN, relatedTarget)
 
     // Explicitly return focus to the trigger element
-    this._element.focus()
+   if (this._element) {
+  this._element.focus();
+}
+
   }
 
   _getConfig(config) {


### PR DESCRIPTION
Fixes #41588

Adds a null check before calling this._element.focus() in the _completeHide function in dropdown.js.  
Prevents an uncaught TypeError when this._element is null after a dropdown item is selected.
