### PR TITLE
Replaced deprecated `.text-light` remaining usage by `.fg-body`

### DIFF
--- a/js/tests/visual/datepicker.html
+++ b/js/tests/visual/datepicker.html
@@ -75,8 +75,8 @@
       <h2>Dark Mode</h2>
       <div class="row mb-4" data-bs-theme="dark">
         <div class="md:col-6">
-          <div class="p-4 bg-dark rounded">
-            <label for="darkDatepicker" class="form-label text-light">Dark mode datepicker</label>
+          <div class="p-4 bg-body rounded">
+            <label for="darkDatepicker" class="form-label fg-body">Dark mode datepicker</label>
             <input type="text" class="form-control" id="darkDatepicker" data-bs-toggle="datepicker" placeholder="Select a date">
           </div>
         </div>


### PR DESCRIPTION
### Description

Replaced deprecated `.text-light` remaining usage by `.fg-body`. `.text-light` (and `.bg-dark`) used here is supposed to be not changing in light and dark mode, but here it makes no sense as the dark mode is forced. So let's rather use the `*-body` classes.

Spotted by the script at https://github.com/twbs/bootstrap/pull/42487.
