### PR TITLE
fix: ensure .form-select in .input-group gets proper border-radius

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -108,6 +108,7 @@
 
   &.has-validation {
     > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+    > .form-select:nth-last-child(n + 3),
     > .dropdown-toggle:nth-last-child(n + 4),
     > .form-floating:nth-last-child(n + 3) > .form-control,
     > .form-floating:nth-last-child(n + 3) > .form-select {
@@ -120,7 +121,8 @@
     $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
   }
 
-  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages},
+  > .form-select:not(:first-child) {
     margin-left: calc(-1 * #{$input-border-width}); // stylelint-disable-line function-disallowed-list
     @include border-start-radius(0);
   }


### PR DESCRIPTION
Closes #42242

## Fix: .input-group form-select border-radius issue

### Problem
When using `.input-group` with `.input-group-text` followed by `.form-select`, Bootstrap incorrectly applies full border-radius to the select element instead of removing the shared right border-radius from the text addon.

**Example:** `.input-group > .input-group-text + .form-select` results in all 4 corners being rounded, instead of right-side-only rounding expected from an input group.

### Root Cause
The SCSS selectors for border-radius in `.input-group` did not include standalone `.form-select` elements:
1. `.has-validation` section was missing `> .form-select:nth-last-child(n + 3)`
2. The `:not(:first-child)` border-start-radius rule was missing standalone `.form-select`

### Fix
Two additions to `scss/forms/_input-group.scss`:
1. Added `> .form-select:nth-last-child(n + 3)` to the `.has-validation` block
2. Added `> .form-select:not(:first-child)` to the `border-start-radius: 0` rule

### Testing
A reduced test case is available in the original issue: https://github.com/twbs/bootstrap/issues/42242

---