### PR TITLE
v6: Update some flex utility examples with class names

### DIFF
--- a/site/src/content/docs/utilities/align-items.mdx
+++ b/site/src/content/docs/utilities/align-items.mdx
@@ -17,29 +17,29 @@ Use `align-items` utilities on flexbox containers to change the alignment of fle
 
 <div class="bd-example bd-example-flex">
   <div class="d-flex align-items-start mb-3" style="height: 100px">
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
+    <div class="p-2 w-5">Align</div>
+    <div class="p-2 w-5">Items</div>
+    <div class="p-2 w-5">Start</div>
   </div>
   <div class="d-flex align-items-end mb-3" style="height: 100px">
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
+    <div class="p-2 w-5">Align</div>
+    <div class="p-2 w-5">Items</div>
+    <div class="p-2 w-5">End</div>
   </div>
   <div class="d-flex align-items-center mb-3" style="height: 100px">
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
+    <div class="p-2 w-5">Align</div>
+    <div class="p-2 w-5">Items</div>
+    <div class="p-2 w-5">Center</div>
   </div>
   <div class="d-flex align-items-baseline mb-3" style="height: 100px">
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
+    <div class="p-2 w-5">Align</div>
+    <div class="p-2 w-5">Items</div>
+    <div class="p-2 w-5">Baseline</div>
   </div>
   <div class="d-flex align-items-stretch" style="height: 100px">
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
-    <div class="p-2">Flex item</div>
+    <div class="p-2 w-5">Align</div>
+    <div class="p-2 w-5">Items</div>
+    <div class="p-2 w-5">Stretch</div>
   </div>
 </div>
 

--- a/site/src/content/docs/utilities/justify-items.mdx
+++ b/site/src/content/docs/utilities/justify-items.mdx
@@ -19,24 +19,24 @@ Use `justify-items` utilities to control the horizontal alignment of grid items.
 
 <div class="bd-example bd-example-flex vstack gap-3">
   <div class="d-grid gap-3 justify-items-start" style="grid-template-columns: 1fr 1fr 1fr;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Justify</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Start</div>
   </div>
   <div class="d-grid gap-3 justify-items-end" style="grid-template-columns: 1fr 1fr 1fr;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Justify</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">End</div>
   </div>
   <div class="d-grid gap-3 justify-items-center" style="grid-template-columns: 1fr 1fr 1fr;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Justify</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Center</div>
   </div>
   <div class="d-grid gap-3 justify-items-stretch" style="grid-template-columns: 1fr 1fr 1fr;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Justify</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Stretch</div>
   </div>
 </div>
 

--- a/site/src/content/docs/utilities/place-items.mdx
+++ b/site/src/content/docs/utilities/place-items.mdx
@@ -19,24 +19,24 @@ Use `place-items` utilities to control the alignment of grid items. Choose from 
 
 <div class="bd-example bd-example-flex vstack gap-3">
   <div class="d-grid gap-3 place-items-start" style="grid-template-columns: 1fr 1fr 1fr; height: 150px;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Place</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Start</div>
   </div>
   <div class="d-grid gap-3 place-items-end" style="grid-template-columns: 1fr 1fr 1fr; height: 150px;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Place</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">End</div>
   </div>
   <div class="d-grid gap-3 place-items-center" style="grid-template-columns: 1fr 1fr 1fr; height: 150px;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Place</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Center</div>
   </div>
   <div class="d-grid gap-3 place-items-stretch" style="grid-template-columns: 1fr 1fr 1fr; height: 150px;">
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
-    <div class="p-2">Grid item</div>
+    <div class="p-2">Place</div>
+    <div class="p-2">Items</div>
+    <div class="p-2">Stretch</div>
   </div>
 </div>
 


### PR DESCRIPTION
### Description

Replace generic "Flex item"/"Grid item" placeholders with descriptive words (e.g. "Align", "Items", "Start/End/Center/Stretch") across align-items, justify-items, and place-items docs.

I added the `w-5` utility to flex examples to give consistent item widths (as they were previously) so alignment demos render more clearly.

### Motivation & Context

This is already done on the [Justify Content](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/utilities/justify-content/#basic-usage) example and I think slightly helps the user understand which class is being used.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42392--twbs-bootstrap.netlify.app/>
