### PR TITLE
Fix nested dropdown keyboard leaving sibling submenus open

### DIFF
--- a/js/src/dropdown.js
+++ b/js/src/dropdown.js
@@ -420,6 +420,15 @@ class Dropdown extends BaseComponent {
 
     if (isUpOrDownEvent) {
       event.stopPropagation()
+
+      // When arrowing between nested submenu toggles (especially with
+      // autoClose: 'outside'), close other open menus first so only the
+      // focused submenu stays shown. Skip when the event target is a
+      // regular menu item so in-menu arrow navigation is unchanged.
+      if (this.matches(SELECTOR_DATA_TOGGLE)) {
+        Dropdown.clearMenus(event)
+      }
+
       instance.show()
       instance._selectMenuItem(event)
       return

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1763,6 +1763,61 @@ describe('Dropdown', () => {
       })
     })
 
+    it('should close sibling submenus when opening nested dropdowns with keyboard navigation', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div class="dropdown">',
+          '  <button id="menuDemo" class="btn dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside">Demo</button>',
+          '  <ul class="dropdown-menu">',
+          '    <li class="dropend">',
+          '      <a id="subMenuDemo1" class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" href="#">Submenu 1</a>',
+          '      <ul id="subMenuDemo1Menu" class="dropdown-menu"><li><a class="dropdown-item" href="#">Menu Item 1A</a></li></ul>',
+          '    </li>',
+          '    <li class="dropend">',
+          '      <a id="subMenuDemo2" class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" href="#">Submenu 2</a>',
+          '      <ul id="subMenuDemo2Menu" class="dropdown-menu"><li><a class="dropdown-item" href="#">Menu Item 2A</a></li></ul>',
+          '    </li>',
+          '    <li class="dropend">',
+          '      <a id="subMenuDemo3" class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" href="#">Submenu 3</a>',
+          '      <ul id="subMenuDemo3Menu" class="dropdown-menu"><li><a class="dropdown-item" href="#">Menu Item 3A</a></li></ul>',
+          '    </li>',
+          '  </ul>',
+          '</div>'
+        ].join('')
+
+        const menuDemo = fixtureEl.querySelector('#menuDemo')
+        const subMenuDemo2 = fixtureEl.querySelector('#subMenuDemo2')
+        const subMenuDemo2Menu = fixtureEl.querySelector('#subMenuDemo2Menu')
+        const subMenuDemo3 = fixtureEl.querySelector('#subMenuDemo3')
+        const subMenuDemo3Menu = fixtureEl.querySelector('#subMenuDemo3Menu')
+
+        subMenuDemo3.addEventListener('shown.bs.dropdown', () => {
+          setTimeout(() => {
+            subMenuDemo2.focus()
+
+            const keydownArrowDown = createEvent('keydown', { bubbles: true })
+            keydownArrowDown.key = 'ArrowDown'
+            subMenuDemo2.dispatchEvent(keydownArrowDown)
+
+            setTimeout(() => {
+              expect(subMenuDemo2).toHaveClass('show')
+              expect(subMenuDemo2Menu).toHaveClass('show')
+              expect(subMenuDemo3).not.toHaveClass('show')
+              expect(subMenuDemo3Menu).not.toHaveClass('show')
+              expect(menuDemo).toHaveClass('show')
+              resolve()
+            })
+          })
+        })
+
+        menuDemo.addEventListener('shown.bs.dropdown', () => {
+          subMenuDemo3.click()
+        })
+
+        menuDemo.click()
+      })
+    })
+
     it('should open the dropdown and focus on the last item when using ArrowUp for the first time', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

When using nested dropdowns with `data-bs-auto-close="outside"`, keyboard arrow navigation between submenu toggles can leave multiple submenus open at once. ArrowUp/ArrowDown on a nested toggle always called `show()` without closing sibling menus first.

This change closes other open menus (via `clearMenus`) when the keydown target is a dropdown toggle, then shows the focused submenu. Regular in-menu item arrow navigation is unchanged.

### Motivation & Context

Fixes #41869.

Overlapping nested submenus during keyboard navigation is a real usability/accessibility problem in multi-level menus (navbars, app menus). A previous PR (#42528) proposed the same approach and was closed by the author without maintainer rejection.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project (`npm run js-lint`)
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Tests

- `npx karma start js/tests/karma.conf.js --single-run` → 810/810 SUCCESS
- `npx eslint js/src/dropdown.js js/tests/unit/dropdown.spec.js` → no errors