### PR TITLE
Fix navbar-brand and nav-link ignoring theme-* accent color classes

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -111,7 +111,7 @@ $nav-underline-tokens: defaults(
     justify-content: var(--nav-link-justify);
     padding: var(--nav-link-padding-y) var(--nav-link-padding-x);
     font-weight: var(--nav-link-font-weight);
-    color: var(--nav-link-color);
+    color: var(--theme-fg, var(--nav-link-color));
     text-decoration: none;
     white-space: nowrap;
     background: none;
@@ -121,20 +121,20 @@ $nav-underline-tokens: defaults(
 
     &:hover,
     &:focus {
-      color: var(--nav-link-hover-color);
-      background-color: var(--nav-link-hover-bg);
+      color: var(--theme-fg-emphasis, var(--nav-link-hover-color));
+      background-color: var(--theme-bg-muted, var(--nav-link-hover-bg));
     }
 
     &:focus-visible {
       --focus-ring-offset: 1px;
-      color: var(--nav-link-hover-color);
+      color: var(--theme-fg-emphasis, var(--nav-link-hover-color));
       @include focus-ring(true);
     }
 
     &.active,
     &:active {
-      color: var(--nav-link-active-color);
-      background-color: var(--nav-link-active-bg);
+      color: var(--theme-fg, var(--nav-link-active-color));
+      background-color: var(--theme-bg-subtle, var(--nav-link-active-bg));
     }
 
     // Disabled state lightens text

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -131,13 +131,13 @@ $navbar-nav-tokens: defaults(
     margin-inline-end: var(--navbar-brand-margin-end);
     font-size: var(--navbar-brand-font-size);
     font-weight: var(--navbar-brand-font-weight);
-    color: var(--navbar-brand-color);
+    color: var(--theme-fg, var(--navbar-brand-color));
     text-decoration: none;
     white-space: nowrap;
 
     &:hover,
     &:focus {
-      color: var(--navbar-brand-hover-color);
+      color: var(--theme-fg-emphasis, var(--navbar-brand-hover-color));
     }
   }
 
@@ -158,7 +158,7 @@ $navbar-nav-tokens: defaults(
     .nav-link {
       &.active,
       &.show {
-        color: var(--navbar-active-color);
+        color: var(--theme-fg, var(--navbar-active-color));
         border: var(--nav-link-border-width) solid var(--nav-link-border-color, transparent);
       }
     }
@@ -175,7 +175,7 @@ $navbar-nav-tokens: defaults(
     a,
     a:hover,
     a:focus {
-      color: var(--navbar-active-color);
+      color: var(--theme-fg, var(--navbar-active-color));
     }
   }
 


### PR DESCRIPTION
### Description

## What's going on

Over in #42752, @JredLewis pointed out that in v6, adding a `.theme-*` class (like `.theme-warning`) to a `.navbar-brand` link doesn't do anything. Indeed, the brand text just stays whatever color it normally is, instead of picking up the theme color the way a regular link does.

I dug into this to confirm it before writing a fix, and it turned out the bug is a bit bigger than the title suggests.

## Root cause

Bootstrap v6 has this really nice system where `.theme-warning`, `.theme-success`, etc. set a handful of custom properties (`--theme-fg`, `--theme-bg`, `--theme-border`, and so on) on whatever element they're applied to. Components are then supposed to read those variables *with a fallback* to their own default color, something like:

```css
color: var(--theme-fg, var(--list-group-color));
```

That way, if a `.theme-*` class is present somewhere up the tree, the component picks up the accent color. If not, it just falls back to its normal color. This pattern is already used consistently in `.list-group-item`, `.page-link`, `.accordion-header`, `.btn`, and several others.

The problem is that `.navbar-brand` never got wired up this way as it just does `color: var(--navbar-brand-color)`, full stop, with no `--theme-fg` fallback. So `.theme-*` has literally nothing to hook into there.

While reproducing the issue I also tested `.nav-link` directly, since the issue report claims `.nav-link` *does* already respect `.theme-*`. That turned out not to be the case either. I tested it both as a standalone `.nav-link` and inside `.navbar-nav`, and in both cases the theme class had zero visual effect. Same story for the plain text links inside `.navbar-text`. So this isn't just a `.navbar-brand`-only bug, it's a missing pattern across basically all of the nav/navbar link colors.

## What I changed

I added the same `--theme-fg` / `--theme-fg-emphasis` fallback pattern (plus `--theme-bg-muted` / `--theme-bg-subtle` for the hover and active background tints) to:

- `.navbar-brand`, in its default and hover/focus states
- `.nav-link`, in its default, hover/focus, focus-visible, and active states (both the base `.nav` component and inside `.navbar-nav`)
- `.navbar-nav .nav-link.active` / `.show`
- the plain `a` links inside `.navbar-text`

I deliberately left the disabled states alone. I'd say that disabled elements aren't supposed to pick up theme accent colors anywhere else in the codebase (`.list-group-item.disabled` behaves the same way), so keeping that consistent felt right rather than "fixing" something that wasn't broken.

## How I verified it

I rebuilt `dist/css/bootstrap.css` locally and opened a small test page in the browser with:
- a plain `<a>` with `.theme-warning` (this always worked, used as a sanity baseline)
- a `.nav-link` with `.theme-warning`
- a `.navbar-brand` with `.theme-warning` (the actual reported bug)
- `.navbar-nav .nav-link`, both default and `.active`, with `.theme-warning`

Before the fix, only the plain link picked up the warning color: everything else stayed the default gray/white. After the fix, all four render in the warning color, including a nicely subtle warning-tinted background on the active nav-link.

I also wanted to make sure this doesn't step on the navbar's documented "Color schemes" feature (the `data-bs-theme="dark"` attribute you can put on a `.navbar` to switch it to a dark variant). That's a completely separate mechanism: it just redefines the underlying `--navbar-brand-color`/`--navbar-color` custom properties, it doesn't touch `--theme-fg` at all. So I tested:
- a dark navbar with `bg-primary` and *no* `.theme-*` class — brand and links stay white, exactly as documented, no regression
- a dark navbar combined *with* `.theme-warning` — the warning color still comes through correctly, and since the underlying color tokens use `light-dark()`, it adapts properly even when dark mode is forced via `data-bs-theme="dark"`

Both worked as expected, so the two systems look to compose fine together.

I put together a small reproduction page ([test.html](https://github.com/user-attachments/files/30427500/test.html)) that covers all of the scenarios above if you want to try before/after yourself. Just copy this patch at the root-level of the repo, run `npm run css`, open the file, then pop the stash, rebuild, and reload.

#### Live previews

- https://deploy-preview-42756--twbs-bootstrap.netlify.app/docs/6.0/components/navbar/ (no expected regression)

### Related issues

Closes #42752
