### PR TITLE
Examples: restore sidebar dropdown focus outline

### DIFF
--- a/site/src/assets/examples/sidebars/sidebars.css
+++ b/site/src/assets/examples/sidebars/sidebars.css
@@ -15,7 +15,7 @@ main {
   overflow-y: hidden;
 }
 
-.dropdown-toggle { outline: 0; }
+.dropdown-toggle:not(:focus) { outline: 0; }
 
 .btn-toggle {
   padding: .25rem .5rem;


### PR DESCRIPTION
### Description

Restores the default focus outline for dropdown toggles in the sidebars example.

### Motivation & Context

The sidebars example removed outlines from every `.dropdown-toggle`, including focused dropdown triggers. The headers example already limits the same outline reset to `.dropdown-toggle:not(:focus)`, preserving the keyboard focus indicator.

Expected: focused sidebar dropdown triggers retain a visible outline.
Actual: focused sidebar dropdown triggers have `outline: 0` with no replacement style.

This updates the sidebars selector to match the existing headers example pattern.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to an example
- [x] I have updated the example accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42710--twbs-bootstrap.netlify.app/>

### Related issues

None.

### Checks

- `git diff --check`
- `npm exec -- prettier --config site/.prettierrc.json -c site/src/assets/examples/sidebars/sidebars.css`
- `npm run docs-build`
