### PR TITLE
Remove unused selector engine helpers

### DIFF
--- a/js/src/dom/selector-engine.ts
+++ b/js/src/dom/selector-engine.ts
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------
  */
 
-import { isDisabled, isVisible, parseSelector } from '../util/index.js'
+import { parseSelector } from '../util/index.js'
 
 const getSelector = (element: Element): string | null => {
   let selector = element.getAttribute('data-bs-target')
@@ -39,10 +39,6 @@ const SelectorEngine = {
 
   findOne<T extends Element = HTMLElement>(selector: string, element: ParentNode = document.documentElement): T | null {
     return Element.prototype.querySelector.call(element as Element, selector) as T | null
-  },
-
-  children<T extends Element = HTMLElement>(element: Element, selector: string): T[] {
-    return [...element.children].filter(child => child.matches(selector)) as T[]
   },
 
   parents(element: Element, selector: string): Element[] {
@@ -87,21 +83,6 @@ const SelectorEngine = {
     }
 
     return []
-  },
-
-  focusableChildren(element: Element): HTMLElement[] {
-    const focusables = [
-      'a',
-      'button',
-      'input',
-      'textarea',
-      'select',
-      'details',
-      '[tabindex]',
-      '[contenteditable="true"]'
-    ].map(selector => `${selector}:not([tabindex^="-"])`).join(',')
-
-    return this.find(focusables, element).filter(el => !isDisabled(el) && isVisible(el))
   },
 
   getSelectorFromElement(element: Element): string | null {

--- a/js/tests/unit/dom/selector-engine.spec.js
+++ b/js/tests/unit/dom/selector-engine.spec.js
@@ -57,24 +57,6 @@ describe('SelectorEngine', () => {
     })
   })
 
-  describe('children', () => {
-    it('should find children', () => {
-      fixtureEl.innerHTML = [
-        '<ul>',
-        '  <li></li>',
-        '  <li></li>',
-        '  <li></li>',
-        '</ul>'
-      ].join('')
-
-      const list = fixtureEl.querySelector('ul')
-      const liList = [...fixtureEl.querySelectorAll('li')]
-      const result = SelectorEngine.children(list, 'li')
-
-      expect(result).toEqual(liList)
-    })
-  })
-
   describe('parents', () => {
     it('should return parents', () => {
       expect(SelectorEngine.parents(fixtureEl, 'body')).toHaveSize(1)
@@ -183,80 +165,6 @@ describe('SelectorEngine', () => {
       const divTest = fixtureEl.querySelector('.test')
 
       expect(SelectorEngine.next(divTest, '.btn')).toEqual([btn])
-    })
-  })
-
-  describe('focusableChildren', () => {
-    it('should return only elements with specific tag names', () => {
-      fixtureEl.innerHTML = [
-        '<div>lorem</div>',
-        '<span>lorem</span>',
-        '<a>lorem</a>',
-        '<button>lorem</button>',
-        '<input>',
-        '<textarea></textarea>',
-        '<select></select>',
-        '<details>lorem</details>'
-      ].join('')
-
-      const expectedElements = [
-        fixtureEl.querySelector('a'),
-        fixtureEl.querySelector('button'),
-        fixtureEl.querySelector('input'),
-        fixtureEl.querySelector('textarea'),
-        fixtureEl.querySelector('select'),
-        fixtureEl.querySelector('details')
-      ]
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
-    })
-
-    it('should return any element with non negative tab index', () => {
-      fixtureEl.innerHTML = [
-        '<div tabindex>lorem</div>',
-        '<div tabindex="0">lorem</div>',
-        '<div tabindex="10">lorem</div>'
-      ].join('')
-
-      const expectedElements = [
-        fixtureEl.querySelector('[tabindex]'),
-        fixtureEl.querySelector('[tabindex="0"]'),
-        fixtureEl.querySelector('[tabindex="10"]')
-      ]
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
-    })
-
-    it('should return not return elements with negative tab index', () => {
-      fixtureEl.innerHTML = '<button tabindex="-1">lorem</button>'
-
-      const expectedElements = []
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
-    })
-
-    it('should return contenteditable elements', () => {
-      fixtureEl.innerHTML = '<div contenteditable="true">lorem</div>'
-
-      const expectedElements = [fixtureEl.querySelector('[contenteditable="true"]')]
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
-    })
-
-    it('should not return disabled elements', () => {
-      fixtureEl.innerHTML = '<button disabled="true">lorem</button>'
-
-      const expectedElements = []
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
-    })
-
-    it('should not return invisible elements', () => {
-      fixtureEl.innerHTML = '<button style="display:none;">lorem</button>'
-
-      const expectedElements = []
-
-      expect(SelectorEngine.focusableChildren(fixtureEl)).toEqual(expectedElements)
     })
   })
 


### PR DESCRIPTION
- Removes `SelectorEngine.children()`, which has no callers in the source or in the tests.
- Removes `SelectorEngine.focusableChildren()`, which also has no callers.
- Drops the now unused `isDisabled` and `isVisible` imports.
- Removes the specs for both helpers.
- Keeps `prev()`. The issue text is stale on that point, because Menu and ScrollSpy still call it.

Closes #42655