### PR TITLE
Docs: add href to active pagination sizing links

### DIFF
--- a/site/src/content/docs/components/pagination.mdx
+++ b/site/src/content/docs/components/pagination.mdx
@@ -101,7 +101,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <Example code={`<nav aria-label="...">
     <ul class="pagination pagination-lg">
       <li class="page-item active" >
-        <a class="page-link" aria-current="page">1</a>
+        <a class="page-link" href="#" aria-current="page">1</a>
       </li>
       <li class="page-item"><a class="page-link" href="#">2</a></li>
       <li class="page-item"><a class="page-link" href="#">3</a></li>
@@ -111,7 +111,7 @@ Fancy larger or smaller pagination? Add `.pagination-lg` or `.pagination-sm` for
 <Example code={`<nav aria-label="...">
     <ul class="pagination pagination-sm">
       <li class="page-item active">
-        <a class="page-link" aria-current="page">1</a>
+        <a class="page-link" href="#" aria-current="page">1</a>
       </li>
       <li class="page-item"><a class="page-link" href="#">2</a></li>
       <li class="page-item"><a class="page-link" href="#">3</a></li>


### PR DESCRIPTION
### Description

Adds missing `href="#"` attributes to the active links in the pagination sizing examples.

### Motivation & Context

The sizing examples use active `<a>` elements with `aria-current="page"`, but those anchors lacked `href` attributes. The page's canonical active example already uses `href="#"` for the same pattern.

Expected: the active pagination links in sizing examples follow the documented active-link pattern.
Actual: the active pagination links are anchors without `href` attributes.

This updates the large and small pagination examples to match the active example on the same page.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42709--twbs-bootstrap.netlify.app/>

### Related issues

None.

### Checks

- `git diff --check`
- `npm exec -- prettier --config site/.prettierrc.json -c site/src/content/docs/components/pagination.mdx`
- `npm run docs-build`
