### PR TITLE
Fix carousel docs index argument type

### DIFF
--- a/site/src/content/docs/getting-started/javascript.mdx
+++ b/site/src/content/docs/getting-started/javascript.mdx
@@ -174,11 +174,11 @@ const myCarouselEl = document.querySelector('#myCarousel')
 const carousel = bootstrap.Carousel.getInstance(myCarouselEl) // Retrieve a Carousel instance
 
 myCarouselEl.addEventListener('slid.bs.carousel', event => {
-  carousel.to('2') // Will slide to the slide 2 as soon as the transition to slide 1 is finished
+  carousel.to(2) // Will slide to the slide 2 as soon as the transition to slide 1 is finished
 })
 
-carousel.to('1') // Will start sliding to the slide 1 and returns to the caller
-carousel.to('2') // !! Will be ignored, as the transition to the slide 1 is not finished !!
+carousel.to(1) // Will start sliding to the slide 1 and returns to the caller
+carousel.to(2) // !! Will be ignored, as the transition to the slide 1 is not finished !!
 ```
 
 #### `dispose` method


### PR DESCRIPTION
### Description

Updates the asynchronous methods example so `carousel.to()` receives numeric slide indexes instead of string values.

### Motivation & Context

The Carousel API describes `to` as targeting a zero-based frame index, and the unit tests use numeric indexes. The getting started example currently uses string arguments, which can imply a different call shape.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

Checks run:

```bash
git diff --check
npm exec --yes --package prettier@3.8.3 -- prettier --config site/.prettierrc.json -c site/src/content/docs/getting-started/javascript.mdx
```

#### Live previews

- Netlify deploy preview will be available after the PR is created.

### Related issues

Closes #41650
