### PR TITLE
Normalize selector operation in scrollspy

### DIFF
--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -214,6 +214,7 @@ class ScrollSpy extends BaseComponent {
       const withEscape = parseSelector(withDecodeUri)
       const observableSection = SelectorEngine.findOne(withEscape, this._element)
 
+      // ensure that the observableSection exists & is visible
       if (isVisible(observableSection)) {
         this._targetLinks.set(withDecodeUri, anchor)
         this._observableSections.set(anchor.hash, observableSection)

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -9,7 +9,7 @@ import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
 import {
-  defineJQueryPlugin, getElement, isDisabled, isVisible
+  defineJQueryPlugin, getElement, isDisabled, isVisible, parseSelector
 } from './util/index.js'
 
 /**
@@ -210,11 +210,12 @@ class ScrollSpy extends BaseComponent {
         continue
       }
 
-      const observableSection = SelectorEngine.findOne(decodeURI(anchor.hash), this._element)
+      const withDecodeUri = decodeURI(anchor.hash)
+      const withEscape = parseSelector(withDecodeUri)
+      const observableSection = SelectorEngine.findOne(withEscape, this._element)
 
-      // ensure that the observableSection exists & is visible
       if (isVisible(observableSection)) {
-        this._targetLinks.set(decodeURI(anchor.hash), anchor)
+        this._targetLinks.set(withDecodeUri, anchor)
         this._observableSections.set(anchor.hash, observableSection)
       }
     }

--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -17,7 +17,7 @@ const TRANSITION_END = 'transitionend'
 const parseSelector = selector => {
   if (selector && window.CSS && window.CSS.escape) {
     // document.querySelector needs escaping to handle IDs (html5+) containing for instance /
-    selector = selector.replace(/#([^\s"#']+)/g, (match, id) => `#${CSS.escape(id)}`)
+    selector = selector.replace(/#([^\s"']+)/g, (match, id) => `#${CSS.escape(id)}`)
   }
 
   return selector

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -194,7 +194,7 @@ describe('ScrollSpy', () => {
       expect(scrollSpy._targetLinks.size).toBe(1)
     })
 
-    it('should take count to escaped IDs', () => {
+    it('should take account of escaped IDs', () => {
       fixtureEl.innerHTML = [
         '<nav id="navigation" class="navbar">',
         '  <ul class="navbar-nav">',

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -194,6 +194,34 @@ describe('ScrollSpy', () => {
       expect(scrollSpy._targetLinks.size).toBe(1)
     })
 
+    it('should take count to escaped IDs', () => {
+      fixtureEl.innerHTML = [
+        '<nav id="navigation" class="navbar">',
+        '  <ul class="navbar-nav">',
+        '    <li class="nav-item"><a class="nav-link active" id="one-link" href="#div-2.1">One</a></li>',
+        '    <li class="nav-item"><a class="nav-link" id="two-link" href="#!@#$_^&*()">Two</a></li>',
+        '    <li class="nav-item"><a class="nav-link" id="three-link" href="#id.div.Element@data-custom=true">Three</a></li>',
+        '    <li class="nav-item"><a class="nav-link" id="four-link" href="#https://domain.to/#%2F%40user%3Aname.test">Four</a></li>',
+        '    <li class="nav-item"><a class="nav-link" id="five-link" href="#https://domain.to/#/@user:name.test">Five</a></li>',
+        '  </ul>',
+        '</nav>',
+        '<div id="content" style="height: 200px; overflow-y: auto;">',
+        '  <div id="div-2.1" style="height: 300px;">test</div>',
+        '  <div id="!@#$_^&*()" style="height: 300px;">test</div>',
+        '  <div id="id.div.Element@data-custom=true" style="height: 300px;">test</div>',
+        '  <div id="https://domain.to/#%2F%40user%3Aname.test" style="height: 300px;">test</div>',
+        '  <div id="https://domain.to/#/@user:name.test">test</div>',
+        '</div>'
+      ].join('')
+
+      const scrollSpy = new ScrollSpy(fixtureEl.querySelector('#content'), {
+        target: '#navigation'
+      })
+
+      expect(scrollSpy._observableSections.size).toBe(5)
+      expect(scrollSpy._targetLinks.size).toBe(5)
+    })
+
     it('should not process element without target', () => {
       fixtureEl.innerHTML = [
         '<nav id="navigation" class="navbar">',


### PR DESCRIPTION
Closes: #39198
Closes: #37858
Closes: #39248
Fix: #35566 (Hope, see below)

### Description

Allows you to select the elements in the Scrollspy component that need to be escaped. 

### Motivation & Context

Users complain that they can't always control how their IDs for a component are filled in.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-41726--twbs-bootstrap.netlify.app/>

### Related issues

#39198
#37858
#32586
#35566 (very important)

In PR #35566, @pierresouchay added a selector search mechanism when escaping `selector = selector.replaceAll(/#([^\s"#']+)/g, (match, id) => '#' + CSS.escape(id))`. I removed the `#` symbol from there, as it interfered with the current implementation, but did not affect the previous functionality (during manual and automatic testing). I do not know why it was not necessary to escape the identifier inside the expression (#firistid#secondId is invalid), but the functionality works. In the worst case, it was necessary, but they just forgot to write the tests. At best, everything is fine.

P.S. A lot of questions, so I will be glad to receive feedback))
