### PR TITLE
Docs: fix dark offcanvas dismiss attribute

### DIFF
--- a/site/src/content/docs/components/offcanvas.mdx
+++ b/site/src/content/docs/components/offcanvas.mdx
@@ -136,7 +136,7 @@ Change the appearance of offcanvases with utilities to better match them to diff
 <Example class="bd-example-offcanvas p-0 bg-body-secondary overflow-hidden" code={`<div class="offcanvas offcanvas-start show text-bg-dark" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasDarkLabel">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title" id="offcanvasDarkLabel">Offcanvas</h5>
-      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvasDark" aria-label="Close"></button>
+      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">
       <p>Place offcanvas content here.</p>


### PR DESCRIPTION
### Description

Fixes the dark offcanvas example's close button dismiss attribute.

### Motivation & Context

The copied dark offcanvas example used `data-bs-dismiss="offcanvasDark"`, but Bootstrap's dismiss trigger listens for `data-bs-dismiss="offcanvas"`. When the example is used in a live offcanvas, clicking the close button does not dismiss the component.

Expected: clicking the close button dismisses the offcanvas.
Actual: the offcanvas remains shown because the dismiss selector does not match.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42706--twbs-bootstrap.netlify.app/>

### Related issues

None.

### Checks

- `git diff --check`
- `npm exec -- prettier --config site/.prettierrc.json -c site/src/content/docs/components/offcanvas.mdx`
- `npm run docs-build`