### PR TITLE
Drop deprecated `.text-muted` remaining usage

### DIFF
--- a/js/tests/visual/dialog.html
+++ b/js/tests/visual/dialog.html
@@ -151,7 +151,7 @@
           <button type="button" class="btn-solid theme-info btn-lg" data-bs-toggle="dialog" data-bs-target="#nonModalDialog" data-bs-modal="false">
             Launch non-modal dialog
           </button>
-          <small class="text-muted">(uses <code>show()</code> instead of <code>showModal()</code>)</small>
+          <small class="fg-secondary">(uses <code>show()</code> instead of <code>showModal()</code>)</small>
         </div>
 
         <div>


### PR DESCRIPTION
### Description

Drop deprecated `.text-muted` remaining usage.

Spotted by the script at https://github.com/twbs/bootstrap/pull/42487.