### PR TITLE
Update v4 to v6 in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `main` (or `v4-dev` branch if the issue is about v4) in the repository.
+   latest `main` (or `v6-dev` branch if the issue is about v6) in the repository.
 
 3. **Isolate the problem** &mdash; ideally create a [reduced test
    case](https://css-tricks.com/reduced-test-cases/) and a live example.


### PR DESCRIPTION
### Description

I updated the v4 references in CONTRIBUTING.md to v6

### Motivation & Context

I did it because v4 is not the newest in-development version of Bootstrap anymore

### Type of change

`meta` change (update to the contributing guidelines)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)

### Related issues

#42141 