### PR TITLE
Drop deprecated `.navbar-dark` remaining usage

### DIFF
--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -10,7 +10,7 @@
     </style>
   </head>
   <body data-bs-spy="scroll" data-bs-target=".navbar" data-bs-offset="70">
-    <nav class="navbar md:navbar-expand navbar-dark bg-dark fixed-top">
+    <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
       <a class="navbar-brand" href="#">Scrollspy test</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/site/src/assets/examples/carousel/index.astro
+++ b/site/src/assets/examples/carousel/index.astro
@@ -5,7 +5,7 @@ import Placeholder from "@shortcodes/Placeholder.astro"
 ---
 
 <header data-bs-theme="dark">
-  <nav class="navbar md:navbar-expand navbar-dark fixed-top bg-dark">
+  <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Carousel</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/site/src/assets/examples/cheatsheet/index.astro
+++ b/site/src/assets/examples/cheatsheet/index.astro
@@ -1217,7 +1217,7 @@ export const body_class = 'bg-body-tertiary'
             </div>
           </nav>
 
-          <nav class="navbar lg:navbar-expand navbar-dark bg-primary mt-5">
+          <nav class="navbar lg:navbar-expand bg-primary mt-5" data-bs-theme="dark">
             <div class="container-fluid">
               <a class="navbar-brand" href="#">
                 <img src="${getVersionedDocsPath('/assets/brand/bootstrap-logo-white.svg')}" width="38" height="30" class="d-inline-block align-top" alt="Bootstrap" loading="lazy">

--- a/site/src/assets/examples/drawer-navbar/index.astro
+++ b/site/src/assets/examples/drawer-navbar/index.astro
@@ -9,7 +9,7 @@ export const aliases = '/docs/[[config:docs_version]]/examples/drawer/'
 import Placeholder from "@shortcodes/Placeholder.astro"
 ---
 
-<nav class="navbar lg:navbar-expand fixed-top navbar-dark bg-dark" aria-label="Main navigation">
+<nav class="navbar lg:navbar-expand fixed-top" data-bs-theme="dark" aria-label="Main navigation">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Drawer navbar</a>
     <button class="navbar-toggler p-0 border-0" type="button" id="navbarSideCollapse" aria-label="Toggle navigation">

--- a/site/src/assets/examples/navbar-bottom/index.astro
+++ b/site/src/assets/examples/navbar-bottom/index.astro
@@ -11,7 +11,7 @@ export const title = 'Bottom navbar example'
     <a class="btn-solid theme-primary btn-lg" href={getVersionedDocsPath('/components/navbar')} role="button">View navbar docs &raquo;</a>
   </div>
 </main>
-<nav class="navbar fixed-bottom sm:navbar-expand navbar-dark bg-dark">
+<nav class="navbar fixed-bottom sm:navbar-expand" data-bs-theme="dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Bottom navbar</a>
     <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/site/src/assets/examples/navbars-drawer/index.astro
+++ b/site/src/assets/examples/navbars-drawer/index.astro
@@ -6,7 +6,7 @@ export const extra_css = ['navbars-drawer.css']
 ---
 
 <main>
-  <nav class="navbar navbar-dark bg-dark" aria-label="Dark drawer navbar">
+  <nav class="navbar" data-bs-theme="dark" aria-label="Dark drawer navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Dark drawer navbar</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbarDark" aria-controls="drawerNavbarDark" aria-label="Toggle navigation">
@@ -86,7 +86,7 @@ export const extra_css = ['navbars-drawer.css']
     </div>
   </nav>
 
-  <nav class="navbar lg:navbar-expand navbar-dark bg-dark" aria-label="Drawer navbar large">
+  <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Drawer navbar large">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Responsive drawer navbar</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#drawerNavbar2" aria-controls="drawerNavbar2" aria-label="Toggle navigation">

--- a/site/src/assets/examples/navbars/index.astro
+++ b/site/src/assets/examples/navbars/index.astro
@@ -233,7 +233,7 @@ export const extra_css = ['navbars.css']
     </div>
   </nav>
 
-  <nav class="navbar lg:navbar-expand navbar-dark bg-dark" aria-label="Eighth navbar example">
+  <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Eighth navbar example">
     <div class="container">
       <a class="navbar-brand" href="#">Container</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample07" aria-controls="navbarsExample07" aria-expanded="false" aria-label="Toggle navigation">
@@ -267,7 +267,7 @@ export const extra_css = ['navbars.css']
     </div>
   </nav>
 
-  <nav class="navbar lg:navbar-expand navbar-dark bg-dark" aria-label="Ninth navbar example">
+  <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Ninth navbar example">
     <div class="xl:container">
       <a class="navbar-brand" href="#">Container XL</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample07XL" aria-controls="navbarsExample07XL" aria-expanded="false" aria-label="Toggle navigation">
@@ -305,7 +305,7 @@ export const extra_css = ['navbars.css']
     <p>Matching .xl:container...</p>
   </div>
 
-  <nav class="navbar lg:navbar-expand navbar-dark bg-dark" aria-label="Tenth navbar example">
+  <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Tenth navbar example">
     <div class="container-fluid">
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample08" aria-controls="navbarsExample08" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>

--- a/site/src/assets/examples/sticky-footer-navbar/index.astro
+++ b/site/src/assets/examples/sticky-footer-navbar/index.astro
@@ -9,7 +9,7 @@ export const body_class = 'd-flex flex-column h-100'
 
 <header>
   <!-- Fixed navbar -->
-  <nav class="navbar md:navbar-expand navbar-dark fixed-top bg-dark">
+  <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Fixed navbar</a>
       <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
### Description

Spotted by https://github.com/twbs/bootstrap/pull/42487.

The `.navbar-dark` class is now deprecated, and the association `.navbar-dark` + `.bg-dark` can be replaced with `data-bs-theme="dark"` directly.

The change is applied to all files.

No need to mention in the migration guide, as it was already deprecated in v5.3.0, I suppose.

#### Live previews

- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/carousel/
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/cheatsheet
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/drawer-navbar
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/navbar-bottom
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/navbars-drawer
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/navbars
- https://deploy-preview-42530--twbs-bootstrap.netlify.app/docs/6.0/examples/sticky-footer-navbar
