### PR TITLE
Drop deprecated `.has-validation` remaining usage

### DIFF
--- a/site/src/assets/examples/cheatsheet/index.astro
+++ b/site/src/assets/examples/cheatsheet/index.astro
@@ -541,7 +541,7 @@ export const body_class = 'bg-body-tertiary'
           </div>
           <div class="md:col-4">
             <label for="validationServerUsername" class="form-label">Username</label>
-            <div class="input-group has-validation">
+            <div class="input-group">
               <span class="input-group-text" id="inputGroupPrepend3">@</span>
               <input type="text" class="form-control is-invalid" id="validationServerUsername" aria-describedby="inputGroupPrepend3" required>
               <div class="invalid-feedback">

--- a/site/src/assets/examples/checkout/index.astro
+++ b/site/src/assets/examples/checkout/index.astro
@@ -85,7 +85,7 @@ export const body_class = 'bg-body-tertiary'
 
             <div class="col-12">
               <label for="username" class="form-label">Username</label>
-              <div class="input-group has-validation">
+              <div class="input-group">
                 <span class="input-group-text">@</span>
                 <input type="text" class="form-control" id="username" placeholder="Username" required>
               <div class="invalid-feedback">


### PR DESCRIPTION
### Description

Drop deprecated `.has-validation-button` remaining usage.

Spotted by the script at https://github.com/twbs/bootstrap/pull/42487.