### PR TITLE
Docs: fix aliases/redirections of main sections

### DIFF
--- a/site/src/content/docs/components/accordion.mdx
+++ b/site/src/content/docs/components/accordion.mdx
@@ -1,9 +1,6 @@
 ---
 title: Accordion
 description: Build vertically collapsing accordions with native HTML `<details>` and `<summary>` elements.
-aliases:
- - "/components/"
- - "/docs/[[config:docs_version]]/components/"
 toc: true
 css_layer: components
 ---

--- a/site/src/content/docs/components/buttons.mdx
+++ b/site/src/content/docs/components/buttons.mdx
@@ -1,6 +1,10 @@
 ---
 title: Buttons
 description: Use Bootstrap’s custom button styles for actions in forms, dialogs, and more with support for multiple sizes, states, and more.
+aliases:
+ - "/docs/[[config:docs_version]]/components/"
+ - "/docs/components/"
+ - "/components/"
 toc: true
 css_layer: components
 ---

--- a/site/src/content/docs/content/reboot.mdx
+++ b/site/src/content/docs/content/reboot.mdx
@@ -1,7 +1,10 @@
 ---
 title: Reboot
 description: Reboot, a collection of element-specific CSS changes in a single file, kickstart Bootstrap to provide an elegant, consistent, and simple baseline to build upon.
-aliases: "/docs/[[config:docs_version]]/content/"
+aliases:
+ - "/docs/[[config:docs_version]]/content/"
+ - "/docs/content/"
+ - "/content/"
 toc: true
 css_layer: reboot
 ---

--- a/site/src/content/docs/customize/overview.mdx
+++ b/site/src/content/docs/customize/overview.mdx
@@ -2,7 +2,10 @@
 title: Customize
 description: Learn how Bootstrap's colors power our design system theme. Customize and extend Bootstrap with Sass, a boatload of global options, and plenty of global and component-specific CSS variables.
 toc: false
-aliases: "/docs/[[config:docs_version]]/customize/"
+aliases:
+ - "/docs/[[config:docs_version]]/customize/"
+ - "/docs/customize/"
+ - "/customize/"
 sections:
   - title: Sass
     description: Utilize our source Sass files to take advantage of variables, maps, mixins, and functions.

--- a/site/src/content/docs/forms/overview.mdx
+++ b/site/src/content/docs/forms/overview.mdx
@@ -2,7 +2,10 @@
 title: Forms
 description: Examples and usage guidelines for form control styles, layout options, and custom components for creating a wide variety of forms.
 toc: true
-aliases: "/docs/[[config:docs_version]]/forms/"
+aliases:
+ - "/docs/[[config:docs_version]]/forms/"
+ - "/docs/forms/"
+ - "/forms/"
 sections:
   - title: Form control
     description: Style textual inputs and textareas with support for multiple states.

--- a/site/src/content/docs/guides/quickstart.mdx
+++ b/site/src/content/docs/guides/quickstart.mdx
@@ -1,6 +1,10 @@
 ---
 title: CDN Quickstart
 description: The official guide for how to include Bootstrap’s CSS and JavaScript in your project using a CDN.
+aliases:
+ - "/docs/[[config:docs_version]]/guides/"
+ - "/docs/guides/"
+ - "/guides/"
 ---
 
 Get started using Bootstrap in seconds by including our production-ready CSS and JavaScript by [using a CDN]([[docsref:/getting-started/install#cdn]]) without the need for any build steps. CDNs provide copies of Bootstrap’s codebase that’s ready to be used in any environment with minimal code changes required on your part.

--- a/site/src/content/docs/helpers/focus-ring.mdx
+++ b/site/src/content/docs/helpers/focus-ring.mdx
@@ -1,6 +1,10 @@
 ---
 title: Focus ring
 description: Utility classes that allows you to add and modify custom focus ring styles to elements and components.
+aliases:
+ - "/docs/[[config:docs_version]]/helpers/"
+ - "/docs/helpers/"
+ - "/helpers/"
 toc: true
 ---
 

--- a/site/src/content/docs/layout/breakpoints.mdx
+++ b/site/src/content/docs/layout/breakpoints.mdx
@@ -1,7 +1,10 @@
 ---
 title: Breakpoints
 description: Breakpoints are customizable widths that determine how your responsive layout behaves across device or viewport sizes in Bootstrap.
-aliases: "/docs/[[config:docs_version]]/layout/"
+aliases:
+ - "/docs/[[config:docs_version]]/layout/"
+ - "/docs/layout/"
+ - "/layout/"
 toc: true
 ---
 

--- a/site/src/content/docs/utilities/api.mdx
+++ b/site/src/content/docs/utilities/api.mdx
@@ -1,7 +1,10 @@
 ---
 title: Utility API
 description: The utility API is a Sass-based tool to generate utility classes.
-aliases: "/docs/[[config:docs_version]]/utilities/"
+aliases:
+ - "/docs/[[config:docs_version]]/utilities/"
+ - "/docs/utilities/"
+ - "/utilities/"
 toc: true
 ---
 


### PR DESCRIPTION
### Description

This PR adds the missing redirections for main sections of our docs in v6.

Example of use cases that should be working:
- https://v6-dev--twbs-bootstrap.netlify.app/utilities
- https://v6-dev--twbs-bootstrap.netlify.app/docs/utilities/
- https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/utilities/

For the "components", it's a bit different as the order has changed, and the Button component is now the first in the sidebar's list