### PR TITLE
Initialize preselected datepickers

### DIFF
--- a/js/src/datepicker.js
+++ b/js/src/datepicker.js
@@ -28,6 +28,10 @@ const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
 const EVENT_FOCUSIN_DATA_API = `focusin${EVENT_KEY}${DATA_API_KEY}`
 
 const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="datepicker"]'
+const SELECTOR_DATA_AUTO_INIT = [
+  `${SELECTOR_DATA_TOGGLE}[data-bs-inline="true"]`,
+  `${SELECTOR_DATA_TOGGLE}[data-bs-selected-dates]`
+].join(',')
 
 const HIDE_DELAY = 100 // ms delay before hiding after selection
 
@@ -472,9 +476,9 @@ EventHandler.on(document, EVENT_FOCUSIN_DATA_API, SELECTOR_DATA_TOGGLE, function
   Datepicker.getOrCreateInstance(this).show()
 })
 
-// Auto-initialize inline datepickers on DOMContentLoaded
+// Auto-initialize datepickers that need their initial state rendered on page load
 EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of document.querySelectorAll(`${SELECTOR_DATA_TOGGLE}[data-bs-inline="true"]`)) {
+  for (const element of document.querySelectorAll(SELECTOR_DATA_AUTO_INIT)) {
     Datepicker.getOrCreateInstance(element)
   }
 })

--- a/js/tests/unit/datepicker.spec.js
+++ b/js/tests/unit/datepicker.spec.js
@@ -842,6 +842,21 @@ describe('Datepicker', () => {
 
       expect(toggleSpy).not.toHaveBeenCalled()
     })
+
+    it('should initialize inputs with selected dates on DOMContentLoaded', () => {
+      fixtureEl.innerHTML = [
+        '<input type="text" data-bs-toggle="datepicker"',
+        'data-bs-selection-mode="multiple-ranged" data-bs-locale="en-US"',
+        'data-bs-selected-dates=\'["2026-06-10", "2026-06-18"]\'>'
+      ].join(' ')
+
+      const inputEl = fixtureEl.querySelector('input')
+      const domContentLoadedEvent = createEvent('DOMContentLoaded', { bubbles: true })
+      document.dispatchEvent(domContentLoadedEvent)
+
+      expect(Datepicker.getInstance(inputEl)).toBeInstanceOf(Datepicker)
+      expect(inputEl.value).toEqual('6/10/2026 – 6/18/2026')
+    })
   })
 
   describe('getInstance', () => {


### PR DESCRIPTION
## Summary

- initialize datepickers with `data-bs-selected-dates` on page load
- keep lazy initialization for ordinary datepickers
- add a data-API regression test for preselected range inputs

Fixes twbs/bootstrap#42616

## Testing

- `git diff --check -- js/src/datepicker.js js/tests/unit/datepicker.spec.js`
- `node --check js/src/datepicker.js`
- `node --check js/tests/unit/datepicker.spec.js`
- source guard confirming the preselected-date auto-init selector and regression test

I could not run the full Karma suite locally because dependency installation ran out of disk space on this machine.
