### PR TITLE
fix(scss): apply card inner border-radius to table corner cells

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -64,6 +64,32 @@
   > .list-group + .card-footer {
     border-top: 0;
   }
+
+  // Tables directly inside a card need their corner cells to carry the card's
+  // inner border-radius so the solid `--bs-table-bg` doesn't paint over the
+  // card's rounded corners (regression introduced in v5.3).
+  // stylelint-disable-next-line selector-max-universal
+  > .table {
+    &:first-child {
+      // Top-left and top-right cells of the first row
+      > :first-child > tr:first-child > :first-child {
+        @include border-top-start-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+      > :first-child > tr:first-child > :last-child {
+        @include border-top-end-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+    }
+
+    &:last-child {
+      // Bottom-left and bottom-right cells of the last row
+      > :last-child > tr:last-child > :first-child {
+        @include border-bottom-start-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+      > :last-child > tr:last-child > :last-child {
+        @include border-bottom-end-radius(var(--#{$prefix}card-inner-border-radius));
+      }
+    }
+  }
 }
 
 .card-body {


### PR DESCRIPTION
## Summary

Since v5.3 introduced a solid `--bs-table-bg` on table cells, the opaque background paints over the card's rounded corners when a `.table` is a direct child of `.card`, making them appear square.

Fixes #41723

## Changes

- Apply the card's inner border-radius to the four corner cells of `.table` elements that are direct children of `.card`
- Follows the same pattern already used for `.card-img-top`, `.card-img-bottom`, and `.card > .list-group`

## Implementation Notes

The fix targets `> .table:first-child > :first-child > tr:first-child > :first-child` (and corresponding last-child selectors) to apply border-radius only to the actual corner cells. This avoids `overflow: hidden` which can cause issues with dropdowns and tooltips inside cards.

---
*Built autonomously by [islo.dev](https://islo.dev)*