### PR TITLE
feature: add .form-caret class for reusable select-style caret

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -1,6 +1,7 @@
 @import "forms/labels";
 @import "forms/form-text";
 @import "forms/form-control";
+@import "forms/form-caret";
 @import "forms/form-select";
 @import "forms/form-check";
 @import "forms/form-range";

--- a/scss/forms/_form-caret.scss
+++ b/scss/forms/_form-caret.scss
@@ -1,0 +1,23 @@
+// Form caret
+//
+// The dropdown caret icon from form-select as a separate class. Use with
+// `form-control` for typeahead, datalist, or other inputs that need a caret
+// without using the full form-select styling.
+
+.form-caret {
+  --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator)};
+
+  padding-right: $form-select-indicator-padding;
+  background-image: var(--#{$prefix}form-select-bg-img);
+  background-repeat: no-repeat;
+  background-position: $form-select-bg-position;
+  background-size: $form-select-bg-size;
+}
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .form-caret {
+      --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator-dark)};
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Implements issue #41754: the form-select caret is now available as a separate .form-caret class so it can be used with form-control for typeahead, datalist, or any input that needs the same caret without full form-select styling.

### Usage
```
<input type="text" class="form-control form-caret" list="options" placeholder="Type to search...">
<datalist id="options">
  <option value="Option 1">
  <option value="Option 2">
</datalist>
```

### Relation
Fixes #41754