### PR TITLE
Docs: enhance versions page to identify 5.3 as latest

### DIFF
--- a/site/data/docs-versions.yml
+++ b/site/data/docs-versions.yml
@@ -57,6 +57,6 @@
 
 - group: v6.x
   baseurl: 'https://getbootstrap.com/docs'
-  description: 'Upcoming major release. First release will be v6.0.0-alpha1.'
+  description: 'Upcoming major release. First release is v6.0.0-alpha1.'
   versions:
     - '6.0'

--- a/site/src/pages/docs/versions.astro
+++ b/site/src/pages/docs/versions.astro
@@ -29,18 +29,22 @@ function getVersionsSortedDesc<TKey extends string, TVersions extends Record<TKe
                 .slice()
                 .sort((a, b) => b.localeCompare(a))
                 .map((version) => {
-                  const isCurrentVersion = version === getConfig().docs_version
+                  // TODO: revert to getConfig().docs_version once we have v6.0.0 released
+                  // const isCurrentVersion = version === getConfig().docs_version
+                  const isCurrentVersion = version === '5.3'
+                  const isAlpha = version === '6.0'
 
                   return (
                     <a
                       class:list={[
                         'list-group-item list-group-item-action py-2 text-primary',
-                        isCurrentVersion && 'd-flex justify-content-between align-items-center'
+                        (isCurrentVersion || isAlpha) && 'd-flex justify-content-between align-items-center'
                       ]}
                       href={`${docsVersion.baseurl}/${version}/`}
                     >
                       {version}
                       {isCurrentVersion && <span class="badge text-bg-primary">Latest</span>}
+                      {isAlpha && <span class="badge text-bg-warning">Alpha</span>}
                     </a>
                   )
                 })}


### PR DESCRIPTION
### Description

`v6-dev` being the branch for `v6.0.0-alpha1` version, it means that 5.3 will still be the latest version, and should be identified as such.

This PR modifies the "Versions" page to do so with a temp code to identify the current version, that can be reverted once v6 stable is released.

It also provides a new "alpha" tag.

#### Live previews

- https://deploy-preview-42081--twbs-bootstrap.netlify.app/docs/versions/