### PR TITLE
Fix accordion border colors when an item is opened

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -114,6 +114,11 @@ $accordion-icon-transform:                rotate(-180deg) !default;
       border-block-start: 0;
     }
 
+    // Remove bottom border when followed by an open item (to avoid double border)
+    &:has(+ .accordion-item[open]) {
+      border-block-end: 0;
+    }
+
     // Only set a border-radius on the last item if the accordion is collapsed
     &:last-of-type {
       @include border-bottom-radius(var(--accordion-border-radius));
@@ -130,6 +135,11 @@ $accordion-icon-transform:                rotate(-180deg) !default;
     // Open state - details[open] applies these styles
     &[open] {
       border-color: var(--theme-border, var(--accordion-border-color));
+
+      // Restore top border for non-first items when open
+      &:not(:first-of-type) {
+        border-block-start: var(--accordion-border-width) solid var(--theme-border, var(--accordion-border-color));
+      }
 
       > .accordion-header {
         color: var(--theme-text, var(--accordion-active-color));


### PR DESCRIPTION
### Description

This PR fixes the accordion border colors when an item is opened, especially when a theme color is applied.

On https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/#variants, you can see that the top border of the open blue accordion is gray:

<img width="453" height="507" alt="Screenshot 2026-02-21 at 15 54 29" src="https://github.com/user-attachments/assets/866934d9-37c6-491c-bebd-a0eef64537c3" />

The issue is actually caused by the previous accordion item keeping a gray bottom border, while the opened item has no top border. This results in the visible gray line.

I’ve updated the Sass logic to better handle these different scenarios. There may be a cleaner or more elegant approach, but I didn’t find one after a quick investigation.

When reviewing, please double-check all variants and edge cases (e.g. flush, always-open, etc.) with `.theme-primary` applied as well. Everything looked correct on my side, but an extra pair of eyes would be appreciated 🙂

### Preview URL

https://deploy-preview-42092--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/#variants