### PR TITLE
v6 docs: various fixes

### DIFF
--- a/site/src/content/docs/components/carousel.mdx
+++ b/site/src/content/docs/components/carousel.mdx
@@ -127,21 +127,21 @@ You can put any markup you like inside each `.carousel-item`. Add content, then 
       <div class="carousel-item active">
         <div class="d-flex flex-column justify-content-center bg-subtle-primary p-9 bg-1 rounded-5" style="min-height: 320px;">
           <h3>Build anything</h3>
-          <p class="text-secondary-emphasis mb-3">Compose slides from your own markup—text, buttons, cards, or media.</p>
+          <p class="fg-emphasis-secondary mb-3">Compose slides from your own markup—text, buttons, cards, or media.</p>
           <div><a class="btn-solid theme-primary" href="#">Get started</a></div>
         </div>
       </div>
       <div class="carousel-item">
         <div class="d-flex flex-column justify-content-center text-center bg-subtle-success p-9 bg-2 rounded-5" style="min-height: 320px;">
           <h3>Style it your way</h3>
-          <p class="text-secondary-emphasis mb-3">Use utilities or custom CSS to size and theme each slide however you need.</p>
+          <p class="fg-emphasis-secondary mb-3">Use utilities or custom CSS to size and theme each slide however you need.</p>
           <div><a class="btn-solid theme-success" href="#">Learn more</a></div>
         </div>
       </div>
       <div class="carousel-item">
         <div class="d-flex flex-column justify-content-center text-end bg-subtle-warning p-9 bg-3 rounded-5" style="min-height: 320px;">
           <h3>Mix and match</h3>
-          <p class="text-secondary-emphasis mb-3">Combine custom content with controls, indicators, and the overlay layout.</p>
+          <p class="fg-emphasis-secondary mb-3">Combine custom content with controls, indicators, and the overlay layout.</p>
           <div><a class="btn-solid theme-inverse" href="#">Browse examples</a></div>
         </div>
       </div>

--- a/site/src/content/docs/customize/color-modes.mdx
+++ b/site/src/content/docs/customize/color-modes.mdx
@@ -61,7 +61,7 @@ For example, to change the color mode of a menu, add `data-bs-theme="light"` or 
   }
   ```
 
-- We use a custom `_variables-dark.scss` to power those shared global CSS variable overrides for dark mode. This file isn’t required for your own custom color modes, but it’s required for our dark mode for two reasons. First, it’s better to have a single place to reset global colors. Second, some Sass variables had to be overridden for background images embedded in our CSS for accordions, form components, and more.
+- Dark mode overrides live in `_root.scss` (via the `color-mode()` mixin) and `_theme.scss`, which adjust global and theme color tokens. You don’t need these files for your own custom color modes, but they give Bootstrap a single place to reset colors for built-in dark mode.
 
 ## Usage
 
@@ -141,7 +141,7 @@ Outputs to:
 
 ## Custom color modes
 
-While the primary use case for color modes is light and dark mode, custom color modes are also possible. Create your own `data-bs-theme` selector with a custom value as the name of your color mode, then modify our Sass and CSS variables as needed. We opted to create a separate `_variables-dark.scss` stylesheet to house Bootstrap’s dark mode specific Sass variables, but that’s not required for you.
+While the primary use case for color modes is light and dark mode, custom color modes are also possible. Create your own `data-bs-theme` selector with a custom value as the name of your color mode, then modify our Sass and CSS variables as needed. Bootstrap’s built-in dark mode uses `_root.scss` and `_theme.scss`, but you can follow the same pattern in your own stylesheet.
 
 For example, you can create a “blue theme” with the selector `data-bs-theme="blue"`. In your custom Sass or CSS file, add the new selector and override any global or component CSS variables as needed. If you’re using Sass, you can also use Sass’s functions within your CSS variable overrides.
 
@@ -192,7 +192,7 @@ Dozens of root level CSS variables are repeated as overrides for dark mode. Thes
 
 ### Sass variables
 
-CSS variables for our dark color mode are partially generated from dark mode specific Sass variables in `_variables-dark.scss`. This also includes some custom overrides for changing the colors of embedded SVGs used throughout our components.
+CSS variables for our dark color mode are generated from Sass in `_root.scss` and `_theme.scss`, including overrides for components that embed SVG data URIs in CSS—primarily via `mask-image` (carousel controls, close buttons, and similar icons), with select dropdown arrows as a remaining `background-image` case.
 
 {/* <ScssDocs name="sass-dark-mode-vars" file="scss/_config.scss" /> */}
 

--- a/site/src/content/docs/customize/sass.mdx
+++ b/site/src/content/docs/customize/sass.mdx
@@ -395,9 +395,9 @@ We use the `escape-svg` function to escape the `<`, `>` and `#` characters for S
 $icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#00000080' stroke-width='2' d='m2 5 6 6 6-6'/></svg>");
 
 // After escape-svg(), the <, >, and # characters are percent-encoded
-// so the data URI works reliably as a CSS background-image
+// so the data URI works reliably in CSS (e.g. as a mask-image or background-image)
 .element {
-  background-image: escape-svg($icon);
+  mask-image: escape-svg($icon);
 }
 ```
 

--- a/site/src/content/docs/guides/webpack.mdx
+++ b/site/src/content/docs/guides/webpack.mdx
@@ -316,7 +316,7 @@ After running `npm run build` again, there will be a new file `dist/main.css`, w
 
 ### Extracting SVG files
 
-Bootstrap’s CSS includes multiple references to SVG files via inline `data:` URIs. If you define a Content Security Policy for your project that blocks `data:` URIs for images, then these SVG files will not load. You can get around this problem by extracting the inline SVG files using Webpack’s asset modules feature.
+Bootstrap’s CSS includes multiple references to SVG files via inline `data:` URIs—mostly as `mask-image` icons (close buttons, carousel controls, and more), with a few remaining `background-image` cases such as select carets. If you define a Content Security Policy for your project that blocks `data:` URIs for images, then these SVG files will not load. You can get around this problem by extracting the inline SVG files using Webpack’s asset modules feature.
 
 Configure Webpack to extract inline SVG files like this:
 

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -11,7 +11,7 @@ import BaseLayout from '@layouts/BaseLayout.astro'
   title="404 - File not found"
 >
   <div class="text-center py-5">
-    <h1 class="display-1">404</h1>
+    <h1 class="fs-6xl">404</h1>
     <h2>File not found</h2>
   </div>
 </BaseLayout>


### PR DESCRIPTION
### Description

Updates docs and examples to reflect recent changes in how Bootstrap handles dark mode and SVG usage. It clarifies the use of new Sass files for color modes, updates class names for color emphasis, and modernizes SVG handling in both Sass and Webpack guides.

**Documentation updates for color modes and dark mode:**
* Updated references to dark mode implementation, specifying that Bootstrap now uses `_root.scss` and `_theme.scss` instead of `_variables-dark.scss` for global and theme color tokens. [[1]](diffhunk://#diff-c093e7ceafd6e962c10c33b099dc664839914f09eadfa46e472cf12a813e675bL64-R64) [[2]](diffhunk://#diff-c093e7ceafd6e962c10c33b099dc664839914f09eadfa46e472cf12a813e675bL144-R144) [[3]](diffhunk://#diff-c093e7ceafd6e962c10c33b099dc664839914f09eadfa46e472cf12a813e675bL195-R195)

**SVG usage and handling improvements:**
* Clarified that SVG icons are primarily used as `mask-image` (with a few remaining `background-image` cases) in both the Sass and Webpack documentation, and updated code examples to reflect this. [[1]](diffhunk://#diff-7c38e0ee19884a4371deaebb7992f4c187df6cae30768fe3f3c91578c9624c92L398-R400) [[2]](diffhunk://#diff-36e0473ff6b8362379cfd2b9f199dd8591c919dbfbc5b6eb703c800ae7610c9bL319-R319)

**Component and style consistency:**
* Updated class names in the carousel component documentation from `text-secondary-emphasis` to `fg-emphasis-secondary` for consistency with the latest Bootstrap naming conventions.
* Changed the 404 page’s heading from `display-1` to `fs-6xl` for improved consistency with new font size utilities.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- <https://deploy-preview-42600--twbs-bootstrap.netlify.app/>
