### PR TITLE
Docs: remove optional `direction` management for RTL

### DIFF
--- a/site/src/components/head/Head.astro
+++ b/site/src/components/head/Head.astro
@@ -9,14 +9,13 @@ import Analytics from '@components/head/Analytics.astro'
 
 interface Props {
   description: string
-  direction?: 'rtl'
   layout: Layout
   robots: string | undefined
   thumbnail: string
   title: string
 }
 
-const { description, direction, layout, robots, thumbnail, title } = Astro.props
+const { description, layout, robots, thumbnail, title } = Astro.props
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
 
@@ -63,7 +62,7 @@ const ScssProd = import.meta.env.PROD ? await import('@components/head/ScssProd.
 </script>
 
 {import.meta.env.PROD && ScssProd && (
-  <Stylesheet direction={direction} layout={layout} />
+  <Stylesheet layout={layout} />
   <ScssProd.default />
 )}
 

--- a/site/src/components/head/Stylesheet.astro
+++ b/site/src/components/head/Stylesheet.astro
@@ -3,11 +3,8 @@ import { getVersionedBsCssProps } from '@libs/bootstrap'
 import type { Layout } from '@libs/layout'
 
 interface Props {
-  direction?: 'rtl'
   layout: Layout
 }
-
-const { direction } = Astro.props
 ---
 
-<link {...getVersionedBsCssProps(direction)} />
+<link {...getVersionedBsCssProps()} />

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -19,7 +19,6 @@ const docsSchema = z.object({
     ])
     .optional(),
   description: z.string(),
-  direction: z.literal('rtl').optional(),
   extra_js: z
     .object({
       async: z.boolean().optional(),

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -49,7 +49,6 @@ const mainProps = overrides?.main ?? {}
   <head>
     <Head
       description={description}
-      direction={frontmatter?.direction}
       layout={layout}
       robots={robots}
       thumbnail={thumbnail}

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -11,16 +11,14 @@ import Icons from '@layouts/partials/Icons.astro'
 
 type Props = ExampleFrontmatter
 
-const { body_class, direction, extra_css, extra_js, html_class, include_js, title = 'Example' } = Astro.props
+const { body_class, extra_css, extra_js, html_class, include_js, title = 'Example' } = Astro.props
 
 const pageTitle = `${title} · ${getConfig().title} v${getConfig().docs_version}`
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
-
-const htmlProps: HTMLAttributes<'html'> = direction === 'rtl' ? { lang: 'ar', dir: 'rtl' } : { lang: 'en' }
 ---
 
 <!DOCTYPE html>
-<html {...htmlProps} class:list={html_class} data-bs-theme="auto">
+<html lang="en" class:list={html_class} data-bs-theme="auto">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -33,7 +31,7 @@ const htmlProps: HTMLAttributes<'html'> = direction === 'rtl' ? { lang: 'ar', di
 
     <script is:inline src={getVersionedDocsPath('assets/js/color-modes.js')}></script>
 
-    <Stylesheet direction={direction} layout="examples" />
+    <Stylesheet layout="examples" />
     <Favicons />
 
     <style is:global>

--- a/site/src/libs/bootstrap.ts
+++ b/site/src/libs/bootstrap.ts
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from 'astro/types'
 import { getConfig } from '@libs/config'
 import { getVersionedDocsPath } from '@libs/path'
 
-export function getVersionedBsCssProps(direction: 'rtl' | undefined) {
+export function getVersionedBsCssProps() {
   let bsCssLinkHref = '/dist/css/bootstrap'
 
   if (import.meta.env.PROD) {

--- a/site/src/libs/examples.ts
+++ b/site/src/libs/examples.ts
@@ -6,7 +6,6 @@ import { getDocsFsPath } from './path'
 
 export const exampleFrontmatterSchema = z.object({
   body_class: z.string().optional(),
-  direction: z.literal('rtl').optional(),
   extra_css: z.string().array().optional(),
   extra_js: z
     .object({


### PR DESCRIPTION
### Description

This PR removes the remaining documentation elements related to handling RTL pages. As we no longer have RTL pages for examples, the `direction` and RTL CSS bundle loading can be removed.

> [!NOTE]
> The [RTL dedicated docs page](https://deploy-preview-42255--twbs-bootstrap.netlify.app/docs/6.0/customize/rtl/#live-demo) handles its own context (JavaScript DOM modifications), so it's not impacted.

#### Live previews

- <https://deploy-preview-42255--twbs-bootstrap.netlify.app/>
