### PR TITLE
Fix focus trap when tabbing to document

### DIFF
--- a/js/src/util/focustrap.js
+++ b/js/src/util/focustrap.js
@@ -88,7 +88,7 @@ class FocusTrap extends Config {
   _handleFocusin(event) {
     const { trapElement } = this._config
 
-    if (event.target === document || event.target === trapElement || trapElement.contains(event.target)) {
+    if (event.target === trapElement || trapElement.contains(event.target)) {
       return
     }
 

--- a/js/tests/unit/util/focustrap.spec.js
+++ b/js/tests/unit/util/focustrap.spec.js
@@ -115,6 +115,40 @@ describe('FocusTrap', () => {
       })
     })
 
+    it('should wrap focus around forward on tab when focus lands on the document', () => {
+      fixtureEl.innerHTML = [
+        '<div id="focustrap" tabindex="-1">',
+        '  <a href="#" id="first">first</a>',
+        '  <a href="#" id="inside">inside</a>',
+        '  <a href="#" id="last">last</a>',
+        '</div>'
+      ].join('')
+
+      const trapElement = fixtureEl.querySelector('div')
+      const focustrap = new FocusTrap({ trapElement })
+      focustrap.activate()
+
+      const first = document.getElementById('first')
+      const inside = document.getElementById('inside')
+      const last = document.getElementById('last')
+
+      spyOn(SelectorEngine, 'focusableChildren').and.callFake(() => [first, inside, last])
+      const spy = spyOn(first, 'focus')
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'Tab'
+      document.dispatchEvent(keydown)
+
+      const focusInEvent = createEvent('focusin', { bubbles: true })
+      Object.defineProperty(focusInEvent, 'target', {
+        value: document
+      })
+
+      document.dispatchEvent(focusInEvent)
+
+      expect(spy).toHaveBeenCalled()
+    })
+
     it('should wrap focus around backwards on shift-tab', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

Treat focus landing on `document` as focus escaping the active trap, so the existing FocusTrap wrap logic can move focus back to the first focusable child.

Previously, tabbing forward from a modal/offcanvas placed at the end of the document could leave focus on `document`, and FocusTrap returned early before wrapping.

### Motivation & Context

Fixes #42503.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

N/A; this changes JavaScript focus behavior only.

### Related issues

Fixes #42503.

### Testing

- `npm run js-test-karma -- --browsers ChromeHeadless`
- `npx eslint --report-unused-disable-directives js/src/util/focustrap.js js/tests/unit/util/focustrap.spec.js`
- `git diff --check`

Note: the Karma command exited successfully with 810/810 tests passing, but still printed `Some of your tests did a full page reload!` after the success summary.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
