### PR TITLE
Docs: update versions selector to mention v6 as alpha and v5 as latest

### DIFF
--- a/site/src/components/header/Versions.astro
+++ b/site/src/components/header/Versions.astro
@@ -21,10 +21,6 @@ if (layout === 'docs' && version === getConfig().docs_version) {
 } else if (layout === 'single' && Astro.url.pathname.startsWith(getVersionedDocsPath(''))) {
   versionsLink = Astro.url.pathname.replace(getVersionedDocsPath(''), '')
 }
-
-const addedIn51 = addedIn?.version === '5.1'
-const addedIn52 = addedIn?.version === '5.2'
-const addedIn53 = addedIn?.version === '5.3'
 ---
 
 <li class="nav-item dropdown">
@@ -42,52 +38,20 @@ const addedIn53 = addedIn?.version === '5.3'
     <span class="visually-hidden">(switch to other versions)</span>
   </button>
   <ul class="dropdown-menu dropdown-menu-end" id="bd-versions-menu">
-    <li><h6 class="dropdown-header">v5 releases</h6></li>
+    <li><h6 class="dropdown-header">v6 releases</h6></li>
     <li>
       <a
         class="dropdown-item d-flex align-items-center justify-content-between active"
         aria-current="true"
         href={isHome ? '/' : `/docs/${getConfig().docs_version}/${versionsLink}`}
       >
-        Latest ({getConfig().docs_version}.x)
+        {getConfig().docs_version}.x <span class="fg-contrast-accent fg-50">(Alpha)</span>
         <svg class="bi" aria-hidden="true"><use href="#check2"></use></svg>
       </a>
     </li>
-    <li>
-      {
-        addedIn53 ? (
-          <div class="dropdown-item disabled">v5.2.3</div>
-        ) : (
-          <a class="dropdown-item" href={`https://getbootstrap.com/docs/5.2/${versionsLink}`}>
-            v5.2.3
-          </a>
-        )
-      }
-    </li>
-    <li>
-      {
-        addedIn52 || addedIn53 ? (
-          <div class="dropdown-item disabled">v5.1.3</div>
-        ) : (
-          <a class="dropdown-item" href={`https://getbootstrap.com/docs/5.1/${versionsLink}`}>
-            v5.1.3
-          </a>
-        )
-      }
-    </li>
-    <li>
-      {
-        addedIn51 || addedIn52 || addedIn53 ? (
-          <div class="dropdown-item disabled">v5.0.2</div>
-        ) : (
-          <a class="dropdown-item" href={`https://getbootstrap.com/docs/5.0/${versionsLink}`}>
-            v5.0.2
-          </a>
-        )
-      }
-    </li>
     <li><hr class="dropdown-divider" /></li>
     <li><h6 class="dropdown-header">Previous releases</h6></li>
+    <li><a class="dropdown-item" href="https://getbootstrap.com/docs/5.3/">v5.3.x <span class="fg-secondary">(Latest)</span></a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/4.6/">v4.6.x</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/docs/3.4/">v3.4.1</a></li>
     <li><a class="dropdown-item" href="https://getbootstrap.com/2.3.2/">v2.3.2</a></li>


### PR DESCRIPTION
### Description

This PR updates the versions selector to improve the presentation and usability of available versions, particularly regarding the transition from v5 to v6.
- v6 is the current active version due to the /6.0/ path. "Alpha" has been added to precise this status.
- v5 is considered as a previous version, but "Latest" has been kept to precise this temp status while v6 is not stable, like in the versions page.

| Dark mode    | Light mode |
| -------- | ------- |
| <img width="169" height="337" alt="Screenshot 2026-02-15 at 09 37 29" src="https://github.com/user-attachments/assets/c3570fb4-7ea4-42bc-9105-06afbb7aeac9" /> |  <img width="177" height="337" alt="Screenshot 2026-02-15 at 09 37 23" src="https://github.com/user-attachments/assets/3a844c06-844f-4792-a077-1fc589129904" /> |

#### Live previews

- <https://deploy-preview-42082--twbs-bootstrap.netlify.app/>