### PR TITLE
Remove deprecated `baseUrl` from `site/tsconfig.json`

### DIFF
--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@bootstrap": ["../dist/js/bootstrap.bundle.js"],
-      "@components/*": ["src/components/*"],
-      "@layouts/*": ["src/layouts/*"],
-      "@libs/*": ["src/libs/*"],
-      "@shortcodes/*": ["src/components/shortcodes/*"]
+      "@components/*": ["./src/components/*"],
+      "@layouts/*": ["./src/layouts/*"],
+      "@libs/*": ["./src/libs/*"],
+      "@shortcodes/*": ["./src/components/shortcodes/*"]
     }
   }
 }


### PR DESCRIPTION
### Description

This PR removes `baseUrl` usage from `site/tsconfig.json` per the following recommendation:

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
>  Visit https://aka.ms/ts6 for migration information.ts

More info at https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259