### PR TITLE
Motion utilities, tokenized component transitions, and animated form controls

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -10,27 +10,27 @@
     },
     {
       "path": "./dist/css/bootstrap-reboot.css",
-      "maxSize": "5.75 kB"
+      "maxSize": "6.0 kB"
     },
     {
       "path": "./dist/css/bootstrap-reboot.min.css",
-      "maxSize": "5.5 kB"
+      "maxSize": "5.75 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.css",
-      "maxSize": "19.0 kB"
+      "maxSize": "19.25 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.min.css",
-      "maxSize": "17.5 kB"
+      "maxSize": "18.0 kB"
     },
     {
       "path": "./dist/css/bootstrap.css",
-      "maxSize": "50.5 kB"
+      "maxSize": "51.25 kB"
     },
     {
       "path": "./dist/css/bootstrap.min.css",
-      "maxSize": "46.75 kB"
+      "maxSize": "47.25 kB"
     },
     {
       "path": "./dist/js/bootstrap.bundle.js",

--- a/dist/css/bootstrap-utilities.metadata.json
+++ b/dist/css/bootstrap-utilities.metadata.json
@@ -1419,6 +1419,22 @@
         "z-tooltip",
         "z-toast"
       ]
+    },
+    "transition": {
+      "class": "transition",
+      "property": "transition",
+      "classes": [
+        "transition-none"
+      ]
+    },
+    "animation": {
+      "class": "animation",
+      "property": "animation",
+      "classes": [
+        "animation-none",
+        "animation-shake",
+        "animation-pop"
+      ]
     }
   }
 }

--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -27,6 +27,7 @@ import {
   execute,
   getElement,
   getNextActiveElement,
+  getTransitionDurationFromElement,
   isDisabled,
   isElement,
   isRTL,
@@ -251,7 +252,15 @@ class Menu extends BaseComponent {
     }
 
     Menu._openInstances.add(this)
-    EventHandler.trigger(this._element, EVENT_SHOWN, relatedTarget)
+
+    // Wait for the CSS entry transition (opacity/transform) to finish before
+    // announcing `shown`, so listeners run against the settled menu.
+    await this._queueCallback(() => {
+      // Bail if the menu was hidden again mid-transition.
+      if (this._isShown()) {
+        EventHandler.trigger(this._element, EVENT_SHOWN, relatedTarget)
+      }
+    }, this._menu, this._isAnimated())
   }
 
   async hide(): Promise<void> {
@@ -263,7 +272,7 @@ class Menu extends BaseComponent {
       relatedTarget: this._element
     }
 
-    this._completeHide(relatedTarget)
+    await this._completeHide(relatedTarget)
   }
 
   override dispose(): void {
@@ -301,7 +310,7 @@ class Menu extends BaseComponent {
     return (wrapper instanceof Element ? wrapper : this._element.parentNode) as HTMLElement
   }
 
-  protected _completeHide(relatedTarget: Record<string, unknown>): void {
+  protected async _completeHide(relatedTarget: Record<string, unknown>): Promise<void> {
     const hideEvent = EventHandler.trigger(this._element, EVENT_HIDE, relatedTarget)
     if (hideEvent.defaultPrevented) {
       return
@@ -315,9 +324,11 @@ class Menu extends BaseComponent {
       }
     }
 
-    this._disposeFloating()
-    this._restoreMenuToOriginalParent()
-
+    // Start the exit transition by removing `.show`. Keep Floating UI active and
+    // the menu in its current DOM location so it animates out in place; the
+    // teardown (dispose floating, restore original parent) is deferred until the
+    // transition ends. Doing it now would move/reposition the menu mid-fade and
+    // make the exit animation appear to snap.
     this._menu.classList.remove(CLASS_NAME_SHOW)
     this._element.classList.remove(CLASS_NAME_SHOW)
 
@@ -326,10 +337,20 @@ class Menu extends BaseComponent {
     }
 
     this._element.setAttribute('aria-expanded', 'false')
-    Manipulator.removeDataAttribute(this._menu, 'placement')
-    Manipulator.removeDataAttribute(this._menu, 'display')
     Menu._openInstances.delete(this)
-    EventHandler.trigger(this._element, EVENT_HIDDEN, relatedTarget)
+
+    await this._queueCallback(() => {
+      // Bail if the menu was reopened during the exit transition.
+      if (this._isShown()) {
+        return
+      }
+
+      this._disposeFloating()
+      this._restoreMenuToOriginalParent()
+      Manipulator.removeDataAttribute(this._menu, 'placement')
+      Manipulator.removeDataAttribute(this._menu, 'display')
+      EventHandler.trigger(this._element, EVENT_HIDDEN, relatedTarget)
+    }, this._menu, this._isAnimated())
   }
 
   protected override _getConfig(config?: ComponentConfig | null): ComponentConfig {
@@ -401,6 +422,13 @@ class Menu extends BaseComponent {
 
   protected _isShown(): boolean {
     return this._menu.classList.contains(CLASS_NAME_SHOW)
+  }
+
+  protected _isAnimated(): boolean {
+    // The menu always defines its transition in CSS; treat a zero computed
+    // duration (e.g. reduced motion or disabled transitions) as non-animated so
+    // callbacks run synchronously.
+    return getTransitionDurationFromElement(this._menu) > 0
   }
 
   protected _getPlacement(): string {

--- a/js/src/toggler.ts
+++ b/js/src/toggler.ts
@@ -34,7 +34,7 @@ type TogglerConfig = {
 // Toggler built without a `value` throws from `_typeCheckConfig`.
 const DefaultType = {
   attribute: 'string',
-  value: '(string|number|boolean)'
+  value: '(string|number|boolean|null)'
 }
 
 const Default: TogglerConfig = {
@@ -81,6 +81,11 @@ class Toggler extends BaseComponent {
 
     if (attribute === 'id') {
       return // You have to be kidding
+    }
+
+    // Nothing to toggle without a value (e.g. missing `data-bs-value`)
+    if (value === null || value === undefined) {
+      return
     }
 
     if (attribute === 'class') {

--- a/js/tests/unit/toggler.spec.js
+++ b/js/tests/unit/toggler.spec.js
@@ -58,6 +58,17 @@ describe('Toggler', () => {
       expect(togglerEl.hasAttribute('hidden')).toBeFalse()
     })
 
+    it('should not throw and should be a no-op when no value is provided', () => {
+      fixtureEl.innerHTML = '<div data-bs-toggle="toggler" data-bs-attribute="class"></div>'
+
+      const togglerEl = fixtureEl.querySelector('[data-bs-toggle="toggler"]')
+      const toggler = new Toggler(togglerEl)
+      const classNameBefore = togglerEl.className
+
+      expect(() => toggler.toggle()).not.toThrow()
+      expect(togglerEl.className).toEqual(classNameBefore)
+    })
+
     it('should not toggle id attribute', () => {
       fixtureEl.innerHTML = '<div data-bs-toggle="toggler" data-bs-value="new-id" data-bs-attribute="id"></div>'
 

--- a/scss/_carousel.scss
+++ b/scss/_carousel.scss
@@ -17,7 +17,10 @@ $carousel-tokens: defaults(
     --carousel-indicator-width: .75rem,
     --carousel-indicator-height: .75rem,
     --carousel-indicator-spacer: .25rem,
-    --carousel-indicator-transition: "opacity .6s ease, width .3s ease",
+    --carousel-indicator-opacity-duration: .6s,
+    --carousel-indicator-opacity-timing: ease,
+    --carousel-indicator-width-duration: .3s,
+    --carousel-indicator-width-timing: ease,
     --carousel-indicator-progress-bg: var(--carousel-indicator-bg),
     --carousel-control-icon-width: 1rem,
     --carousel-control-prev-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0'/></svg>"),
@@ -34,6 +37,7 @@ $carousel-tokens: defaults(
     --carousel-items-gap: 0px,
     --carousel-items-peek: 0px,
     --carousel-fade-duration: .6s,
+    --carousel-fade-timing: ease,
   ),
   $carousel-tokens
 );
@@ -122,13 +126,13 @@ $carousel-tokens: defaults(
       width: 100%;
       visibility: hidden;
       opacity: 0;
-      @include transition(opacity var(--carousel-fade-duration) ease, visibility 0s linear var(--carousel-fade-duration));
+      @include transition(opacity var(--carousel-fade-duration) var(--carousel-fade-timing), visibility 0s linear var(--carousel-fade-duration));
     }
 
     .carousel-item.active {
       visibility: visible;
       opacity: 1;
-      @include transition(opacity var(--carousel-fade-duration) ease);
+      @include transition(opacity var(--carousel-fade-duration) var(--carousel-fade-timing));
     }
   }
 
@@ -201,7 +205,7 @@ $carousel-tokens: defaults(
       background-color: transparent;
       border: 1px solid var(--carousel-indicator-bg);
       @include border-radius(var(--carousel-indicator-width));
-      @include transition(var(--carousel-indicator-transition));
+      @include transition(opacity var(--carousel-indicator-opacity-duration) var(--carousel-indicator-opacity-timing), width var(--carousel-indicator-width-duration) var(--carousel-indicator-width-timing));
     }
 
     .active {

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -29,7 +29,7 @@ $dialog-tokens: defaults(
     --dialog-border-radius: var(--radius-7),
     --dialog-box-shadow: var(--box-shadow-xl),
     --dialog-transition-duration: .3s,
-    --dialog-transition-timing: cubic-bezier(.22, 1, .36, 1),
+    --dialog-transition-timing: var(--transition-timing-overlay),
     --dialog-backdrop-bg: light-dark(rgb(0 0 0 / 50%), rgb(0 0 0 / 65%)),
     --dialog-backdrop-blur: 8px,
     --dialog-header-padding: 1rem,

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -28,7 +28,7 @@ $drawer-tokens: defaults(
     --drawer-border-radius: var(--radius-7),
     --drawer-box-shadow: var(--box-shadow-xl),
     --drawer-transition-duration: .3s,
-    --drawer-transition-timing: cubic-bezier(.22, 1, .36, 1),
+    --drawer-transition-timing: var(--transition-timing-overlay),
     --drawer-title-line-height: 1.5,
     --drawer-backdrop-bg: color-mix(in oklch, var(--bg-body) 25%, transparent),
     --drawer-backdrop-blur: 8px,

--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -45,7 +45,7 @@ $menu-tokens: defaults(
     --menu-header-padding-x: .75rem,
     --menu-header-padding-y: .25rem,
     --menu-transition-duration: .15s,
-    --menu-transition-timing: cubic-bezier(.22, 1, .36, 1),
+    --menu-transition-timing: var(--transition-timing-overlay),
   ),
   $menu-tokens
 );

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -183,6 +183,7 @@ $navbar-nav-tokens: defaults(
   .navbar-toggler {
     --btn-bg: transparent;
     --btn-hover-bg: var(--bg-2);
+    @include transition(var(--navbar-toggler-transition));
   }
 
   // Hamburger icon, rendered via CSS mask so it inherits the navbar color

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -77,6 +77,9 @@ $root-tokens: defaults(
     --control-active-border-color: var(--control-active-bg),
     --control-disabled-bg: var(--bg-3),
     --control-disabled-opacity: .65,
+    // Shared motion for checkbox/radio marks; slight overshoot so the mark pops in
+    --control-transition-duration: .15s,
+    --control-transition-timing: cubic-bezier(.34, 1.56, .64, 1),
 
     --btn-input-fg: var(--fg-body),
     --btn-input-bg: var(--bg-body),

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -56,6 +56,11 @@ $root-tokens: defaults(
     --shadow-strength: 1,
     // scss-docs-end root-box-shadow-variables
 
+    // scss-docs-start root-transition-variables
+    // Shared easing curve for overlay components (dialog, drawer, menu)
+    --transition-timing-overlay: cubic-bezier(.22, 1, .36, 1),
+    // scss-docs-end root-transition-variables
+
     --spacer: 1rem,
 
     // scss-docs-start root-focus-variables

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -84,6 +84,7 @@ $root-tokens: defaults(
     --btn-input-fg: var(--fg-body),
     --btn-input-bg: var(--bg-body),
 
+    --btn-input-gap: .375rem,
     --btn-input-min-height: 2.375rem,
     --btn-input-padding-y: .375rem,
     --btn-input-padding-x: .75rem,
@@ -91,6 +92,7 @@ $root-tokens: defaults(
     --btn-input-line-height: var(--body-line-height),
     --btn-input-border-radius: var(--radius-5),
 
+    --btn-input-xs-gap: var(--spacer-1),
     --btn-input-xs-min-height: 1.5rem,
     --btn-input-xs-padding-y: .125rem,
     --btn-input-xs-padding-x: .5rem,
@@ -98,6 +100,7 @@ $root-tokens: defaults(
     --btn-input-xs-line-height: 1.125,
     --btn-input-xs-border-radius: var(--radius-5),
 
+    --btn-input-sm-gap: .375rem,
     --btn-input-sm-min-height: 2rem,
     --btn-input-sm-padding-y: .25rem,
     --btn-input-sm-padding-x: .625rem,
@@ -105,6 +108,7 @@ $root-tokens: defaults(
     --btn-input-sm-line-height: var(--line-height-sm),
     --btn-input-sm-border-radius: var(--radius-5),
 
+    --btn-input-lg-gap: .375rem,
     --btn-input-lg-min-height: 2.75rem,
     --btn-input-lg-padding-y: .5rem,
     --btn-input-lg-padding-x: 1rem,

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -8,7 +8,8 @@ $collapse-tokens: () !default;
 // stylelint-disable scss/dollar-variable-default
 $fade-tokens: defaults(
   (
-    --transition-fade: opacity .15s linear,
+    --transition-fade-duration: .15s,
+    --transition-fade-timing: linear,
   ),
   $fade-tokens
 );
@@ -16,8 +17,8 @@ $fade-tokens: defaults(
 // scss-docs-start collapse-transition
 $collapse-tokens: defaults(
   (
-    --transition-collapse: height .35s ease,
-    --transition-collapse-width: width .35s ease,
+    --transition-collapse-duration: .35s,
+    --transition-collapse-timing: ease,
   ),
   $collapse-tokens
 );
@@ -25,7 +26,7 @@ $collapse-tokens: defaults(
 
 .fade {
   @include tokens($fade-tokens);
-  @include transition(var(--transition-fade));
+  @include transition(opacity var(--transition-fade-duration) var(--transition-fade-timing));
 
   &:not(.show) {
     opacity: 0;
@@ -43,12 +44,12 @@ $collapse-tokens: defaults(
   @include tokens($collapse-tokens);
   height: 0;
   overflow: hidden;
-  @include transition(var(--transition-collapse));
+  @include transition(height var(--transition-collapse-duration) var(--transition-collapse-timing));
 
   &.collapse-horizontal {
     width: 0;
     height: auto;
-    @include transition(var(--transition-collapse-width));
+    @include transition(width var(--transition-collapse-duration) var(--transition-collapse-timing));
   }
 }
 // scss-docs-end collapse-classes

--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -6,6 +6,7 @@ $fade-tokens: () !default;
 $collapse-tokens: () !default;
 
 // stylelint-disable scss/dollar-variable-default
+// scss-docs-start fade-transition
 $fade-tokens: defaults(
   (
     --transition-fade-duration: .15s,
@@ -13,6 +14,7 @@ $fade-tokens: defaults(
   ),
   $fade-tokens
 );
+// scss-docs-end fade-transition
 
 // scss-docs-start collapse-transition
 $collapse-tokens: defaults(

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -1036,6 +1036,26 @@ $utilities: map.merge(
       values: $zindex-levels,
     ),
     // scss-docs-end utils-zindex
+    // scss-docs-start utils-transition
+    "transition": (
+      property: transition,
+      class: transition,
+      values: (
+        none: none,
+      )
+    ),
+    // scss-docs-end utils-transition
+    // scss-docs-start utils-animation
+    "animation": (
+      property: animation,
+      class: animation,
+      values: (
+        none: none,
+        shake: animation-shake .82s cubic-bezier(.36, .07, .19, .97) both,
+        pop: animation-pop .3s cubic-bezier(.34, 1.56, .64, 1) both,
+      )
+    ),
+    // scss-docs-end utils-animation
   ),
   $utilities
 );

--- a/scss/buttons/_button.scss
+++ b/scss/buttons/_button.scss
@@ -17,6 +17,7 @@ $button-tokens: () !default;
 // scss-docs-start btn-tokens
 $button-tokens: defaults(
   (
+    --btn-gap: var(--btn-input-gap),
     --btn-min-height: var(--btn-input-min-height),
     --btn-padding-x: var(--btn-input-padding-x),
     --btn-padding-y: var(--btn-input-padding-y),
@@ -177,7 +178,7 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
     @include tokens($button-tokens);
 
     display: inline-flex;
-    gap: var(--btn-gap, .375rem);
+    gap: var(--btn-gap);
     align-items: center;
     justify-content: center;
     min-height: var(--btn-min-height);
@@ -349,6 +350,7 @@ $btn-variant-selectors: (string.unquote(".btn"), string.unquote(".btn-link"), st
   @each $size, $_ in $button-sizes {
     .btn-#{$size},
     .btn-group-#{$size} > [class*="btn-"] {
+      --btn-gap: var(--btn-input-#{$size}-gap);
       --btn-min-height: var(--btn-input-#{$size}-min-height);
       --btn-padding-y: var(--btn-input-#{$size}-padding-y);
       --btn-padding-x: var(--btn-input-#{$size}-padding-x);

--- a/scss/forms/_check.scss
+++ b/scss/forms/_check.scss
@@ -2,6 +2,7 @@
 @use "../mixins/focus-ring" as *;
 @use "../mixins/mask-icon" as *;
 @use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $check-tokens: () !default;
@@ -48,25 +49,42 @@ $check-tokens: defaults(
     border: 1px solid var(--theme-bg, var(--check-border-color));
     // stylelint-disable-next-line property-disallowed-list
     border-radius: 33%;
+    @include transition(
+      background-color var(--control-transition-duration) var(--control-transition-timing),
+      border-color var(--control-transition-duration) var(--control-transition-timing)
+    );
+
+    // Check/indeterminate mark, overlaid on the input and rendered via a CSS
+    // mask so it inherits the contrast color without an inline SVG. Always
+    // present but scaled/faded out until checked so it can pop in. `mask-image`
+    // cannot be transitioned, so the tick stays masked in every state — drop it
+    // and the mark would flash as a solid block while fading out on uncheck.
+    &::before {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      content: "";
+      background-color: var(--theme-contrast, var(--primary-contrast));
+      opacity: 0;
+      transform: scale(0);
+      @include mask-icon(var(--check-icon-checked));
+      @include transition(
+        opacity var(--control-transition-duration) var(--control-transition-timing),
+        transform var(--control-transition-duration) var(--control-transition-timing)
+      );
+    }
 
     &:checked,
     &:indeterminate {
       background-color: var(--theme-bg, var(--check-checked-bg));
       border-color: var(--theme-bg, var(--check-checked-border-color));
 
-      // Check/indeterminate mark, overlaid on the input and rendered via a CSS
-      // mask so it inherits the contrast color without an inline SVG.
       &::before {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        content: "";
-        background-color: var(--theme-contrast, var(--primary-contrast));
-        @include mask-icon();
+        opacity: 1;
+        transform: scale(1);
       }
     }
 
-    &:checked::before { mask-image: var(--check-icon-checked); }
     &:indeterminate::before { mask-image: var(--check-icon-indeterminate); }
 
     &:focus-visible {

--- a/scss/forms/_radio.scss
+++ b/scss/forms/_radio.scss
@@ -1,6 +1,7 @@
 @use "../functions" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $radio-tokens: () !default;
@@ -37,6 +38,29 @@ $radio-tokens: defaults(
     border: 1px solid var(--theme-bg, var(--radio-border-color));
     // stylelint-disable-next-line property-disallowed-list
     border-radius: 50%;
+    // `color` is transitioned because the dot paints with `currentcolor`; without
+    // it the dot would snap to the body color as it fades out on uncheck.
+    @include transition(
+      color var(--control-transition-duration) var(--control-transition-timing),
+      background-color var(--control-transition-duration) var(--control-transition-timing),
+      border-color var(--control-transition-duration) var(--control-transition-timing)
+    );
+
+    // Inner dot: always present but scaled/faded out until checked so it pops in.
+    &::before {
+      position: absolute;
+      inset: calc(var(--radio-size) * .25);
+      content: "";
+      background-color: currentcolor;
+      // stylelint-disable-next-line property-disallowed-list
+      border-radius: 50%;
+      opacity: 0;
+      transform: scale(0);
+      @include transition(
+        opacity var(--control-transition-duration) var(--control-transition-timing),
+        transform var(--control-transition-duration) var(--control-transition-timing)
+      );
+    }
 
     &:checked {
       color: var(--theme-contrast, var(--primary-contrast));
@@ -44,12 +68,8 @@ $radio-tokens: defaults(
       border-color: var(--theme-bg, var(--radio-checked-border-color));
 
       &::before {
-        position: absolute;
-        inset: calc(var(--radio-size) * .25);
-        content: "";
-        background-color: currentcolor;
-        // stylelint-disable-next-line property-disallowed-list
-        border-radius: 50%;
+        opacity: 1;
+        transform: scale(1);
       }
     }
 

--- a/scss/forms/_switch.scss
+++ b/scss/forms/_switch.scss
@@ -1,6 +1,7 @@
 @use "../functions" as *;
 @use "../mixins/focus-ring" as *;
 @use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
 
 // stylelint-disable custom-property-no-missing-var-function
 $switch-tokens: () !default;
@@ -13,6 +14,10 @@ $switch-tokens: defaults(
     --switch-width: calc(var(--switch-height) * 1.75),
     --switch-padding: .0625rem,
     --switch-margin-block: .125rem,
+    // Share the form-control motion tokens so switch, checkbox, and radio move
+    // in sync; the overshoot ("back") easing makes the thumb bounce as it settles.
+    --switch-transition-duration: var(--control-transition-duration),
+    --switch-transition-timing: var(--control-transition-timing),
     --switch-bg: var(--bg-3),
     --switch-border-width: var(--border-width),
     --switch-border-color: var(--border-color),
@@ -45,8 +50,7 @@ $switch-tokens: defaults(
     // stylelint-disable-next-line property-disallowed-list
     border-radius: 10rem;
     box-shadow: inset 0 1px 2px rgb(0 0 0 / .05);
-    // stylelint-disable-next-line property-disallowed-list
-    transition: background-color .15s ease-in-out;
+    @include transition(background-color var(--switch-transition-duration) var(--switch-transition-timing));
 
     &::before {
       position: absolute;
@@ -59,8 +63,7 @@ $switch-tokens: defaults(
       // stylelint-disable-next-line property-disallowed-list
       border-radius: 10rem;
       box-shadow: 0 1px 2px rgb(0 0 0 / .1);
-      // stylelint-disable-next-line property-disallowed-list
-      transition: inset-inline-start .15s ease-in-out;
+      @include transition(inset-inline-start var(--switch-transition-duration) var(--switch-transition-timing));
     }
 
     input {

--- a/scss/helpers/_hover-lift.scss
+++ b/scss/helpers/_hover-lift.scss
@@ -1,0 +1,35 @@
+@use "../functions" as *;
+@use "../mixins/box-shadow" as *;
+@use "../mixins/tokens" as *;
+@use "../mixins/transition" as *;
+
+$hover-lift-tokens: () !default;
+
+// scss-docs-start hover-lift-tokens
+// stylelint-disable-next-line scss/dollar-variable-default
+$hover-lift-tokens: defaults(
+  (
+    --hover-lift-transition-duration: .2s,
+    --hover-lift-transition-timing: ease,
+    --hover-lift-transform: translateY(-.25rem),
+    --hover-lift-box-shadow: var(--box-shadow-lg),
+  ),
+  $hover-lift-tokens
+);
+// scss-docs-end hover-lift-tokens
+
+@layer helpers {
+  .hover-lift {
+    @include tokens($hover-lift-tokens);
+    @include transition(
+      transform var(--hover-lift-transition-duration) var(--hover-lift-transition-timing),
+      box-shadow var(--hover-lift-transition-duration) var(--hover-lift-transition-timing)
+    );
+
+    &:hover,
+    &:focus-visible {
+      transform: var(--hover-lift-transform);
+      @include box-shadow(var(--hover-lift-box-shadow));
+    }
+  }
+}

--- a/scss/helpers/index.scss
+++ b/scss/helpers/index.scss
@@ -1,4 +1,5 @@
 @forward "focus-ring";
+@forward "hover-lift";
 @forward "icon-link";
 @forward "position";
 @forward "stacks";

--- a/scss/utilities/_api.scss
+++ b/scss/utilities/_api.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "../config" as *;
 @use "../mixins/utilities" as *;
 @use "../utilities" as *;
@@ -9,4 +10,46 @@
 
 @layer utilities {
   @include generate-utilities-loop($utilities, $breakpoints);
+
+  // The keyframe animation utilities (.animation-shake, .animation-pop) are
+  // decorative, so disable them when the user prefers reduced motion.
+  @if map.has-key($utilities, "animation") and $enable-reduced-motion {
+    @media (prefers-reduced-motion: reduce) {
+      .animation-shake,
+      .animation-pop {
+        animation: none;
+      }
+    }
+  }
+}
+
+// Keyframes powering the animation utilities. Declared outside the cascade
+// layer since @keyframes registration is global and unaffected by layers — which
+// is also why they carry the utility prefix, so they cannot collide with a
+// `shake` or `pop` animation of your own.
+// Bundles such as `bootstrap-grid` narrow `$utilities` before importing this
+// file, so skip the keyframes when the animation utility is filtered out.
+@if map.has-key($utilities, "animation") {
+  @keyframes animation-shake {
+    10%,
+    90% { transform: translate3d(-1px, 0, 0); }
+
+    20%,
+    80% { transform: translate3d(2px, 0, 0); }
+
+    30%,
+    50%,
+    70% { transform: translate3d(-4px, 0, 0); }
+
+    40%,
+    60% { transform: translate3d(4px, 0, 0); }
+  }
+
+  // Scales from 0 to 1; the back-easing curve on the utility supplies the
+  // slight overshoot, so the keyframes stay a simple two-stop scale.
+  @keyframes animation-pop {
+    from { transform: scale(0); }
+
+    to { transform: scale(1); }
+  }
 }

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -247,5 +247,8 @@
         - title: User select
     - group: Effects
       pages:
+        - title: Motion
+          meta:
+            - added: 6.0.0
         - title: Opacity
         - title: Shadows

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -168,6 +168,9 @@
   icon_color: orange
   pages:
     - title: Focus ring
+    - title: Hover lift
+      meta:
+        - added: 6.0.0
     - title: Icon link
     - title: Position
     - title: Stacks

--- a/site/src/assets/partials/snippets.js
+++ b/site/src/assets/partials/snippets.js
@@ -159,4 +159,29 @@ export default () => {
       }, false)
     })
   }
+
+  // -------------------------------
+  // Motion utilities
+  // -------------------------------
+  // Replay the one-shot animation utilities (.animation-shake, .animation-pop)
+  // in docs demos by removing and re-adding the class after a reflow. The
+  // trigger typically lives in the Example toolbar via its `actions` slot.
+  document.querySelectorAll('[data-bd-replay]')
+    .forEach(trigger => {
+      const target = document.querySelector(trigger.getAttribute('data-bd-replay'))
+      if (!target) {
+        return
+      }
+
+      const animationClass = [...target.classList].find(name => name.startsWith('animation-'))
+      if (!animationClass) {
+        return
+      }
+
+      trigger.addEventListener('click', () => {
+        target.classList.remove(animationClass)
+        target.offsetHeight // eslint-disable-line no-unused-expressions
+        target.classList.add(animationClass)
+      })
+    })
 }

--- a/site/src/components/PageMeta.astro
+++ b/site/src/components/PageMeta.astro
@@ -66,7 +66,7 @@ const depsTitles = deps.map((dep) => dep.title).join(', ')
           <use href="#filetype-css" />
         </svg>
         <span>
-          In <code class="fg-body">{frontmatter.css_layer}</code> layer
+          Layer: <code class="fg-body">{frontmatter.css_layer}</code>
         </span>
       </div>
     )

--- a/site/src/components/icons/Symbols.astro
+++ b/site/src/components/icons/Symbols.astro
@@ -3,6 +3,10 @@
 ---
 
 <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+  <symbol id="arrow-counterclockwise" viewBox="0 0 16 16">
+    <path fill-rule="evenodd" d="M8 3a5 5 0 1 1-4.546 2.914.5.5 0 0 0-.908-.417A6 6 0 1 0 8 2z"></path>
+    <path d="M8 4.466V.534a.25.25 0 0 0-.41-.192L5.23 2.308a.25.25 0 0 0 0 .384l2.36 1.966A.25.25 0 0 0 8 4.466"></path>
+  </symbol>
   <symbol id="arrow-right" viewBox="0 0 16 16">
     <path
       fill-rule="evenodd"

--- a/site/src/components/shortcodes/Code.astro
+++ b/site/src/components/shortcodes/Code.astro
@@ -215,7 +215,8 @@ const highlightedCode =
           ) : (
             <div class="font-monospace text-uppercase fs-xs fg-3">{displayLang}</div>
           )}
-          <div class="d-flex ms-auto">
+          <div class="d-flex ms-auto align-items-center gap-1">
+            <slot name="actions" />
             {addStackblitzJs && (
               <button type="button" class="btn-edit text-nowrap" title="Try it on StackBlitz">
                 <svg class="bi" aria-hidden="true">
@@ -269,7 +270,8 @@ const highlightedCode =
           ) : (
             <div class="font-monospace text-uppercase fs-xs fg-3">{displayLang}</div>
           )}
-          <div class="d-flex ms-auto">
+          <div class="d-flex ms-auto align-items-center gap-1">
+            <slot name="actions" />
             <button type="button" class="btn btn-xs btn-icon bg-transparent" title="Copy" data-bd-clipboard>
               <svg class="bi fs-md" aria-hidden="true">
                 <use href="#copy" />

--- a/site/src/components/shortcodes/Example.astro
+++ b/site/src/components/shortcodes/Example.astro
@@ -47,6 +47,13 @@ interface Props {
   showPreview?: boolean
 }
 
+// Named slots:
+// - `actions`: optional nodes rendered in the code toolbar, to the left of the
+//   copy/StackBlitz icons (e.g. a replay button for a one-shot animation).
+//   Slots are how Astro passes renderable markup/components — there is no prop
+//   equivalent. Wire up any interactive behavior in
+//   `site/src/assets/partials/snippets.js`.
+
 const {
   addStackblitzJs = false,
   code,
@@ -86,7 +93,9 @@ const simplifiedMarkup = sourceMarkup
   }
   {
     showMarkup && (
-      <Code code={simplifiedMarkup} lang={lang} file={file} nestedInExample={true} addStackblitzJs={addStackblitzJs} />
+      <Code code={simplifiedMarkup} lang={lang} file={file} nestedInExample={true} addStackblitzJs={addStackblitzJs}>
+        <slot name="actions" slot="actions" />
+      </Code>
     )
   }
 </div>

--- a/site/src/content/docs/components/toggler.mdx
+++ b/site/src/content/docs/components/toggler.mdx
@@ -111,7 +111,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `attribute` | string | `class` | The attribute which will be toggled on each click |
-| `value` | string | null | Allow body scrolling while toggler is open |
+| `value` | string, number, boolean, null | null | The value to toggle for the given attribute, such as a class name. Toggling is a no-op when no value is set. |
 </BsTable>
 
 ### Methods

--- a/site/src/content/docs/forms/radio.mdx
+++ b/site/src/content/docs/forms/radio.mdx
@@ -18,9 +18,13 @@ Similar to checkboxes, radios are styled with the `.radio` class. However, there
 
 Wrap the `.radio` in a `.form-field` layout wrapper and add your label. The grid layout places the radio and label side by side.
 
-<Example code={`<div class="form-field">
-    <input type="radio" id="radioLabel" class="radio" />
-    <label for="radioLabel">Example new radio</label>
+<Example class="d-flex flex-column gap-2" code={`<div class="form-field">
+    <input class="radio" name="radios" type="radio" id="radioLabel" />
+    <label for="radioLabel">First example radio</label>
+  </div>
+  <div class="form-field">
+    <input class="radio" name="radios" type="radio" id="radioLabel2" />
+    <label for="radioLabel2">Second example radio</label>
   </div>`} />
 
 ## Description

--- a/site/src/content/docs/guides/migration.mdx
+++ b/site/src/content/docs/guides/migration.mdx
@@ -98,6 +98,11 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 | Print | `.d-print-none` | `.print:d-none` |
 </BsTable>
 
+- **New motion utilities.** Added `.transition-none` and `.animation-none` to switch off a component’s transition or keyframe animation on a single element, plus decorative `.animation-shake` and `.animation-pop` helpers. See the [Motion utilities]([[docsref:/utilities/motion]]) page. The decorative animations disable themselves under `prefers-reduced-motion`.
+- **Checkboxes, radios, and switches now animate their marks.** The checkbox tick, radio dot, and switch thumb ease in with a subtle overshoot, driven by shared `--control-transition-duration` and `--control-transition-timing` tokens so all three move in sync. The motion is skipped for users who prefer reduced motion, and no markup changes are required.
+- **Split the fade and collapse transition tokens.** v5’s single `$transition-fade` and `$transition-collapse` values are now CSS custom property pairs—`--transition-fade-duration` / `--transition-fade-timing` and `--transition-collapse-duration` / `--transition-collapse-timing`—so duration and easing can be tuned independently. Overlay components (dialog, drawer, menu) also share a new `--transition-timing-overlay` easing token. Update any overrides of the old values to the new token names.
+- **New `.hover-lift` helper.** Raises an element with a transform and deeper shadow on hover and keyboard focus, customizable via `--hover-lift-*` tokens and reduced-motion aware. See the [Hover lift]([[docsref:/helpers/hover-lift]]) helper.
+
 ### Sass
 
 - Dropped support for Node Sass, including no longer testing any of our source CSS against it.
@@ -180,6 +185,7 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 - Removed jQuery support and the `js-test-jquery` test target.
 - **Removed the internal `util/backdrop`, `util/focustrap`, and `util/scrollbar` helpers.** They’re obsolete now that Dialog and Drawer build on the native `<dialog>` element—the browser provides the backdrop (`::backdrop`), focus trap, and an inert top layer, and the body scroll-lock is handled in CSS (`:root.dialog-open` with `scrollbar-gutter: stable`). If you imported any of these modules directly from `bootstrap/js/src/util/`, they’re gone.
 - **Replaced the Dropdown component with Menu.** All `.dropdown-*` classes are now `.menu-*` classes, and `data-bs-toggle="dropdown"` is now `data-bs-toggle="menu"`. See the [Menu docs]([[docsref:/components/menus]]) for full details.
+- **Menu `shown.bs.menu` and `hidden.bs.menu` now fire after the CSS transition finishes**, rather than synchronously when `show()` / `hide()` are called—matching Dialog and Drawer. The menu also stays positioned in the DOM through its closing transition instead of being torn down immediately. Move any logic that assumed the old synchronous timing (or that the menu was removed the instant `hide()` returned) into the `shown` / `hidden` event handlers.
   - Renamed CSS classes: `.dropdown-menu` to `.menu`, `.dropdown-item` to `.menu-item`, `.dropdown-divider` to `.menu-divider`, `.dropdown-header` to `.menu-header`, `.dropdown-submenu` to `.submenu`.
   - Deprecated directional wrappers: `.dropstart`, `.dropend`, and `.dropup`. Use `data-bs-placement` to control direction instead (for example, `.dropup` becomes `data-bs-placement="top"`).
   - Removed the `.dropdown-toggle` class — menu toggles no longer require a toggle class.

--- a/site/src/content/docs/helpers/hover-lift.mdx
+++ b/site/src/content/docs/helpers/hover-lift.mdx
@@ -1,0 +1,43 @@
+---
+title: Hover lift
+description: Raise an element with a subtle transform and shadow on hover and keyboard focus.
+toc: true
+---
+
+## How it works
+
+Add `.hover-lift` to any element to gently raise it—translating it upward and deepening its shadow—when the user hovers over it or focuses it with the keyboard. It’s a lightweight way to signal that cards, tiles, or other surfaces are interactive.
+
+The effect is driven by CSS custom properties and applied with our `transition()` mixin, so it’s fully customizable and automatically honors the [`prefers-reduced-motion`]([[docsref:/getting-started/accessibility#reduced-motion]]) media feature—users who prefer reduced motion get the raised shadow and offset without the animation.
+
+## Example
+
+Hover or tab to the card below to see it lift.
+
+<Example class="bg-1" code={`<a href="#" class="card hover-lift text-decoration-none" style="max-width: 20rem;">
+    <div class="card-body">
+      <h5 class="card-title">Hover me</h5>
+      <p class="card-text mb-0">This card lifts on hover and keyboard focus.</p>
+    </div>
+  </a>`} />
+
+Because it only sets `transform` and `box-shadow`, `.hover-lift` composes with any element—buttons, list items, or plain containers.
+
+<Example class="bg-1 d-flex gap-3" code={`<button type="button" class="btn-solid theme-primary hover-lift">Lift on hover</button>`} />
+
+## CSS
+
+### Variables
+
+<CSSVariables component="Hover lift helpers" className="hover-lift" />
+
+<ScssDocs name="hover-lift-tokens" file="scss/helpers/_hover-lift.scss" />
+
+Override the tokens to tune the lift distance, shadow, or timing. For example, a larger rise with a snappier transition:
+
+<Example class="bg-1" code={`<a href="#" class="card hover-lift text-decoration-none" style="--bs-hover-lift-transform: translateY(-.5rem); --bs-hover-lift-transition-duration: .1s; max-width: 20rem;">
+    <div class="card-body">
+      <h5 class="card-title">Bigger lift</h5>
+      <p class="card-text mb-0">Customized transform and duration.</p>
+    </div>
+  </a>`} />

--- a/site/src/content/docs/utilities/motion.mdx
+++ b/site/src/content/docs/utilities/motion.mdx
@@ -1,0 +1,78 @@
+---
+title: Motion
+description: Disable or apply CSS transitions and animations on individual elements with motion utilities.
+toc: true
+utility:
+  - transition
+  - animation
+---
+
+## Overview
+
+Bootstrap animates many components with CSS transitions and animations. The motion utilities let you disable that motion on a single element (`.transition-none`, `.animation-none`) or apply a small predefined animation (`.animation-shake`, `.animation-pop`).
+
+To disable motion globally at build time, set the `$enable-transitions` Sass option to `false` instead.
+
+## Transition
+
+Add `.transition-none` to set `transition: none`, so property changes apply instantly rather than animating. Hover both buttons below: the default one eases its hover color change, while the second snaps instantly.
+
+<Example class="d-flex gap-3" code={`<button type="button" class="btn-solid theme-primary">Default</button>
+<button type="button" class="btn-solid theme-primary transition-none">No hover transition</button>`} />
+
+## Animation
+
+### Disable an animation
+
+Add `.animation-none` to set `animation: none`, which stops any running keyframe animation (such as a spinner) on that element.
+
+<Example class="d-flex align-items-center gap-3" code={`<div class="spinner-border" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+  <div class="spinner-border animation-none" role="status"><!--[!code highlight]-->
+    <span class="visually-hidden">Loading...</span>
+  </div>`} />
+
+### Shake
+
+Add `.animation-shake` to play a brief horizontal shake once. It pairs well with invalid form feedback—apply it to a field (or toggle it via JavaScript when validation fails) to draw attention to what needs fixing.
+
+<Example code={`<input type="text" class="form-control is-invalid animation-shake" id="motionShakeDemo" value="Not quite right">`}>
+  <button type="button" class="btn btn-xs fg-secondary bg-transparent" data-bd-replay="#motionShakeDemo" slot="actions"><svg class="bi" aria-hidden="true"><use href="#arrow-counterclockwise" /></svg>Replay</button>
+</Example>
+
+### Pop
+
+Add `.animation-pop` to scale an element in with a slight overshoot. It’s a good fit for content that appears dynamically, such as a badge whose count just updated.
+
+<Example code={`<span class="badge theme-primary animation-pop" id="motionPopDemo">New</span>`}>
+  <button type="button" class="btn btn-xs fg-secondary bg-transparent" data-bd-replay="#motionPopDemo" slot="actions"><svg class="bi" aria-hidden="true"><use href="#arrow-counterclockwise" /></svg>Replay</button>
+</Example>
+
+## Reduced motion
+
+`.transition-none` and `.animation-none` are always applied, regardless of a user’s motion preference—reach for them when you want to remove motion in every case. Bootstrap already respects the [`prefers-reduced-motion` media feature]([[docsref:/getting-started/accessibility#reduced-motion]]) for its own components, so you don’t need them just to honor that setting.
+
+The motion-adding utilities, `.animation-shake` and `.animation-pop`, are decorative, so they’re automatically disabled when the user prefers reduced motion.
+
+## CSS
+
+### Variables
+
+Components declare their motion as `-duration` and `-timing` token pairs, so you can retune speed and easing independently. For example, the fade and collapse transitions read from `--bs-transition-fade-duration` / `--bs-transition-fade-timing` and `--bs-transition-collapse-duration` / `--bs-transition-collapse-timing`.
+
+<ScssDocs name="fade-transition" file="scss/_transitions.scss" />
+
+<ScssDocs name="collapse-transition" file="scss/_transitions.scss" />
+
+Our overlay components—dialog, drawer, and menu—share one easing curve at the `:root` level, so a single override restyles all three.
+
+<ScssDocs name="root-transition-variables" file="scss/_root.scss" />
+
+### Sass utilities API
+
+Motion utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]([[docsref:/utilities/api#using-the-api]])
+
+<ScssDocs name="utils-transition" file="scss/_utilities.scss" />
+
+<ScssDocs name="utils-animation" file="scss/_utilities.scss" />


### PR DESCRIPTION
- Add motion utilities: `.transition-none`, `.animation-none`, `.animation-shake`, `.animation-pop`, plus a `.hover-lift` helper; documented on a new Motion page and a new Hover lift page.
- Standardize component transitions into `-duration`/`-timing` token pairs with a shared overlay easing (dialog, drawer, menu, carousel, navbar toggler), and document the pairs on the Motion page.
- Animate the checkbox tick, radio dot, and switch thumb with a shared overshoot; respects reduced motion. The tick keeps its mask in every state and the radio transitions `color`, so the mark fades out instead of flashing as a solid block on uncheck.
- Defer menu `shown`/`hidden` events until the CSS transition completes so the menu no longer snaps away mid-animation. `show()` and `hide()` await the queued callback, so the promises added in #42802 resolve when the transition ends, which is what the migration guide promises for Menu.
- Scope the `animation-shake` / `animation-pop` keyframes to builds that ship the `animation` utility, so `bootstrap-grid.css` no longer carries dead keyframes. The keyframes are also namespaced to avoid colliding with user-defined `shake` / `pop` animations.
- Add `--btn-input-gap` plus `--btn-input-sm-gap` and `--btn-input-lg-gap` alongside the new `xs` token, so no button size resolves `--btn-gap` to an undefined value.
- Smaller fixes: toggler no-op when no value is set, correct the `value` row in the Toggler options table, page-meta layer label, grouped radio example.
- Raise the CSS bundlewatch budgets and refresh `dist/css/bootstrap-utilities.metadata.json` for the new utilities. The budgets now also cover `bootstrap-reboot.css` and its minified file, because the new transition tokens land in `:root`, which `bootstrap-reboot.scss` forwards.

Closes #41047
Closes #38150
