### PR TITLE
Fix modal dispose scroll reset

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -144,6 +144,12 @@ class Modal extends BaseComponent {
     EventHandler.off(window, EVENT_KEY)
     EventHandler.off(this._dialog, EVENT_KEY)
 
+    if (this._isShown) {
+      document.body.classList.remove(CLASS_NAME_OPEN)
+      this._resetAdjustments()
+      this._scrollBar.reset()
+    }
+
     this._backdrop.dispose()
     this._focustrap.deactivate()
 

--- a/js/tests/unit/modal.spec.js
+++ b/js/tests/unit/modal.spec.js
@@ -861,6 +861,27 @@ describe('Modal', () => {
       expect(spyOff).toHaveBeenCalledTimes(3)
       expect(spyDeactivate).toHaveBeenCalled()
     })
+
+    it('should reset scrollbars when disposing a shown modal', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = '<div id="exampleModal" class="modal"><div class="modal-dialog"></div></div>'
+
+        const modalEl = fixtureEl.querySelector('.modal')
+        const modal = new Modal(modalEl)
+        const spyReset = spyOn(ScrollBarHelper.prototype, 'reset').and.callThrough()
+
+        modalEl.addEventListener('shown.bs.modal', () => {
+          modal.dispose()
+
+          expect(spyReset).toHaveBeenCalled()
+          expect(document.body).not.toHaveClass('modal-open')
+          expect(document.body.style.overflow).toEqual('')
+          resolve()
+        })
+
+        modal.show()
+      })
+    })
   })
 
   describe('handleUpdate', () => {


### PR DESCRIPTION
### Description

Resets the body scrollbar state when disposing a shown modal.

### Motivation & Context

Showing a modal adds `modal-open` to the body and hides body overflow. If `dispose()` is called while the modal is still shown, the instance is removed but the body scroll lock is left behind.

Expected: disposing the shown modal clears the scroll lock it created.
Actual: disposing the shown modal leaves `modal-open` on the body and keeps `body.style.overflow` set to `hidden`.

This mirrors the normal hide cleanup for the dispose path and adds unit coverage for disposing a shown modal.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Actual screenshots

Before disposing the shown modal, the body remains scroll-locked:

<img width="1200" height="742" alt="Modal before dispose fix: modal-open remains true and body overflow remains hidden" src="https://github.com/user-attachments/assets/55e23e81-df12-4e59-8433-0b88672c709d" />

After the fix, disposing clears `modal-open` and body overflow:

<img width="1200" height="742" alt="Modal after dispose fix: modal-open is false and body overflow is cleared" src="https://github.com/user-attachments/assets/5995944c-f61b-4080-b7d2-7f5796c891bf" />

### Related issues

None.

### Checks

- `git diff --check`
- `npm exec -- eslint --report-unused-disable-directives js/src/modal.js js/tests/unit/modal.spec.js`
- `npm run js-test-karma`
