### PR TITLE
Fix Prettier formatting in spacing docs shortcodes

### DIFF
--- a/site/src/components/shortcodes/SpacingNotation.astro
+++ b/site/src/components/shortcodes/SpacingNotation.astro
@@ -67,14 +67,16 @@ const sizeValues = [
 ---
 
 <p>
-  {capitalizedNoun} utilities that apply to all breakpoints, from <code>xs</code> to <code>2xl</code>, have no breakpoint
-  prefix in them. This is because those classes are applied from <code>min-width: 0</code> and up, and thus are not
-  bound by a media query. The remaining breakpoints, however, do include a breakpoint prefix.
+  {capitalizedNoun} utilities that apply to all breakpoints, from <code>xs</code> to <code>2xl</code>, have no
+  breakpoint prefix in them. This is because those classes are applied from <code>min-width: 0</code> and up, and thus are
+  not bound by a media query. The remaining breakpoints, however, do include a breakpoint prefix.
 </p>
 
 <p>
   The classes are named using the format <code>{format}</code> for <code>xs</code> and{' '}
-  <code>{`{breakpoint}:${format}`}</code> for <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>, and{' '}
+  <code>{`{breakpoint}:${format}`}</code> for <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>, and{
+    ' '
+  }
   <code>2xl</code>.
 </p>
 

--- a/site/src/components/shortcodes/SpacingResponsive.astro
+++ b/site/src/components/shortcodes/SpacingResponsive.astro
@@ -25,9 +25,20 @@ const breakpoints = getData('breakpoints')
       {breakpoints.map((breakpoint) => (
         <li>
           {/* prettier-ignore */}
-          <code>.{breakpoint.abbr}{className}-0</code> through <code>.{breakpoint.abbr}{className}-9</code>
+          <code>.{breakpoint.abbr}{className}-0</code> through{' '}
+          <code>
+            .{breakpoint.abbr}
+            {className}-9
+          </code>
           {includeAuto && (
-            <Fragment> and <code>.{breakpoint.abbr}{className}-auto</code></Fragment>
+            <Fragment>
+              {' '}
+              and{' '}
+              <code>
+                .{breakpoint.abbr}
+                {className}-auto
+              </code>
+            </Fragment>
           )}
         </li>
       ))}


### PR DESCRIPTION
### Description

Reformats the `SpacingNotation.astro` and `SpacingResponsive.astro` docs shortcodes to satisfy `docs-prettier-check`.

### Motivation & Context

The **Lint** CI job on `v6-dev` was failing because `docs-lint` → `docs-prettier-check` flagged unformatted code in these two shortcodes (introduced in #42454). The changes are purely stylistic line-reflow and explicit whitespace markers, so rendered output is unchanged. Verified with `npm run docs-prettier-check`.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
