### PR TITLE
docs: clarify form-adorn usage and input type

### DIFF
--- a/site/src/content/docs/forms/form-adorn.mdx
+++ b/site/src/content/docs/forms/form-adorn.mdx
@@ -7,19 +7,19 @@ css_layer: forms
 
 ## How it works
 
-The `.form-adorn` wrapper replicates `.form-control` styling (border, background, focus states) while using flexbox to position adornments alongside a "ghost input," a form control that has virtually no visual styling. The `.form-ghost` input inside is transparent and inherits styles from the wrapper.
+Apply both `.form-control` and `.form-adorn` to a wrapper element. `.form-control` provides the border, background, padding, and focus states; `.form-adorn` uses flexbox to position adornments alongside a "ghost input," a form control that has virtually no visual styling. The `.form-ghost` input inside is transparent and inherits styles from the wrapper.
 
 See the [form control]([[docsref:/forms/form-control]]) documentation for more information on the `.form-control` and `.form-ghost` classes.
 
 ## Example
 
-Wrap an icon and a `.form-ghost` input inside `.form-adorn`. Place the adornment before the input in the DOM for start position (left in LTR).
+Wrap an icon and a `.form-ghost` input inside a `<div>` with `.form-control` and `.form-adorn`. Place the adornment before the input in the DOM for start position (left in LTR).
 
 <Example code={`<div class="form-control form-adorn">
     <div class="form-adorn-icon">
       <svg class="bi" width="16" height="16"><use href="#search" /></svg>
     </div>
-    <input type="text" class="form-ghost" placeholder="Search...">
+    <input type="search" class="form-ghost" placeholder="Search...">
   </div>`} />
 
 Use `.form-adorn-end` to position the adornment on the trailing side (keeps DOM order, uses CSS to flip visually):
@@ -41,7 +41,7 @@ Add a label outside the `.form-adorn` wrapper for proper form semantics:
       <div class="form-adorn-icon">
         <svg class="bi" width="16" height="16"><use href="#search" /></svg>
       </div>
-      <input type="text" class="form-ghost" id="searchInput" placeholder="Search...">
+      <input type="search" class="form-ghost" id="searchInput" placeholder="Search...">
     </div>
   </div>
   <div>
@@ -64,7 +64,7 @@ Wrap a `.form-adorn` in a `.form-field` to pair it with a label and description 
       <div class="form-adorn-icon">
         <svg class="bi" width="16" height="16"><use href="#search" /></svg>
       </div>
-      <input type="text" class="form-ghost" id="adornField" placeholder="Search...">
+      <input type="search" class="form-ghost" id="adornField" placeholder="Search...">
     </div>
     <small class="form-text">Search across all pages and posts.</small>
   </div>`} />


### PR DESCRIPTION
### Description

- Clarify that both .form-control and .form-adorn should be applied to the wrapper and update example markup to use a <div> with those classes.
- Replace input type="text" with type="search" in examples for semantic correctness
- Tweak wording for clarity around .form-ghost and adornment positioning.

### Motivation & Context

make docs good.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42547--twbs-bootstrap.netlify.app/docs/6.0/forms/form-adorn/>

### Related issues

<!-- Please link any related issues here. -->
