### PR TITLE
Fix docs links in inline HTML

### DIFF
--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -130,8 +130,8 @@ You can also do the old fashioned thing and download Bootstrap manually. Choose 
 <BsTable>
 | Type | Description | Link |
 | --- | --- | --- |
-| <strong class="text-nowrap">Distribution files</strong> | Ready-to-use compiled and minified CSS and JavaScript files. Doesn't include documentation, source files, or dependencies like Floating UI. | {/*<a href="[[config:download.dist]]" class="btn-subtle theme-accent">Download</a>*/} |
-| <strong class="text-nowrap">Source files</strong> | Sass, JavaScript, and documentation files for compiling with your own asset pipeline. Requires [Sass compiler]([[docsref:/guides/contribute#sass]]), [Autoprefixer](https://github.com/postcss/autoprefixer), and a JavaScript bundler like [Rollup](https://rollupjs.org/) or [Webpack](https://webpack.js.org/). | {/*<a href="[[config:download.source]]" class="btn-subtle theme-accent">Download</a>*/} |
+| <strong class="text-nowrap">Distribution files</strong> | Ready-to-use compiled and minified CSS and JavaScript files. Doesn't include documentation, source files, or dependencies like Floating UI. | <a href="[[config:download.dist]]" class="btn-subtle theme-accent btn-sm">Download</a> |
+| <strong class="text-nowrap">Source files</strong> | Sass, JavaScript, and documentation files for compiling with your own asset pipeline. Requires [Sass compiler]([[docsref:/guides/contribute#sass]]), [Autoprefixer](https://github.com/postcss/autoprefixer), and a JavaScript bundler like [Rollup](https://rollupjs.org/) or [Webpack](https://webpack.js.org/). | <a href="[[config:download.source]]" class="btn-subtle theme-accent btn-sm">Download</a> |
 </BsTable>
 
 Should you require our full set of [build tools]([[docsref:/guides/contribute#tooling-setup]]), they are included for developing Bootstrap and its docs, but they’re likely unsuitable for your own purposes.

--- a/site/src/libs/remark.ts
+++ b/site/src/libs/remark.ts
@@ -26,34 +26,38 @@ export const remarkBsConfig: Plugin<[], Root> = function () {
 
     // https://github.com/syntax-tree/mdast#nodes
     // https://github.com/syntax-tree/mdast-util-mdx-jsx#nodes
-    visit(ast, ['code', 'definition', 'image', 'inlineCode', 'link', 'mdxJsxFlowElement', 'mdxJsxTextElement', 'text'], (node) => {
-      switch (node.type) {
-        case 'code':
-        case 'inlineCode':
-        case 'text': {
-          node.value = replaceConfigInText(node.value)
-          break
-        }
-        case 'image': {
-          if (node.alt) {
-            node.alt = replaceConfigInText(node.alt)
+    visit(
+      ast,
+      ['code', 'definition', 'image', 'inlineCode', 'link', 'mdxJsxFlowElement', 'mdxJsxTextElement', 'text'],
+      (node) => {
+        switch (node.type) {
+          case 'code':
+          case 'inlineCode':
+          case 'text': {
+            node.value = replaceConfigInText(node.value)
+            break
           }
+          case 'image': {
+            if (node.alt) {
+              node.alt = replaceConfigInText(node.alt)
+            }
 
-          node.url = replaceConfigInText(node.url)
-          break
-        }
-        case 'definition':
-        case 'link': {
-          node.url = replaceConfigInText(node.url)
-          break
-        }
-        case 'mdxJsxFlowElement':
-        case 'mdxJsxTextElement': {
-          node.attributes = replaceConfigInAttributes(node.attributes)
-          break
+            node.url = replaceConfigInText(node.url)
+            break
+          }
+          case 'definition':
+          case 'link': {
+            node.url = replaceConfigInText(node.url)
+            break
+          }
+          case 'mdxJsxFlowElement':
+          case 'mdxJsxTextElement': {
+            node.attributes = replaceConfigInAttributes(node.attributes)
+            break
+          }
         }
       }
-    })
+    )
   }
 }
 

--- a/site/src/libs/remark.ts
+++ b/site/src/libs/remark.ts
@@ -26,7 +26,7 @@ export const remarkBsConfig: Plugin<[], Root> = function () {
 
     // https://github.com/syntax-tree/mdast#nodes
     // https://github.com/syntax-tree/mdast-util-mdx-jsx#nodes
-    visit(ast, ['code', 'definition', 'image', 'inlineCode', 'link', 'mdxJsxFlowElement', 'text'], (node) => {
+    visit(ast, ['code', 'definition', 'image', 'inlineCode', 'link', 'mdxJsxFlowElement', 'mdxJsxTextElement', 'text'], (node) => {
       switch (node.type) {
         case 'code':
         case 'inlineCode':
@@ -47,7 +47,8 @@ export const remarkBsConfig: Plugin<[], Root> = function () {
           node.url = replaceConfigInText(node.url)
           break
         }
-        case 'mdxJsxFlowElement': {
+        case 'mdxJsxFlowElement':
+        case 'mdxJsxTextElement': {
           node.attributes = replaceConfigInAttributes(node.attributes)
           break
         }
@@ -70,13 +71,14 @@ export const remarkBsDocsref: Plugin<[], Root> = function () {
 
     // https://github.com/syntax-tree/mdast#nodes
     // https://github.com/syntax-tree/mdast-util-mdx-jsx#nodes
-    visit(ast, ['definition', 'link', 'mdxJsxTextElement'], (node) => {
+    visit(ast, ['definition', 'link', 'mdxJsxFlowElement', 'mdxJsxTextElement'], (node) => {
       switch (node.type) {
         case 'definition':
         case 'link': {
           node.url = replaceDocsrefInText(node.url)
           break
         }
+        case 'mdxJsxFlowElement':
         case 'mdxJsxTextElement': {
           node.attributes = replaceDocsrefInAttributes(node.attributes)
           break


### PR DESCRIPTION
Lets inline `<a href="">` instances use our docs link syntax.