### PR TITLE
Fix aria-pressed initialization for toggle buttons

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -27,6 +27,16 @@ const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
  */
 
 class Button extends BaseComponent {
+  constructor(element) {
+    super(element)
+
+    if (!this._element || this._element.hasAttribute('aria-pressed')) {
+      return
+    }
+
+    this._element.setAttribute('aria-pressed', this._element.classList.contains(CLASS_NAME_ACTIVE))
+  }
+
   // Getters
   static get NAME() {
     return NAME

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -22,6 +22,20 @@ describe('Button', () => {
     expect(buttonByElement._element).toEqual(buttonEl)
   })
 
+  it('should initialize aria-pressed when missing', () => {
+    fixtureEl.innerHTML = [
+      '<button class="btn" data-bs-toggle="button"></button>',
+      '<button class="btn active" data-bs-toggle="button"></button>'
+    ].join('')
+
+    const buttons = fixtureEl.querySelectorAll('[data-bs-toggle="button"]')
+    const buttonInstances = [...buttons].map(button => new Button(button))
+
+    expect(buttonInstances).toHaveSize(2)
+    expect(buttons[0].getAttribute('aria-pressed')).toEqual('false')
+    expect(buttons[1].getAttribute('aria-pressed')).toEqual('true')
+  })
+
   describe('VERSION', () => {
     it('should return plugin version', () => {
       expect(Button.VERSION).toEqual(jasmine.any(String))


### PR DESCRIPTION
### Description

Initializes missing `aria-pressed` on button plugin instances from the current `.active` state. Inactive toggle buttons now get `aria-pressed="false"`, and already-active toggle buttons get `aria-pressed="true"` when the attribute was not present in the markup.

### Motivation & Context

Fixes #42328.

The button plugin already keeps `aria-pressed` in sync when toggling. This covers the initial state so assistive technologies can identify the button as a toggle before the first click.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project (`npm run js-lint`)
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Tests

- Red check: `npm_config_cache=/tmp/bootstrap-42328-npm-cache npm run js-test-karma` failed before the implementation with the new test seeing `aria-pressed` as `null`.
- Green check: `npm_config_cache=/tmp/bootstrap-42328-npm-cache npm run js-test-karma` reported 810/810 successful tests and exited 0. Karma also printed its existing full-page-reload shutdown warning.
- `npm_config_cache=/tmp/bootstrap-42328-npm-cache npm run js-lint` exited 0, with existing warning-comment warnings in unrelated files.
- `git diff --check`

AI assistance was used for implementation and verification. I reviewed the code and test results before submitting.