### PR TITLE
Docs: fix Shiki dark mode rendering

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
         light: { ...bootstrapLight, name: '', type: 'light' },
         dark: { ...bootstrapDark, name: '', type: 'dark' }
       },
+      defaultColor: 'light-dark()',
       transformers: [
         transformerNotationDiff(),
         transformerNotationHighlight(),


### PR DESCRIPTION
Closes #42566

### Description

In dark mode, structural tokens inside certain code blocks were rendered as near-black and therefore invisible against the dark background. This was specifically visible in the `<script type="importmap">` example on the Install page, where the JSON structure characters (`{`, `}`, `:`) would disappear.

The site has two code rendering paths:
- **`<Code>` tab components** — use `highlight.ts`, which already passes `defaultColor: 'light-dark()'` to Shiki.
- **Markdown fenced code blocks** — use Astro's built-in Shiki integration configured in `astro.config.ts`, which was missing `defaultColor: 'light-dark()'`.

Without it, Shiki defaults to `defaultColor: 'light'`, generating `color: var(--shiki-light)` for all uncolored/structural tokens. The Bootstrap VS Code light theme's `editor.foreground` is `#0b0c0d` (near-black), which is fine on a light background but invisible in dark mode.

Explicitly colored tokens (strings, property names, tags) were unaffected because their spans carry both `--shiki-light` and `--shiki-dark` CSS variables. Only tokens falling back to the default foreground were broken.

The fix is rather simple: add `defaultColor: 'light-dark()'` to the `shikiConfig` in `astro.config.ts`, consistent with `highlight.ts`.

With this option, Shiki emits `color: light-dark(var(--shiki-light), var(--shiki-dark))` for default-colored tokens. The CSS `light-dark()` function reads the `color-scheme` property, which Bootstrap already sets to `dark` on `[data-bs-theme="dark"]`, so the correct dark foreground (`#f6f7f8`) is applied automatically.

New rendering:

| Before the fix | Now |
|---|---|
|  <img width="909" height="716" alt="Screenshot 2026-06-28 at 10 42 06" src="https://github.com/user-attachments/assets/bd252241-3326-4367-9e94-0eaa06168d68" /> |  <img width="918" height="718" alt="Screenshot 2026-06-28 at 10 42 53" src="https://github.com/user-attachments/assets/4733cee7-dd9d-43ae-97bf-9921104b8bfb" /> |

#### Live previews

- https://deploy-preview-42591--twbs-bootstrap.netlify.app/docs/6.0/getting-started/install/#cdn