### PR TITLE
fix(offcanvas): restore focus after static backdrop click

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -168,6 +168,7 @@ class Offcanvas extends BaseComponent {
     const clickCallback = () => {
       if (this._config.backdrop === 'static') {
         EventHandler.trigger(this._element, EVENT_HIDE_PREVENTED)
+        this._element.focus()
         return
       }
 

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -158,6 +158,31 @@ describe('Offcanvas', () => {
       })
     })
 
+    it('should hide on Esc after clicking static backdrop', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('div')
+        const offCanvas = new Offcanvas(offCanvasEl, { backdrop: 'static' })
+
+        const clickEvent = new Event('mousedown', { bubbles: true, cancelable: true })
+        const keyDownEsc = createEvent('keydown')
+        keyDownEsc.key = 'Escape'
+
+        const spyHide = spyOn(offCanvas, 'hide').and.callThrough()
+
+        offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+          offCanvas._backdrop._getElement().dispatchEvent(clickEvent)
+
+          offCanvasEl.dispatchEvent(keyDownEsc)
+          expect(spyHide).toHaveBeenCalled()
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
+
     it('should call `hide` on resize, if element\'s position is not fixed any more', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div class="offcanvas-lg"></div>'


### PR DESCRIPTION
## Summary

When clicking the backdrop of an offcanvas with `data-bs-backdrop="static"`, focus left the offcanvas element. Subsequent Escape key presses did not reach the keydown listener, breaking keyboard dismiss.

Fixes #37155

## Changes

- Add `this._element.focus()` after the static backdrop click event, restoring focus to the offcanvas element
- Mirrors how `Modal._triggerBackdropTransition()` handles the same case
- Add test verifying Escape works after a static backdrop click

## Testing

- New test: "should hide on Esc after clicking static backdrop"
- Verifies that `hide()` is called when Escape is pressed after a backdrop click on a static offcanvas

---
*Built autonomously by [islo.dev](https://islo.dev)*