### PR TITLE
Datepicker: populate input with preselected dates on load

### DIFF
--- a/js/src/datepicker.js
+++ b/js/src/datepicker.js
@@ -472,9 +472,12 @@ EventHandler.on(document, EVENT_FOCUSIN_DATA_API, SELECTOR_DATA_TOGGLE, function
   Datepicker.getOrCreateInstance(this).show()
 })
 
-// Auto-initialize inline datepickers on DOMContentLoaded
+// Auto-initialize datepickers that need to render on load:
+// - inline datepickers (always visible)
+// - datepickers with preselected dates (so the value populates without focus)
 EventHandler.on(document, `DOMContentLoaded${EVENT_KEY}${DATA_API_KEY}`, () => {
-  for (const element of document.querySelectorAll(`${SELECTOR_DATA_TOGGLE}[data-bs-inline="true"]`)) {
+  const selector = `${SELECTOR_DATA_TOGGLE}[data-bs-inline="true"], ${SELECTOR_DATA_TOGGLE}[data-bs-selected-dates]`
+  for (const element of document.querySelectorAll(selector)) {
     Datepicker.getOrCreateInstance(element)
   }
 })

--- a/js/tests/unit/datepicker.spec.js
+++ b/js/tests/unit/datepicker.spec.js
@@ -121,6 +121,16 @@ describe('Datepicker', () => {
       expect(datepicker._config.selectionMode).toEqual('multiple')
       expect(datepicker._config.firstWeekday).toEqual(0)
     })
+
+    it('should populate the input value with preselected dates', () => {
+      fixtureEl.innerHTML = '<input type="text" data-bs-toggle="datepicker" data-bs-selection-mode="multiple-ranged" data-bs-selected-dates=\'["2026-06-10", "2026-06-18"]\'>'
+
+      const inputEl = fixtureEl.querySelector('input')
+      const datepicker = new Datepicker(inputEl)
+
+      expect(datepicker._config.selectedDates).toEqual(['2026-06-10', '2026-06-18'])
+      expect(inputEl.value).not.toEqual('')
+    })
   })
 
   describe('show', () => {
@@ -841,6 +851,25 @@ describe('Datepicker', () => {
       divEl.dispatchEvent(clickEvent)
 
       expect(toggleSpy).not.toHaveBeenCalled()
+    })
+
+    it('should auto-initialize datepickers with preselected dates on DOMContentLoaded', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<input type="text" data-bs-toggle="datepicker" data-bs-selection-mode="multiple-ranged" data-bs-selected-dates=\'["2026-06-10", "2026-06-18"]\'>'
+
+        const inputEl = fixtureEl.querySelector('input')
+
+        expect(Datepicker.getInstance(inputEl)).toBeNull()
+
+        const domContentLoadedEvent = createEvent('DOMContentLoaded')
+        document.dispatchEvent(domContentLoadedEvent)
+
+        setTimeout(() => {
+          expect(Datepicker.getInstance(inputEl)).not.toBeNull()
+          expect(inputEl.value).not.toEqual('')
+          resolve()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Fixes #42616

`data-bs-selected-dates` wasn't showing up in the field until you focused it — the input just sat there with its placeholder.

The reason is that input/button datepickers are only created lazily on focus/click. Only inline datepickers get auto-initialized on `DOMContentLoaded`, so any preselected dates never rendered on load.

This extends the `DOMContentLoaded` auto-init to also grab datepickers with `data-bs-selected-dates` so the value populates right away. The population logic itself already worked once an instance existed.

Added a couple of tests to cover it.
