### PR TITLE
Fix collapse trigger state after hiding target

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -183,9 +183,17 @@ class Collapse extends BaseComponent {
     this._element.classList.remove(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
 
     for (const trigger of this._triggerArray) {
-      const element = SelectorEngine.getElementFromSelector(trigger)
+      // Check *all* targets for this trigger. Using only the first match
+      // (findOne) incorrectly marks multi-target triggers as collapsed when
+      // an earlier sibling is hidden while a later one is still open.
+      // Also, if the selector depends on `.collapse` (removed during the
+      // transition), querySelector may find nothing — still treat as closed
+      // so aria-expanded / .collapsed stay in sync (see #40841).
+      const openTargets = SelectorEngine
+        .getMultipleElementsFromSelector(trigger)
+        .filter(element => this._isShown(element))
 
-      if (element && !this._isShown(element)) {
+      if (openTargets.length === 0) {
         this._addAriaAndCollapsedClass([trigger], false)
       }
     }

--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -183,12 +183,6 @@ class Collapse extends BaseComponent {
     this._element.classList.remove(CLASS_NAME_COLLAPSE, CLASS_NAME_SHOW)
 
     for (const trigger of this._triggerArray) {
-      // Check *all* targets for this trigger. Using only the first match
-      // (findOne) incorrectly marks multi-target triggers as collapsed when
-      // an earlier sibling is hidden while a later one is still open.
-      // Also, if the selector depends on `.collapse` (removed during the
-      // transition), querySelector may find nothing — still treat as closed
-      // so aria-expanded / .collapsed stay in sync (see #40841).
       const openTargets = SelectorEngine
         .getMultipleElementsFromSelector(trigger)
         .filter(element => this._isShown(element))

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -941,6 +941,61 @@ describe('Collapse', () => {
         trigger3.click()
       })
     })
+
+    it('should keep multi-target trigger expanded when the first matched target is hidden first', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<a id="triggerMulti" role="button" data-bs-toggle="collapse" href=".multi"></a>',
+          '<a id="triggerFirst" role="button" data-bs-toggle="collapse" href="#first"></a>',
+          '<div id="first" class="collapse multi show"></div>',
+          '<div id="second" class="collapse multi show"></div>'
+        ].join('')
+
+        const triggerMulti = fixtureEl.querySelector('#triggerMulti')
+        const triggerFirst = fixtureEl.querySelector('#triggerFirst')
+        const first = fixtureEl.querySelector('#first')
+        const second = fixtureEl.querySelector('#second')
+
+        // Ensure trigger state is initialized against both open targets
+        Collapse.getOrCreateInstance(first, { toggle: false })
+        Collapse.getOrCreateInstance(second, { toggle: false })
+
+        expect(triggerMulti.getAttribute('aria-expanded')).toEqual('true')
+        expect(triggerMulti).not.toHaveClass('collapsed')
+
+        first.addEventListener('hidden.bs.collapse', () => {
+          expect(first).not.toHaveClass('show')
+          expect(second).toHaveClass('show')
+          expect(triggerMulti.getAttribute('aria-expanded')).toEqual('true')
+          expect(triggerMulti).not.toHaveClass('collapsed')
+          resolve()
+        })
+
+        triggerFirst.click()
+      })
+    })
+
+    it('should set aria-expanded to false when data-bs-target selector includes .collapse', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div id="wrapper">',
+          '  <button type="button" data-bs-toggle="collapse" data-bs-target="#wrapper .collapse" aria-expanded="true">Toggle</button>',
+          '  <div class="collapse show">Content</div>',
+          '</div>'
+        ].join('')
+
+        const trigger = fixtureEl.querySelector('button')
+        const target = fixtureEl.querySelector('.collapse')
+
+        target.addEventListener('hidden.bs.collapse', () => {
+          expect(trigger.getAttribute('aria-expanded')).toEqual('false')
+          expect(trigger).toHaveClass('collapsed')
+          resolve()
+        })
+
+        trigger.click()
+      })
+    })
   })
 
   describe('jQueryInterface', () => {


### PR DESCRIPTION
Fixes #40841.

When a collapse target begins hiding, its `.collapse` class is removed before triggers are updated. A selector such as `#wrapper .collapse` can therefore temporarily match no elements, leaving the trigger with `aria-expanded="true"`.

Update trigger state using all matching targets and mark a trigger collapsed when none remain shown. This also fixes a multi-target trigger being marked collapsed when its first target hides while another target remains open.

Tests: `npm run js-test-karma`; `npm run js-lint` (no errors; existing warnings only).
