### PR TITLE
Redo z-index execution

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,19 +18,19 @@
     },
     {
       "path": "./dist/css/bootstrap-utilities.css",
-      "maxSize": "18.5 kB"
+      "maxSize": "18.75 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.min.css",
-      "maxSize": "17.25 kB"
+      "maxSize": "17.5 kB"
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "50.25 kB"
+      "maxSize": "50.5 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "46.5 kB"
+      "maxSize": "46.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/dist/css/bootstrap-utilities.metadata.json
+++ b/dist/css/bootstrap-utilities.metadata.json
@@ -1409,7 +1409,15 @@
         "z-0",
         "z-1",
         "z-2",
-        "z-3"
+        "z-3",
+        "z-menu",
+        "z-sticky",
+        "z-fixed",
+        "z-drawer",
+        "z-dialog",
+        "z-popover",
+        "z-tooltip",
+        "z-toast"
       ]
     }
   }

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -301,24 +301,20 @@ $font-sizes: defaults(
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.
 
-// scss-docs-start zindex-stack
-$zindex-menu:                       1000 !default;
-$zindex-sticky:                     1020 !default;
-$zindex-fixed:                      1030 !default;
-// $zindex-drawer-backdrop:         1040 !default;
-$zindex-drawer:                  1045 !default;
-$zindex-dialog:                     1055 !default;
-$zindex-popover:                    1070 !default;
-$zindex-tooltip:                    1080 !default;
-$zindex-toast:                      1090 !default;
-// scss-docs-end zindex-stack
-
 // scss-docs-start zindex-levels-map
 $zindex-levels: (
   n1: -1,
   0: 0,
   1: 1,
   2: 2,
-  3: 3
+  3: 3,
+  menu: 1000,
+  sticky: 1010,
+  fixed: 1020,
+  drawer: 1030,
+  dialog: 1040,
+  popover: 1050,
+  tooltip: 1060,
+  toast: 1070,
 ) !default;
 // scss-docs-end zindex-levels-map

--- a/scss/_datepicker.scss
+++ b/scss/_datepicker.scss
@@ -22,7 +22,7 @@ $datepicker-tokens: defaults(
     --datepicker-box-shadow: var(--box-shadow),
     --datepicker-font-size: var(--font-size-sm),
     --datepicker-min-width: 280px,
-    --datepicker-zindex: #{$zindex-menu},
+    --datepicker-zindex: var(--z-menu),
     --datepicker-header-font-weight: 600,
     --datepicker-weekday-color: var(--fg-3),
     --datepicker-day-hover-bg: var(--bg-1),

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -185,7 +185,7 @@ $dialog-sizes: defaults(
       position: fixed;
       inset-block-start: 50%;
       inset-inline-start: 50%;
-      z-index: $zindex-dialog;
+      z-index: var(--z-dialog);
       margin-inline: 0;
       transform: translate(-50%, -50%);
     }

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -16,7 +16,7 @@ $drawer-tokens: () !default;
 $drawer-tokens: defaults(
   (
     --drawer-inset: var(--spacer),
-    --drawer-zindex: #{$zindex-drawer},
+    --drawer-zindex: var(--z-drawer),
     --drawer-width: 400px,
     --drawer-height: 30vh,
     --drawer-padding-x: var(--spacer),

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -11,7 +11,7 @@ $menu-tokens: () !default;
 // scss-docs-start menu-tokens
 $menu-tokens: defaults(
   (
-    --menu-zindex: #{$zindex-menu},
+    --menu-zindex: var(--z-menu),
     --menu-gap: .125rem,
     --menu-min-width: 10rem,
     --menu-padding-x: .25rem,

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -11,7 +11,7 @@ $popover-tokens: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $popover-tokens: defaults(
   (
-    --popover-zindex: #{$zindex-popover},
+    --popover-zindex: var(--z-popover),
     --popover-max-width: 280px,
     --popover-font-size: var(--font-size-sm),
     --popover-bg: var(--bg-body),

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -178,6 +178,11 @@ $root-tokens: map.set($root-tokens, --radius-pill, 50rem);
 }
 // scss-docs-end root-box-shadow-loop
 
+// Generate z-index tokens
+@each $key, $value in $zindex-levels {
+  $root-tokens: map.set($root-tokens, --z-#{$key}, $value);
+}
+
 :root {
   @include tokens($root-tokens);
 

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -10,7 +10,7 @@ $toast-tokens: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $toast-tokens: defaults(
   (
-    --toast-zindex: #{$zindex-toast},
+    --toast-zindex: var(--z-toast),
     --toast-padding-x: 1rem,
     --toast-padding-y: .75rem,
     --toast-spacing: #{$container-padding-x},
@@ -59,7 +59,7 @@ $toast-tokens: defaults(
   }
 
   .toast-container {
-    --toast-zindex: #{$zindex-toast};
+    --toast-zindex: var(--z-toast);
 
     position: absolute;
     z-index: var(--toast-zindex);

--- a/scss/_tooltip.scss
+++ b/scss/_tooltip.scss
@@ -10,7 +10,7 @@ $tooltip-tokens: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $tooltip-tokens: defaults(
   (
-    --tooltip-zindex: #{$zindex-tooltip},
+    --tooltip-zindex: var(--z-tooltip),
     --tooltip-max-width: 200px,
     --tooltip-padding-x: var(--spacer-3),
     --tooltip-padding-y: calc(var(--spacer) * .375),

--- a/scss/helpers/_position.scss
+++ b/scss/helpers/_position.scss
@@ -6,13 +6,13 @@
   .fixed-top {
     position: fixed;
     inset: 0 0 auto;
-    z-index: $zindex-fixed;
+    z-index: var(--z-fixed);
   }
 
   .fixed-bottom {
     position: fixed;
     inset: auto 0 0;
-    z-index: $zindex-fixed;
+    z-index: var(--z-fixed);
   }
 
   // Responsive sticky top and bottom
@@ -23,13 +23,13 @@
       .#{$prefix}sticky-top {
         position: sticky;
         top: 0;
-        z-index: $zindex-sticky;
+        z-index: var(--z-sticky);
       }
 
       .#{$prefix}sticky-bottom {
         position: sticky;
         bottom: 0;
-        z-index: $zindex-sticky;
+        z-index: var(--z-sticky);
       }
     }
   }

--- a/site/src/content/docs/layout/z-index.mdx
+++ b/site/src/content/docs/layout/z-index.mdx
@@ -9,6 +9,6 @@ These higher values start at an arbitrary number, high and specific enough to id
 
 We don’t encourage customization of these individual values; should you change one, you likely need to change them all.
 
-<ScssDocs name="zindex-stack" file="scss/_config.scss" />
+<ScssDocs name="zindex-levels-map" file="scss/_config.scss" />
 
 To handle overlapping borders within components (e.g., buttons and inputs in input groups), we use low single digit `z-index` values of `1`, `2`, and `3` for default, hover, and active states. On hover/focus/active, we bring a particular element to the forefront with a higher `z-index` value to show their border over the sibling elements.

--- a/site/src/content/docs/utilities/z-index.mdx
+++ b/site/src/content/docs/utilities/z-index.mdx
@@ -10,15 +10,34 @@ utility:
 
 Use `z-index` utilities to stack elements on top of one another. Requires a `position` value other than `static`, which can be set with custom styles or using our [position utilities]([[docsref:/utilities/position/]]).
 
-<Callout>
+### Low-level stack
+
 We call these “low-level” `z-index` utilities because of their default values of `-1` through `3`, which we use for the layout of overlapping components. High-level `z-index` values are used for overlay components like modals and tooltips.
-</Callout>
 
 <Example class="bd-example-zindex-levels position-relative" code={`<div class="z-3 position-absolute p-9 rounded-3"><span>z-3</span></div>
 <div class="z-2 position-absolute p-9 rounded-3"><span>z-2</span></div>
 <div class="z-1 position-absolute p-9 rounded-3"><span>z-1</span></div>
 <div class="z-0 position-absolute p-9 rounded-3"><span>z-0</span></div>
 <div class="z-n1 position-absolute p-9 rounded-3"><span>z-n1</span></div>`} />
+
+### Component stack
+
+The component `z-index` utilities are used for overlay components like dialogs, popovers, and more. Classes are available for all of them, and their CSS variables are used in their respective components out of the box.
+
+<BsTable>
+| Class | Value | CSS variable |
+| --- | --- | --- |
+| `z-menu` | `1000` | `var(--z-menu)` |
+| `z-sticky` | `1010` | `var(--z-sticky)` |
+| `z-fixed` | `1020` | `var(--z-fixed)` |
+| `z-drawer` | `1030` | `var(--z-drawer)` |
+| `z-dialog` | `1040` | `var(--z-dialog)` |
+| `z-popover` | `1050` | `var(--z-popover)` |
+| `z-tooltip` | `1060` | `var(--z-tooltip)` |
+| `z-toast` | `1070` | `var(--z-toast)` |
+</BsTable>
+
+Read more about the component `z-index` values in the [`z-index` layout page]([[docsref:/layout/z-index]]).
 
 ## Overlays
 


### PR DESCRIPTION
Make all z-index part of the same scale. This is an old branch I found that never got opened for review. It's a maybe for me, but curious @julien-deramond and @coliff thoughts.

Alternative here would be to have a utility-focused z-index scale (like the current `$zindex-levels` map) and a separate `$zindex-component-levels` for those values. I could see something like this being better for customizing so you don't blow away the component levels by adding a new utility level.