### PR TITLE
v6: docs - Update utility class names in docs and examples

### DIFF
--- a/site/src/assets/examples/blog/index.astro
+++ b/site/src/assets/examples/blog/index.astro
@@ -21,13 +21,13 @@ import Placeholder from "@shortcodes/Placeholder.astro"
   <header class="border-bottom lh-1 py-3">
     <div class="row flex-nowrap justify-content-between align-items-center">
       <div class="col-4 pt-1">
-        <a class="link-secondary" href="#">Subscribe</a>
+        <a class="theme-secondary" href="#">Subscribe</a>
       </div>
       <div class="col-4 text-center">
         <a class="blog-header-logo text-body-emphasis text-decoration-none" href="#">Large</a>
       </div>
       <div class="col-4 d-flex justify-content-end align-items-center">
-        <a class="link-secondary" href="#" aria-label="Search">
+        <a class="theme-secondary" href="#" aria-label="Search">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="mx-3" role="img" viewBox="0 0 24 24"><title>Search</title><circle cx="10.5" cy="10.5" r="7.5"/><path d="M21 21l-5.2-5.2"/></svg>
         </a>
         <a class="btn-outline theme-secondary btn-sm" href="#">Sign up</a>

--- a/site/src/assets/examples/dashboard/index.astro
+++ b/site/src/assets/examples/dashboard/index.astro
@@ -128,7 +128,7 @@ export const extra_js = [
 
           <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 fg-2 text-uppercase">
             <span>Saved reports</span>
-            <a class="link-secondary" href="#" aria-label="Add a new report">
+            <a class="theme-secondary" href="#" aria-label="Add a new report">
               <svg class="bi" aria-hidden="true"><use href="#plus-circle"/></svg>
             </a>
           </h6>

--- a/site/src/assets/examples/drawer-navbar/index.astro
+++ b/site/src/assets/examples/drawer-navbar/index.astro
@@ -52,7 +52,7 @@ import Placeholder from "@shortcodes/Placeholder.astro"
     <a class="nav-link active" aria-current="page" href="#">Dashboard</a>
     <a class="nav-link" href="#">
       Friends
-      <span class="badge text-bg-light rounded-pill align-text-bottom">27</span>
+      <span class="badge theme-secondary rounded-pill align-text-bottom">27</span>
     </a>
     <a class="nav-link" href="#">Explore</a>
     <a class="nav-link" href="#">Suggestions</a>

--- a/site/src/assets/examples/headers/index.astro
+++ b/site/src/assets/examples/headers/index.astro
@@ -72,7 +72,7 @@ export const extra_css = ['headers.css']
       </div>
 
       <ul class="nav col-12 md:col-auto mb-2 justify-content-center md:mb-0">
-        <li><a href="#" class="nav-link px-2 link-secondary">Home</a></li>
+        <li><a href="#" class="nav-link px-2 theme-secondary">Home</a></li>
         <li><a href="#" class="nav-link px-2">Features</a></li>
         <li><a href="#" class="nav-link px-2">Pricing</a></li>
         <li><a href="#" class="nav-link px-2">FAQs</a></li>
@@ -125,7 +125,7 @@ export const extra_css = ['headers.css']
         </a>
 
         <ul class="nav col-12 lg:col-auto lg:me-auto mb-2 justify-content-center md:mb-0">
-          <li><a href="#" class="nav-link px-2 link-secondary">Overview</a></li>
+          <li><a href="#" class="nav-link px-2 theme-secondary">Overview</a></li>
           <li><a href="#" class="nav-link px-2 link-body-emphasis">Inventory</a></li>
           <li><a href="#" class="nav-link px-2 link-body-emphasis">Customers</a></li>
           <li><a href="#" class="nav-link px-2 link-body-emphasis">Products</a></li>

--- a/site/src/assets/examples/navbar-fixed/index.astro
+++ b/site/src/assets/examples/navbar-fixed/index.astro
@@ -8,7 +8,7 @@ export const extra_css = ['navbar-fixed.css']
 <nav class="navbar md:navbar-expand navbar-dark fixed-top bg-dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Fixed navbar</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <svg class="navbar-toggler-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"><path d="M1 3.5h14M1 8h14M1 12.5h14"/></svg>
     </button>
     <div class="collapse navbar-collapse" id="navbarCollapse">

--- a/site/src/assets/examples/navbars-drawer/index.astro
+++ b/site/src/assets/examples/navbars-drawer/index.astro
@@ -9,7 +9,7 @@ export const extra_css = ['navbars-drawer.css']
   <nav class="navbar navbar-dark bg-dark" aria-label="Dark drawer navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Dark drawer navbar</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbarDark" aria-controls="drawerNavbarDark" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbarDark" aria-controls="drawerNavbarDark" aria-label="Toggle navigation">
         <svg class="navbar-toggler-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"><path d="M1 3.5h14M1 8h14M1 12.5h14"/></svg>
       </button>
       <dialog class="drawer drawer-end text-bg-dark" tabindex="-1" id="drawerNavbarDark" aria-labelledby="drawerNavbarDarkLabel">
@@ -49,7 +49,7 @@ export const extra_css = ['navbars-drawer.css']
   <nav class="navbar bg-body-tertiary" aria-label="Light drawer navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Light drawer navbar</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbarLight" aria-controls="drawerNavbarLight" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbarLight" aria-controls="drawerNavbarLight" aria-label="Toggle navigation">
         <svg class="navbar-toggler-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"><path d="M1 3.5h14M1 8h14M1 12.5h14"/></svg>
       </button>
       <dialog class="drawer drawer-end" tabindex="-1" id="drawerNavbarLight" aria-labelledby="drawerNavbarLightLabel">
@@ -89,7 +89,7 @@ export const extra_css = ['navbars-drawer.css']
   <nav class="navbar lg:navbar-expand navbar-dark bg-dark" aria-label="Drawer navbar large">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Responsive drawer navbar</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbar2" aria-controls="drawerNavbar2" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbar2" aria-controls="drawerNavbar2" aria-label="Toggle navigation">
         <svg class="navbar-toggler-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"><path d="M1 3.5h14M1 8h14M1 12.5h14"/></svg>
       </button>
       <dialog class="drawer drawer-end text-bg-dark" tabindex="-1" id="drawerNavbar2" aria-labelledby="drawerNavbar2Label">

--- a/site/src/assets/examples/pricing/index.astro
+++ b/site/src/assets/examples/pricing/index.astro
@@ -155,30 +155,30 @@ export const extra_css = ['pricing.css']
       <div class="col-6 md:col">
         <h5>Features</h5>
         <ul class="list-unstyled text-small">
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Cool stuff</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Random feature</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Team feature</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Stuff for developers</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Another one</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Last time</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Cool stuff</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Random feature</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Team feature</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Stuff for developers</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Another one</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Last time</a></li>
         </ul>
       </div>
       <div class="col-6 md:col">
         <h5>Resources</h5>
         <ul class="list-unstyled text-small">
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Resource</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Resource name</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Another resource</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Final resource</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Resource</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Resource name</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Another resource</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Final resource</a></li>
         </ul>
       </div>
       <div class="col-6 md:col">
         <h5>About</h5>
         <ul class="list-unstyled text-small">
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Team</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Locations</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Privacy</a></li>
-          <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Terms</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Team</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Locations</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Privacy</a></li>
+          <li class="mb-1"><a class="theme-secondary text-decoration-none" href="#">Terms</a></li>
         </ul>
       </div>
     </div>

--- a/site/src/assets/examples/product/index.astro
+++ b/site/src/assets/examples/product/index.astro
@@ -148,39 +148,39 @@ export const extra_css = ['product.css']
     <div class="col-6 md:col">
       <h5>Features</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="link-secondary text-decoration-none" href="#">Cool stuff</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Random feature</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Team feature</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Stuff for developers</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Another one</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Last time</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Cool stuff</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Random feature</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Team feature</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Stuff for developers</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Another one</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Last time</a></li>
       </ul>
     </div>
     <div class="col-6 md:col">
       <h5>Resources</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="link-secondary text-decoration-none" href="#">Resource name</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Resource</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Another resource</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Final resource</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Resource name</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Resource</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Another resource</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Final resource</a></li>
       </ul>
     </div>
     <div class="col-6 md:col">
       <h5>Resources</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="link-secondary text-decoration-none" href="#">Business</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Education</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Government</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Gaming</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Business</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Education</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Government</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Gaming</a></li>
       </ul>
     </div>
     <div class="col-6 md:col">
       <h5>About</h5>
       <ul class="list-unstyled text-small">
-        <li><a class="link-secondary text-decoration-none" href="#">Team</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Locations</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Privacy</a></li>
-        <li><a class="link-secondary text-decoration-none" href="#">Terms</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Team</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Locations</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Privacy</a></li>
+        <li><a class="theme-secondary text-decoration-none" href="#">Terms</a></li>
       </ul>
     </div>
   </div>

--- a/site/src/components/home/MastHead.astro
+++ b/site/src/components/home/MastHead.astro
@@ -50,9 +50,9 @@ import ResponsiveImage from '@layouts/partials/ResponsiveImage.astro'
       <p class="fg-2 mb-0">
         Currently <strong>v{getConfig().current_version}</strong>
         <span class="px-1">&middot;</span>
-        <a href={getVersionedDocsPath('getting-started/install')} class="link-secondary">Download</a>
+        <a href={getVersionedDocsPath('getting-started/install')} class="theme-secondary">Download</a>
         <span class="px-1">&middot;</span>
-        <a href="/docs/versions/" class="link-secondary text-nowrap">All releases</a>
+        <a href="/docs/versions/" class="theme-secondary text-nowrap">All releases</a>
       </p>
       <Ads />
     </div>

--- a/site/src/content/docs/components/navbar.mdx
+++ b/site/src/content/docs/components/navbar.mdx
@@ -246,7 +246,7 @@ Place various form controls and components within a navbar:
     <div class="container-fluid">
       <form class="d-flex" role="search">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
     </div>
   </nav>`} />
@@ -258,7 +258,7 @@ Immediate child elements of `.navbar` use flex layout and will default to `justi
       <a class="navbar-brand">Navbar</a>
       <form class="d-flex" role="search">
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-        <button class="btn btn-outline-success" type="submit">Search</button>
+        <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
     </div>
   </nav>`} />
@@ -278,8 +278,8 @@ Various buttons are supported as part of these navbar forms, too. This is also a
 
 <Example code={`<nav class="navbar bg-1 fg-2">
     <form class="container-fluid justify-content-start">
-      <button class="btn btn-outline-success me-2" type="button">Main button</button>
-      <button class="btn btn-sm btn-outline-secondary" type="button">Smaller button</button>
+      <button class="btn-outline theme-success me-2" type="button">Main button</button>
+      <button class="btn-outline theme-secondary btn-sm" type="button">Smaller button</button>
     </form>
   </nav>`} />
 
@@ -433,7 +433,7 @@ Navbar themes are easier than ever thanks to Bootstrap’s combination of Sass a
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-          <button class="btn btn-outline theme-secondary" type="submit">Search</button>
+          <button class="btn-outline theme-secondary" type="submit">Search</button>
         </form>
       </div>
     </dialog>
@@ -468,7 +468,7 @@ Navbar themes are easier than ever thanks to Bootstrap’s combination of Sass a
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" data-bs-theme="light" type="search" placeholder="Search" aria-label="Search"/>
-          <button class="btn btn-solid theme-inverse" type="submit">Search</button>
+          <button class="btn-solid theme-inverse" type="submit">Search</button>
         </form>
       </div>
     </dialog>
@@ -503,7 +503,7 @@ Navbar themes are easier than ever thanks to Bootstrap’s combination of Sass a
         </ul>
         <form class="d-flex" role="search">
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-          <button class="btn btn-outline-primary" type="submit">Search</button>
+          <button class="btn-outline theme-primary" type="submit">Search</button>
         </form>
       </div>
     </dialog>
@@ -645,7 +645,7 @@ With no `.navbar-brand` shown (hidden inside the drawer):
           </ul>
           <form class="d-flex" role="search">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-            <button class="btn btn-outline-success" type="submit">Search</button>
+            <button class="btn-outline theme-success" type="submit">Search</button>
           </form>
         </div>
       </dialog>
@@ -673,7 +673,7 @@ With a brand name shown on the left and toggler on the right:
           </ul>
           <form class="d-flex" role="search">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-            <button class="btn btn-outline-success" type="submit">Search</button>
+            <button class="btn-outline theme-success" type="submit">Search</button>
           </form>
         </div>
       </dialog>
@@ -701,7 +701,7 @@ With a toggler on the left and brand name on the right:
           </ul>
           <form class="d-flex" role="search">
             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"/>
-            <button class="btn btn-outline-success" type="submit">Search</button>
+            <button class="btn-outline theme-success" type="submit">Search</button>
           </form>
         </div>
       </dialog>

--- a/site/src/content/docs/components/spinner.mdx
+++ b/site/src/content/docs/components/spinner.mdx
@@ -82,7 +82,7 @@ Use [flexbox utilities][flex], [float utilities][float], or [text alignment][tex
 
 #### Floats
 
-<Example code={`<div class="clearfix">
+<Example code={`<div class="d-flow-root">
     <div class="spinner-border float-end" role="status">
       <span class="visually-hidden">Loading...</span>
     </div>

--- a/site/src/content/docs/content/reboot.mdx
+++ b/site/src/content/docs/content/reboot.mdx
@@ -127,7 +127,7 @@ The `<hr>` element has been simplified. Similar to browser defaults, `<hr>`s are
 
 <Example code={`<hr>
 
-  <div class="text-success">
+  <div class="fg-success">
     <hr>
   </div>
 

--- a/site/src/content/docs/getting-started/accessibility.mdx
+++ b/site/src/content/docs/getting-started/accessibility.mdx
@@ -29,7 +29,7 @@ Some combinations of colors that currently make up Bootstrap’s default palette
 Content which should be visually hidden, but remain accessible to assistive technologies such as screen readers, can be styled using the `.visually-hidden` class. This can be useful in situations where additional visual information or cues (such as meaning denoted through the use of color) need to also be conveyed to non-visual users.
 
 ```html
-<p class="text-danger">
+<p class="fg-danger">
   <span class="visually-hidden">Danger: </span>
   This action is not reversible
 </p>

--- a/site/src/content/docs/layout/columns.mdx
+++ b/site/src/content/docs/layout/columns.mdx
@@ -311,7 +311,7 @@ The classes can be used together with utilities to create responsive floated ima
     <Placeholder width="100%" height="210" class="md:col-6 md:float-end mb-3 md:ms-3" text="Responsive floated image" />
 
     <p>
-      A paragraph of placeholder text. We’re using it here to show the use of the clearfix class. We’re adding quite a few meaningless phrases here to demonstrate how the columns interact here with the floated image.
+      A paragraph of placeholder text. We’re using it here to show the use of the d-flow-root utility. We’re adding quite a few meaningless phrases here to demonstrate how the columns interact here with the floated image.
     </p>
 
     <p>

--- a/site/src/content/docs/utilities/object-fit.mdx
+++ b/site/src/content/docs/utilities/object-fit.mdx
@@ -30,17 +30,17 @@ Add the `object-fit-{value}` class to the [replaced element](https://developer.m
 
 ## Responsive
 
-Responsive variations also exist for each `object-fit` value using the format `.object-fit-{breakpoint}-{value}`, for the following breakpoint abbreviations: `sm`, `md`, `lg`, `xl`, and `2xl`. Classes can be combined for various effects as you need.
+Responsive variations also exist for each `object-fit` value using the format `.{breakpoint}:object-fit-{value}`, for the following breakpoint abbreviations: `sm`, `md`, `lg`, `xl`, and `2xl`. Classes can be combined for various effects as you need.
 
-<Example class="d-flex overflow-auto" code={`<Placeholder width="140" height="80" class="object-fit-sm-contain border rounded" text="Contain on sm" markup="img" />
-<Placeholder width="140" height="80" class="object-fit-md-contain border rounded" text="Contain on md" markup="img" />
-<Placeholder width="140" height="80" class="object-fit-lg-contain border rounded" text="Contain on lg" markup="img" />
-<Placeholder width="140" height="80" class="object-fit-xl-contain border rounded" text="Contain on xl" markup="img" />
-<Placeholder width="140" height="80" class="object-fit-2xl-contain border rounded" text="Contain on 2xl" markup="img" />`} />
+<Example class="d-flex overflow-auto" code={`<Placeholder width="140" height="80" class="sm:object-fit-contain border rounded" text="Contain on sm" markup="img" />
+<Placeholder width="140" height="80" class="md:object-fit-contain border rounded" text="Contain on md" markup="img" />
+<Placeholder width="140" height="80" class="lg:object-fit-contain border rounded" text="Contain on lg" markup="img" />
+<Placeholder width="140" height="80" class="xl:object-fit-contain border rounded" text="Contain on xl" markup="img" />
+<Placeholder width="140" height="80" class="2xl:object-fit-contain border rounded" text="Contain on 2xl" markup="img" />`} />
 
 ## Video
 
-The `.object-fit-{value}` and responsive `.object-fit-{breakpoint}-{value}` utilities also work on `<video>` elements.
+The `.object-fit-{value}` and responsive `.{breakpoint}:object-fit-{value}` utilities also work on `<video>` elements.
 
 ```html
 <video src="..." class="object-fit-contain" autoplay></video>

--- a/site/src/layouts/partials/ExamplesMain.astro
+++ b/site/src/layouts/partials/ExamplesMain.astro
@@ -34,7 +34,7 @@ import { getSlug } from '@libs/utils'
                     <p class="fg-2">{example.description}</p>
                     <p>
                       <a
-                        class="icon-link small link-secondary link-offset-1"
+                        class="icon-link small theme-secondary link-offset-1"
                         href={`https://stackblitz.com/github/twbs${example.url}?file=${
                           example.indexPath ? example.indexPath : 'index.html'
                         }`}

--- a/site/src/pages/docs/versions.astro
+++ b/site/src/pages/docs/versions.astro
@@ -43,8 +43,8 @@ function getVersionsSortedDesc<TKey extends string, TVersions extends Record<TKe
                       href={`${docsVersion.baseurl}/${version}/`}
                     >
                       {version}
-                      {isCurrentVersion && <span class="badge text-bg-primary">Latest</span>}
-                      {isAlpha && <span class="badge text-bg-warning">Alpha</span>}
+                      {isCurrentVersion && <span class="badge theme-primary">Latest</span>}
+                      {isAlpha && <span class="badge theme-warning">Alpha</span>}
                     </a>
                   )
                 })}


### PR DESCRIPTION
### Description / Motivation & Context

Replace deprecated utility classes with the updated names across site docs and examples. Changes include switching text-* classes to fg-*, text-bg-* badge classes to theme-*, and replacing clearfix with d-flow-root. Affected files: cover and drawer-navbar examples, spinner example, reboot, accessibility, columns docs, and versions page to keep examples consistent with the new utility naming.
135

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42418--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->
