### PR TITLE
docs: use https for browserhacks link

### DIFF
--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -66,7 +66,7 @@ Page zooming inevitably presents rendering artifacts in some components, both in
 
 ## Validators
 
-In order to provide the best possible experience to old and buggy browsers, Bootstrap uses [CSS browser hacks](http://browserhacks.com/) in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren’t yet fully standardized, but these are used purely for progressive enhancement.
+In order to provide the best possible experience to old and buggy browsers, Bootstrap uses [CSS browser hacks](https://browserhacks.com/) in several places to target special CSS to certain browser versions in order to work around bugs in the browsers themselves. These hacks understandably cause CSS validators to complain that they are invalid. In a couple places, we also use bleeding-edge CSS features that aren’t yet fully standardized, but these are used purely for progressive enhancement.
 
 These validation warnings don’t matter in practice since the non-hacky portion of our CSS does fully validate and the hacky portions don’t interfere with the proper functioning of the non-hacky portion, hence why we deliberately ignore these particular warnings.
 


### PR DESCRIPTION
### Description
Updates a docs link in the “Browsers and devices” guide to use HTTPS:

- `http://browserhacks.com/` → `https://browserhacks.com/`

### Motivation & Context
Using HTTPS avoids an insecure link/redirect and is generally preferred for documentation hygiene and security. No functional behavior changes.

### Type of changes
- [x] Refactoring (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist
- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using npm run lint)_  <!-- docs-only change -->
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes  <!-- not applicable -->
- [ ] All new and existing tests passed  <!-- not required for docs-only; local test run not necessary -->

#### Live previews
- <https://deploy-preview-42111--twbs-bootstrap.netlify.app/>

### Related issues
- n/a