### PR TITLE
Fix drawer-sheet not respecting start/end placement

### DIFF
--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -251,19 +251,58 @@ $drawer-backdrop-tokens: defaults(
 
   // Sheet variant: flush-to-edge panel with no inset, border-radius, or shadow.
   // Overrides tokens so placement transforms (which use calc() with --drawer-inset)
-  // automatically position the drawer at the viewport edge.
+  // automatically position the drawer at the viewport edge. Placement-aware:
+  // bottom/top sheets are full-bleed horizontally (capped at a max-width on
+  // large screens), start/end sheets are full-bleed vertically (capped at a
+  // max-height on large screens).
   .drawer-sheet {
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100vw;
-    margin-inline: auto;
-    margin-bottom: calc(-1 * var(--drawer-border-width));
-    border-end-start-radius: 0;
-    border-end-end-radius: 0;
+    &:where(.drawer-bottom, .drawer-top) {
+      right: 0;
+      left: 0;
+      width: 100vw;
+      margin-inline: auto;
 
-    @include media-breakpoint-up(lg) {
-      max-width: var(--drawer-sheet-width, 760px);
+      @include media-breakpoint-up(lg) {
+        max-width: var(--drawer-sheet-width, 760px);
+      }
+    }
+
+    &:where(.drawer-bottom) {
+      bottom: 0;
+      margin-bottom: calc(-1 * var(--drawer-border-width));
+      border-end-start-radius: 0;
+      border-end-end-radius: 0;
+    }
+
+    &:where(.drawer-top) {
+      top: 0;
+      margin-top: calc(-1 * var(--drawer-border-width));
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+    }
+
+    &:where(.drawer-start, .drawer-end) {
+      inset-block: 0;
+      height: 100vh;
+      margin-block: auto;
+
+      @include media-breakpoint-up(lg) {
+        max-height: var(--drawer-sheet-height, 760px);
+      }
+    }
+
+    &:where(.drawer-start) {
+      inset-inline-start: 0;
+      margin-inline-start: calc(-1 * var(--drawer-border-width));
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+
+    &:where(.drawer-end) {
+      inset-inline-end: 0;
+      margin-inline-end: calc(-1 * var(--drawer-border-width));
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
     }
   }
 

--- a/site/src/content/docs/components/drawer.mdx
+++ b/site/src/content/docs/components/drawer.mdx
@@ -176,7 +176,7 @@ Add `.drawer-translucent` to the drawer panel to blur and saturate the backgroun
 
 ## Sheet
 
-Add `.drawer-sheet` to render the panel flush against the viewport edge. The sheet variant removes the drawer’s inset, border, border-radius, and box-shadow, so it sits edge-to-edge like a traditional offcanvas. It works with any placement.
+Add `.drawer-sheet` to render the panel flush against the viewport edge. The sheet variant removes the drawer’s inset, border, border-radius, and box-shadow, so it sits edge-to-edge like a traditional offcanvas. It works with any placement: combine it with `.drawer-bottom`/`.drawer-top` for a full-bleed panel capped by `--drawer-sheet-width`, or with `.drawer-start`/`.drawer-end` for a full-bleed panel capped by `--drawer-sheet-height`.
 
 <Example code={`<button class="btn-solid theme-primary" type="button" data-bs-toggle="drawer" data-bs-target="#drawerSheet" aria-controls="drawerSheet">
     Toggle sheet drawer
@@ -185,6 +185,22 @@ Add `.drawer-sheet` to render the panel flush against the viewport edge. The she
   <dialog class="drawer drawer-bottom drawer-sheet" tabindex="-1" id="drawerSheet" aria-labelledby="drawerSheetLabel">
     <div class="drawer-header">
       <h5 class="drawer-title" id="drawerSheetLabel">Sheet drawer</h5>
+      <CloseButton dismiss="drawer" />
+    </div>
+    <div class="drawer-body">
+      Content for the sheet drawer goes here. It sits flush to the edge with no inset, border, rounded corners, or shadow.
+    </div>
+  </dialog>`} />
+
+`.drawer-sheet` also works with `.drawer-end` (or `.drawer-start`), pinning the panel flush against the right (or left) edge of the viewport instead:
+
+<Example code={`<button class="btn-solid theme-primary" type="button" data-bs-toggle="drawer" data-bs-target="#drawerSheetEnd" aria-controls="drawerSheetEnd">
+    Toggle sheet drawer
+  </button>
+
+  <dialog class="drawer drawer-end drawer-sheet" tabindex="-1" id="drawerSheetEnd" aria-labelledby="drawerSheetEndLabel">
+    <div class="drawer-header">
+      <h5 class="drawer-title" id="drawerSheetEndLabel">Sheet drawer</h5>
       <CloseButton dismiss="drawer" />
     </div>
     <div class="drawer-body">


### PR DESCRIPTION
### Description

Make .drawer-sheet respect .drawer-start and .drawer-end. Fixes #42754.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

In the current state of v6-dev, the Sheet drawer works only when aligned to bottom. Aligning to left or right does not work, the drawer is always centered horizontally.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

- No live preview available because netlify somehow doesn't work for me...

### Related issues

#42754

