### PR TITLE
v6: Remove extra bottom border on card navigation nav-tabs

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -171,7 +171,7 @@ $card-tokens: defaults(
   // Combined selector because of specificity match with `.nav` base class
   .nav.card-header-tabs {
     margin-inline: calc(-.5 * var(--card-cap-padding-x));
-    margin-bottom: calc(-1 * var(--card-cap-padding-y));
+    margin-bottom: calc(-1 * var(--bs-card-cap-padding-y) - var(--bs-nav-tabs-border-width));
     border-block-end: 0;
 
     .nav-link.active {

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -171,7 +171,7 @@ $card-tokens: defaults(
   // Combined selector because of specificity match with `.nav` base class
   .nav.card-header-tabs {
     margin-inline: calc(-.5 * var(--card-cap-padding-x));
-    margin-bottom: calc(-1 * var(--bs-card-cap-padding-y) - var(--bs-nav-tabs-border-width));
+    margin-bottom: calc(-1 * var(--card-cap-padding-y) - var(--nav-tabs-border-width));
     border-block-end: 0;
 
     .nav-link.active {


### PR DESCRIPTION
### Description

Adding navigation to a card’s header with the current v6 adds an extra border which is visible in the documentation, see https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/card/#navigation

<img width="1834" height="766" alt="Image" src="https://github.com/user-attachments/assets/2b87d10f-1cf5-4a74-a2df-047a55ae0fb9" />

This commit removes the extra border.

### Notes

This is my first contribution to Bootstrap. I hope I did everything correctly. Feel free to edit this PR if I touched the wrong selector. Thanks for creating v6, it's looking awesome!

<img width="1950" height="1454" alt="Scan 2026-06-26 at 7 58 35 AM" src="https://github.com/user-attachments/assets/74cce357-bc2f-4d62-a2dd-a2762cee5db2" />
