### PR TITLE
Add expectation to dropdown invalid markup test

### DIFF
--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -72,6 +72,7 @@ describe('Dropdown', () => {
 
         const dropdownElem = fixtureEl.querySelector('.dropdown-menu')
         const dropdown = new Dropdown(dropdownElem)
+        expect(dropdown).toBeDefined()
 
         dropdownElem.addEventListener('shown.bs.dropdown', () => {
           resolve()


### PR DESCRIPTION
### Description

Adds an explicit expectation to the Dropdown constructor should work on invalid markup spec to avoid the “has no expectations” warning.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

This change fixes the warning reported in BrowserStack/LambdaTest for the Dropdown constructor should work on invalid markup test, which previously had no explicit expectations.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [ x ] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ x ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ x ] I have added tests to cover my changes
- [ x ] All new and existing tests passed

### Related issues

Closes #38371
