### PR TITLE
Tests: fix dialog/drawer dispose-while-open scroll-lock assertions

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "82.75 kB"
+      "maxSize": "83.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "54.0 kB"
+      "maxSize": "54.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",

--- a/js/tests/unit/dialog.spec.js
+++ b/js/tests/unit/dialog.spec.js
@@ -723,12 +723,12 @@ describe('Dialog', () => {
 
         dialogEl.addEventListener('shown.bs.dialog', () => {
           expect(dialogEl.open).toBeTrue()
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
 
           dialog.dispose()
 
           expect(dialogEl.open).toBeFalse()
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
 

--- a/js/tests/unit/drawer.spec.js
+++ b/js/tests/unit/drawer.spec.js
@@ -580,12 +580,12 @@ describe('Drawer', () => {
 
         drawerEl.addEventListener('shown.bs.drawer', () => {
           expect(drawerEl.open).toBeTrue()
-          expect(document.body.classList.contains('dialog-open')).toBeTrue()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeTrue()
 
           drawer.dispose()
 
           expect(drawerEl.open).toBeFalse()
-          expect(document.body.classList.contains('dialog-open')).toBeFalse()
+          expect(document.documentElement.classList.contains('dialog-open')).toBeFalse()
           resolve()
         })
 


### PR DESCRIPTION
The dispose-while-open specs added in #42544 asserted the `dialog-open` scroll-lock class on `document.body`, but #42545 moved the lock to the root element (`documentElement`). Each PR was green in isolation; together on v6-dev the two stale assertions fail. This aligns the two specs with the rest of the suite, which already asserts on `documentElement`.