### PR TITLE
Add `util()` Sass mixin

### DIFF
--- a/scss/mixins/_util.scss
+++ b/scss/mixins/_util.scss
@@ -1,0 +1,142 @@
+@use "sass:list";
+@use "sass:map";
+@use "sass:meta";
+@use "sass:string";
+@use "../config" as config;
+// Loaded for its side effect: the utility definitions merge into
+// `config.$utilities`, which util() reads.
+@use "../utilities"; // check-unused-imports-disable-line
+@use "utilities" as gen;
+
+// util() — emit a utility's base declarations into the current selector.
+@mixin util($classes...) {
+  @each $arg in $classes {
+    @each $name in -util-split($arg) {
+      $resolved: -util-resolve($name);
+
+      @if $resolved == null {
+        @error "util(): unknown utility class `#{$name}`";
+      }
+
+      // Never emit `!important`, even if the utility requests it.
+      $utility: map.remove(map.get($resolved, "utility"), important);
+
+      @include gen.generate-variables($utility, map.get($resolved, "value"));
+      @include gen.generate-properties(
+        $utility,
+        map.get($resolved, "property-map"),
+        map.get($resolved, "properties"),
+        map.get($resolved, "value")
+      );
+    }
+  }
+}
+
+// Flatten variadic args into a flat list, splitting space-separated strings.
+@function -util-split($arg) {
+  $result: ();
+
+  @if meta.type-of($arg) == "list" {
+    @each $item in $arg {
+      @each $name in -util-split($item) {
+        $result: list.append($result, $name);
+      }
+    }
+  } @else if meta.type-of($arg) == "string" {
+    @each $part in string.split($arg, " ") {
+      @if $part != "" {
+        $result: list.append($result, $part);
+      }
+    }
+  } @else {
+    $result: list.append($result, $arg);
+  }
+
+  @return $result;
+}
+
+// Find the utility and value that produce $name by mirroring the class-name
+// construction in `generate-utility`. Returns a map of
+// `(utility, property-map, properties, value)`, or null if no utility matches.
+@function -util-resolve($name) {
+  @each $key, $utility in config.$utilities {
+    @if meta.type-of($utility) == "map" and map.get($utility, enabled) != false {
+      // Attribute-selector utilities have no class-name form to match against.
+      $selector-type: "class";
+      @if map.has-key($utility, selector) {
+        $selector-type: map.get($utility, selector);
+      }
+
+      @if $selector-type == "class" {
+        $selector-class: map.get($utility, class);
+
+        $values: map.get($utility, values);
+        @if meta.type-of($values) != "map" {
+          @if meta.type-of($values) == "list" {
+            $list: ();
+            @each $value in $values {
+              $list: map.merge($list, ($value: $value));
+            }
+            $values: $list;
+          } @else {
+            $values: (null: $values);
+          }
+        }
+
+        @each $value-key, $value in $values {
+          $properties: map.get($utility, property);
+          $property-map: null;
+          $custom-class: "";
+
+          @if meta.type-of($properties) == "map" {
+            $property-map: $properties;
+            @if map.has-key($utility, class) {
+              $custom-class: map.get($utility, class);
+            }
+          } @else {
+            @if meta.type-of($properties) == "string" {
+              $properties: list.append((), $properties);
+            }
+            @if map.has-key($utility, class) {
+              $custom-class: map.get($utility, class);
+            } @else {
+              $custom-class: list.nth($properties, 1);
+            }
+            @if $custom-class == null {
+              $custom-class: "";
+            }
+          }
+
+          $custom-class-modifier: "";
+          @if $value-key {
+            @if $custom-class == "" {
+              $custom-class-modifier: $value-key;
+            } @else {
+              $custom-class-modifier: "-" + $value-key;
+            }
+          }
+
+          $class-name: "";
+          @if $custom-class != "" {
+            $class-name: $custom-class + $custom-class-modifier;
+          } @else if $selector-class != null and $selector-class != "" {
+            $class-name: $selector-class + $custom-class-modifier;
+          } @else {
+            $class-name: $custom-class-modifier;
+          }
+
+          @if "#{$class-name}" == "#{$name}" {
+            @return (
+              "utility": $utility,
+              "property-map": $property-map,
+              "properties": $properties,
+              "value": $value
+            );
+          }
+        }
+      }
+    }
+  }
+
+  @return null;
+}

--- a/scss/mixins/index.scss
+++ b/scss/mixins/index.scss
@@ -18,6 +18,7 @@
 
 // Utilities
 @forward "utilities";
+@forward "util";
 
 // Components
 @forward "backdrop";

--- a/scss/tests/jasmine.cjs
+++ b/scss/tests/jasmine.cjs
@@ -8,7 +8,7 @@ module.exports = {
   spec_dir: 'scss',
   // Make Jasmine look for `.test.scss` files
   // spec_files: ['**/*.{test,spec}.scss'],
-  spec_files: ['**/_utilities.test.scss', '**/utilities/_api.test.scss', '**/modules/_configuration.test.scss', '**/modules/_root-tokens.test.scss', '**/forms/_validation.test.scss'],
+  spec_files: ['**/_utilities.test.scss', '**/mixins/_util.test.scss', '**/utilities/_api.test.scss', '**/modules/_configuration.test.scss', '**/modules/_root-tokens.test.scss', '**/forms/_validation.test.scss'],
   // Compile them into JS scripts running `sass-true`
   requires: [path.join(__dirname, 'sass-true/register.cjs')],
   // Ensure we use `require` so that the require.extensions works

--- a/scss/tests/mixins/_util.test.scss
+++ b/scss/tests/mixins/_util.test.scss
@@ -1,0 +1,138 @@
+// check-unused-imports-disable — test infrastructure imports.
+//
+// Extra utilities so we can assert user-extended ones resolve through util().
+@use "../../config" as * with (
+  $utilities: (
+    "demo-color": (
+      property: color,
+      class: demo,
+      values: (brand: #bada55)
+    ),
+    "demo-var": (
+      property: (
+        "--demo": null,
+        "color": var(--demo)
+      ),
+      class: demovar,
+      values: (one: #06c)
+    )
+  )
+);
+@use "../../mixins/util" as *;
+@use "../../layout/breakpoints" as *;
+
+$true-terminal-output: false;
+
+@include describe("util") {
+  @include describe("base output") {
+    @include it("emits a utility's declaration with no !important") {
+      @include assert() {
+        @include output() {
+          @include util(p-3);
+        }
+
+        @include expect() {
+          padding: .75rem;
+        }
+      }
+    }
+
+    @include it("accepts multiple class names") {
+      @include assert() {
+        @include output() {
+          @include util(d-flex, justify-content-between);
+        }
+
+        @include expect() {
+          display: flex;
+          justify-content: space-between;
+        }
+      }
+    }
+
+    @include it("splits a space-separated string, @apply-style") {
+      @include assert() {
+        @include output() {
+          @include util("d-flex p-3");
+        }
+
+        @include expect() {
+          display: flex;
+          padding: .75rem;
+        }
+      }
+    }
+  }
+
+  @include describe("custom properties") {
+    @include it("emits the local variable and the property that references it") {
+      @include assert() {
+        @include output() {
+          @include util(demovar-one);
+        }
+
+        @include expect() {
+          --demo: #06c;
+          color: var(--demo);
+        }
+      }
+    }
+  }
+
+  @include describe("custom utilities") {
+    @include it("resolves a user-extended utility") {
+      @include assert() {
+        @include output() {
+          @include util(demo-brand);
+        }
+
+        @include expect() {
+          color: #bada55;
+        }
+      }
+    }
+  }
+
+  @include describe("composition") {
+    @include it("lands inside a media query via media-breakpoint-up()") {
+      @include assert() {
+        @include output() {
+          .test {
+            @include media-breakpoint-up(md) {
+              @include util(p-4);
+            }
+          }
+        }
+
+        @include expect() {
+          @media (width >= 768px) {
+            .test {
+              padding: 1rem;
+            }
+          }
+        }
+      }
+    }
+
+    @include it("lands on a pseudo-class via plain nesting") {
+      @include assert() {
+        @include output() {
+          .test {
+            &:hover {
+              @include util(demo-brand);
+            }
+          }
+        }
+
+        @include expect() {
+          .test:hover {
+            color: #bada55;
+          }
+        }
+      }
+    }
+  }
+}
+
+// The unknown-class `@error` path can't be asserted here — a compile error
+// halts sass-true — so it's verified manually.

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -180,6 +180,9 @@
   icon_color: red
   pages:
     - title: API
+    - title: Util mixin
+      meta:
+        - added: 6.0.0
     - group: Color
       pages:
         - title: Colors

--- a/site/src/content/docs/utilities/util-mixin.mdx
+++ b/site/src/content/docs/utilities/util-mixin.mdx
@@ -1,0 +1,165 @@
+---
+title: Util mixin
+description: Skip the utilities in your HTML and apply any Bootstrap utility in Sass using your own selector with the `util()` mixin.
+toc: true
+added:
+  version: 6.0.0
+---
+
+The `util()` mixin emits any Bootstrap utility’s declarations with your own selector in Sass. You get the exact styles a utility class would generate without adding the class to your markup and without any `!important`. It works with the built-in utilities, plus any you’ve added or extended through the [utility API]([[docsref:/utilities/api]]).
+
+## How it works
+
+`util()` reads the same `$utilities` map that powers our generated utility classes. For each class name you pass, it resolves the matching utility and value, then emits the identical declarations the generated class would—reusing the utility API’s own emitters. The output is byte-for-byte the same as the utility class, minus any optional `!important` you may have configured.
+
+Unlike the utility classes, `util()` never parses responsive or state prefixes. You get those from composition with existing tools instead (see [Responsive and states](#responsive-and-states)).
+
+For error protection, passing an invalid class name causes a Sass error (`util(): unknown utility class \`…\``), so typos fail at compile time without causing further issues down the line.
+
+## Usage
+
+Import the mixins and include `util()` inside any selector, passing one or more utility class names:
+
+```scss
+@use "bootstrap/scss/mixins" as *;
+
+.my-component {
+  @include util(p-3, d-flex, justify-content-between);
+}
+```
+
+You can pass class names as separate arguments or as a single space-separated string—whichever reads better:
+
+```scss
+.my-component {
+  @include util("p-3 d-flex justify-content-between");
+}
+```
+
+## Examples
+
+### Single utility
+
+```scss
+.single {
+  @include util(p-3);
+}
+```
+
+```css
+.single {
+  padding: 0.75rem;
+}
+```
+
+### Multiple utilities
+
+Pass as many class names as you like. They’re emitted in the order given.
+
+```scss
+.multi {
+  @include util(d-flex, justify-content-between, p-3);
+}
+```
+
+```css
+.multi {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem;
+}
+```
+
+### Space-separated string
+
+The string form splits on whitespace, mirroring how you’d write the classes in HTML.
+
+```scss
+.multi {
+  @include util("d-flex justify-content-between p-3");
+}
+```
+
+```css
+.multi {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem;
+}
+```
+
+### Utilities with custom properties
+
+Utilities that set CSS custom properties emit those variables too, exactly as the generated class does.
+
+```scss
+.badge {
+  @include util(bg-primary);
+}
+```
+
+```css
+.badge {
+  --bg: var(--primary-bg);
+  background-color: var(--bg);
+}
+```
+
+## Responsive and states
+
+`util()` only emits a utility’s base declarations. Compose responsive or state variants with normal CSS, our existing mixins, and plain Sass nesting. Compiled CSS will land in the right `@media` block or on the right pseudo-class, matching the generated variant classes.
+
+```scss
+@use "bootstrap/scss/mixins" as *;
+@use "bootstrap/scss/layout/breakpoints" as *;
+
+.responsive {
+  @include media-breakpoint-up(md) {
+    @include util(p-4);
+  }
+
+  &:hover {
+    @include util(bg-primary);
+  }
+}
+```
+
+```css
+@media (width >= 768px) {
+  .responsive {
+    padding: 1rem;
+  }
+}
+
+.responsive:hover {
+  --bg: var(--primary-bg);
+  background-color: var(--bg);
+}
+```
+
+## Custom utilities
+
+Because `util()` reads the merged `$utilities` map, any utility you add or extend through the [utility API]([[docsref:/utilities/api]]) resolves too. Define it once, then reuse it anywhere:
+
+```scss
+@use "bootstrap/scss/config" as * with (
+  $utilities: (
+    "brand": (
+      property: color,
+      class: brand,
+      values: (accent: #bada55)
+    )
+  )
+);
+@use "bootstrap/scss/mixins" as *;
+
+.headline {
+  @include util(brand-accent);
+}
+```
+
+```css
+.headline {
+  color: #bada55;
+}
+```


### PR DESCRIPTION
Adds a `util()` mixin—basically a native Sass `@apply` for our utilities. Pass it any utility class name (or a space-separated string) and it drops that utility's declarations straight into your own selector. No class in your markup, no `!important`.

A few things it does:

- Works with multiple utilities at once: `@include util(p-3, d-flex)` or `@include util("p-3 d-flex")`
- Reads the same `$utilities` map we generate classes from, so your own custom/extended utilities work too
- Stays base-only on purpose—compose with `media-breakpoint-up()` and plain nesting for responsive and state variants
- Errors on an unknown class name so typos fail at compile time

Comes with sass-true tests and a new docs page under Utilities (right below the API page).

Closes #33861, replaces #35465.
