### PR TITLE
fix(dropdown): prevent re-show on arrow key nav with auto-close outside

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -420,7 +420,9 @@ class Dropdown extends BaseComponent {
 
     if (isUpOrDownEvent) {
       event.stopPropagation()
-      instance.show()
+      if(!instance._isShown()) {
+        instance.show()
+      }
       instance._selectMenuItem(event)
       return
     }


### PR DESCRIPTION
## What does this fix?
When using data-bs-auto-close="outside" with nested submenus, 
pressing the arrow keys caused multiple submenus to remain open 
at the same time instead of auto-closing the previous one.

## Root Cause
In dataApiKeydownHandler, instance.show() was called 
unconditionally on every arrow key press, re-showing already 
dismissed dropdowns.

## Fix
Wrapped instance.show() with a !instance._isShown() check 
so it only opens the dropdown if it is not already visible.

## Steps to reproduce
1. Click Demo top level menu
2. Click Submenu 3
3. Press Arrow Up multiple times
4. Previously: all submenus stayed open ❌
5. Now: only current submenu shows ✅

Fixes #42366