### PR TITLE
Docs: fix nested kbd markup in Reboot example

### DIFF
--- a/site/src/content/docs/content/reboot.mdx
+++ b/site/src/content/docs/content/reboot.mdx
@@ -184,7 +184,7 @@ For indicating variables use the `<var>` tag.
 Use the `<kbd>` to indicate input that is typically entered via keyboard.
 
 <Example code={`To switch directories, type <kbd>cd</kbd> followed by the name of the directory.<br>
-To edit settings, press <kbd><kbd>Ctrl</kbd> + <kbd>,</kbd></kbd>`} />
+To edit settings, press <kbd>Ctrl</kbd> + <kbd>,</kbd>`} />
 
 ## Sample output
 


### PR DESCRIPTION
### Description

- replace the nested `<kbd>` markup in the Reboot keyboard input example
- render Ctrl and , as separate keyboard entries joined by plain text

### Motivation & Context

Issue #38000 points out that the current example marks Ctrl + , as one combined keyboard key because the markup nests multiple `<kbd>` elements inside another `<kbd>`.

This change keeps the example visually the same while making the markup semantically correct and easier to understand.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (using npm run lint)
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- https://deploy-preview-42277--twbs-bootstrap.netlify.app/docs/5.3/content/reboot/#user-input

### Validation

- ran `npm run docs-prettier-check`
- reviewed the rendered example source in `site/src/content/docs/content/reboot.mdx` to confirm the shortcut now uses separate `<kbd>` elements
- confirmed the Netlify deploy preview was created successfully
- not run the full docs build locally in this environment

### Related issues

Closes #38000