### PR TITLE
Add `--menu-max-width` token to the menu component

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -14,6 +14,7 @@ $menu-tokens: defaults(
     --menu-zindex: #{$zindex-menu},
     --menu-gap: .125rem,
     --menu-min-width: 10rem,
+    --menu-max-width: none,
     --menu-padding-x: .25rem,
     --menu-padding-y: .25rem,
     --menu-spacer: .125rem,
@@ -64,6 +65,7 @@ $menu-tokens: defaults(
     flex-direction: column;
     gap: var(--menu-gap);
     min-width: var(--menu-min-width);
+    max-width: var(--menu-max-width);
     max-height: var(--menu-max-height, none);
     padding: var(--menu-padding-y) var(--menu-padding-x);
     margin: 0;


### PR DESCRIPTION
## Summary

Adds a configurable **`--menu-max-width`** custom property to the menu component.

- New token `--menu-max-width` (default `none`) in `$menu-tokens`.
- Applied as `max-width` on `.menu`, alongside the existing `min-width`/`max-height`.

This lets menus be constrained to a maximum width via the CSS variable without overriding the rule directly—useful for menus with longer content.
