### PR TITLE
Fix responsive drawer close example

### DIFF
--- a/site/src/content/docs/components/drawer.mdx
+++ b/site/src/content/docs/components/drawer.mdx
@@ -212,7 +212,7 @@ To make a responsive drawer, replace the `.drawer` base class with a responsive 
   <dialog class="lg:drawer drawer-end" tabindex="-1" id="drawerResponsive" aria-labelledby="drawerResponsiveLabel">
     <div class="drawer-header">
       <h5 class="drawer-title" id="drawerResponsiveLabel">Responsive drawer</h5>
-      <CloseButton dismiss="drawer" />
+      <CloseButton dismiss="drawer" target="#drawerResponsive" />
     </div>
     <div class="drawer-body">
       <p class="mb-0">This is content within an <code>.lg:drawer</code>.</p>


### PR DESCRIPTION
## Summary

- add the explicit close-button target required by the responsive drawer example
- keep the rendered example consistent with the text immediately above it

Fixes twbs/bootstrap#42611

## Testing

- source check that the responsive drawer example close button targets `#drawerResponsive`
- `git diff --check -- site/src/content/docs/components/drawer.mdx`
