### PR TITLE
Fix(collapse): fix race condition when rapidly clicking accordion triggers

### DIFF
--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -823,6 +823,39 @@ describe('Collapse', () => {
       })
     })
 
+    it('should not open multiple accordion panels when rapidly clicking different triggers', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div id="accordion">',
+          '  <a id="linkTriggerOne" data-bs-toggle="collapse" data-bs-target="#collapseOne" href="#" aria-expanded="false"></a>',
+          '  <a id="linkTriggerTwo" data-bs-toggle="collapse" data-bs-target="#collapseTwo" href="#" aria-expanded="false"></a>',
+          '  <a id="linkTriggerThree" data-bs-toggle="collapse" data-bs-target="#collapseThree" href="#" aria-expanded="false"></a>',
+          '  <div id="collapseOne" class="collapse" data-bs-parent="#accordion"></div>',
+          '  <div id="collapseTwo" class="collapse" data-bs-parent="#accordion"></div>',
+          '  <div id="collapseThree" class="collapse" data-bs-parent="#accordion"></div>',
+          '</div>'
+        ].join('')
+
+        const triggerOne = fixtureEl.querySelector('#linkTriggerOne')
+        const triggerTwo = fixtureEl.querySelector('#linkTriggerTwo')
+        const triggerThree = fixtureEl.querySelector('#linkTriggerThree')
+        const collapseOne = fixtureEl.querySelector('#collapseOne')
+        const collapseTwo = fixtureEl.querySelector('#collapseTwo')
+        const collapseThree = fixtureEl.querySelector('#collapseThree')
+
+        collapseOne.addEventListener('shown.bs.collapse', () => {
+          expect(collapseOne).toHaveClass('show')
+          expect(collapseTwo).not.toHaveClass('show')
+          expect(collapseThree).not.toHaveClass('show')
+          resolve()
+        })
+
+        triggerOne.click()
+        triggerTwo.click()
+        triggerThree.click()
+      })
+    })
+
     it('should collapse accordion children but not nested accordion children', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

Fixes a race condition in the Collapse component that can cause multiple accordion panels to open simultaneously when rapidly clicking different triggers in sequence. Accordion behavior should ensure that opening one panel closes any other open panel within the same parent.

### Problem

When rapidly clicking different accordion triggers in sequence, multiple panels can remain open.

**Steps to reproduce:**
1. Open accordion example (e.g., https://getbootstrap.com/docs/5.3/components/accordion/#example).
2. Rapidly click on several accordion buttons in sequence.
3. Observe that multiple panels remain open.

**Root causes identified:**
1. Incorrect `SELECTOR_ACTIVES` - the selector `.collapse.show, .collapse.collapsing` is incorrect because `.collapse.collapsing` never matches: when `.collapsing` is added, `.collapse` is removed (and vice versa). As a result, elements in transition were not reliably detected.
2. Incorrect transition check - the check `activeChildren.length && activeChildren[0]._isTransitioning` only inspected the first active element and did not distinguish between opening vs closing transitions, causing improper blocking logic.

During the investigation, I also discovered a test case `should allow accordion to target multiple elements`, which verifies that a single trigger can control multiple targets. The same race condition bug affects this scenario as well - when rapidly switching between triggers, all corresponding panels open.

### Solution

1. Fix `SELECTOR_ACTIVES` to `.collapse.show, .collapsing` to properly match elements during transition.
2. Add `_isShowing` flag to track the opening animation direction.
3. Filter `activeChildren` by shared triggers - elements controlled by the same trigger should not block each other (this enables proper handling of multiple targets per trigger).
4. Change the blocking condition to check `_isShowing` flag across all active elements instead of checking `_isTransitioning` on the first one only.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Related issues

Fixes #41883