### PR TITLE
Docs: enable `prettier-plugin-astro` plugin

### DIFF
--- a/site/.prettierrc.json
+++ b/site/.prettierrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
   "arrowParens": "always",
+  "plugins": ["prettier-plugin-astro"],
   "printWidth": 120,
   "semi": false,
   "singleQuote": true,

--- a/site/src/components/DocsScripts.astro
+++ b/site/src/components/DocsScripts.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <script src="../assets/stackblitz.js"></script>

--- a/site/src/components/head/Scss.astro
+++ b/site/src/components/head/Scss.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <style is:global lang="scss">

--- a/site/src/components/head/ScssProd.astro
+++ b/site/src/components/head/ScssProd.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <style is:global lang="scss">

--- a/site/src/components/icons/Symbols.astro
+++ b/site/src/components/icons/Symbols.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <svg xmlns="http://www.w3.org/2000/svg" class="d-none">

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -19,7 +19,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
 const htmlProps: HTMLAttributes<'html'> = direction === 'rtl' ? { lang: 'ar', dir: 'rtl' } : { lang: 'en' }
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html {...htmlProps} class:list={html_class} data-bs-theme="auto">
   <head>
     <meta charset="utf-8" />
@@ -57,7 +57,9 @@ const htmlProps: HTMLAttributes<'html'> = direction === 'rtl' ? { lang: 'ar', di
         background-color: rgba(0, 0, 0, 0.1);
         border: solid rgba(0, 0, 0, 0.15);
         border-width: 1px 0;
-        box-shadow: inset 0 0.5em 1.5em rgba(0, 0, 0, 0.1), inset 0 0.125em 0.5em rgba(0, 0, 0, 0.15);
+        box-shadow:
+          inset 0 0.5em 1.5em rgba(0, 0, 0, 0.1),
+          inset 0 0.125em 0.5em rgba(0, 0, 0, 0.15);
       }
 
       .b-example-vr {


### PR DESCRIPTION
### Description

This PR enables `prettier-plugin-astro` that is in our dependencies, but wasn't used in the `.prettierrc.json`. This has been spotted thanks to https://github.com/twbs/bootstrap/pull/42389 by @pierluigilenoci, added as a co-author of this PR.

With this plugin enabled, running `npm run docs-prettier-check` raised some errors that have been fixed automatically by running `npm run docs-prettier-format`

No need to backport to v6, as it's already in place.

