### PR TITLE
Docs: fix some code copy use cases

### DIFF
--- a/site/src/components/shortcodes/Code.astro
+++ b/site/src/components/shortcodes/Code.astro
@@ -269,7 +269,7 @@ if (highlightedCode) {
   })
 
   const clipboard = new ClipboardJS('.btn-clipboard', {
-    target: (trigger) => trigger.closest('.bd-code-snippet')?.querySelector('.highlight')!,
+    target: (trigger) => trigger.closest('.bd-code-snippet')?.querySelector('.astro-code')!,
     text: (trigger) => {
       // For tabbed code, find the active tab's code
       const snippet = trigger.closest('.bd-code-snippet')


### PR DESCRIPTION
### Description

I haven't checked all the pages, but I stumbled about this use case at least not working in the first code snippet at http://localhost:9001/docs/5.3/getting-started/install/. Where one clicks on the "Copy to clipboard":

```
Uncaught Error: Invalid "target" value, use a valid Element
    D https://deploy-preview-42067--twbs-bootstrap.netlify.app/docs/6.0/assets/clipboard.BDUec7xn.js:6
    value https://deploy-preview-42067--twbs-bootstrap.netlify.app/docs/6.0/assets/clipboard.BDUec7xn.js:6
    listener https://deploy-preview-42067--twbs-bootstrap.netlify.app/docs/6.0/assets/clipboard.BDUec7xn.js:6
    h https://deploy-preview-42067--twbs-bootstrap.netlify.app/docs/6.0/assets/clipboard.BDUec7xn.js:6
 ```

#### Live previews

- https://deploy-preview-42068--twbs-bootstrap.netlify.app/docs/5.3/getting-started/install/
