### PR TITLE
Docs: clarify toast accessibility guidance

### DIFF
--- a/site/src/content/docs/components/toasts.mdx
+++ b/site/src/content/docs/components/toasts.mdx
@@ -262,6 +262,10 @@ You can also get fancy with flexbox utilities to align toasts horizontally and/o
 
 Toasts are intended to be small interruptions to your visitors or users, so to help those with screen readers and similar assistive technologies, you should wrap your toasts in an [`aria-live` region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Changes to live regions (such as injecting/updating a toast component) are automatically announced by screen readers without needing to move the user’s focus or otherwise interrupt the user. Additionally, include `aria-atomic="true"` to ensure that the entire toast is always announced as a single (atomic) unit, rather than just announcing what was changed (which could lead to problems if you only update part of the toast’s content, or if displaying the same toast content at a later point in time). If the information needed is important for the process, e.g. for a list of errors in a form, then use the [alert component]([[docsref:/components/alerts]]) instead of toast.
 
+<Callout type="warning">
+Toasts work best for optional, non-critical updates that users can ignore. If a message requires immediate attention, blocks progress, or asks the user to take action, use a more persistent pattern such as an [alert]([[docsref:/components/alerts]]) instead.
+</Callout>
+
 Note that the live region needs to be present in the markup *before* the toast is generated or updated. If you dynamically generate both at the same time and inject them into the page, they will generally not be announced by assistive technologies.
 
 You also need to adapt the `role` and `aria-live` level depending on the content. If it’s an important message like an error, use `role="alert" aria-live="assertive"`, otherwise use `role="status" aria-live="polite"` attributes.


### PR DESCRIPTION
### Description

- add a warning callout to the toast accessibility section
- clarify that toasts are best for optional, non-critical updates
- recommend alerts for messages that require immediate attention or user action

### Motivation & Context

Issue #41873 asks for clearer guidance about the usability and accessibility tradeoffs of toast notifications. The page already explains the ARIA setup for toasts, but it does not explicitly warn readers when a toast is the wrong pattern to use.

This change adds that guidance directly in the existing accessibility section and points readers to alerts when a message should be more persistent.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (using npm run lint)
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- https://deploy-preview-42276--twbs-bootstrap.netlify.app/docs/5.3/components/toasts/#accessibility

### Validation

- ran `npm run docs-prettier-check`
- reviewed the MDX diff to confirm the guidance is placed in the Accessibility section and uses the existing docs callout pattern
- confirmed the Netlify deploy preview was created successfully
- not run the full docs build locally in this environment

### Related issues

Closes #41873