### PR TITLE
docs:Add a mechanism to specify aria-labels on the copy and edit buttons in code examples

### DIFF
--- a/site/src/components/shortcodes/Code.astro
+++ b/site/src/components/shortcodes/Code.astro
@@ -38,9 +38,16 @@ interface Props {
    * @default false
    */
   nestedInExample?: boolean
+  /**
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   */
+  buttonLabel?: string
 }
 
-const { class: className, code, containerClass, fileMatch, filePath, lang, nestedInExample = false } = Astro.props
+const { class: className, code, containerClass, fileMatch, filePath, lang, nestedInExample = false, buttonLabel } = Astro.props
+
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} code to clipboard` : filePath ?
+  `Copy ${filePath} code to clipboard` : 'Copy code to clipboard'
 
 let codeToDisplay = filePath
   ? fs.readFileSync(path.join(process.cwd(), filePath), 'utf8')
@@ -62,17 +69,15 @@ if (filePath && fileMatch && codeToDisplay) {
 <script>
   import ClipboardJS from 'clipboard'
 
-  const btnTitle = 'Copy to clipboard'
-  const btnEdit = 'Edit on StackBlitz'
-
-  function snippetButtonTooltip(selector: string, title: string) {
+  function snippetButtonTooltip(selector: string, tooltipLabel: string) {
     document.querySelectorAll(selector).forEach((btn) => {
-      bootstrap.Tooltip.getOrCreateInstance(btn, { title })
+      bootstrap.Tooltip.getOrCreateInstance(btn, { title: tooltipLabel })
     })
   }
 
-  snippetButtonTooltip('.btn-clipboard', btnTitle)
-  snippetButtonTooltip('.btn-edit', btnEdit)
+  const clipboardTooltip = 'Copy to clipboard'
+  snippetButtonTooltip('.btn-clipboard', clipboardTooltip)
+  snippetButtonTooltip('.btn-edit', 'Edit on StackBlitz')
 
   const clipboard = new ClipboardJS('.btn-clipboard', {
     target: (trigger) => trigger.closest('.bd-code-snippet')?.querySelector('.highlight')!,
@@ -100,7 +105,7 @@ if (filePath && fileMatch && codeToDisplay) {
     event.trigger.addEventListener(
       'hidden.bs.tooltip',
       () => {
-        tooltipBtn?.setContent({ '.tooltip-inner': btnTitle })
+        tooltipBtn?.setContent({ '.tooltip-inner': clipboardTooltip })
       },
       { once: true }
     )
@@ -128,7 +133,7 @@ if (filePath && fileMatch && codeToDisplay) {
     event.trigger.addEventListener(
       'hidden.bs.tooltip',
       () => {
-        tooltipBtn?.setContent({ '.tooltip-inner': btnTitle })
+        tooltipBtn?.setContent({ '.tooltip-inner': clipboardTooltip })
       },
       { once: true }
     )
@@ -145,8 +150,8 @@ if (filePath && fileMatch && codeToDisplay) {
         )
         : (
           <div class="bd-clipboard">
-            <button type="button" class="btn-clipboard">
-              <svg class="bi" role="img" aria-label="Copy">
+            <button type="button" class="btn-clipboard" title={clipboardLabel}>
+              <svg class="bi" aria-hidden="true">
                 <use xlink:href="#clipboard" />
               </svg>
             </button>

--- a/site/src/components/shortcodes/Code.astro
+++ b/site/src/components/shortcodes/Code.astro
@@ -39,7 +39,7 @@ interface Props {
    */
   nestedInExample?: boolean
   /**
-   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons aria-labels.
    */
   buttonLabel?: string
 }

--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -37,7 +37,7 @@ interface Props {
    */
   showPreview?: boolean
   /**
-   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons aria-labels.
    */
   buttonLabel?: string
 }

--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -36,6 +36,10 @@ interface Props {
    * @default true
    */
   showPreview?: boolean
+  /**
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   */
+  buttonLabel?: string
 }
 
 const {
@@ -45,11 +49,15 @@ const {
   id,
   lang = 'html',
   showMarkup = true,
-  showPreview = true
+  showPreview = true,
+  buttonLabel
 } = Astro.props
 
 let markup = Array.isArray(code) ? code.join('\n') : code
 markup = replacePlaceholdersInHtml(markup)
+
+const stackblitzLabel = buttonLabel ? `Edit ${buttonLabel} code on StackBlitz` : 'Edit code on StackBlitz'
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} code to clipboard` : 'Copy code to clipboard'
 
 const simplifiedMarkup = markup
   .replace(
@@ -81,14 +89,14 @@ const simplifiedMarkup = markup
               <button
                 type="button"
                 class="btn-edit text-nowrap"
-                title="Try it on StackBlitz"
+                title={stackblitzLabel}
                 data-sb-js-snippet={addStackblitzJs ? true : undefined}
               >
                 <svg class="bi" aria-hidden="true">
                   <use xlink:href="#lightning-charge-fill" />
                 </svg>
               </button>
-              <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">
+              <button type="button" class="btn-clipboard mt-0 me-0" title={clipboardLabel}>
                 <svg class="bi" aria-hidden="true">
                   <use xlink:href="#clipboard" />
                 </svg>
@@ -96,7 +104,7 @@ const simplifiedMarkup = markup
             </div>
           </div>
         )}
-        <Code code={simplifiedMarkup} lang={lang} nestedInExample={true} />
+        <Code code={simplifiedMarkup} lang={lang} nestedInExample={true} buttonLabel={buttonLabel} />
       </>
     )
   }

--- a/site/src/components/shortcodes/JsDocs.astro
+++ b/site/src/components/shortcodes/JsDocs.astro
@@ -16,7 +16,7 @@ interface Props {
    */
   file: string
   /**
-   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   * Defines label to complete 'Copy JS to clipboard' button aria-label.
    */
   buttonLabel?: string
 }

--- a/site/src/components/shortcodes/JsDocs.astro
+++ b/site/src/components/shortcodes/JsDocs.astro
@@ -15,15 +15,21 @@ interface Props {
    * File path that contains the content to display relative to the root of the repository.
    */
   file: string
+  /**
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   */
+  buttonLabel?: string
 }
 
-const { name, file } = Astro.props
+const { name, file, buttonLabel } = Astro.props
 
 if (!name || !file) {
   throw new Error(
     `Missing required parameter(s) for the '<JsDocs />' component, expected both 'name' and 'file' but got 'name: ${name}' and 'file: ${file}'.`
   )
 }
+
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} JS to clipboard` : `Copy ${name} JS to clipboard`
 
 let content: string
 
@@ -52,7 +58,7 @@ try {
 }
 ---
 
-<Code containerClass="bd-example-snippet bd-code-snippet bd-file-ref" code={content} lang="js">
+<Code containerClass="bd-example-snippet bd-code-snippet bd-file-ref" code={content} lang="js" buttonLabel={buttonLabel}>
   <div slot="pre" class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
     <a
       class="font-monospace link-secondary link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small"
@@ -61,7 +67,7 @@ try {
       {file}
     </a>
     <div class="d-flex ms-auto">
-      <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">
+      <button type="button" class="btn-clipboard mt-0 me-0" title={clipboardLabel}>
         <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
       </button>
     </div>

--- a/site/src/components/shortcodes/ScssDocs.astro
+++ b/site/src/components/shortcodes/ScssDocs.astro
@@ -15,15 +15,21 @@ interface Props {
    * File path that contains the content to display relative to the root of the repository.
    */
   file: string
+  /**
+   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   */
+  buttonLabel?: string
 }
 
-const { name, file } = Astro.props
+const { name, file, buttonLabel } = Astro.props
 
 if (!name || !file) {
   throw new Error(
     `Missing required parameter(s) for the '<ScssDocs />' component, expected both 'name' and 'file' but got 'name: ${name}' and 'file: ${file}'.`
   )
 }
+
+const clipboardLabel = buttonLabel ? `Copy ${buttonLabel} SCSS to clipboard` : `Copy ${name} SCSS to clipboard`
 
 let content: string
 
@@ -54,7 +60,7 @@ try {
 }
 ---
 
-<Code containerClass="bd-example-snippet bd-file-ref" code={content} lang="scss">
+<Code containerClass="bd-example-snippet bd-file-ref" code={content} lang="scss" buttonLabel={buttonLabel}>
   <div slot="pre" class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
     <a
       class="font-monospace link-secondary link-underline-secondary link-underline-opacity-0 link-underline-opacity-100-hover small"
@@ -63,7 +69,7 @@ try {
       {file}
     </a>
     <div class="d-flex ms-auto">
-      <button type="button" class="btn-clipboard mt-0 me-0" title="Copy to clipboard">
+      <button type="button" class="btn-clipboard mt-0 me-0" title={clipboardLabel}>
         <svg class="bi" aria-hidden="true"><use xlink:href="#clipboard"></use></svg>
       </button>
     </div>

--- a/site/src/components/shortcodes/ScssDocs.astro
+++ b/site/src/components/shortcodes/ScssDocs.astro
@@ -16,7 +16,7 @@ interface Props {
    */
   file: string
   /**
-   * Defines label to complete 'Edit code on Stackblitz' and/or 'Copy code to clipboard' buttons labels.
+   * Defines label to complete 'Copy SCSS to clipboard' button aria-label.
    */
   buttonLabel?: string
 }

--- a/site/src/content/docs/docsref.mdx
+++ b/site/src/content/docs/docsref.mdx
@@ -36,7 +36,7 @@ robots: noindex,follow
 
 <Example showMarkup={false} code={`The <abbr title="HyperText Markup Language">HTML</abbr> abbreviation element.`} />
 
-<Example code={`<div class="test">This is a test.</div>`} />
+<Example buttLabel="test" code={`<div class="test">This is a test.</div>`} />
 
 <ScssDocs name="variable-gradient" file="scss/_variables.scss" />
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->
For all the examples buttons in the doc, add a new parameter buttonLabel to all code display components (Example , Code, JsDocs, ScssDocs) to manage the aria-labels of the buttons. The tooltip content remains "Copy to clipboard" and "Edit on Stackblitz": 

- For **JsDocs** component, as an aria-label for the "Copy to clipboard button", use:
  - "Copy `buttonLabel` JS to clipboard", if `buttonLabel` is provided
  - If not provided, "Copy `name` JS to clipboard" on the button, where `name` is a parameter provided to identify the relevant section of the document to display
- For **ScssDocs** component, as an aria-label for the "Copy to clipboard button", use:
  - "Copy `buttonLabel` SCSS to clipboard", if `buttonLabel` is provided
  - If not provided, "Copy `name` SCSS to clipboard" on the button, where `name` is a parameter provided to identify the relevant section of the document to display
- For **Code** component, as an aria-label for the "Copy to clipboard button", use:
  - "Copy `buttonLabel` code to clipboard", if `buttonLabel` is provided
  - If not provided, "Copy `filepath` code to clipboard" on the button, where `filpath` is a parameter provided to identify the file to display
  -  If not provided, "Copy code to clipboard"
- For **Example** component, as an aria-label for the "Copy to clipboard button", use:
  - "Copy `buttonLabel` code to clipboard", if `buttonLabel` is provided
  -  If not provided, "Copy code to clipboard"
  - ==> same logic for the "Edit on Stackblitz" button

Add an example in docsref

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
All the buttons of examples have the same label, either "Copy to clipboard" or "Edit in Stackblitz", which is not right for accessibility.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
