### PR TITLE
Docs: fix theme selector not triggered in Cheatsheet/Sidebars examples

### DIFF
--- a/site/src/assets/examples/cheatsheet/cheatsheet.js
+++ b/site/src/assets/examples/cheatsheet/cheatsheet.js
@@ -1,4 +1,4 @@
-import { Tooltip, Popover, Toast } from '../../dist/js/bootstrap.bundle.js'
+import { Tooltip, Popover, Toast } from '@bootstrap'
 
 document.querySelectorAll('.tooltip-demo')
   .forEach(tooltip => {

--- a/site/src/assets/examples/sidebars/sidebars.js
+++ b/site/src/assets/examples/sidebars/sidebars.js
@@ -1,4 +1,4 @@
-import { Tooltip } from '../../dist/js/bootstrap.bundle.js'
+import { Tooltip } from '@bootstrap'
 
 const tooltipTriggerList = [...document.querySelectorAll('[data-bs-toggle="tooltip"]')]
 tooltipTriggerList.forEach(tooltipTriggerEl => {

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -15,6 +15,7 @@ const { body_class, extra_css, extra_js, html_class, include_js, title = 'Exampl
 
 const pageTitle = `${title} · ${getConfig().title} v${getConfig().docs_version}`
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
+const bootstrapJsProps = getVersionedBsJsProps()
 ---
 
 <!doctype html>
@@ -121,7 +122,14 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
     {
       include_js !== false && (
         <Fragment>
-          <script is:inline {...getVersionedBsJsProps()} />
+          <script type="importmap" is:inline>
+            {JSON.stringify({
+              imports: {
+                '@bootstrap': bootstrapJsProps.src
+              }
+            })}
+          </script>
+          <script is:inline {...bootstrapJsProps} />
           {extra_js?.map((js) => (
             <script
               is:inline

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -16,6 +16,11 @@ const { body_class, extra_css, extra_js, html_class, include_js, title = 'Exampl
 const pageTitle = `${title} · ${getConfig().title} v${getConfig().docs_version}`
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
 const bootstrapJsProps = getVersionedBsJsProps()
+const importMap = JSON.stringify({
+  imports: {
+    '@bootstrap': bootstrapJsProps.src
+  }
+})
 ---
 
 <!doctype html>
@@ -122,13 +127,7 @@ const bootstrapJsProps = getVersionedBsJsProps()
     {
       include_js !== false && (
         <Fragment>
-          <script type="importmap" is:inline>
-            {JSON.stringify({
-              imports: {
-                '@bootstrap': bootstrapJsProps.src
-              }
-            })}
-          </script>
+          <script type="importmap" is:inline set:html={importMap} />
           <script is:inline {...bootstrapJsProps} />
           {extra_js?.map((js) => (
             <script


### PR DESCRIPTION
### Description

This PR fixes the theme selector that is not working only in the Cheatsheet and Sidebars doc examples:
- https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/examples/cheatsheet/
- https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/examples/sidebars/

Funny things though, it worked when you were loading https://deploy-preview-42382--twbs-bootstrap.netlify.app/docs/6.0/examples/, then used your mouse or keyboard to access the page. If you were loading the page directly, it didn't work.