### PR TITLE
Restore `border-radius` to `.card`

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "48.5 kB"
+      "maxSize": "48.75 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -47,7 +47,7 @@ $card-tokens: defaults(
     word-wrap: break-word;
     background-color: var(--card-bg);
     // border: var(--card-border-width) solid var(--card-border-color);
-    // @include border-radius(var(--card-border-radius));
+    @include border-radius(var(--card-border-radius));
     @include box-shadow(var(--card-box-shadow));
 
     > hr {


### PR DESCRIPTION
Needed when we do fills, `box-shadow` and more. Fixes #42421.