### PR TITLE
Docs: change mobile navbar background color

### DIFF
--- a/site/src/scss/_navbar.scss
+++ b/site/src/scss/_navbar.scss
@@ -77,7 +77,6 @@
     }
 
     .offcanvas-lg {
-      background-color: var(--bd-violet-bg);
       border-inline-start: 0;
 
       @include media-breakpoint-down(lg) {


### PR DESCRIPTION
### Description

There's a rendering issue with the mobile docs navbar:

<img width="516" height="642" alt="Screenshot 2026-01-25 at 11 46 46" src="https://github.com/user-attachments/assets/413762f4-3371-4f3e-891b-75957bc76976" />

Based on the new desktop header and footer rendering (white in light mode, and black in dark mode), I applied the same default color. If you were thinking about something else, feel free to close this PR :)

<img width="514" height="639" alt="Screenshot 2026-01-25 at 11 47 22" src="https://github.com/user-attachments/assets/67fab0ef-9e21-4cb8-9457-93f1f2550cb3" />

#### Live previews

- <https://deploy-preview-42042--twbs-bootstrap.netlify.app/>
