### PR TITLE
Define `.browserslistrc` as the single source of truth and embed it in npm package

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./dist/css/bootstrap-reboot.min.css",
-      "maxSize": "5.0 kB"
+      "maxSize": "5.25 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.css",

--- a/build/css-minify.mjs
+++ b/build/css-minify.mjs
@@ -17,8 +17,17 @@ const distDir = path.join(process.cwd(), 'dist/css')
 const cssFiles = fs.readdirSync(distDir)
   .filter(file => file.endsWith('.css') && !file.endsWith('.min.css'))
 
-// Target browsers (matching Bootstrap's browser support)
-const targets = browserslistToTargets(['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead'])
+// Target browsers (read from .browserslistrc when available)
+let targets
+try {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  const { default: browserslist } = await import('browserslist')
+  const browsers = browserslist()
+  console.log('Target browsers from .browserslistrc:', browsers)
+  targets = browserslistToTargets(browsers)
+} catch {
+  console.error('Could not load browserslist')
+}
 
 for (const file of cssFiles) {
   const inputPath = path.join(distDir, file)

--- a/package.json
+++ b/package.json
@@ -198,7 +198,8 @@
     "js/{src,dist}/**/*.{js,map}",
     "js/index.js",
     "scss/**/*.scss",
-    "!scss/tests/**"
+    "!scss/tests/**",
+    ".browserslistrc"
   ],
   "overrides": {
     "volar-service-emmet": "0.0.63"

--- a/site/src/content/docs/customize/optimize.mdx
+++ b/site/src/content/docs/customize/optimize.mdx
@@ -48,7 +48,7 @@ const dialog = new Dialog(document.getElementById('myDialog'))
 
 ## Autoprefixer .browserslistrc
 
-Bootstrap depends on Autoprefixer to automatically add browser prefixes to certain CSS properties. Prefixes are dictated by our `.browserslistrc` file, found in the root of the Bootstrap repo. Customizing this list of browsers and recompiling the Sass will automatically remove some CSS from your compiled CSS, if there are vendor prefixes unique to that browser or version.
+Bootstrap depends on Autoprefixer to automatically add browser prefixes to certain CSS properties. Prefixes are dictated by our `.browserslistrc` file, found in the root of the Bootstrap repo and at the root of the npm package (`node_modules/bootstrap/.browserslistrc`). Customizing this list of browsers and recompiling the Sass will automatically remove some CSS from your compiled CSS, if there are vendor prefixes unique to that browser or version.
 
 ## Unused CSS
 

--- a/site/src/content/docs/getting-started/approach.mdx
+++ b/site/src/content/docs/getting-started/approach.mdx
@@ -139,6 +139,8 @@ You can find our supported range of browsers and their versions [in our `.browse
 
 <Code lang="plaintext" filePath=".browserslistrc" />
 
+If you installed Bootstrap via npm, you can also find this file locally at `node_modules/bootstrap/.browserslistrc`.
+
 We use [Autoprefixer](https://github.com/postcss/autoprefixer) to handle intended browser support via CSS prefixes, which uses [Browserslist](https://github.com/browserslist/browserslist) to manage these browser versions. Consult their documentation for how to integrate these tools into your projects.
 
 ## Guiding principles

--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -41,6 +41,7 @@ Bootstrap’s `package.json` contains some additional metadata under the followi
 
 - `sass` - path to Bootstrap’s main [Sass](https://sass-lang.com/) source file
 - `style` - path to Bootstrap’s non-minified CSS that’s been compiled using the default settings (no customization)
+- `.browserslistrc` - shipped at the package root for Browserslist/Autoprefixer browser targets
 
 ### Using Yarn
 


### PR DESCRIPTION
### Description

#### Single source of truth for browserslist config

Previously, in this branch, Bootstrap's browser targets were defined in two places:
- `.browserslistrc` used by PostCSS and other tooling
- `css-minify.mjs` which hardcoded its own list: `['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead']`

These two lists were inconsistent, which could lead to subtle differences in the generated CSS depending on the tool used.

This PR consolidates everything into a single source of truth. Two approaches were considered:

**Option A — Move config into `package.json`**

Browserslist supports a `browserslist` key directly in `package.json`. This keeps everything in one file and avoids an extra file at the root. However, `.browserslistrc` is currently excluded from the npm package (`files` in `package.json`), and moving the config into `package.json` wouldn't straightforwardly solve shareability either — consumers would need to extract the key manually.

**Option B — Keep `.browserslistrc` and include it in the npm package**

This is the approach taken in this PR. By adding `.browserslistrc` to the `files` field in `package.json`, it becomes part of the published package and can be referenced or reused directly by consumers in their own projects. It also stays compatible with all browserslist-aware tooling out of the box, without any extra configuration.

`css-minify.mjs` is updated to read from `.browserslistrc` instead of its own hardcoded list, ensuring both tools use the exact same targets.

#### Checklist

- [ ] Check with @mdo which browsers list was actually used/tested between `.browserslistrc` and what was in `css-minify.mjs`.
  - [ ] Bundlewatch is not happy with `./dist/css/bootstrap-reboot.min.css`. Meaning it's bigger, meaning it has more rules, meaning we support more thing than before. Which is logical because what was used to minify CSS was in the script's content (and not the `.browserslistrc`); `['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead']`
- [x] Embed `.browserslistrc` into the npm package
- [x] Modify the docs to mention that the `.browserlistrc` file is also in the npm package