### PR TITLE
Drop deprecated `.m-{breakpoint}` remaining usage

### DIFF
--- a/js/tests/visual/menu-submenu.html
+++ b/js/tests/visual/menu-submenu.html
@@ -229,7 +229,7 @@
               <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarSubmenu">
-              <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <ul class="navbar-nav me-auto mb-2 lg:mb-0">
                 <li class="nav-item">
                   <a class="nav-link active" aria-current="page" href="#">Home</a>
                 </li>


### PR DESCRIPTION
### Description

Spotted by https://github.com/twbs/bootstrap/pull/42487.

This PR replaces deprecated `.m-{breakpoint}-*` remaining usage with `{breakpoint}:m-** classes.
