### PR TITLE
v6: More component tweaks (accordion, spinner, badge, button)

### DIFF
--- a/scss/_accordion.scss
+++ b/scss/_accordion.scss
@@ -4,6 +4,7 @@
 @use "mixins/focus-ring" as *;
 @use "mixins/tokens" as *;
 
+// stylelint-disable custom-property-no-missing-var-function
 $accordion-tokens: () !default;
 
 // scss-docs-start accordion-tokens
@@ -31,6 +32,7 @@ $accordion-tokens: defaults(
   $accordion-tokens
 );
 // scss-docs-end accordion-tokens
+// stylelint-enable custom-property-no-missing-var-function
 
 @layer components {
   .accordion {
@@ -76,6 +78,7 @@ $accordion-tokens: defaults(
   }
 
   .accordion-item {
+    position: relative;
     color: var(--accordion-color);
     background-color: var(--accordion-bg);
     border: var(--accordion-border-width) solid var(--accordion-border-color);
@@ -99,7 +102,8 @@ $accordion-tokens: defaults(
     }
 
     &:not(:first-of-type) {
-      border-block-start: 0;
+      // border-block-start: 0;
+      margin-top: calc(-1 * var(--accordion-border-width));
     }
 
     // Only set a border-radius on the last item if the accordion is collapsed
@@ -117,8 +121,9 @@ $accordion-tokens: defaults(
 
     // Open state - details[open] applies these styles
     &[open] {
-
+      z-index: 2;
       border-color: var(--theme-border, var(--accordion-border-color));
+
       &::details-content {
         block-size: auto;
       }
@@ -142,6 +147,21 @@ $accordion-tokens: defaults(
 
   .accordion-body {
     padding: var(--accordion-body-padding-y, var(--accordion-padding-y)) var(--accordion-body-padding-x, var(--accordion-padding-x));
+    font-size: var(--accordion-font-size, var(--font-size-base));
+  }
+
+
+  // Small accordion
+  //
+  // Tighten up padding, border-radius, and font size for a more compact accordion.
+
+  .accordion-sm {
+    // scss-docs-start accordion-sm-css-vars
+    --accordion-padding-x: .875rem;
+    --accordion-padding-y: .625rem;
+    --accordion-border-radius: var(--radius-5);
+    --accordion-font-size: var(--font-size-sm);
+    // scss-docs-end accordion-sm-css-vars
   }
 
 

--- a/scss/_badge.scss
+++ b/scss/_badge.scss
@@ -9,6 +9,7 @@ $badge-tokens: () !default;
 // scss-docs-start badge-tokens
 $badge-tokens: defaults(
   (
+    --badge-gap: .375em,
     --badge-padding-x: .625em,
     --badge-padding-y: .25em,
     --badge-font-size: clamp(12px, .75em, .75em),
@@ -45,6 +46,7 @@ $badge-variants: (
     @include tokens($badge-tokens);
 
     display: inline-flex;
+    gap: var(--badge-gap);
     align-items: center;
     justify-content: center;
     min-height: 1.375rem;
@@ -59,7 +61,6 @@ $badge-variants: (
     background-color: var(--theme-bg, var(--badge-bg));
     border: var(--badge-border-width) solid var(--badge-border-color);
     @include border-radius(var(--badge-border-radius));
-    // @include gradient-bg();
 
     // Empty badges collapse automatically
     &:empty {

--- a/scss/_spinner.scss
+++ b/scss/_spinner.scss
@@ -9,11 +9,11 @@ $spinner-border-tokens: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $spinner-border-tokens: defaults(
   (
-    --spinner-width: 2rem,
-    --spinner-height: 2rem,
-    --spinner-vertical-align: -.125em,
-    --spinner-border-width: .25em,
-    --spinner-animation-speed: .75s,
+    --spinner-width: 1em,
+    --spinner-height: 1em,
+    --spinner-border-width: .125em,
+    --spinner-animation-speed: 1s,
+    --spinner-animation-timing-function: linear,
     --spinner-animation-name: spinner-border,
   ),
   $spinner-border-tokens
@@ -26,10 +26,10 @@ $spinner-grow-tokens: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default
 $spinner-grow-tokens: defaults(
   (
-    --spinner-width: 2rem,
-    --spinner-height: 2rem,
-    --spinner-vertical-align: -.125em,
-    --spinner-animation-speed: .75s,
+    --spinner-width: 1em,
+    --spinner-height: 1em,
+    --spinner-animation-speed: 1s,
+    --spinner-animation-timing-function: ease-in-out,
     --spinner-animation-name: spinner-grow,
   ),
   $spinner-grow-tokens
@@ -43,17 +43,16 @@ $spinner-grow-tokens: defaults(
 //
 
 @layer components {
-  // TODO: refactor this to assume flex parent and remove `vertical-align`
+  // Assumes a flex parent
   .spinner-grow,
   .spinner-border {
-    display: inline-block;
+    display: inline-flex;
     flex-shrink: 0;
     width: var(--spinner-width);
     height: var(--spinner-height);
-    vertical-align: var(--spinner-vertical-align);
     // stylelint-disable-next-line property-disallowed-list
     border-radius: 50%;
-    animation: var(--spinner-animation-speed) linear infinite var(--spinner-animation-name);
+    animation: var(--spinner-animation-speed) var(--spinner-animation-timing-function) infinite var(--spinner-animation-name);
   }
 
   // scss-docs-start spinner-border-keyframes
@@ -69,11 +68,10 @@ $spinner-grow-tokens: defaults(
     border-inline-end-color: transparent;
   }
 
-  .spinner-border-sm {
+  .spinner-sm {
     // scss-docs-start spinner-border-sm-css-vars
-    --spinner-width: 1rem;
-    --spinner-height: 1rem;
-    --spinner-border-width: .2em;
+    --spinner-width: .75em;
+    --spinner-height: .75em;
     // scss-docs-end spinner-border-sm-css-vars
   }
 
@@ -100,11 +98,9 @@ $spinner-grow-tokens: defaults(
     opacity: 0;
   }
 
-  .spinner-grow-sm {
-    // scss-docs-start spinner-grow-sm-css-vars
-    --spinner-width: 1rem;
-    --spinner-height: 1rem;
-    // scss-docs-end spinner-grow-sm-css-vars
+  // Generic class for rotating custom spinners
+  .spinner-rotate {
+    animation: 1s linear infinite spinner-border;
   }
 
   @if $enable-reduced-motion {

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -72,7 +72,7 @@ $button-styled-tokens: defaults(
     --btn-border-hover-mix-amount: 12.5%,
     --btn-border-active-mix-amount: 20%,
     --btn-shadow: "0 1px 2px rgb(0 0 0 / 15%), inset 0 1px 0 rgb(255 255 255 / 10%)",
-    --btn-active-shadow: inset 0 2px 4px rgb(0 0 0 / .15) ,
+    --btn-active-shadow: inset 0 2px 4px rgb(0 0 0 / .15),
   ),
   $button-styled-tokens
 );
@@ -177,12 +177,11 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     @include tokens($button-tokens);
 
     display: inline-flex;
-    gap: var(--btn-gap, .25rem);
+    gap: var(--btn-gap, .375rem);
     align-items: center;
     justify-content: center;
     min-height: var(--btn-min-height);
     padding: var(--btn-padding-y) var(--btn-padding-x);
-    // font-family: var(--btn-font-family);
     font-size: var(--btn-font-size);
     font-weight: var(--btn-font-weight);
     line-height: var(--btn-line-height);

--- a/site/src/content/docs/components/accordion.mdx
+++ b/site/src/content/docs/components/accordion.mdx
@@ -81,13 +81,51 @@ Use the contextual `.theme-{color}` classes to apply a semantic theme color to o
         <strong>This is the third item’s accordion body.</strong> This exclusive accordion behavior is built into the browser—no Bootstrap JavaScript required. Just use matching <code>name</code> attributes on your <code>&lt;details&gt;</code> elements.
       </div>
     </details>
+  </div>`} customMarkup={`<div class="accordion theme-primary"><!--[!code highlight]-->
+    <!-- Accordion items here -->
+  </div>`} />
+
+## Small
+
+Add `.accordion-sm` to the `.accordion` for a more compact accordion with tighter padding, a smaller border radius, and a smaller font size.
+
+<Example code={`<div class="accordion accordion-sm">
+    <details class="accordion-item" name="accordionSmall" open>
+      <summary class="accordion-header">
+        Accordion Item #1
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the first item’s accordion body.</strong> The <code>.accordion-sm</code> class tightens up the padding, border radius, and font size for a more compact presentation.
+      </div>
+    </details>
+    <details class="accordion-item" name="accordionSmall">
+      <summary class="accordion-header">
+        Accordion Item #2
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the second item’s accordion body.</strong> Everything is driven by CSS custom properties, so you can fine-tune the compact sizing to taste.
+      </div>
+    </details>
+    <details class="accordion-item" name="accordionSmall">
+      <summary class="accordion-header">
+        Accordion Item #3
+        <svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+      </summary>
+      <div class="accordion-body">
+        <strong>This is the third item’s accordion body.</strong> Combine <code>.accordion-sm</code> with other variants like <code>.accordion-flush</code> as needed.
+      </div>
+    </details>
+  </div>`} customMarkup={`<div class="accordion accordion-sm"><!--[!code highlight]-->
+    <!-- Accordion items here -->
   </div>`} />
 
 ## Flush
 
 Add `.accordion-flush` to remove some borders and rounded corners to render accordions edge-to-edge with their parent container.
 
-<Example class="bg-body-secondary" code={`<div class="accordion accordion-flush">
+<Example class="bg-1" code={`<div class="accordion accordion-flush">
     <details class="accordion-item" name="accordionFlushExample">
       <summary class="accordion-header">
         Accordion Item #1
@@ -109,6 +147,8 @@ Add `.accordion-flush` to remove some borders and rounded corners to render acco
       </summary>
       <div class="accordion-body">Placeholder content for this accordion, which is intended to demonstrate the <code>.accordion-flush</code> class. This is the third item’s accordion body. Nothing more exciting happening here in terms of content, but just filling up the space to make it look, at least at first glance, a bit more representative of how this would look in a real-world application.</div>
     </details>
+  </div>`} customMarkup={`<div class="accordion accordion-flush"><!--[!code highlight]-->
+    <!-- Accordion items here -->
   </div>`} />
 
 ## Always open
@@ -143,6 +183,11 @@ Omit the `name` attribute on each `<details>` element to allow multiple accordio
         <strong>This is the third item’s accordion body.</strong> Each item is completely independent—open or close them in any combination you like.
       </div>
     </details>
+  </div>`} customMarkup={`<div class="accordion">
+    <details class="accordion-item" open><!--[!code highlight]-->
+      <!-- No name attribute, so items open independently -->
+    </details>
+    <!-- More accordion items here -->
   </div>`} />
 
 ## Nested

--- a/site/src/content/docs/components/spinner.mdx
+++ b/site/src/content/docs/components/spinner.mdx
@@ -111,7 +111,3 @@ Used for creating the CSS animations for our spinners. Included in `scss/_spinne
 <ScssDocs name="spinner-grow-keyframes" file="scss/_spinner.scss" />
 
 [color]: [[docsref:/utilities/colors]]
-[flex]: [[docsref:/utilities/flex]]
-[float]: [[docsref:/utilities/float]]
-[margin]: [[docsref:/utilities/margin]]
-[text-alignment]: [[docsref:/utilities/text-alignment]]

--- a/site/src/content/docs/components/spinner.mdx
+++ b/site/src/content/docs/components/spinner.mdx
@@ -9,11 +9,9 @@ css_layer: components
 
 import { getData } from '@libs/data'
 
-## About
+Bootstrap “spinners” can be used to show the loading state in your projects. They’re built only with HTML and CSS, meaning you don’t need any JavaScript to create them. You may, however, need some custom JavaScript to toggle their visibility. Their appearance, alignment, and sizing can be easily customized with our utility classes.
 
-Bootstrap “spinners” can be used to show the loading state in your projects. They’re built only with HTML and CSS, meaning you don’t need any JavaScript to create them. You will, however, need some custom JavaScript to toggle their visibility. Their appearance, alignment, and sizing can be easily customized with our amazing utility classes.
-
-For accessibility purposes, each loader here includes `role="status"` and a nested `<span class="visually-hidden">Loading...</span>`.
+For accessibility purposes, each loader here includes `role="status"` and a nested `<span class="visually-hidden">Loading…</span>`.
 
 <Callout name="info-prefersreducedmotion" />
 
@@ -21,122 +19,74 @@ For accessibility purposes, each loader here includes `role="status"` and a nest
 
 Use the border spinners for a lightweight loading indicator.
 
-<Example code={`<div class="spinner-border" role="status">
-    <span class="visually-hidden">Loading...</span>
-  </div>`} />
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-border" role="status">
+    <span class="visually-hidden">Loading…</span>
+  </div>
 
-### Colors
+  <span class="badge theme-primary">
+    <span class="spinner-border" aria-hidden="true"></span>
+    <span role="status">Loading</span>
+  </span>
 
-The border spinner uses `currentColor` for its `border-color`, meaning you can customize the color with [text color utilities][color]. You can use any of our text color utilities on the standard spinner.
-
-<Example code={getData('theme-colors').map((themeColor) => `<div class="spinner-border fg-${themeColor.name}" role="status">
-    <span class="visually-hidden">Loading...</span>
-  </div>`)} />
-
-<Callout>
-**Why not use `border-color` utilities?** Each border spinner specifies a `transparent` border for at least one side, so `.border-{color}` utilities would override that.
-</Callout>
+  <button class="btn-subtle theme-primary" type="button" disabled>
+    <span class="spinner-border" aria-hidden="true"></span>
+    <span role="status">Loading…</span>
+  </button>`} />
 
 ## Growing spinner
 
 If you don’t fancy a border spinner, switch to the grow spinner. While it doesn’t technically spin, it does repeatedly grow!
 
-<Example code={`<div class="spinner-grow" role="status">
-    <span class="visually-hidden">Loading...</span>
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-grow" role="status">
+    <span class="visually-hidden">Loading…</span>
   </div>`} />
 
-Once again, this spinner is built with `currentColor`, so you can easily change its appearance with [text color utilities][color]. Here it is in blue, along with the supported variants.
+## Variants
 
-<Example code={getData('theme-colors').map((themeColor) => `<div class="spinner-grow fg-${themeColor.name}" role="status">
-    <span class="visually-hidden">Loading...</span>
-  </div>`)} />
+Spinners use `currentColor` for their appearance, meaning you can customize the color with [text color utilities][color]. You can use any of our text color utilities on the standard spinner.
 
-## Alignment
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-border fg-primary" role="status"><!--[!code highlight]-->
+    <span class="visually-hidden">Loading…</span>
+  </div>
 
-Spinners in Bootstrap are built with `rem`s, `currentColor`, and `display: inline-flex`. This means they can easily be resized, recolored, and quickly aligned.
-
-### Margin
-
-Use [margin utilities][margin] like `.m-5` for easy spacing.
-
-<Example code={`<div class="spinner-border m-5" role="status">
-    <span class="visually-hidden">Loading...</span>
-  </div>`} />
-
-### Placement
-
-Use [flexbox utilities][flex], [float utilities][float], or [text alignment][text-alignment] utilities to place spinners exactly where you need them in any situation.
-
-#### Flex
-
-<Example code={`<div class="d-flex justify-content-center">
-    <div class="spinner-border" role="status">
-      <span class="visually-hidden">Loading...</span>
-    </div>
-  </div>`} />
-
-<Example code={`<div class="d-flex align-items-center">
-    <strong role="status">Loading...</strong>
-    <div class="spinner-border ms-auto" aria-hidden="true"></div>
-  </div>`} />
-
-#### Floats
-
-<Example code={`<div class="d-flow-root">
-    <div class="spinner-border float-end" role="status">
-      <span class="visually-hidden">Loading...</span>
-    </div>
-  </div>`} />
-
-#### Text align
-
-<Example code={`<div class="text-center">
-    <div class="spinner-border" role="status">
-      <span class="visually-hidden">Loading...</span>
-    </div>
+  <div class="spinner-grow fg-accent" role="status"><!--[!code highlight]-->
+    <span class="visually-hidden">Loading…</span>
   </div>`} />
 
 ## Size
 
-Add `.spinner-border-sm` and `.spinner-grow-sm` to make a smaller spinner that can quickly be used within other components.
+Spinner are `1em` by `1em` by default, all Add `.spinner-sm` to make a smaller spinner that can quickly be used within other components.
 
-<Example code={`<div class="spinner-border spinner-border-sm" role="status">
-    <span class="visually-hidden">Loading...</span>
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-border spinner-sm" role="status">
+    <span class="visually-hidden">Loading…</span>
   </div>
-  <div class="spinner-grow spinner-grow-sm" role="status">
-    <span class="visually-hidden">Loading...</span>
+  <div class="spinner-grow spinner-sm" role="status">
+    <span class="visually-hidden">Loading…</span>
   </div>`} />
 
 Or, use custom CSS or inline styles to change the dimensions as needed.
 
-<Example code={`<div class="spinner-border" style="width: 3rem; height: 3rem;" role="status">
-    <span class="visually-hidden">Loading...</span>
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-border" style="width: 3rem; height: 3rem;" role="status">
+    <span class="visually-hidden">Loading…</span>
   </div>
   <div class="spinner-grow" style="width: 3rem; height: 3rem;" role="status">
-    <span class="visually-hidden">Loading...</span>
+    <span class="visually-hidden">Loading…</span>
   </div>`} />
 
-## Buttons
+## Custom spinners
 
-Use spinners within buttons to indicate an action is currently processing or taking place. You may also swap the text out of the spinner element and utilize button text as needed.
+You can use the `.spinner-rotate` class to rotate a custom SVG spinner.
 
-<Example code={`<button class="btn-solid theme-primary" type="button" disabled>
-    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
-    <span class="visually-hidden" role="status">Loading...</span>
-  </button>
-  <button class="btn-solid theme-primary" type="button" disabled>
-    <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
-    <span role="status">Loading...</span>
-  </button>`} />
-
-<Example code={`<button class="btn-solid theme-primary" type="button" disabled>
-    <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
-    <span class="visually-hidden" role="status">Loading...</span>
-  </button>
-  <button class="btn-solid theme-primary" type="button" disabled>
-    <span class="spinner-grow spinner-grow-sm" aria-hidden="true"></span>
-    <span role="status">Loading...</span>
-  </button>`} />
+<Example code={`<svg class="bi spinner-rotate" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentcolor" stroke-width="2" stroke-linecap="round">
+    <path d="M8 1V4"/>
+    <path opacity="0.8" d="M3.05 3.05L5.17 5.17"/>
+    <path opacity="0.6" d="M4 8L1 8"/>
+    <path opacity="0.5" d="M5.17 10.83L3.05 12.95"/>
+    <path opacity="0.4" d="M8 12V15"/>
+    <path opacity="0.3" d="M10.83 10.83L12.95 12.95"/>
+    <path opacity="0.2" d="M15 8L12 8"/>
+    <path opacity="0.1" d="M12.95 3.05L10.83 5.17"/>
+  </svg>`} />
 
 ## CSS
 
@@ -151,12 +101,6 @@ Border spinner tokens:
 Growing spinner tokens:
 
 <ScssDocs name="spinner-grow-tokens" file="scss/_spinner.scss" />
-
-Small spinner modifier tokens:
-
-<ScssDocs name="spinner-border-sm-css-vars" file="scss/_spinner.scss" />
-
-<ScssDocs name="spinner-grow-sm-css-vars" file="scss/_spinner.scss" />
 
 ### Keyframes
 

--- a/site/src/scss/_masthead.scss
+++ b/site/src/scss/_masthead.scss
@@ -1,7 +1,4 @@
-// @use "sass:math";
 @use "../../../scss/layout/breakpoints" as *;
-// @use "../../../scss/mixins/border-radius" as *;
-// @use "../../../scss/mixins/transition" as *;
 
 @layer custom {
   .bd-masthead {
@@ -31,6 +28,10 @@
       background-color: transparent;
     }
 
+    .btn-styled {
+      box-shadow: var(--bs-box-shadow), var(--bs-btn-shadow);
+    }
+
     #carbonads { // stylelint-disable-line selector-max-id
       max-width: 400px;
       margin-block-start: 3rem;
@@ -41,59 +42,5 @@
       place-items: center;
       height: calc(100vh - var(--bd-navbar-offset));
     }
-
-    @include media-breakpoint-up(lg) {
-      // padding-block: 6rem;
-    }
   }
-
-  // .masthead-followup {
-  //   h2,
-  //   h3,
-  //   h4 {
-  //     --bs-heading-color: var(--bs-fg-body);
-  //   }
-
-  //   .lead {
-  //     font-size: 1rem;
-  //   }
-
-  //   @include media-breakpoint-up(md) {
-  //     .lead {
-  //       font-size: 1.25rem;
-  //     }
-  //   }
-  // }
-
-  // .masthead-followup-icon {
-  //   padding: 1rem;
-  //   color: rgba(var(--bg-rgb), 1);
-  //   background-color: rgba(var(--bg-rgb), .1);
-  //   background-blend-mode: multiply;
-  //   @include border-radius(1rem);
-  //   mix-blend-mode: darken;
-
-  //   svg {
-  //     filter: drop-shadow(0 1px 1px var(--bs-bg-body));
-  //   }
-  // }
-
-  // .masthead-notice {
-  //   background-color: var(--bd-accent);
-  //   box-shadow: inset 0 -1px 1px color-mix(in oklch, var(--body-color) #{math.percentage(.15)}, transparent), 0 .25rem 1.5rem color-mix(in oklch, var(--body-bg) #{math.percentage(.75)}, transparent);
-  // }
-
-  // .animate-img {
-  //   > img {
-  //     @include transition(transform .2s ease-in-out);
-  //   }
-
-  //   &:hover > img {
-  //     transform: scale(1.1);
-  //   }
-
-  //   &:active > img {
-  //     transform: scale(1);
-  //   }
-  // }
 }


### PR DESCRIPTION
A batch of small v6 component improvements and docs cleanup:

- **Accordion**: add `small` and `separated` variants (closes #42092)
- **Spinner**: rework sizing and simplify the size variants (fixes #42656)
- **Badge**: add a configurable gap between contents
- **Button**: increase the default gap to `.375rem`
- **Docs**: clean up masthead styles
