### PR TITLE
Docs: fix 'originals' → 'originates' typo in Prose page

### DIFF
--- a/site/src/content/docs/content/prose.mdx
+++ b/site/src/content/docs/content/prose.mdx
@@ -7,7 +7,7 @@ css_layer: content
 
 ## How it works
 
-Wrap your content in the `.prose` class to get modified font-size, line-height, and spacing specifically designed for long form content that originals from source Markdown files or WYSIWYG editors. Here's what we do with that class:
+Wrap your content in the `.prose` class to get modified font-size, line-height, and spacing specifically designed for long form content that originates from source Markdown files or WYSIWYG editors. Here's what we do with that class:
 
 - Set a base `font-size`, `line-height`, and some local CSS variables on the parent element.
 - Normalize the spacing of lists


### PR DESCRIPTION
### Description

_Originally spotted in https://github.com/orgs/twbs/discussions/42337 by @sgilberg_

FYI, @sgilberg, I've added you as a co-author for this commit/fix. 