### PR TITLE
Fix cropped navbar content when expanded

### DIFF
--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -234,6 +234,9 @@ $navbar-nav-tokens: defaults(
       max-height: none !important;
       padding: 0;
       margin: 0;
+      // Allow focus rings on inlined form controls to paint outside the dialog box.
+      // Without this, UA/drawer `overflow` clips the top/bottom of `:focus-visible` outlines.
+      overflow: visible !important;
       visibility: visible !important;
       background-color: transparent !important;
       border: 0 !important;

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -234,8 +234,6 @@ $navbar-nav-tokens: defaults(
       max-height: none !important;
       padding: 0;
       margin: 0;
-      // Allow focus rings on inlined form controls to paint outside the dialog box.
-      // Without this, UA/drawer `overflow` clips the top/bottom of `:focus-visible` outlines.
       overflow: visible !important;
       visibility: visible !important;
       background-color: transparent !important;


### PR DESCRIPTION
## Description

When a navbar is expanded, its drawer is inlined as a static flex child but still inherits `overflow` from drawer/dialog styles. That clips the top and bottom of `:focus-visible` outlines on form controls inside the drawer (visible on the main navbar example search field).

This resets `overflow: visible` on inlined drawers in `navbar-expanded()`, matching the existing `overflow-y: visible` on `.drawer-body`.

## Motivation & Context

Fixes #42738. Regular (non-drawer) navbar form examples already showed a full focus ring; the resizable example that uses a drawer did not.

## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

- <https://deploy-preview-42753--twbs-bootstrap.netlify.app/>

### Related issues

Fixes #42738