### PR TITLE
Docs: document the shipped `.user-select-text` utility

### DIFF
--- a/site/src/content/docs/utilities/user-select.mdx
+++ b/site/src/content/docs/utilities/user-select.mdx
@@ -15,12 +15,14 @@ Change the way in which the content is selected when the user interacts with it 
 
 <Example code={`<p class="user-select-all">This paragraph will be entirely selected when clicked by the user.</p>
 <p class="user-select-auto">This paragraph has default select behavior.</p>
+<p class="user-select-text">This paragraph will only allow the text to be selected when clicked by the user, even if the CSS \`user-select\` property is set to something else.</p>
 <p class="user-select-none">This paragraph will not be selectable when clicked by the user.</p>`} />
 
 ## Use cases
 
 - **`.user-select-all`** - Useful for code snippets, IDs, or other content users might want to copy entirely
 - **`.user-select-auto`** - Default browser behavior, allows normal text selection
+- **`.user-select-text`** - Forces text to remain selectable, useful for overriding a `user-select: none` set by an ancestor
 - **`.user-select-none`** - Prevents text selection, useful for UI elements, buttons, or decorative text
 
 <Callout>

--- a/site/src/content/docs/utilities/user-select.mdx
+++ b/site/src/content/docs/utilities/user-select.mdx
@@ -15,7 +15,7 @@ Change the way in which the content is selected when the user interacts with it 
 
 <Example code={`<p class="user-select-all">This paragraph will be entirely selected when clicked by the user.</p>
 <p class="user-select-auto">This paragraph has default select behavior.</p>
-<p class="user-select-text">This paragraph will only allow the text to be selected when clicked by the user, even if the CSS \`user-select\` property is set to something else.</p>
+<p class="user-select-text">This paragraph will only allow the text to be selected when clicked by the user, even if the CSS <code>user-select</code> property is set to something else.</p>
 <p class="user-select-none">This paragraph will not be selectable when clicked by the user.</p>`} />
 
 ## Use cases


### PR DESCRIPTION
### Description

- `user-select.mdx` never mentioned the shipped `.user-select-text` utility class, even though `scss/_utilities.scss` defines it alongside `all`/`auto`/`none`.
- Adds a `.user-select-text` example and use-case bullet to the docs page.

#### Live previews

- <https://deploy-preview-42767--twbs-bootstrap.netlify.app/>
