### PR TITLE
Fix custom mouse event handler semantics

### DIFF
--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -24,6 +24,13 @@ interface WrappedHandler {
 
 type ElementEvents = Record<string, Record<string, WrappedHandler>>
 
+interface NormalizedParameters {
+  isDelegated: boolean
+  callable: EventCallable
+  typeEvent: string
+  handlerTypeEvent: string
+}
+
 /**
  * Constants
  */
@@ -105,13 +112,19 @@ function getElementEvents(element: Element & { uidEvent?: string | number }): El
   return eventRegistry[uid]
 }
 
+// `mouseenter` and `mouseleave` ride on `mouseover` and `mouseout`, which also fire when
+// the pointer moves between descendants of the listening element. Drop those events, so the
+// handler only sees the pointer entering or leaving `delegateTarget` itself.
+// `Node.contains()` is inclusive, so this also covers `relatedTarget === delegateTarget`.
 function isMouseEventWithinTarget(event: BootstrapEvent): boolean {
   const { delegateTarget, relatedTarget } = event
 
-  return Boolean(relatedTarget && (relatedTarget === delegateTarget || delegateTarget.contains(relatedTarget)))
+  return Boolean(relatedTarget && delegateTarget.contains(relatedTarget))
 }
 
-function bootstrapHandler(element: Element, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
+function bootstrapHandler(element: Element, fn: EventCallable, handlerTypeEvent: string): WrappedHandler {
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
+
   return function handler(event: Event) {
     const bootstrapEvent = hydrateObj(event, { delegateTarget: element })
 
@@ -120,14 +133,16 @@ function bootstrapHandler(element: Element, fn: EventCallable, isCustomMouseEven
     }
 
     if ((handler as WrappedHandler).oneOff) {
-      EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, (handler as WrappedHandler).callable)
+      EventHandler.off(element, handlerTypeEvent, fn)
     }
 
     return fn.apply(element, [bootstrapEvent])
   } as WrappedHandler
 }
 
-function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
+function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable, handlerTypeEvent: string): WrappedHandler {
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
+
   return function handler(this: Element, event: Event) {
     const domElements = element.querySelectorAll(selector)
 
@@ -144,7 +159,7 @@ function bootstrapDelegationHandler(element: Element, selector: string, fn: Even
         }
 
         if ((handler as WrappedHandler).oneOff) {
-          EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, selector, (handler as WrappedHandler).callable)
+          EventHandler.off(element, handlerTypeEvent, selector, fn)
         }
 
         return fn.apply(target, [bootstrapEvent])
@@ -158,22 +173,25 @@ function findHandler(events: Record<string, WrappedHandler>, callable: EventCall
     .find(event => event.callable === callable && event.handlerTypeEvent === handlerTypeEvent && event.delegationSelector === delegationSelector)
 }
 
-function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): [boolean, EventCallable, string] {
+// `typeEvent` is the DOM event type the listener is registered under. `handlerTypeEvent` is
+// the type the caller asked for. The two differ only for `mouseenter` and `mouseleave`, which
+// the registry must keep apart from the `mouseover` and `mouseout` listeners they share.
+function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): NormalizedParameters {
   const isDelegated = typeof handler === 'string'
   const callable = (isDelegated ? delegationFunction : (handler || delegationFunction)) as EventCallable
-  let typeEvent = getTypeEvent(originalTypeEvent)
+  // Strip the namespace to get the plain event ('click.bs.button' --> 'click')
+  const baseTypeEvent = originalTypeEvent.replace(stripNameRegex, '')
+  let typeEvent = customEvents[baseTypeEvent] || baseTypeEvent
 
   if (!nativeEvents.has(typeEvent)) {
     typeEvent = originalTypeEvent
   }
 
-  return [isDelegated, callable, typeEvent]
-}
+  const handlerTypeEvent = baseTypeEvent in customEvents ? baseTypeEvent : typeEvent
 
-function getHandlerTypeEvent(originalTypeEvent: string, typeEvent: string): string {
-  const baseTypeEvent = originalTypeEvent.replace(stripNameRegex, '')
-
-  return baseTypeEvent in customEvents ? baseTypeEvent : typeEvent
+  return {
+    isDelegated, callable, typeEvent, handlerTypeEvent
+  }
 }
 
 function addHandler(element: Element, originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable, oneOff?: boolean): void {
@@ -181,9 +199,7 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
     return
   }
 
-  const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-  const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
-  const isCustomMouseEvent = handlerTypeEvent in customEvents
+  const { isDelegated, callable, typeEvent, handlerTypeEvent } = normalizeParameters(originalTypeEvent, handler, delegationFunction)
   const events = getElementEvents(element)
   const handlers = events[typeEvent] || (events[typeEvent] = {})
   const previousFunction = findHandler(handlers, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
@@ -196,8 +212,8 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
 
   const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ''))
   const fn = isDelegated ?
-    bootstrapDelegationHandler(element, handler as string, callable, isCustomMouseEvent) :
-    bootstrapHandler(element, callable, isCustomMouseEvent)
+    bootstrapDelegationHandler(element, handler as string, callable, handlerTypeEvent) :
+    bootstrapHandler(element, callable, handlerTypeEvent)
 
   fn.delegationSelector = isDelegated ? (handler as string) : null
   fn.callable = callable
@@ -222,12 +238,6 @@ function removeNamespacedHandlers(element: Element, events: ElementEvents, typeE
       removeHandler(element, events, typeEvent, event)
     }
   }
-}
-
-function getTypeEvent(event: string): string {
-  // allow to get the native events from namespaced events ('click.bs.button' --> 'click')
-  event = event.replace(stripNameRegex, '')
-  return customEvents[event] || event
 }
 
 function trigger(element: EventTarget, event: string, args?: Record<string, unknown>): BootstrapEvent
@@ -256,8 +266,9 @@ const EventHandler = {
       return
     }
 
-    const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-    const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
+    const { isDelegated, callable, typeEvent, handlerTypeEvent } = normalizeParameters(originalTypeEvent, handler, delegationFunction)
+    // The caller gave a namespace when neither event type matches what they passed in.
+    // `handlerTypeEvent` must take part, or plain `mouseenter` looks namespaced next to `mouseover`.
     const inNamespace = typeEvent !== originalTypeEvent && handlerTypeEvent !== originalTypeEvent
     const events = getElementEvents(element as Element)
     const storeElementEvent = events[typeEvent] || {}

--- a/js/src/dom/event-handler.ts
+++ b/js/src/dom/event-handler.ts
@@ -19,6 +19,7 @@ interface WrappedHandler {
   uidEvent?: string | number
   callable?: EventCallable
   delegationSelector?: string | null
+  handlerTypeEvent?: string
 }
 
 type ElementEvents = Record<string, Record<string, WrappedHandler>>
@@ -104,19 +105,29 @@ function getElementEvents(element: Element & { uidEvent?: string | number }): El
   return eventRegistry[uid]
 }
 
-function bootstrapHandler(element: Element, fn: EventCallable): WrappedHandler {
-  return function handler(event: Event) {
-    hydrateObj(event, { delegateTarget: element })
+function isMouseEventWithinTarget(event: BootstrapEvent): boolean {
+  const { delegateTarget, relatedTarget } = event
 
-    if ((handler as WrappedHandler).oneOff) {
-      EventHandler.off(element, event.type, fn)
+  return Boolean(relatedTarget && (relatedTarget === delegateTarget || delegateTarget.contains(relatedTarget)))
+}
+
+function bootstrapHandler(element: Element, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
+  return function handler(event: Event) {
+    const bootstrapEvent = hydrateObj(event, { delegateTarget: element })
+
+    if (isCustomMouseEvent && isMouseEventWithinTarget(bootstrapEvent)) {
+      return
     }
 
-    return fn.apply(element, [event as BootstrapEvent])
+    if ((handler as WrappedHandler).oneOff) {
+      EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, (handler as WrappedHandler).callable)
+    }
+
+    return fn.apply(element, [bootstrapEvent])
   } as WrappedHandler
 }
 
-function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable): WrappedHandler {
+function bootstrapDelegationHandler(element: Element, selector: string, fn: EventCallable, isCustomMouseEvent: boolean): WrappedHandler {
   return function handler(this: Element, event: Event) {
     const domElements = element.querySelectorAll(selector)
 
@@ -126,21 +137,25 @@ function bootstrapDelegationHandler(element: Element, selector: string, fn: Even
           continue
         }
 
-        hydrateObj(event, { delegateTarget: target })
+        const bootstrapEvent = hydrateObj(event, { delegateTarget: target })
 
-        if ((handler as WrappedHandler).oneOff) {
-          EventHandler.off(element, event.type, selector, fn)
+        if (isCustomMouseEvent && isMouseEventWithinTarget(bootstrapEvent)) {
+          return
         }
 
-        return fn.apply(target, [event as BootstrapEvent])
+        if ((handler as WrappedHandler).oneOff) {
+          EventHandler.off(element, (handler as WrappedHandler).handlerTypeEvent!, selector, (handler as WrappedHandler).callable)
+        }
+
+        return fn.apply(target, [bootstrapEvent])
       }
     }
   } as WrappedHandler
 }
 
-function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, delegationSelector: string | null = null): WrappedHandler | undefined {
+function findHandler(events: Record<string, WrappedHandler>, callable: EventCallable, handlerTypeEvent: string, delegationSelector: string | null = null): WrappedHandler | undefined {
   return Object.values(events)
-    .find(event => event.callable === callable && event.delegationSelector === delegationSelector)
+    .find(event => event.callable === callable && event.handlerTypeEvent === handlerTypeEvent && event.delegationSelector === delegationSelector)
 }
 
 function normalizeParameters(originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable): [boolean, EventCallable, string] {
@@ -155,30 +170,23 @@ function normalizeParameters(originalTypeEvent: string, handler?: string | Event
   return [isDelegated, callable, typeEvent]
 }
 
+function getHandlerTypeEvent(originalTypeEvent: string, typeEvent: string): string {
+  const baseTypeEvent = originalTypeEvent.replace(stripNameRegex, '')
+
+  return baseTypeEvent in customEvents ? baseTypeEvent : typeEvent
+}
+
 function addHandler(element: Element, originalTypeEvent: string, handler?: string | EventCallable, delegationFunction?: EventCallable, oneOff?: boolean): void {
   if (typeof originalTypeEvent !== 'string' || !element) {
     return
   }
 
-  let [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-
-  // in case of mouseenter or mouseleave wrap the handler within a function that checks for its DOM position
-  // this prevents the handler from being dispatched the same way as mouseover or mouseout does
-  if (originalTypeEvent in customEvents) {
-    const wrapFunction = (fn: EventCallable): EventCallable => {
-      return function (this: any, event: BootstrapEvent) {
-        if (!event.relatedTarget || (event.relatedTarget !== event.delegateTarget && !event.delegateTarget.contains(event.relatedTarget))) {
-          return fn.call(this, event)
-        }
-      }
-    }
-
-    callable = wrapFunction(callable)
-  }
-
+  const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
+  const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
+  const isCustomMouseEvent = handlerTypeEvent in customEvents
   const events = getElementEvents(element)
   const handlers = events[typeEvent] || (events[typeEvent] = {})
-  const previousFunction = findHandler(handlers, callable, isDelegated ? (handler as string) : null)
+  const previousFunction = findHandler(handlers, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
 
   if (previousFunction) {
     previousFunction.oneOff = previousFunction.oneOff && oneOff
@@ -188,11 +196,12 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
 
   const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ''))
   const fn = isDelegated ?
-    bootstrapDelegationHandler(element, handler as string, callable) :
-    bootstrapHandler(element, callable)
+    bootstrapDelegationHandler(element, handler as string, callable, isCustomMouseEvent) :
+    bootstrapHandler(element, callable, isCustomMouseEvent)
 
   fn.delegationSelector = isDelegated ? (handler as string) : null
   fn.callable = callable
+  fn.handlerTypeEvent = handlerTypeEvent
   fn.oneOff = oneOff
   fn.uidEvent = uid
   handlers[uid] = fn
@@ -200,15 +209,9 @@ function addHandler(element: Element, originalTypeEvent: string, handler?: strin
   element.addEventListener(typeEvent, fn, isDelegated)
 }
 
-function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: EventCallable, delegationSelector: string | null): void {
-  const fn = findHandler(events[typeEvent], handler, delegationSelector)
-
-  if (!fn) {
-    return
-  }
-
-  element.removeEventListener(typeEvent, fn, Boolean(delegationSelector))
-  delete events[typeEvent][fn.uidEvent!]
+function removeHandler(element: Element, events: ElementEvents, typeEvent: string, handler: WrappedHandler): void {
+  element.removeEventListener(typeEvent, handler, Boolean(handler.delegationSelector))
+  delete events[typeEvent][handler.uidEvent!]
 }
 
 function removeNamespacedHandlers(element: Element, events: ElementEvents, typeEvent: string, namespace: string): void {
@@ -216,7 +219,7 @@ function removeNamespacedHandlers(element: Element, events: ElementEvents, typeE
 
   for (const [handlerKey, event] of Object.entries(storeElementEvent)) {
     if (handlerKey.includes(namespace)) {
-      removeHandler(element, events, typeEvent, event.callable!, event.delegationSelector!)
+      removeHandler(element, events, typeEvent, event)
     }
   }
 }
@@ -254,7 +257,8 @@ const EventHandler = {
     }
 
     const [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction)
-    const inNamespace = typeEvent !== originalTypeEvent
+    const handlerTypeEvent = getHandlerTypeEvent(originalTypeEvent, typeEvent)
+    const inNamespace = typeEvent !== originalTypeEvent && handlerTypeEvent !== originalTypeEvent
     const events = getElementEvents(element as Element)
     const storeElementEvent = events[typeEvent] || {}
     const isNamespace = originalTypeEvent.startsWith('.')
@@ -265,7 +269,12 @@ const EventHandler = {
         return
       }
 
-      removeHandler(element as Element, events, typeEvent, callable, isDelegated ? (handler as string) : null)
+      const fn = findHandler(storeElementEvent, callable, handlerTypeEvent, isDelegated ? (handler as string) : null)
+
+      if (fn) {
+        removeHandler(element as Element, events, typeEvent, fn)
+      }
+
       return
     }
 
@@ -278,8 +287,8 @@ const EventHandler = {
     for (const [keyHandlers, event] of Object.entries(storeElementEvent)) {
       const handlerKey = keyHandlers.replace(stripUidRegex, '')
 
-      if (!inNamespace || originalTypeEvent.includes(handlerKey)) {
-        removeHandler(element as Element, events, typeEvent, event.callable!, event.delegationSelector!)
+      if (event.handlerTypeEvent === handlerTypeEvent && (!inNamespace || originalTypeEvent.includes(handlerKey))) {
+        removeHandler(element as Element, events, typeEvent, event)
       }
     }
   },

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -1173,6 +1173,47 @@ describe('Carousel', () => {
       expect(carousel._interval).not.toBeNull()
     })
 
+    it('should stay paused while the pointer moves between slides', () => {
+      fixtureEl.innerHTML = basicMarkup({ autoplay: true })
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const item = fixtureEl.querySelector('#item1')
+      const carousel = new Carousel(carouselEl)
+      const cycleSpy = spyOn(carousel, 'cycle')
+
+      // The pointer enters the carousel, then moves onto one of its slides. `mouseout`
+      // fires with a `relatedTarget` inside the carousel, so cycling must not resume.
+      carouselEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: item
+      }))
+
+      expect(cycleSpy).not.toHaveBeenCalled()
+
+      carouselEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: document.body
+      }))
+
+      expect(cycleSpy).toHaveBeenCalled()
+    })
+
+    it('should not pause again while the pointer moves between slides', () => {
+      fixtureEl.innerHTML = basicMarkup({ autoplay: true })
+
+      const carouselEl = fixtureEl.querySelector('#myCarousel')
+      const item = fixtureEl.querySelector('#item1')
+      const carousel = new Carousel(carouselEl)
+      const pauseSpy = spyOn(carousel, 'pause')
+
+      item.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: carouselEl
+      }))
+
+      expect(pauseSpy).not.toHaveBeenCalled()
+    })
+
     it('should toggle the playing class and expose the interval while cycling', () => {
       fixtureEl.innerHTML = basicMarkup({ autoplay: true })
 

--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -154,66 +154,6 @@ describe('EventHandler', () => {
         }, 20)
       })
     })
-
-    it('should ignore related transitions for namespaced mouseenter/mouseleave events', () => {
-      fixtureEl.innerHTML = '<div><span></span></div>'
-
-      const div = fixtureEl.querySelector('div')
-      const child = fixtureEl.querySelector('span')
-      const enterSpy = jasmine.createSpy('mouseenter')
-      const leaveSpy = jasmine.createSpy('mouseleave')
-
-      EventHandler.on(div, 'mouseenter.namespace', enterSpy)
-      EventHandler.on(div, 'mouseleave.namespace', leaveSpy)
-
-      child.dispatchEvent(new MouseEvent('mouseover', {
-        bubbles: true,
-        relatedTarget: div
-      }))
-      child.dispatchEvent(new MouseEvent('mouseout', {
-        bubbles: true,
-        relatedTarget: div
-      }))
-
-      expect(enterSpy).not.toHaveBeenCalled()
-      expect(leaveSpy).not.toHaveBeenCalled()
-    })
-
-    it('should deduplicate and remove custom mouse event handlers', () => {
-      fixtureEl.innerHTML = '<div></div>'
-
-      const div = fixtureEl.querySelector('div')
-      const handler = jasmine.createSpy('mouseenter')
-
-      EventHandler.on(div, 'mouseenter', handler)
-      EventHandler.on(div, 'mouseenter', handler)
-      div.dispatchEvent(new MouseEvent('mouseover'))
-
-      expect(handler.calls.count()).toEqual(1)
-
-      EventHandler.off(div, 'mouseenter', handler)
-      div.dispatchEvent(new MouseEvent('mouseover'))
-
-      expect(handler.calls.count()).toEqual(1)
-    })
-
-    it('should keep mouseenter handlers separate from mouseover handlers', () => {
-      fixtureEl.innerHTML = '<div></div>'
-
-      const div = fixtureEl.querySelector('div')
-      const handler = jasmine.createSpy('mouse handler')
-
-      EventHandler.on(div, 'mouseenter', handler)
-      EventHandler.on(div, 'mouseover', handler)
-      div.dispatchEvent(new MouseEvent('mouseover'))
-
-      expect(handler.calls.count()).toEqual(2)
-
-      EventHandler.off(div, 'mouseenter')
-      div.dispatchEvent(new MouseEvent('mouseover'))
-
-      expect(handler.calls.count()).toEqual(3)
-    })
   })
 
   describe('one', () => {
@@ -263,35 +203,6 @@ describe('EventHandler', () => {
           resolve()
         }, 20)
       })
-    })
-
-    it('should not consume custom mouse listeners on related transitions', () => {
-      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
-
-      const outer = fixtureEl.querySelector('.outer')
-      const inner = fixtureEl.querySelector('.inner')
-      const child = fixtureEl.querySelector('span')
-      const enterSpy = jasmine.createSpy('mouseenter')
-      const delegateEnterSpy = jasmine.createSpy('delegated mouseenter')
-
-      EventHandler.one(inner, 'mouseenter', enterSpy)
-      EventHandler.one(outer, 'mouseenter', '.inner', delegateEnterSpy)
-
-      child.dispatchEvent(new MouseEvent('mouseover', {
-        bubbles: true,
-        relatedTarget: inner
-      }))
-      inner.dispatchEvent(new MouseEvent('mouseover', {
-        bubbles: true,
-        relatedTarget: outer
-      }))
-      inner.dispatchEvent(new MouseEvent('mouseover', {
-        bubbles: true,
-        relatedTarget: outer
-      }))
-
-      expect(enterSpy.calls.count()).toEqual(1)
-      expect(delegateEnterSpy.calls.count()).toEqual(1)
     })
   })
 
@@ -528,6 +439,248 @@ describe('EventHandler', () => {
 
       // listener removed again
       expect(i).toEqual(5)
+    })
+  })
+
+  // `mouseenter` and `mouseleave` do not bubble, so `EventHandler` emulates them with
+  // `mouseover` and `mouseout` listeners. The registry must still treat them as their own
+  // event types, or removal, deduplication and one-off bookkeeping hit the wrong handler.
+  describe('custom mouse events', () => {
+    const moveMouse = (from, to) => {
+      from.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: to }))
+      to.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: from }))
+    }
+
+    it('should ignore transitions between descendants for namespaced listeners', () => {
+      fixtureEl.innerHTML = '<div class="outer"><span></span></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(outer, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(outer, 'mouseleave.namespace', leaveSpy)
+
+      moveMouse(outer, child)
+      moveMouse(child, outer)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+
+      moveMouse(document.body, outer)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    it('should ignore transitions between descendants for delegated listeners', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.on(outer, 'mouseenter.namespace', '.inner', enterSpy)
+
+      moveMouse(inner, child)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+
+      moveMouse(outer, inner)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+    })
+
+    it('should register the same callback only once', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should keep mouseenter listeners apart from mouseover listeners', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouse handler')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseover', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(div, 'mouseover')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      // only the mouseenter listener is left
+      expect(handler.calls.count()).toEqual(3)
+
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(3)
+    })
+
+    it('should keep a delegated listener apart from a direct one', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(outer, 'mouseenter', handler)
+      EventHandler.on(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      // the direct listener survives
+      expect(handler.calls.count()).toEqual(3)
+    })
+
+    it('should remove a listener by reference', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.off(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should remove a delegated listener by reference', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const handler = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.on(outer, 'mouseenter', '.inner', handler)
+      EventHandler.off(outer, 'mouseenter', '.inner', handler)
+      inner.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('should remove every listener for the event type', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const first = jasmine.createSpy('first')
+      const second = jasmine.createSpy('second')
+
+      EventHandler.on(div, 'mouseenter', first)
+      EventHandler.on(div, 'mouseenter.namespace', second)
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(first).not.toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+    })
+
+    it('should remove only the namespaced listener when a namespace is given', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const plain = jasmine.createSpy('plain')
+      const namespaced = jasmine.createSpy('namespaced')
+
+      EventHandler.on(div, 'mouseenter', plain)
+      EventHandler.on(div, 'mouseenter.namespace', namespaced)
+      EventHandler.off(div, 'mouseenter.namespace')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(plain.calls.count()).toEqual(1)
+      expect(namespaced).not.toHaveBeenCalled()
+    })
+
+    it('should remove listeners when only a namespace is given', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(div, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(div, 'mouseleave.namespace', leaveSpy)
+      EventHandler.off(div, '.namespace')
+
+      div.dispatchEvent(new MouseEvent('mouseover'))
+      div.dispatchEvent(new MouseEvent('mouseout'))
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    // Components such as Menu add a listener each time they open a submenu, then drop it on
+    // close. A failed removal used to leave one live listener behind per cycle.
+    it('should not accumulate listeners across repeated add and remove cycles', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      for (let i = 0; i < 5; i++) {
+        EventHandler.on(div, 'mouseenter', () => handler())
+        EventHandler.off(div, 'mouseenter')
+      }
+
+      EventHandler.on(div, 'mouseenter', () => handler())
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should not consume a one-off listener on a transition between descendants', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const delegateEnterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.one(inner, 'mouseenter', enterSpy)
+      EventHandler.one(outer, 'mouseenter', '.inner', delegateEnterSpy)
+
+      moveMouse(inner, child)
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(delegateEnterSpy).not.toHaveBeenCalled()
+
+      moveMouse(outer, inner)
+      moveMouse(outer, inner)
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(delegateEnterSpy.calls.count()).toEqual(1)
+    })
+
+    it('should call a namespaced one-off listener just once', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.one(div, 'mouseenter.namespace', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
     })
   })
 

--- a/js/tests/unit/dom/event-handler.spec.js
+++ b/js/tests/unit/dom/event-handler.spec.js
@@ -154,6 +154,66 @@ describe('EventHandler', () => {
         }, 20)
       })
     })
+
+    it('should ignore related transitions for namespaced mouseenter/mouseleave events', () => {
+      fixtureEl.innerHTML = '<div><span></span></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const leaveSpy = jasmine.createSpy('mouseleave')
+
+      EventHandler.on(div, 'mouseenter.namespace', enterSpy)
+      EventHandler.on(div, 'mouseleave.namespace', leaveSpy)
+
+      child.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: div
+      }))
+      child.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: div
+      }))
+
+      expect(enterSpy).not.toHaveBeenCalled()
+      expect(leaveSpy).not.toHaveBeenCalled()
+    })
+
+    it('should deduplicate and remove custom mouse event handlers', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouseenter')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+
+      EventHandler.off(div, 'mouseenter', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(1)
+    })
+
+    it('should keep mouseenter handlers separate from mouseover handlers', () => {
+      fixtureEl.innerHTML = '<div></div>'
+
+      const div = fixtureEl.querySelector('div')
+      const handler = jasmine.createSpy('mouse handler')
+
+      EventHandler.on(div, 'mouseenter', handler)
+      EventHandler.on(div, 'mouseover', handler)
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(2)
+
+      EventHandler.off(div, 'mouseenter')
+      div.dispatchEvent(new MouseEvent('mouseover'))
+
+      expect(handler.calls.count()).toEqual(3)
+    })
   })
 
   describe('one', () => {
@@ -203,6 +263,35 @@ describe('EventHandler', () => {
           resolve()
         }, 20)
       })
+    })
+
+    it('should not consume custom mouse listeners on related transitions', () => {
+      fixtureEl.innerHTML = '<div class="outer"><div class="inner"><span></span></div></div>'
+
+      const outer = fixtureEl.querySelector('.outer')
+      const inner = fixtureEl.querySelector('.inner')
+      const child = fixtureEl.querySelector('span')
+      const enterSpy = jasmine.createSpy('mouseenter')
+      const delegateEnterSpy = jasmine.createSpy('delegated mouseenter')
+
+      EventHandler.one(inner, 'mouseenter', enterSpy)
+      EventHandler.one(outer, 'mouseenter', '.inner', delegateEnterSpy)
+
+      child.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: inner
+      }))
+      inner.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: outer
+      }))
+      inner.dispatchEvent(new MouseEvent('mouseover', {
+        bubbles: true,
+        relatedTarget: outer
+      }))
+
+      expect(enterSpy.calls.count()).toEqual(1)
+      expect(delegateEnterSpy.calls.count()).toEqual(1)
     })
   })
 

--- a/js/tests/unit/menu.spec.js
+++ b/js/tests/unit/menu.spec.js
@@ -2661,6 +2661,49 @@ describe('Menu', () => {
   })
 
   describe('submenu', () => {
+    // `_openSubmenu()` adds a `mouseenter` listener and `_closeSubmenu()` drops it again.
+    // A failed removal used to leave one live listener behind per open and close cycle.
+    it('should not accumulate mouseenter listeners across open and close cycles', () => {
+      return new Promise(resolve => {
+        fixtureEl.innerHTML = [
+          '<div>',
+          '  <button class="btn" data-bs-toggle="menu">Menu</button>',
+          '  <ul class="menu">',
+          '    <li class="submenu">',
+          '      <button class="menu-item" type="button">More options</button>',
+          '      <ul class="menu">',
+          '        <li><a class="menu-item" href="#">Sub-action</a></li>',
+          '      </ul>',
+          '    </li>',
+          '  </ul>',
+          '</div>'
+        ].join('')
+
+        const btnMenu = fixtureEl.querySelector('[data-bs-toggle="menu"]')
+        const submenuTrigger = fixtureEl.querySelector('.submenu > .menu-item')
+        const submenu = fixtureEl.querySelector('.submenu > .menu')
+
+        btnMenu.addEventListener('shown.bs.menu', () => {
+          for (let i = 0; i < 3; i++) {
+            submenuTrigger.click()
+            submenuTrigger.click()
+          }
+
+          submenuTrigger.click()
+          expect(submenu.classList.contains('show')).toBeTrue()
+
+          const spy = spyOn(menu, '_cancelSubmenuCloseTimeout')
+          submenu.dispatchEvent(new MouseEvent('mouseover'))
+
+          expect(spy.calls.count()).toEqual(1)
+          resolve()
+        })
+
+        const menu = new Menu(btnMenu)
+        btnMenu.click()
+      })
+    })
+
     it('should open submenu on click', () => {
       return new Promise(resolve => {
         fixtureEl.innerHTML = [

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1215,6 +1215,31 @@ describe('Tooltip', () => {
         tooltip.show()
       })
     })
+
+    it('should not start hiding while the pointer moves between children of the trigger', () => {
+      fixtureEl.innerHTML = '<a href="#" rel="tooltip" title="Another tooltip"><span>child</span></a>'
+
+      const tooltipEl = fixtureEl.querySelector('a')
+      const childEl = fixtureEl.querySelector('span')
+      const tooltip = new Tooltip(tooltipEl, { trigger: 'hover' })
+      const spy = spyOn(tooltip, '_leave')
+
+      // The pointer leaves the child but stays inside the trigger, so `mouseout` carries a
+      // `relatedTarget` within the trigger. This must not count as a leave.
+      childEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: tooltipEl
+      }))
+
+      expect(spy).not.toHaveBeenCalled()
+
+      tooltipEl.dispatchEvent(new MouseEvent('mouseout', {
+        bubbles: true,
+        relatedTarget: document.body
+      }))
+
+      expect(spy).toHaveBeenCalled()
+    })
   })
 
   describe('update', () => {


### PR DESCRIPTION
Builds on @ShiroKSH's work in #42776, keeping their commit and adding a cleanup pass plus full test coverage.

`EventHandler` emulates `mouseenter` and `mouseleave` with `mouseover` and `mouseout` listeners. Two defects broke that emulation:

- The guard read `originalTypeEvent in customEvents`, which only matches the bare strings. Every Bootstrap component namespaces its events, so no component ever got the containment check.
- When the guard did match, it replaced the caller's callback with a wrapper and stored the wrapper as `callable`. Removal by reference, deduplication, and one-off bookkeeping all compared against a function the caller never held.

## Changes

- Store the semantic event type on the handler as `handlerTypeEvent`, so the registry keeps `mouseenter` apart from the `mouseover` listener it shares.
- Apply the containment check inside the handler instead of wrapping the callback, which keeps the caller's function identity intact.
- Derive `handlerTypeEvent` in `normalizeParameters()` so the namespace is stripped once per call, and fold `getTypeEvent()` into it.
- Hand `handlerTypeEvent` to the handler factories, so they read the callback and the event type from their own closure. This removes four casts and two non-null assertions.
- Give `removeHandler()` the handler it already holds, which drops a redundant `findHandler()` scan. The bulk `off()` path goes from quadratic to linear over the handlers in a bucket.

## Fixed behavior

| Call | Before | After |
| --- | --- | --- |
| `off(el, 'mouseenter')` | silent no-op | removes |
| `off(el, 'mouseenter', fn)` | silent no-op | removes |
| `off(el, 'mouseenter', '.sel', fn)` | silent no-op | removes |
| `on(el, 'mouseenter', fn)` twice | 2 listeners | 1 listener |
| `off(el, 'mouseover')` | also removed `mouseenter` handlers | leaves them |
| `mouseenter.bs.*` | no containment check | filtered |
| `one(el, 'mouseenter', fn)` | consumed by an internal move | survives |

Three components were affected. Carousel with `pause: 'hover'` resumed autoplay when the pointer moved between slides. Tooltip with `trigger: 'hover'` started to hide when the pointer moved between children of its trigger. Menu leaked one submenu listener per open and close cycle, because `EventHandler.off(submenu, 'mouseenter')` did nothing.

## Tests

Groups the custom mouse event specs in one block and adds the missing cases, plus regression tests for Carousel, Tooltip, and Menu. 14 of the 17 new tests fail on `v6-dev` without the fix.

`on(el, 'mouseenter', fn)` called twice now registers one listener instead of two. That matches how `click` has always behaved.

Supersedes #42776
