### PR TITLE
Docs: fix 'Duplicate id warning-data-bs-title-vs-title found'

### DIFF
--- a/site/src/libs/content.ts
+++ b/site/src/libs/content.ts
@@ -1,4 +1,4 @@
-import { getCollection, getEntry, getEntryBySlug } from 'astro:content'
+import { getCollection, getEntry } from 'astro:content'
 
 export const docsPages = await getCollection('docs')
 export const callouts = await getCollection('callouts')
@@ -9,7 +9,7 @@ export const aliasedDocsPages = await getCollection('docs', ({ data }) => {
 })
 
 export function getCalloutByName(name: string) {
-  return getEntryBySlug('callouts', name)
+  return getEntry('callouts', name)
 }
 
 export function getDetailsByName(name: string) {


### PR DESCRIPTION
### Description

This PR fixes the following warning happening when running `npm run docs`:

```
09:59:44 [WARN] [glob-loader] Duplicate id "warning-data-bs-title-vs-title" found in /Users/ju/twbs/bootstrap/site/src/content/callouts/warning-data-bs-title-vs-title.md. Later items with the same id will overwrite earlier ones.
```

The warning message is not really explicit about the real problem that is located in `site/src/libs/content.ts` where `getEntryBySlug` is deprecated and can be replaced by `getEntry`.

#### Live previews

The callouts are still well rendered; for instance:
- https://deploy-preview-42038--twbs-bootstrap.netlify.app/docs/5.3/components/popover/#live-demo
- https://deploy-preview-42038--twbs-bootstrap.netlify.app/docs/5.3/components/tooltip/#tooltips-on-links
- https://deploy-preview-42038--twbs-bootstrap.netlify.app/docs/5.3/components/carousel/#methods