### PR TITLE
Docs: remove stale pre-v6 version callouts

### DIFF
--- a/site/src/content/docs/customize/options.mdx
+++ b/site/src/content/docs/customize/options.mdx
@@ -17,11 +17,11 @@ You can find and customize these variables for key global options in Bootstrap�
 | `$enable-transitions`          | `true` (default) or `false`        | Enables predefined `transition`s on various components. |
 | `$enable-reduced-motion`       | `true` (default) or `false`        | Enables the [`prefers-reduced-motion` media query]([[docsref:/getting-started/accessibility#reduced-motion]]), which suppresses certain animations/transitions based on the users’ browser/operating system preferences. |
 | `$enable-grid-classes`         | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.row`, `.md:col-1`, etc.). |
-| `$enable-cssgrid`              | `true` or `false` (default)        | Enables the experimental CSS Grid system (e.g. `.grid`, `.md:g-col-1`, etc.). |
-| `$enable-container-classes`    | `true` (default) or `false`        | Enables the generation of CSS classes for layout containers. (New in v5.2.0) |
+| `$enable-cssgrid`              | `true` or `false` (default)        | Enables the [CSS Grid system]([[docsref:/layout/css-grid]]) (e.g. `.grid`, `.md:g-col-1`, etc.). |
+| `$enable-container-classes`    | `true` (default) or `false`        | Enables the generation of CSS classes for layout containers. |
 | `$enable-caret`                | `true` (default) or `false`        | Enables pseudo element caret on `[data-bs-toggle="menu"]`. |
 | `$enable-button-pointers`      | `true` (default) or `false`        | Add “hand” cursor to non-disabled button elements. |
 | `$enable-negative-margins`     | `true` or `false` (default)        | Enables the generation of [negative margin utilities]([[docsref:/utilities/margin#negative-margin]]). |
-| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in `v6`. |
+| `$enable-deprecation-messages` | `true` (default) or `false`        | Set to `false` to hide warnings when using any of the deprecated mixins and functions that are planned to be removed in a future major version. |
 | `$enable-smooth-scroll`        | `true` (default) or `false`        | Applies `scroll-behavior: smooth` globally, except for users asking for reduced motion through [`prefers-reduced-motion` media query]([[docsref:/getting-started/accessibility#reduced-motion]]) |
 </BsTable>

--- a/site/src/content/docs/layout/css-grid.mdx
+++ b/site/src/content/docs/layout/css-grid.mdx
@@ -11,7 +11,7 @@ csstricks:
 Bootstrap’s default grid system represents the culmination of over a decade of CSS layout techniques, tried and tested by millions of people. But, it was also created without many of the modern CSS features and techniques we’re seeing in browsers like the new CSS Grid.
 
 <Callout type="warning">
-**Heads up—our CSS Grid system is experimental and opt-in as of v5.1.0!** We included it in our documentation’s CSS to demonstrate it for you, but it’s disabled by default. Keep reading to learn how to enable it in your projects.
+**Heads up—our CSS Grid system is opt-in!** We included it in our documentation’s CSS to demonstrate it for you, but it’s disabled by default. Keep reading to learn how to enable it in your projects. See also our [container query utilities]([[docsref:/utilities/container-queries]]), which cover a related but distinct use case.
 </Callout>
 
 ## How it works


### PR DESCRIPTION
### Description

- Remove the "experimental ... as of v5.1.0" framing from the CSS Grid docs; it's just opt-in now, and add a cross-link to the container query utilities page.
- Drop the "(New in v5.2.0)" callout from `$enable-container-classes` in the options table.
- Reword `$enable-cssgrid`'s matching stale "experimental" description and link it to the CSS Grid page.
- Reword `$enable-deprecation-messages`'s "removed in v6" wording to "a future major version", since v6 is now current and nothing is actually queued for removal.

### Live previews

- https://deploy-preview-42763--twbs-bootstrap.netlify.app/docs/6.0/customize/options/
- https://deploy-preview-42763--twbs-bootstrap.netlify.app/docs/6.0/layout/css-grid/
