### PR TITLE
Docs: update silenced SCSS deprecations for Vite

### DIFF
--- a/site/src/content/docs/getting-started/vite.mdx
+++ b/site/src/content/docs/getting-started/vite.mdx
@@ -97,8 +97,8 @@ With dependencies installed and our project folder ready for us to start coding,
         preprocessorOptions: {
            scss: {
              silenceDeprecations: [
+               'if-function',
                'import',
-               'mixed-decls',
                'color-functions',
                'global-builtin',
              ],


### PR DESCRIPTION
### Description

Removes `mixed-decls` from and adds `if-function` to the list of silenced SCSS deprecations.

### Motivation & Context

 - There's ~78 violations of `if-function`
 - Silencing `mixed-decls` now throws this warning:
```
Warning: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.
```
and removing it from the silenceDeprecations list works (no errors or warnings are output as a result).

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [N/A] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [N/A] I have added tests to cover my changes
- [N/A] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42069--twbs-bootstrap.netlify.app/docs/5.3/getting-started/vite/#configure-vite>
