### PR TITLE
Docs: only mention Bootstrap 6 and 5 in footer

### DIFF
--- a/site/src/components/footer/Footer.astro
+++ b/site/src/components/footer/Footer.astro
@@ -57,10 +57,10 @@ import { getVersionedDocsPath } from '@libs/path'
         <h5>Projects</h5>
         <ul class="list-unstyled">
           <li class="mb-2">
-            <a href={`${getConfig().github_org}/bootstrap`} target="_blank" rel="noopener">Bootstrap 5</a>
+            <a href={`${getConfig().github_org}/bootstrap`} target="_blank" rel="noopener">Bootstrap 6</a>
           </li>
           <li class="mb-2">
-            <a href={`${getConfig().github_org}/bootstrap/tree/v4-dev`} target="_blank" rel="noopener">Bootstrap 4</a>
+            <a href={`${getConfig().github_org}/bootstrap/tree/v5-dev`} target="_blank" rel="noopener">Bootstrap 5</a>
           </li>
           <li class="mb-2"><a href={`${getConfig().github_org}/icons`} target="_blank" rel="noopener">Icons</a></li>
           <li class="mb-2">


### PR DESCRIPTION
### Description

This PR updates the docs footer to only mention Bootstrap 6 and 5 versions, Bootstrap 4 being way too old to be there.

I supposed that whenever we'll release the v6.0 alpha version, the following will be true:
* v6 = `main` branch
* v5 = `v5-dev` branch

I don't think that the links being not correct for now is really an issue. At least we won't forget to update them in the future if it's done right now 😄 

<img width="155" height="194" alt="Screenshot 2026-02-15 at 09 58 40" src="https://github.com/user-attachments/assets/1855f611-3a94-41f6-8477-f86645f888f4" />

#### Live previews

- <https://deploy-preview-42084--twbs-bootstrap.netlify.app/>