### PR TITLE
Fix Replace deprecated vendor prefixed property value

### DIFF
--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -356,12 +356,12 @@ caption {
 
 // 1. Removes font-weight bold by inheriting
 // 2. Matches default `<td>` alignment by inheriting `text-align`.
-// 3. Fix alignment for Safari
+// 3. Fix alignment
 
 th {
   font-weight: $table-th-font-weight; // 1
   text-align: inherit; // 2
-  text-align: -webkit-match-parent; // 3
+  text-align: match-parent; // 3
 }
 
 thead,


### PR DESCRIPTION
### Description

The property `-webkit-match-parent` is no longer supported. 
Replaced the property with a non-prefix version `match-parent`.

### Motivation & Context

Solves css validation issues and since browsers no longer support it the css rule is currently useless.
Stylelint complains about this property and it cannot be fixed using the `--fix`-flag

This property was originally included to fix an issue in Safari back in 2020. However Safari has supported the non-prefix `match-parent` since 2021. [(can-i-use: match-parent)](https://caniuse.com/?search=match-parent)

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
