### PR TITLE
v6: remove figure-img from image docs

### DIFF
--- a/site/src/content/docs/content/images.mdx
+++ b/site/src/content/docs/content/images.mdx
@@ -32,19 +32,19 @@ Align images with the [helper float classes]([[docsref:/utilities/float]]) or [t
 
 ## Figures
 
-Anytime you need to display a piece of content—like an image with an optional caption, consider using a `<figure>` Figures are flex containers in Bootstrap, so you can easily modify the layout and alignment with our [flex utilities]([[docsref:/utilities/flex]]).
+Anytime you need to display a piece of content—like an image with an optional caption, consider using a `<figure>` element. Figures are flex containers in Bootstrap, so you can easily modify the layout and alignment with our [flex utilities]([[docsref:/utilities/flex]]).
 
-Use the included `.figure`, `.figure-img` and `.figure-caption` classes to provide some baseline styles for the HTML5 `<figure>` and `<figcaption>` elements. Images in figures have no explicit size, so be sure to add the `.img-fluid` class to your `<img>` to make it responsive.
+Use the included `.figure` and `.figure-caption` classes to provide some baseline styles for the HTML5 `<figure>` and `<figcaption>` elements. Images in figures have no explicit size, so be sure to add the `.img-fluid` class to your `<img>` to make it responsive.
 
 <Example code={`<figure class="figure">
-    <Placeholder width="400" height="300" class="figure-img img-fluid rounded-3" />
+    <Placeholder width="400" height="300" class="img-fluid rounded-3" />
     <figcaption class="figure-caption">A caption for the above image.</figcaption>
   </figure>`} />
 
 And with a reverse alignment:
 
 <Example code={`<figure class="figure align-items-end"><!-- [!code highlight] -->
-    <Placeholder width="400" height="300" class="figure-img img-fluid rounded-3" />
+    <Placeholder width="400" height="300" class="img-fluid rounded-3" />
     <figcaption class="figure-caption">A caption for the above image.</figcaption>
   </figure>`} />
 


### PR DESCRIPTION
### Description / Motivation & Context

`figure-img` is not needed/used and not included in Bootstrap CSS.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist



- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42457--twbs-bootstrap.netlify.app/docs/6.0/content/images/#figures>
