### PR TITLE
Replace actions-cool/issues-helper by actions/github-script

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -10,17 +10,18 @@ permissions:
 jobs:
   issue-labeled:
     permissions:
-      # allow actions-cool/issues-helper to update issues and PRs
       issues: write
-      pull-requests: write
     if: github.repository == 'twbs/bootstrap'
     runs-on: ubuntu-latest
     steps:
       - name: awaiting reply
         if: github.event.label.name == 'needs-example'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          actions: "create-comment"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. Bug reports must include a **live demo** of the issue. Per our [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md), please create a reduced test case on [CodePen](https://codepen.io/) or [StackBlitz](https://stackblitz.com/) and report back with your link, Bootstrap version, and specific browser and Operating System details.
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Hello @${context.payload.issue.user.login}. Bug reports must include a **live demo** of the issue. Per our [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md), please create a reduced test case on [CodePen](https://codepen.io/) or [StackBlitz](https://stackblitz.com/) and report back with your link, Bootstrap version, and specific browser and Operating System details.`
+            })


### PR DESCRIPTION
This PR replaces [`actions-cool/issues-helper`](https://github.com/actions-cool/issues-helper) by [`actions/github-script`](https://github.com/actions/script) as the former has now been disabled:

<img width="1132" height="420" alt="Screenshot 2026-05-24 at 10 22 20" src="https://github.com/user-attachments/assets/20b5a95c-65b6-4e28-9a41-5532a2f653e9" />

`actions/script` is the official GitHub action that looks like is able to do exactly the same thing as before.

> [!IMPORTANT]
> In order to test it, I have to merge this PR to `main`.