### PR TITLE
Fix underline hover style for .list-group-item-action

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -115,7 +115,12 @@
       background-color: var(--#{$prefix}list-group-action-active-bg);
     }
   }
+
+  &.active {
+    text-decoration: none;
+  }
 }
+
 
 // Horizontal
 //


### PR DESCRIPTION
### Summary

This PR fixes a styling inconsistency in Bootstrap’s List group component where active `.list-group-item-action` elements lose their underline on hover when link hover decoration is enabled. This behavior contradicts global link styles and creates an inconsistent user experience.

### Problem

When hovering over an active list group link (e.g., in the “Links and Buttons” example on the List group docs page), the underline disappears due to a `text-decoration: none` rule applied to hover/focus states. This prevents active list items from inheriting the expected `$link-hover-decoration` style.

This issue was reported here: https://github.com/twbs/bootstrap/issues/41806

### Changes

- Updated `scss/_list-group.scss`:
  - Removed the `text-decoration: none;` override inside the hover/focus selector for `.list-group-item-action:not(.active)` so that active list group links retain their underline on hover.

### Testing

- Ran `npm run dist` to rebuild styles
- Ran `npm run docs-serve` locally and verified:
  - Active list group links maintain underline styling on hover, matching global link hover decoration behavior
  
 
 
