### PR TITLE
Fix carousel touch handling without Pointer Events

### DIFF
--- a/js/src/util/swipe.js
+++ b/js/src/util/swipe.js
@@ -51,6 +51,7 @@ class Swipe extends Config {
     }
 
     this._config = this._getConfig(config)
+    this._startX = 0
     this._deltaX = 0
     this._supportPointerEvents = Boolean(window.PointerEvent)
     this._initEvents()
@@ -76,20 +77,22 @@ class Swipe extends Config {
 
   // Private
   _start(event) {
+    this._deltaX = 0
+
     if (!this._supportPointerEvents) {
-      this._deltaX = event.touches[0].clientX
+      this._startX = event.touches[0].clientX
 
       return
     }
 
     if (this._eventIsPointerPenTouch(event)) {
-      this._deltaX = event.clientX
+      this._startX = event.clientX
     }
   }
 
   _end(event) {
     if (this._eventIsPointerPenTouch(event)) {
-      this._deltaX = event.clientX - this._deltaX
+      this._deltaX = event.clientX - this._startX
     }
 
     this._handleSwipe()
@@ -99,7 +102,7 @@ class Swipe extends Config {
   _move(event) {
     this._deltaX = event.touches && event.touches.length > 1 ?
       0 :
-      event.touches[0].clientX - this._deltaX
+      event.touches[0].clientX - this._startX
   }
 
   _handleSwipe() {

--- a/js/tests/unit/util/swipe.spec.js
+++ b/js/tests/unit/util/swipe.spec.js
@@ -35,6 +35,11 @@ describe('Swipe', () => {
     Simulator.gestures.swipe(element, _options)
   }
 
+  const triggerTouchEvent = (element, type, clientX) => {
+    const touches = [{ x: clientX, y: 10, target: element }]
+    Simulator.events.touch.trigger(touches, element, type)
+  }
+
   beforeEach(() => {
     fixtureEl = getFixture()
     const cssStyle = [
@@ -156,7 +161,43 @@ describe('Swipe', () => {
     })
   })
 
-  describe('Functionality on PointerEvents', () => {
+  describe('Functionality', () => {
+    it('should not interpret a tap as a swipe with touch events', () => {
+      clearPointerEvents()
+      defineDocumentElementOntouchstart()
+
+      const leftCallback = jasmine.createSpy('leftCallback')
+      const rightCallback = jasmine.createSpy('rightCallback')
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, { leftCallback, rightCallback })
+
+      triggerTouchEvent(swipeEl, 'start', 200)
+      triggerTouchEvent(swipeEl, 'end', 200)
+
+      expect(leftCallback).not.toHaveBeenCalled()
+      expect(rightCallback).not.toHaveBeenCalled()
+      restorePointerEvents()
+    })
+
+    it('should preserve the swipe direction across touchmove events', () => {
+      clearPointerEvents()
+      defineDocumentElementOntouchstart()
+
+      const leftCallback = jasmine.createSpy('leftCallback')
+      const rightCallback = jasmine.createSpy('rightCallback')
+      // eslint-disable-next-line no-new
+      new Swipe(swipeEl, { leftCallback, rightCallback })
+
+      triggerTouchEvent(swipeEl, 'start', 300)
+      triggerTouchEvent(swipeEl, 'move', 250)
+      triggerTouchEvent(swipeEl, 'move', 200)
+      triggerTouchEvent(swipeEl, 'end', 200)
+
+      expect(leftCallback).toHaveBeenCalledTimes(1)
+      expect(rightCallback).not.toHaveBeenCalled()
+      restorePointerEvents()
+    })
+
     it('should not allow pinch with touch events', () => {
       Simulator.setType('touch')
       clearPointerEvents()


### PR DESCRIPTION
On browsers without Pointer Events, carousel taps and multi-event swipes can move slides in the wrong direction.

### Description

- Keep the gesture's starting X coordinate separate from its current delta.
- Reset the delta when each gesture begins.
- Cover taps and repeated `touchmove` events with regression tests.

### Motivation & Context

- Observable sequence: activate a carousel control on iOS 12 Safari, then activate it again or swipe through multiple touch-move events.
- Expected: tapping a control does not also count as a swipe, and a left swipe remains left.
- Actual: a tap can be interpreted as a right swipe, while repeated touch-move calculations can flip direction.
- Root cause: the touch path reused `_deltaX` first for the starting coordinate and then for the calculated delta. Pointer Events bypassed that path, which is why enabling Safari 12's experimental Pointer Events setting avoided the bug.

This restores the separate start-coordinate and delta semantics used before the v5.2 swipe-helper extraction.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Validation

- `pnpm exec eslint js/src/util/swipe.js js/tests/unit/util/swipe.spec.js`
- The regression tests dispatch `touchstart`, repeated `touchmove`, and `touchend` events through the registered listeners.
- Unpatched `main` with the regression tests: 809 passed, 2 failed—the tap called `rightCallback`, and a left swipe called `rightCallback` instead of `leftCallback`.
- Patched branch: `pnpm run js-test-karma` — 811 of 811 tests passed in Chrome Headless.
- Bootstrap's BrowserStack matrix includes a real iPhone 7 running iOS 12 for upstream browser validation.

### Related issues

Addresses #39721.