### PR TITLE
Fix v6 menu keyboard navigation for nested submenus

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -34,19 +34,19 @@
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",
-      "maxSize": "88.0 kB"
+      "maxSize": "88.5 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.min.js",
-      "maxSize": "54.75 kB"
+      "maxSize": "55.0 kB"
     },
     {
       "path": "./dist/js/bootstrap.js",
-      "maxSize": "59.25 kB"
+      "maxSize": "59.75 kB"
     },
     {
       "path": "./dist/js/bootstrap.min.js",
-      "maxSize": "32.75 kB"
+      "maxSize": "33.0 kB"
     }
   ],
   "ci": {

--- a/js/src/menu.js
+++ b/js/src/menu.js
@@ -950,6 +950,29 @@ class Menu extends BaseComponent {
     }
   }
 
+  static _getToggleFromKeydownContext(element, event) {
+    if (element.matches?.(SELECTOR_DATA_TOGGLE)) {
+      return element
+    }
+
+    // Root panel is usually a sibling of the toggle (when not moved to a container).
+    const siblingToggle = SelectorEngine.prev(element, SELECTOR_DATA_TOGGLE)[0] ||
+      SelectorEngine.next(element, SELECTOR_DATA_TOGGLE)[0]
+    if (siblingToggle) {
+      return siblingToggle
+    }
+
+    // Nested submenu panels (and menus moved to `container`) are not siblings of
+    // the toggle. Resolve the owning open Menu instance from the event target.
+    for (const instance of Menu._openInstances) {
+      if (instance._menu?.contains(event.target) || instance._element === event.target) {
+        return instance._element
+      }
+    }
+
+    return SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, event.delegateTarget.parentNode)
+  }
+
   static dataApiKeydownHandler(event) {
     // Treat contenteditable hosts (e.g. rich-text editors) like inputs so the
     // menu doesn't hijack their arrow keys.
@@ -971,11 +994,7 @@ class Menu extends BaseComponent {
       return
     }
 
-    const getToggleButton = this.matches(SELECTOR_DATA_TOGGLE) ?
-      this :
-      (SelectorEngine.prev(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.next(this, SELECTOR_DATA_TOGGLE)[0] ||
-        SelectorEngine.findOne(SELECTOR_DATA_TOGGLE, event.delegateTarget.parentNode))
+    const getToggleButton = Menu._getToggleFromKeydownContext(this, event)
 
     if (!getToggleButton) {
       return

--- a/js/src/menu.js
+++ b/js/src/menu.js
@@ -787,8 +787,9 @@ class Menu extends BaseComponent {
   _getItemsInMenu(menu) {
     // Items may be direct children of `.menu`, or submenu triggers nested as
     // `.menu > .submenu > .menu-item` (see menu-submenu visual tests / docs).
+    // Always use SELECTOR_VISIBLE_ITEMS so disabled triggers are skipped too.
     return SelectorEngine.find(
-      `:scope > ${SELECTOR_VISIBLE_ITEMS}, :scope > ${SELECTOR_SUBMENU_TOGGLE}`,
+      `:scope > ${SELECTOR_VISIBLE_ITEMS}, :scope > ${SELECTOR_SUBMENU} > ${SELECTOR_VISIBLE_ITEMS}`,
       menu
     ).filter(element => isVisible(element))
   }

--- a/js/src/menu.js
+++ b/js/src/menu.js
@@ -784,16 +784,46 @@ class Menu extends BaseComponent {
   // Keyboard navigation
   // -------------------------------------------------------------------------
 
+  _getItemsInMenu(menu) {
+    // Items may be direct children of `.menu`, or submenu triggers nested as
+    // `.menu > .submenu > .menu-item` (see menu-submenu visual tests / docs).
+    return SelectorEngine.find(
+      `:scope > ${SELECTOR_VISIBLE_ITEMS}, :scope > ${SELECTOR_SUBMENU_TOGGLE}`,
+      menu
+    ).filter(element => isVisible(element))
+  }
+
   _selectMenuItem({ key, target }) {
     const currentMenu = target.closest(SELECTOR_MENU) || this._menu
-    const items = SelectorEngine.find(`:scope > ${SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-      .filter(element => isVisible(element))
+    const items = this._getItemsInMenu(currentMenu)
 
     if (!items.length) {
       return
     }
 
-    getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target)).focus()
+    const nextItem = getNextActiveElement(items, target, key === ARROW_DOWN_KEY, !items.includes(target))
+    nextItem.focus()
+
+    // Arrowing between items at this level must close open sibling submenus that
+    // no longer relate to focus (mouse/click already do this via _closeSiblingSubmenus).
+    this._closeUnrelatedSubmenus(currentMenu, nextItem)
+  }
+
+  _closeUnrelatedSubmenus(currentMenu, focusedElement) {
+    for (const [submenu] of this._openSubmenus) {
+      const submenuWrapper = submenu.closest(SELECTOR_SUBMENU)
+      // Only consider submenus that are direct children of the menu being navigated
+      if (!submenuWrapper || submenuWrapper.parentElement !== currentMenu) {
+        continue
+      }
+
+      // Keep open when focus is on that submenu's trigger or still inside it
+      if (submenuWrapper.contains(focusedElement)) {
+        continue
+      }
+
+      this._closeSubmenu(submenu, submenuWrapper)
+    }
   }
 
   _handleSubmenuKeydown(event) {
@@ -867,12 +897,12 @@ class Menu extends BaseComponent {
       event.stopPropagation()
 
       const currentMenu = target.closest(SELECTOR_MENU)
-      const items = SelectorEngine.find(`:scope > ${SELECTOR_VISIBLE_ITEMS}`, currentMenu)
-        .filter(element => isVisible(element))
+      const items = this._getItemsInMenu(currentMenu)
 
       if (items.length) {
         const targetItem = key === HOME_KEY ? items[0] : items.at(-1)
         targetItem.focus()
+        this._closeUnrelatedSubmenus(currentMenu, targetItem)
       }
 
       return true

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -2862,6 +2862,51 @@ describe('Menu', () => {
       })
     })
 
+    it('should skip disabled submenu triggers during keyboard navigation', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu" id="submenu1">',
+          '      <button class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 1</a></div>',
+          '    </div>',
+          '    <div class="submenu" id="submenuDisabled">',
+          '      <button class="menu-item" type="button" disabled>Disabled submenu</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Hidden</a></div>',
+          '    </div>',
+          '    <div class="submenu" id="submenu2">',
+          '      <button class="menu-item" type="button">Submenu 2</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 2</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const submenu1Trigger = fixtureEl.querySelector('#submenu1 > .menu-item')
+        const submenu2Trigger = fixtureEl.querySelector('#submenu2 > .menu-item')
+        const disabledTrigger = fixtureEl.querySelector('#submenuDisabled > .menu-item')
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          submenu1Trigger.focus()
+
+          const keydown = createEvent('keydown', { bubbles: true })
+          keydown.key = 'ArrowDown'
+          submenu1Trigger.dispatchEvent(keydown)
+
+          expect(document.activeElement).toEqual(submenu2Trigger)
+          expect(document.activeElement).not.toEqual(disabledTrigger)
+          resolve()
+        })
+
+        // eslint-disable-next-line no-new
+        new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+
     it('should open submenu with ArrowRight key', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -2765,6 +2765,103 @@ describe('Menu', () => {
       })
     })
 
+    it('should close open sibling submenu when keyboard focus moves to another item', () => {
+      return new Promise(resolve => {
+        // Match the supported markup from visual/menu-submenu.html
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu" id="submenu1">',
+          '      <button class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu">',
+          '        <a class="menu-item" href="#">Action 1</a>',
+          '      </div>',
+          '    </div>',
+          '    <div class="submenu" id="submenu2">',
+          '      <button class="menu-item" type="button">Submenu 2</button>',
+          '      <div class="menu">',
+          '        <a class="menu-item" href="#">Action 2</a>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const submenu1Wrapper = fixtureEl.querySelector('#submenu1')
+        const submenu2Wrapper = fixtureEl.querySelector('#submenu2')
+        const submenu1Trigger = submenu1Wrapper.querySelector(':scope > .menu-item')
+        const submenu2Trigger = submenu2Wrapper.querySelector(':scope > .menu-item')
+        const submenu1 = submenu1Wrapper.querySelector('.menu')
+        const submenu2 = submenu2Wrapper.querySelector('.menu')
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          // Open first submenu via click (same as mouse path)
+          submenu1Trigger.click()
+          expect(submenu1.classList.contains('show')).toBeTrue()
+
+          // Move keyboard focus to the other sibling submenu trigger
+          submenu1Trigger.focus()
+          const keydown = createEvent('keydown', { bubbles: true })
+          keydown.key = 'ArrowDown'
+          submenu1Trigger.dispatchEvent(keydown)
+
+          expect(document.activeElement).toEqual(submenu2Trigger)
+          expect(submenu1.classList.contains('show')).toBeFalse()
+          expect(submenu2.classList.contains('show')).toBeFalse()
+          resolve()
+        })
+
+        // eslint-disable-next-line no-new
+        new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+
+    it('should keyboard-navigate between submenu triggers at the top level', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu" id="submenu1">',
+          '      <button class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 1</a></div>',
+          '    </div>',
+          '    <a id="plainItem" class="menu-item" href="#">Plain item</a>',
+          '    <div class="submenu" id="submenu2">',
+          '      <button class="menu-item" type="button">Submenu 2</button>',
+          '      <div class="menu"><a class="menu-item" href="#">Action 2</a></div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const submenu1Trigger = fixtureEl.querySelector('#submenu1 > .menu-item')
+        const plainItem = fixtureEl.querySelector('#plainItem')
+        const submenu2Trigger = fixtureEl.querySelector('#submenu2 > .menu-item')
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          submenu1Trigger.focus()
+
+          const keydown = createEvent('keydown', { bubbles: true })
+          keydown.key = 'ArrowDown'
+          submenu1Trigger.dispatchEvent(keydown)
+          expect(document.activeElement).toEqual(plainItem)
+
+          plainItem.dispatchEvent(keydown)
+          expect(document.activeElement).toEqual(submenu2Trigger)
+          resolve()
+        })
+
+        // eslint-disable-next-line no-new
+        new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+
     it('should open submenu with ArrowRight key', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -2907,6 +2907,53 @@ describe('Menu', () => {
       })
     })
 
+    it('should arrow-navigate items inside an open nested submenu', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <div class="menu">',
+          '    <div class="submenu" id="submenu1">',
+          '      <button class="menu-item" type="button">Submenu 1</button>',
+          '      <div class="menu" id="nestedMenu">',
+          '        <a id="nested1" class="menu-item" href="#">Action 1</a>',
+          '        <a id="nested2" class="menu-item" href="#">Action 2</a>',
+          '      </div>',
+          '    </div>',
+          '  </div>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const submenuTrigger = fixtureEl.querySelector('#submenu1 > .menu-item')
+        const nested1 = fixtureEl.querySelector('#nested1')
+        const nested2 = fixtureEl.querySelector('#nested2')
+        const nestedMenu = fixtureEl.querySelector('#nestedMenu')
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          submenuTrigger.click()
+          expect(nestedMenu.classList.contains('show')).toBeTrue()
+
+          nested1.focus()
+          const keydown = createEvent('keydown', { bubbles: true })
+          keydown.key = 'ArrowDown'
+          nested1.dispatchEvent(keydown)
+
+          expect(document.activeElement).toEqual(nested2)
+
+          const keyup = createEvent('keydown', { bubbles: true })
+          keyup.key = 'ArrowUp'
+          nested2.dispatchEvent(keyup)
+          expect(document.activeElement).toEqual(nested1)
+          resolve()
+        })
+
+        // eslint-disable-next-line no-new
+        new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+
     it('should open submenu with ArrowRight key', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [


### PR DESCRIPTION
### Description

Bootstrap v6’s Menu component supports nested submenus (`.menu > .submenu > .menu-item`), but keyboard arrow navigation only collected **direct** `.menu-item` children of `.menu`. That skipped submenu triggers, so ↑/↓ could not move between them.

This PR:

1. Collects keyboard-navigable items as both direct menu items **and** submenu triggers.
2. When focus moves to another item at the same level, closes open **sibling** submenus that no longer relate to focus (matching click/hover behavior via `_closeSiblingSubmenus`).

### Motivation & Context

@mdo invited exploring nested-menu improvements on `v6-dev` after closing the v5-only nested dropdown PR (#42694): nested menus are supported in v6.

This is the keyboard counterpart of existing click/hover sibling-close behavior already covered in unit tests.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Tests

- `npm run js-test-karma` → **1131/1131 SUCCESS**
- ESLint: no errors on changed files (existing warning-level rules only)