### PR TITLE
Docs: add integrity to importmap configuration

### DIFF
--- a/build/generate-sri.mjs
+++ b/build/generate-sri.mjs
@@ -36,6 +36,14 @@ const files = [
   {
     file: 'dist/js/bootstrap.bundle.min.js',
     configPropertyName: 'js_bundle_hash'
+  },
+  {
+    file: 'node_modules/@floating-ui/dom/dist/floating-ui.dom.esm.js',
+    configPropertyName: 'floating_ui_esm_hash'
+  },
+  {
+    file: 'node_modules/vanilla-calendar-pro/index.mjs',
+    configPropertyName: 'vanilla_calendar_pro_esm_hash'
   }
 ]
 

--- a/config.yml
+++ b/config.yml
@@ -34,14 +34,16 @@ download:
 
 cdn:
   # See https://www.srihash.org for info on how to generate the hashes
-  css:                  "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/css/bootstrap.min.css"
-  css_hash:             "sha384-TDmpFhAO5TwSQwPF95I/odgwpTUuv0aaVm9/0fL7b+kKe7hFBp/+9cBCMkydgGOi"
-  js:                   "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.min.js"
-  js_hash:              "sha384-Php492snRLTR5p+hMyxpV6gYwp1avWXn4AaX31MgANrvsjr9Dpodl3Nw60L7Pewl"
-  js_bundle:            "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.bundle.min.js"
-  js_bundle_hash:       "sha384-I2J4jlw924JZXHU9un9Mcuixq/rKhd5A8/B1NQ6ifPAiBFacZjwNcec8d6L38jQv"
-  floating_ui_esm:      "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.6/dist/floating-ui.dom.esm.min.js"
-  vanilla_calendar_pro_esm: "https://cdn.jsdelivr.net/npm/vanilla-calendar-pro@3.1.0/index.mjs"
+  css:                           "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/css/bootstrap.min.css"
+  css_hash:                      "sha384-TDmpFhAO5TwSQwPF95I/odgwpTUuv0aaVm9/0fL7b+kKe7hFBp/+9cBCMkydgGOi"
+  js:                            "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.min.js"
+  js_hash:                       "sha384-Php492snRLTR5p+hMyxpV6gYwp1avWXn4AaX31MgANrvsjr9Dpodl3Nw60L7Pewl"
+  js_bundle:                     "https://cdn.jsdelivr.net/npm/bootstrap@6.0.0-alpha1/dist/js/bootstrap.bundle.min.js"
+  js_bundle_hash:                "sha384-I2J4jlw924JZXHU9un9Mcuixq/rKhd5A8/B1NQ6ifPAiBFacZjwNcec8d6L38jQv"
+  floating_ui_esm:               "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.6/dist/floating-ui.dom.esm.js"
+  floating_ui_esm_hash:          "sha384-xovEHHpm3FhkiFUAGz5wPlJL39EW6cK9oRkwHaIjtGaw0nF5RtjHWV6oJB+tNbc2"
+  vanilla_calendar_pro_esm:      "https://cdn.jsdelivr.net/npm/vanilla-calendar-pro@3.1.0/index.mjs"
+  vanilla_calendar_pro_esm_hash: "sha384-5quhKh5ILxed/sN+sno/4zf+ksFY5P4ekIM5SnguE49mgszu8obwGevh7IUEV3rm"
 
 anchors:
   min:                  2

--- a/site/src/content/docs/customize/rtl.mdx
+++ b/site/src/content/docs/customize/rtl.mdx
@@ -99,6 +99,10 @@ Here's a modified RTL starter template:
       "imports": {
         "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]",
         "vanilla-calendar-pro": "[[config:cdn.vanilla_calendar_pro_esm]]"
+      },
+      "integrity": {
+        "[[config:cdn.floating_ui_esm]]": "[[config:cdn.floating_ui_esm_hash]]",
+        "[[config:cdn.vanilla_calendar_pro_esm]]": "[[config:cdn.vanilla_calendar_pro_esm_hash]]"
       }
     }
     </script>

--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -97,6 +97,10 @@ If you prefer to include Floating UI and Vanilla Calendar Pro separately instead
   "imports": {
     "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]",
     "vanilla-calendar-pro": "[[config:cdn.vanilla_calendar_pro_esm]]"
+  },
+  "integrity": {
+    "[[config:cdn.floating_ui_esm]]": "[[config:cdn.floating_ui_esm_hash]]",
+    "[[config:cdn.vanilla_calendar_pro_esm]]": "[[config:cdn.vanilla_calendar_pro_esm_hash]]"
   }
 }
 </script>
@@ -108,7 +112,13 @@ If you prefer to include Floating UI and Vanilla Calendar Pro separately instead
 | --- | --- |
 | CSS | [`[[config:cdn.css]]`]([[config:cdn.css]]) |
 | JS bundle (with Floating UI and Vanilla Calendar Pro) | [`[[config:cdn.js_bundle]]`]([[config:cdn.js_bundle]]) |
+| Floating UI ESM | [`[[config:cdn.floating_ui_esm]]`]([[config:cdn.floating_ui_esm]]) |
+| Vanilla Calendar Pro ESM | [`[[config:cdn.vanilla_calendar_pro_esm]]`]([[config:cdn.vanilla_calendar_pro_esm]]) |
 </BsTable>
+
+<Callout>
+jsDelivr also provides a minified ESM version of Floating UI, but it can't be used with the integrity attribute.
+</Callout>
 
 ### Using CDNs
 

--- a/site/src/content/docs/getting-started/javascript.mdx
+++ b/site/src/content/docs/getting-started/javascript.mdx
@@ -84,7 +84,12 @@ Using ESM in the browser requires full paths or an [import map](https://develope
       "imports": {
         "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]",
         "vanilla-calendar-pro": "[[config:cdn.vanilla_calendar_pro_esm]]",
-        "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@[[config:current_version]]/dist/js/bootstrap.min.js"
+        "bootstrap": "[[config:cdn.js]]"
+      },
+      "integrity": {
+        "[[config:cdn.floating_ui_esm]]": "[[config:cdn.floating_ui_esm_hash]]",
+        "[[config:cdn.vanilla_calendar_pro_esm]]": "[[config:cdn.vanilla_calendar_pro_esm_hash]]"
+        "[[config:cdn.js]]": "[[config:cdn.js_hash]]"
       }
     }
     </script>

--- a/site/src/content/docs/guides/quickstart.mdx
+++ b/site/src/content/docs/guides/quickstart.mdx
@@ -51,6 +51,10 @@ Get started using Bootstrap in seconds by including our production-ready CSS and
      "imports": {
        "@floating-ui/dom": "[[config:cdn.floating_ui_esm]]",
        "vanilla-calendar-pro": "[[config:cdn.vanilla_calendar_pro_esm]]"
+     },
+     "integrity": {
+       "[[config:cdn.floating_ui_esm]]": "[[config:cdn.floating_ui_esm_hash]]",
+       "[[config:cdn.vanilla_calendar_pro_esm]]": "[[config:cdn.vanilla_calendar_pro_esm_hash]]"
      }
    }
    </script>

--- a/site/src/libs/config.ts
+++ b/site/src/libs/config.ts
@@ -28,7 +28,9 @@ const configSchema = z.object({
     js_bundle: z.string().url(),
     js_bundle_hash: z.string(),
     floating_ui_esm: z.string().url(),
-    vanilla_calendar_pro_esm: z.string().url()
+    floating_ui_esm_hash: z.string(),
+    vanilla_calendar_pro_esm: z.string().url(),
+    vanilla_calendar_pro_esm_hash: z.string()
   }),
   current_version: zVersionSemver,
   current_ruby_version: zVersionSemver,


### PR DESCRIPTION
> [!WARNING]
> Heavily draft

### Description

This PR adds import map integrity metadata to our CDN ESM docs examples and exposes the corresponding hashes in the docs config.

This improves the security guidance around CDN-based ESM usage by showing how to use Subresource Integrity not only for the top-level Bootstrap module, but also for modules resolved through an import map such as Floating UI and Vanilla Calendar Pro.

## Changes

- Generate SRI hashes for the ESM CDN dependencies used in our docs examples:
  - Floating UI ESM
  - Vanilla Calendar Pro ESM
- Add the new hash values to `config.yml`
- Extend the docs config schema to include those new hash properties
- Update the CDN/import map examples in the docs to include an `integrity` section keyed by resolved module URLs
- Align the Bootstrap ESM import-map example with the configured CDN URL
- Document the separate Floating UI and Vanilla Calendar Pro ESM CDN URLs in the install docs
- Add a note explaining why the minified jsDelivr Floating UI ESM build is not used for integrity examples

## Extra notes

The Floating UI URL uses the non-minified ESM file because that is the file we can hash and reference directly for SRI. When one navigates to https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.6/dist/floating-ui.dom.esm.min.js, they can see mentioned "Minified by jsDelivr using Terser v5.39.0". So it's not safe to provide an integrity in our docs for the minified version. Indeed, as mentioned in [Using SRI - jsDelivr](https://www.jsdelivr.com/using-sri-with-dynamic-files):

> Minifying the exact same source code multiple times might not result in the exact same generated code. While we store all generated files in our permanent storage, we might need to re-minify the file in certain situation, e.g., as a part of failover, if our storage provider goes down.

Vanilla Calendar Pro's `index.mjs` is already the published module entry used in the examples.

## References

- MDN import map integrity metadata:
  https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#integrity_metadata_map

### Checklist

- [ ] Provide a CodePen showing the approach with integrity with Bootstrap v5

> [!WARNING]
> Started to create a CodePen at https://codepen.io/editor/julien-deramond/pen/019d07ed-f263-72c6-99e7-0b003e265962, but changing the `integrity` value doesn't seem to change anything

- [ ] If it works well, do we backport to v5 docs?

#### Live previews

- https://deploy-preview-42210--twbs-bootstrap.netlify.app/docs/6.0/customize/rtl/#starter-template
- https://deploy-preview-42210--twbs-bootstrap.netlify.app/docs/6.0/getting-started/install/#cdn
- https://deploy-preview-42210--twbs-bootstrap.netlify.app/docs/6.0/getting-started/javascript/#using-bootstrap-as-a-module
- https://deploy-preview-42210--twbs-bootstrap.netlify.app/docs/6.0/guides/quickstart/