### PR TITLE
Docs: switch to /6.0/ and mention 6.0.0-alpha1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://getbootstrap.com/">
-    <img src="https://getbootstrap.com/docs/5.3/assets/brand/bootstrap-logo-shadow.png" alt="Bootstrap logo" width="200" height="165">
+    <img src="https://getbootstrap.com/docs/6.0/assets/brand/bootstrap-logo-shadow.png" alt="Bootstrap logo" width="200" height="165">
   </a>
 </p>
 
@@ -9,7 +9,7 @@
 <p align="center">
   Sleek, intuitive, and powerful front-end framework for faster and easier web development.
   <br>
-  <a href="https://getbootstrap.com/docs/5.3/"><strong>Explore Bootstrap docs »</strong></a>
+  <a href="https://getbootstrap.com/docs/6.0/"><strong>Explore Bootstrap docs »</strong></a>
   <br>
   <br>
   <a href="https://github.com/twbs/bootstrap/issues/new?assignees=-&labels=bug&template=bug_report.yml">Report bug</a>
@@ -20,9 +20,9 @@
 </p>
 
 
-## Bootstrap 5
+## Bootstrap 6
 
-Our default branch is for development of our Bootstrap 5 release. Head to the [`v4-dev` branch](https://github.com/twbs/bootstrap/tree/v4-dev) to view the readme, documentation, and source code for Bootstrap 4.
+Our default branch is for development of our Bootstrap 6 release. Head to the [`v5-dev` branch](https://github.com/twbs/bootstrap/tree/v5-dev) to view the readme, documentation, and source code for Bootstrap 5.
 
 
 ## Table of contents
@@ -44,15 +44,15 @@ Our default branch is for development of our Bootstrap 5 release. Head to the [`
 
 Several quick start options are available:
 
-- [Download the latest release](https://github.com/twbs/bootstrap/archive/v5.3.8.zip)
+- [Download the latest release](https://github.com/twbs/bootstrap/archive/v6.0.0-alpha1.zip)
 - Clone the repo: `git clone https://github.com/twbs/bootstrap.git`
-- Install with [npm](https://www.npmjs.com/): `npm install bootstrap@v5.3.8`
-- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@v5.3.8`
-- Install with [Bun](https://bun.sh/): `bun add bootstrap@v5.3.8`
-- Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:5.3.8`
+- Install with [npm](https://www.npmjs.com/): `npm install bootstrap@6.0.0-alpha1`
+- Install with [yarn](https://yarnpkg.com/): `yarn add bootstrap@6.0.0-alpha1`
+- Install with [Bun](https://bun.sh/): `bun add bootstrap@6.0.0-alpha1`
+- Install with [Composer](https://getcomposer.org/): `composer require twbs/bootstrap:6.0.0-alpha1`
 - Install with [NuGet](https://www.nuget.org/): CSS: `Install-Package bootstrap` Sass: `Install-Package bootstrap.sass`
 
-Read the [Getting started page](https://getbootstrap.com/docs/5.3/getting-started/) for information on the framework contents, templates, examples, and more.
+Read the [Getting started page](https://getbootstrap.com/docs/6.0/getting-started/) for information on the framework contents, templates, examples, and more.
 
 
 ## Status

--- a/config.yml
+++ b/config.yml
@@ -7,9 +7,9 @@ subtitle:               "The most popular HTML, CSS, and JS library in the world
 description:            "Powerful, extensible, and feature-packed frontend toolkit. Build and customize with Sass, utilize prebuilt grid system and components, and bring projects to life with powerful JavaScript plugins."
 authors:                "Mark Otto, Jacob Thornton, and Bootstrap contributors"
 
-current_version:        "5.3.8"
-current_ruby_version:   "5.3.8"
-docs_version:           "5.3"
+current_version:        "6.0.0-alpha1"
+current_ruby_version:   "6.0.0-alpha1"
+docs_version:           "6.0"
 rfs_version:            "v10.0.0"
 github_org:             "https://github.com/twbs"
 repo:                   "https://github.com/twbs/bootstrap"
@@ -28,17 +28,17 @@ algolia:
   index_name:            "bootstrap"
 
 download:
-  source:               "https://github.com/twbs/bootstrap/archive/v5.3.8.zip"
-  dist:                 "https://github.com/twbs/bootstrap/releases/download/v5.3.8/bootstrap-5.3.8-dist.zip"
-  dist_examples:        "https://github.com/twbs/bootstrap/releases/download/v5.3.8/bootstrap-5.3.8-examples.zip"
+  source:               "https://github.com/twbs/bootstrap/archive/v6.0.0-alpha1.zip"
+  dist:                 "https://github.com/twbs/bootstrap/releases/download/v6.0.0-alpha1/bootstrap-6.0.0-alpha1-dist.zip"
+  dist_examples:        "https://github.com/twbs/bootstrap/releases/download/v6.0.0-alpha1/bootstrap-6.0.0-alpha1-examples.zip"
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css:                  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+  css:                  "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/css/bootstrap.min.css"
   css_hash:             "sha384-TDmpFhAO5TwSQwPF95I/odgwpTUuv0aaVm9/0fL7b+kKe7hFBp/+9cBCMkydgGOi"
-  js:                   "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js"
+  js:                   "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.min.js"
   js_hash:              "sha384-Php492snRLTR5p+hMyxpV6gYwp1avWXn4AaX31MgANrvsjr9Dpodl3Nw60L7Pewl"
-  js_bundle:            "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  js_bundle:            "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.bundle.min.js"
   js_bundle_hash:       "sha384-I2J4jlw924JZXHU9un9Mcuixq/rKhd5A8/B1NQ6ifPAiBFacZjwNcec8d6L38jQv"
   floating_ui:          "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.0/dist/floating-ui.dom.umd.min.js"
   floating_ui_hash:     "sha384-R7p1RqabZNhI+RdPNIzTouzd/LBVorZ0Tn3ApcogSOk+HF3o+P0HIenrUw/n0MOj"

--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -14,7 +14,7 @@ import { executeAfterTransition, getElement } from './util/index.js'
  * Constants
  */
 
-const VERSION = '5.3.8'
+const VERSION = '6.0.0-alpha1'
 
 /**
  * Class definition

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@
 Package.describe({
   name: 'twbs:bootstrap', // https://atmospherejs.com/twbs/bootstrap
   summary: 'The most popular front-end framework for developing responsive, mobile first projects on the web.',
-  version: '5.3.8',
+  version: '6.0.0-alpha1',
   git: 'https://github.com/twbs/bootstrap.git'
 })
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "bootstrap",
   "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
-  "version": "5.3.8",
+  "version": "6.0.0-alpha1",
   "bootstrap": {
-    "versionShort": "5.3"
+    "versionShort": "6.0"
   },
   "keywords": [
     "css",

--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,6 +1,6 @@
 @mixin bsBanner($file) {
   /*!
-   * Bootstrap #{$file} v5.3.8 (https://getbootstrap.com/)
+   * Bootstrap #{$file} v6.0.0-alpha1 (https://getbootstrap.com/)
    * Copyright 2011-2025 The Bootstrap Authors
    * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
    */

--- a/site/data/docs-versions.yml
+++ b/site/data/docs-versions.yml
@@ -57,6 +57,6 @@
 
 - group: v6.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Upcoming major release. First release will be v6.0.'
+  description: 'Upcoming major release. First release will be v6.0.0-alpha1.'
   versions:
     - '6.0'

--- a/site/src/content/docs/utilities/border-color.mdx
+++ b/site/src/content/docs/utilities/border-color.mdx
@@ -3,7 +3,7 @@ title: Border color
 description: Utilities for controlling border color and opacity.
 toc: true
 alias:
-  - /docs/5.3/utilities/border-color/
+  - /docs/6.0/utilities/border-color/
 mdn: https://developer.mozilla.org/en-US/docs/Web/CSS/border-color
 utility:
   - border-color

--- a/site/src/content/docs/utilities/border.mdx
+++ b/site/src/content/docs/utilities/border.mdx
@@ -3,7 +3,7 @@ title: Border
 description: Use border utilities to quickly style the border and border-radius of an element. Great for images, buttons, or any other element.
 toc: true
 alias:
-  - /docs/5.3/utilities/border/
+  - /docs/6.0/utilities/border/
 mdn: https://developer.mozilla.org/en-US/docs/Web/CSS/border
 utility:
   - border


### PR DESCRIPTION
### Description

This PR basically does 2 things:
- Switch the current version from 5.3.0 to 6.0.0-alpha1 (the first alpha we'll release)
- Switch the docs path from /5.3/ to /6.0/

> [!NOTE]
> I used https://github.com/twbs/bootstrap/commit/ac576614a5515e429f27e756fad81d5aa05e95a6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 as a reference to see what files should be modified when we're tackling an alpha version

Things that are voluntarily not tackled yet, and can be in follow up PRs:
- Versions dropdown content
- Versions mentioned in the footer
- CDN hashes in `config.yml` that should be updated when running the `release` npm scripts
- Some pages still mentioning v5 as the main version

#### Live previews

- https://deploy-preview-42067--twbs-bootstrap.netlify.app/
- https://deploy-preview-42067--twbs-bootstrap.netlify.app/docs/6.0/