### PR TITLE
New root defaults for inputs and buttons

### DIFF
--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -119,8 +119,8 @@ $root-tokens: defaults(
     --btn-input-fg: var(--fg-body),
     --btn-input-bg: var(--bg-body),
 
-    --btn-input-min-height: 2.5rem,
-    --btn-input-padding-y: .375rem,
+    --btn-input-min-height: 2.375rem,
+    --btn-input-padding-y: .3125rem,
     --btn-input-padding-x: .75rem,
     --btn-input-font-size: var(--font-size-base),
     --btn-input-line-height: var(--line-height-base),
@@ -133,14 +133,14 @@ $root-tokens: defaults(
     --btn-input-xs-line-height: 1.125,
     --btn-input-xs-border-radius: var(--border-radius-xs),
 
-    --btn-input-sm-min-height: 2.25rem,
+    --btn-input-sm-min-height: 2rem,
     --btn-input-sm-padding-y: .25rem,
     --btn-input-sm-padding-x: .625rem,
     --btn-input-sm-font-size: var(--font-size-sm),
     --btn-input-sm-line-height: var(--line-height-sm),
     --btn-input-sm-border-radius: var(--border-radius-sm),
 
-    --btn-input-lg-min-height: 3rem,
+    --btn-input-lg-min-height: 2.75rem,
     --btn-input-lg-padding-y: .5rem,
     --btn-input-lg-padding-x: 1rem,
     --btn-input-lg-font-size: var(--font-size-md),

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -120,7 +120,7 @@ $root-tokens: defaults(
     --btn-input-bg: var(--bg-body),
 
     --btn-input-min-height: 2.375rem,
-    --btn-input-padding-y: .3125rem,
+    --btn-input-padding-y: .375rem,
     --btn-input-padding-x: .75rem,
     --btn-input-font-size: var(--font-size-base),
     --btn-input-line-height: var(--line-height-base),


### PR DESCRIPTION
In my opinion, both the buttons and the inputs on Bootstrap 6 are too large for what they're intended for.

This PR normalizes the difference between variants by making them more uniform, while also slightly adjusting their height.

It also makes it match more closely to BS4, BS5, Tailwind, Catalyst, etc.

I don't want to repeat everything that I've wrote in the v6 feedback, so kindly please have a read at: https://github.com/orgs/twbs/discussions/42138

Feel free to decline this PR if you believe the current defaults are fine.