### PR TITLE
Drawer: fix double scrollbar on responsive/modal drawers

### DIFF
--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -81,6 +81,7 @@ $drawer-backdrop-tokens: defaults(
         max-height: calc(100% - var(--drawer-inset) * 2);
         padding: 0;
         margin: 0;
+        overflow: hidden;
         color: var(--drawer-color);
         visibility: hidden;
         background-color: var(--drawer-bg);
@@ -288,6 +289,7 @@ $drawer-backdrop-tokens: defaults(
     flex-direction: column;
     gap: var(--drawer-padding-y);
     @include dialog-body(var(--drawer-padding-y) var(--drawer-padding-x));
+    min-height: 0; // allow the body to shrink for inner scrolling
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## Summary

Responsive and modal drawers could render two scrollbars when their content overflowed (most visibly the docs mobile navigation menu): one on the `<dialog>` itself and one on `.drawer-body`.

The native `<dialog>` element has a UA default of `overflow: auto`, which the base `.dialog` component already resets (`overflow: visible`), but the drawer's responsive/modal reset never did. So the `<dialog>` became its own scroll container in addition to the intended `.drawer-body` scroll area.

## Changes

`scss/_drawer.scss` only:

- Add `overflow: hidden` in the responsive drawer reset (inside `media-breakpoint-down`) so the `<dialog>` is no longer a scroll container and clips to its rounded box.
- Add `min-height: 0` to `.drawer-body` so the flex body reliably shrinks below its content height and scrolls internally.

No docs changes are needed; the same fix resolves both the docs sidebar (`#bdSidebar`) and table-of-contents (`#bdTocSidebar`) drawers, plus any tall responsive or modal drawer.

## Test plan

- [x] `npm run css-lint` passes
- [x] `npm run css` builds cleanly
- [x] Docs mobile nav drawer: verified a single scrollbar (body only); header stays fixed, no clipped content
- [x] Desktop (above `lg`): responsive drawer still renders inline as the sticky sidebar (no regression)
