### PR TITLE
Add NuGet guides and move Sass files out of wwwroot

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -143,6 +143,7 @@
     "Packagist",
     "Pagefind",
     "popperjs",
+    "Pkgbootstrap",
     "prebuild",
     "prefersreducedmotion",
     "prepended",
@@ -201,6 +202,7 @@
     "WCAG",
     "webp",
     "worktrees",
+    "wwwroot",
     "xlink",
     "zindex"
   ],

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,92 @@
+name: NuGet
+
+on:
+  push:
+    branches:
+      - main
+      - v6-dev
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package-nuget:
+    runs-on: windows-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up NuGet
+        uses: nuget/setup-nuget@fd55a6f3b34392fa83fde1454582407d8c714123 # v4.0
+        with:
+          nuget-version: "5.x"
+
+      - name: Pack NuGet packages
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts
+          nuget pack "nuget\bootstrap.nuspec" -Verbosity detailed -NonInteractive -BasePath . -Version 0.0.0-ci -OutputDirectory artifacts
+          nuget pack "nuget\bootstrap.sass.nuspec" -Verbosity detailed -NonInteractive -BasePath . -Version 0.0.0-ci -OutputDirectory artifacts
+
+      - name: Validate package contents
+        shell: pwsh
+        run: |
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+          function Get-PackageEntries($path) {
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($path)
+
+            try {
+              return @($archive.Entries | ForEach-Object { $_.FullName })
+            } finally {
+              $archive.Dispose()
+            }
+          }
+
+          $cssEntries = Get-PackageEntries "artifacts\bootstrap.0.0.0-ci.nupkg"
+          $sassEntries = Get-PackageEntries "artifacts\bootstrap.sass.0.0.0-ci.nupkg"
+
+          if (-not $cssEntries.Contains("README.md")) {
+            throw "The bootstrap package does not contain README.md."
+          }
+
+          if (-not $sassEntries.Contains("README.md")) {
+            throw "The bootstrap.sass package does not contain README.md."
+          }
+
+          if (-not $cssEntries.Contains("contentFiles/any/any/wwwroot/css/bootstrap.min.css")) {
+            throw "The bootstrap package does not contain the minified CSS file."
+          }
+
+          if (-not $sassEntries.Contains("contentFiles/any/any/Styles/bootstrap.scss")) {
+            throw "The bootstrap.sass package does not contain the Sass entry point."
+          }
+
+          if ($sassEntries -match '^contentFiles/any/any/(wwwroot/)?scss/') {
+            throw "The bootstrap.sass package contains the old scss path."
+          }
+
+          if (-not $sassEntries.Contains("contentFiles/any/any/wwwroot/js/bootstrap.bundle.min.js")) {
+            throw "The bootstrap.sass package does not contain the JavaScript bundle."
+          }
+
+      - name: Test an SDK-style project
+        shell: pwsh
+        run: |
+          $packageSource = (Resolve-Path "artifacts").Path
+          dotnet new web -o validation-app --no-restore
+          dotnet add validation-app package bootstrap.sass --version 0.0.0-ci --source $packageSource
+          dotnet publish validation-app --no-restore --output validation-publish
+
+          if (Get-ChildItem "validation-publish\wwwroot" -Filter "*.scss" -Recurse) {
+            throw "The published application exposes Sass below wwwroot."
+          }
+
+          if (-not (Test-Path "validation-publish\wwwroot\js\bootstrap.bundle.min.js")) {
+            throw "The published application does not contain the JavaScript bundle."
+          }

--- a/nuget/bootstrap.nuspec
+++ b/nuget/bootstrap.nuspec
@@ -14,6 +14,7 @@
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <repository type="git" url="https://github.com/twbs/bootstrap.git" branch="main" />
     <icon>bootstrap.png</icon>
+    <readme>README.md</readme>
     <license type="expression">MIT</license>
     <copyright>Copyright 2011-2026</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -24,6 +25,7 @@
   </metadata>
   <files>
     <file src="nuget\bootstrap.png" target="" />
+    <file src="nuget\bootstrap\README.md" target="" />
 
     <file src="dist\css\*.*" target="content\Content" />
     <file src="dist\js\bootstrap*.js" target="content\Scripts" />

--- a/nuget/bootstrap.sass.nuspec
+++ b/nuget/bootstrap.sass.nuspec
@@ -14,6 +14,7 @@
     <projectUrl>https://getbootstrap.com/</projectUrl>
     <repository type="git" url="https://github.com/twbs/bootstrap.git" branch="main" />
     <icon>bootstrap.png</icon>
+    <readme>README.md</readme>
     <license type="expression">MIT</license>
     <copyright>Copyright 2011-2026</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -24,12 +25,13 @@
   </metadata>
   <files>
     <file src="nuget\bootstrap.png" target="" />
+    <file src="nuget\bootstrap.sass\README.md" target="" />
 
     <file src="scss\**\*.scss" target="content\Content\bootstrap" />
     <file src="dist\js\bootstrap*.js" target="content\Scripts" />
     <file src="dist\js\bootstrap*.js.map" target="content\Scripts" />
 
-    <file src="scss\**\*.scss" target="contentFiles\any\any\wwwroot\scss" />
+    <file src="scss\**\*.scss" target="contentFiles\any\any\Styles" />
     <file src="dist\js\bootstrap*.js" target="contentFiles\any\any\wwwroot\js" />
     <file src="dist\js\bootstrap*.js.map" target="contentFiles\any\any\wwwroot\js" />
   </files>

--- a/nuget/bootstrap.sass/README.md
+++ b/nuget/bootstrap.sass/README.md
@@ -17,11 +17,9 @@ You can also use the NuGet Package Manager Console:
 Install-Package bootstrap.sass
 ```
 
-## Compile the Sass source
+## Compile the Sass source at build
 
-Use a Sass compiler that supports Dart Sass.
-Compile Sass during the build, during publish, or at run time.
-Write the generated CSS to a public path such as `wwwroot/css`.
+Use a Sass compiler that supports Dart Sass. Write the generated CSS to a public path such as `wwwroot/css`.
 
 Set `GeneratePathProperty="true"` on the `bootstrap.sass` package reference.
 NuGet then creates the `$(Pkgbootstrap_sass)` MSBuild property.
@@ -40,16 +38,9 @@ $(Pkgbootstrap_sass)\contentFiles\any\any\Styles
 
 Use the [Bootstrap Sass guide](https://getbootstrap.com/docs/6.0/customize/sass/) to customize Bootstrap.
 
-These community packages can compile Sass without Node.js:
+## Copy Sass for runtime compilation
 
-- [EmbeddedSass.Net](https://github.com/gumbarros/EmbeddedSass.Net)
-- [AspNetCore.SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler)
-
-Follow the selected compiler’s documentation for its current setup.
-
-### Copy Sass for run-time compilation
-
-A run-time compiler needs the Sass files in the application output.
+A runtime compiler needs the Sass files in the application output.
 Add this item to your project file:
 
 ```xml
@@ -61,8 +52,22 @@ Add this item to your project file:
 </ItemGroup>
 ```
 
-Use `Styles/bootstrap` as a compiler load path at run time.
+Use `Styles/bootstrap` as a compiler load path at runtime.
 Do not serve that directory as static web content.
+
+## Install a Sass compiler
+
+These community packages can compile Sass without Node.js:
+
+- [EmbeddedSass.Net](https://github.com/gumbarros/EmbeddedSass.Net)
+- [AspNetCore.SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler)
+
+They both support build time and runtime compilations.
+
+Follow the selected compiler’s documentation for its current setup.
+
+### 
+
 
 ## Use the JavaScript
 

--- a/nuget/bootstrap.sass/README.md
+++ b/nuget/bootstrap.sass/README.md
@@ -59,8 +59,8 @@ Do not serve that directory as static web content.
 
 These community packages can compile Sass without Node.js:
 
-- [EmbeddedSass.Net](https://github.com/gumbarros/EmbeddedSass.Net)
 - [AspNetCore.SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler)
+- [EmbeddedSass.Net](https://github.com/gumbarros/EmbeddedSass.Net)
 
 They both support build time and runtime compilations.
 

--- a/nuget/bootstrap.sass/README.md
+++ b/nuget/bootstrap.sass/README.md
@@ -11,12 +11,6 @@ Install the package with the .NET CLI:
 dotnet add package bootstrap.sass
 ```
 
-You can also use the NuGet Package Manager Console:
-
-```powershell
-Install-Package bootstrap.sass
-```
-
 ## Compile the Sass source at build
 
 Use a Sass compiler that supports Dart Sass. Write the generated CSS to a public path such as `wwwroot/css`.

--- a/nuget/bootstrap.sass/README.md
+++ b/nuget/bootstrap.sass/README.md
@@ -1,0 +1,86 @@
+# Bootstrap Sass
+
+This package provides the Bootstrap Sass source and compiled JavaScript files.
+It does not compile Sass into CSS.
+
+## Install
+
+Install the package with the .NET CLI:
+
+```console
+dotnet add package bootstrap.sass
+```
+
+You can also use the NuGet Package Manager Console:
+
+```powershell
+Install-Package bootstrap.sass
+```
+
+## Compile the Sass source
+
+Use a Sass compiler that supports Dart Sass.
+Compile Sass during the build, during publish, or at run time.
+Write the generated CSS to a public path such as `wwwroot/css`.
+
+Set `GeneratePathProperty="true"` on the `bootstrap.sass` package reference.
+NuGet then creates the `$(Pkgbootstrap_sass)` MSBuild property.
+
+The Bootstrap Sass entry point is at this path:
+
+```text
+$(Pkgbootstrap_sass)\contentFiles\any\any\Styles\bootstrap.scss
+```
+
+Set your compiler load path to this directory:
+
+```text
+$(Pkgbootstrap_sass)\contentFiles\any\any\Styles
+```
+
+Use the [Bootstrap Sass guide](https://getbootstrap.com/docs/6.0/customize/sass/) to customize Bootstrap.
+
+These community packages can compile Sass without Node.js:
+
+- [EmbeddedSass.Net](https://github.com/gumbarros/EmbeddedSass.Net)
+- [AspNetCore.SassCompiler](https://github.com/koenvzeijl/AspNetCore.SassCompiler)
+
+Follow the selected compiler’s documentation for its current setup.
+
+### Copy Sass for run-time compilation
+
+A run-time compiler needs the Sass files in the application output.
+Add this item to your project file:
+
+```xml
+<ItemGroup>
+  <None Include="$(Pkgbootstrap_sass)\contentFiles\any\any\Styles\**\*.scss"
+        Link="Styles\bootstrap\%(RecursiveDir)%(Filename)%(Extension)"
+        CopyToOutputDirectory="PreserveNewest"
+        CopyToPublishDirectory="PreserveNewest" />
+</ItemGroup>
+```
+
+Use `Styles/bootstrap` as a compiler load path at run time.
+Do not serve that directory as static web content.
+
+## Use the JavaScript
+
+SDK-style projects expose the compiled JavaScript at `wwwroot/js`.
+Add the bundle to your page:
+
+```html
+<script src="/js/bootstrap.bundle.min.js"></script>
+```
+
+## Migrate from Bootstrap 5
+
+Bootstrap 6 stores Sass below `contentFiles/any/any/Styles` in the package.
+Bootstrap 5 stored Sass below `contentFiles/any/any/wwwroot/scss`.
+Update custom package paths when you upgrade.
+
+## Other resources
+
+- Read the [Bootstrap documentation](https://getbootstrap.com/).
+- Report problems in the [Bootstrap issue tracker](https://github.com/twbs/bootstrap/issues).
+- Read the [MIT license](https://github.com/twbs/bootstrap/blob/main/LICENSE).

--- a/nuget/bootstrap/README.md
+++ b/nuget/bootstrap/README.md
@@ -10,12 +10,6 @@ Install the package with the .NET CLI:
 dotnet add package bootstrap
 ```
 
-You can also use the NuGet Package Manager Console:
-
-```powershell
-Install-Package bootstrap
-```
-
 ## Use the files
 
 SDK-style projects expose the files at these paths:

--- a/nuget/bootstrap/README.md
+++ b/nuget/bootstrap/README.md
@@ -1,0 +1,42 @@
+# Bootstrap CSS
+
+This package provides the compiled Bootstrap CSS and JavaScript files.
+
+## Install
+
+Install the package with the .NET CLI:
+
+```console
+dotnet add package bootstrap
+```
+
+You can also use the NuGet Package Manager Console:
+
+```powershell
+Install-Package bootstrap
+```
+
+## Use the files
+
+SDK-style projects expose the files at these paths:
+
+- `wwwroot/css`
+- `wwwroot/js`
+
+Add the minified CSS and bundled JavaScript to your page:
+
+```html
+<link rel="stylesheet" href="/css/bootstrap.min.css">
+<script src="/js/bootstrap.bundle.min.js"></script>
+```
+
+The JavaScript bundle includes Bootstrap’s JavaScript dependencies.
+
+.NET Framework projects that use `packages.config` receive CSS files in `Content`.
+They receive JavaScript files in `Scripts`.
+
+## Other resources
+
+- Read the [Bootstrap documentation](https://getbootstrap.com/).
+- Report problems in the [Bootstrap issue tracker](https://github.com/twbs/bootstrap/issues).
+- Read the [MIT license](https://github.com/twbs/bootstrap/blob/main/LICENSE).

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "docs-compile": "npm run docs-build",
     "docs-html-validate": "node build/html-validate.mjs",
     "docs-mdx": "markdownlint \"site/src/content/**/*.mdx\"",
-    "docs-md": "markdownlint \"*.md\" \"skills/**/*.md\"",
+    "docs-md": "markdownlint \"*.md\" \"nuget/**/*.md\" \"skills/**/*.md\"",
     "docs-lint": "npm-run-all docs-prettier-check docs-html-validate",
     "docs-prettier-check": "prettier --config site/.prettierrc.json -c --cache site",
     "docs-prettier-format": "prettier --config site/.prettierrc.json --write --cache site",

--- a/site/src/content/docs/getting-started/install.mdx
+++ b/site/src/content/docs/getting-started/install.mdx
@@ -76,7 +76,13 @@ gem install bootstrap -v [[config:current_ruby_version]]
 
 ### Using NuGet
 
-If you develop in .NET Framework, you can also install and manage Bootstrap’s [CSS](https://www.nuget.org/packages/bootstrap/) or [Sass](https://www.nuget.org/packages/bootstrap.sass/) and JavaScript using [NuGet](https://www.nuget.org/). Newer projects should use [libman](https://learn.microsoft.com/en-us/aspnet/core/client-side/libman/) or another method as NuGet is designed for compiled code, not frontend assets.
+[NuGet](https://www.nuget.org/) supports Bootstrap in .NET Framework and SDK-style .NET projects.
+Use the [compiled CSS package](https://www.nuget.org/packages/bootstrap/) when you do not need Sass customization.
+See the [CSS package README]([[config:repo]]/blob/v[[config:current_version]]/nuget/bootstrap/README.md) for file paths and setup instructions.
+
+Use the [Sass package](https://www.nuget.org/packages/bootstrap.sass/) when you want to customize and compile Bootstrap.
+The Sass package requires a Sass compiler.
+See the [Sass package README]([[config:repo]]/blob/v[[config:current_version]]/nuget/bootstrap.sass/README.md) for MSBuild paths and compiler options.
 
 ## CDN
 


### PR DESCRIPTION
### Description

- Add dedicated README files for the `bootstrap` and `bootstrap.sass` NuGet packages.
- Document setup instructions for both .NET Framework and SDK-style projects.
- Move Sass files from `contentFiles/any/any/wwwroot/scss` to `contentFiles/any/any/Styles`.
- Add CI checks for NuGet package contents and .NET publishing.

### Motivation and context

The NuGet packages previously showed only installation commands and did not explain how to use the included assets.

The Sass package also published source files under `wwwroot`, making the `.scss` files publicly accessible in ASP.NET Core applications at the browser.

### Type of changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that changes existing functionality)

This breaking change is very worth, nobody from ASP.NET Core world expects a .scss file in wwwroot, wwwroot are only meant for browser files. Even for v5 I think its worth because its a bug.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the project's code style (`npm run lint`).
- [x] My change introduces documentation changes.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#### Live preview

[`https://deploy-preview-42788--twbs-bootstrap.netlify.app/`](https://deploy-preview-42788--twbs-bootstrap.netlify.app/)
### Related issues

Fixes #42742