### PR TITLE
Fix: add null check for activeIndicator in Carousel

### DIFF
--- a/js/src/carousel.js
+++ b/js/src/carousel.js
@@ -274,8 +274,10 @@ class Carousel extends BaseComponent {
 
     const activeIndicator = SelectorEngine.findOne(SELECTOR_ACTIVE, this._indicatorsElement)
 
-    activeIndicator.classList.remove(CLASS_NAME_ACTIVE)
-    activeIndicator.removeAttribute('aria-current')
+    if (activeIndicator) {
+      activeIndicator.classList.remove(CLASS_NAME_ACTIVE)
+      activeIndicator.removeAttribute('aria-current')
+    }
 
     const newActiveIndicator = SelectorEngine.findOne(`[data-bs-slide-to="${index}"]`, this._indicatorsElement)
 

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -877,6 +877,35 @@ describe('Carousel', () => {
       })
     })
 
+    it('should handle indicators without an active indicator on initialization', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div id="myCarousel" class="carousel slide">',
+          '  <div class="carousel-indicators">',
+          '    <button type="button" data-bs-target="myCarousel" data-bs-slide-to="0" aria-label="Slide 1"></button>',
+          '    <button type="button" id="secondIndicator" data-bs-target="myCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>',
+          '  </div>',
+          '  <div class="carousel-inner">',
+          '    <div class="carousel-item active">item 1</div>',
+          '    <div class="carousel-item">item 2</div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const carouselEl = fixtureEl.querySelector('#myCarousel')
+        const secondIndicator = fixtureEl.querySelector('#secondIndicator')
+        const carousel = new Carousel(carouselEl)
+
+        carouselEl.addEventListener('slid.bs.carousel', () => {
+          expect(secondIndicator).toHaveClass('active')
+          expect(secondIndicator.getAttribute('aria-current')).toEqual('true')
+          resolve()
+        })
+
+        carousel.next()
+      })
+    })
+
     it('should call next()/prev() instance methods when clicking the respective direction buttons', () => {
       fixtureEl.innerHTML = [
         '<div id="carousel" class="carousel slide">',


### PR DESCRIPTION
### Description

Adds null check for activeIndicator to match the pattern used for newActiveIndicator on line 282.

### Motivation & Context

While testing carousel behavior with modified DOM, I noticed SelectorEngine.findOne() can return null if there's no active indicator, which would cause an error on classList.remove(). This adds the same safety check that's already in place for newActiveIndicator.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

N/A