### PR TITLE
Docs: add 'Browsers & devices' page documenting the support policy

### DIFF
--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -10,6 +10,7 @@
     - title: Approach
     - title: CSS variables
     - title: JavaScript
+    - title: Browsers & devices
     - title: Accessibility
 
 - title: Guides

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -1,0 +1,78 @@
+---
+title: Browsers & devices
+description: Learn about the browsers and devices, from modern to old, that are supported by Bootstrap, and the modern platform features the framework is built on.
+toc: true
+---
+
+## Supported browsers
+
+Bootstrap supports the **latest, stable releases** of all major browsers and platforms—more precisely, the last two major versions of each. The exact policy lives in [our `.browserslistrc` file](https://github.com/twbs/bootstrap/blob/v6-dev/.browserslistrc):
+
+```text
+last 2 major versions
+not dead
+Chrome >= 130
+Edge >= 130
+Firefox >= 132
+iOS >= 18.0
+Safari >= 18.0
+```
+
+<BsTable>
+| Browser | Minimum version |
+| --- | --- |
+| Chrome | 130 |
+| Edge | 130 |
+| Firefox | 132 |
+| Safari (macOS) | 18 |
+| Safari (iOS and iPadOS) | 18 |
+</BsTable>
+
+Alternative browsers built on these engines (Chromium-based browsers like Brave, Opera, or Vivaldi, and browsers using WebKit on iOS) are not explicitly tested, but should be fully supported at equivalent engine versions.
+
+### Why these versions?
+
+Bootstrap’s CSS is written against the modern platform baseline: [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) for [color modes]([[docsref:/customize/color-modes]]), `oklch()` and `color-mix()` for the [color system]([[docsref:/customize/color]]), native CSS nesting, container queries, and `:has()`. The version floors are set on native `light-dark()` support so our build pipeline doesn’t have to lower these features to brittle custom-property polyfills. This floor covers roughly 90% of global browser usage; raising it further was possible, lowering it was not without compromising the color-mode architecture.
+
+Unlike previous major versions, Bootstrap 6 does not ship fallbacks, prefixes, or polyfills for browsers below this floor. Pages will not render correctly in unsupported browsers—most visibly, colors depending on `light-dark()` will not resolve.
+
+## Modern platform features
+
+The table below lists the platform features v6 relies on and how each behaves at—and below—the support floor.
+
+<BsTable>
+| Feature | Used by | Behavior in supported browsers |
+| --- | --- | --- |
+| `light-dark()` | [Color modes]([[docsref:/customize/color-modes]]), all theme tokens | Defines the support floor; no fallback below it |
+| `oklch()`, `color-mix()` | [Color system]([[docsref:/customize/color]]), theme variants | Fully supported above the floor |
+| Container queries (`@container`) | [Card groups]([[docsref:/components/card#card-groups]]), [horizontal list groups]([[docsref:/components/list-group#horizontal]]) | Fully supported above the floor; these components also require an ancestor query container (`.contains-inline`)—without one they stay stacked |
+| `:has()` | Forms, button groups with menus, and other contextual styling | Fully supported above the floor |
+| Native `<dialog>` | [Dialog]([[docsref:/components/dialog]]), [Drawer]([[docsref:/components/drawer]]) | Fully supported above the floor; focus containment and `inert` behavior come from the browser |
+| `<details name="…">` | [Exclusive accordions]([[docsref:/components/accordion]]) | Fully supported above the floor; in older, unsupported browsers accordion items degrade gracefully to independently openable `<details>` elements |
+| CSS scroll snap | [Carousel]([[docsref:/components/carousel]]) | Fully supported above the floor; native touch, wheel, and keyboard scrolling |
+| Logical properties | Spacing, borders, and [RTL]([[docsref:/customize/rtl]]) support throughout | Fully supported above the floor |
+</BsTable>
+
+## JavaScript
+
+Bootstrap’s JavaScript ships as **native ES modules only**. Load it with `<script type="module">`—a classic `<script src>` without `type="module"` will not execute it, and there is no global `window.bootstrap` object. See the [JavaScript getting-started guide]([[docsref:/getting-started/javascript]]) for loading patterns, including import maps for the bundle’s dependencies.
+
+All browsers meeting the CSS support floor above fully support ES modules, `import`/`export` syntax, and the DOM APIs Bootstrap’s plugins use—no transpilation or polyfills are required or provided.
+
+## Mobile devices
+
+Generally speaking, Bootstrap supports the latest versions of each major platform’s default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile’s Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
+
+<BsTable>
+| Platform | Supported browsers |
+| --- | --- |
+| Android | Chrome (last two major versions) |
+| iOS and iPadOS | Safari 18+, Chrome (uses WebKit on iOS) |
+| Windows, macOS, Linux | Chrome, Edge, and Firefox (last two major versions); Safari 18+ on macOS |
+</BsTable>
+
+As with v5, make sure you include the responsive viewport meta tag in your `<head>` for proper rendering on mobile devices:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```

--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -44,7 +44,7 @@ Bootstrap’s `package.json` contains some additional metadata under the followi
 - `sass` - path to Bootstrap’s main [Sass](https://sass-lang.com/) source file
 - `style` - path to Bootstrap’s non-minified CSS that’s been compiled using the default settings (no customization)
 
-Additionally, Bootstrap ships a `.browserslistrc` file at the package root, which defines browser targets for tools like Browserslist and Autoprefixer.
+Additionally, Bootstrap ships a `.browserslistrc` file at the package root, which defines browser targets for tools like Browserslist and Autoprefixer. See [Browsers & devices]([[docsref:/getting-started/browsers-devices]]) for the full support policy.
 
 ### Using Yarn
 


### PR DESCRIPTION
### Description

Adds a new "Browsers & devices" page under Getting started, restoring a page that existed in v5 but had no v6 equivalent. It covers:

- The supported-browser matrix (Chrome/Edge ≥ 130, Firefox ≥ 132, Safari/iOS ≥ 18), sourced directly from `.browserslistrc`

> [!NOTE]
> I would rather display the content of `.browserslistrc`, but the rest could be difficult to handle anyway automatically. With AI now, it would be way simpler to maintain.

- Why the floor is where it is: the version minimums are pinned on native `light-dark()` support so the build pipeline doesn't lower our color-mode system to custom-property polyfills, while keeping ~90% global coverage
- A per-feature table of the modern platform features v6 relies on (`light-dark()`, `oklch()`/`color-mix()`, container queries, `:has()`, native `<dialog>`, `<details name>`, scroll snap, logical properties) with degradation notes — e.g. exclusive accordions fall back to independently openable items, and card groups/horizontal list groups need an ancestor `.contains-inline` query container
- A JavaScript section stating v6 is ESM-only (`<script type="module">` required, no `window.bootstrap`)
- Mobile device support and the responsive viewport meta tag

Also adds the sidebar entry (after JavaScript) and links the page from the existing `.browserslistrc` mention on the Install page.

## Why

v6 leans on modern CSS features much more than v5 did, and "which browsers does it support?" will be one of the first questions at alpha. Until now the answer only existed as a comment inside `.browserslistrc`.

## Verification

- `markdownlint`, Prettier (site config), and cspell all pass on the touched files
- Every `[[docsref:...]]` link target and heading anchor verified against the target pages
- Version numbers cross-checked against `.browserslistrc`

## Out of scope

- A cross-link from the migration guide — left out deliberately to avoid conflicting with the in-flight migration-guide work; can be added there in one line later

#### Live previews

- https://deploy-preview-42671--twbs-bootstrap.netlify.app/docs/6.0/getting-started/browsers-devices/

