### PR TITLE
fix(accordion): use z-index overlap for themed open item borders (alternative to #42092)

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -119,15 +119,14 @@ $accordion-tokens: defaults(
     &[open] {
       position: relative;
       z-index: 2;
-
-      // Overlap previous item's bottom border with our themed top border
-      &:not(:first-of-type) {
-        margin-block-start: calc(-1 * var(--accordion-border-width));
-      }
-
       border-color: var(--theme-border, var(--accordion-border-color));
+
       &::details-content {
         block-size: auto;
+      }
+
+      &:not(:first-of-type) {
+        margin-block-start: calc(-1 * var(--accordion-border-width));
       }
 
       > .accordion-header {

--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -117,6 +117,13 @@ $accordion-tokens: defaults(
 
     // Open state - details[open] applies these styles
     &[open] {
+      position: relative;
+      z-index: 2;
+
+      // Overlap previous item's bottom border with our themed top border
+      &:not(:first-of-type) {
+        margin-block-start: calc(-1 * var(--accordion-border-width));
+      }
 
       border-color: var(--theme-border, var(--accordion-border-color));
       &::details-content {


### PR DESCRIPTION
Closes #42092

### Problem
When a themed accordion item is opened, the top border appears gray instead of the theme color. This happens because the previous (closed) item retains a gray `border-bottom`, and the open item has no `border-top` (from the `&:not(:first-of-type) { border-block-start: 0; }` rule).

### Approach (per @mdo's review suggestion)
Instead of manipulating borders with `:has()` and explicit `border-block-start`, use relative positioning on the open item:

1. `position: relative; z-index: 2` — lifts the open item above siblings
2. `margin-block-start: calc(-1 * var(--accordion-border-width))` — pulls it up by one border-width, visually overlapping the previous item's bottom border

This is simpler than PR #42092's approach:
- No `:has()` dependency (better browser support)
- Only 3 properties added
- Naturally works with all variants (flush, always-open, theme-*)

### Testing
- [ ] `npm run css-lint` passes
- [ ] `npm run css` builds cleanly
- [ ] Visual: open accordion with `.theme-primary` shows correct colored top border
- [ ] Visual: flush variant unchanged
- [ ] Visual: always-open variant unchanged