### PR TITLE
Dispose existing instance when a component is re-instantiated on an element

### DIFF
--- a/js/src/base-component.js
+++ b/js/src/base-component.js
@@ -32,6 +32,13 @@ class BaseComponent extends Config {
     this._element = element
     this._config = this._getConfig(config)
 
+    // Dispose any existing instance bound to this element before registering the new one,
+    // so its event listeners and timers are cleaned up instead of leaking
+    const existingInstance = Data.get(this._element, this.constructor.DATA_KEY)
+    if (existingInstance) {
+      existingInstance.dispose()
+    }
+
     Data.set(this._element, this.constructor.DATA_KEY, this)
   }
 
@@ -47,7 +54,14 @@ class BaseComponent extends Config {
 
   // Private
   _queueCallback(callback, element, isAnimated = true) {
-    executeAfterTransition(callback, element, isAnimated)
+    executeAfterTransition(() => {
+      // Don't run the completion callback if the instance was disposed mid-transition
+      if (!this._element) {
+        return
+      }
+
+      callback()
+    }, element, isAnimated)
   }
 
   _getConfig(config) {

--- a/js/tests/unit/alert.spec.js
+++ b/js/tests/unit/alert.spec.js
@@ -18,9 +18,9 @@ describe('Alert', () => {
 
     const alertEl = fixtureEl.querySelector('.alert')
     const alertBySelector = new Alert('.alert')
-    const alertByElement = new Alert(alertEl)
-
     expect(alertBySelector._element).toEqual(alertEl)
+
+    const alertByElement = new Alert(alertEl)
     expect(alertByElement._element).toEqual(alertEl)
   })
 

--- a/js/tests/unit/base-component.spec.js
+++ b/js/tests/unit/base-component.spec.js
@@ -93,6 +93,19 @@ describe('Base Component', () => {
         expect(elInstance._element).not.toBeDefined()
         expect(selectorInstance._element).not.toBeDefined()
       })
+
+      it('should dispose an existing instance when re-instantiated on the same element', () => {
+        fixtureEl.innerHTML = '<div id="foo"></div>'
+
+        const el = fixtureEl.querySelector('#foo')
+        const firstInstance = new DummyClass(el)
+        const disposeSpy = spyOn(firstInstance, 'dispose').and.callThrough()
+        const secondInstance = new DummyClass(el)
+
+        expect(disposeSpy).toHaveBeenCalled()
+        expect(DummyClass.getInstance(el)).toEqual(secondInstance)
+        expect(DummyClass.getInstance(el)).not.toEqual(firstInstance)
+      })
     })
 
     describe('dispose', () => {
@@ -113,6 +126,21 @@ describe('Base Component', () => {
         instance.dispose()
 
         expect(spy).toHaveBeenCalledWith(element, DummyClass.EVENT_KEY)
+      })
+
+      it('should not run a queued transition callback once the instance is disposed', () => {
+        return new Promise(resolve => {
+          createInstance()
+          const callbackSpy = jasmine.createSpy('callback')
+
+          instance._queueCallback(callbackSpy, element, true)
+          instance.dispose()
+
+          setTimeout(() => {
+            expect(callbackSpy).not.toHaveBeenCalled()
+            resolve()
+          }, 50)
+        })
       })
     })
 

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -16,9 +16,9 @@ describe('Button', () => {
     fixtureEl.innerHTML = '<button data-bs-toggle="button">Placeholder</button>'
     const buttonEl = fixtureEl.querySelector('[data-bs-toggle="button"]')
     const buttonBySelector = new Button('[data-bs-toggle="button"]')
-    const buttonByElement = new Button(buttonEl)
-
     expect(buttonBySelector._element).toEqual(buttonEl)
+
+    const buttonByElement = new Button(buttonEl)
     expect(buttonByElement._element).toEqual(buttonEl)
   })
 

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -145,9 +145,9 @@ describe('Carousel', () => {
 
       const carouselEl = fixtureEl.querySelector('#myCarousel')
       const carouselBySelector = new Carousel('#myCarousel')
-      const carouselByElement = new Carousel(carouselEl)
-
       expect(carouselBySelector._element).toEqual(carouselEl)
+
+      const carouselByElement = new Carousel(carouselEl)
       expect(carouselByElement._element).toEqual(carouselEl)
     })
 

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -37,9 +37,9 @@ describe('Collapse', () => {
 
       const collapseEl = fixtureEl.querySelector('div.my-collapse')
       const collapseBySelector = new Collapse('div.my-collapse')
-      const collapseByElement = new Collapse(collapseEl)
-
       expect(collapseBySelector._element).toEqual(collapseEl)
+
+      const collapseByElement = new Collapse(collapseEl)
       expect(collapseByElement._element).toEqual(collapseEl)
     })
 

--- a/js/tests/unit/datepicker.spec.js
+++ b/js/tests/unit/datepicker.spec.js
@@ -67,9 +67,9 @@ describe('Datepicker', () => {
 
       const inputEl = fixtureEl.querySelector('#datepickerEl')
       const datepickerBySelector = new Datepicker('#datepickerEl')
-      const datepickerByElement = new Datepicker(inputEl)
-
       expect(datepickerBySelector._element).toEqual(inputEl)
+
+      const datepickerByElement = new Datepicker(inputEl)
       expect(datepickerByElement._element).toEqual(inputEl)
     })
 

--- a/js/tests/unit/dialog.spec.js
+++ b/js/tests/unit/dialog.spec.js
@@ -50,9 +50,9 @@ describe('Dialog', () => {
 
       const dialogEl = fixtureEl.querySelector('.dialog')
       const dialogBySelector = new Dialog('#testDialog')
-      const dialogByElement = new Dialog(dialogEl)
-
       expect(dialogBySelector._element).toEqual(dialogEl)
+
+      const dialogByElement = new Dialog(dialogEl)
       expect(dialogByElement._element).toEqual(dialogEl)
     })
   })

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -53,9 +53,9 @@ describe('Menu', () => {
 
       const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
       const menuBySelector = new Menu('[data-bs-toggle="menu"]')
-      const menuByElement = new Menu(btnMenu)
-
       expect(menuBySelector._element).toEqual(btnMenu)
+
+      const menuByElement = new Menu(btnMenu)
       expect(menuByElement._element).toEqual(btnMenu)
     })
 

--- a/js/tests/unit/nav-overflow.spec.js
+++ b/js/tests/unit/nav-overflow.spec.js
@@ -43,12 +43,11 @@ describe('NavOverflow', () => {
 
       const navEl = fixtureEl.querySelector('[data-bs-toggle="nav-overflow"]')
       const navBySelector = new NavOverflow('[data-bs-toggle="nav-overflow"]')
-      const navByElement = new NavOverflow(navEl)
-
       expect(navBySelector._element).toEqual(navEl)
+
+      const navByElement = new NavOverflow(navEl)
       expect(navByElement._element).toEqual(navEl)
 
-      navBySelector.dispose()
       navByElement.dispose()
     })
 

--- a/js/tests/unit/otp-input.spec.js
+++ b/js/tests/unit/otp-input.spec.js
@@ -52,9 +52,9 @@ describe('OtpInput', () => {
 
       const otpEl = fixtureEl.querySelector('.otp')
       const otpBySelector = new OtpInput('.otp')
-      const otpByElement = new OtpInput(otpEl)
-
       expect(otpBySelector._element).toEqual(otpEl)
+
+      const otpByElement = new OtpInput(otpEl)
       expect(otpByElement._element).toEqual(otpEl)
     })
 

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -100,9 +100,9 @@ describe('ScrollSpy', () => {
 
       const sSpyEl = fixtureEl.querySelector('.content')
       const sSpyBySelector = new ScrollSpy('.content')
-      const sSpyByElement = new ScrollSpy(sSpyEl)
-
       expect(sSpyBySelector._element).toEqual(sSpyEl)
+
+      const sSpyByElement = new ScrollSpy(sSpyEl)
       expect(sSpyByElement._element).toEqual(sSpyEl)
     })
 

--- a/js/tests/unit/strength.spec.js
+++ b/js/tests/unit/strength.spec.js
@@ -71,9 +71,9 @@ describe('Strength', () => {
 
       const strengthEl = fixtureEl.querySelector('.strength')
       const strengthBySelector = new Strength('.strength')
-      const strengthByElement = new Strength(strengthEl)
-
       expect(strengthBySelector._element).toEqual(strengthEl)
+
+      const strengthByElement = new Strength(strengthEl)
       expect(strengthByElement._element).toEqual(strengthEl)
     })
 

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -33,9 +33,9 @@ describe('Tab', () => {
 
       const tabEl = fixtureEl.querySelector('[href="#home"]')
       const tabBySelector = new Tab('[href="#home"]')
-      const tabByElement = new Tab(tabEl)
-
       expect(tabBySelector._element).toEqual(tabEl)
+
+      const tabByElement = new Tab(tabEl)
       expect(tabByElement._element).toEqual(tabEl)
     })
 

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -32,9 +32,9 @@ describe('Toast', () => {
 
       const toastEl = fixtureEl.querySelector('.toast')
       const toastBySelector = new Toast('.toast')
-      const toastByElement = new Toast(toastEl)
-
       expect(toastBySelector._element).toEqual(toastEl)
+
+      const toastByElement = new Toast(toastEl)
       expect(toastByElement._element).toEqual(toastEl)
     })
 

--- a/js/tests/unit/toggler.spec.js
+++ b/js/tests/unit/toggler.spec.js
@@ -24,9 +24,9 @@ describe('Toggler', () => {
 
       const togglerEl = fixtureEl.querySelector('[data-bs-toggle="toggler"]')
       const togglerBySelector = new Toggler('[data-bs-toggle="toggler"]')
-      const togglerByElement = new Toggler(togglerEl)
-
       expect(togglerBySelector._element).toEqual(togglerEl)
+
+      const togglerByElement = new Toggler(togglerEl)
       expect(togglerByElement._element).toEqual(togglerEl)
     })
   })

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -62,9 +62,9 @@ describe('Tooltip', () => {
 
       const tooltipEl = fixtureEl.querySelector('#tooltipEl')
       const tooltipBySelector = new Tooltip('#tooltipEl')
-      const tooltipByElement = new Tooltip(tooltipEl)
-
       expect(tooltipBySelector._element).toEqual(tooltipEl)
+
+      const tooltipByElement = new Tooltip(tooltipEl)
       expect(tooltipByElement._element).toEqual(tooltipEl)
     })
 


### PR DESCRIPTION
### Description

Bootstrap's instances registry allows only one instance per element. But when the **same** component is constructed twice on one element (e.g. `new Toast(el)` while a Toast already exists), `Data.set` silently overwrote the registry entry — the old instance was never torn down, so its event listeners and timers stayed attached to the DOM as an unreachable "ghost", causing double-firing events and hard-to-debug side effects.

This makes re-instantiation **dispose the existing instance first**, then register the new one. The observable contract is unchanged (`getInstance()` still returns the newest instance — as it did with the old overwrite), but the previous instance is now properly cleaned up instead of leaking. `getOrCreateInstance()` is unaffected since it checks `getInstance()` first.

While fixing this, the same change surfaced a second, pre-existing defect: disposing a component **mid-transition** leaves the queued `executeAfterTransition` completion callback to fire afterward against a now-nulled `_element`, throwing `this._element is null` (#41473). Since every component routes its transition completion through `BaseComponent._queueCallback`, this guards that single method to skip the completion callback once the instance has been disposed — fixing it for all components (Collapse, Drawer, Dialog, Modal, Toast, Tab, Tooltip, Alert) at once.

### Motivation & Context

Accidental re-use of a component constructor (e.g. `new Toast(el)`) leads to orphaned instances and a variety of unexpected runtime errors. This is the approach the maintainers settled on in the discussion under #37442 / #37584 (dispose the previous instance rather than refusing the new one). The transition-callback guard additionally resolves the long-standing `dispose()`-mid-transition crash reported in #41473.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Related issues

Closes #37245
Closes #41473
rel: #37442, #37584

### Notes for reviewers

- The 15 component "should take care of element either passed as a CSS selector or DOM element" unit tests instantiated twice on the same element and asserted the *first* instance stayed live. They've been reordered to assert the selector-form's `_element` before the element-form construction disposes it — the test intent (both input forms resolve correctly) is preserved.
- Two new regression tests in `base-component.spec.js` cover re-instantiation disposal and the disposed-mid-transition callback guard (both verified to fail without the source changes).
- Verified with the full `js-test` suite green across repeated runs (jasmine random order), `1091 SUCCESS`, lint clean.
