### PR TITLE
feat(a11y): use `list-style-type: ""` instead of `list-style: none`

### DIFF
--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -39,7 +39,7 @@ $breadcrumb-tokens: defaults(
     align-items: center;
     padding: var(--breadcrumb-padding-y, 0) var(--breadcrumb-padding-x, 0);
     font-size: var(--breadcrumb-font-size);
-    list-style: none;
+    list-style-type: "";
     background-color: var(--breadcrumb-bg);
     @include border-radius(var(--breadcrumb-border-radius));
   }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -39,7 +39,7 @@ $list-group-tokens: defaults(
     display: flex;
     flex-direction: column;
 
-    // No need to set list-style: none; since .list-group-item is block level
+    // No need to set list-style-type: ""; since .list-group-item is block level
     padding-inline-start: 0; // reset padding because ul and ol
     margin-bottom: 0;
     @include border-radius(var(--list-group-border-radius));

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -71,7 +71,7 @@ $menu-tokens: defaults(
     font-size: var(--menu-font-size);
     color: var(--menu-color);
     text-align: start;
-    list-style: none;
+    list-style-type: "";
     background-color: var(--menu-bg);
     background-clip: padding-box;
     border: var(--menu-border-width, var(--border-width)) solid var(--menu-border-color, var(--border-color-translucent));

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -97,7 +97,7 @@ $nav-underline-tokens: defaults(
     gap: var(--nav-gap);
     padding-inline-start: 0;
     margin-bottom: 0;
-    list-style: none;
+    list-style-type: "";
   }
 
   .nav-item {

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -153,7 +153,7 @@ $navbar-nav-tokens: defaults(
     gap: var(--nav-gap);
     padding-inline-start: 0;
     margin-bottom: 0;
-    list-style: none;
+    list-style-type: "";
 
     .nav-link {
       &.active,

--- a/scss/_stepper.scss
+++ b/scss/_stepper.scss
@@ -61,7 +61,7 @@ $stepper-tokens: defaults(
     grid-auto-flow: row;
     gap: var(--stepper-gap);
     padding-inline-start: 0;
-    list-style: none;
+    list-style-type: "";
     counter-reset: stepper;
   }
 

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -3,5 +3,5 @@
 // Unstyled keeps list items block level, just removes default browser padding and list-style
 @mixin list-unstyled {
   padding-inline-start: 0;
-  list-style: none;
+  list-style-type: "";
 }

--- a/site/src/scss/_search.scss
+++ b/site/src/scss/_search.scss
@@ -193,7 +193,7 @@ bd-search-results {
 
   gap: var(--spacer-2);
   padding-block-start: var(--spacer-1);
-  list-style: none;
+  list-style-type: "";
 }
 
 .bd-search-result {


### PR DESCRIPTION
### Description

Replace `list-style: none` with `list-style-type: ""` on list containers.

This ports twbs/bootstrap#41778 to the v6 branch.

### Motivation & Context

In Safari, `list-style: none` removes the element's semantic list role, so lists are no longer announced as such by screen readers. Using `list-style-type: ""` produces the same visual result (no markers) while preserving the list semantics. See [Manuel Matuzović's write-up](https://www.matuzo.at/blog/2023/removing-list-styles-without-affecting-semantics).

### What changed

Applied to genuine `<ul>`/`<ol>` containers:

- `scss/_breadcrumb.scss`, `scss/_nav.scss`, `scss/_navbar.scss`, `scss/mixins/_lists.scss` (the `list-unstyled` mixin), and the `_list-group.scss` comment — direct equivalents of the upstream PR
- `scss/_menu.scss` — v6's renamed `_dropdown.scss`
- `scss/_stepper.scss` and `site/src/scss/_search.scss` — new v6 list containers with the same rationale

Intentionally **not** changed (these use `list-style: none` to remove the `<summary>` disclosure marker, not for lists):

- `scss/_accordion.scss` (`.accordion-header`)
- `site/src/scss/_details.scss` (`.bd-details-summary`)

`site/src/scss/_toc.scss` needs no change — it already routes through the `list-unstyled` mixin.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)