### PR TITLE
Docs: fix vertical alignment of header's LinkItems with icons

### DIFF
--- a/site/src/components/header/Navigation.astro
+++ b/site/src/components/header/Navigation.astro
@@ -91,12 +91,12 @@ const { addedIn, layout, title } = Astro.props
         <hr class="d-lg-none text-white-50" />
 
         <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
-          <LinkItem class="nav-link py-2 px-0 px-lg-2" href={getConfig().github_org} target="_blank" rel="noopener">
+          <LinkItem class="nav-link py-2 px-0 px-lg-2 align-items-center" href={getConfig().github_org} target="_blank" rel="noopener">
             <GitHubIcon class="navbar-nav-svg" height={16} width={16} />
             <small class="d-lg-none ms-2">GitHub</small>
           </LinkItem>
           <LinkItem
-            class="nav-link py-2 px-0 px-lg-2"
+            class="nav-link py-2 px-0 px-lg-2 align-items-center"
             href={`https://x.com/${getConfig().x}`}
             target="_blank"
             rel="noopener"
@@ -104,7 +104,7 @@ const { addedIn, layout, title } = Astro.props
             <XIcon class="navbar-nav-svg" height={16} width={16} />
             <small class="d-lg-none ms-2">X</small>
           </LinkItem>
-          <LinkItem class="nav-link py-2 px-0 px-lg-2" href={getConfig().opencollective} target="_blank" rel="noopener">
+          <LinkItem class="nav-link py-2 px-0 px-lg-2 align-items-center" href={getConfig().opencollective} target="_blank" rel="noopener">
             <OpenCollectiveIcon class="navbar-nav-svg" height={16} width={16} />
             <small class="d-lg-none ms-2">Open Collective</small>
           </LinkItem>


### PR DESCRIPTION
### Description

There's an issue with the vertical alignment of the header's `LinkItem`s:

<img width="1408" height="53" alt="Screenshot 2026-01-25 at 11 34 13" src="https://github.com/user-attachments/assets/eac4a321-6ea4-43a6-88d7-0d7c99b92dad" />

With the fix contained in this PR:

<img width="1421" height="57" alt="Screenshot 2026-01-25 at 11 34 00" src="https://github.com/user-attachments/assets/5fca1807-5dfe-425e-b589-3fc5924dd14c" />

Adding `align-items-center` could have also be added directly in the `LinkItem.astro` file. But I preferred to add specifically this class at the right places.

#### Live previews

- <https://deploy-preview-42041--twbs-bootstrap.netlify.app/>

