### PR TITLE
Fix menus with unclickable items inside drawers

### DIFF
--- a/js/src/menu.ts
+++ b/js/src/menu.ts
@@ -460,7 +460,10 @@ class Menu extends BaseComponent {
           toFloatingOffset(offsetValue)
       ),
       flip({
-        fallbackPlacements: this._getFallbackPlacements()
+        fallbackPlacements: this._getFallbackPlacements(),
+        // When no placement fits, keep the initial one. Overflow below can be
+        // scrolled to; overflow above the scroll origin can never be reached.
+        fallbackStrategy: 'initialPlacement'
       }),
       shift({
         boundary: (this._config.boundary === 'clippingParents' ? 'clippingAncestors' : this._config.boundary) as Boundary

--- a/scss/_drawer.scss
+++ b/scss/_drawer.scss
@@ -284,6 +284,9 @@ $drawer-backdrop-tokens: defaults(
 
   // Scrollable body
   .drawer-body {
+    // Contain absolutely positioned children (e.g. menus) so they scroll with
+    // the body instead of being clipped by the drawer's overflow.
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: var(--drawer-padding-y);


### PR DESCRIPTION
- Add `position: relative` to `.drawer-body` so absolutely positioned menus resolve against the scroll container instead of `.drawer`. Menus now grow the scrollable area of the body rather than being clipped by the `overflow: hidden` added in #42629.
- Set `fallbackStrategy: 'initialPlacement'` on the `flip` middleware of Menu. When no placement fits, the menu stays below its toggle. Overflow below the scroll container can be scrolled to, but overflow above the scroll origin can never be reached.
- Verified in Chromium at 731×411 (Pixel 2 landscape) with the reduced test case from the issue. Before: the first menu had zero scroll range and lost `dog`; the second flipped to `top-start` and clipped 127px, losing four items. After: both stay `bottom-start`, the drawer body gains 39px and 128px of scroll range, and every item is reachable.
- Normal flipping is unchanged. `initialPlacement` only applies when no placement fits at all, so a menu that fits above its toggle still flips there.

Fixes #42704
