### PR TITLE
Bump prettier from 3.7.4 to 3.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "npm-run-all2": "^8.0.4",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
-        "prettier": "^3.7.4",
+        "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
         "rehype-autolink-headings": "^7.1.0",
         "remark": "^15.0.1",
@@ -15537,9 +15537,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "npm-run-all2": "^8.0.4",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
-    "prettier": "^3.7.4",
+    "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
     "rehype-autolink-headings": "^7.1.0",
     "remark": "^15.0.1",


### PR DESCRIPTION
This PR bumps prettier from 3.7.4 to 3.8.1.

No warnings observed while running the different linting npm scripts.