### PR TITLE
Use `node-version-file` in GitHub workflows

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -29,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/css.yml
+++ b/.github/workflows/css.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
           cache: npm
 
       - run: java -version

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -32,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ env.NODE }}
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/node-sass.yml
+++ b/.github/workflows/node-sass.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 22
 
 permissions:
   contents: read
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "${{ env.NODE }}"
+          node-version-file: ".nvmrc"
 
       - name: Build CSS with node-sass
         run: |


### PR DESCRIPTION
Closes #42412

## What

- Add `.nvmrc` file at repo root with Node `22`
- Update all 7 workflow files to use `node-version-file: ".nvmrc"` instead of hardcoded `NODE: 22` env variable

## Why

Node version was duplicated across 7 workflow files. A single `.nvmrc` makes future upgrades a one-line change and lets contributors using `nvm` automatically pick the correct version.

## Files changed

- `.nvmrc` (new)
- `.github/workflows/browserstack.yml`
- `.github/workflows/bundlewatch.yml`
- `.github/workflows/css.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/js.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/node-sass.yml`
