### PR TITLE
docs(util): improve JSDoc for parseSelector, reflow and getNextActiveElement

### DIFF
--- a/js/src/util/index.js
+++ b/js/src/util/index.js
@@ -10,9 +10,11 @@ const MILLISECONDS_MULTIPLIER = 1000
 const TRANSITION_END = 'transitionend'
 
 /**
- * Properly escape IDs selectors to handle weird IDs
- * @param {string} selector
- * @returns {string}
+ * Properly escapes ID selectors to handle special characters in IDs
+ * (e.g. forward slashes, periods) so that they work with `document.querySelector`.
+ *
+ * @param {string} selector the selector to escape
+ * @returns {string} the escaped selector
  */
 const parseSelector = selector => {
   if (selector && window.CSS && window.CSS.escape) {
@@ -165,10 +167,10 @@ const findShadowRoot = element => {
 const noop = () => {}
 
 /**
- * Trick to restart an element's animation
+ * Trick to restart an element's animation by forcing a reflow.
  *
- * @param {HTMLElement} element
- * @return void
+ * @param {HTMLElement} element the element whose animation should be restarted
+ * @returns {void}
  *
  * @see https://www.harrytheo.com/blog/2021/02/restart-a-css-animation-with-javascript/#restarting-a-css-animation
  */
@@ -258,11 +260,11 @@ const executeAfterTransition = (callback, transitionElement, waitForTransition =
 /**
  * Return the previous/next element of a list.
  *
- * @param {array} list    The list of elements
- * @param activeElement   The active element
- * @param shouldGetNext   Choose to get next or previous element
- * @param isCycleAllowed
- * @return {Element|elem} The proper element
+ * @param {array} list           the list of elements to traverse
+ * @param {Element} activeElement the currently active element
+ * @param {boolean} shouldGetNext whether to return the next element (`true`) or the previous one (`false`)
+ * @param {boolean} isCycleAllowed whether to cycle back to the opposite end of the list when reaching the boundary
+ * @returns {Element} the appropriate previous/next element from the list
  */
 const getNextActiveElement = (list, activeElement, shouldGetNext, isCycleAllowed) => {
   const listLength = list.length


### PR DESCRIPTION
## Description

This PR improves the JSDoc blocks for three public utility helpers exported from `js/src/util/index.js`. No runtime behaviour is changed — only comments.

### `parseSelector`
- Rewrote the description to be more explicit about *why* escaping is needed (special characters such as `/` and `.` in IDs break `document.querySelector`).
- Added descriptions for `@param` and `@returns`.

### `reflow`
- Clarified the description ("by forcing a reflow").
- Documented the `@param` and added `@returns {void}`.
- Replaced the non-standard `@return void` with the canonical `@returns {void}` for consistency with the rest of the file (e.g. `parseSelector`).

### `getNextActiveElement`
- Added the missing type annotations for `activeElement`, `shouldGetNext` and `isCycleAllowed` (previously only `list` had a type).
- Added a description for `isCycleAllowed`, which previously had none.
- Fixed the return type: `{Element|elem}` was incorrect (`elem` is not a type). It is now `{Element}`.
- Switched `@return` to `@returns` to match the rest of the file.

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor
- [x] Docs / typos
- [ ] New feature

## Checklist

- [x] My code follows the code style of this project.
- [x] My change generates no new warnings.
- [x] I have read the **[contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)**.

## Why

These three helpers are the only ones in `util/index.js` that carry JSDoc blocks, but the blocks were inconsistent (mixed `@return`/`@returns`, missing types, missing descriptions, an invalid return type). Cleaning them up improves IDE hover hints, TypeDoc/VSCode IntelliSense and makes the intent of the helpers easier to grok at a glance.