### PR TITLE
Add placeholder text alignment utilities

### DIFF
--- a/scss/_helpers.scss
+++ b/scss/_helpers.scss
@@ -4,6 +4,7 @@
 @import "helpers/focus-ring";
 @import "helpers/icon-link";
 @import "helpers/ratio";
+@import "helpers/placeholder-text";
 @import "helpers/position";
 @import "helpers/stacks";
 @import "helpers/visually-hidden";

--- a/scss/helpers/_placeholder-text.scss
+++ b/scss/helpers/_placeholder-text.scss
@@ -1,0 +1,17 @@
+// Placeholder text alignment utilities
+//
+// Utilities for controlling the text-align property of input placeholder text.
+// These utilities allow independent alignment of placeholder text from input value text,
+// useful for RTL/LTR mixed layouts and numeric inputs.
+
+.placeholder-start::placeholder {
+  text-align: left if($enable-important-utilities, !important, null);
+}
+
+.placeholder-end::placeholder {
+  text-align: right if($enable-important-utilities, !important, null);
+}
+
+.placeholder-center::placeholder {
+  text-align: center if($enable-important-utilities, !important, null);
+}


### PR DESCRIPTION
Fixes #41926

Adds three helper utilities (`.placeholder-start`, `.placeholder-end`, `.placeholder-center`) to control placeholder text alignment independently from input text alignment. Pretty handy for RTL forms where you want numeric inputs left-aligned but placeholders matching the rest of the UI.
