### PR TITLE
Bump zod from 4.1.12 to 4.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "stylelint-order": "^7.0.1",
         "terser": "^5.44.1",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.1.12"
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.7.6",
@@ -19858,9 +19858,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "stylelint-order": "^7.0.1",
     "terser": "^5.44.1",
     "unist-util-visit": "^5.0.0",
-    "zod": "^4.1.12"
+    "zod": "^4.3.6"
   },
   "files": [
     "dist/{css,js}/*.{css,js,map}",

--- a/site/src/libs/config.ts
+++ b/site/src/libs/config.ts
@@ -18,17 +18,17 @@ const configSchema = z.object({
     max: z.number()
   }),
   authors: z.string(),
-  baseURL: z.string().url(),
-  blog: z.string().url(),
+  baseURL: z.url(),
+  blog: z.url(),
   cdn: z.object({
-    css: z.string().url(),
+    css: z.url(),
     css_hash: z.string(),
-    js: z.string().url(),
+    js: z.url(),
     js_hash: z.string(),
-    js_bundle: z.string().url(),
+    js_bundle: z.url(),
     js_bundle_hash: z.string(),
-    floating_ui_esm: z.string().url(),
-    vanilla_calendar_pro_esm: z.string().url()
+    floating_ui_esm: z.url(),
+    vanilla_calendar_pro_esm: z.url()
   }),
   current_version: zVersionSemver,
   current_ruby_version: zVersionSemver,
@@ -36,17 +36,17 @@ const configSchema = z.object({
   docs_version: zVersionMajorMinor,
   docsDir: z.string(),
   download: z.object({
-    dist: z.string().url(),
-    dist_examples: z.string().url(),
-    source: z.string().url()
+    dist: z.url(),
+    dist_examples: z.url(),
+    source: z.url()
   }),
-  github_org: z.string().url(),
-  icons: z.string().url(),
-  opencollective: z.string().url(),
-  repo: z.string().url(),
+  github_org: z.url(),
+  icons: z.url(),
+  opencollective: z.url(),
+  repo: z.url(),
   rfs_version: zPrefixedVersionSemver,
   subtitle: z.string(),
-  swag: z.string().url(),
+  swag: z.url(),
   title: z.string(),
   toc: z.object({
     min: z.number(),

--- a/site/src/libs/data.ts
+++ b/site/src/libs/data.ts
@@ -30,7 +30,7 @@ const dataDefinitions = {
   'docs-versions': z
     .object({
       group: z.string(),
-      baseurl: z.string().url(),
+      baseurl: z.url(),
       description: z.string(),
       versions: z.union([zVersionSemver, zVersionMajorMinor]).array()
     })
@@ -54,13 +54,13 @@ const dataDefinitions = {
     preferred: z
       .object({
         name: z.string(),
-        website: z.string().url()
+        website: z.url()
       })
       .array(),
     more: z
       .object({
         name: z.string(),
-        website: z.string().url()
+        website: z.url()
       })
       .array()
   }),
@@ -105,7 +105,7 @@ const dataDefinitions = {
       name: z.string(),
       code: zLanguageCode,
       description: z.string(),
-      url: z.string().url()
+      url: z.url()
     })
     .array()
 } satisfies Record<string, DataSchema>


### PR DESCRIPTION
This PR bumps zod from 4.1.12 to 4.3.6.

During the process, I noticed that we're still using `z.string().url()` that has been deprecated. So it's been replaced by `z.url()`.