### PR TITLE
Fix/dialog content overflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "editor.renderWhitespace": "all",
   "scss.validate": false,
   "stylelint.enable": true,
-  "stylelint.validate": ["scss"]
+  "stylelint.validate": ["scss"],
+  "[scss]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint"
+  }
 }

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -76,6 +76,7 @@ $dialog-sizes: defaults(
     flex-direction: column;
     width: var(--dialog-width);
     max-width: calc(100% - var(--dialog-margin) * 2);
+    min-height: max-content;
     max-height: calc(100% - var(--dialog-margin) * 2);
     padding: 0;
     margin: auto;
@@ -97,8 +98,10 @@ $dialog-sizes: defaults(
       // Exit transition: opacity and transform animate out, then visibility
       // flips hidden after the animation completes (via the delay).
       @include transition(
-        opacity var(--dialog-transition-duration) var(--dialog-transition-timing),
-        transform var(--dialog-transition-duration) var(--dialog-transition-timing),
+        opacity var(--dialog-transition-duration)
+        var(--dialog-transition-timing),
+        transform var(--dialog-transition-duration)
+          var(--dialog-transition-timing),
         visibility 0s var(--dialog-transition-duration)
       );
 
@@ -128,8 +131,10 @@ $dialog-sizes: defaults(
         visibility: visible;
         opacity: 1;
         @include transition(
-          opacity var(--dialog-transition-duration) var(--dialog-transition-timing),
-          transform var(--dialog-transition-duration) var(--dialog-transition-timing),
+          opacity var(--dialog-transition-duration)
+          var(--dialog-transition-timing),
+          transform var(--dialog-transition-duration)
+            var(--dialog-transition-timing),
           visibility 0s
         );
         transform: none;
@@ -148,7 +153,10 @@ $dialog-sizes: defaults(
       &::backdrop {
         background-color: var(--dialog-backdrop-bg);
         backdrop-filter: blur(var(--dialog-backdrop-blur));
-        @include backdrop-transitions(var(--dialog-transition-duration), var(--dialog-transition-timing));
+        @include backdrop-transitions(
+          var(--dialog-transition-duration),
+          var(--dialog-transition-timing)
+        );
       }
 
       // Exit: fade the native backdrop out alongside the dialog. The dialog
@@ -225,7 +233,9 @@ $dialog-sizes: defaults(
 
   // Dialog sizes
   @each $size, $value in $dialog-sizes {
-    .dialog-#{$size} { --dialog-width: #{$value}; }
+    .dialog-#{$size} {
+      --dialog-width: #{$value};
+    }
   }
 
   // Fullscreen dialog
@@ -263,7 +273,9 @@ $dialog-sizes: defaults(
   // Dialog header
   .dialog-header {
     @include dialog-header(var(--dialog-header-padding));
-    border-block-end: var(--dialog-header-border-width) solid var(--dialog-header-border-color);
+    border-block-end:
+      var(--dialog-header-border-width) solid
+      var(--dialog-header-border-color);
 
     .btn-close {
       margin-inline-start: auto;
@@ -284,6 +296,11 @@ $dialog-sizes: defaults(
 
   // Dialog footer
   .dialog-footer {
-    @include dialog-footer(var(--dialog-footer-padding), var(--dialog-footer-gap), var(--dialog-footer-border-width), var(--dialog-footer-border-color));
+    @include dialog-footer(
+      var(--dialog-footer-padding),
+      var(--dialog-footer-gap),
+      var(--dialog-footer-border-width),
+      var(--dialog-footer-border-color)
+    );
   }
 }

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -101,7 +101,7 @@ $dialog-sizes: defaults(
         opacity var(--dialog-transition-duration)
         var(--dialog-transition-timing),
         transform var(--dialog-transition-duration)
-          var(--dialog-transition-timing),
+        var(--dialog-transition-timing),
         visibility 0s var(--dialog-transition-duration)
       );
 
@@ -134,7 +134,7 @@ $dialog-sizes: defaults(
           opacity var(--dialog-transition-duration)
           var(--dialog-transition-timing),
           transform var(--dialog-transition-duration)
-            var(--dialog-transition-timing),
+          var(--dialog-transition-timing),
           visibility 0s
         );
         transform: none;


### PR DESCRIPTION
Previously I created an [issue](https://github.com/twbs/bootstrap/issues/42459) that was closed, and there was already a [PR](https://github.com/twbs/bootstrap/pull/42473#issuecomment-4828681216) intended to fix it. After reading that comment I found it very convincing. After careful thought, I realized we may have actually fallen into a misconception — in order to fix this issue we even considered reverting to the v5 behavior and then introducing a redundant HTML structure. By chance, while experimenting with v6 locally, I found an elegant fix that doesn't break the existing structure at all. We absolutely don't need to wait for the first alpha of v6 to be released and see how people react to this issue.

Below is the effect of the fix:


https://github.com/user-attachments/assets/7ef0850c-9eb5-4e04-a653-ab67d0e0e401

Comparison before and after:


https://github.com/user-attachments/assets/88203b40-c3d4-4dac-b511-b9f94ddaa98d



Additionally, in the VSCode workspace for that PR I set the SCSS formatter to use stylelint, because I have Prettier installed locally and it often conflicts with stylelint. That issue is now resolved.