### PR TITLE
Dialog/Drawer: lock scroll on the root element to prevent layout shift

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "82.5 kB"
+      "maxSize": "82.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "53.75 kB"
+      "maxSize": "54.0 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",

--- a/js/src/dialog-base.js
+++ b/js/src/dialog-base.js
@@ -159,7 +159,11 @@ class DialogBase extends BaseComponent {
     }
 
     if (preventBodyScroll) {
-      document.body.classList.add(CLASS_NAME_OPEN)
+      // Lock scroll on the root element (not <body>) so it lands on the same
+      // element that carries `scrollbar-gutter: stable`. Co-locating them keeps
+      // the gutter reserved while the scrollbar is hidden, so the page doesn't
+      // shift (and the ::backdrop covers the gutter instead of leaving a strip).
+      document.documentElement.classList.add(CLASS_NAME_OPEN)
     }
   }
 
@@ -181,15 +185,15 @@ class DialogBase extends BaseComponent {
     }
   }
 
-  // Closes the native <dialog> and tears down body-scroll prevention.
+  // Closes the native <dialog> and tears down scroll prevention.
   // Safe to call multiple times — close() is a no-op on a closed dialog.
   _closeAndCleanup() {
     this._element.close()
     this._openedAsModal = false
 
-    // Only restore body scroll if no other modal dialogs are open
+    // Only restore scroll if no other modal dialogs are open
     if (!document.querySelector('dialog[open]:modal')) {
-      document.body.classList.remove(CLASS_NAME_OPEN)
+      document.documentElement.classList.remove(CLASS_NAME_OPEN)
     }
   }
 

--- a/js/tests/unit/dialog.spec.js
+++ b/js/tests/unit/dialog.spec.js
@@ -15,7 +15,7 @@ describe('Dialog', () => {
   afterEach(() => {
     clearFixture()
     clearBodyAndDocument()
-    document.body.classList.remove('dialog-open')
+    document.documentElement.classList.remove('dialog-open')
 
     for (const dialog of document.querySelectorAll('dialog[open]')) {
       dialog.close()
@@ -94,7 +94,7 @@ describe('Dialog', () => {
 
         dialogEl.addEventListener('shown.bs.dialog', () => {
           expect(dialogEl.open).toBeTrue()
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
           resolve()
         })
 
@@ -251,7 +251,7 @@ describe('Dialog', () => {
 
         dialogEl.addEventListener('hidden.bs.dialog', () => {
           expect(dialogEl.open).toBeFalse()
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
 
@@ -460,8 +460,8 @@ describe('Dialog', () => {
         dialogEl.addEventListener('shown.bs.dialog', () => {
           expect(dialogEl.open).toBeTrue()
           expect(dialogEl.classList.contains('dialog-nonmodal')).toBeTrue()
-          // Non-modal dialogs should not add dialog-open to body
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          // Non-modal dialogs should not add dialog-open to the root element
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
 
@@ -1036,7 +1036,7 @@ describe('Dialog', () => {
   })
 
   describe('stacked modals', () => {
-    it('should keep dialog-open on body when closing one of two open modal dialogs', () => {
+    it('should keep dialog-open on the root element when closing one of two open modal dialogs', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [
           '<dialog id="dialog1" class="dialog"></dialog>',
@@ -1053,18 +1053,18 @@ describe('Dialog', () => {
         })
 
         dialog2El.addEventListener('shown.bs.dialog', () => {
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
           dialog1.hide()
         })
 
         dialog1El.addEventListener('hidden.bs.dialog', () => {
           expect(dialog2El.open).toBeTrue()
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
           dialog2.hide()
         })
 
         dialog2El.addEventListener('hidden.bs.dialog', () => {
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
 

--- a/js/tests/unit/drawer.spec.js
+++ b/js/tests/unit/drawer.spec.js
@@ -16,7 +16,7 @@ describe('Drawer', () => {
 
   afterEach(() => {
     clearFixture()
-    document.body.classList.remove('dialog-open')
+    document.documentElement.classList.remove('dialog-open')
     clearBodyAndDocument()
 
     for (const dialog of document.querySelectorAll('dialog[open]')) {
@@ -255,7 +255,7 @@ describe('Drawer', () => {
   })
 
   describe('options', () => {
-    it('if scroll is enabled, should not add dialog-open class to body', () => {
+    it('if scroll is enabled, should not add dialog-open class to the root element', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<dialog class="drawer"></dialog>'
 
@@ -263,7 +263,7 @@ describe('Drawer', () => {
         const drawer = new Drawer(drawerEl, { scroll: true, backdrop: false })
 
         drawerEl.addEventListener('shown.bs.drawer', () => {
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           drawer.hide()
         })
         drawerEl.addEventListener('hidden.bs.drawer', () => {
@@ -273,7 +273,7 @@ describe('Drawer', () => {
       })
     })
 
-    it('if scroll is disabled, should add dialog-open class to body', () => {
+    it('if scroll is disabled, should add dialog-open class to the root element', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = '<dialog class="drawer"></dialog>'
 
@@ -281,11 +281,11 @@ describe('Drawer', () => {
         const drawer = new Drawer(drawerEl, { scroll: false })
 
         drawerEl.addEventListener('shown.bs.drawer', () => {
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
           drawer.hide()
         })
         drawerEl.addEventListener('hidden.bs.drawer', () => {
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
         drawer.show()

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -59,8 +59,11 @@ $dialog-sizes: defaults(
 // scss-docs-end dialog-sizes
 
 @layer components {
-  // Prevent body scroll when dialog is open
-  .dialog-open {
+  // Prevent page scroll when a dialog is open. Applied to the root element so
+  // `overflow: hidden` sits on the same element as `scrollbar-gutter: stable`
+  // (see _root.scss): the gutter stays reserved while the scrollbar is hidden,
+  // so the page doesn't shift when a dialog opens.
+  :root.dialog-open {
     overflow: hidden;
   }
 

--- a/site/src/content/docs/guides/migration.mdx
+++ b/site/src/content/docs/guides/migration.mdx
@@ -177,7 +177,7 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
   - Data key: `bs.modal` &rarr; `bs.dialog` (affects `Dialog.getInstance()` and `Dialog.getOrCreateInstance()`).
   - CSS variables: `--modal-*` &rarr; `--dialog-*`.
   - Backdrop: The `.modal-backdrop` DOM element and the legacy `util/backdrop` helper are gone — Dialog uses the native `::backdrop` pseudo-element with `backdrop-filter: blur()` support.
-  - Body scroll prevention: `.modal-open` on `<body>` &rarr; `.dialog-open` on the `<body>` element.
+  - Scroll prevention: `.modal-open` on `<body>` &rarr; `.dialog-open` on the root (`<html>`) element, so it pairs with `scrollbar-gutter: stable` and the page doesn't shift when a dialog opens.
   - New variant classes: `.dialog-slide-up`, `.dialog-slide-down` (slide animations), `.dialog-instant` (no animation), `.dialog-static` (static backdrop bounce), `.dialog-nonmodal` (non-modal positioning), `.dialog-scrollable`.
   - Non-modal support: Set `modal: false` or `data-bs-modal="false"` for non-modal dialogs.
   - Dialog swapping: Triggers inside an open dialog can open a new dialog and close the current one automatically.


### PR DESCRIPTION
## Problem

Opening a dialog/drawer can shift page content sideways, and with `scrollbar-gutter: stable` the reserved gutter renders as a bare white strip instead of the dimmed overlay (#40659).

## Cause

`scrollbar-gutter: stable` is on `:root` (`_root.scss`), so the viewport scrollbar and its reserved gutter live on `<html>`. But the scroll-lock applied `overflow: hidden` to `<body>`. Because `<html>`'s overflow is `visible`, the body→viewport overflow-propagation quirk hides the scrollbar at the viewport level while the gutter reservation stays on `<html>` — and in that split state browsers don't reliably honor the gutter, so content reflows and the gutter strip falls outside the native `::backdrop`.

## Fix

Apply the `dialog-open` lock to the **root element** (`<html>`), co-locating `overflow: hidden` with `scrollbar-gutter: stable`. The gutter stays reserved while the scrollbar hides (no shift), and since `<html>` is the viewport scroller the `::backdrop` covers the gutter (no white strip).

- `dialog-base.js`: toggle `dialog-open` on `document.documentElement` instead of `document.body`.
- `_dialog.scss`: scope the rule to `:root.dialog-open`.
- Tests + migration note updated.

Fixes #39221, fixes #39972, fixes #40908, fixes #40659.
