### PR TITLE
docs: fix menu clipping in resizable examples + configurable dev port

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     "watch-js-main": "nodemon --watch js/src/ --ext js --exec \"npm-run-all js-lint js-compile\"",
     "watch-js-docs": "nodemon --watch site/src/assets/ --ext js --exec \"npm run js-lint\"",
     "astro-clean": "rm -rf site/.astro site/node_modules/.astro",
-    "astro-dev": "astro dev --root site --port 9001",
+    "astro-dev": "astro dev --root site",
     "astro-build": "astro build --root site && rm -rf _site && cp -r site/dist _site && pagefind --site _site",
-    "astro-preview": "astro preview --root site --port 9001",
+    "astro-preview": "astro preview --root site",
     "spellcheck": "cspell --config .cspell.json \"**/*.{md,mdx}\""
   },
   "peerDependencies": {

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -17,9 +17,13 @@ const bootstrapBundlePath = fileURLToPath(new URL('../dist/js/bootstrap.bundle.j
 
 const isDev = process.env.NODE_ENV === 'development'
 
+// Allow the dev/preview server port to be overridden via `PORT` (falling back to
+// 9001) so multiple worktrees can run side by side without colliding.
+const port = Number.parseInt(process.env.PORT ?? '', 10) || 9001
+
 const site = isDev
   ? // In development mode, use the local dev server.
-    'http://localhost:9001'
+    `http://localhost:${port}`
   : process.env.DEPLOY_PRIME_URL !== undefined
     ? // If deploying on Netlify, use the `DEPLOY_PRIME_URL` environment variable.
       process.env.DEPLOY_PRIME_URL
@@ -65,6 +69,9 @@ export default defineConfig({
   },
   devToolbar: {
     enabled: false
+  },
+  server: {
+    port
   },
   site,
   vite: {

--- a/site/src/components/shortcodes/ResizableExample.astro
+++ b/site/src/components/shortcodes/ResizableExample.astro
@@ -47,6 +47,15 @@ const containerClass = className || classFromClass
 let markup = Array.isArray(code) ? code.join('\n') : code
 markup = replacePlaceholdersInHtml(markup)
 
+// The resizable container needs `overflow: hidden` for the CSS `resize` handle
+// to work, which clips popovers like menus/dropdowns when they open. Render them
+// with a fixed positioning strategy in the live preview only so they can spill
+// outside the container. The displayed markup below is left untouched.
+const previewMarkup = markup.replace(
+  /data-bs-toggle="(menu|dropdown)"(?![^>]*\bdata-bs-strategy=)/g,
+  'data-bs-toggle="$1" data-bs-strategy="fixed"'
+)
+
 const simplifiedMarkup = markup.replace(
   /<svg.*class="bd-placeholder-img(?:-lg)?(?: *?bd-placeholder-img-lg)? ?(.*?)".*?<\/svg>/g,
   (match, classes) => `<img src="..."${classes ? ` class="${classes}"` : ''} alt="...">`
@@ -59,7 +68,7 @@ const simplifiedMarkup = markup.replace(
       class:list={['bd-resizable-container', containerClass]}
       style={`width: ${initialWidth}; min-width: ${minWidth};`}
     >
-      <Fragment set:html={markup} />
+      <Fragment set:html={previewMarkup} />
     </div>
   </div>
   {showMarkup && <Code code={simplifiedMarkup} lang="html" nestedInExample={true} />}


### PR DESCRIPTION
## Summary

Two related docs/tooling fixes:

- **Resizable examples no longer clip menus.** The resizable container needs `overflow: hidden` for the CSS `resize` handle to work, which was clipping `.menu`/dropdown popovers when they opened (e.g. the navbar "Menu link" example). The live preview now renders those toggles with `data-bs-strategy="fixed"` so `position: fixed` lets the menu spill outside the container. The displayed/copyable markup is left untouched, and a negative lookahead avoids duplicating a strategy if one is already set.
- **Astro dev/preview port is configurable.** The port was hardcoded to `9001`. It now reads `PORT` (defaulting to `9001`) in `astro.config.ts` for both `server.port` and the dev `site` URL, and the hardcoded `--port 9001` flags were dropped from the npm scripts. This lets multiple worktrees run side by side without colliding:

  ```bash
  PORT=9123 npm start
  ```

## Notes

- `dist/` is intentionally not included.