### PR TITLE
Docs: mention sliders in range docs

### DIFF
--- a/site/src/content/docs/forms/range.mdx
+++ b/site/src/content/docs/forms/range.mdx
@@ -1,12 +1,12 @@
 ---
 title: Range
-description: Use our custom range inputs for consistent cross-browser styling and built-in customization.
+description: Use our custom range inputs (sliders) for consistent cross-browser styling and built-in customization.
 toc: true
 ---
 
 ## Overview
 
-Create custom `<input type="range">` controls with `.form-range`. The track (the background) and thumb (the value) are both styled to appear the same across browsers. As only Firefox supports “filling” their track from the left or right of the thumb as a means to visually indicate progress, we do not currently support it.
+Create custom `<input type="range">` controls with `.form-range`. These controls are sometimes also referred to as sliders. The track (the background) and thumb (the value) are both styled to appear the same across browsers. As only Firefox supports “filling” their track from the left or right of the thumb as a means to visually indicate progress, we do not currently support it.
 
 <Example code={`<label for="range1" class="form-label">Example range</label>
 <input type="range" class="form-range" id="range1">`} />


### PR DESCRIPTION
### Description

- mention that range inputs are also commonly called sliders
- add the term slider to the page description and overview text for better discoverability

### Motivation & Context

Issue #38712 notes that people often search for this control using the term slider and may not realize it is documented under Range in Bootstrap.

This change keeps the page title and structure intact while adding the common term in two natural places so the docs are easier to find and understand.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (using npm run lint)
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- N/A (docs-only change; I did not generate a hosted preview link in this checkout)

### Validation

- 
px prettier --config site/.prettierrc.json --check site/src/content/docs/forms/range.mdx
- git diff --check
- 
px cspell --no-progress site/src/content/docs/forms/range.mdx
- attempted a local docs build, but the project build wrapper did not produce actionable output in this Windows checkout

### Related issues

Closes #38712