### PR TITLE
Remove link to translation associated with supply chain attack

### DIFF
--- a/site/data/translations.yml
+++ b/site/data/translations.yml
@@ -3,11 +3,6 @@
   description: Bootstrap 5 繁體中文手冊
   url: https://bootstrap5.hexschool.com/
 
-- name: Simplified Chinese
-  code: zh-CN
-  description: Bootstrap 5 中文文档
-  url: https://v5.bootcss.com/
-
 - name: Japanese
   code: ja
   description: Bootstrap 5 日本語リファレンス


### PR DESCRIPTION
This PR removes a link from our documentation to a community-provided Mandarin Chinese (Simplified) translation of our documentation. The translation is hosted on a sub-domain of the `bootcss.com` domain previously involved in the `polyfill.io` supply chain attack.

News article: https://www.bleepingcomputer.com/news/security/polyfillio-bootcdn-bootcss-staticfile-attack-traced-to-1-operator/

See also: https://github.com/uBlockOrigin/uAssets/pull/24255

Preview: https://deploy-preview-41973--twbs-bootstrap.netlify.app/docs/5.3/about/translations/
