### PR TITLE
Fix popovers dismiss in Chrome browsers

### DIFF
--- a/js/src/popover.js
+++ b/js/src/popover.js
@@ -86,24 +86,19 @@ const initPopover = event => {
     return
   }
 
-  // Prevent default for click events to avoid navigation
+  // Prevent default for click events to avoid navigation (e.g. <a href="#">)
   if (event.type === 'click') {
     event.preventDefault()
   }
 
-  // Get or create instance
-  const popover = Popover.getOrCreateInstance(target)
-
-  // Trigger the appropriate action based on event type
-  if (event.type === 'click') {
-    popover.toggle()
-  } else if (event.type === 'focusin') {
-    popover._activeTrigger.focus = true
-    popover._enter()
-  }
+  // Lazily create the instance. The instance's own `_setListeners()` registers
+  // the appropriate listeners on the element for the configured triggers
+  // (click/focus/hover), so we don't toggle or call `_enter` here — doing so
+  // would duplicate handlers and leave stale state on `_activeTrigger`.
+  Popover.getOrCreateInstance(target)
 }
 
-// Support click (default), hover, and focus triggers
+// Auto-initialize popovers on first interaction for click, hover, and focus triggers
 EventHandler.on(document, EVENT_CLICK, SELECTOR_DATA_TOGGLE, initPopover)
 EventHandler.on(document, EVENT_FOCUSIN, SELECTOR_DATA_TOGGLE, initPopover)
 EventHandler.on(document, EVENT_MOUSEENTER, SELECTOR_DATA_TOGGLE, initPopover)

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -733,16 +733,17 @@ const initTooltip = event => {
     return
   }
 
-  // Get or create instance and trigger the appropriate action
-  const tooltip = Tooltip.getOrCreateInstance(target)
-
-  // For focus events, manually trigger enter to show
-  if (event.type === 'focusin') {
-    tooltip._activeTrigger.focus = true
-    tooltip._enter()
-  }
+  // Lazily create the instance. The instance's own `_setListeners()` registers
+  // the appropriate listeners on the element for the configured triggers
+  // (hover/focus by default), so we don't mutate `_activeTrigger` or call
+  // `_enter` here — doing so would show tooltips for triggers the user didn't
+  // opt into (e.g. `focusin` firing for click-focused buttons in Chromium,
+  // even when `trigger="hover"` or `trigger="manual"`) and leave stale state
+  // on `_activeTrigger`.
+  Tooltip.getOrCreateInstance(target)
 }
 
+// Auto-initialize tooltips on first interaction for hover and focus triggers
 EventHandler.on(document, EVENT_FOCUSIN, SELECTOR_DATA_TOGGLE, initTooltip)
 EventHandler.on(document, EVENT_MOUSEENTER, SELECTOR_DATA_TOGGLE, initTooltip)
 


### PR DESCRIPTION
Popovers initialized via `data-bs-toggle="popover"` wouldn't dismiss when you clicked their trigger a second time in Chromium browsers. Safari was fine.

The data API shouldn't be duplicating trigger handling — `_setListeners()` already handles `click`, `focus`, and `hover` based on the trigger config. `initPopover` now just calls `Popover.getOrCreateInstance(target)` (plus `preventDefault()` on click to preserve the `<a href="#">` behavior).

On a fresh popover the first click still works: the capture-phase document handler creates the instance, which registers the click listener on the element, and the newly-added listener fires in the same dispatch's target phase. No more double-toggle, no more stuck `_activeTrigger.focus`.

Fixes #42339.