### PR TITLE
Fix visual JavaScript tests to load `bootstrap.bundle.js` as a module

### DIFF
--- a/js/tests/visual/alert.html
+++ b/js/tests/visual/alert.html
@@ -47,6 +47,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/button.html
+++ b/js/tests/visual/button.html
@@ -44,6 +44,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/carousel.html
+++ b/js/tests/visual/carousel.html
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       let t0
       let t1

--- a/js/tests/visual/collapse.html
+++ b/js/tests/visual/collapse.html
@@ -71,6 +71,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/datepicker.html
+++ b/js/tests/visual/datepicker.html
@@ -111,7 +111,7 @@
 
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       /* global bootstrap: false */
 

--- a/js/tests/visual/dialog.html
+++ b/js/tests/visual/dialog.html
@@ -174,7 +174,7 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       /* global bootstrap: false */
 

--- a/js/tests/visual/floating-label.html
+++ b/js/tests/visual/floating-label.html
@@ -388,6 +388,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/input.html
+++ b/js/tests/visual/input.html
@@ -73,6 +73,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/menu-submenu.html
+++ b/js/tests/visual/menu-submenu.html
@@ -473,6 +473,6 @@
       </section>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/menu.html
+++ b/js/tests/visual/menu.html
@@ -199,6 +199,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/popover.html
+++ b/js/tests/visual/popover.html
@@ -31,7 +31,7 @@
       </button>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       /* global bootstrap: false */
 

--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -95,6 +95,6 @@
       <p>Ad leggings keytar, brunch id art party dolor labore.</p>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/tab.html
+++ b/js/tests/visual/tab.html
@@ -218,6 +218,6 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
   </body>
 </html>

--- a/js/tests/visual/toast.html
+++ b/js/tests/visual/toast.html
@@ -50,7 +50,7 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       /* global bootstrap: false */
 

--- a/js/tests/visual/tooltip.html
+++ b/js/tests/visual/tooltip.html
@@ -83,7 +83,7 @@
       </div>
     </div>
 
-    <script src="../../../dist/js/bootstrap.bundle.js"></script>
+    <script src="../../../dist/js/bootstrap.bundle.js" type="module"></script>
     <script>
       /* global bootstrap: false */
 


### PR DESCRIPTION
### Description

This PR fixes our visual JavaScript tests to correctly load `bootstrap.bundle.js` as a module by adding `type="module"`. For instance, when loading http://127.0.0.1:8080/js/tests/visual/menu-submenu.html, the menus were not working at all.
