### PR TITLE
Fix dropdown form child clicks

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -376,8 +376,12 @@ class Dropdown extends BaseComponent {
         continue
       }
 
+      const isFormChild = event.target && typeof event.target.closest === 'function' &&
+        event.target.closest('form')
+
       // Tab navigation through the dropdown menu or events from contained inputs shouldn't close the menu
-      if (context._menu.contains(event.target) && ((event.type === 'keyup' && event.key === TAB_KEY) || /input|select|option|textarea|form/i.test(event.target.tagName))) {
+      if (context._menu.contains(event.target) && ((event.type === 'keyup' && event.key === TAB_KEY) ||
+        /input|select|option|textarea|form/i.test(event.target.tagName) || isFormChild)) {
         continue
       }
 

--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -376,8 +376,9 @@ class Dropdown extends BaseComponent {
         continue
       }
 
-      const isFormChild = event.target && typeof event.target.closest === 'function' &&
+      const closestForm = event.target && typeof event.target.closest === 'function' &&
         event.target.closest('form')
+      const isFormChild = closestForm && context._menu.contains(closestForm)
 
       // Tab navigation through the dropdown menu or events from contained inputs shouldn't close the menu
       if (context._menu.contains(event.target) && ((event.type === 'keyup' && event.key === TAB_KEY) ||

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1875,6 +1875,39 @@ describe('Dropdown', () => {
       })
     })
 
+    it('should not close the dropdown if the user clicks on a form label within dropdown-menu', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+          '  <div class="dropdown-menu">',
+          '    <form>',
+          '      <label for="dropdown-input">Label</label>',
+          '      <input id="dropdown-input" type="text">',
+          '    </form>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const triggerDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const label = fixtureEl.querySelector('label')
+
+        triggerDropdown.addEventListener('shown.bs.dropdown', () => {
+          expect(triggerDropdown).toHaveClass('show')
+          label.dispatchEvent(createEvent('click', {
+            bubbles: true
+          }))
+
+          setTimeout(() => {
+            expect(triggerDropdown).toHaveClass('show')
+            resolve()
+          })
+        })
+
+        triggerDropdown.click()
+      })
+    })
+
     it('should close the dropdown if the user clicks on a text field that is not contained within dropdown-menu', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
@@ -1896,6 +1929,37 @@ describe('Dropdown', () => {
 
         triggerDropdown.addEventListener('shown.bs.dropdown', () => {
           input.dispatchEvent(createEvent('click', {
+            bubbles: true
+          }))
+        })
+
+        triggerDropdown.click()
+      })
+    })
+
+    it('should close the dropdown if the user clicks on a form label that is not contained within dropdown-menu', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button class="btn dropdown-toggle" data-bs-toggle="dropdown">Dropdown</button>',
+          '  <div class="dropdown-menu"></div>',
+          '</div>',
+          '<form>',
+          '  <label for="outside-input">Label</label>',
+          '  <input id="outside-input" type="text">',
+          '</form>'
+        ].join('')
+
+        const triggerDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const label = fixtureEl.querySelector('label')
+
+        triggerDropdown.addEventListener('hidden.bs.dropdown', () => {
+          expect(triggerDropdown).not.toHaveClass('show')
+          resolve()
+        })
+
+        triggerDropdown.addEventListener('shown.bs.dropdown', () => {
+          label.dispatchEvent(createEvent('click', {
             bubbles: true
           }))
         })

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1968,6 +1968,38 @@ describe('Dropdown', () => {
       })
     })
 
+    it('should close the dropdown if the user clicks a menu item within an outer form', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<form>',
+          '  <div class="dropdown">',
+          '    <button class="btn dropdown-toggle" data-bs-toggle="dropdown" type="button">Dropdown</button>',
+          '    <div class="dropdown-menu">',
+          '      <button class="dropdown-item" type="button">Secondary item</button>',
+          '    </div>',
+          '  </div>',
+          '</form>'
+        ].join('')
+
+        const triggerDropdown = fixtureEl.querySelector('[data-bs-toggle="dropdown"]')
+        const item = fixtureEl.querySelector('.dropdown-item')
+
+        triggerDropdown.addEventListener('hidden.bs.dropdown', () => {
+          expect(triggerDropdown).not.toHaveClass('show')
+          resolve()
+        })
+
+        triggerDropdown.addEventListener('shown.bs.dropdown', () => {
+          expect(triggerDropdown).toHaveClass('show')
+          item.dispatchEvent(createEvent('click', {
+            bubbles: true
+          }))
+        })
+
+        triggerDropdown.click()
+      })
+    })
+
     it('should ignore keyboard events for <input>s and <textarea>s within dropdown-menu, except for escape key', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

Keeps dropdowns open when clicking elements inside a form within a dropdown menu, such as a label associated with an input.

### Motivation & Context

Fixes #41803. Bootstrap already keeps dropdowns open for direct input, select, option, textarea, and form clicks inside the menu. This extends that behavior to descendants of forms, matching the expected behavior for form controls and labels embedded in dropdown menus.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

N/A

### Related issues

Fixes #41803

### Testing

- `npm run js-lint -- --quiet`
- `npm run js-test-karma -- --browsers ChromeHeadless` (811 specs passing)