### PR TITLE
Remove remaining Prism usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@astrojs/check": "^0.9.6",
         "@astrojs/markdown-remark": "^6.3.10",
         "@astrojs/mdx": "^4.3.13",
-        "@astrojs/prism": "^3.3.0",
         "@astrojs/sitemap": "^3.6.0",
         "@babel/cli": "^7.28.3",
         "@babel/core": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/markdown-remark": "^6.3.10",
     "@astrojs/mdx": "^4.3.13",
-    "@astrojs/prism": "^3.3.0",
     "@astrojs/sitemap": "^3.6.0",
     "@babel/cli": "^7.28.3",
     "@babel/core": "^7.28.5",

--- a/site/src/components/shortcodes/ButtonPlayground.astro
+++ b/site/src/components/shortcodes/ButtonPlayground.astro
@@ -206,12 +206,6 @@ const rounded = ['default', 'pill', 'square']
     // Update the code content
     codeSnippet.className = 'language-html'
     codeSnippet.textContent = htmlCode
-
-    // Trigger Prism highlighting if available
-    // Prism from @astrojs/prism is server-side, but we can try to use Prism.js if loaded
-    if (typeof window !== 'undefined' && (window as any).Prism) {
-      (window as any).Prism.highlightElement(codeSnippet)
-    }
   }
 
   function updateButtons() {

--- a/site/src/components/shortcodes/DropdownPlacementPlayground.astro
+++ b/site/src/components/shortcodes/DropdownPlacementPlayground.astro
@@ -193,10 +193,6 @@ const logicalPlacements = [
 
     codeSnippet.className = 'language-html'
     codeSnippet.textContent = htmlCode
-
-    if (typeof window !== 'undefined' && (window as any).Prism) {
-      (window as any).Prism.highlightElement(codeSnippet)
-    }
   }
 
   // Initialize placement dropdown

--- a/site/src/components/shortcodes/NavbarPlacementPlayground.astro
+++ b/site/src/components/shortcodes/NavbarPlacementPlayground.astro
@@ -122,10 +122,6 @@ const placements = [
 
     codeSnippet.className = 'language-html'
     codeSnippet.textContent = htmlCode
-
-    if (typeof window !== 'undefined' && (window as any).Prism) {
-      (window as any).Prism.highlightElement(codeSnippet)
-    }
   }
 
   // Initialize dropdown

--- a/site/src/components/shortcodes/StepperPlayground.astro
+++ b/site/src/components/shortcodes/StepperPlayground.astro
@@ -254,10 +254,6 @@ const stepCounts = [3, 4, 5, 6]
     const htmlCode = generateHTML()
     codeSnippet.className = 'language-html'
     codeSnippet.textContent = htmlCode
-
-    if (typeof window !== 'undefined' && (window as any).Prism) {
-      (window as any).Prism.highlightElement(codeSnippet)
-    }
   }
 
   function updateActiveDropdown() {


### PR DESCRIPTION
### Description

This PR follows up https://github.com/twbs/bootstrap/pull/42182 to remove remaining usage of Prism.

All the code similar to didn't do anything special:

```
if (typeof window !== 'undefined' && (window as any).Prism) {
  (window as any).Prism.highlightElement(codeSnippet)
}
```

so `@astrojs/prism` can be removed as well.

If we go to https://deploy-preview-42193--twbs-bootstrap.netlify.app/docs/6.0/components/buttons#playground, we can see that the playground is still working, and that the code snippet is still displayed. It isn't modified dynamically, but that's already not working in the `v6-dev` branch: https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/buttons/

> [!NOTE]
> No need to backport this to v5 as we'll continue to use Prism in v5