### PR TITLE
fix: inherit dark mode styles for navbar and dropdown-menu from data-…

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -232,7 +232,8 @@
 }
 
 // Dark dropdowns
-.dropdown-menu-dark {
+.dropdown-menu-dark,
+[data-bs-theme="dark"] .dropdown-menu {
   // scss-docs-start dropdown-dark-css-vars
   --#{$prefix}dropdown-color: #{$dropdown-dark-color};
   --#{$prefix}dropdown-bg: #{$dropdown-dark-bg};

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -267,7 +267,8 @@
 }
 
 .navbar-dark,
-.navbar[data-bs-theme="dark"] {
+.navbar[data-bs-theme="dark"],
+[data-bs-theme="dark"] .navbar {
   // scss-docs-start navbar-dark-css-vars
   --#{$prefix}navbar-color: #{$navbar-dark-color};
   --#{$prefix}navbar-hover-color: #{$navbar-dark-hover-color};


### PR DESCRIPTION
…bs-theme="dark"

Description

This PR updates the SCSS selectors in _navbar.scss and _dropdown.scss to ensure dark mode styles are automatically applied when a parent element (such as <body>) uses data-bs-theme="dark".

Motivation & Context

Currently, .navbar and .dropdown-menu only apply dark styling when the data-bs-theme="dark" attribute is set directly on them or when the .navbar-dark / .dropdown-menu-dark classes are added.
With this change, dark mode correctly cascades when the page or parent container has data-bs-theme="dark", improving consistency and expected behavior.

 Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

Live previews

(Not applicable for SCSS-only fix)

Related issues

#41836 
