### PR TITLE
docs(floating-labels): capitalize JavaScript

### DIFF
--- a/site/src/content/docs/forms/floating-labels.mdx
+++ b/site/src/content/docs/forms/floating-labels.mdx
@@ -116,7 +116,7 @@ Floating labels also support `.input-group`.
     </div>
   </div>`} />
 
-When using `.input-group` and `.form-floating` along with form validation, the `-feedback` should be placed outside of the `.form-floating`, but inside of the `.input-group`. This means that the feedback will need to be shown using javascript.
+When using `.input-group` and `.form-floating` along with form validation, the `-feedback` should be placed outside of the `.form-floating`, but inside of the `.input-group`. This means that the feedback will need to be shown using JavaScript.
 
 <Example code={`<div class="input-group has-validation">
     <span class="input-group-text">@</span>


### PR DESCRIPTION
## Summary
- Capitalize "javascript" → "JavaScript" in the floating labels validation note, matching the spelling used throughout the rest of the docs.

## Test plan
- [x] `git diff` shows a single-character change on one line in `site/src/content/docs/forms/floating-labels.mdx`.