### PR TITLE
Guard placeholder glow/wave animations behind prefers-reduced-motion

### DIFF
--- a/scss/_placeholder.scss
+++ b/scss/_placeholder.scss
@@ -1,4 +1,5 @@
 @use "colors" as *;
+@use "config" as *;
 @use "functions" as *;
 @use "mixins/tokens" as *;
 
@@ -49,6 +50,12 @@ $placeholder-tokens: defaults(
   .placeholder-glow {
     .placeholder {
       animation: placeholder-glow 2s ease-in-out infinite;
+
+      @if $enable-reduced-motion {
+        @media (prefers-reduced-motion: reduce) {
+          animation: none;
+        }
+      }
     }
   }
 
@@ -62,6 +69,12 @@ $placeholder-tokens: defaults(
     mask-image: linear-gradient(130deg, $black 55%, rgb(0 0 0 / calc(1 - var(--placeholder-opacity-min))) 75%, $black 95%);
     mask-size: 200% 100%;
     animation: placeholder-wave 2s linear infinite;
+
+    @if $enable-reduced-motion {
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
   }
 
   @keyframes placeholder-wave {


### PR DESCRIPTION
### Description

`.placeholder-glow` and `.placeholder-wave` use an infinite 2s CSS animation to create their loading-shimmer effect. Unlike every other looping animation in the codebase, these two had no way to opt out for users who have `prefers-reduced-motion: reduce` set in their OS/browser. It's a real accessibility gap for anyone sensitive to motion.

This PR closes that gap by wrapping both animations in the same reduced-motion guard used elsewhere in the project.

- `.placeholder-glow`'s animation and `.placeholder-wave`'s animation are now disabled (`animation: none`) inside `@media (prefers-reduced-motion: reduce)`.
- The guard is wrapped in `@if $enable-reduced-motion` so it can still be compiled out entirely via the existing Sass config flag, consistent with how `_progress.scss`, `_spinner.scss`, and the shared `transition()` mixin in `mixins/_transition.scss` already handle this.

> [!NOTE]
> This might worth checking v5 to backport this modification if not already handled

### How to test

On macOS, it's easily testable by enabling/disabling motion in Accessibility settings.

<img width="718" height="347" alt="" src="https://github.com/user-attachments/assets/be9767d3-9840-4b0f-82bd-7cc83b57994b" />

