### PR TITLE
Drop `system-ui` from the default body font stack

### DIFF
--- a/scss/_datepicker.scss
+++ b/scss/_datepicker.scss
@@ -47,7 +47,7 @@ $datepicker-tokens: defaults(
     flex-direction: column;
     min-width: var(--datepicker-min-width);
     padding: var(--datepicker-padding);
-    font-family: var(--font-sans-serif);
+    font-family: var(--body-font-family);
     font-size: var(--datepicker-font-size);
     color: var(--datepicker-color);
     color-scheme: light dark;

--- a/scss/_root.scss
+++ b/scss/_root.scss
@@ -20,10 +20,13 @@ $root-tokens: defaults(
     --gradient: #{$gradient},
 
     // scss-docs-start root-body-variables
-    --body-font-family: system-ui,
+    // The stack omits system-ui. It resolves to the user interface font of the
+    // locale, which shows non-Latin text incorrectly. See twbs/bootstrap#42703.
+    --body-font-family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
     --body-font-size: 1rem,
     --body-font-weight: var(--font-weight-normal),
     --body-line-height: 1.5,
+    // scss-docs-end root-body-variables
 
     --heading-color: inherit,
 
@@ -34,7 +37,7 @@ $root-tokens: defaults(
     --link-underline-offset: .2em,
     --link-hover-color: color-mix(in oklch, var(--link-color) 90%, #000),
 
-    --font-mono: "ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', Consolas, 'Liberation Mono', monospace;",
+    --font-mono: "ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', Consolas, 'Liberation Mono', monospace",
     --code-font-size: 95%,
     --code-color: var(--fg-2),
 

--- a/site/src/content/docs/content/reboot.mdx
+++ b/site/src/content/docs/content/reboot.mdx
@@ -53,28 +53,11 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 
 Bootstrap utilizes a “native font stack” or “system font stack” for optimum text rendering on every device and OS. These system fonts have been designed specifically with today’s devices in mind, with improved rendering on screens, variable font support, and more. Read more about [native font stacks in this *Smashing Magazine* article](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/).
 
-```scss
-$font-family-sans-serif:
-  // Cross-platform generic font family (default user interface font)
-  system-ui,
-  // Safari for macOS and iOS (San Francisco)
-  -apple-system,
-  // Windows
-  "Segoe UI",
-  // Android
-  Roboto,
-  // older macOS and iOS
-  "Helvetica Neue",
-  // Linux
-  "Noto Sans",
-  "Liberation Sans",
-  // Basic web fallback
-  Arial,
-  // Sans serif fallback
-  sans-serif,
-  // Emoji fonts
-  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
-```
+The stack starts with `-apple-system` and `BlinkMacSystemFont` for Apple devices, then `Segoe UI` for Windows, `Roboto` for Android, and `Noto Sans` or `Liberation Sans` for Linux. `Arial` and `sans-serif` are the web fallbacks, and four emoji fonts close the list.
+
+The stack omits the `system-ui` keyword. On some systems, `system-ui` resolves to the user interface font of the locale. That font can show non-Latin text with the wrong glyphs—see [issue #42703](https://github.com/twbs/bootstrap/issues/42703).
+
+<ScssDocs name="root-body-variables" file="scss/_root.scss" />
 
 Note that because the font stack includes emoji fonts, many common symbol/dingbat Unicode characters will be rendered as multicolored pictographs. Their appearance will vary, depending on the style used in the browser/platform’s native emoji font, and they won’t be affected by any CSS `color` styles.
 

--- a/site/src/content/docs/getting-started/css-variables.mdx
+++ b/site/src/content/docs/getting-started/css-variables.mdx
@@ -58,7 +58,7 @@ CSS variables offer similar flexibility to Sass’s variables, but without the n
 
 ```css
 body {
-  font: 1rem/1.5 var(--bs-font-sans-serif);
+  font: 1rem/1.5 var(--bs-body-font-family);
 }
 a {
   color: var(--bs-blue);


### PR DESCRIPTION
- Replace the `--body-font-family` value of `system-ui` with the full native font stack, minus `system-ui`: `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif` plus the four emoji fonts.
- `system-ui` resolves to the user interface font of the locale, not to a neutral font. On Japanese Windows it becomes Yu Gothic UI, which draws bold Greek (Ω as и) and Simplified Chinese glyphs incorrectly, and which is too condensed for body text. The CSS Fonts 4 draft says the keyword is for application UI, not for articles.
- Tailwind ([#20318](https://github.com/tailwindlabs/tailwindcss/pull/20318)), Starlight ([#3729](https://github.com/withastro/starlight/pull/3729)), and VitePress ([#4988](https://github.com/vuejs/vitepress/pull/4988)) shipped the same change. Our stack now matches theirs, including the emoji fonts and the order that keeps `Noto Sans` ahead of `Arial`. Starlight's Linux tests showed that fontconfig aliases `Arial` to `Liberation Sans` and hijacks the match otherwise.
- Keep both `-apple-system` and `BlinkMacSystemFont`. Chromium ignores `-apple-system`, and WebKit and Gecko ignore `BlinkMacSystemFont`. Do not add `ui-sans-serif`: only Safari reads it, and a future mapping could bring the same problem back.
- Close the `root-body-variables` scss-docs marker, which had no end marker, and use it in the Reboot docs. The "Native font stack" section showed the removed v5 `$font-family-sans-serif` variable.
- Point `scss/_datepicker.scss` and the CSS variables example at `--body-font-family`. Both used `--font-sans-serif`, which no v6 file defines.
- Remove the semicolon inside the `--font-mono` string, which made the build print `--bs-font-mono: ...monospace;;`.

Fixes #42703
