### PR TITLE
Examples: fix malformed `--bs-bs-bs-bs-bs-` custom properties in example CSS

### DIFF
--- a/site/src/assets/examples/breadcrumbs/breadcrumbs.css
+++ b/site/src/assets/examples/breadcrumbs/breadcrumbs.css
@@ -1,5 +1,5 @@
 .breadcrumb-chevron {
-  --bs-bs-bs-bs-bs-breadcrumb-divider: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%236c757d'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E");
+  --bs-breadcrumb-divider: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%236c757d'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E");
   gap: .5rem;
 }
 .breadcrumb-chevron .breadcrumb-item {
@@ -34,9 +34,9 @@
   height: 50px;
   margin-top: -25px;
   content: "";
-  background-color: var(--bs-bs-bs-bs-bs-tertiary-bg);
+  background-color: var(--bs-tertiary-bg);
   border-top-right-radius: .5rem;
-  box-shadow: 1px -1px var(--bs-bs-bs-bs-bs-border-color);
+  box-shadow: 1px -1px var(--bs-border-color);
   transform: scale(.707) rotate(45deg);
 }
 .breadcrumb-custom .breadcrumb-item:first-child {

--- a/site/src/assets/examples/cheatsheet/cheatsheet.css
+++ b/site/src/assets/examples/cheatsheet/cheatsheet.css
@@ -26,29 +26,29 @@ body {
   padding: .1875rem .5rem;
   margin-top: .125rem;
   margin-left: .3125rem;
-  color: var(--bs-bs-bs-bs-bs-body-color);
+  color: var(--bs-body-color);
 }
 
 .bd-aside a:hover,
 .bd-aside a:focus {
-  color: var(--bs-bs-bs-bs-bs-body-color);
+  color: var(--bs-body-color);
   background-color: rgba(121, 82, 179, .1);
 }
 
 .bd-aside .active {
   font-weight: 600;
-  color: var(--bs-bs-bs-bs-bs-body-color);
+  color: var(--bs-body-color);
 }
 
 .bd-aside .btn {
   padding: .25rem .5rem;
   font-weight: 600;
-  color: var(--bs-bs-bs-bs-bs-body-color);
+  color: var(--bs-body-color);
 }
 
 .bd-aside .btn:hover,
 .bd-aside .btn:focus {
-  color: var(--bs-bs-bs-bs-bs-body-color);
+  color: var(--bs-body-color);
   background-color: rgba(121, 82, 179, .1);
 }
 

--- a/site/src/assets/examples/headers/headers.css
+++ b/site/src/assets/examples/headers/headers.css
@@ -1,5 +1,5 @@
 .form-control-dark {
-  border-color: var(--bs-bs-bs-bs-bs-gray);
+  border-color: var(--bs-gray);
 }
 .form-control-dark:focus {
   border-color: #fff;

--- a/site/src/assets/examples/jumbotrons/jumbotrons.css
+++ b/site/src/assets/examples/jumbotrons/jumbotrons.css
@@ -1,1 +1,1 @@
-.border-dashed { --bs-bs-bs-bs-bs-border-style: dashed; }
+.border-dashed { --bs-border-style: dashed; }

--- a/site/src/assets/examples/list-groups/list-groups.css
+++ b/site/src/assets/examples/list-groups/list-groups.css
@@ -23,12 +23,12 @@
   clip: rect(0, 0, 0, 0);
 }
 .list-group-item-check:hover + .list-group-item {
-  background-color: var(--bs-bs-bs-bs-bs-secondary-bg);
+  background-color: var(--bs-secondary-bg);
 }
 .list-group-item-check:checked + .list-group-item {
   color: #fff;
-  background-color: var(--bs-bs-bs-bs-bs-primary);
-  border-color: var(--bs-bs-bs-bs-bs-primary);
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 .list-group-item-check[disabled] + .list-group-item,
 .list-group-item-check:disabled + .list-group-item {
@@ -47,13 +47,13 @@
 }
 .list-group-radio .list-group-item:hover,
 .list-group-radio .list-group-item:focus {
-  background-color: var(--bs-bs-bs-bs-bs-secondary-bg);
+  background-color: var(--bs-secondary-bg);
 }
 
 .list-group-radio .radio:checked + .list-group-item {
-  background-color: var(--bs-bs-bs-bs-bs-body);
-  border-color: var(--bs-bs-bs-bs-bs-primary);
-  box-shadow: 0 0 0 2px var(--bs-bs-bs-bs-bs-primary);
+  background-color: var(--bs-body);
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 2px var(--bs-primary);
 }
 .list-group-radio .radio[disabled] + .list-group-item,
 .list-group-radio .radio:disabled + .list-group-item {

--- a/site/src/assets/examples/pricing/pricing.css
+++ b/site/src/assets/examples/pricing/pricing.css
@@ -1,5 +1,5 @@
 body {
-  background-image: linear-gradient(180deg, var(--bs-bs-bs-bs-bs-secondary-bg), var(--bs-bs-bs-bs-bs-body-bg) 100px, var(--bs-bs-bs-bs-bs-body-bg));
+  background-image: linear-gradient(180deg, var(--bs-secondary-bg), var(--bs-body-bg) 100px, var(--bs-body-bg));
 }
 
 .container {

--- a/site/src/assets/examples/sidebars/sidebars.css
+++ b/site/src/assets/examples/sidebars/sidebars.css
@@ -17,13 +17,13 @@ main {
 .btn-toggle {
   padding: .25rem .5rem;
   font-weight: 600;
-  color: var(--bs-bs-bs-bs-bs-emphasis-color);
+  color: var(--bs-emphasis-color);
   background-color: transparent;
 }
 .btn-toggle:hover,
 .btn-toggle:focus {
-  color: rgba(var(--bs-bs-bs-bs-bs-emphasis-color-rgb), .85);
-  background-color: var(--bs-bs-bs-bs-bs-tertiary-bg);
+  color: rgba(var(--bs-emphasis-color-rgb), .85);
+  background-color: var(--bs-tertiary-bg);
 }
 
 .btn-toggle::before {
@@ -39,7 +39,7 @@ main {
 }
 
 .btn-toggle[aria-expanded="true"] {
-  color: rgba(var(--bs-bs-bs-bs-bs-emphasis-color-rgb), .85);
+  color: rgba(var(--bs-emphasis-color-rgb), .85);
 }
 .btn-toggle[aria-expanded="true"]::before {
   transform: rotate(90deg);
@@ -52,7 +52,7 @@ main {
 }
 .btn-toggle-nav a:hover,
 .btn-toggle-nav a:focus {
-  background-color: var(--bs-bs-bs-bs-bs-tertiary-bg);
+  background-color: var(--bs-tertiary-bg);
 }
 
 .scrollarea {


### PR DESCRIPTION
### Description

Fixes malformed CSS custom property names (`--bs-bs-bs-bs-bs-*` instead of `--bs-*`) introduced by a previous commit. This affected example stylesheets used in the docs: breadcrumbs, cheatsheet, headers, jumbotrons, list-groups, pricing, sidebars.

### Live preview

- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/breadcrumbs/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/cheatsheet/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/headers/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/jumbotrons/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/list-groups/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/pricing/
- https://deploy-preview-42747--twbs-bootstrap.netlify.app/docs/6.0/examples/sidebars/