### PR TITLE
Examples: remove unused `.text-small`

### DIFF
--- a/site/src/assets/examples/checkout-rtl/index.astro
+++ b/site/src/assets/examples/checkout-rtl/index.astro
@@ -220,7 +220,7 @@ export const body_class = 'bg-body-tertiary'
       </div>
     </div>
   </main>
-  <footer class="my-5 pt-5 text-body-secondary text-center text-small">
+  <footer class="my-5 pt-5 text-body-secondary text-center">
     <p class="mb-1">&copy; {new Date().getFullYear()}-2017 اسم الشركة</p>
     <ul class="list-inline">
       <li class="list-inline-item"><a href="#">سياسة الخصوصية</a></li>

--- a/site/src/assets/examples/checkout/index.astro
+++ b/site/src/assets/examples/checkout/index.astro
@@ -220,7 +220,7 @@ export const body_class = 'bg-body-tertiary'
     </div>
   </main>
 
-  <footer class="my-5 pt-5 text-body-secondary text-center text-small">
+  <footer class="my-5 pt-5 text-body-secondary text-center">
     <p class="mb-1">&copy; 2017–{new Date().getFullYear()} Company Name</p>
     <ul class="list-inline">
       <li class="list-inline-item"><a href="#">Privacy</a></li>

--- a/site/src/assets/examples/pricing/index.astro
+++ b/site/src/assets/examples/pricing/index.astro
@@ -154,7 +154,7 @@ export const extra_css = ['pricing.css']
       </div>
       <div class="col-6 col-md">
         <h5>Features</h5>
-        <ul class="list-unstyled text-small">
+        <ul class="list-unstyled">
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Cool stuff</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Random feature</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Team feature</a></li>
@@ -165,7 +165,7 @@ export const extra_css = ['pricing.css']
       </div>
       <div class="col-6 col-md">
         <h5>Resources</h5>
-        <ul class="list-unstyled text-small">
+        <ul class="list-unstyled">
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Resource</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Resource name</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Another resource</a></li>
@@ -174,7 +174,7 @@ export const extra_css = ['pricing.css']
       </div>
       <div class="col-6 col-md">
         <h5>About</h5>
-        <ul class="list-unstyled text-small">
+        <ul class="list-unstyled">
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Team</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Locations</a></li>
           <li class="mb-1"><a class="link-secondary text-decoration-none" href="#">Privacy</a></li>

--- a/site/src/assets/examples/product/index.astro
+++ b/site/src/assets/examples/product/index.astro
@@ -147,7 +147,7 @@ export const extra_css = ['product.css']
     </div>
     <div class="col-6 col-md">
       <h5>Features</h5>
-      <ul class="list-unstyled text-small">
+      <ul class="list-unstyled">
         <li><a class="link-secondary text-decoration-none" href="#">Cool stuff</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Random feature</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Team feature</a></li>
@@ -158,7 +158,7 @@ export const extra_css = ['product.css']
     </div>
     <div class="col-6 col-md">
       <h5>Resources</h5>
-      <ul class="list-unstyled text-small">
+      <ul class="list-unstyled">
         <li><a class="link-secondary text-decoration-none" href="#">Resource name</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Resource</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Another resource</a></li>
@@ -167,7 +167,7 @@ export const extra_css = ['product.css']
     </div>
     <div class="col-6 col-md">
       <h5>Resources</h5>
-      <ul class="list-unstyled text-small">
+      <ul class="list-unstyled">
         <li><a class="link-secondary text-decoration-none" href="#">Business</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Education</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Government</a></li>
@@ -176,7 +176,7 @@ export const extra_css = ['product.css']
     </div>
     <div class="col-6 col-md">
       <h5>About</h5>
-      <ul class="list-unstyled text-small">
+      <ul class="list-unstyled">
         <li><a class="link-secondary text-decoration-none" href="#">Team</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Locations</a></li>
         <li><a class="link-secondary text-decoration-none" href="#">Privacy</a></li>

--- a/site/src/assets/examples/sidebars/index.astro
+++ b/site/src/assets/examples/sidebars/index.astro
@@ -75,7 +75,7 @@ export const extra_js = [{src: 'sidebars.js'}]
         <img src="https://github.com/mdo.png" alt="" width="32" height="32" class="rounded-circle me-2">
         <strong>mdo</strong>
       </a>
-      <ul class="dropdown-menu text-small shadow" data-bs-theme="dark">
+      <ul class="dropdown-menu shadow" data-bs-theme="dark">
         <li><a class="dropdown-item" href="#">New project...</a></li>
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
@@ -131,7 +131,7 @@ export const extra_js = [{src: 'sidebars.js'}]
         <img src="https://github.com/mdo.png" alt="" width="32" height="32" class="rounded-circle me-2">
         <strong>mdo</strong>
       </a>
-      <ul class="dropdown-menu text-small shadow">
+      <ul class="dropdown-menu shadow">
         <li><a class="dropdown-item" href="#">New project...</a></li>
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>
@@ -179,7 +179,7 @@ export const extra_js = [{src: 'sidebars.js'}]
       <a class="d-flex align-items-center justify-content-center p-3 link-body-emphasis text-decoration-none dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
         <img src="https://github.com/mdo.png" alt="mdo" width="24" height="24" class="rounded-circle">
       </a>
-      <ul class="dropdown-menu text-small shadow">
+      <ul class="dropdown-menu shadow">
         <li><a class="dropdown-item" href="#">New project...</a></li>
         <li><a class="dropdown-item" href="#">Settings</a></li>
         <li><a class="dropdown-item" href="#">Profile</a></li>


### PR DESCRIPTION
### Description

This PR backports the removal of the `.text-small` class in our examples from https://github.com/twbs/bootstrap/pull/42455.

Indeed, `.text-small` only exists in the dedicated CSS file of the Headers example page.
