### PR TITLE
Add `.not-prose` class to opt out of `.prose` typography styles.

### DIFF
--- a/scss/content/_prose.scss
+++ b/scss/content/_prose.scss
@@ -21,115 +21,93 @@
       --content-gap: 24px;
     }
 
-    p,
-    ul,
-    ol,
-    dl,
-    pre,
-    table,
-    blockquote {
+    :where(p, ul, ol, dl, pre, table, blockquote):not(:where(.not-prose, .not-prose *)) {
       margin-block: 0;
     }
 
-    :where(ul, ol):not([class]) li:not(:last-child) {
+    :where(ul, ol):not([class]):not(:where(.not-prose, .not-prose *)) li:not(:last-child) {
       margin-bottom: calc(var(--content-gap) / 4);
     }
 
-    li ul,
-    li ol {
+    :where(li ul, li ol):not(:where(.not-prose, .not-prose *)) {
       margin-top: calc(var(--content-gap) / 4);
     }
 
-    hr {
+    :where(hr):not(:where(.not-prose, .not-prose *)) {
       margin: calc(var(--content-gap) * 1.5) 0;
       border: 0;
       border-block-start: var(--border-width) solid var(--hr-border-color);
     }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      &:not([class]) {
-        margin-top: 0;
-        margin-bottom: calc(var(--content-gap) / -2);
-        font-weight: 500;
-        line-height: 1.25;
+    :where(h1, h2, h3, h4, h5, h6):not([class]):not(:where(.not-prose, .not-prose *)) {
+      margin-top: 0;
+      margin-bottom: calc(var(--content-gap) / -2);
+      font-weight: 500;
+      line-height: 1.25;
 
-        code {
-          font-weight: 600;
-          color: inherit;
-        }
+      code {
+        font-weight: 600;
+        color: inherit;
       }
     }
 
-    h1,
-    h2 {
-      &:not(:first-child) {
-        margin-top: calc(var(--content-gap) * 1.5);
-      }
+    :where(h1, h2):not(:first-child):not(:where(.not-prose, .not-prose *)) {
+      margin-top: calc(var(--content-gap) * 1.5);
     }
 
-    h3,
-    h4,
-    h5,
-    h6 {
-      &:not(:first-child) {
-        margin-top: calc(var(--content-gap) * 1.25);
-      }
+    :where(h3, h4, h5, h6):not(:first-child):not(:where(.not-prose, .not-prose *)) {
+      margin-top: calc(var(--content-gap) * 1.25);
     }
 
-    h1 {
+    :where(h1):not(:where(.not-prose, .not-prose *)) {
       font-size: 2.25em;
       line-height: 1.1;
     }
-    h2 {
+    :where(h2):not(:where(.not-prose, .not-prose *)) {
       font-size: 1.75em;
     }
-    h3 {
+    :where(h3):not(:where(.not-prose, .not-prose *)) {
       font-size: 1.5em;
     }
-    h4 {
+    :where(h4):not(:where(.not-prose, .not-prose *)) {
       font-size: 1.25em;
     }
-    h5 {
+    :where(h5):not(:where(.not-prose, .not-prose *)) {
       font-size: 1.125em;
     }
-    h6 {
+    :where(h6):not(:where(.not-prose, .not-prose *)) {
       font-size: 1em;
     }
 
-    a:not([class]) {
+    :where(a:not([class])):not(:where(.not-prose, .not-prose *)) {
       color: var(--link-color);
       text-decoration: underline;
       text-decoration-color: color-mix(in srgb, var(--link-color) 25%, transparent);
       text-underline-offset: 4px;
       @include transition(.1s text-decoration-color ease-in-out);
+
+      &:hover {
+        text-decoration-color: var(--link-hover-color);
+      }
     }
 
-    a:not([class]):hover {
-      text-decoration-color: var(--link-hover-color);
-    }
-
-    img {
+    :where(img):not(:where(.not-prose, .not-prose *)) {
       max-width: 100%;
     }
 
-    blockquote {
+    :where(blockquote):not(:where(.not-prose, .not-prose *)) {
       padding-inline-start: calc(var(--content-gap) / 2);
       margin: 0;
       border-inline-start: 4px solid var(--border-color);
     }
 
-    table {
+    :where(table):not(:where(.not-prose, .not-prose *)) {
       width: 100%;
       border-spacing: 0;
       border-collapse: collapse;
     }
 
-    :where(table:not([class])) {
+    :where(table:not([class])):not(:where(.not-prose, .not-prose *)) {
       td,
       th {
         padding: 6px 12px;
@@ -138,12 +116,11 @@
       }
     }
 
-    dt {
+    :where(dt):not(:where(.not-prose, .not-prose *)) {
       font-weight: 500;
     }
 
-    video,
-    img {
+    :where(video, img):not(:where(.not-prose, .not-prose *)) {
       max-width: 100%;
     }
   }

--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -73,7 +73,7 @@ const simplifiedMarkup = sourceMarkup
   )
 ---
 
-<div class="bd-example-snippet bd-code-snippet">
+<div class="bd-example-snippet bd-code-snippet not-prose">
   {showPreview && (
     <div id={id} class:list={['bd-example', className]}>
       <Fragment set:html={markup} />

--- a/site/src/content/docs/content/prose.mdx
+++ b/site/src/content/docs/content/prose.mdx
@@ -14,6 +14,10 @@ Wrap your content in the `.prose` class to get modified font-size, line-height, 
 - Some headings get an additional `margin-top` to ensure proper spacing between headings and other content.
 - Style blockquotes, code, and other inline elements.
 
+<Callout>
+  The `.not-prose` utility class can be used to opt out of `.prose` typography styles in specific elements. This is useful for components that have their own styling, such as code snippets or examples. Adding a `.prose` within a `.not-prose` won't work.
+</Callout>
+
 ## Example
 
 This is an example of source Markdown that shows several types of HTML content supported in this `.prose` wrapper class.


### PR DESCRIPTION
### Description

This PR introduces a `.not-prose` utility class to opt out of `.prose` typography styles.

The naming follows the official Tailwind Typography convention:
https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#undoing-typography-styles

### Motivation & Context

Our Markdown documentation pages are wrapped in `.prose` to apply consistent typography styling. However, this also affects embedded code examples, which should render exactly as they would in real usage.

Because `.prose` modifies elements such as headings, spacing, and typography, it can unintentionally alter the appearance of these examples. This breaks visual consistency and, in some cases, layout behavior.

A concrete example can be seen in the [Scrollspy documentation](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/scrollspy/), where heading styles were incorrectly overridden by `.prose`, resulting in broken rendering:

<img width="903" height="466" alt="Screenshot 2026-02-22 at 22 14 51" src="https://github.com/user-attachments/assets/259609fe-00e5-4c03-9953-a7defdbb869d" />

By introducing `.not-prose`, we allow specific sections (such as live examples) to opt out of typography styles and render accurately.

#### For the review

- New callout mentioning `.not-prose` at https://deploy-preview-42095--twbs-bootstrap.netlify.app/docs/6.0/content/prose/
- Check that Scrollspy example is fixed at https://deploy-preview-42095--twbs-bootstrap.netlify.app/docs/6.0/components/scrollspy/#navbar
- Compare rendering of layouts between https://deploy-preview-42095--twbs-bootstrap.netlify.app/docs/6.0/ and https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/