### PR TITLE
Clean up commented out WebKit form control sizing CSS & docs

### DIFF
--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -96,33 +96,8 @@ $form-control-sizes: defaults(
       opacity: 1;
     }
 
-    // Date and time inputs
-    // &::-webkit-date-and-time-value {
-    //   // On Android Chrome, form-control's "width: 100%" makes the input width too small
-    //   // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
-    //   //
-    //   // On iOS Safari, form-control's "appearance: none" + "width: 100%" makes the input width too small
-    //   // Tested under iOS 16.2 / Safari 16.2
-    //   min-width: 85px; // Seems to be a good minimum safe width
-
-    //   // Add some height to date inputs on iOS
-    //   // https://github.com/twbs/bootstrap/issues/23307
-    //   // TODO: we can remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=198959 is resolved
-    //   // Multiply line-height by 1em if it has no unit
-    //   height: 1.5em;
-
-    //   // Android Chrome type="date" is taller than the other inputs
-    //   // because of "margin: 1px 24px 1px 4px" inside the shadow DOM
-    //   // Tested under Android 11 / Chrome 89, Android 12 / Chrome 100, Android 13 / Chrome 109
-    //   margin: 0;
-    //   background-color: var(--red-500);
-    // }
-
     // Prevent excessive date input height in WebKit/Blink; see
-    // https://github.com/twbs/bootstrap/issues/34433. Firefox ignores these
-    // -webkit- pseudo-elements. Kept minimal so the field wrapper inherits the
-    // control's own font-size, line-height, and padding and scales with the size
-    // modifiers instead of a fixed height.
+    // https://github.com/twbs/bootstrap/issues/34433.
     &::-webkit-datetime-edit {
       display: block;
       padding: 0;

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -118,18 +118,14 @@ $form-control-sizes: defaults(
     //   background-color: var(--red-500);
     // }
 
-    // Prevent excessive date input height in Webkit
-    // https://github.com/twbs/bootstrap/issues/34433
-
-    // TODO: verify these rules across the supported browser matrix
+    // Prevent excessive date input height in WebKit/Blink; see
+    // https://github.com/twbs/bootstrap/issues/34433. Firefox ignores these
+    // -webkit- pseudo-elements. Kept minimal so the field wrapper inherits the
+    // control's own font-size, line-height, and padding and scales with the size
+    // modifiers instead of a fixed height.
     &::-webkit-datetime-edit {
       display: block;
-      height: 1.5rem;
       padding: 0;
-      margin-bottom: -.125rem;
-    }
-    &::-webkit-datetime-edit-fields-wrapper {
-      height: 1.5rem;
     }
 
     // File inputs

--- a/site/src/content/docs/forms/form-control.mdx
+++ b/site/src/content/docs/forms/form-control.mdx
@@ -371,19 +371,3 @@ Some inputs and buttons share some root variables for consistency across all for
 We use a Sass map to define the sizes of the form controls, so you can easily add or modify sizes.
 
 <ScssDocs name="form-control-sizes" file="scss/forms/_form-control.scss" />
-
-{/* TODO: clean these up, possibly find new homes */}
-
-{/* `$input-*` are shared across most of our form controls (and not buttons).
-
-<ScssDocs name="form-input-variables" file="scss/forms/_form-variables.scss" />
-
-`$form-label-*` and `$form-text-*` are for our `<label>`s and `.form-text` component.
-
-<ScssDocs name="form-label-variables" file="scss/forms/_labels.scss" />
-
-<ScssDocs name="form-text-variables" file="scss/forms/_form-text.scss" />
-
-`$form-file-*` are for file input.
-
-<ScssDocs name="form-file-variables" file="scss/forms/_form-variables.scss" /> */}


### PR DESCRIPTION
Cleans up the WebKit date-input height handling in `.form-control`.

- Remove the fixed `1.5rem` heights (and negative margin) on `::-webkit-datetime-edit` and `::-webkit-datetime-edit-fields-wrapper` so date inputs inherit the control's `font-size`, `line-height`, and padding, scaling with the size modifiers
- Clarify the accompanying comment (WebKit/Blink only; Firefox ignores these pseudo-elements)
- Remove a stale commented-out variables block from the form-control docs page

Refs #34433