### PR TITLE
Widen custom switch component

### DIFF
--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -10,7 +10,7 @@ $switch-tokens: () !default;
 $switch-tokens: defaults(
   (
     --switch-height: 1.25rem,
-    --switch-width: calc(var(--switch-height) * 1.5),
+    --switch-width: calc(var(--switch-height) * 1.75),
     --switch-padding: .0625rem,
     --switch-margin-block: .125rem,
     --switch-bg: var(--bg-3),


### PR DESCRIPTION
### Description

Widen the custom switch by increasing the `--switch-width` token multiplier from `1.5` to `1.75` of the switch height, giving the track more room and a longer thumb travel. The indicator is sized off height, so the thumb is unchanged and `switch-sm`/`switch-lg` scale automatically.

### Motivation & Context

The switch looked a little narrow; this gives it a more balanced proportion.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

<!-- Please link any related issues here. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)