### PR TITLE
fix(tooltip): coerce boolean title/content to string

### DIFF
--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -565,11 +565,11 @@ class Tooltip extends BaseComponent {
       }
     }
 
-    if (typeof config.title === 'number') {
+    if (typeof config.title === 'number' || typeof config.title === 'boolean') {
       config.title = config.title.toString()
     }
 
-    if (typeof config.content === 'number') {
+    if (typeof config.content === 'number' || typeof config.content === 'boolean') {
       config.content = config.content.toString()
     }
 

--- a/js/tests/unit/popover.spec.js
+++ b/js/tests/unit/popover.spec.js
@@ -57,6 +57,17 @@ describe('Popover', () => {
     })
   })
 
+  describe('config', () => {
+    it('should accept "true"/"false" string content from data-bs-content as literal strings', () => {
+      fixtureEl.innerHTML = '<a href="#" title="Popover" data-bs-content="true">BS</a>'
+
+      const popoverEl = fixtureEl.querySelector('a')
+      const popover = new Popover(popoverEl)
+
+      expect(popover._config.content).toEqual('true')
+    })
+  })
+
   describe('show', () => {
     it('should toggle a popover after show', () => {
       return new Promise(resolve => {

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -90,6 +90,19 @@ describe('Tooltip', () => {
       expect(tooltip._config.content).toEqual('7')
     })
 
+    it('should convert title and content to string if booleans', () => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip"></a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const tooltip = new Tooltip(tooltipEl, {
+        title: true,
+        content: false
+      })
+
+      expect(tooltip._config.title).toEqual('true')
+      expect(tooltip._config.content).toEqual('false')
+    })
+
     it('should enable selector delegation', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<div></div>'


### PR DESCRIPTION
## Summary

Fixes #41925.

`data-bs-content=\"true\"` (or `\"false\"`) on a popover/tooltip throws:

> TypeError: POPOVER: Option \"content\" provided type \"boolean\" but expected type \"(null|string|element|function)\".

This is because `Manipulator.normalizeData` converts the strings `\"true\"`/`\"false\"` to actual booleans before the config type check runs. `_configAfterMerge` already coerces numeric `title`/`content` back to strings — this PR extends that same pattern to booleans, so the literal strings `\"true\"`/`\"false\"` render as expected.

## Test plan

- [x] Added unit test in \`tooltip.spec.js\` mirroring the existing \"convert title and content to string if numbers\" test, but for booleans.
- [x] Added unit test in \`popover.spec.js\` covering the original repro: \`data-bs-content=\"true\"\` produces \`_config.content === 'true'\`.
- [ ] CI runs the full karma suite.