### PR TITLE
Use `@forward` instead of `@use` for proper customization

### DIFF
--- a/scss/bootstrap-utilities.scss
+++ b/scss/bootstrap-utilities.scss
@@ -6,11 +6,11 @@
 // @forward "variables";
 
 // Layout & components
-@use "root" as *;
+@forward "root";
 
 // Helpers
 @forward "helpers";
 
 // Utilities
-@use "utilities" as *;
-@use "utilities/api";
+@forward "utilities";
+@forward "utilities/api";

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,40 +1,40 @@
-@use "banner";
+@forward "banner";
 
 // scss-docs-start import-stack
 // Global CSS variables, layer definitions, and configuration
-@use "root";
+@forward "root";
 
 // Subdir imports
-@use "content";
-@use "layout";
-@use "forms";
-@use "buttons";
+@forward "content";
+@forward "layout";
+@forward "forms";
+@forward "buttons";
 
 // Components
-@use "accordion";
-@use "alert";
-@use "badge";
-@use "breadcrumb";
-@use "card";
-@use "carousel";
-@use "dropdown";
-@use "list-group";
-@use "modal";
-@use "nav";
-@use "navbar";
-@use "offcanvas";
-@use "pagination";
-@use "placeholders";
-@use "popover";
-@use "progress";
-@use "spinners";
-@use "toasts";
-@use "tooltip";
-@use "transitions";
+@forward "accordion";
+@forward "alert";
+@forward "badge";
+@forward "breadcrumb";
+@forward "card";
+@forward "carousel";
+@forward "dropdown";
+@forward "list-group";
+@forward "modal";
+@forward "nav";
+@forward "navbar";
+@forward "offcanvas";
+@forward "pagination";
+@forward "placeholders";
+@forward "popover";
+@forward "progress";
+@forward "spinners";
+@forward "toasts";
+@forward "tooltip";
+@forward "transitions";
 
 // Helpers
-@use "helpers";
+@forward "helpers";
 
 // Utilities
-@use "utilities/api";
+@forward "utilities/api";
 // scss-docs-end import-stack

--- a/scss/tests/jasmine.js
+++ b/scss/tests/jasmine.js
@@ -8,7 +8,7 @@ module.exports = {
   spec_dir: 'scss',
   // Make Jasmine look for `.test.scss` files
   // spec_files: ['**/*.{test,spec}.scss'],
-  spec_files: ['**/_utilities.test.scss'],
+  spec_files: ['**/_utilities.test.scss', '**/modules/_configuration.test.scss'],
   // Compile them into JS scripts running `sass-true`
   requires: [path.join(__dirname, 'sass-true/register')],
   // Ensure we use `require` so that the require.extensions works

--- a/scss/tests/modules/_configuration.test.scss
+++ b/scss/tests/modules/_configuration.test.scss
@@ -1,0 +1,123 @@
+// Test @use with configuration syntax using a single module instance
+@use "../../alert" as alert with (
+  $alert-margin-bottom: 3rem,
+  $alert-link-font-weight: 800
+);
+@use "../../variables" as vars;
+
+$true-terminal-output: false;
+
+@include describe("Bootstrap module configuration") {
+  @include describe("@use with configuration syntax") {
+    @include it("should allow configuring alert variables with @use ... with") {
+      @include assert {
+        @include output {
+          $test-margin: alert.$alert-margin-bottom;
+          $test-weight: alert.$alert-link-font-weight;
+
+          .test {
+            margin-bottom: $test-margin;
+            font-weight: $test-weight;
+          }
+        }
+
+        @include expect {
+          .test {
+            margin-bottom: 3rem;
+            font-weight: 800;
+          }
+        }
+      }
+    }
+
+    @include it("should maintain other alert variables with default values") {
+      @include assert {
+        @include output {
+          .test {
+            padding-y: alert.$alert-padding-y;
+            padding-x: alert.$alert-padding-x;
+            border-radius: alert.$alert-border-radius;
+          }
+        }
+
+        @include expect {
+          .test {
+            padding-y: alert.$alert-padding-y;
+            padding-x: alert.$alert-padding-x;
+            border-radius: alert.$alert-border-radius;
+          }
+        }
+      }
+    }
+
+    @include it("should demonstrate @use with() syntax works correctly") {
+      // This test verifies that the @use with() configuration syntax from your test.scss works
+      // If this test passes, it means Bootstrap 6's module system supports variable configuration
+      @include assert {
+        @include output {
+          .test {
+            @if type-of(alert.$alert-margin-bottom) == "number" {
+              configured-margin: true;
+            }
+            @if type-of(alert.$alert-link-font-weight) == "number" {
+              configured-weight: true;
+            }
+          }
+        }
+
+        @include expect {
+          .test {
+            configured-margin: true;
+            configured-weight: true;
+          }
+        }
+      }
+    }
+  }
+
+  @include describe("Module system integrity") {
+    @include it("should maintain @use module boundaries and expose functions") {
+      @include assert {
+        @include output {
+          .test {
+            @if function-exists("strip-unit", vars) {
+              strip-unit-exists: true;
+            }
+          }
+        }
+
+        @include expect {
+          .test {
+            strip-unit-exists: true;
+          }
+        }
+      }
+    }
+
+    @include it("should make configured variables accessible via namespace") {
+      @include assert {
+        @include output {
+          .test {
+            @if variable-exists("alert-margin-bottom") {
+              margin-var-exists: true;
+            }
+            @if variable-exists("alert-link-font-weight") {
+              weight-var-exists: true;
+            }
+            @if variable-exists("alert-padding-y") {
+              padding-var-exists: true;
+            }
+          }
+        }
+
+        @include expect {
+          .test {
+            margin-var-exists: true;
+            weight-var-exists: true;
+            padding-var-exists: true;
+          }
+        }
+      }
+    }
+  }
+}

--- a/scss/tests/modules/_configuration.test.scss
+++ b/scss/tests/modules/_configuration.test.scss
@@ -10,8 +10,8 @@ $true-terminal-output: false;
 @include describe("Bootstrap module configuration") {
   @include describe("@use with configuration syntax") {
     @include it("should allow configuring alert variables with @use ... with") {
-      @include assert {
-        @include output {
+      @include assert() {
+        @include output() {
           $test-margin: alert.$alert-margin-bottom;
           $test-weight: alert.$alert-link-font-weight;
 
@@ -21,7 +21,7 @@ $true-terminal-output: false;
           }
         }
 
-        @include expect {
+        @include expect() {
           .test {
             margin-bottom: 3rem;
             font-weight: 800;
@@ -31,19 +31,21 @@ $true-terminal-output: false;
     }
 
     @include it("should maintain other alert variables with default values") {
-      @include assert {
-        @include output {
+      @include assert() {
+        @include output() {
           .test {
             padding-y: alert.$alert-padding-y;
             padding-x: alert.$alert-padding-x;
+            // stylelint-disable-next-line property-disallowed-list
             border-radius: alert.$alert-border-radius;
           }
         }
 
-        @include expect {
+        @include expect() {
           .test {
             padding-y: alert.$alert-padding-y;
             padding-x: alert.$alert-padding-x;
+            // stylelint-disable-next-line property-disallowed-list
             border-radius: alert.$alert-border-radius;
           }
         }
@@ -53,8 +55,8 @@ $true-terminal-output: false;
     @include it("should demonstrate @use with() syntax works correctly") {
       // This test verifies that the @use with() configuration syntax from your test.scss works
       // If this test passes, it means Bootstrap 6's module system supports variable configuration
-      @include assert {
-        @include output {
+      @include assert() {
+        @include output() {
           .test {
             @if type-of(alert.$alert-margin-bottom) == "number" {
               configured-margin: true;
@@ -65,7 +67,7 @@ $true-terminal-output: false;
           }
         }
 
-        @include expect {
+        @include expect() {
           .test {
             configured-margin: true;
             configured-weight: true;
@@ -77,8 +79,8 @@ $true-terminal-output: false;
 
   @include describe("Module system integrity") {
     @include it("should maintain @use module boundaries and expose functions") {
-      @include assert {
-        @include output {
+      @include assert() {
+        @include output() {
           .test {
             @if function-exists("strip-unit", vars) {
               strip-unit-exists: true;
@@ -86,7 +88,7 @@ $true-terminal-output: false;
           }
         }
 
-        @include expect {
+        @include expect() {
           .test {
             strip-unit-exists: true;
           }
@@ -95,8 +97,8 @@ $true-terminal-output: false;
     }
 
     @include it("should make configured variables accessible via namespace") {
-      @include assert {
-        @include output {
+      @include assert() {
+        @include output() {
           .test {
             @if variable-exists("alert-margin-bottom") {
               margin-var-exists: true;
@@ -110,7 +112,7 @@ $true-terminal-output: false;
           }
         }
 
-        @include expect {
+        @include expect() {
           .test {
             margin-var-exists: true;
             weight-var-exists: true;

--- a/scss/tests/modules/_configuration.test.scss
+++ b/scss/tests/modules/_configuration.test.scss
@@ -1,9 +1,9 @@
 // Test @use with configuration syntax using a single module instance
-@use "../../alert" as alert with (
+@use "../../alert" as * with (
   $alert-margin-bottom: 3rem,
   $alert-link-font-weight: 800
 );
-@use "../../variables" as vars;
+@use "../../variables" as *;
 
 $true-terminal-output: false;
 
@@ -12,12 +12,9 @@ $true-terminal-output: false;
     @include it("should allow configuring alert variables with @use ... with") {
       @include assert() {
         @include output() {
-          $test-margin: alert.$alert-margin-bottom;
-          $test-weight: alert.$alert-link-font-weight;
-
           .test {
-            margin-bottom: $test-margin;
-            font-weight: $test-weight;
+            margin-bottom: $alert-margin-bottom;
+            font-weight: $alert-link-font-weight;
           }
         }
 
@@ -34,89 +31,19 @@ $true-terminal-output: false;
       @include assert() {
         @include output() {
           .test {
-            padding-y: alert.$alert-padding-y;
-            padding-x: alert.$alert-padding-x;
+            padding-y: $alert-padding-y;
+            padding-x: $alert-padding-x;
             // stylelint-disable-next-line property-disallowed-list
-            border-radius: alert.$alert-border-radius;
+            border-radius: $alert-border-radius;
           }
         }
 
         @include expect() {
           .test {
-            padding-y: alert.$alert-padding-y;
-            padding-x: alert.$alert-padding-x;
+            padding-y: 1rem;
+            padding-x: 1rem;
             // stylelint-disable-next-line property-disallowed-list
-            border-radius: alert.$alert-border-radius;
-          }
-        }
-      }
-    }
-
-    @include it("should demonstrate @use with() syntax works correctly") {
-      // This test verifies that the @use with() configuration syntax from your test.scss works
-      // If this test passes, it means Bootstrap 6's module system supports variable configuration
-      @include assert() {
-        @include output() {
-          .test {
-            @if type-of(alert.$alert-margin-bottom) == "number" {
-              configured-margin: true;
-            }
-            @if type-of(alert.$alert-link-font-weight) == "number" {
-              configured-weight: true;
-            }
-          }
-        }
-
-        @include expect() {
-          .test {
-            configured-margin: true;
-            configured-weight: true;
-          }
-        }
-      }
-    }
-  }
-
-  @include describe("Module system integrity") {
-    @include it("should maintain @use module boundaries and expose functions") {
-      @include assert() {
-        @include output() {
-          .test {
-            @if function-exists("strip-unit", vars) {
-              strip-unit-exists: true;
-            }
-          }
-        }
-
-        @include expect() {
-          .test {
-            strip-unit-exists: true;
-          }
-        }
-      }
-    }
-
-    @include it("should make configured variables accessible via namespace") {
-      @include assert() {
-        @include output() {
-          .test {
-            @if variable-exists("alert-margin-bottom") {
-              margin-var-exists: true;
-            }
-            @if variable-exists("alert-link-font-weight") {
-              weight-var-exists: true;
-            }
-            @if variable-exists("alert-padding-y") {
-              padding-var-exists: true;
-            }
-          }
-        }
-
-        @include expect() {
-          .test {
-            margin-var-exists: true;
-            weight-var-exists: true;
-            padding-var-exists: true;
+            border-radius: var(--bs-border-radius);
           }
         }
       }


### PR DESCRIPTION
Fixes #41761.

Might need to audit the other stylesheets more still. I also wouldn't mind more tests here—had Claude add one for this stuff to ensure we're tracking _something_ at least.