### PR TITLE
Replace actions-cool/issues-helper by actions/stale

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -10,17 +10,20 @@ permissions:
 jobs:
   issue-close-require:
     permissions:
-      # allow actions-cool/issues-helper to update issues and PRs
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     if: github.repository == 'twbs/bootstrap'
     steps:
       - name: awaiting reply
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          actions: "close-issues"
-          labels: "awaiting-reply"
-          inactive-day: 14
-          body: |
+          only-issue-labels: 'awaiting-reply'
+          days-before-stale: 1 # TODO: change to 14
+          days-before-close: 0
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-message: ''
+          close-issue-message: |
             As the issue was labeled with `awaiting-reply`, but there has been no response in 14 days, this issue will be closed. If you have any questions, you can comment/reply.
+          close-issue-reason: not_planned


### PR DESCRIPTION
This PR replaces [`actions-cool/issues-helper`](https://github.com/actions-cool/issues-helper) by [`actions/stale`](https://github.com/actions/stale) as the former has now been disabled:

<img width="1132" height="420" alt="Screenshot 2026-05-24 at 10 22 20" src="https://github.com/user-attachments/assets/20b5a95c-65b6-4e28-9a41-5532a2f653e9" />

`actions/stale` is the official GitHub action that looks like is able to do exactly the same thing as before.

> [!IMPORTANT]
> In order to test it, I have to merge this PR to `main`. I've set `days-before-stale` to 1 so that I can create a fake issue, put the `awaiting-reply` label, and see how it goes 1 day from there. If it works, I'll modify `days-before-stale` to 14 as before.