### PR TITLE
Allow hidden="until-found"

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -610,8 +610,8 @@ progress {
 
 // Hidden attribute
 //
-// Always hide an element with the `hidden` HTML attribute.
+// Always hide an element with the `hidden` HTML attribute, unless until-found is used.
 
-[hidden] {
+[hidden]:not([hidden="until-found"]) {
   display: none !important;
 }

--- a/site/src/content/docs/content/reboot.mdx
+++ b/site/src/content/docs/content/reboot.mdx
@@ -430,7 +430,7 @@ The default `cursor` on summary is `text`, so we reset that to `pointer` to conv
 
 ## HTML5 `[hidden]` attribute
 
-HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which is styled as `display: none` by default. Borrowing an idea from [PureCSS](https://purecss.io/), we improve upon this default by making `[hidden] { display: none !important; }` to help prevent its `display` from getting accidentally overridden.
+HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which is styled as `display: none` by default. Borrowing an idea from [PureCSS](https://purecss.io/), we improve upon this default by making `[hidden]:not([hidden="until-found"]) { display: none !important; }` to help prevent its `display` from getting accidentally overridden.
 
 ```html
 <input type="text" hidden>


### PR DESCRIPTION
### Description

The default rule for `[hidden]` in Reboot (see [Docs](https://getbootstrap.com/docs/5.3/content/reboot/#html5-hidden-attribute)) prevents the usage of the [`hidden=until-found` feature](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_until_found_state) of browsers. This PR excludes elements with `hidden=until-found` from the reboot rule.

### Motivation & Context

I want to use the `hidden=until-found` feature for an application in which I use Bootstrap, but I can't because of the current reboot rule.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42025--twbs-bootstrap.netlify.app>

### Related issues

#40688 

### Test
I'm using the following minimal sample for testing:
```html
<h1>Hidden until-found</h1>
<div>I'm always visible</div>
<div hidden="until-found">Search for me</div>
<div hidden>I'm always hidden</div>
<div>I'm always visible</div>
```
When I search for “Search” in the browser before the fix, the text is not found and displayed:
<img width="539" height="126" alt="image" src="https://github.com/user-attachments/assets/59440638-f0d4-4763-8e46-3120bab55620" />
With the fix, the element with `hidden=until-found` is displayed. As before, the element with `hidden` is generally not visible:
<img width="553" height="151" alt="image" src="https://github.com/user-attachments/assets/a9e32ac7-0889-4076-9d3c-97f7704ccc65" />
