### PR TITLE
fix(util): correct typo in isVisible comment (falsie → falsely)

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -102,7 +102,7 @@ const isVisible = element => {
   }
 
   const elementIsVisible = getComputedStyle(element).getPropertyValue('visibility') === 'visible'
-  // Handle `details` element as its content may falsie appear visible when it is closed
+  // Handle `details` element as its content may falsely appear visible when it is closed
   const closedDetails = element.closest('details:not([open])')
 
   if (!closedDetails) {


### PR DESCRIPTION
## Description

This PR fixes a small spelling typo in an inline code comment inside the  utility ().

**Before:**
```js
// Handle `details` element as its content may falsie appear visible when it is closed
```

**After:**
```js
// Handle `details` element as its content may falsely appear visible when it is closed
```

"falsie" is not a word; the intended adverb is "falsely". The comment describes how a closed `<details>` element's content can *falsely* appear visible to the visibility check.

## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor
- [ ] Docs / typos
- [ ] New feature

## Checklist

- [x] My code follows the code style of this project.
- [x] My change generates no new warnings.
- [x] I have read the **[contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)**.

## Context

Found while reading the `isVisible` helper. The typo is also propagated to the generated `dist/js/*.js` bundles (which are produced from this source), so fixing it here is the right place.