### PR TITLE
Fix list group action item color

### DIFF
--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -187,6 +187,7 @@
     --#{$prefix}list-group-color: var(--#{$prefix}#{$state}-text-emphasis);
     --#{$prefix}list-group-bg: var(--#{$prefix}#{$state}-bg-subtle);
     --#{$prefix}list-group-border-color: var(--#{$prefix}#{$state}-border-subtle);
+    --#{$prefix}list-group-action-color: var(--#{$prefix}list-group-color);
     --#{$prefix}list-group-action-hover-color: var(--#{$prefix}emphasis-color);
     --#{$prefix}list-group-action-hover-bg: var(--#{$prefix}#{$state}-border-subtle);
     --#{$prefix}list-group-action-active-color: var(--#{$prefix}emphasis-color);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1600,7 +1600,7 @@ $list-group-active-border-color:    $list-group-active-bg !default;
 $list-group-disabled-color:         var(--#{$prefix}secondary-color) !default;
 $list-group-disabled-bg:            $list-group-bg !default;
 
-$list-group-action-color:           var(--#{$prefix}secondary-color) !default;
+$list-group-action-color:           var(--#{$prefix}list-group-color) !default;
 $list-group-action-hover-color:     var(--#{$prefix}emphasis-color) !default;
 
 $list-group-action-active-color:    var(--#{$prefix}body-color) !default;

--- a/scss/tests/components/_list-group.test.scss
+++ b/scss/tests/components/_list-group.test.scss
@@ -1,0 +1,19 @@
+@import "../../functions";
+@import "../../variables";
+
+@include describe("list group variables") {
+  @include it("uses the regular item color for action items") {
+    @include assert-equal(
+      $list-group-action-color,
+      var(--#{$prefix}list-group-color),
+      "Action items should inherit the regular list group item color"
+    );
+  }
+
+  @include it("keeps action items visually distinct from disabled items") {
+    @include assert-true(
+      $list-group-action-color != $list-group-disabled-color,
+      "Action items should not use the disabled list group color"
+    );
+  }
+}


### PR DESCRIPTION
## Description

Fixes #41725.

List group action items and disabled items both resolved to the secondary text color, which made enabled action items look disabled in the links/buttons example, especially in dark mode.

This changes the action item color variable to follow the regular list group item color instead. Default action items now use the normal list group text color, contextual list group variants continue to inherit their variant text color through `--bs-list-group-color`, and disabled items keep using the disabled color.

No generated `dist/` files are committed.

## Testing

- `npm run css-test` (48 specs, 0 failures)
- `npx stylelint scss/_variables.scss scss/tests/components/_list-group.test.scss`
- `npm run css-lint-stylelint`
- `npm run css-lint-vars`
- `npx sass --style expanded --no-source-map scss/bootstrap.scss /tmp/bootstrap-41725.css`
- `git diff --check`
