### PR TITLE
v6: accordions - hide default WebKit details marker (old Safari)

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -50,6 +50,10 @@ $accordion-tokens: defaults(
     background-color: var(--accordion-btn-bg);
     @include transition(var(--accordion-transition));
 
+    &::-webkit-details-marker {
+      display: none;
+    }
+
     .accordion-icon {
       flex-shrink: 0;
       width: var(--accordion-btn-icon-width);


### PR DESCRIPTION
### Description / Motivation & Context

Suppress the native disclosure marker in WebKit by adding &::-webkit-details-marker { display: none; } to the accordion button styles. This prevents the browser's default triangle from overlapping the custom .accordion-icon and ensures consistent appearance across browsers

Issue discovered using Browserstack.
See comment: https://github.com/orgs/twbs/discussions/42398#discussion-10018925

Improves design on older Safari versions.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42401--twbs-bootstrap.netlify.app/>

Screenshot of deploy preview (Safari 16.5):

<img width="1951" height="1392" alt="image" src="https://github.com/user-attachments/assets/8bc997f4-0f11-4443-8c98-9f8362ca6581" />
