### PR TITLE
Fix custom mouse event handler semantics

### DIFF
--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -19,6 +19,7 @@ interface WrappedHandler {
   uidEvent?: string | number
   callable?: EventCallable
   delegationSelector?: string | null
+  handlerTypeEvent?: string
 }
 
 type ElementEvents = Record<string, Record<string, WrappedHandler>>
@@ -104,19 +105,29 @@ function getElementEvents(element: Element & { uidEvent?: string | number }): El
   return eventRegistry[uid]
 }
 
-function bootstrapHandler(element: Element, fn: EventCallable): WrappedHandler {
-  return function handler(event: Event) {
-    hydrateObj(event, { delegateTarget: element })
+function isMouseEventWithinTarget(event: BootstrapEvent): boolean {
+  const { delegateTarget, relatedTarget } = event
 
-    if ((handler as WrappedHandler).oneOff) {
-      EventHandler.off(element, event.type, fn)
+  return Boolean(relatedTarget && (relatedTarget === delegateTarget || delegateTarget.contains(relatedTarget)))
+}
+
+function bootstrapHandler(element: Element, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
+  return function handler(event: Event) {
+    const bootstrapEvent = hydrateObj(event, { delegateTarget: element })
+
+    if (isCustomMouseEvent && isMouseEventWithinTarget(bootstrapEvent)) {
+      return
     }
 
-    return fn.apply(element, [event as BootstrapEvent])
+    if ((handler as WrappedHandler).oneOff) {
+      EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, (handler as WrappedHandler).callable)
+    }
+
+    return fn.apply(element, [bootstrapEvent])
   } as WrappedHandler
 }
 
-function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable): WrappedHandler {
+function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
   return function handler(this: Element, event: Event) {
     const domElements = element.querySelectorAll(selector)
 
@@ -126,21 +137,25 @@ function bootstrapDelegationHandler(element: Element, selector: string, fn: Even
           continue
         }
 
-        hydrateObj(event, { delegateTarget: target })
+        const bootstrapEvent = hydrateObj(event, { delegateTarget: target })
 
-        if ((handler as WrappedHandler).oneOff) {
-          EventHandler.off(element, event.type, selector, fn)
+        if (isCustomMouseEvent && isMouseEventWithinTarget(bootstrapEvent)) {
+          return
         }
 
-        return fn.apply(target, [event as BootstrapEvent])
+        if ((handler as WrappedHandler).oneOff) {
+          EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, selector, (handler as WrappedHandler).callable)
+        }
+
+        return fn.apply(target, [bootstrapEvent])
       }
     }
   } as WrappedHandler
 }
 
-function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, delegationSelector: string | null = null): WrappedHandler | undefined {
+function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, handlerTypeEvent: string, delegationSelector: string | null = null): WrappedHandler | undefined {
   return Object.values(events)
-    .find(event => event.callable === callable && event.delegationSelector === delegationSelector)
+    .find(event => event.callable === callable && event.handlerTypeEvent === handlerTypeEvent && event.delegationSelector === delegationSelector)
 }
 
 function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): [boolean, EventCallable, string] {
@@ -155,30 +170,23 @@ function normalizeParameters(originalTypeEvent: string, handler?: string | Event
   return [isDelegated, callable, typeEvent]
 }
 
+function getHandlerTypeEvent(originalTypeEvent: string, typeEvent: string): string {
+  const baseTypeEvent = originalTypeEvent.replace(stripNameRegex, '')
+
+  return baseTypeEvent in customEvents ? baseTypeEvent : typeEvent
+}
+
 function addHandler(element: Element, originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable, oneOff?: boolean): void {
   if (typeof originalTypeEvent !== 'string' || !element) {
     return
   }
 
-  let [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-
-  // in case of mouseenter or mouseleave wrap the handler within a function that checks for its DOM position
-  // this prevents the handler from being dispatched the same way as mouseover or mouseout does
-  if (originalTypeEvent in customEvents) {
-    const wrapFunction = (fn: EventCallable): EventCallable => {
-      return function (this: any, event: BootstrapEvent) {
-        if (!event.relatedTarget || (event.relatedTarget !== event.delegateTarget && !event.delegateTarget.contains(event.relatedTarget))) {
-          return fn.call(this, event)
-        }
-      }
-    }
-
-    callable = wrapFunction(callable)
-  }
-
+  const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
+  const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
   const events = getElementEvents(element)
   const handlers = events[typeEvent] || (events[typeEvent] = {})
-  const previousFunction = findHandler(handlers, callable, isDelegated ? (handler as string) : null)
+  const previousFunction = findHandler(handlers, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
 
   if (previousFunction) {
     previousFunction.oneOff = previousFunction.oneOff && oneOff
@@ -188,11 +196,12 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
 
   const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ''))
   const fn = isDelegated ?
-    bootstrapDelegationHandler(element, handler as string, callable) :
-    bootstrapHandler(element, callable)
+    bootstrapDelegationHandler(element, handler as string, callable, isCustomMouseEvent) :
+    bootstrapHandler(element, callable, isCustomMouseEvent)
 
   fn.delegationSelector = isDelegated ? (handler as string) : null
   fn.callable = callable
+  fn.handlerTypeEvent = handlerTypeEvent
   fn.oneOff = oneOff
   fn.uidEvent = uid
   handlers[uid] = fn
@@ -200,15 +209,9 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
   element.addEventListener(typeEvent, fn, isDelegated)
 }
 
-function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: EventCallable, delegationSelector: string | null): void {
-  const fn = findHandler(events[typeEvent], handler, delegationSelector)
-
-  if (!fn) {
-    return
-  }
-
-  element.removeEventListener(typeEvent, fn, Boolean(delegationSelector))
-  delete events[typeEvent][fn.uidEvent!]
+function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: WrappedHandler): void {
+  element.removeEventListener(typeEvent, handler, Boolean(handler.delegationSelector))
+  delete events[typeEvent][handler.uidEvent!]
 }
 
 function removeNamespacedHandlers(element: Element, events: ElementEvents, typeEvent: string, namespace: string): void {
@@ -216,7 +219,7 @@ function removeNamespacedHandlers(element: Element, events: ElementEvents, typeE
 
   for (const [handlerKey, event] of Object.entries(storeElementEvent)) {
     if (handlerKey.includes(namespace)) {
-      removeHandler(element, events, typeEvent, event.callable!, event.delegationSelector!)
+      removeHandler(element, events, typeEvent, event)
     }
   }
 }
@@ -254,7 +257,8 @@ const EventHandler = {
     }
 
     const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-    const inNamespace = typeEvent !== originalTypeEvent
+    const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
+    const inNamespace = typeEvent !== originalTypeEvent && handlerTypeEvent !== originalTypeEvent
     const events = getElementEvents(element as Element)
     const storeElementEvent = events[typeEvent] || {}
     const isNamespace = originalTypeEvent.startsWith('.')
@@ -265,7 +269,12 @@ const EventHandler = {
         return
       }
 
-      removeHandler(element as Element, events, typeEvent, callable, isDelegated ? (handler as string) : null)
+      const fn = findHandler(storeElementEvent, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
+
+      if (fn) {
+        removeHandler(element as Element, events, typeEvent, fn)
+      }
+
       return
     }
 
@@ -278,8 +287,8 @@ const EventHandler = {
     for (const [keyHandlers, event] of Object.entries(storeElementEvent)) {
       const handlerKey = keyHandlers.replace(stripUidRegex, '')
 
-      if (!inNamespace || originalTypeEvent.includes(handlerKey)) {
-        removeHandler(element as Element, events, typeEvent, event.callable!, event.delegationSelector!)
+      if (event.handlerTypeEvent === handlerTypeEvent && (!inNamespace || originalTypeEvent.includes(handlerKey))) {
+        removeHandler(element as Element, events, typeEvent, event)
       }
     }
   },

--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -154,6 +154,66 @@ describe('EventHandler', () => {
         }, 20)
       })
     })
+
+    it('should ignore related transitions for namespaced mouseenter/mouseleave events', () => {
+      fixtureEl.innerHTML = '<div><span></span></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(div, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(div, 'mouseleave.namespace', leaveSpy)
+
+      child.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: div
+      }))
+      child.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: div
+      }))
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    it('should deduplicate and remove custom mouse event handlers', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+
+      EventHandler.off(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should keep mouseenter handlers separate from mouseover handlers', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouse handler')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseover', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(3)
+    })
   })
 
   describe('one', () => {
@@ -203,6 +263,35 @@ describe('EventHandler', () => {
           resolve()
         }, 20)
       })
+    })
+
+    it('should not consume custom mouse listeners on related transitions', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const delegateEnterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.one(inner, 'mouseenter', enterSpy)
+      EventHandler.one(outer, 'mouseenter', '.inner', delegateEnterSpy)
+
+      child.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: inner
+      }))
+      inner.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: outer
+      }))
+      inner.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: outer
+      }))
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(delegateEnterSpy.calls.count()).toEqual(1)
     })
   })
 


### PR DESCRIPTION
- Preserve `mouseenter` and `mouseleave` semantics when handlers use event namespaces.
- Store semantic event types separately from their backing DOM event types.
- Fix callback removal, remove-all, deduplication, and one-off handler behavior.
- Add regression tests for direct and delegated handlers.
- Verify the full suite with `npm test` (1,239 tests).
