### PR TITLE
Migrate navbar examples/tests from collapse to drawer and remove deprecated `.navbar-collapse`

### DIFF
--- a/js/tests/visual/menu-submenu.html
+++ b/js/tests/visual/menu-submenu.html
@@ -225,10 +225,15 @@
         <nav class="navbar lg:navbar-expand bg-1 rounded">
           <div class="container-fluid">
             <a class="navbar-brand" href="#">Navbar</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSubmenu" aria-controls="navbarSubmenu" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarSubmenu" aria-controls="navbarSubmenu" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse" id="navbarSubmenu">
+            <dialog class="drawer drawer-end" tabindex="-1" id="navbarSubmenu" aria-labelledby="navbarSubmenuLabel">
+              <div class="drawer-header">
+                <h5 class="drawer-title" id="navbarSubmenuLabel">Menu</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+              </div>
+              <div class="drawer-body">
               <ul class="navbar-nav me-auto mb-2 lg:mb-0">
                 <li class="nav-item">
                   <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -266,7 +271,8 @@
                   <a class="nav-link" href="#">About</a>
                 </li>
               </ul>
-            </div>
+              </div>
+            </dialog>
           </div>
         </nav>
       </section>

--- a/js/tests/visual/menu.html
+++ b/js/tests/visual/menu.html
@@ -12,11 +12,16 @@
 
       <nav class="navbar md:navbar-expand">
         <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
 
-        <div class="collapse navbar-collapse" id="navbarResponsive">
+        <dialog class="drawer drawer-end" tabindex="-1" id="navbarResponsive" aria-labelledby="navbarResponsiveLabel">
+          <div class="drawer-header">
+            <h5 class="drawer-title" id="navbarResponsiveLabel">Menu</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+          </div>
+          <div class="drawer-body">
           <ul class="navbar-nav">
             <li class="nav-item">
               <a class="nav-link active" href="#" aria-current="page">Home</a>
@@ -36,7 +41,8 @@
               </div>
             </li>
           </ul>
-        </div>
+          </div>
+        </dialog>
       </nav>
 
       <ul class="nav nav-pills mt-3">

--- a/js/tests/visual/scrollspy.html
+++ b/js/tests/visual/scrollspy.html
@@ -12,10 +12,15 @@
   <body data-bs-spy="scroll" data-bs-target=".navbar" data-bs-offset="70">
     <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
       <a class="navbar-brand" href="#">Scrollspy test</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <div class="navbar-collapse collapse" id="navbarSupportedContent">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarSupportedContent" aria-labelledby="navbarSupportedContentLabel">
+        <div class="drawer-header">
+          <h5 class="drawer-title" id="navbarSupportedContentLabel">Menu</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+        </div>
+        <div class="drawer-body">
         <ul class="navbar-nav me-auto">
           <li class="nav-item">
             <a class="nav-link" href="#fat">@fat</a>
@@ -36,7 +41,8 @@
             <a class="nav-link" href="#final">Final</a>
           </li>
         </ul>
-      </div>
+        </div>
+      </dialog>
     </nav>
     <div class="container">
       <h2 id="fat">@fat</h2>

--- a/site/src/assets/examples/carousel/index.astro
+++ b/site/src/assets/examples/carousel/index.astro
@@ -8,10 +8,15 @@ import Placeholder from "@shortcodes/Placeholder.astro"
   <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Carousel</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
-      <div class="collapse navbar-collapse" id="navbarCollapse">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarCollapse" aria-labelledby="navbarCollapseLabel">
+        <div class="drawer-header">
+          <h5 class="drawer-title" id="navbarCollapseLabel">Menu</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+        </div>
+        <div class="drawer-body">
         <ul class="navbar-nav me-auto mb-2 md:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -27,7 +32,8 @@ import Placeholder from "@shortcodes/Placeholder.astro"
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
           <button class="btn-outline theme-success" type="submit">Search</button>
         </form>
-      </div>
+        </div>
+      </dialog>
     </div>
   </nav>
 </header>

--- a/site/src/assets/examples/cheatsheet/index.astro
+++ b/site/src/assets/examples/cheatsheet/index.astro
@@ -1186,10 +1186,10 @@ export const body_class = 'bg-1'
               <a class="navbar-brand" href="#">
                 <img src="${getVersionedDocsPath('/assets/brand/bootstrap-logo-white.svg')}" width="38" height="30" class="d-inline-block align-top" alt="Bootstrap" loading="lazy" style="filter: invert(1) grayscale(100%) brightness(200%);">
               </a>
-              <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+              <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon" aria-hidden="true"></span>
               </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
+              <dialog class="drawer drawer-end" tabindex="-1" id="navbarSupportedContent" aria-label="Navigation">
                 <ul class="navbar-nav me-auto mb-2 lg:mb-0">
                   <li class="nav-item">
                     <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -1216,7 +1216,7 @@ export const body_class = 'bg-1'
                   <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
                   <button class="btn-solid theme-outline-dark" type="submit">Search</button>
                 </form>
-              </div>
+              </dialog>
             </div>
           </nav>
 
@@ -1225,10 +1225,10 @@ export const body_class = 'bg-1'
               <a class="navbar-brand" href="#">
                 <img src="${getVersionedDocsPath('/assets/brand/bootstrap-logo-white.svg')}" width="38" height="30" class="d-inline-block align-top" alt="Bootstrap" loading="lazy">
               </a>
-              <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent2" aria-controls="navbarSupportedContent2" aria-expanded="false" aria-label="Toggle navigation">
+              <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarSupportedContent2" aria-controls="navbarSupportedContent2" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon" aria-hidden="true"></span>
               </button>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent2">
+              <dialog class="drawer drawer-end" tabindex="-1" id="navbarSupportedContent2" aria-label="Navigation">
                 <ul class="navbar-nav me-auto mb-2 lg:mb-0">
                   <li class="nav-item">
                     <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -1255,7 +1255,7 @@ export const body_class = 'bg-1'
                   <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
                   <button class="btn-solid theme-outline-light" type="submit">Search</button>
                 </form>
-              </div>
+              </dialog>
             </div>
           </nav>
           `} />

--- a/site/src/assets/examples/drawer-navbar/index.astro
+++ b/site/src/assets/examples/drawer-navbar/index.astro
@@ -16,7 +16,7 @@ import Placeholder from "@shortcodes/Placeholder.astro"
       <span class="navbar-toggler-icon" aria-hidden="true"></span>
     </button>
 
-    <div class="navbar-collapse drawer-collapse" id="navbarsExampleDefault">
+    <div class="drawer-collapse" id="navbarsExampleDefault">
       <ul class="navbar-nav me-auto mb-2 lg:mb-0">
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Dashboard</a>

--- a/site/src/assets/examples/navbar-bottom/index.astro
+++ b/site/src/assets/examples/navbar-bottom/index.astro
@@ -14,10 +14,15 @@ export const title = 'Bottom navbar example'
 <nav class="navbar fixed-bottom sm:navbar-expand" data-bs-theme="dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Bottom navbar</a>
-    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon" aria-hidden="true"></span>
     </button>
-    <div class="collapse navbar-collapse" id="navbarCollapse">
+    <dialog class="drawer drawer-end" tabindex="-1" id="navbarCollapse" aria-labelledby="navbarCollapseLabel">
+      <div class="drawer-header">
+        <h5 class="drawer-title" id="navbarCollapseLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+      </div>
+      <div class="drawer-body">
       <ul class="navbar-nav">
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -37,6 +42,7 @@ export const title = 'Bottom navbar example'
           </div>
         </li>
       </ul>
-    </div>
+      </div>
+    </dialog>
   </div>
 </nav>

--- a/site/src/assets/examples/navbar-fixed/index.astro
+++ b/site/src/assets/examples/navbar-fixed/index.astro
@@ -8,10 +8,15 @@ export const extra_css = ['navbar-fixed.css']
 <nav class="navbar md:navbar-expand bg-black fixed-top" data-bs-theme="dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Fixed navbar</a>
-    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon" aria-hidden="true"></span>
     </button>
-    <div class="collapse navbar-collapse" id="navbarCollapse">
+    <dialog class="drawer drawer-end" tabindex="-1" id="navbarCollapse" aria-labelledby="navbarCollapseLabel">
+      <div class="drawer-header">
+        <h5 class="drawer-title" id="navbarCollapseLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+      </div>
+      <div class="drawer-body">
       <ul class="navbar-nav me-auto mb-2 md:mb-0">
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -27,7 +32,8 @@ export const extra_css = ['navbar-fixed.css']
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
         <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
-    </div>
+      </div>
+    </dialog>
   </div>
 </nav>
 

--- a/site/src/assets/examples/navbar-static/index.astro
+++ b/site/src/assets/examples/navbar-static/index.astro
@@ -8,10 +8,15 @@ export const extra_css = ['navbar-static.css']
 <nav class="navbar md:navbar-expand bg-black bg-90 mb-4" data-bs-theme="dark">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Top navbar</a>
-    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon" aria-hidden="true"></span>
     </button>
-    <div class="collapse navbar-collapse" id="navbarCollapse">
+    <dialog class="drawer drawer-end" tabindex="-1" id="navbarCollapse" aria-labelledby="navbarCollapseLabel">
+      <div class="drawer-header">
+        <h5 class="drawer-title" id="navbarCollapseLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+      </div>
+      <div class="drawer-body">
       <ul class="navbar-nav me-auto mb-2 md:mb-0">
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -27,7 +32,8 @@ export const extra_css = ['navbar-static.css']
         <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
         <button class="btn-outline theme-success" type="submit">Search</button>
       </form>
-    </div>
+      </div>
+    </dialog>
   </div>
 </nav>
 

--- a/site/src/assets/examples/navbars/index.astro
+++ b/site/src/assets/examples/navbars/index.astro
@@ -9,11 +9,11 @@ export const extra_css = ['navbars.css']
   <nav class="navbar bg-black" aria-label="First navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Never expand</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample01" aria-controls="navbarsExample01" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample01" aria-controls="navbarsExample01" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample01">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample01" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -36,18 +36,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar navbar-expand bg-black" aria-label="Second navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Always expand</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample02" aria-controls="navbarsExample02" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample02" aria-controls="navbarsExample02" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample02">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample02" aria-label="Navigation">
         <ul class="navbar-nav me-auto">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -59,18 +59,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar sm:navbar-expand bg-black" aria-label="Third navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Expand at sm</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample03" aria-controls="navbarsExample03" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample03" aria-controls="navbarsExample03" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample03">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample03" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 sm:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -93,18 +93,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar md:navbar-expand bg-black" aria-label="Fourth navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Expand at md</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample04" aria-controls="navbarsExample04" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample04" aria-controls="navbarsExample04" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample04">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample04" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 md:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -127,18 +127,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar lg:navbar-expand bg-black" aria-label="Fifth navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Expand at lg</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample05" aria-controls="navbarsExample05" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample05" aria-controls="navbarsExample05" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample05">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample05" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 lg:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -161,18 +161,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar xl:navbar-expand bg-black" aria-label="Sixth navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Expand at xl</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample06" aria-controls="navbarsExample06" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample06" aria-controls="navbarsExample06" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample06">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample06" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 xl:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -195,18 +195,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar 2xl:navbar-expand bg-black" aria-label="Seventh navbar example" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Expand at 2xl</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample2xl" aria-controls="navbarsExample2xl" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample2xl" aria-controls="navbarsExample2xl" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample2xl">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample2xl" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 xl:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -229,18 +229,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Eighth navbar example">
     <div class="container">
       <a class="navbar-brand" href="#">Container</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample07" aria-controls="navbarsExample07" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample07" aria-controls="navbarsExample07" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample07">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample07" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 lg:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -263,18 +263,18 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
   <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Ninth navbar example">
     <div class="xl:container">
       <a class="navbar-brand" href="#">Container XL</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample07XL" aria-controls="navbarsExample07XL" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample07XL" aria-controls="navbarsExample07XL" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse" id="navbarsExample07XL">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample07XL" aria-label="Navigation">
         <ul class="navbar-nav me-auto mb-2 lg:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -297,7 +297,7 @@ export const extra_css = ['navbars.css']
         <form role="search">
           <input class="form-control" type="search" placeholder="Search" aria-label="Search">
         </form>
-      </div>
+      </dialog>
     </div>
   </nav>
 
@@ -307,11 +307,11 @@ export const extra_css = ['navbars.css']
 
   <nav class="navbar lg:navbar-expand" data-bs-theme="dark" aria-label="Tenth navbar example">
     <div class="container-fluid">
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample08" aria-controls="navbarsExample08" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample08" aria-controls="navbarsExample08" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
 
-      <div class="collapse navbar-collapse md:justify-content-center" id="navbarsExample08">
+      <dialog class="drawer drawer-end md:justify-content-center" tabindex="-1" id="navbarsExample08" aria-label="Navigation">
         <ul class="navbar-nav">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Centered nav only</a>
@@ -331,7 +331,7 @@ export const extra_css = ['navbars.css']
             </div>
           </li>
         </ul>
-      </div>
+      </dialog>
     </div>
   </nav>
 
@@ -339,11 +339,11 @@ export const extra_css = ['navbars.css']
     <nav class="navbar lg:navbar-expand bg-1 rounded" aria-label="Eleventh navbar example">
       <div class="container-fluid">
         <a class="navbar-brand" href="#">Navbar</a>
-        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample09" aria-controls="navbarsExample09" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample09" aria-controls="navbarsExample09" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon" aria-hidden="true"></span>
         </button>
 
-        <div class="collapse navbar-collapse" id="navbarsExample09">
+        <dialog class="drawer drawer-end" tabindex="-1" id="navbarsExample09" aria-label="Navigation">
           <ul class="navbar-nav me-auto mb-2 lg:mb-0">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -366,17 +366,17 @@ export const extra_css = ['navbars.css']
           <form role="search">
             <input class="form-control" type="search" placeholder="Search" aria-label="Search">
           </form>
-        </div>
+        </dialog>
       </div>
     </nav>
 
     <nav class="navbar lg:navbar-expand bg-1 rounded" aria-label="Twelfth navbar example">
       <div class="container-fluid">
-        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample10" aria-controls="navbarsExample10" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample10" aria-controls="navbarsExample10" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon" aria-hidden="true"></span>
         </button>
 
-        <div class="collapse navbar-collapse md:justify-content-center" id="navbarsExample10">
+        <dialog class="drawer drawer-end md:justify-content-center" tabindex="-1" id="navbarsExample10" aria-label="Navigation">
           <ul class="navbar-nav">
             <li class="nav-item">
               <a class="nav-link active" aria-current="page" href="#">Centered nav only</a>
@@ -396,17 +396,17 @@ export const extra_css = ['navbars.css']
               </div>
             </li>
           </ul>
-        </div>
+        </dialog>
       </div>
     </nav>
 
     <nav class="navbar lg:navbar-expand bg-1 rounded" aria-label="Thirteenth navbar example">
       <div class="container-fluid">
-        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExample11" aria-controls="navbarsExample11" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarsExample11" aria-controls="navbarsExample11" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon" aria-hidden="true"></span>
         </button>
 
-        <div class="collapse navbar-collapse lg:d-flex" id="navbarsExample11">
+        <dialog class="drawer drawer-end lg:d-flex" tabindex="-1" id="navbarsExample11" aria-label="Navigation">
           <a class="navbar-brand lg:col-3 me-0" href="#">Centered nav</a>
           <ul class="navbar-nav lg:col-6 lg:justify-content-center">
             <li class="nav-item">
@@ -430,7 +430,7 @@ export const extra_css = ['navbars.css']
           <div class="lg:d-flex lg:col-3 lg:justify-content-end">
             <button class="btn-solid theme-primary">Button</button>
           </div>
-        </div>
+        </dialog>
       </div>
     </nav>
 
@@ -439,7 +439,7 @@ export const extra_css = ['navbars.css']
         <div class="sm:col-8 mx-auto">
           <h1>Navbar examples</h1>
           <p>This example is a quick exercise to illustrate how the navbar and its contents work. Some navbars extend the width of the viewport, others are confined within a <code>.container</code>. For positioning of navbars, checkout the <a href={getVersionedDocsPath('/examples/navbar-static/')}>top</a> and <a href={getVersionedDocsPath('/examples/navbar-fixed/')}>fixed top</a> examples.</p>
-          <p>At the smallest breakpoint, the collapse plugin is used to hide the links and show a menu button to toggle the collapsed content.</p>
+          <p>At the smallest breakpoint, a drawer is used to hide the links and show a menu button to toggle the collapsed content.</p>
           <p>
             <a class="btn-solid theme-primary" href={getVersionedDocsPath('/components/navbar')} role="button">View navbar docs &raquo;</a>
           </p>

--- a/site/src/assets/examples/sticky-footer-navbar/index.astro
+++ b/site/src/assets/examples/sticky-footer-navbar/index.astro
@@ -12,10 +12,15 @@ export const body_class = 'd-flex flex-column h-100'
   <nav class="navbar md:navbar-expand fixed-top" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">Fixed navbar</a>
-      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="btn-icon navbar-toggler" type="button" data-bs-toggle="drawer" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon" aria-hidden="true"></span>
       </button>
-      <div class="collapse navbar-collapse" id="navbarCollapse">
+      <dialog class="drawer drawer-end" tabindex="-1" id="navbarCollapse" aria-labelledby="navbarCollapseLabel">
+        <div class="drawer-header">
+          <h5 class="drawer-title" id="navbarCollapseLabel">Menu</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="drawer" aria-label="Close"></button>
+        </div>
+        <div class="drawer-body">
         <ul class="navbar-nav me-auto mb-2 md:mb-0">
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
@@ -31,7 +36,8 @@ export const body_class = 'd-flex flex-column h-100'
           <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
           <button class="btn-solid theme-success" type="submit">Search</button>
         </form>
-      </div>
+        </div>
+      </dialog>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
Spotted in https://github.com/twbs/bootstrap/pull/42487

### Description

This PR updates all remaining navbar example and visual test markup to match the v6 navbar behavior.

The old collapse-based pattern (`data-bs-toggle="collapse"` with `.navbar-collapse`) is replaced with drawer-based toggles and drawer containers, and the leftover deprecated `.navbar-collapse` usage is removed from the custom drawer example.

This migration was needed because responsive navbar collapsing in v6 is implemented with Drawer, not Collapse, so these examples now reflect the current API and avoid deprecated classes.

#### Live previews

- https://deploy-preview-42745--twbs-bootstrap.netlify.app/

