### PR TITLE
Docs: remove alpha mention for BootstrapVueNext in JavaScript page

### DIFF
--- a/site/src/content/docs/getting-started/javascript.mdx
+++ b/site/src/content/docs/getting-started/javascript.mdx
@@ -39,7 +39,7 @@ A better alternative for those using this type of frameworks is to use a framewo
   **Try it yourself!** Download the source code and working demo for using Bootstrap with React, Next.js, and React Bootstrap from the [twbs/examples repository](https://github.com/twbs/examples/tree/main/react-nextjs). You can also [open the example in StackBlitz](https://stackblitz.com/github/twbs/examples/tree/main/react-nextjs?file=src%2Fpages%2Findex.tsx).
   </Callout>
 - Vue: [BootstrapVue](https://bootstrap-vue.org/) (Bootstrap 4)
-- Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5, currently in alpha)
+- Vue 3: [BootstrapVueNext](https://bootstrap-vue-next.github.io/bootstrap-vue-next/) (Bootstrap 5)
 - Angular: [ng-bootstrap](https://ng-bootstrap.github.io/) or [ngx-bootstrap](https://valor-software.com/ngx-bootstrap)
 
 ## Using Bootstrap as a module


### PR DESCRIPTION
### Description

This PR removes the "alpha" mention of BootstrapVueNext in the JavaScript page, as the stable release is there (see https://github.com/bootstrap-vue-next/bootstrap-vue-next repository).

> [!NOTE]
> This should be backported to `main` (or `v5-dev`) branch

#### Live previews

- https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/