### PR TITLE
v6: Detect unused Sass imports

### DIFF
--- a/build/check-unused-imports.mjs
+++ b/build/check-unused-imports.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+/*!
+ * Script to detect unused SCSS @use statements.
+ *
+ * Copyright 2017-2026 The Bootstrap Authors
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import path from 'node:path'
+
+const DISABLE_FILE = 'check-unused-imports-disable'
+const DISABLE_NEXT_LINE = 'check-unused-imports-disable-next-line'
+const DISABLE_LINE = 'check-unused-imports-disable-line'
+
+function findScssFiles(dirs) {
+  const files = []
+  for (const dir of dirs) {
+    const resolvedDir = path.resolve(dir)
+    if (!existsSync(resolvedDir)) {
+      throw new Error(`Directory does not exist: ${dir}`)
+    }
+
+    walk(resolvedDir, files)
+  }
+
+  return files.sort()
+}
+
+function walk(dir, results) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(full, results)
+    } else if (entry.name.endsWith('.scss')) {
+      results.push(full)
+    }
+  }
+}
+
+function parseUseStatements(content) {
+  const lines = content.split('\n')
+  const uses = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('//')) {
+      if (trimmed.includes(DISABLE_FILE)) {
+        return []
+      }
+
+      continue
+    }
+
+    break
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+    if (!trimmed.startsWith('@use ')) {
+      continue
+    }
+
+    // Suppression comments
+    if (trimmed.includes(DISABLE_LINE)) {
+      continue
+    }
+
+    if (i > 0 && lines[i - 1].trim().includes(DISABLE_NEXT_LINE)) {
+      continue
+    }
+
+    if (/\bwith\s*\(/.test(trimmed)) {
+      continue
+    }
+
+    const match = trimmed.match(/^@use\s+["']([^"']+)["'](?:\s+as\s+(\*|[\w-]+))?/)
+    if (!match) {
+      continue
+    }
+
+    const modulePath = match[1]
+    const asClause = match[2]
+
+    let namespace
+    let isGlob = false
+
+    if (asClause === '*') {
+      isGlob = true
+      namespace = '*'
+    } else if (asClause) {
+      namespace = asClause
+    } else {
+      namespace = modulePath.split('/').at(-1).replace(/^_/, '')
+    }
+
+    uses.push({
+      line: i + 1,
+      modulePath,
+      namespace,
+      isGlob,
+      isBuiltin: modulePath.startsWith('sass:')
+    })
+  }
+
+  return uses
+}
+
+function resolveModule(modulePath, fromFile) {
+  if (modulePath.startsWith('sass:')) {
+    return null
+  }
+
+  const fromDir = path.dirname(fromFile)
+  const target = path.resolve(fromDir, modulePath)
+  const dir = path.dirname(target)
+  const base = path.basename(target)
+
+  const candidates = [
+    path.join(dir, `_${base}.scss`),
+    `${target}.scss`,
+    path.join(target, '_index.scss'),
+    path.join(target, 'index.scss')
+  ]
+
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      return c
+    }
+  }
+
+  return null
+}
+
+const exportCache = new Map()
+
+function getModuleExports(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return { variables: new Set(), mixins: new Set(), functions: new Set() }
+  }
+
+  const real = path.resolve(filePath)
+  if (exportCache.has(real)) {
+    return exportCache.get(real)
+  }
+
+  const exports = { variables: new Set(), mixins: new Set(), functions: new Set() }
+  exportCache.set(real, exports)
+
+  const content = readFileSync(real, 'utf8')
+  const lines = content.split('\n')
+
+  for (const line of lines) {
+    const v = line.match(/^\$([a-zA-Z][\w-]*)\s*:/)
+    if (v) {
+      exports.variables.add(v[1])
+    }
+
+    const m = line.match(/^@mixin\s+([a-zA-Z][\w-]*)/)
+    if (m) {
+      exports.mixins.add(m[1])
+    }
+
+    const f = line.match(/^@function\s+([a-zA-Z][\w-]*)/)
+    if (f) {
+      exports.functions.add(f[1])
+    }
+  }
+
+  for (const line of lines) {
+    const fwd = line.trim().match(/^@forward\s+["']([^"']+)["']/)
+    if (fwd) {
+      const resolved = resolveModule(fwd[1], real)
+      if (resolved) {
+        const fwdExports = getModuleExports(resolved)
+        for (const variable of fwdExports.variables) {
+          exports.variables.add(variable)
+        }
+
+        for (const mixin of fwdExports.mixins) {
+          exports.mixins.add(mixin)
+        }
+
+        for (const fn of fwdExports.functions) {
+          exports.functions.add(fn)
+        }
+      }
+    }
+  }
+
+  return exports
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isNamespaceUsed(namespace, body) {
+  return new RegExp(`(?<![\\w-])${escapeRegExp(namespace)}\\.`).test(body)
+}
+
+function isGlobImportUsed(moduleExports, body) {
+  for (const name of moduleExports.variables) {
+    if (new RegExp(`\\$${escapeRegExp(name)}(?![\\w-])`).test(body)) {
+      return true
+    }
+  }
+
+  for (const name of moduleExports.mixins) {
+    if (new RegExp(`@include\\s+${escapeRegExp(name)}(?![\\w-])`).test(body)) {
+      return true
+    }
+  }
+
+  for (const name of moduleExports.functions) {
+    if (new RegExp(`(?<![\\w-])${escapeRegExp(name)}\\s*\\(`).test(body)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function getBody(content) {
+  const lines = content.split('\n')
+  const filtered = []
+  let inBlockComment = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!inBlockComment && trimmed.startsWith('@use ')) {
+      continue
+    }
+
+    if (!inBlockComment && trimmed.startsWith('@forward ')) {
+      continue
+    }
+
+    let current = line
+    if (inBlockComment) {
+      const end = current.indexOf('*/')
+      if (end === -1) {
+        continue
+      }
+
+      current = current.slice(end + 2)
+      inBlockComment = false
+    }
+
+    for (;;) {
+      const start = current.indexOf('/*')
+      if (start === -1) {
+        break
+      }
+
+      const end = current.indexOf('*/', start + 2)
+      if (end === -1) {
+        current = current.slice(0, start)
+        inBlockComment = true
+        break
+      }
+
+      current = `${current.slice(0, start)}${current.slice(end + 2)}`
+    }
+
+    const singleCommentStart = current.indexOf('//')
+    if (singleCommentStart !== -1) {
+      current = current.slice(0, singleCommentStart)
+    }
+
+    filtered.push(current)
+  }
+
+  return filtered.join('\n')
+}
+
+function isUseUnused(use, body, file) {
+  if (use.isBuiltin) {
+    const name = use.modulePath.split(':')[1]
+    return !isNamespaceUsed(name, body)
+  }
+
+  if (!use.isGlob) {
+    return !isNamespaceUsed(use.namespace, body)
+  }
+
+  const resolved = resolveModule(use.modulePath, file)
+  if (!resolved) {
+    return false
+  }
+
+  const moduleExports = getModuleExports(resolved)
+  const hasExports =
+    moduleExports.variables.size > 0 ||
+    moduleExports.mixins.size > 0 ||
+    moduleExports.functions.size > 0
+
+  if (!hasExports) {
+    return false
+  }
+
+  return !isGlobImportUsed(moduleExports, body)
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  if (args.length === 0) {
+    console.error('Usage: node check-unused-imports.mjs <dir1> [dir2] ...')
+    process.exit(2)
+  }
+
+  let files
+  try {
+    files = findScssFiles(args)
+  } catch (error) {
+    console.error(error.message)
+    process.exit(2)
+  }
+
+  let total = 0
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8')
+    const uses = parseUseStatements(content)
+    if (uses.length === 0) {
+      continue
+    }
+
+    const body = getBody(content)
+    for (const use of uses) {
+      if (isUseUnused(use, body, file)) {
+        const rel = path.relative(process.cwd(), file)
+        console.log(`${rel}:${use.line}\tUnused @use "${use.modulePath}"`)
+        total++
+      }
+    }
+  }
+
+  if (total > 0) {
+    console.log(`\nFound ${total} unused @use statement${total === 1 ? '' : 's'}`)
+    process.exit(1)
+  }
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "css-docs": "node build/generate-utilities-json.mjs",
     "css-lint": "npm-run-all --aggregate-output --continue-on-error --parallel css-lint-*",
     "css-lint-stylelint": "stylelint \"**/*.{css,scss}\" --cache --cache-location .cache/.stylelintcache",
+    "css-lint-imports": "node build/check-unused-imports.mjs scss/ site/src/scss/",
     "css-lint-vars": "fusv scss/ site/src/scss/",
     "css-minify": "npm-run-all --aggregate-output --parallel css-minify-*",
     "css-minify-main": "node build/css-minify.mjs",

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -1,6 +1,3 @@
-@use "sass:map";
-@use "config" as *;
-@use "variables" as *;
 @use "functions" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/transition" as *;

--- a/scss/_alert.scss
+++ b/scss/_alert.scss
@@ -1,7 +1,5 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
-@use "theme" as *;
 @use "variables" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/tokens" as *;

--- a/scss/_avatar.scss
+++ b/scss/_avatar.scss
@@ -1,7 +1,5 @@
 @use "sass:map";
 @use "functions" as *;
-@use "variables" as *;
-@use "theme" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/transition" as *;
 @use "mixins/tokens" as *;

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -1,8 +1,4 @@
-@use "sass:map";
-@use "colors" as *;
 @use "functions" as *;
-@use "variables" as *;
-@use "theme" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/gradients" as *;
 @use "mixins/tokens" as *;

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -1,7 +1,3 @@
-@use "sass:map";
-@use "sass:string";
-@use "config" as *;
-@use "variables" as *;
 @use "functions" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/transition" as *;

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -1,4 +1,3 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
 @use "variables" as *;
@@ -190,7 +189,6 @@ $card-tokens: defaults(
   .card-img-bottom {
     @include border-bottom-radius(var(--card-inner-border-radius));
   }
-
 
   .card-row {
     flex-direction: row;

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -1,10 +1,7 @@
-@use "sass:map";
 @use "config" as *;
 @use "colors" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "mixins/transition" as *;
-@use "mixins/gradients" as *;
 @use "mixins/color-mode" as *;
 @use "mixins/tokens" as *;
 
@@ -112,7 +109,6 @@ $carousel-dark-tokens: defaults(
     transform: translateX(-100%);
   }
 
-
   //
   // Alternate transitions
   //
@@ -138,7 +134,6 @@ $carousel-dark-tokens: defaults(
       @include transition(opacity 0s var(--carousel-transition-duration));
     }
   }
-
 
   //
   // Left/right controls for nav
@@ -248,7 +243,6 @@ $carousel-dark-tokens: defaults(
       opacity: var(--carousel-indicator-active-opacity);
     }
   }
-
 
   // Optional captions
   //

--- a/scss/_chip.scss
+++ b/scss/_chip.scss
@@ -1,8 +1,4 @@
-@use "sass:map";
-@use "colors" as *;
 @use "functions" as *;
-@use "variables" as *;
-@use "theme" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -1,5 +1,3 @@
-@use "config" as *;
-
 // stylelint-disable hue-degree-notation, @stylistic/number-leading-zero
 
 // Easily convert colors to oklch() with https://oklch.com/

--- a/scss/_datepicker.scss
+++ b/scss/_datepicker.scss
@@ -1,8 +1,5 @@
 // stylelint-disable selector-max-attribute, property-disallowed-list, selector-no-qualifying-type -- VCP uses extensive data attributes and requires direct border-radius properties for range selection
 
-@use "sass:map";
-@use "config" as *;
-@use "colors" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "mixins/border-radius" as *;
@@ -206,7 +203,6 @@ $datepicker-tokens: defaults(
     }
   }
 
-
   [data-vc="content"] {
     display: flex;
     flex-grow: 1;
@@ -355,7 +351,6 @@ $datepicker-tokens: defaults(
     color: var(--datepicker-day-today-color);
     background-color: var(--datepicker-day-today-bg);
   }
-
 
   // Outside month
   [data-vc-date-month="next"] [data-vc-date-btn],

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -1,13 +1,10 @@
-@use "sass:map";
 @use "config" as *;
-@use "colors" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/box-shadow" as *;
 @use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
-@use "mixins/transition" as *;
 
 $dropdown-tokens: () !default;
 

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -1,6 +1,4 @@
 @use "sass:map";
-@use "colors" as *;
-@use "theme" as *;
 @use "config" as *;
 @use "functions" as *;
 @use "variables" as *;
@@ -175,7 +173,6 @@ $list-group-tokens: defaults(
       }
     }
   }
-
 
   // Flush list items
   //

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -1,5 +1,3 @@
-@use "sass:map";
-@use "config" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "mixins/border-radius" as *;
@@ -184,7 +182,6 @@ $nav-underline-tokens: defaults(
     }
   }
 
-
   //
   // Pills
   //
@@ -200,7 +197,6 @@ $nav-underline-tokens: defaults(
       @include gradient-bg(var(--nav-pills-link-active-bg));
     }
   }
-
 
   //
   // Underline
@@ -230,7 +226,6 @@ $nav-underline-tokens: defaults(
     }
   }
 
-
   //
   // Justified variants
   //
@@ -258,7 +253,6 @@ $nav-underline-tokens: defaults(
       width: 100%; // Make sure button will grow
     }
   }
-
 
   // Tabbable tabs
   //

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -1,6 +1,5 @@
 @use "sass:map";
 @use "config" as *;
-@use "colors" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "layout/breakpoints" as *;
@@ -99,7 +98,6 @@ $navbar-dark-tokens: defaults(
     }
   }
 
-
   // Navbar brand
   //
   // Used for brand, project, or site names.
@@ -118,7 +116,6 @@ $navbar-dark-tokens: defaults(
       color: var(--navbar-brand-hover-color);
     }
   }
-
 
   // Navbar nav
   //
@@ -154,7 +151,6 @@ $navbar-dark-tokens: defaults(
     // }
   }
 
-
   // Navbar text
   //
   //
@@ -171,7 +167,6 @@ $navbar-dark-tokens: defaults(
       color: var(--navbar-active-color);
     }
   }
-
 
   // Responsive navbar
   //

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,7 +1,4 @@
-@use "sass:map";
-@use "config" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "mixins/lists" as *;
 @use "mixins/border-radius" as *;
 @use "mixins/focus-ring" as *;
@@ -119,7 +116,6 @@ $pagination-sizes: defaults(
       }
     }
   }
-
 
   //
   // Sizing

--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,8 +1,5 @@
-@use "sass:map";
 @use "colors" as *;
-@use "config" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "mixins/tokens" as *;
 
 $placeholder-tokens: () !default;

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -1,4 +1,3 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
 @use "variables" as *;

--- a/scss/_progress.scss
+++ b/scss/_progress.scss
@@ -1,8 +1,5 @@
-@use "sass:map";
 @use "config" as *;
-@use "colors" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "mixins/transition" as *;
 @use "mixins/gradients" as *;
 @use "mixins/border-radius" as *;
@@ -28,7 +25,6 @@ $progress-tokens: defaults(
   $progress-tokens
 );
 // scss-docs-end progress-tokens
-
 
 // Disable animation if transitions are disabled
 

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -1,12 +1,9 @@
-@use "sass:meta";
 @use "sass:map";
 @use "colors" as *;
-@use "config" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "theme" as *;
 // @use "maps" as *;
-@use "mixins/color-mode" as *;
 @use "mixins/tokens" as *;
 @use "forms/form-variables" as *;
 

--- a/scss/_spinner.scss
+++ b/scss/_spinner.scss
@@ -1,7 +1,5 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "mixins/tokens" as *;
 
 // stylelint-disable custom-property-no-missing-var-function

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -1,13 +1,9 @@
 @use "sass:map";
 @use "config" as *;
 @use "functions" as *;
-@use "variables" as *;
 @use "layout/breakpoints" as *;
 @use "mixins/border-radius" as *;
-@use "mixins/box-shadow" as *;
-@use "mixins/gradients" as *;
 @use "mixins/tokens" as *;
-@use "mixins/transition" as *;
 
 $stepper-tokens: () !default;
 
@@ -78,7 +74,6 @@ $stepper-tokens: defaults(
   justify-items: start;
   text-align: center;
   text-decoration: none;
-
 
   // The counter
   &::before {

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -1,7 +1,5 @@
 @use "sass:meta";
 @use "sass:map";
-@use "config" as *;
-@use "colors" as *;
 
 @function theme-color-values($key) {
   $result: ();

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -1,4 +1,3 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
 @use "variables" as *;

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -1,12 +1,9 @@
-@use "sass:map";
 @use "config" as *;
 @use "functions" as *;
 @use "variables" as *;
 @use "mixins/border-radius" as *;
-@use "mixins/deprecate" as *;
 @use "mixins/reset-text" as *;
 @use "mixins/tokens" as *;
-
 
 $tooltip-tokens: () !default;
 

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -1,4 +1,3 @@
-@use "config" as *;
 @use "variables" as *;
 @use "mixins/transition" as *;
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1,6 +1,5 @@
 @use "sass:map";
 @use "config" as *;
-@use "colors" as *;
 @use "variables" as *;
 @use "functions" as *;
 @use "theme" as *;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@use "sass:map";
-@use "sass:string";
 @use "colors" as *;
 @use "config" as *;
 @use "functions" as *;
@@ -91,7 +88,6 @@ $icon-link-icon-transform:    translate3d(.25em, 0, 0) !default;
 // Style p element.
 
 $paragraph-margin-bottom:   1rem !default;
-
 
 // Components
 //

--- a/scss/bootstrap-grid.scss
+++ b/scss/bootstrap-grid.scss
@@ -2,10 +2,7 @@
   $file: "Grid"
 );
 
-@use "sass:map";
-@use "colors" as *;
 @use "config" as *;
-@use "variables" as *;
 @use "functions" as *;
 // @use "maps" as *;
 
@@ -56,4 +53,5 @@ $utilities: map-get-multiple(
   )
 );
 
+// check-unused-imports-disable-next-line — side-effect import: generates utility CSS.
 @use "utilities/api";

--- a/scss/buttons/_button-group.scss
+++ b/scss/buttons/_button-group.scss
@@ -1,7 +1,4 @@
-@use "../config" as *;
-@use "../variables" as *;
 @use "../mixins/border-radius" as *;
-@use "../mixins/box-shadow" as *;
 
 @layer components {
   // Make the div behave like a button

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -1,17 +1,12 @@
-@use "sass:color";
 @use "sass:list";
 @use "sass:map";
 @use "sass:meta";
 @use "sass:string";
-@use "../colors" as *;
 @use "../config" as *;
-@use "../theme" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
-@use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
 
@@ -166,7 +161,6 @@ $button-variants: defaults(
 // scss-docs-end btn-variants
 // stylelint-enable custom-property-no-missing-var-function, scss/dollar-variable-default
 
-
 //
 // Base styles
 //
@@ -238,7 +232,6 @@ $btn-variant-selectors: () !default;
     }
   }
 
-
   // Main button style generator mixin
   // Generate button variant classes (e.g., .btn-solid, .btn-outline, etc.)
   // scss-docs-start btn-variant-mixin
@@ -268,7 +261,6 @@ $btn-variant-selectors: () !default;
           --btn-disabled-#{$property}: var(--theme-#{$value});
         }
       }
-
 
       &:hover {
         @each $property, $value in map.get($button-variants, $variant, "hover") {
@@ -345,7 +337,6 @@ $btn-variant-selectors: () !default;
 
     // No need for an active state here
   }
-
 
   //
   // Button Sizes

--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -1,10 +1,5 @@
-@use "sass:map";
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
 

--- a/scss/content/_images.scss
+++ b/scss/content/_images.scss
@@ -1,7 +1,4 @@
-@use "sass:map";
-@use "../config" as *;
 @use "../functions" as *;
-@use "../variables" as *;
 @use "../mixins/image" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;

--- a/scss/content/_prose.scss
+++ b/scss/content/_prose.scss
@@ -1,5 +1,3 @@
-@use "sass:map";
-@use "../config" as *;
 @use "../functions" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -1,4 +1,3 @@
-@use "sass:map";
 @use "../colors" as *;
 @use "../config" as *;
 @use "../functions" as *;
@@ -47,7 +46,6 @@ $reboot-mark-tokens: defaults(
   //
   // Normalize is licensed MIT. https://github.com/necolas/normalize.css
 
-
   // Document
   //
   // Change from `box-sizing: content-box` so that `width` is not affected by `padding` or `border`.
@@ -57,7 +55,6 @@ $reboot-mark-tokens: defaults(
   *::after {
     box-sizing: border-box;
   }
-
 
   // Root
   //
@@ -74,7 +71,6 @@ $reboot-mark-tokens: defaults(
       }
     }
   }
-
 
   // Body
   //
@@ -103,7 +99,6 @@ $reboot-mark-tokens: defaults(
     border: 0;
     border-block-start: var(--border-width) solid var(--hr-border-color);
   }
-
 
   // Typography
   //
@@ -157,7 +152,6 @@ $reboot-mark-tokens: defaults(
     font-size: $h6-font-size;
   }
 
-
   // Reset margins on paragraphs
   //
   // Similarly, the top margin on `<p>`s get reset. However, we also reset the
@@ -167,7 +161,6 @@ $reboot-mark-tokens: defaults(
     margin-top: 0;
     margin-bottom: $paragraph-margin-bottom;
   }
-
 
   // Abbreviations
   //
@@ -181,7 +174,6 @@ $reboot-mark-tokens: defaults(
     text-decoration-skip-ink: none; // 3
   }
 
-
   // Address
 
   address {
@@ -189,7 +181,6 @@ $reboot-mark-tokens: defaults(
     font-style: normal;
     line-height: inherit;
   }
-
 
   // Lists
 
@@ -223,7 +214,6 @@ $reboot-mark-tokens: defaults(
     margin-bottom: .5rem;
   }
 
-
   // Blockquote
 
   blockquote {
@@ -232,7 +222,6 @@ $reboot-mark-tokens: defaults(
       margin-block: 0;
     }
   }
-
 
   // Strong
   //
@@ -243,7 +232,6 @@ $reboot-mark-tokens: defaults(
     font-weight: $font-weight-bolder;
   }
 
-
   // Small
   //
   // Add the correct font size in all browsers
@@ -252,7 +240,6 @@ $reboot-mark-tokens: defaults(
   .small {
     font-size: var(--small-font-size, var(--font-size-sm));
   }
-
 
   // Mark
 
@@ -263,7 +250,6 @@ $reboot-mark-tokens: defaults(
     color: var(--mark-color);
     background-color: var(--mark-bg);
   }
-
 
   // Sub and Sup
   //
@@ -280,7 +266,6 @@ $reboot-mark-tokens: defaults(
 
   sub { bottom: -.25em; }
   sup { top: -.5em; }
-
 
   // Links
 
@@ -309,7 +294,6 @@ $reboot-mark-tokens: defaults(
       text-decoration: none;
     }
   }
-
 
   // Code
 
@@ -367,7 +351,6 @@ $reboot-mark-tokens: defaults(
     }
   }
 
-
   // Figures
   //
   // Apply a consistent margin strategy (matches our type styles).
@@ -376,14 +359,12 @@ $reboot-mark-tokens: defaults(
     margin: 0 0 1rem;
   }
 
-
   // Images and content
 
   img,
   svg {
     vertical-align: middle;
   }
-
 
   // Tables
   //
@@ -423,7 +404,6 @@ $reboot-mark-tokens: defaults(
     border-style: solid;
     border-width: 0;
   }
-
 
   // Forms
   //
@@ -613,7 +593,6 @@ $reboot-mark-tokens: defaults(
     padding: 0;
   }
 
-
   // 1. Inherit font family and line height for file input buttons
   // 2. Correct the inability to style clickable types in iOS and Safari.
 
@@ -643,7 +622,6 @@ $reboot-mark-tokens: defaults(
     cursor: pointer;
   }
 
-
   // Progress
   //
   // Add the correct vertical alignment in Chrome, Firefox, and Opera.
@@ -651,7 +629,6 @@ $reboot-mark-tokens: defaults(
   progress {
     vertical-align: baseline;
   }
-
 
   // Hidden attribute
   //

--- a/scss/content/_tables.scss
+++ b/scss/content/_tables.scss
@@ -1,8 +1,5 @@
-@use "sass:color";
 @use "sass:map";
 @use "../config" as *;
-@use "../colors" as *;
-@use "../theme" as *;
 @use "../variables" as *;
 @use "../functions" as *;
 @use "../layout/breakpoints" as *;
@@ -97,7 +94,6 @@ $table-striped-columns-order: even !default;
     caption-side: top;
   }
 
-
   //
   // Condensed table w/ half padding
   //
@@ -109,7 +105,6 @@ $table-striped-columns-order: even !default;
       --table-cell-padding-x: .25rem;
     }
   }
-
 
   // Border versions
   //

--- a/scss/content/_type.scss
+++ b/scss/content/_type.scss
@@ -1,7 +1,4 @@
-@use "sass:map";
-@use "../config" as *;
 @use "../functions" as *;
-@use "../variables" as *;
 @use "../mixins/lists" as *;
 @use "../mixins/tokens" as *;
 
@@ -41,7 +38,6 @@ $blockquote-tokens: defaults(
       margin-inline-end: var(--list-inline-padding, var(--spacer) / 2);
     }
   }
-
 
   //
   // Misc

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -1,14 +1,6 @@
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "sass:map";
-@use "../mixins/border-radius" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $check-tokens: () !default;

--- a/scss/forms/_chip-input.scss
+++ b/scss/forms/_chip-input.scss
@@ -1,14 +1,7 @@
-@use "sass:map";
-@use "../config" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "../theme" as *;
 @use "../mixins/border-radius" as *;
-@use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 $chip-input-tokens: () !default;
 

--- a/scss/forms/_floating-labels.scss
+++ b/scss/forms/_floating-labels.scss
@@ -1,13 +1,7 @@
-@use "sass:map";
-@use "sass:math";
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 $form-floating-tokens: () !default;
 

--- a/scss/forms/_form-adorn.scss
+++ b/scss/forms/_form-adorn.scss
@@ -1,13 +1,6 @@
-@use "sass:map";
-@use "../config" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "../mixins/border-radius" as *;
-@use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 $form-adorn-tokens: () !default;
 

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -1,16 +1,10 @@
-@use "sass:map";
-@use "sass:math";
-@use "../config" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 $form-control-tokens: () !default;
 

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -1,6 +1,4 @@
-@use "../config" as *;
 @use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/box-shadow" as *;
@@ -8,8 +6,6 @@
 @use "../mixins/transition" as *;
 @use "../mixins/gradients" as *;
 @use "../mixins/tokens" as *;
-@use "sass:map";
-@use "form-variables" as *;
 
 $range-tokens: () !default;
 
@@ -79,7 +75,6 @@ $range-tokens: defaults(
 
     &:focus {
       outline: 0;
-
 
       // Pseudo-elements must be split across multiple rulesets to have an effect.
       &::-webkit-slider-thumb {

--- a/scss/forms/_form-text.scss
+++ b/scss/forms/_form-text.scss
@@ -1,5 +1,3 @@
-@use "sass:map";
-@use "../config" as *;
 @use "../functions" as *;
 @use "../mixins/tokens" as *;
 

--- a/scss/forms/_form-variables.scss
+++ b/scss/forms/_form-variables.scss
@@ -1,7 +1,3 @@
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
-
 // scss-docs-start form-feedback-variables
 $form-feedback-margin-top:          .5rem !default;
 $form-feedback-font-size:           var(--font-size-xs) !default;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -1,8 +1,5 @@
 @use "sass:map";
 @use "sass:string";
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;
@@ -72,7 +69,6 @@ $input-group-sizes: defaults(
     }
   }
 
-
   // Textual addons
   //
   // Serves as a catch-all element for any text or radio/checkbox input you wish
@@ -92,7 +88,6 @@ $input-group-sizes: defaults(
     border: var(--border-width) solid var(--input-group-addon-border-color);
     @include border-radius(var(--btn-input-border-radius));
   }
-
 
   // Sizing
   //

--- a/scss/forms/_labels.scss
+++ b/scss/forms/_labels.scss
@@ -1,7 +1,4 @@
-@use "sass:map";
-@use "../variables" as *;
 @use "../functions" as *;
-@use "form-variables" as *;
 
 $form-label-tokens: () !default;
 

--- a/scss/forms/_otp-input.scss
+++ b/scss/forms/_otp-input.scss
@@ -1,8 +1,4 @@
-@use "../config" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "sass:map";
-@use "form-variables" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;
 

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -1,14 +1,6 @@
-@use "../config" as *;
-@use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "sass:map";
-@use "../mixins/border-radius" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $radio-tokens: () !default;

--- a/scss/forms/_strength.scss
+++ b/scss/forms/_strength.scss
@@ -1,12 +1,8 @@
 @use "sass:list";
-@use "sass:map";
-@use "../config" as *;
-@use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
 @use "../mixins/tokens" as *;
 @use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $strength-tokens: () !default;

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,15 +1,7 @@
-@use "../config" as *;
 @use "../colors" as *;
-@use "../variables" as *;
 @use "../functions" as *;
-@use "sass:map";
-@use "../mixins/border-radius" as *;
-@use "../mixins/box-shadow" as *;
-@use "../mixins/color-mode" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
-@use "../mixins/transition" as *;
-@use "form-variables" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $switch-tokens: () !default;

--- a/scss/forms/_validation.scss
+++ b/scss/forms/_validation.scss
@@ -2,7 +2,6 @@
 @use "../variables" as *;
 @use "../functions" as *;
 @use "../mixins/border-radius" as *;
-@use "../mixins/box-shadow" as *;
 @use "../mixins/focus-ring" as *;
 @use "form-variables" as *;
 @use "../tooltip" as *; // bring in tooltip variables

--- a/scss/helpers/_focus-ring.scss
+++ b/scss/helpers/_focus-ring.scss
@@ -1,5 +1,3 @@
-@use "../config" as *;
-
 @layer helpers {
   .focus-ring:focus-visible {
     outline: var(--focus-ring);

--- a/scss/helpers/_icon-link.scss
+++ b/scss/helpers/_icon-link.scss
@@ -1,4 +1,3 @@
-@use "../config" as *;
 @use "../variables" as *;
 @use "../mixins/transition" as *;
 

--- a/scss/helpers/_vr.scss
+++ b/scss/helpers/_vr.scss
@@ -1,5 +1,3 @@
-@use "../variables" as *;
-
 @layer helpers {
   .vr {
     display: inline-block;

--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -1,7 +1,5 @@
-@use "sass:map";
 @use "../config" as *;
 @use "../mixins/grid" as *;
-@use "breakpoints" as *;
 
 // mdo-do
 // - check gap utilities as replacement for gutter classes from v5

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -2,7 +2,6 @@
 @use "sass:math";
 @use "sass:meta";
 @use "../config" as *;
-@use "../variables" as *;
 
 // stylelint-disable property-disallowed-list
 // Single side border-radius

--- a/scss/mixins/_caret.scss
+++ b/scss/mixins/_caret.scss
@@ -1,5 +1,4 @@
 @use "../config" as *;
-@use "../variables" as *;
 
 // scss-docs-start caret-variables
 $caret-width:                 .3em !default;

--- a/scss/mixins/_focus-ring.scss
+++ b/scss/mixins/_focus-ring.scss
@@ -1,6 +1,3 @@
-@use "../config" as *;
-@use "../variables" as *;
-
 @mixin focus-ring($offset: false, $color: null) {
   @if $color != null {
     outline: var(--focus-ring-width) solid #{$color};

--- a/scss/mixins/_reset-text.scss
+++ b/scss/mixins/_reset-text.scss
@@ -1,5 +1,3 @@
-@use "../variables" as *;
-
 @mixin reset-text {
   font-family: var(--body-font-family);
   // We deliberately do NOT reset font-size or overflow-wrap / word-wrap.

--- a/scss/mixins/_utilities.scss
+++ b/scss/mixins/_utilities.scss
@@ -1,8 +1,6 @@
 @use "sass:list";
 @use "sass:map";
 @use "sass:meta";
-@use "sass:string";
-@use "../config" as *;
 
 // stylelint-disable scss/dollar-variable-pattern
 

--- a/scss/tests/mixins/_box-shadow.test.scss
+++ b/scss/tests/mixins/_box-shadow.test.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — test infrastructure imports.
 @use "../../functions" as *;
 @use "../../variables" as *;
 @use "../../mixins" as *;

--- a/scss/tests/mixins/_media-query-color-mode-full.test.scss
+++ b/scss/tests/mixins/_media-query-color-mode-full.test.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — test infrastructure imports.
 $color-mode-type: media-query;
 $true-terminal-output: false;
 

--- a/scss/tests/mixins/_utilities.test.scss
+++ b/scss/tests/mixins/_utilities.test.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — test infrastructure imports.
 @use "../../variables" as *;
 @use "../../functions" as *;
 @use "../../mixins/utilities" as *;

--- a/scss/tests/utilities/_api.test.scss
+++ b/scss/tests/utilities/_api.test.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — test infrastructure imports.
 @use "../../functions";
 @use "../../variables";
 @use "../../maps";

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -1,7 +1,6 @@
 @use "sass:map";
 @use "sass:meta";
 @use "../config" as *;
-@use "../variables" as *;
 @use "../layout/breakpoints" as *;
 @use "../mixins/utilities" as *;
 @use "../utilities" as *;
@@ -24,7 +23,6 @@
       }
     }
   }
-
 
   // Print utilities
   @media print {

--- a/site/src/scss/_ads.scss
+++ b/site/src/scss/_ads.scss
@@ -1,4 +1,3 @@
-@use "../../../scss/layout/breakpoints" as *;
 @use "../../../scss/mixins/border-radius" as *;
 
 // stylelint-disable declaration-no-important, selector-max-id

--- a/site/src/scss/_anchor.scss
+++ b/site/src/scss/_anchor.scss
@@ -1,5 +1,3 @@
-@use "../../../scss/config" as *;
-@use "../../../scss/variables" as *;
 @use "../../../scss/mixins/transition" as *;
 
 @layer custom {

--- a/site/src/scss/_brand.scss
+++ b/site/src/scss/_brand.scss
@@ -1,4 +1,3 @@
-@use "../../../scss/config" as *;
 @use "../../../scss/colors" as *;
 @use "../../../scss/layout/breakpoints" as *;
 @use "variables" as *;
@@ -31,7 +30,6 @@
       }
     }
   }
-
 
   //
   // Color swatches

--- a/site/src/scss/_callouts.scss
+++ b/site/src/scss/_callouts.scss
@@ -1,5 +1,3 @@
-@use "../../../scss/config" as *;
-@use "../../../scss/colors" as *;
 @use "../../../scss/mixins/border-radius" as *;
 @use "variables" as *;
 

--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -2,7 +2,6 @@
 @use "../../../scss/variables" as *;
 @use "../../../scss/layout/breakpoints" as *;
 @use "../../../scss/mixins/border-radius" as *;
-@use "../../../scss/mixins/box-shadow" as *;
 @use "variables" as *;
 
 //
@@ -219,7 +218,6 @@
       @include border-radius(var(--bs-border-radius));
     }
   }
-
 
   .bd-example-offcanvas {
     .offcanvas {

--- a/site/src/scss/_content.scss
+++ b/site/src/scss/_content.scss
@@ -1,7 +1,5 @@
 @use "sass:color";
 @use "../../../scss/colors" as *;
-@use "../../../scss/config" as *;
-@use "../../../scss/variables" as *;
 @use "../../../scss/layout/breakpoints" as *;
 
 //

--- a/site/src/scss/_content.scss
+++ b/site/src/scss/_content.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-@use "../../../scss/colors" as *;
 @use "../../../scss/layout/breakpoints" as *;
 
 //

--- a/site/src/scss/_details.scss
+++ b/site/src/scss/_details.scss
@@ -1,5 +1,3 @@
-@use "../../../scss/config" as *;
-@use "../../../scss/colors" as *;
 @use "../../../scss/mixins/border-radius" as *;
 @use "../../../scss/mixins/transition" as *;
 

--- a/site/src/scss/_masthead.scss
+++ b/site/src/scss/_masthead.scss
@@ -1,11 +1,7 @@
 @use "sass:math";
-@use "../../../scss/config" as *;
-@use "../../../scss/colors" as *;
-@use "../../../scss/variables" as *;
 @use "../../../scss/layout/breakpoints" as *;
 @use "../../../scss/mixins/border-radius" as *;
 @use "../../../scss/mixins/transition" as *;
-@use "../../../scss/mixins/color-mode" as *;
 
 @layer custom {
   .bd-masthead {

--- a/site/src/scss/_navbar.scss
+++ b/site/src/scss/_navbar.scss
@@ -1,6 +1,5 @@
 @use "../../../scss/config" as *;
 @use "../../../scss/colors" as *;
-@use "../../../scss/functions" as *;
 @use "../../../scss/mixins" as *;
 @use "../../../scss/variables" as *;
 @use "../../../scss/layout/breakpoints" as *;

--- a/site/src/scss/_search.scss
+++ b/site/src/scss/_search.scss
@@ -1,8 +1,6 @@
-@use "variables" as *;
 @use "../../../scss/layout/breakpoints" as *;
 @use "../../../scss/mixins/color-mode" as *;
 @use "../../../scss/mixins/border-radius" as *;
-@use "../../../scss/mixins/focus-ring" as *;
 
 // stylelint-disable selector-class-pattern
 

--- a/site/src/scss/_search.scss
+++ b/site/src/scss/_search.scss
@@ -1,5 +1,4 @@
 @use "variables" as *;
-@use "../../../scss/colors" as *;
 @use "../../../scss/layout/breakpoints" as *;
 @use "../../../scss/mixins/color-mode" as *;
 @use "../../../scss/mixins/border-radius" as *;

--- a/site/src/scss/_sidebar.scss
+++ b/site/src/scss/_sidebar.scss
@@ -1,7 +1,4 @@
-@use "../../../scss/variables" as *;
 @use "../../../scss/layout/breakpoints" as *;
-@use "../../../scss/mixins/border-radius" as *;
-@use "../../../scss/mixins/focus-ring" as *;
 
 @layer custom {
   .bd-sidebar {

--- a/site/src/scss/_syntax.scss
+++ b/site/src/scss/_syntax.scss
@@ -1,9 +1,4 @@
-@use "sass:color";
-@use "../../../scss/config" as *;
-@use "../../../scss/colors" as *;
-@use "../../../scss/variables" as *;
 @use "../../../scss/mixins/border-radius" as *;
-@use "../../../scss/mixins/color-mode" as *;
 @use "../../../scss/mixins/transition" as *;
 
 // Shell prompt colors for light mode

--- a/site/src/scss/_variables.scss
+++ b/site/src/scss/_variables.scss
@@ -1,8 +1,4 @@
 @use "sass:color";
-@use "../../../scss/config" as *;
-@use "../../../scss/colors" as *;
-@use "../../../scss/functions" as *;
-@use "../../../scss/mixins/color-mode" as *;
 
 // Local docs variables
 $bd-purple:        #4c0bce;

--- a/site/src/scss/docs.scss
+++ b/site/src/scss/docs.scss
@@ -1,4 +1,5 @@
 // check-unused-imports-disable — all @use statements load component CSS (side-effect imports).
+
 /* Bootstrap Docs (https://getbootstrap.com/)
  * Copyright 2011-2026 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.

--- a/site/src/scss/docs.scss
+++ b/site/src/scss/docs.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — all @use statements load component CSS (side-effect imports).
 /* Bootstrap Docs (https://getbootstrap.com/)
  * Copyright 2011-2026 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.

--- a/site/src/scss/docs_search.scss
+++ b/site/src/scss/docs_search.scss
@@ -1,3 +1,4 @@
+// check-unused-imports-disable — side-effect CSS imports.
 /*!
  * Bootstrap Docs (https://getbootstrap.com/)
  * Copyright 2024-2026 The Bootstrap Authors

--- a/site/src/scss/docs_search.scss
+++ b/site/src/scss/docs_search.scss
@@ -1,4 +1,5 @@
 // check-unused-imports-disable — side-effect CSS imports.
+
 /*!
  * Bootstrap Docs (https://getbootstrap.com/)
  * Copyright 2024-2026 The Bootstrap Authors


### PR DESCRIPTION
Adds a new lint script to detect unused Sass imports. Turns out we had 200+ unused across our project and docs source Sass files. Eventually could be nice to turn this into something more powerful, but for now this works great it seems.