### PR TITLE
Fix offcanvas dispose scroll reset

### DIFF
--- a/js/src/offcanvas.js
+++ b/js/src/offcanvas.js
@@ -158,6 +158,10 @@ class Offcanvas extends BaseComponent {
   }
 
   dispose() {
+    if (this._isShown && !this._config.scroll) {
+      new ScrollBarHelper().reset()
+    }
+
     this._backdrop.dispose()
     this._focustrap.deactivate()
     super.dispose()

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -621,6 +621,26 @@ describe('Offcanvas', () => {
       expect(offCanvas._focustrap).toBeNull()
       expect(Offcanvas.getInstance(offCanvasEl)).toBeNull()
     })
+
+    it('should reset scrollbars when disposing a shown offcanvas with disabled scroll', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div class="offcanvas"></div>'
+
+        const offCanvasEl = fixtureEl.querySelector('div')
+        const offCanvas = new Offcanvas(offCanvasEl)
+        const spyReset = spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
+
+        offCanvasEl.addEventListener('shown.bs.offcanvas', () => {
+          offCanvas.dispose()
+
+          expect(spyReset).toHaveBeenCalled()
+          expect(document.body.style.overflow).toEqual('')
+          resolve()
+        })
+
+        offCanvas.show()
+      })
+    })
   })
 
   describe('data-api', () => {


### PR DESCRIPTION
### Description

Resets the body scrollbar state when disposing a shown offcanvas with scrolling disabled.

### Motivation & Context

Showing an offcanvas with the default `scroll: false` hides body overflow. If `dispose()` is called while the offcanvas is still shown, the instance is removed but the body scroll lock is left behind.

Expected: disposing the shown offcanvas clears the scroll lock it created.
Actual: disposing the shown offcanvas leaves `body.style.overflow` set to `hidden`.

This mirrors the normal hide cleanup for the dispose path and adds unit coverage for disposing a shown offcanvas.

Related closed reports: #39910 and #36397.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Actual screenshots

Before disposing the shown offcanvas, body overflow remains locked:

<img width="1200" height="742" alt="Offcanvas before dispose fix: body overflow remains hidden" src="https://github.com/user-attachments/assets/b89a7a08-8db5-4e4b-acc9-b4aa2238ef0c" />

After the fix, disposing clears the body overflow lock:

<img width="1200" height="742" alt="Offcanvas after dispose fix: body overflow is cleared" src="https://github.com/user-attachments/assets/fe8b8a46-7fe2-491d-9aa5-204dfa60fe52" />

### Related issues

Related: #39910, #36397.

### Checks

- `git diff --check`
- `npm exec -- eslint --report-unused-disable-directives js/src/offcanvas.js js/tests/unit/offcanvas.spec.js`
- `npm run js-test-karma`
