### PR TITLE
Examples: fix local execution of JavaScript showing Toast

### DIFF
--- a/site/src/assets/examples/cheatsheet/cheatsheet.js
+++ b/site/src/assets/examples/cheatsheet/cheatsheet.js
@@ -13,12 +13,11 @@ document.querySelectorAll('[data-bs-toggle="popover"]')
   })
 
 document.querySelectorAll('.toast')
-  .forEach(toastNode => {
-    const toast = new Toast(toastNode, {
+  .forEach(toast => {
+    const toastInstance = new Toast(toast, {
       autohide: false
     })
-
-    toast.show()
+    toastInstance.show()
   })
 
 document.querySelectorAll('[href="#"], [type="submit"]')

--- a/site/src/layouts/ExamplesLayout.astro
+++ b/site/src/layouts/ExamplesLayout.astro
@@ -33,6 +33,8 @@ const importMap = JSON.stringify({
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>
 
+    {include_js !== false && <script type="importmap" is:inline set:html={importMap} />}
+
     <link rel="canonical" href={canonicalUrl} />
 
     {/* Loaded as `is:inline` (not via Vite) so the theme is applied before paint. */}
@@ -127,7 +129,6 @@ const importMap = JSON.stringify({
     {
       include_js !== false && (
         <Fragment>
-          <script type="importmap" is:inline set:html={importMap} />
           <script is:inline {...bootstrapJsProps} />
           {extra_js?.map((js) => (
             <script


### PR DESCRIPTION
### Description

When running `npm run start` and going to http://localhost:9001/docs/6.0/examples/cheatsheet/#toasts, the Toast component is not displayed. However, it is at https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/examples/cheatsheet/#toasts.

1. The issue only happened in dev mode (`npm run start`) because the browser saw module scripts before it saw the import map.
2. The import map for `@bootstrap` was inside the page body, which is too late for reliable module resolution in that scenario.
3. I moved the import map into the head so it is parsed early, before module scripts run: ExamplesLayout.astro
4. Then I kept the cheatsheet example using the normal ESM import from `@bootstrap`: cheatsheet.js

Result: `@bootstrap` resolves correctly in both built docs and live dev mode.

#### Live previews

- https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/examples/cheatsheet/#toasts
