### PR TITLE
Docs: add v6 in versions page

### DIFF
--- a/site/data/docs-versions.yml
+++ b/site/data/docs-versions.yml
@@ -36,7 +36,7 @@
 
 - group: v4.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Our previous major release with its minor releases. Last update was v4.6.2.'
+  description: 'Every minor release from v4 is listed below. Last update was v4.6.2.'
   versions:
     - '4.0'
     - '4.1'
@@ -48,9 +48,15 @@
 
 - group: v5.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Current major release. Last update was v5.3.8.'
+  description: 'Our previous major release with its minor releases. Last update was v5.3.8.'
   versions:
     - '5.0'
     - '5.1'
     - '5.2'
     - '5.3'
+
+- group: v6.x
+  baseurl: 'https://getbootstrap.com/docs'
+  description: 'Current major release. Last update was v6.0.0.'
+  versions:
+    - '6.0'

--- a/site/data/docs-versions.yml
+++ b/site/data/docs-versions.yml
@@ -48,7 +48,7 @@
 
 - group: v5.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Our previous major release with its minor releases. Last update was v5.3.8.'
+  description: 'Current major release. Last update was v5.3.8.'
   versions:
     - '5.0'
     - '5.1'
@@ -57,6 +57,6 @@
 
 - group: v6.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Current major release. Last update was v6.0.0.'
+  description: 'Upcoming major release. First release will be v6.0.'
   versions:
     - '6.0'

--- a/site/src/pages/docs/versions.astro
+++ b/site/src/pages/docs/versions.astro
@@ -15,7 +15,7 @@ function getVersionsSortedDesc<TKey extends string, TVersions extends Record<TKe
 
 <SingleLayout
   title="Versions"
-  description="An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v5."
+  description="An appendix of hosted documentation for nearly every release of Bootstrap, from v1 through v6."
 >
   <div class="row">
     {


### PR DESCRIPTION
### Description

This PR updates the "Versions" page to add the version 6.

The "Latest" tag is not at the right place, but it'll be automatically changed whenever we modify `docs_version` in `config.yml`. This would be a follow-up PR that handles the URLs as well.

#### Live previews

- <https://deploy-preview-42040--twbs-bootstrap.netlify.app/docs/versions/>

