### PR TITLE
Docs: clarify that `.browserslistrc` is a shipped file, not a `package.json` metadata field

### DIFF
--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -43,7 +43,8 @@ Bootstrap’s `package.json` contains some additional metadata under the followi
 
 - `sass` - path to Bootstrap’s main [Sass](https://sass-lang.com/) source file
 - `style` - path to Bootstrap’s non-minified CSS that’s been compiled using the default settings (no customization)
-- `.browserslistrc` - shipped at the package root for Browserslist/Autoprefixer browser targets
+
+Additionally, Bootstrap ships a `.browserslistrc` file at the package root, which defines browser targets for tools like Browserslist and Autoprefixer.
 
 ### Using Yarn
 


### PR DESCRIPTION
### Description

Technically, there's not really an additional metadata in the `package.json` named `.browserslistrc`, contrary to `sass` and `style`:

```json
{
  "sass": "scss/bootstrap.scss",
  "style": "dist/css/bootstrap.css",
}
```

This PR simply changes the paragraph to explain it slightly differently.

Note: other explanations in Bootstrap docs related to `.browserslistrc` look OK.