### PR TITLE
Fix compiled banner version and wire the live banner into `change-version.mjs`

### DIFF
--- a/build/change-version.mjs
+++ b/build/change-version.mjs
@@ -19,7 +19,7 @@ const FILES = [
   'config.yml',
   'js/src/base-component.js',
   'package.js',
-  'scss/mixins/_banner.scss',
+  'scss/_banner.scss',
   'site/data/docs-versions.yml'
 ]
 

--- a/scss/_banner.scss
+++ b/scss/_banner.scss
@@ -1,7 +1,7 @@
 $file: "" !default;
 
 /*!
-  * Bootstrap #{$file} v6.0.0-dev (https://getbootstrap.com/)
+  * Bootstrap #{$file} v6.0.0-alpha1 (https://getbootstrap.com/)
   * Copyright 2011-2026 The Bootstrap Authors
   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
   */

--- a/scss/bootstrap.scss
+++ b/scss/bootstrap.scss
@@ -1,6 +1,6 @@
+// scss-docs-start import-stack
 @forward "banner";
 
-// scss-docs-start import-stack
 @forward "colors";
 
 // Global CSS variables, layer definitions, and configuration

--- a/scss/mixins/_banner.scss
+++ b/scss/mixins/_banner.scss
@@ -1,7 +1,0 @@
-@mixin bsBanner($file) {
-  /*!
-   * Bootstrap #{$file} v6.0.0-alpha1 (https://getbootstrap.com/)
-   * Copyright 2011-2026 The Bootstrap Authors
-   * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
-   */
-}


### PR DESCRIPTION
### Description

This PR fixes the version string emitted at the top of every compiled CSS artifact and makes the release tooling own it:

- `scss/_banner.scss`: v6.0.0-dev → v6.0.0-alpha1, so dist CSS headers agree with `package.json` and `js/src/base-component.js` (VERSION = '6.0.0-alpha1')
- `build/change-version.mjs`: registers `scss/_banner.scss` (the banner actually `@use`d by all four entry points) instead of `scss/mixins/_banner.scss`, so future version bumps propagate automatically
- `scss/mixins/_banner.scss`: deleted — dead v5 leftover. Its `bsBanner()` mixin has zero call sites in the tree and isn't forwarded by `scss/mixins/index.scss`; it was only reachable by the version-bump script, which kept updating a file nobody compiles
- `scss/bootstrap.scss`: moved @forward "banner" inside the `scss-docs-start import-stack` markers so docs extraction shows the complete import stack