### PR TITLE
feature: add $form-select-focus-bg variable for focused select inputs

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1024,6 +1024,7 @@ $form-select-border-radius:       $input-border-radius !default;
 $form-select-box-shadow:          var(--#{$prefix}box-shadow-inset) !default;
 
 $form-select-focus-border-color:  $input-focus-border-color !default;
+$form-select-focus-bg:            $input-focus-bg !default;
 $form-select-focus-width:         $input-focus-width !default;
 $form-select-focus-box-shadow:    0 0 0 $form-select-focus-width $input-btn-focus-color !default;
 

--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -26,6 +26,7 @@
   @include transition($form-select-transition);
 
   &:focus {
+    background-color: $form-select-focus-bg;
     border-color: $form-select-focus-border-color;
     outline: 0;
     @if $enable-shadows {


### PR DESCRIPTION
## Description
Adds the SASS variable `$form-select-focus-bg` to control the background color of focused select inputs.

Closes #42006

## Motivation
As `$input-focus-bg` can tint the background of focused inputs, it makes sense to have equivalent control for focused select inputs. This allows users to customize or tint the focus state of form selects independently or in line with inputs.

## Changes
- **`scss/_variables.scss`**: Added `$form-select-focus-bg` (defaults to `$input-focus-bg`) alongside other form-select focus variables
- **`scss/forms/_form-select.scss`**: Set `background-color: $form-select-focus-bg` on `:focus` state

## Usage
// Customize focused select background
$form-select-focus-bg: tint-color($primary, 95%);
@import "bootstrap/scss/bootstrap";
