### PR TITLE
Docs: use concrete checks and radios aria labels

### DIFF
--- a/site/src/content/docs/forms/checks-radios.mdx
+++ b/site/src/content/docs/forms/checks-radios.mdx
@@ -221,11 +221,11 @@ Put your checkboxes, radios, and switches on the opposite side with the `.form-c
 Omit the wrapping `.form-check` for checkboxes and radios that have no label text. Remember to still provide some form of accessible name for assistive technologies (for instance, using `aria-label`). See the [forms overview accessibility]([[docsref:/forms/overview/#accessibility]]) section for details.
 
 <Example code={`<div>
-    <input class="form-check-input" type="checkbox" id="checkboxNoLabel" value="" aria-label="...">
+    <input class="form-check-input" type="checkbox" id="checkboxNoLabel" value="" aria-label="Checkbox without label">
   </div>
 
   <div>
-    <input class="form-check-input" type="radio" name="radioNoLabel" id="radioNoLabel1" value="" aria-label="...">
+    <input class="form-check-input" type="radio" name="radioNoLabel" id="radioNoLabel1" value="" aria-label="Radio button without label">
   </div>`} />
 
 ## Toggle buttons


### PR DESCRIPTION
### Description

Replaces placeholder accessible names in the checks and radios "Without labels" example.

### Motivation & Context

The example explains that controls without visible labels still need an accessible name, but the copied markup used literal `aria-label="..."` values.

Expected: the example uses concrete accessible names.
Actual: the example exposes `...` as the checkbox and radio accessible names.

This updates the example to use concrete labels for the checkbox and radio inputs.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42708--twbs-bootstrap.netlify.app/>

### Related issues

None.

### Checks

- `git diff --check`
- `npm exec -- prettier --config site/.prettierrc.json -c site/src/content/docs/forms/checks-radios.mdx`
- `npm run docs-build`
