### PR TITLE
v6: docs - Fix wording in radio and switch docs

### DIFF
--- a/site/src/content/docs/forms/radio.mdx
+++ b/site/src/content/docs/forms/radio.mdx
@@ -10,7 +10,7 @@ import { getData } from '@libs/data'
 
 ## Basic radio
 
-Similar to checkboxes, radios are styled with the `.radio` class. However, there's no custom SVG as we pure CSS to style the input and its checked state.
+Similar to checkboxes, radios are styled with the `.radio` class. However, there's no custom SVG as we use pure CSS to style the input and its checked state.
 
 <Example code={`<input type="radio" id="radio" class="radio" />`} />
 
@@ -37,7 +37,7 @@ Add a description or other content after the label. We recommend wrapping the la
 
 ## Theme colors
 
-Modify the appearance of checked checkboxes by adding the `.theme-{color}` class to the `.radio` element. This will set the checked background and border color to the theme color.
+Modify the appearance of checked radios by adding the `.theme-{color}` class to the `.radio` element. This will set the checked background and border color to the theme color.
 
 <Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((themeColor) => `<div class="form-field">
     <input type="radio" id="radio${themeColor.name}" class="radio theme-${themeColor.name}" checked />

--- a/site/src/content/docs/forms/switch.mdx
+++ b/site/src/content/docs/forms/switch.mdx
@@ -28,7 +28,7 @@ Wrap the `.switch` in a `.form-field` layout wrapper and add your label. The gri
 
 ## Theme colors
 
-Modify the appearance of checked checkboxes by adding the `.checked-{color}` class to the `.switch` element. This will set the checked background and border color to the theme color.
+Modify the appearance of switches by adding the `.checked-{color}` class to the `.switch` element. This will set the checked background and border color to the theme color.
 
 <Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((themeColor) => ` <div class="form-field">
     <div class="switch theme-${themeColor.name}">

--- a/site/src/content/docs/forms/switch.mdx
+++ b/site/src/content/docs/forms/switch.mdx
@@ -28,7 +28,7 @@ Wrap the `.switch` in a `.form-field` layout wrapper and add your label. The gri
 
 ## Theme colors
 
-Modify the appearance of switches by adding the `.checked-{color}` class to the `.switch` element. This will set the checked background and border color to the theme color.
+Modify the appearance of switches by adding the `.theme-{color}` class to the `.switch` element. This will set the checked background and border color to the theme color.
 
 <Example class="d-flex flex-column gap-2" code={getData('theme-colors').map((themeColor) => ` <div class="form-field">
     <div class="switch theme-${themeColor.name}">


### PR DESCRIPTION
Correct minor copy and terminology errors in form component documentation. radio.mdx: fix grammar ('as we use pure CSS' instead of 'as we pure CSS') and clarify 'checked radios' instead of 'checked checkboxes'. switch.mdx: clarify wording to describe switches rather than checkboxes for the `.checked-{color}` class.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42372--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
