### PR TITLE
Fix icon symbol IDs colliding with heading anchors

### DIFF
--- a/site/src/components/PageMeta.astro
+++ b/site/src/components/PageMeta.astro
@@ -63,7 +63,7 @@ const depsTitles = deps.map((dep) => dep.title).join(', ')
     frontmatter.css_layer && (
       <div class="d-flex align-items-center gap-2">
         <svg class="bi fg-accent" aria-hidden="true">
-          <use href="#css" />
+          <use href="#filetype-css" />
         </svg>
         <span>
           In <code class="fg-body">{frontmatter.css_layer}</code> layer

--- a/site/src/components/icons/Symbols.astro
+++ b/site/src/components/icons/Symbols.astro
@@ -118,18 +118,13 @@
       d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"
     ></path>
   </symbol>
-  <symbol id="code" viewBox="0 0 16 16">
-    <path
-      d="M5.854 4.854a.5.5 0 1 0-.708-.708l-3.5 3.5a.5.5 0 0 0 0 .708l3.5 3.5a.5.5 0 0 0 .708-.708L2.707 8l3.147-3.146zm4.292 0a.5.5 0 0 1 .708-.708l3.5 3.5a.5.5 0 0 1 0 .708l-3.5 3.5a.5.5 0 0 1-.708-.708L13.293 8l-3.147-3.146z"
-    ></path>
-  </symbol>
   <symbol id="copy" viewBox="0 0 16 16">
     <path
       fill-rule="evenodd"
       d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
     ></path>
   </symbol>
-  <symbol id="css" viewBox="0 0 16 16">
+  <symbol id="filetype-css" viewBox="0 0 16 16">
     <path
       fill="currentcolor"
       fill-rule="evenodd"


### PR DESCRIPTION
Fixes #42705

### Description

Two docs icons in the SVG sprite used IDs that collide with auto-generated heading anchors, so clicking the anchor jumped to the invisible `<symbol>` instead of the heading.

- `<symbol id="css">` collided with the `#css` heading anchor on component pages → renamed to `filetype-css` (consistent with the existing `filetype-js`), and updated the single `<use>` reference in `PageMeta.astro`.
- `<symbol id="code">` collided with the `### Code` heading on `/content/prose/` → removed it, since it was unused (no `<use href="#code">` anywhere).

No heading anchors were touched, so existing cross-page links like `/layout/grid#css` keep working.

### Motivation & Context

The "On this page" sidebar anchors in the CSS section were broken. SVG `<symbol>` IDs and heading IDs share the same document ID namespace, and since the symbol appears first in the DOM, the browser resolves the anchor to it instead of the heading.

I raised this on the issue first and got the go-ahead from a maintainer before opening this PR. This is my first contribution to Bootstrap. Happy to adjust anything. 

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (using `npm run lint`)
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
