### PR TITLE
Docs: add missing `.theme-border` class in the example code labels of Utilities > Theme

### DIFF
--- a/site/src/content/docs/utilities/theme.mdx
+++ b/site/src/content/docs/utilities/theme.mdx
@@ -29,7 +29,7 @@ Subtle pairs the `bg-subtle` theme token with the `text` text color for a lower-
 
 And with borders:
 
-<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-subtle theme-border">.theme-${themeColor.name} .theme-subtle</div>`)} />
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-subtle theme-border">.theme-${themeColor.name} .theme-subtle .theme-border</div>`)} />
 
 ### Muted
 
@@ -39,7 +39,7 @@ Muted pairs the `bg-muted` theme token with the `text-emphasis` text color for a
 
 And with borders:
 
-<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-muted theme-border">.theme-${themeColor.name} .theme-muted</div>`)} />
+<Example class="d-grid gap-2" code={getData('theme-colors').map((themeColor) => `<div class="p-2 theme-${themeColor.name} theme-muted theme-border">.theme-${themeColor.name} .theme-muted .theme-border</div>`)} />
 
 ## Comparison
 


### PR DESCRIPTION
This PR makes minor improvements to the documentation examples in the Utilities > Theme page. The changes clarify the example output by including the `.theme-border` class in the example code labels.

<img width="891" height="531" alt="Screenshot 2026-01-09 at 20 20 45" src="https://github.com/user-attachments/assets/24883eb2-3561-4e20-89af-7089fa29085c" />
