### PR TITLE
Adjust vertical padding and border width for navbar-nav links

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -124,13 +124,14 @@ $navbar-dark-tokens: defaults(
     --nav-gap: .25rem;
     --nav-link-gap: .5rem;
     --nav-link-padding-x: .5rem;
-    --nav-link-padding-y: .5rem;
+    --nav-link-padding-y: .375rem;
     --nav-link-color: var(--navbar-color);
     --nav-link-hover-color: var(--navbar-hover-color);
     --nav-link-hover-bg: transparent;
     --nav-link-active-color: var(--navbar-active-color);
     --nav-link-active-bg: transparent;
     --nav-link-disabled-color: var(--navbar-disabled-color);
+    --nav-link-border-width: var(--border-width);
     // scss-docs-end navbar-nav-css-vars
 
     display: flex;
@@ -143,6 +144,7 @@ $navbar-dark-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
+        border: var(--nav-link-border-width) solid transparent;
         color: var(--navbar-active-color);
       }
     }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -132,6 +132,7 @@ $navbar-dark-tokens: defaults(
     --nav-link-active-bg: transparent;
     --nav-link-disabled-color: var(--navbar-disabled-color);
     --nav-link-border-width: var(--border-width);
+    //--nav-link-border-color: var(--border-color),
     // scss-docs-end navbar-nav-css-vars
 
     display: flex;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -126,13 +126,13 @@ $navbar-dark-tokens: defaults(
     --nav-link-padding-x: .5rem;
     --nav-link-padding-y: .375rem;
     --nav-link-color: var(--navbar-color);
+    --nav-link-border-width: var(--border-width);
+    //--nav-link-border-color: var(--border-color);
     --nav-link-hover-color: var(--navbar-hover-color);
     --nav-link-hover-bg: transparent;
     --nav-link-active-color: var(--navbar-active-color);
     --nav-link-active-bg: transparent;
     --nav-link-disabled-color: var(--navbar-disabled-color);
-    --nav-link-border-width: var(--border-width);
-    //--nav-link-border-color: var(--border-color);
     // scss-docs-end navbar-nav-css-vars
 
     display: flex;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -145,8 +145,8 @@ $navbar-dark-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
-        border: var(--nav-link-border-width) solid var(--nav-link-border-color, transparent);
         color: var(--navbar-active-color);
+        border: var(--nav-link-border-width) solid var(--nav-link-border-color, transparent);
       }
     }
   }

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -132,7 +132,7 @@ $navbar-dark-tokens: defaults(
     --nav-link-active-bg: transparent;
     --nav-link-disabled-color: var(--navbar-disabled-color);
     --nav-link-border-width: var(--border-width);
-    //--nav-link-border-color: var(--border-color),
+    //--nav-link-border-color: var(--border-color);
     // scss-docs-end navbar-nav-css-vars
 
     display: flex;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -144,7 +144,7 @@ $navbar-dark-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
-        border: var(--nav-link-border-width) solid transparent;
+        border: var(--nav-link-border-width) solid var(--nav-link-border-color, transparent);
         color: var(--navbar-active-color);
       }
     }


### PR DESCRIPTION
Currently, `nav-link` paddings on `navbar-nav` is set to `.5rem` which computes to a `40px` in height, making them larger other common elements, such as `input`, or `button` elements.

This issue is clearly visible in the docs demo:

<img width="941" height="113" alt="image" src="https://github.com/user-attachments/assets/ce383ade-ce4f-47fb-9801-dfa638f60d99" />

This fix normalizes the `nav-link` height to match the `button` and `input` height, by setting the `padding` to `.375rem`, and adding an invisible border around them so that they compute to `38px` in height.

The `navbar-nav` links now look like this, which makes the inline input & button align vertically as it should:

<img width="923" height="111" alt="image" src="https://github.com/user-attachments/assets/eb0253ba-d352-4c70-9ad4-83b5a074bced" />