### PR TITLE
Extend container-query grid to the flexbox grid

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -243,7 +243,7 @@ $card-tokens: defaults(
   //
 
   // Card groups lay out their cards in a row using a container query, so wrap the
-  // group in a query container (e.g., the `.contains-inline` utility) for the row
+  // group in a query container (e.g., the `.container-inline` utility) for the row
   // layout to take effect. Without a query container the cards remain stacked.
   .card-group {
     // The child selector allows nested `.card` within `.card-group`

--- a/scss/_config.scss
+++ b/scss/_config.scss
@@ -60,7 +60,7 @@ $spacers: (
 
 $negative-spacers: (
   "-1": $spacer * -.25,
-  "-2": $spacer * -.5,
+  "-2": $spacer * -.375,
 ) !default;
 // scss-docs-end spacer-variables-maps
 

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -233,6 +233,7 @@ $dialog-sizes: defaults(
     --dialog-width: 100vw;
     --dialog-margin: 0;
     --dialog-border-radius: 0;
+    --dialog-border-width: 0;
 
     width: 100%;
     max-width: none;

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -135,7 +135,7 @@ $list-group-tokens: defaults(
   //
   // Change the layout of list group items from vertical (default) to horizontal.
   // The responsive variants use container queries, so wrap the list group in a
-  // query container (e.g., the `.contains-inline` utility) for them to take effect.
+  // query container (e.g., the `.container-inline` utility) for them to take effect.
 
   @include loop-breakpoints-up() using ($breakpoint, $prefix) {
     .#{$prefix}list-group-horizontal {

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -94,14 +94,16 @@ $utilities: map.merge(
       values: auto hidden visible scroll,
     ),
     // scss-docs-end utils-overflow
+    // scss-docs-start utils-container
     "container": (
       property: container-type,
-      class: contains,
+      class: container,
       values: (
         "inline": inline-size,
         "size": size,
       )
     ),
+    // scss-docs-end utils-container
     // scss-docs-start utils-display
     "display": (
       responsive: true,

--- a/scss/content/_reboot.scss
+++ b/scss/content/_reboot.scss
@@ -121,6 +121,8 @@ $reboot-mark-tokens: defaults(
     background-color: var(--bg-body); // 2
     -webkit-text-size-adjust: 100%; // 3
     -webkit-tap-highlight-color: transparent; // 4
+    container-type: inline-size;
+    container-name: body;
   }
   // scss-docs-end reboot-body-rules
 

--- a/scss/layout/_containers.scss
+++ b/scss/layout/_containers.scss
@@ -21,6 +21,8 @@
     // 100% wide container at all breakpoints
     .container-fluid {
       @include make-container();
+      container-type: inline-size;
+      container-name: layout;
     }
 
     // Responsive containers that are 100% wide until a breakpoint

--- a/scss/layout/_grid.scss
+++ b/scss/layout/_grid.scss
@@ -1,4 +1,5 @@
 @use "../config" as *;
+@use "breakpoints" as *;
 @use "../mixins/grid" as *;
 
 // TODO: check gap utilities as replacement for gutter classes from v5
@@ -22,11 +23,12 @@
       --rows: 1;
       --gap: #{$grid-gutter-x};
 
+      @include set-container();
+
       display: grid;
       grid-template-rows: repeat(var(--rows), 1fr);
       grid-template-columns: repeat(var(--columns), 1fr);
       gap: var(--gap);
-
     }
 
     @include make-cssgrid();

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -135,7 +135,7 @@
   @each $breakpoint in map.keys($breakpoints) {
     $prefix: breakpoint-prefix($breakpoint, $breakpoints);
 
-    @include media-breakpoint-up($breakpoint, $breakpoints) {
+    @include container-breakpoint-up($breakpoint, $breakpoints: $breakpoints) {
       @if $columns > 0 {
         @for $i from 1 through $columns {
           .#{$prefix}g-col-#{$i} {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -11,6 +11,9 @@
 @mixin make-row($gutter-x: $grid-gutter-x, $gutter-y: $grid-gutter-y) {
   --gutter-x: #{$gutter-x};
   --gutter-y: #{$gutter-y};
+
+  @include set-container();
+
   display: flex;
   flex-wrap: wrap;
   // TODO: Revisit calc order after https://github.com/react-bootstrap/react-bootstrap/issues/6039 is fixed
@@ -75,7 +78,7 @@
   @each $breakpoint in map.keys($breakpoints) {
     $prefix: breakpoint-prefix($breakpoint, $breakpoints);
 
-    @include media-breakpoint-up($breakpoint, $breakpoints) {
+    @include container-breakpoint-up($breakpoint, $breakpoints: $breakpoints) {
       .#{$prefix}col {
         flex: 1 0 0;
       }

--- a/site/data/sidebar.yml
+++ b/site/data/sidebar.yml
@@ -191,6 +191,9 @@
     - group: Layout
       pages:
         - title: Aspect ratio
+        - title: Container
+          meta:
+            - added: 6.0.0
         - title: Display
         - title: Float
         - title: Object fit

--- a/site/src/components/shortcodes/ResizableExample.astro
+++ b/site/src/components/shortcodes/ResizableExample.astro
@@ -76,11 +76,7 @@ const simplifiedMarkup = markup.replace(
       style={`width: ${initialWidth}; min-width: ${minWidth};`}
     >
       <Fragment set:html={previewMarkup} />
-      {
-        showBreakpoint && (
-          <output class="bd-resizable-badge" data-resizable-badge aria-live="polite" />
-        )
-      }
+      {showBreakpoint && <output class="bd-resizable-badge" data-resizable-badge aria-live="polite" />}
     </div>
   </div>
   {showMarkup && <Code code={simplifiedMarkup} lang="html" nestedInExample={true} />}
@@ -112,8 +108,7 @@ const simplifiedMarkup = markup.replace(
 
     // Measure the actual query container (e.g. `.grid`) when present so the badge
     // matches what `@container` evaluates; otherwise fall back to the container.
-    const target =
-      container.querySelector<HTMLElement>(':scope > *:not(.bd-resizable-badge)') ?? container
+    const target = container.querySelector<HTMLElement>(':scope > *:not(.bd-resizable-badge)') ?? container
 
     const update = (width: number) => {
       const bp = activeBreakpoint(width)

--- a/site/src/components/shortcodes/ResizableExample.astro
+++ b/site/src/components/shortcodes/ResizableExample.astro
@@ -30,6 +30,12 @@ interface Props {
    * @default true
    */
   showMarkup?: boolean
+  /**
+   * Whether to show a floating badge indicating the active container query
+   * breakpoint for the resized container.
+   * @default false
+   */
+  showBreakpoint?: boolean
 }
 
 const {
@@ -38,7 +44,8 @@ const {
   className,
   initialWidth = '100%',
   minWidth = '200px',
-  showMarkup = true
+  showMarkup = true,
+  showBreakpoint = false
 } = Astro.props
 
 // Support both class and className props
@@ -69,7 +76,58 @@ const simplifiedMarkup = markup.replace(
       style={`width: ${initialWidth}; min-width: ${minWidth};`}
     >
       <Fragment set:html={previewMarkup} />
+      {
+        showBreakpoint && (
+          <output class="bd-resizable-badge" data-resizable-badge aria-live="polite" />
+        )
+      }
     </div>
   </div>
   {showMarkup && <Code code={simplifiedMarkup} lang="html" nestedInExample={true} />}
 </div>
+
+<script>
+  // Breakpoints mirror `$breakpoints` in scss/_config.scss. Container queries are
+  // evaluated against the content-box inline size of the nearest query container.
+  const breakpoints = [
+    { name: 'xs', min: 0 },
+    { name: 'sm', min: 576 },
+    { name: 'md', min: 768 },
+    { name: 'lg', min: 1024 },
+    { name: 'xl', min: 1280 },
+    { name: '2xl', min: 1536 }
+  ]
+
+  function activeBreakpoint(width: number) {
+    let active = breakpoints[0]
+    for (const bp of breakpoints) {
+      if (width >= bp.min) active = bp
+    }
+    return active
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-resizable-badge]').forEach((badge) => {
+    const container = badge.closest<HTMLElement>('.bd-resizable-container')
+    if (!container) return
+
+    // Measure the actual query container (e.g. `.grid`) when present so the badge
+    // matches what `@container` evaluates; otherwise fall back to the container.
+    const target =
+      container.querySelector<HTMLElement>(':scope > *:not(.bd-resizable-badge)') ?? container
+
+    const update = (width: number) => {
+      const bp = activeBreakpoint(width)
+      badge.dataset.breakpoint = bp.name
+      badge.textContent = `${bp.name} · ${Math.round(width)}px`
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const inlineSize = entry.contentBoxSize?.[0]?.inlineSize ?? entry.contentRect.width
+        update(inlineSize)
+      }
+    })
+
+    observer.observe(target, { box: 'content-box' })
+  })
+</script>

--- a/site/src/components/shortcodes/SpacingNotation.astro
+++ b/site/src/components/shortcodes/SpacingNotation.astro
@@ -55,13 +55,13 @@ const capitalizedNoun = noun.charAt(0).toUpperCase() + noun.slice(1)
 // Multipliers for sizes `1` through `9`, mirroring the default `$spacers` map.
 const sizeValues = [
   '$spacer * .25',
+  '$spacer * .375',
   '$spacer * .5',
   '$spacer * .75',
   '$spacer',
   '$spacer * 1.25',
   '$spacer * 1.5',
   '$spacer * 2',
-  '$spacer * 2.5',
   '$spacer * 3'
 ]
 ---

--- a/site/src/content/docs/components/card.mdx
+++ b/site/src/content/docs/components/card.mdx
@@ -431,9 +431,9 @@ In addition to styling the content within cards, Bootstrap includes a few option
 
 Use card groups to render cards as a single, attached element with equal width and height columns. Card groups start off stacked and use `display: flex;` to become attached with uniform dimensions starting at the `sm` breakpoint.
 
-This layout uses [container queries]([[docsref:/layout/breakpoints#container-queries]]), so wrap the card group in a query container—add the `.contains-inline` utility to a parent element—for the row layout to take effect. Without a query container, the cards remain stacked.
+This layout uses [container queries]([[docsref:/layout/breakpoints#container-queries]]), so wrap the card group in a query container—add the `.container-inline` utility to a parent element—for the row layout to take effect. Without a query container, the cards remain stacked.
 
-<ResizableExample code={`<div class="contains-inline">
+<ResizableExample code={`<div class="container-inline">
     <div class="card-group">
     <div class="card">
       <Placeholder width="100%" height="180" class="card-img-top" text="Image cap" />
@@ -464,7 +464,7 @@ This layout uses [container queries]([[docsref:/layout/breakpoints#container-que
 
 When using card groups with footers, their content will automatically line up.
 
-<Example code={`<div class="contains-inline">
+<Example code={`<div class="container-inline">
     <div class="card-group">
     <div class="card">
       <Placeholder width="100%" height="180" class="card-img-top" text="Image cap" />

--- a/site/src/content/docs/components/list-group.mdx
+++ b/site/src/content/docs/components/list-group.mdx
@@ -116,13 +116,13 @@ These work great with custom content as well.
 
 Add `.list-group-horizontal` to change the layout of list group items from vertical to horizontal across all container sizes. Alternatively, choose a responsive variant `.{sm|md|lg|xl|2xl}:list-group-horizontal` to make a list group horizontal starting at that breakpoint’s width.
 
-The responsive variants use [container queries]([[docsref:/layout/breakpoints#container-queries]]), so wrap the list group in a query container—add the `.contains-inline` utility to a parent element—for them to take effect. Currently **horizontal list groups cannot be combined with flush list groups.**
+The responsive variants use [container queries]([[docsref:/layout/breakpoints#container-queries]]), so wrap the list group in a query container—add the `.container-inline` utility to a parent element—for them to take effect. Currently **horizontal list groups cannot be combined with flush list groups.**
 
 **ProTip:** Want equal-width list group items when horizontal? Add `.flex-fill` to each list group item.
 
 <Example
   class="vstack gap-3"
-  code={getData('breakpoints').map((breakpoint) => `<div class="contains-inline">
+  code={getData('breakpoints').map((breakpoint) => `<div class="container-inline">
     <ul class="list-group ${breakpoint.abbr}list-group-horizontal">
       <li class="list-group-item">An item</li>
       <li class="list-group-item">A second item</li>
@@ -132,7 +132,7 @@ The responsive variants use [container queries]([[docsref:/layout/breakpoints#co
 
 Drag the handle to resize the container below and watch the list group switch between vertical and horizontal layouts as the container—not the viewport—crosses the `md` breakpoint.
 
-<ResizableExample code={`<div class="contains-inline">
+<ResizableExample code={`<div class="container-inline">
     <ul class="list-group md:list-group-horizontal">
       <li class="list-group-item">An item</li>
       <li class="list-group-item">A second item</li>

--- a/site/src/content/docs/components/stepper.mdx
+++ b/site/src/content/docs/components/stepper.mdx
@@ -23,9 +23,9 @@ Here’s a simple example of a vertical stepper.
 
 ### Responsive
 
-Steppers can be made horizontal at specific breakpoints using the `contains-inline` utility on a parent element and by adding the responsive `.stepper-horizontal-{breakpoint}` modifier classes on the stepper. The extra parent element is required when using container queries.
+Steppers can be made horizontal at specific breakpoints using the `container-inline` utility on a parent element and by adding the responsive `.stepper-horizontal-{breakpoint}` modifier classes on the stepper. The extra parent element is required when using container queries.
 
-<ResizableExample code={`<div class="contains-inline">
+<ResizableExample code={`<div class="container-inline">
     <ol class="stepper sm:stepper-horizontal">
       <li class="stepper-item active">Create account</li>
       <li class="stepper-item active">Confirm email</li>

--- a/site/src/content/docs/getting-started/browsers-devices.mdx
+++ b/site/src/content/docs/getting-started/browsers-devices.mdx
@@ -45,7 +45,7 @@ The table below lists the platform features v6 relies on and how each behaves at
 | --- | --- | --- |
 | `light-dark()` | [Color modes]([[docsref:/customize/color-modes]]), all theme tokens | Defines the support floor; no fallback below it |
 | `oklch()`, `color-mix()` | [Color system]([[docsref:/customize/color]]), theme variants | Fully supported above the floor |
-| Container queries (`@container`) | [Card groups]([[docsref:/components/card#card-groups]]), [horizontal list groups]([[docsref:/components/list-group#horizontal]]) | Fully supported above the floor; these components also require an ancestor query container (`.contains-inline`)—without one they stay stacked |
+| Container queries (`@container`) | [Card groups]([[docsref:/components/card#card-groups]]), [horizontal list groups]([[docsref:/components/list-group#horizontal]]) | Fully supported above the floor; these components also require an ancestor query container (`.container-inline`)—without one they stay stacked |
 | `:has()` | Forms, button groups with menus, and other contextual styling | Fully supported above the floor |
 | Native `<dialog>` | [Dialog]([[docsref:/components/dialog]]), [Drawer]([[docsref:/components/drawer]]) | Fully supported above the floor; focus containment and `inert` behavior come from the browser |
 | `<details name="…">` | [Exclusive accordions]([[docsref:/components/accordion]]) | Fully supported above the floor; in older, unsupported browsers accordion items degrade gracefully to independently openable `<details>` elements |

--- a/site/src/content/docs/guides/migration.mdx
+++ b/site/src/content/docs/guides/migration.mdx
@@ -94,6 +94,9 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 | Print | `.d-print-none` | `.print:d-none` |
 </BsTable>
 
+- **Both grids now respond to their container instead of the viewport.** Every `.row` and `.grid` is a query container (`container-type: inline-size`), and the responsive grid classes—`.md:col-*`, `.md:offset-*`, `.md:row-cols-*`, `.md:g-col-*`, `.md:g-start-*`, and the `.md:g-*` gutters—are generated with `@container` queries rather than `@media` queries. A `.md:col-6` inside a narrow sidebar now splits when the *row* reaches 768px, not when the viewport does. `<body>`, `.container`, and `.container-fluid` are query containers too, so a top-level `.row` still resolves against the page width. Note that responsive [utilities]([[docsref:/utilities/api]]) like `.md:d-flex` remain viewport-based, so the same prefix can switch at two different widths within one subtree.
+- **Setting `container-type` has layout side effects.** Because `.row` and `.grid` apply layout containment, they establish a containing block for `position: absolute`/`fixed` descendants and create a stacking context. Absolutely positioned children now resolve against the row or grid, and a `z-index` on a `.col` can no longer stack above content outside its row.
+
 ### Sass
 
 - Dropped support for Node Sass, including no longer testing any of our source CSS against it.
@@ -223,8 +226,8 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 - **Rebuilt close button markup.** `.btn-close` now renders its icon via a CSS `mask-image` (`--btn-close-icon`) tinted with `background-color: currentcolor`, so the button is self-contained—no child `<svg>` is required. The filter-based dark mode approach (`$btn-close-white-filter`) has been replaced by `currentcolor` inheritance, and the `.btn-close-white` class has been removed—on dark backgrounds (e.g., `.text-bg-dark`) the icon now inherits the contrast color automatically.
 - **Removed `.alert-dismissible`.** Dismissible alerts no longer require the `.alert-dismissible` modifier class. Place a `.btn-close` directly inside the alert—the alert's flex layout positions it automatically. Remove any `.alert-dismissible` class from your markup.
 - **Restructured cards.** Borders now live on `.card-body` and `.card-list` segments rather than a single outer `.card` border. Added `--card-box-shadow` and `--card-body-gap` tokens. New variant classes: `.card-translucent` (frosted glass effect) and `.card-subtle` (themed with subtle backgrounds). Horizontal cards use a new `.card-row` class. Removed `.card-link` class.
-- **Card groups now use container queries.** `.card-group` switches to its attached, equal-width row layout with a `@container` query instead of a viewport `@media` query, so it responds to the width of a parent query container rather than the viewport. Wrap the card group in a query container—e.g. add the `.contains-inline` utility to a parent element—or the cards stay stacked.
-- **List group horizontal variants now use container queries.** The `.*:list-group-horizontal` classes switch between vertical and horizontal layouts with `@container` queries instead of viewport `@media` queries, responding to a parent query container rather than the viewport. Wrap the list group in a query container (e.g. `.contains-inline`) for the responsive variants to take effect.
+- **Card groups now use container queries.** `.card-group` switches to its attached, equal-width row layout with a `@container` query instead of a viewport `@media` query, so it responds to the width of a parent query container rather than the viewport. Wrap the card group in a query container—e.g. add the `.container-inline` utility to a parent element—or the cards stay stacked.
+- **List group horizontal variants now use container queries.** The `.*:list-group-horizontal` classes switch between vertical and horizontal layouts with `@container` queries instead of viewport `@media` queries, responding to a parent query container rather than the viewport. Wrap the list group in a query container (e.g. `.container-inline`) for the responsive variants to take effect.
 - **Reworked badge variants.** Badge color variants now use `.badge-subtle` and `.badge-outline` combined with `.theme-*` classes (e.g., `.badge-subtle .theme-primary`), replacing the v5 `.bg-primary` utility pattern on badges.
 - **Added theme variant support to pagination.** Add a `.theme-{color}` class to `.pagination` (e.g., `.pagination.theme-primary`) to color links, hover, focus, and the active page item with a semantic theme color, matching the pattern already used by alerts and accordions.
 - **Updated breadcrumb markup.** Breadcrumbs now use `.breadcrumb-link` as an interactive element with padding, min-height, and hover background, and explicit `.breadcrumb-divider` elements as separators between items. An empty `.breadcrumb-divider` renders a default chevron via a CSS `mask-image` (`--breadcrumb-divider-icon`) tinted with `background-color: currentcolor`; add your own SVG, text, or markup inside it to override. This replaces the v5 `--bs-breadcrumb-divider` content string on the `.breadcrumb-item::before` pseudo-element.
@@ -364,13 +367,13 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 |---|---|---|
 | 0 | `0` | `0` |
 | 1 | `0.25rem` | `0.25rem` |
-| 2 | `0.5rem` | `0.5rem` |
-| 3 | `1rem` | `0.75rem` (new) |
-| 4 | `1.5rem` | `1rem` (was key 3) |
-| 5 | `3rem` | `1.25rem` (new) |
-| 6 | — | `1.5rem` (was key 4) |
-| 7 | — | `2rem` (new) |
-| 8 | — | `2.5rem` (new) |
+| 2 | `0.5rem` | `0.375rem` (new) |
+| 3 | `1rem` | `0.5rem` (was key 2) |
+| 4 | `1.5rem` | `0.75rem` (new) |
+| 5 | `3rem` | `1rem` (was key 3) |
+| 6 | — | `1.25rem` (new) |
+| 7 | — | `1.5rem` (was key 4) |
+| 8 | — | `2rem` (new) |
 | 9 | — | `3rem` (was key 5) |
 </BsTable>
 
@@ -471,7 +474,7 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
   To preserve v5 visual roundness, shift class numbers up the scale (e.g. `.rounded-1` &rarr; `.rounded-3`, `.rounded-2` &rarr; `.rounded-4`, `.rounded-3` &rarr; `.rounded-5`, `.rounded-4` &rarr; `.rounded-8`, `.rounded-5` &rarr; `.rounded-9`). The `.rounded-{top,end,bottom,start}-*` directional variants follow the same scale.
 
 - **Font weight additions.** Added `.fw-medium` (`500`) and `.fw-semibold` (`600`) utilities. v5 only had `lighter`, `light` (`300`), `normal` (`400`), `bold` (`700`), and `bolder`.
-- **Negative margins limited.** Negative spacers are reduced to only `-1` (`-0.25rem`) and `-2` (`-0.5rem`), and only applied to `margin-inline-start` (`.ms--1`, `.ms--2`) and `margin-inline-end` (`.me--1`, `.me--2`). The v5 full negative margin utilities across all sides have been removed.
+- **Negative margins limited.** Negative spacers are reduced to only `-1` (`-0.25rem`) and `-2` (`-0.375rem`), and only applied to `margin-inline-start` (`.ms--1`, `.ms--2`) and `margin-inline-end` (`.me--1`, `.me--2`). The v5 full negative margin utilities across all sides have been removed.
 - **Spacing and border utilities now use CSS logical properties.** `margin-top` &rarr; `margin-block-start`, `margin-right` &rarr; `margin-inline-end`, `padding-left` &rarr; `padding-inline-start`, `border-right` &rarr; `border-inline-end`, etc. Class names (`.mt-*`, `.me-*`, `.ps-*`, `.border-end`) remain the same, but the underlying CSS properties are now logical, improving RTL and writing-mode support.
 - **Text wrap additions.** Added `.text-balance` and `.text-pretty` values to the text-wrap utility.
 - **Color utility renames.** `.text-*` color utilities have been replaced by `.fg-*` (foreground) utilities. New `.fg-emphasis-*` and `.fg-contrast-*` variants. Background utilities now include `.bg-subtle-*` and `.bg-muted-*` in addition to `.bg-*`. Added `.fg-bg` and `.bg-fg` cross-reference utilities; removed `.fg-inherit` and `.bg-inherit`. Renamed `.bg-opacity-*` to `.bg-*`. Renamed `.text-reset` to `.fg-reset`.
@@ -510,7 +513,7 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
 - **Flex & Grid utilities:**
   - Added `.place-items` and `.justify-items` utilities.
   - Added `.grid-cols-*` utilities for `grid-template-columns` (1–4 and 6 column layouts), `.grid-cols-fill` for spanning all columns, `.grid-cols-subgrid` for adopting a parent grid's column tracks, and `.grid-auto-flow` utility.
-- **Container query utilities.** New `.contains-inline` and `.contains-size` utilities for `container-type`.
+- **Container query utilities (renamed from `.contains-*` in earlier v6 alphas).** New `.container-inline` and `.container-size` utilities for `container-type`.
 - Ratio helpers are now powered by the utility API and use simplified values without `calc()`.
 - **State variants now use prefix syntax.** Pseudo-state utility classes like hover and focus variants now use a `state:class` prefix pattern (e.g., `hover:opacity-50` instead of `opacity-50-hover`), matching the responsive prefix convention.
 - **Utility API cleanup.** Removed `css-var`, `css-variable-name`, and `local-vars` options from the utility API. Use the `property` map approach for CSS custom properties and `variables` for static CSS custom properties within utility classes.

--- a/site/src/content/docs/layout/css-grid.mdx
+++ b/site/src/content/docs/layout/css-grid.mdx
@@ -2,6 +2,7 @@
 title: CSS Grid
 description: Learn how to enable, use, and customize our alternate layout system built on CSS Grid with examples and code snippets.
 toc: true
+js: required
 csstricks:
   url: https://css-tricks.com/snippets/css/complete-guide-grid/
   label: CSS Grid Guide
@@ -25,7 +26,7 @@ Bootstrap includes an optional grid system built on CSS Grid, but with a Bootstr
 
 - **Columns and gutter sizes are set via CSS variables.** Set these on the parent `.grid` and customize however you want, inline or in a stylesheet, with `--bs-columns` and `--bs-gap`.
 
-In the future, Bootstrap will likely shift to a hybrid solution as the `gap` property has achieved nearly full browser support for flexbox.
+- **Responsive classes use container queries.** Each `.grid` is a query container (`container-type: inline-size`), so responsive `.g-col-*` and `.g-start-*` classes respond to the width of the `.grid` itself rather than the viewport.
 
 ## Key differences
 
@@ -45,7 +46,7 @@ Compared to the default grid system:
 
 ### Three columns
 
-Three equal-width columns across all viewports and devices can be created by using the `.g-col-4` classes. Add [responsive classes](#responsive) to change the layout by viewport size.
+Three equal-width columns across all container sizes and devices can be created by using the `.g-col-4` classes. Add [responsive classes](#responsive) to change the layout by the `.grid` container’s width.
 
 <Example class="bd-example-cssgrid" code={`<div class="grid text-center">
     <div class="g-col-4">.g-col-4</div>
@@ -55,20 +56,70 @@ Three equal-width columns across all viewports and devices can be created by usi
 
 ### Responsive
 
-Use responsive classes to adjust your layout across viewports. Here we start with two columns on the narrowest viewports, and then grow to three columns on medium viewports and above.
+Use responsive classes to adjust your layout across breakpoints. Here we start with two columns on the narrowest containers, and then grow to three columns on medium containers and above. Drag the example’s handle to resize the `.grid` and watch the columns reflow based on its width rather than the viewport.
 
-<Example class="bd-example-cssgrid" code={`<div class="grid text-center">
+<Callout>
+Responsive `.g-col-*` and `.g-start-*` classes are powered by [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) rather than media queries. The `.grid` is set as a query container (`container-type: inline-size`), so its grid items respond to the width of the `.grid` itself instead of the viewport. This means a `.grid` placed inside a narrow column will switch layouts based on that column’s width, not the size of the browser window.
+</Callout>
+
+<ResizableExample class="bd-example-cssgrid" showBreakpoint code={`<div class="grid text-center">
     <div class="g-col-6 md:g-col-4">.g-col-6 .md:g-col-4</div>
     <div class="g-col-6 md:g-col-4">.g-col-6 .md:g-col-4</div>
     <div class="g-col-6 md:g-col-4">.g-col-6 .md:g-col-4</div>
   </div>`} />
 
-Compare that to this two column layout at all viewports.
+Compare that to this two column layout at all container sizes.
 
 <Example class="bd-example-cssgrid" code={`<div class="grid text-center">
     <div class="g-col-6">.g-col-6</div>
     <div class="g-col-6">.g-col-6</div>
   </div>`} />
+
+### Playground
+
+The examples above are constrained by the width of this page, so you can only resize them up to the `sm` range before running out of room. Open the fullscreen demo below to drag a set of grids across the full range of breakpoints and watch each layout reflow based on the container's width rather than the viewport.
+
+<button type="button" class="btn-solid theme-primary" data-bs-toggle="dialog" data-bs-target="#gridPlaygroundDialog">
+  Open fullscreen grid demo
+</button>
+
+<dialog class="dialog dialog-fullscreen dialog-scrollable" id="gridPlaygroundDialog">
+  <div class="dialog-header">
+    <h1 class="dialog-title">CSS Grid container queries</h1>
+    <CloseButton dismiss="dialog" />
+  </div>
+  <div class="dialog-body">
+    <p>Drag the handle on the right edge of the example to resize it. The badge shows the active container-query breakpoint, and every grid below responds to the example's width&mdash;not the size of the browser window.</p>
+    <ResizableExample class="bd-example-cssgrid" showBreakpoint showMarkup={false} code={`<div class="grid text-center">
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+      <div class="g-col-12 sm:g-col-6 md:g-col-4 lg:g-col-3 xl:g-col-2">cell</div>
+    </div>
+    <div class="grid text-center">
+      <div class="g-col-6 md:g-col-3">card</div>
+      <div class="g-col-6 md:g-col-3">card</div>
+      <div class="g-col-6 md:g-col-3">card</div>
+      <div class="g-col-6 md:g-col-3">card</div>
+    </div>
+    <div class="grid text-center">
+      <div class="g-col-12 lg:g-col-3">sidebar</div>
+      <div class="g-col-12 lg:g-col-9">main content</div>
+    </div>
+    <div class="grid text-center">
+      <div class="g-col-12 lg:g-col-8">primary</div>
+      <div class="g-col-12 lg:g-col-4">secondary</div>
+    </div>
+    <div class="grid text-center">
+      <div class="g-col-12 md:g-col-6 md:g-start-4">centered with .md:g-start-4</div>
+    </div>`} />
+  </div>
+  <div class="dialog-footer">
+    <button type="button" class="btn-solid theme-secondary" data-bs-dismiss="dialog">Close</button>
+  </div>
+</dialog>
 
 ## Wrapping
 

--- a/site/src/content/docs/layout/css-grid.mdx
+++ b/site/src/content/docs/layout/css-grid.mdx
@@ -2,7 +2,6 @@
 title: CSS Grid
 description: Learn how to enable, use, and customize our alternate layout system built on CSS Grid with examples and code snippets.
 toc: true
-js: required
 csstricks:
   url: https://css-tricks.com/snippets/css/complete-guide-grid/
   label: CSS Grid Guide

--- a/site/src/content/docs/layout/grid.mdx
+++ b/site/src/content/docs/layout/grid.mdx
@@ -2,6 +2,7 @@
 title: Grid system
 description: Use our powerful mobile-first flexbox grid to build layouts of all shapes and sizes thanks to a twelve column system, six default responsive tiers, Sass variables and mixins, and dozens of predefined classes.
 toc: true
+js: required
 csstricks:
   url: https://css-tricks.com/snippets/css/a-guide-to-flexbox/
   label: Flexbox Guide
@@ -12,7 +13,7 @@ csstricks:
 Bootstrap’s grid system uses a series of containers, rows, and columns to layout and align content. It’s built with [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) and is fully responsive. Below is an example and an in-depth explanation for how the grid system comes together.
 
 <Callout>
-**New to or unfamiliar with flexbox?** [Read this CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets.
+**Unfamiliar with flexbox?** [Read this CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets.
 </Callout>
 
 <Example class="bd-example-row" code={`<div class="container text-center">
@@ -35,7 +36,9 @@ The above example creates three equal-width columns across all devices and viewp
 
 Breaking it down, here’s how the grid system comes together:
 
-- **Our grid supports [six responsive breakpoints]([[docsref:/layout/breakpoints]]).**  Breakpoints are based on `min-width` media queries, meaning they affect that breakpoint and all those above it (e.g., `.sm:col-4` applies to `sm`, `md`, `lg`, `xl`, and `2xl`). This means you can control container and column sizing and behavior by each breakpoint.
+- **Our grid supports [six responsive breakpoints]([[docsref:/layout/breakpoints]]).** Breakpoints use `min-width` container queries, meaning they affect that breakpoint and all those above it (e.g., `.sm:col-4` applies to `sm`, `md`, `lg`, `xl`, and `2xl`). This means you can control column sizing and behavior by each breakpoint.
+
+- **Responsive classes respond to the `.row`, not the viewport.** Each `.row` is a query container (`container-type: inline-size`), so responsive `.col-*` classes react to the width of the `.row` itself rather than the browser window. Drop a `.row` into a narrow column and its columns reflow based on that column’s width.
 
 - **Containers center and horizontally pad your content.** Use `.container` for a responsive pixel width, `.container-fluid` for `width: 100%` across all viewports and devices, or a responsive container (e.g., `.md:container`) for a combination of fluid and pixel widths.
 
@@ -208,13 +211,17 @@ Use `{breakpoint}:col-auto` classes to size columns based on the natural width o
 
 ## Responsive classes
 
-Bootstrap’s grid includes six tiers of predefined classes for building complex responsive layouts. Customize the size of your columns on extra small, small, medium, large, or extra large devices however you see fit.
+Bootstrap’s grid includes six tiers, one for each [breakpoint]([[docsref:/layout/breakpoints]]), of predefined classes for building complex responsive layouts. Customize the size of your columns on extra small, small, medium, etc. devices however you see fit.
+
+<Callout>
+Responsive `.col-*` classes are powered by [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) rather than media queries. The `.row` is set as a query container (`container-type: inline-size`), so its columns respond to the width of the `.row` itself instead of the viewport. This means a `.row` placed inside a narrow column will switch layouts based on that column’s width, not the size of the browser window. Drag the handle on the examples below to resize the `.row` and watch the columns reflow.
+</Callout>
 
 ### All breakpoints
 
 For grids that are the same from the smallest of devices to the largest, use the `.col` and `.col-*` classes. Specify a numbered class when you need a particularly sized column; otherwise, feel free to stick to `.col`.
 
-<Example class="bd-example-row" code={`<div class="container text-center">
+<ResizableExample class="bd-example-row" code={`<div class="container text-center">
     <div class="row">
       <div class="col">col</div>
       <div class="col">col</div>
@@ -231,7 +238,7 @@ For grids that are the same from the smallest of devices to the largest, use the
 
 Using a single set of `.sm:col-*` classes, you can create a basic grid system that starts out stacked and becomes horizontal at the small breakpoint (`sm`).
 
-<Example class="bd-example-row" code={`<div class="container text-center">
+<ResizableExample class="bd-example-row" showBreakpoint code={`<div class="container text-center">
     <div class="row">
       <div class="sm:col-8">sm:col-8</div>
       <div class="sm:col-4">sm:col-4</div>
@@ -247,7 +254,7 @@ Using a single set of `.sm:col-*` classes, you can create a basic grid system th
 
 Don’t want your columns to simply stack in some grid tiers? Use a combination of different classes for each tier as needed. See the example below for a better idea of how it all works.
 
-<Example class="bd-example-row" code={`<div class="container text-center">
+<ResizableExample class="bd-example-row" showBreakpoint code={`<div class="container text-center">
     <!-- Stack the columns on mobile by making one full-width and the other half-width -->
     <div class="row">
       <div class="md:col-8">.md:col-8</div>
@@ -268,14 +275,68 @@ Don’t want your columns to simply stack in some grid tiers? Use a combination 
     </div>
   </div>`} />
 
+### Playground
+
+The examples above are constrained by the width of this page, so you can only resize them up to the `sm` range before running out of room. Open the fullscreen demo below to drag a set of rows across the full range of breakpoints and watch each layout reflow based on the `.row`’s width rather than the viewport.
+
+<button type="button" class="btn-solid theme-primary align-self-start" data-bs-toggle="dialog" data-bs-target="#flexGridPlaygroundDialog">
+  Open fullscreen grid demo
+</button>
+
+<dialog class="dialog dialog-fullscreen dialog-scrollable" id="flexGridPlaygroundDialog">
+  <div class="dialog-header">
+    <h1 class="dialog-title">Flexbox grid container queries</h1>
+    <CloseButton dismiss="dialog" />
+  </div>
+  <div class="dialog-body">
+    <p class="mb-3">Drag the handle on the right edge of the example to resize it. The badge shows the active container-query breakpoint, and every row below responds to the example's width&mdash;not the size of the browser window.</p>
+    <ResizableExample class="bd-example-row" showBreakpoint showMarkup={false} code={`<div class="container text-center">
+      <div class="row">
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+        <div class="col-12 sm:col-6 md:col-4 lg:col-3 xl:col-2">cell</div>
+      </div>
+      <div class="row">
+        <div class="col-6 md:col-3">card</div>
+        <div class="col-6 md:col-3">card</div>
+        <div class="col-6 md:col-3">card</div>
+        <div class="col-6 md:col-3">card</div>
+      </div>
+      <div class="row">
+        <div class="col-12 lg:col-3">sidebar</div>
+        <div class="col-12 lg:col-9">main content</div>
+      </div>
+      <div class="row">
+        <div class="col-12 lg:col-8">primary</div>
+        <div class="col-12 lg:col-4">secondary</div>
+      </div>
+      <div class="row">
+        <div class="col-12 md:col-6 md:offset-3">centered with .md:offset-3</div>
+      </div>
+      <div class="row row-cols-2 sm:row-cols-3 md:row-cols-4 lg:row-cols-6">
+        <div class="col">cell</div>
+        <div class="col">cell</div>
+        <div class="col">cell</div>
+        <div class="col">cell</div>
+        <div class="col">cell</div>
+        <div class="col">cell</div>
+      </div>
+    </div>`} />
+  </div>
+  <div class="dialog-footer">
+    <button type="button" class="btn-solid theme-secondary" data-bs-dismiss="dialog">Close</button>
+  </div>
+</dialog>
+
 ### Row columns
 
-Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.md:col-4`), the row columns classes are set on the parent `.row` as a shortcut. With `.row-cols-auto` you can give the columns their natural width.
-
-Use these row columns classes to quickly create basic grid layouts or to control your card layouts.
+Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.md:col-4`), the row columns classes are set on the parent `.row` as a shortcut.
 
 <Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-2">
+    <div class="row row-cols-2"><!-- [!code highlight] -->
       <div class="col">Column</div>
       <div class="col">Column</div>
       <div class="col">Column</div>
@@ -283,8 +344,12 @@ Use these row columns classes to quickly create basic grid layouts or to control
     </div>
   </div>`} />
 
+`.row-cols-*` can be used with any number 1 to 6.
+
 <Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-3">
+    <div class="row row-cols-3"><!-- [!code highlight] -->
+      <div class="col">Column</div>
+      <div class="col">Column</div>
       <div class="col">Column</div>
       <div class="col">Column</div>
       <div class="col">Column</div>
@@ -292,8 +357,10 @@ Use these row columns classes to quickly create basic grid layouts or to control
     </div>
   </div>`} />
 
+With `.row-cols-auto` you can give the columns their natural width.
+
 <Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-auto">
+    <div class="row row-cols-auto"><!-- [!code highlight] -->
       <div class="col">Column</div>
       <div class="col">Column</div>
       <div class="col">Column</div>
@@ -301,26 +368,21 @@ Use these row columns classes to quickly create basic grid layouts or to control
     </div>
   </div>`} />
 
+You can also mix `.row-cols-*` with `.col-*` classes to create more complex layouts.
+
 <Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-4">
+    <div class="row row-cols-4"><!-- [!code highlight] -->
       <div class="col">Column</div>
       <div class="col">Column</div>
-      <div class="col">Column</div>
+      <div class="col-6">Column</div><!-- [!code highlight] -->
       <div class="col">Column</div>
     </div>
   </div>`} />
 
-<Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-4">
-      <div class="col">Column</div>
-      <div class="col">Column</div>
-      <div class="col-6">Column</div>
-      <div class="col">Column</div>
-    </div>
-  </div>`} />
+And lastly, you can combine responsive variants.
 
-<Example class="bd-example-row" code={`<div class="container text-center">
-    <div class="row row-cols-1 sm:row-cols-2 md:row-cols-4">
+<ResizableExample class="bd-example-row" code={`<div class="container text-center">
+    <div class="row row-cols-1 sm:row-cols-2 md:row-cols-4"><!-- [!code highlight] -->
       <div class="col">Column</div>
       <div class="col">Column</div>
       <div class="col">Column</div>
@@ -346,7 +408,7 @@ You can also use the accompanying Sass mixin, `row-cols()`:
 
 To nest your content with the default grid, add a new `.row` and set of `.sm:col-*` columns within an existing `.sm:col-*` column. Nested rows should include a set of columns that add up to 12 or fewer (it is not required that you use all 12 available columns).
 
-<Example class="bd-example-row" code={`<div class="container text-center">
+<ResizableExample class="bd-example-row" code={`<div class="container text-center">
     <div class="row">
       <div class="sm:col-3">
         Level 1: .sm:col-3

--- a/site/src/content/docs/layout/gutters.mdx
+++ b/site/src/content/docs/layout/gutters.mdx
@@ -121,6 +121,27 @@ Gutter classes can also be added to [row columns]([[docsref:/layout/grid#row-col
     </div>
   </div>`} />
 
+## Responsive gutters
+
+Resize the container below to test responsive gutter classes. The gutter width should widen as the container crosses breakpoints.
+
+<ResizableExample showBreakpoint class="bd-example-cols" code={`<div class="container text-center">
+    <div class="row sm:g-1 md:g-3 lg:g-5 xl:g-8">
+      <div class="col-6">
+        <div class="p-3">Column</div>
+      </div>
+      <div class="col-6">
+        <div class="p-3">Column</div>
+      </div>
+      <div class="col-6">
+        <div class="p-3">Column</div>
+      </div>
+      <div class="col-6">
+        <div class="p-3">Column</div>
+      </div>
+    </div>
+  </div>`} />
+
 ## No gutters
 
 The gutters between columns in our predefined grid classes can be removed with `.g-0`. This removes the negative `margin`s from `.row` and the horizontal `padding` from all immediate children columns.
@@ -143,9 +164,13 @@ $grid-gutter-x: 1.5rem;
 $gutters: (
   0: 0,
   1: $spacer * .25,
-  2: $spacer * .5,
-  3: $spacer,
-  4: $spacer * 1.5,
-  5: $spacer * 3,
+  2: $spacer * .375,
+  3: $spacer * .5,
+  4: $spacer * .75,
+  5: $spacer,
+  6: $spacer * 1.25,
+  7: $spacer * 1.5,
+  8: $spacer * 2,
+  9: $spacer * 3,
 );
 ```

--- a/site/src/content/docs/utilities/container.mdx
+++ b/site/src/content/docs/utilities/container.mdx
@@ -1,0 +1,63 @@
+---
+title: Container
+description: Use the container utility to set an element as a CSS query container for `@container` queries.
+toc: true
+mdn: https://developer.mozilla.org/en-US/docs/Web/CSS/container-type
+utility:
+  - container
+---
+
+## Container
+
+Set an element as a query container with the `.container-inline` or `.container-size` utility. Elements inside can then respond to the container's size rather than the viewport using `@container` queries.
+
+- `.container-inline` sets `container-type: inline-size`, creating a containment context on the inline axis (most common for responsive layouts).
+- `.container-size` sets `container-type: size`, creating a containment context on both block and inline axes.
+
+```html
+<div class="container-inline">
+  <div class="vstack md:hstack gap-3">...</div>
+</div>
+```
+
+Without a query container, responsive container query classes (like `.md:hstack`) have no effect.
+
+## How it works
+
+Container queries let components respond to the width of a parent container instead of the viewport. This is useful when the same component appears in different layout contexts (e.g., a sidebar and a main content area).
+
+Resize the example below. The stack switches from vertical to horizontal when the query container—not the viewport—is at least `768px` wide.
+
+<ResizableExample showBreakpoint code={`<div class="container-inline p-3">
+    <div class="vstack md:hstack gap-3">
+      <div class="p-3 bg-subtle-primary rounded-2 flex-fill">Item 1</div>
+      <div class="p-3 bg-subtle-primary rounded-2 flex-fill">Item 2</div>
+      <div class="p-3 bg-subtle-primary rounded-2 flex-fill">Item 3</div>
+    </div>
+  </div>`} />
+
+<Callout type="warning">
+Only some responsive classes are container-driven. Grid columns, [stacks]([[docsref:/helpers/stacks]]), and the responsive component variants listed below evaluate against their query container, while responsive [utilities]([[docsref:/utilities/api]]) such as `.md:d-flex` or `.md:text-center` still evaluate against the viewport. The same `md:` prefix can therefore switch at two different widths within one subtree.
+</Callout>
+
+## Components using container queries
+
+Several Bootstrap components use container queries to respond to their parent container:
+
+- **[Navbar]([[docsref:/components/navbar]])** — The `.*:navbar-expand` classes respond to the navbar's own width.
+- **[Card groups]([[docsref:/components/card#card-groups]])** — Wrap a card group in `.container-inline` to enable its row layout.
+- **[List group horizontal]([[docsref:/components/list-group#horizontal]])** — Wrap a list group in `.container-inline` for responsive horizontal variants.
+- **[Stepper]([[docsref:/components/stepper]])** — Wrap a stepper in `.container-inline` for responsive horizontal variants.
+- **[Stacks]([[docsref:/helpers/stacks]])** — The responsive `.*:hstack` and `.*:vstack` classes respond to the nearest query container.
+- **[CSS Grid]([[docsref:/layout/css-grid]])** — Each `.grid` is automatically a query container.
+- **[Default Grid]([[docsref:/layout/grid]])** — Each `.row` is automatically a query container.
+
+The `<body>` element and `.container`/`.container-fluid` are also query containers, named `body` and `layout` respectively, so responsive grid and gutter classes resolve against the page or the layout container when there is no closer query container.
+
+## CSS
+
+### Sass utilities API
+
+Container utilities are declared in our utilities API in `scss/_utilities.scss`. [Learn how to use the utilities API.]([[docsref:/utilities/api#using-the-api]])
+
+<ScssDocs name="utils-container" file="scss/_utilities.scss" />

--- a/site/src/content/docs/utilities/margin.mdx
+++ b/site/src/content/docs/utilities/margin.mdx
@@ -152,7 +152,7 @@ Bootstrap includes an `.mx-auto` class for horizontally centering fixed-width bl
 
 ## Negative margin
 
-In CSS, `margin` properties can utilize negative values (`padding` cannot). In v6, negative margins are limited to `margin-inline-start` and `margin-inline-end` only, using spacers `-1` (`-0.25rem`) and `-2` (`-0.5rem`):
+In CSS, `margin` properties can utilize negative values (`padding` cannot). In v6, negative margins are limited to `margin-inline-start` and `margin-inline-end` only, using spacers `-1` (`-0.25rem`) and `-2` (`-0.375rem`):
 
 ```html
 <div class="ms--1">.ms--1</div>

--- a/site/src/content/docs/utilities/space.mdx
+++ b/site/src/content/docs/utilities/space.mdx
@@ -38,10 +38,14 @@ Where *size* is one of:
 
 - `0` - for classes that eliminate the spacing by setting it to `0`
 - `1` - (by default) for classes that set the spacing to `$spacer * .25`
-- `2` - (by default) for classes that set the spacing to `$spacer * .5`
-- `3` - (by default) for classes that set the spacing to `$spacer`
-- `4` - (by default) for classes that set the spacing to `$spacer * 1.5`
-- `5` - (by default) for classes that set the spacing to `$spacer * 3`
+- `2` - (by default) for classes that set the spacing to `$spacer * .375`
+- `3` - (by default) for classes that set the spacing to `$spacer * .5`
+- `4` - (by default) for classes that set the spacing to `$spacer * .75`
+- `5` - (by default) for classes that set the spacing to `$spacer`
+- `6` - (by default) for classes that set the spacing to `$spacer * 1.25`
+- `7` - (by default) for classes that set the spacing to `$spacer * 1.5`
+- `8` - (by default) for classes that set the spacing to `$spacer * 2`
+- `9` - (by default) for classes that set the spacing to `$spacer * 3`
 
 (You can add more sizes by adding entries to the `$spacers` Sass map variable.)
 
@@ -89,7 +93,7 @@ Space utilities apply `margin-inline-end` or `margin-block-end` to every direct 
 
 ```css
 :where(.space-x-3 > :not(:last-child)) {
-  margin-inline-end: 1rem;
+  margin-inline-end: 0.5rem;
 }
 ```
 

--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -365,12 +365,29 @@
   }
 
   .bd-resizable-container {
+    position: relative;
     max-width: 100%;
     padding: 1rem;
     overflow: hidden;
     resize: horizontal;
     background-color: var(--bs-bg-body);
     @include border-radius(var(--radius-4));
+  }
+
+  .bd-resizable-badge {
+    position: absolute;
+    inset-block-start: .5rem;
+    inset-inline-end: .5rem;
+    z-index: 2;
+    padding: .125rem .5rem;
+    font-family: var(--bs-font-mono);
+    font-size: .75rem;
+    line-height: 1.5;
+    color: var(--bs-fg-2);
+    pointer-events: none;
+    background-color: var(--bs-bg-body);
+    border: 1px solid var(--bs-border-color);
+    @include border-radius(var(--radius-3));
   }
 
   //

--- a/site/src/scss/_component-examples.scss
+++ b/site/src/scss/_component-examples.scss
@@ -62,6 +62,10 @@
       --bd-example-padding: 1.5rem;
     }
 
+    &.bd-example-resizable {
+      --bd-example-padding: .375rem;
+    }
+
     + p {
       margin-top: 2rem;
     }
@@ -125,8 +129,8 @@
   // Grid examples
   //
 
-  .bd-example-row [class^="col"],
-  .bd-example-cols [class^="col"] > *,
+  .bd-example-row [class*="col"],
+  .bd-example-cols [class*="col"] > *,
   .bd-example-cssgrid [class*="grid"] > * {
     padding-block: .75rem;
     background-color: color-mix(in srgb, var(--bd-violet) 15%, transparent);
@@ -359,11 +363,6 @@
   // Resizable examples
   //
 
-  .bd-example-resizable {
-    position: relative;
-    padding: .375rem;
-  }
-
   .bd-resizable-container {
     position: relative;
     max-width: 100%;
@@ -371,7 +370,7 @@
     overflow: hidden;
     resize: horizontal;
     background-color: var(--bs-bg-body);
-    @include border-radius(var(--radius-4));
+    @include border-radius(var(--radius-3));
   }
 
   .bd-resizable-badge {


### PR DESCRIPTION
Draft — opening this to capture where the container-query grid work stands. `dist/` is intentionally not rebuilt here.

## Summary

Picks up the CSS Grid container-query work and extends it to the flexbox grid, plus a few things that got tangled up with it.

**Both grids are now container-driven.** `.row` joins `.grid` as a query container (`container-type: inline-size`), and `make-grid-columns()` generates `.md:col-*`, `.md:offset-*`, `.md:row-cols-*`, and the `.md:g-*` gutters with `@container` instead of `@media`. A `.md:col-6` in a narrow sidebar now splits when the row hits 768px rather than the viewport.

**Query containers on `body` and `.container`.** Gutter classes are set on the `.row` itself, and an element can never query its own `container-type`, so the responsive gutter variants were previously dead code. Making `<body>` (named `body`) and `.container`/`.container-fluid` (named `layout`) query containers gives them an ancestor to resolve against.

**`.contains-*` renamed to `.container-*`.** New `.container-inline` / `.container-size` naming, with a new `utilities/container` docs page, a sidebar entry, and all the stale `.contains-inline` references in card, list group, and stepper examples updated.

**Spacing scale rework.** `$spacers` and `$gutters` key 2 becomes `.375rem` with finer steps through the middle of the range, which ripples through the spacing, margin, and gutter docs.

**Docs.** Grid and gutter examples switch to `ResizableExample` with the container-query breakpoint badge, there's a fullscreen grid playground dialog, and the migration guide gains notes for the viewport-to-container change and its containment side effects.

## Outstanding todos

Carried over from an adversarial review of this work. None are blockers for reviewing the direction, but they should be resolved before this ships.

- [ ] **Decide whether responsive gutters are actually correct.** They now resolve, but against the *parent* (`.container` or `body`), not the row they're applied to. `.md:g-3` on a nested row keys off whatever ancestor container happens to be nearest, which is a different reference box than the sibling `.md:col-*` classes on the same row. The alternative is moving gutter declarations onto `> *` so they resolve against the row like everything else.
- [ ] **`md:` means two things.** Grid columns are container-based, but responsive utilities (`.md:d-flex`, `.md:text-center`, sticky, display, flex) are still viewport media queries. It's documented in the migration guide and on the new utilities page, but we should decide whether that split is the long-term story.
- [ ] **Audit the containment side effects.** `container-type: inline-size` establishes a containing block for `position: absolute`/`fixed` descendants and creates a stacking context, and Chrome 129+ deliberately diverges from Safari/Firefox here. Worth checking dropdowns, tooltips, and menus inside rows across the browser matrix. Also: a `.row` whose inline size depends on its contents can collapse to zero.
- [ ] **No fallback for engines without container query support.** There's no `@supports` guard, so unsupported browsers drop every responsive column class and stack completely. Media-query grids degraded far more gracefully. Decide whether we care given the v6 support floor.
- [ ] **`ResizableExample` badge mismeasures flexbox demos.** It observes the first child of `.bd-resizable-container`, which for flexbox examples is `.container`, not the `.row` that actually carries `container-type`. Between container padding and row negative margins it reads roughly one gutter low near each boundary. It should target the nearest descendant with `container-type`.
- [ ] **Confirm the spacing scale change belongs here.** The `$spacers` / `$negative-spacers` / `$gutters` rework is global and unrelated to the grid migration. It may deserve its own PR.
- [ ] **Consider an opt-out.** Right now there's no way to keep media-query grids short of overriding `container-type` yourself.

Verified locally: `css-lint`, `css-compile`, `docs-build` (no broken links), and `docs-lint` all pass.
