### PR TITLE
Rearrange some type styles

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -90,32 +90,38 @@ hr {
   color: var(--#{$prefix}heading-color);
 }
 
-h1 {
+h1,
+.h1 {
   @extend %heading;
   @include font-size($h1-font-size);
 }
 
-h2 {
+h2,
+.h2 {
   @extend %heading;
   @include font-size($h2-font-size);
 }
 
-h3 {
+h3,
+.h3 {
   @extend %heading;
   @include font-size($h3-font-size);
 }
 
-h4 {
+h4,
+.h4 {
   @extend %heading;
   @include font-size($h4-font-size);
 }
 
-h5 {
+h5,
+.h5 {
   @extend %heading;
   @include font-size($h5-font-size);
 }
 
-h6 {
+h6,
+.h6 {
   @extend %heading;
   @include font-size($h6-font-size);
 }
@@ -208,14 +214,16 @@ strong {
 //
 // Add the correct font size in all browsers
 
-small {
+small,
+.small {
   @include font-size($small-font-size);
 }
 
 
 // Mark
 
-mark {
+mark,
+.mark {
   padding: $mark-padding;
   color: var(--#{$prefix}highlight-color);
   background-color: var(--#{$prefix}highlight-bg);

--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -1,30 +1,6 @@
 //
 // Headings
 //
-.h1 {
-  @extend h1;
-}
-
-.h2 {
-  @extend h2;
-}
-
-.h3 {
-  @extend h3;
-}
-
-.h4 {
-  @extend h4;
-}
-
-.h5 {
-  @extend h5;
-}
-
-.h6 {
-  @extend h6;
-}
-
 
 .lead {
   @include font-size($lead-font-size);
@@ -40,17 +16,6 @@
     line-height: $display-line-height;
     @include font-size($font-size);
   }
-}
-
-//
-// Emphasis
-//
-.small {
-  @extend small;
-}
-
-.mark {
-  @extend mark;
 }
 
 //


### PR DESCRIPTION
Co-locates heading classes and additional type classes in Reboot to avoid some extends and extra dependencies once we migrate to Sass modules.
