### PR TITLE
Drop deprecated `.accordion-button` remaining usage

### DIFF
--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -316,7 +316,7 @@ describe('Collapse', () => {
           '<div class="accordion" id="accordionExample">',
           '  <div class="accordion-item">',
           '    <h2 class="accordion-header">',
-          '      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">',
+          '      <button type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">',
           '        Accordion Item #1',
           '      </button>',
           '    </h2>',


### PR DESCRIPTION
### Description

Drop deprecated `.accordion-button` remaining usage.

Spotted by the script at https://github.com/twbs/bootstrap/pull/42487.