### PR TITLE
Docs: remove unused `.bd-file-ref` class

### DIFF
--- a/site/src/components/shortcodes/JsDocs.astro
+++ b/site/src/components/shortcodes/JsDocs.astro
@@ -52,7 +52,7 @@ try {
 }
 ---
 
-<Code containerClass="bd-example-snippet bd-code-snippet bd-file-ref" code={content} lang="js">
+<Code containerClass="bd-example-snippet bd-code-snippet" code={content} lang="js">
   <div slot="pre" class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
     <a
       class="text-decoration-none color-body"

--- a/site/src/components/shortcodes/ScssDocs.astro
+++ b/site/src/components/shortcodes/ScssDocs.astro
@@ -54,7 +54,7 @@ try {
 }
 ---
 
-<Code containerClass="bd-example-snippet bd-file-ref" code={content} lang="scss">
+<Code containerClass="bd-example-snippet" code={content} lang="scss">
   <div slot="pre" class="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-bottom">
     <a
       class="text-decoration-none color-body"


### PR DESCRIPTION
This PR removes the use of `.bd-file-ref` class that doesn't have anymore a corresponding CSS rule.

In our `main` branch, we have this code allowing to have a clean rounded corner for some code snippets:

```scss
.bd-file-ref {
  .highlight-toolbar {
    @include media-breakpoint-up(md) {
      @include border-top-radius(calc(var(--bs-border-radius) - 1px));
    }
  }
}
```

Avoiding this:

<img width="483" height="402" alt="Screenshot 2026-02-21 at 15 00 55" src="https://github.com/user-attachments/assets/b3d7244a-e8c4-4d15-b73f-6d7846f83f8f" />

In the `v6-dev` branch, this rendering is already handled by the `@media (width >= 768px) { .highlight-toolbar:first-child` CSS rule.