### PR TITLE
Docs: fix 'Icon link > Sass utilities API' example

### DIFF
--- a/site/src/content/docs/helpers/icon-link.mdx
+++ b/site/src/content/docs/helpers/icon-link.mdx
@@ -78,7 +78,7 @@ Customize the icon link Sass variables to modify all icon link styles across you
 
 Modify icon links with any of [our link utilities]([[docsref:/utilities/link/]]) for modifying underline color and offset.
 
-<Example code={`<a class="icon-link icon-link-hover link-success link-underline-success link-underline-opacity-25" href="#">
+<Example code={`<a class="icon-link icon-link-hover theme-success underline-success underline-25 underline-offset-3" href="#">
     Icon link
     <svg xmlns="http://www.w3.org/2000/svg" class="bi" viewBox="0 0 16 16" aria-hidden="true">
       <path d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>


### PR DESCRIPTION
### Description

This PR fixes the 'Icon link > Sass utilities API' example by adapting the deprecated classes, replaces by other utilities around links and text decoration.

These classes (`.link-underline-opacity-25`, `.link-success`, and `.link-underline-success`) were used only here.

> [!NOTE]
> The pararaph says "for modifying underline color and offset", so I added the offset utility as well.

Spotted by the script at https://github.com/twbs/bootstrap/pull/42487.