### PR TITLE
js: simplify bootstrapDelegationHandler function

### DIFF
--- a/js/src/dom/event-handler.js
+++ b/js/src/dom/event-handler.js
@@ -101,22 +101,18 @@ function bootstrapHandler(element, fn) {
 
 function bootstrapDelegationHandler(element, selector, fn) {
   return function handler(event) {
-    const domElements = element.querySelectorAll(selector)
+    const { target } = event
 
-    for (let { target } = event; target && target !== this; target = target.parentNode) {
-      for (const domElement of domElements) {
-        if (domElement !== target) {
-          continue
-        }
+    const trigger = target.closest(selector)
 
-        hydrateObj(event, { delegateTarget: target })
+    if (trigger && element.contains(trigger)) {
+      hydrateObj(event, { delegateTarget: trigger })
 
-        if (handler.oneOff) {
-          EventHandler.off(element, event.type, selector, fn)
-        }
-
-        return fn.apply(target, [event])
+      if (handler.oneOff) {
+        EventHandler.off(element, event.type, selector, fn)
       }
+
+      return fn.apply(trigger, [event])
     }
   }
 }

--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -70,6 +70,38 @@ describe('EventHandler', () => {
       })
     })
 
+    it('should find the correct target element via event delegation', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="component">',
+          '<!-- Comment -->',
+          '<section>',
+          '<b>',
+          'Just text content',
+          '<svg>',
+          '<i>',
+          '<p>',
+          '<span>Click me</span>',
+          '</p>',
+          '</i>',
+          '</svg>',
+          '</b>',
+          '</section>',
+          '</div>'
+        ].join('')
+
+        EventHandler.on(document, 'click', '.component', () => {
+          expect(component).toHaveClass('component')
+          resolve()
+        })
+
+        const component = document.querySelector('.component')
+        const span = fixtureEl.querySelector('span')
+
+        EventHandler.trigger(span, 'click')
+      })
+    })
+
     it('should handle event delegation', () => {
       return new Promise(resolve => {
         EventHandler.on(document, 'click', '.test', () => {

--- a/js/tests/unit/util/focustrap.spec.js
+++ b/js/tests/unit/util/focustrap.spec.js
@@ -96,6 +96,7 @@ describe('FocusTrap', () => {
         const last = document.getElementById('last')
         const outside = document.getElementById('outside')
 
+        document.closest = () => undefined
         spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [first, inside, last])
         const spy = spyOn(first, 'focus').and.callThrough()
 
@@ -135,6 +136,7 @@ describe('FocusTrap', () => {
         const last = document.getElementById('last')
         const outside = document.getElementById('outside')
 
+        document.closest = () => undefined
         spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [first, inside, last])
         const spy = spyOn(last, 'focus').and.callThrough()
 


### PR DESCRIPTION
Closes #41116

### Description

The bootstrapDelegationHandler function has been changed as suggested by @frkly. Added a test that verifies that the `bootstrapDelegationHandler` callback finds the desired element. Fixed tests in `js/tests/unit/util/focustrap.spec.js`, two tests used `document` for `dispatchEvent`,  `document` does not have `closest`. As I understand it, the only way to get to this case is testing, since EventHandler is a private API. 

### Motivation & Context

The parent element search function can be simplified. Current support for the closest is 96.01%

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed