### PR TITLE
Move `postcss-prefix-custom-properties` from `peerDependencies` to `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "playwright": "^1.61.0",
         "postcss": "^8.5.12",
         "postcss-cli": "^11.0.1",
+        "postcss-prefix-custom-properties": "^0.1.0",
         "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
         "rehype-autolink-headings": "^7.1.0",
@@ -100,7 +101,6 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "postcss-prefix-custom-properties": "^0.1.0",
         "vanilla-calendar-pro": "^3.1.0"
       }
     },
@@ -17667,6 +17667,7 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18541,6 +18542,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -18640,6 +18642,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18821,8 +18824,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/postcss-prefix-custom-properties/-/postcss-prefix-custom-properties-0.1.0.tgz",
       "integrity": "sha512-sAKQSRw+KTl9G549Q9awV/ra06fOZNEIVIIRTwiSTbvkV1t8z7WPqNQ5XBbxF1fV2mp0yQFObavc5J/GxP0a6g==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -18946,6 +18949,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -20819,6 +20823,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "postcss-prefix-custom-properties": "^0.1.0",
     "vanilla-calendar-pro": "^3.1.0"
   },
   "devDependencies": {
@@ -183,6 +182,7 @@
     "playwright": "^1.61.0",
     "postcss": "^8.5.12",
     "postcss-cli": "^11.0.1",
+    "postcss-prefix-custom-properties": "^0.1.0",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "rehype-autolink-headings": "^7.1.0",


### PR DESCRIPTION
### Description

`postcss-prefix-custom-properties` is currently listed as a peer dependency, but it is used as part of Bootstrap's internal build process to generate the final CSS output.

Some users who build Bootstrap from the Sass source with their own custom toolchain may rely on this PostCSS step, but this is not the default usage pattern. Most users consume Bootstrap's prebuilt CSS, where this transformation has already been applied.

Moving it to `devDependencies` keeps ownership of this build step within Bootstrap while still allowing advanced users with custom build pipelines to explicitly include the plugin when needed. On top of that, we don't force the use of PostCSS by adding it to peer dependencies.

This does not change the generated CSS or the Sass customization workflow; it only updates the dependency declaration to better reflect how the package is consumed.
