### PR TITLE
Bump htmlparser2 from 10.0.0 to 10.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "github-slugger": "^2.0.0",
         "globby": "^16.0.0",
         "hammer-simulator": "0.0.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "image-size": "^2.0.2",
         "ip": "^2.0.1",
         "jasmine": "^5.13.0",
@@ -9607,9 +9607,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -9622,8 +9622,21 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "github-slugger": "^2.0.0",
     "globby": "^16.0.0",
     "hammer-simulator": "0.0.1",
-    "htmlparser2": "^10.0.0",
+    "htmlparser2": "^10.1.0",
     "image-size": "^2.0.2",
     "ip": "^2.0.1",
     "jasmine": "^5.13.0",


### PR DESCRIPTION
This PR backports https://github.com/twbs/bootstrap/pull/42200 from `v6-dev`