### PR TITLE
v6: Add animation for expanding/collapsing accordions

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -80,6 +80,16 @@ $accordion-tokens: defaults(
     background-color: var(--accordion-bg);
     border: var(--accordion-border-width) solid var(--accordion-border-color);
 
+    @media (prefers-reduced-motion: no-preference) {
+      interpolate-size: allow-keywords;
+    }
+
+    &::details-content {
+      block-size: 0;
+      overflow-y: clip;
+      @include transition(content-visibility .2s allow-discrete, block-size .2s);
+    }
+
     &:first-of-type {
       @include border-top-radius(var(--accordion-border-radius));
 
@@ -107,7 +117,11 @@ $accordion-tokens: defaults(
 
     // Open state - details[open] applies these styles
     &[open] {
+
       border-color: var(--theme-border, var(--accordion-border-color));
+      &::details-content {
+        block-size: auto;
+      }
 
       > .accordion-header {
         color: var(--theme-fg, var(--accordion-active-color));


### PR DESCRIPTION
### Description

Add animation for expanding/collapsing accordions. This is only available in Chromium browsers right now but coming to Firefox (any probably Safari) soon.

It supports the `prefers-reduced-motion` media query too.

Copied from demo/code for Bootstrap 5: https://code.christianoliff.com/bootstrap-accordion-no-js/

(Originally inspired by https://nerdy.dev/open-and-close-transitions-for-the-details-element).

### Motivation & Context

Nicer UX for browsers which support it. Discussed with @mdo on chat. :-) 

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42047--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/#example>
