### PR TITLE
Docs: add missing `open` attribute to first Accordion example

### DIFF
--- a/site/src/content/docs/components/accordion.mdx
+++ b/site/src/content/docs/components/accordion.mdx
@@ -17,7 +17,7 @@ Click the accordions below to expand/collapse the accordion content. Each `<deta
 To render an accordion that's expanded by default, add the `open` attribute to the `<details>` element.
 
 <Example code={`<div class="accordion">
-    <details class="accordion-item" name="accordionExample">
+    <details class="accordion-item" name="accordionExample" open>
       <summary class="accordion-header">
         Accordion Item #1
         <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>


### PR DESCRIPTION
### Description

Spotted in https://github.com/orgs/twbs/discussions/42337, this PR fixes the first example of the [v6 Accordion page](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/) where the `open` attribute was missing.
