### PR TITLE
Enforce focus on dropdown trigger

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -202,15 +202,15 @@ class Dropdown extends BaseComponent {
       this._popper.destroy()
     }
 
-    if (this._menu.contains(document.activeElement)) {
-      this._element.focus()
-    }
-
     this._menu.classList.remove(CLASS_NAME_SHOW)
     this._element.classList.remove(CLASS_NAME_SHOW)
     this._element.setAttribute('aria-expanded', 'false')
     Manipulator.removeDataAttribute(this._menu, 'popper')
     EventHandler.trigger(this._element, EVENT_HIDDEN, relatedTarget)
+
+    if (this._menu?.contains(document.activeElement)) {
+      this._element?.focus()
+    }
   }
 
   _getConfig(config) {

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -202,6 +202,10 @@ class Dropdown extends BaseComponent {
       this._popper.destroy()
     }
 
+    if (this._menu.contains(document.activeElement)) {
+      this._element.focus()
+    }
+
     this._menu.classList.remove(CLASS_NAME_SHOW)
     this._element.classList.remove(CLASS_NAME_SHOW)
     this._element.setAttribute('aria-expanded', 'false')

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -208,8 +208,8 @@ class Dropdown extends BaseComponent {
     Manipulator.removeDataAttribute(this._menu, 'popper')
     EventHandler.trigger(this._element, EVENT_HIDDEN, relatedTarget)
 
-    if (this._menu?.contains(document.activeElement)) {
-      this._element?.focus()
+    if (this._menu && this._menu.contains(document.activeElement)) {
+      this._element.focus()
     }
   }
 

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -2097,6 +2097,34 @@ describe('Dropdown', () => {
       })
     })
 
+    it('should focus the dropdown trigger when an item is selected (and the dropdown is hidden)', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <a class="dropdown-item" href="#">Some Item</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const toggle = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const item = fixtureEl.querySelector('.dropdown-item')
+
+        toggle.addEventListener('shown.bs.dropdown', () => {
+          item.focus()
+          item.click()
+        })
+
+        toggle.addEventListener('hidden.bs.dropdown', () => setTimeout(() => {
+          expect(document.activeElement).toEqual(toggle)
+          resolve()
+        }))
+
+        toggle.click()
+      })
+    })
+
     it('should close dropdown (only) by clicking inside the dropdown menu when it has data-attribute `data-bs-auto-close="inside"`', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -2125,6 +2125,72 @@ describe('Dropdown', () => {
       })
     })
 
+    it('should not focus the dropdown trigger when an item is selected and something else is focused in the hidden event', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<button class="focus-target"></button>',
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <a class="dropdown-item" href="#">Some Item</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const toggle = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const item = fixtureEl.querySelector('.dropdown-item')
+        const focusTarget = fixtureEl.querySelector('.focus-target')
+
+        toggle.addEventListener('shown.bs.dropdown', () => {
+          item.focus()
+          item.click()
+        })
+
+        toggle.addEventListener('hidden.bs.dropdown', () => {
+          focusTarget.focus()
+          setTimeout(() => {
+            expect(document.activeElement).toEqual(focusTarget)
+            expect(document.activeElement).not.toEqual(toggle)
+            resolve()
+          })
+        })
+
+        toggle.click()
+      })
+    })
+
+    it('should not throw an error when the dropdown was disposed in the hidden event', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <a class="dropdown-item" href="#">Some Item</a>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const toggle = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const item = fixtureEl.querySelector('.dropdown-item')
+
+        toggle.addEventListener('shown.bs.dropdown', () => {
+          item.click()
+        })
+
+        toggle.addEventListener('hidden.bs.dropdown', () => {
+          const dropdown = Dropdown.getInstance(toggle)
+          dropdown.dispose()
+
+          setTimeout(() => {
+            expect(dropdown._menu).toBeNull()
+            resolve()
+          })
+        })
+
+        toggle.click()
+      })
+    })
+
     it('should close dropdown (only) by clicking inside the dropdown menu when it has data-attribute `data-bs-auto-close="inside"`', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

Enforce focus on the dropdown trigger after an item has been selected (and the dropdown is hidden).

### Motivation & Context

See #35793

Regarding the implementation - I've seen some proposed implementation by @julien-deramond in another issue, but he mentioned it might be quite complex. This way the focus is only moved to the trigger, if the active focus resides within the dropdown menu. As such it shouldn't conflict if the focus was moved prior/in the event of being hidden.

~I set the focus before the hidden event is dispatched, in case some implementor wanted to change the focus to something else, via the event handler (or in case the dropdown is being disposed in the handler - to prevent an error in case the element doesn't exist anymore). Although in that case, I could imagine that screen readers would announce multiple focus jumps (not sure tho), that may require additional tweaks.~

Changed the implementation to focus after the hidden event dispatched. If a user manually moves the focus in the event outside of the dropdown, it shouldn't interfere with it anyway. Added a test to the spec to confirm that. As well as another test to make sure no error is thrown if the menu is disposed in the hidden event.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41711--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
Closes #35793
Closes #41588 (tbf this can be closed already, just so we don't forget about it)