### PR TITLE
Use min/max width to prevent Close button collapsing in flex containers

### DIFF
--- a/scss/buttons/_close.scss
+++ b/scss/buttons/_close.scss
@@ -31,8 +31,8 @@ $btn-close-tokens: defaults(
     @include tokens($btn-close-tokens);
 
     box-sizing: content-box;
-    width: var(--btn-close-size);
-    height: var(--btn-close-size);
+    min-width: var(--btn-close-size);
+    min-height: var(--btn-close-size);
     padding: 0;
     color: var(--btn-close-color);
     background-color: currentcolor;


### PR DESCRIPTION
### Context

In [Alert > Dismiss](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/#dismiss), if the content more than one line, and is big, there's a rendering issue with the close button:

<img width="841" height="104" alt="Screenshot 2026-06-16 at 21 30 46" src="https://github.com/user-attachments/assets/d26d59d5-3c2b-413f-aab7-3cdf083e9a33" />

However, when we use a regular button, or an icon button, the rendering turns out OK:

<img width="842" height="129" alt="Screenshot 2026-06-16 at 21 28 39" src="https://github.com/user-attachments/assets/59fa66da-4d39-4d76-b679-6c2790276d0b" />
<img width="840" height="123" alt="Screenshot 2026-06-16 at 21 29 18" src="https://github.com/user-attachments/assets/6bf9df4b-5f9b-43fe-95ee-499e6c61a76c" />

### Fix

The close button used `width` and `height` set to `--btn-close-size (1.5rem)`. These hard dimensions seems to be ignored as a minimum constraint by flex, as a flex container can shrink the button below that size when its flex-shrink kicks in.

Replacing `width`/`height` with `min-width`/`min-height` ensures the button never collapses below its intended size in any flex layout (e.g. alert dismiss rows, drawer headers), while still allowing it to grow if needed.

<img width="844" height="129" alt="Screenshot 2026-06-16 at 21 31 16" src="https://github.com/user-attachments/assets/0dcff3b7-8d60-4af9-9774-6e74b36af4f5" />

### Non-regression testing

I've quickly looked at components and docs using this Close button and haven't spotted any issues, but it might worth double-check.

#### Live previews

- https://deploy-preview-42518--twbs-bootstrap.netlify.app/docs/6.0/components/alert/#dismiss

