### PR TITLE
Add `docs-lint` to `lint` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "js-test-integration-bundle": "rollup --config js/tests/integration/rollup.bundle.js",
     "js-test-integration-modularity": "rollup --config js/tests/integration/rollup.bundle-modularity.js",
     "js-test-cloud": "cross-env BROWSERSTACK=true npm run js-test-karma",
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel js-lint css-lint lockfile-lint lint-mdx",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel js-lint css-lint lockfile-lint lint-mdx docs-lint",
     "lint-mdx": "markdownlint \"site/src/content/**/*.mdx\"",
     "docs": "npm-run-all docs-build docs-lint",
     "docs-build": "npm run astro-build",

--- a/site/src/content/details/warning-color-assistive-technologies.md
+++ b/site/src/content/details/warning-color-assistive-technologies.md
@@ -1,5 +1,5 @@
 ---
-title: "Accessibility Tip: Using color to convey meaning"
+title: 'Accessibility Tip: Using color to convey meaning'
 ---
 
 Using color to add meaning only provides a visual indication, which will not be conveyed to users of assistive technologies like screen readers. Please ensure the meaning is obvious from the content itself (e.g., the visible text with a [_sufficient_ color contrast](/docs/[[config:docs_version]]/getting-started/accessibility/#color-contrast)) or is included through alternative means, such as additional text hidden with the `.visually-hidden` class.


### PR DESCRIPTION
The current `docs.yml` GitHub Action runs `docs-build`, but `docs-lint `is only executed when running `docs`.

This PR adds `docs-lint` to the `lint` command.

The initial commit caused the jobs to fail; running `npm run docs-prettier-format` fixed the reported issues. The resulting change is included in https://github.com/twbs/bootstrap/pull/42039/changes/97acb3fc404b4ae0079053df85ef3993c8de31f6, allowing the job to pass successfully.