### PR TITLE
Initialize aria-pressed for toggle buttons

### DIFF
--- a/js/src/button.js
+++ b/js/src/button.js
@@ -27,6 +27,16 @@ const EVENT_CLICK_DATA_API = `click${EVENT_KEY}${DATA_API_KEY}`
  */
 
 class Button extends BaseComponent {
+  constructor(element) {
+    super(element)
+
+    if (!this._element || this._element.hasAttribute('aria-pressed')) {
+      return
+    }
+
+    this._element.setAttribute('aria-pressed', this._element.classList.contains(CLASS_NAME_ACTIVE))
+  }
+
   // Getters
   static get NAME() {
     return NAME

--- a/js/tests/unit/button.spec.js
+++ b/js/tests/unit/button.spec.js
@@ -22,6 +22,23 @@ describe('Button', () => {
     expect(buttonByElement._element).toEqual(buttonEl)
   })
 
+  it('should initialize aria-pressed when missing', () => {
+    fixtureEl.innerHTML = [
+      '<button class="btn" data-bs-toggle="button"></button>',
+      '<button class="btn active" data-bs-toggle="button"></button>',
+      '<button class="btn active" data-bs-toggle="button" aria-pressed="false"></button>'
+    ].join('')
+
+    const buttons = fixtureEl.querySelectorAll('[data-bs-toggle="button"]')
+
+    const buttonInstances = [...buttons].map(button => new Button(button))
+
+    expect(buttonInstances).toHaveSize(3)
+    expect(buttons[0].getAttribute('aria-pressed')).toEqual('false')
+    expect(buttons[1].getAttribute('aria-pressed')).toEqual('true')
+    expect(buttons[2].getAttribute('aria-pressed')).toEqual('false')
+  })
+
   describe('VERSION', () => {
     it('should return plugin version', () => {
       expect(Button.VERSION).toEqual(jasmine.any(String))


### PR DESCRIPTION
Toggle buttons initialized without `aria-pressed` are not exposed as toggle buttons to assistive technologies until their first activation.

### Description

- Initialize a missing `aria-pressed` value from the button's current `.active` state.
- Preserve an explicit author-provided `aria-pressed` value.
- Cover inactive, pre-active, and explicitly configured buttons with a regression test.

### Motivation & Context

Fixes #42328.

Observable sequence:

- Create inactive and pre-active elements with `data-bs-toggle="button"`.
- Initialize the Button plugin for each element.
- Expected: `aria-pressed="false"` and `aria-pressed="true"`, matching each element's initial state.
- Actual: both attributes remain absent until the button is toggled.

This replaces #42466 with a focused change based on current `main` and expands coverage for explicit author-provided values.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `pnpm run js-lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Actual screenshots

**Before (current `main`):** the regression test receives `null` instead of the expected initial ARIA state.

<img width="1331" height="768" alt="Before: aria-pressed initialization regression test fails" src="https://github.com/user-attachments/assets/98a8f369-873b-4232-b6d8-c744da5e23fc" />

**After (this PR):** the same Chrome Headless run reports 810/810 successful tests.

<img width="1331" height="768" alt="After: Bootstrap JavaScript tests report 810 successes" src="https://github.com/user-attachments/assets/58cdf58e-133b-4522-b93b-a40df634c171" />

### Validation

- `pnpm exec karma start js/tests/karma.conf.js --single-run`: 810/810 successful
- `pnpm run js-lint`: passes with 18 pre-existing warning-comment warnings
- `git diff --check`

The local Karma process prints its existing full-page-reload shutdown warning after the test result.

### Related issues

- Fixes #42328
- Replaces #42466
