### PR TITLE
Fix luminance with non-integer Sass color channels

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -188,7 +188,7 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
   );
 
   @each $name, $value in $rgb {
-    $value: if(divide($value, 255) < .04045, divide(divide($value, 255), 12.92), nth($_luminance-list, $value + 1));
+    $value: if(divide($value, 255) < .04045, divide(divide($value, 255), 12.92), nth($_luminance-list, min(255, max(0, round($value))) + 1));
     $rgb: map-merge($rgb, ($name: $value));
   }
 

--- a/scss/tests/functions/_luminance.test.scss
+++ b/scss/tests/functions/_luminance.test.scss
@@ -1,0 +1,22 @@
+@import "../../functions";
+
+// Simulate Sass color channel functions returning non-integer channel values.
+@function red($color) {
+  @return 241.5;
+}
+
+@function green($color) {
+  @return 135.5;
+}
+
+@function blue($color) {
+  @return 8.5;
+}
+
+@include describe("luminance function") {
+  @include it("should round non-integer channel values before reading the luminance table") {
+    $result: luminance(#f7941c);
+
+    @include assert-true($result > 0 and $result < 1, "Non-integer color channels should not crash luminance()");
+  }
+}


### PR DESCRIPTION
### Description

Rounds and clamps Sass RGB channel values before using them as indexes into the precomputed luminance lookup table.

### Motivation & Context

Fixes #42447. Sass color operations can produce fractional channel values; using those values directly as `nth()` indexes can raise an invalid index error.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

Fixes #42447

### Verification

- `npm run css-test`
- `npm run css-lint`
- `npm run lint` (passes with existing TODO/FIXME warnings)
- `npx stylelint scss/_functions.scss scss/tests/functions/_luminance.test.scss --cache --cache-location .cache/.stylelintcache`
- `git diff --check`
