### PR TITLE
Remove the Collapse toggle option

### DIFF
--- a/js/src/collapse.ts
+++ b/js/src/collapse.ts
@@ -44,17 +44,14 @@ const SELECTOR_DATA_TOGGLE = '[data-bs-toggle="collapse"]'
 
 type CollapseConfig = {
   parent: string | Element | null
-  toggle: boolean
 }
 
 const Default: CollapseConfig = {
-  parent: null,
-  toggle: true
+  parent: null
 }
 
 const DefaultType = {
-  parent: '(null|element)',
-  toggle: 'boolean'
+  parent: '(null|element)'
 }
 
 /**
@@ -88,10 +85,6 @@ class Collapse extends BaseComponent {
 
     if (!this._config.parent) {
       this._setAriaExpanded(this._triggerArray, this._isShown())
-    }
-
-    if (this._config.toggle) {
-      this.toggle()
     }
   }
 
@@ -128,7 +121,7 @@ class Collapse extends BaseComponent {
     if (this._config.parent) {
       activeChildren = this._getFirstLevelChildren(SELECTOR_ACTIVES)
         .filter(element => element !== this._element)
-        .map(element => Collapse.getOrCreateInstance(element, { toggle: false }))
+        .map(element => Collapse.getOrCreateInstance(element))
     }
 
     if (activeChildren.length && activeChildren[0]._isTransitioning) {
@@ -219,7 +212,6 @@ class Collapse extends BaseComponent {
   }
 
   protected override _configAfterMerge(config: ComponentConfig): ComponentConfig {
-    config.toggle = Boolean(config.toggle) // Coerce string values
     config.parent = getElement(config.parent)
     return config
   }
@@ -272,7 +264,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
   }
 
   for (const element of SelectorEngine.getMultipleElementsFromSelector(this)) {
-    Collapse.getOrCreateInstance(element, { toggle: false }).toggle()
+    Collapse.getOrCreateInstance(element).toggle()
   }
 })
 

--- a/js/tests/types/api.ts
+++ b/js/tests/types/api.ts
@@ -53,7 +53,7 @@ declare const element: HTMLElement
 const tooltipFromSelector: Tooltip = new Tooltip('#tip', { animation: false })
 const tooltipFromElement: Tooltip = new Tooltip(element)
 const toast: Toast = new Toast(element, { autohide: false, delay: 5000 })
-const collapse: Collapse = new Collapse(element, { toggle: false })
+const collapse: Collapse = new Collapse(element, { parent: '#accordion' })
 const carousel: Carousel = new Carousel(element, { interval: 2000 })
 const dialog: Dialog = new Dialog(element, { modal: true, keyboard: false })
 const drawer: Drawer = new Drawer(element, { scroll: true })
@@ -132,7 +132,7 @@ const inputs: HTMLInputElement[] = SelectorEngine.find<HTMLInputElement>('input'
 new Toast(element, { autohype: true })
 
 // @ts-expect-error — config value types are enforced
-new Collapse(element, { toggle: 'yes' })
+new Collapse(element, { parent: 42 })
 
 // The Vanilla Calendar Pro unions reject out-of-range values, which a plain
 // `number` or `string` would have accepted silently

--- a/js/tests/types/consumer.ts
+++ b/js/tests/types/consumer.ts
@@ -60,7 +60,7 @@ declare const element: HTMLElement
 const tooltipFromSelector: Tooltip = new Tooltip('#tip', { animation: false })
 const tooltipFromElement: Tooltip = new Tooltip(element)
 const toast: Toast = new Toast(element, { autohide: false, delay: 5000 })
-const collapse: Collapse = new Collapse(element, { toggle: false })
+const collapse: Collapse = new Collapse(element, { parent: '#accordion' })
 const carousel: Carousel = new Carousel(element, { interval: 2000 })
 const dialog: Dialog = new Dialog(element, { modal: true, keyboard: false })
 const drawer: Drawer = new Drawer(element, { scroll: true })
@@ -148,7 +148,7 @@ const inputs: HTMLInputElement[] = SelectorEngine.find<HTMLInputElement>('input'
 new Toast(element, { autohype: true })
 
 // @ts-expect-error — config value types are enforced
-new Collapse(element, { toggle: 'yes' })
+new Collapse(element, { parent: 42 })
 
 // getOrCreateInstance types its config per component through the shipped types
 Toast.getOrCreateInstance(element, { autohide: false })

--- a/js/tests/unit/collapse.spec.js
+++ b/js/tests/unit/collapse.spec.js
@@ -100,9 +100,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="show"></div>'
 
       const collapseEl = fixtureEl.querySelector('.show')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       const spy = spyOn(collapse, 'hide')
 
@@ -132,8 +130,7 @@ describe('Collapse', () => {
 
         const collapseList = [...fixtureEl.querySelectorAll('.collapse')]
           .map(el => new Collapse(el, {
-            parent,
-            toggle: false
+            parent
           }))
 
         collapseEl2.addEventListener('shown.bs.collapse', () => {
@@ -154,9 +151,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.show()
@@ -170,9 +165,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.show()
 
@@ -184,9 +177,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse" style="height: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.bs.collapse', () => {
           expect(collapseEl.style.height).toEqual('0px')
@@ -206,9 +197,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse collapse-horizontal" style="width: 0px;"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('show.bs.collapse', () => {
           expect(collapseEl.style.width).toEqual('0px')
@@ -236,9 +225,7 @@ describe('Collapse', () => {
 
         const el1 = fixtureEl.querySelector('#collapse1')
         const el2 = fixtureEl.querySelector('#collapse2')
-        const collapse = new Collapse(el1, {
-          toggle: false
-        })
+        const collapse = new Collapse(el1)
 
         el1.addEventListener('shown.bs.collapse', () => {
           expect(el1).toHaveClass('show')
@@ -357,7 +344,8 @@ describe('Collapse', () => {
           collapse.hide()
         })
 
-        collapse.show()
+        // The element starts shown, so close it to begin the hide/show cycle
+        collapse.hide()
       })
     })
 
@@ -366,9 +354,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -398,9 +384,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse._isTransitioning = true
       collapse.hide()
@@ -414,9 +398,7 @@ describe('Collapse', () => {
       const spy = spyOn(EventHandler, 'trigger')
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       collapse.hide()
 
@@ -428,9 +410,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         collapseEl.addEventListener('hidden.bs.collapse', () => {
           expect(collapseEl).not.toHaveClass('show')
@@ -447,9 +427,7 @@ describe('Collapse', () => {
         fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
         const collapseEl = fixtureEl.querySelector('div')
-        const collapse = new Collapse(collapseEl, {
-          toggle: false
-        })
+        const collapse = new Collapse(collapseEl)
 
         const expectEnd = () => {
           setTimeout(() => {
@@ -477,9 +455,7 @@ describe('Collapse', () => {
       fixtureEl.innerHTML = '<div class="collapse show"></div>'
 
       const collapseEl = fixtureEl.querySelector('div')
-      const collapse = new Collapse(collapseEl, {
-        toggle: false
-      })
+      const collapse = new Collapse(collapseEl)
 
       expect(Collapse.getInstance(collapseEl)).toEqual(collapse)
 
@@ -949,11 +925,11 @@ describe('Collapse', () => {
 
       expect(Collapse.getInstance(div)).toBeNull()
       const collapse = Collapse.getOrCreateInstance(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(collapse).toBeInstanceOf(Collapse)
 
-      expect(collapse._config.toggle).toBeFalse()
+      expect(collapse._config.parent).toEqual(fixtureEl)
     })
 
     it('should return the instance when exists without given configuration', () => {
@@ -961,17 +937,17 @@ describe('Collapse', () => {
 
       const div = fixtureEl.querySelector('div')
       const collapse = new Collapse(div, {
-        toggle: false
+        parent: fixtureEl
       })
       expect(Collapse.getInstance(div)).toEqual(collapse)
 
       const collapse2 = Collapse.getOrCreateInstance(div, {
-        toggle: true
+        parent: null
       })
       expect(collapse).toBeInstanceOf(Collapse)
       expect(collapse2).toEqual(collapse)
 
-      expect(collapse2._config.toggle).toBeFalse()
+      expect(collapse2._config.parent).toEqual(fixtureEl)
     })
   })
 })

--- a/site/src/content/docs/components/collapse.mdx
+++ b/site/src/content/docs/components/collapse.mdx
@@ -151,7 +151,6 @@ const collapseList = [...collapseElementList].map(collapseEl => new bootstrap.Co
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 `parent` | selector, DOM element | `null` | If parent is provided, then all collapsible elements under the specified parent will be closed when this collapsible item is shown. (similar to traditional accordion behavior - this is dependent on the `card` class). The attribute has to be set on the target collapsible area. |
-`toggle` | boolean | `true` | Toggles the collapsible element on invocation. |
 </BsTable>
 
 ### Methods
@@ -160,12 +159,11 @@ const collapseList = [...collapseElementList].map(collapseEl => new bootstrap.Co
 
 Activates your content as a collapsible element. Accepts an optional options `object`.
 
-You can create a collapse instance with the constructor, for example:
+The constructor keeps the state that your markup declares. Add `.show` to open the element, and leave it off to keep the element closed. Call `show()`, `hide()`, or `toggle()` to change the state.
 
 ```js
-const bsCollapse = new bootstrap.Collapse('#myCollapse', {
-  toggle: false
-})
+const bsCollapse = new bootstrap.Collapse('#myCollapse')
+bsCollapse.show()
 ```
 
 <BsTable>

--- a/site/src/content/docs/guides/migration.mdx
+++ b/site/src/content/docs/guides/migration.mdx
@@ -282,6 +282,18 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
   ```
 
 - **Collapse triggers now use `aria-expanded` as the state signal.** Bootstrap v6 no longer adds or removes a `.collapsed` class on collapse trigger elements. If you styled or queried trigger state with `.collapsed`, migrate those selectors to `[aria-expanded="false"]` and open-state selectors to `[aria-expanded="true"]`.
+- **Removed the Collapse `toggle` option.** The constructor now keeps the state your markup declares, instead of flipping it. Drop `toggle: false` from your config, it is the behavior you already get. If you relied on the old `toggle: true` default to change the state on init, call the matching method instead.
+
+  ```js
+  // v5
+  new bootstrap.Collapse(el)                  // opened a closed element
+  new bootstrap.Collapse(el, { toggle: false })
+
+  // v6
+  new bootstrap.Collapse(el).show()
+  new bootstrap.Collapse(el)
+  ```
+
 - **Dismiss triggers now find responsive drawers.** `data-bs-dismiss="drawer"` resolves breakpoint-prefixed drawers such as `.lg:drawer`, so a close button inside a responsive drawer no longer needs `data-bs-target`. Existing `data-bs-target` attributes keep working.
 - **Navbar toggler icon now uses a CSS mask.** `.navbar-toggler-icon` renders via `mask-image` (`--navbar-toggler-icon`) tinted with `background-color: currentcolor` instead of an embedded `background-image` SVG. The markup stays an empty `<span class="navbar-toggler-icon">`, but the icon now inherits the current text color (including dark mode), so the separate light/dark toggler SVGs are no longer needed.
 - **Rebuilt the carousel on CSS scroll snap.** The slide engine no longer uses `float` + `translateX` class juggling or a custom swipe handler—`.carousel-inner` is now a native horizontal scroll-snap container, so sliding, touch dragging, momentum, and keyboard scrolling come from the browser. The markup is unchanged (`.carousel` &rarr; `.carousel-inner` &rarr; `.carousel-item`), and the public JavaScript API (`next`, `prev`, `to`, `cycle`, `pause`) plus the `slide.bs.carousel` / `slid.bs.carousel` events are preserved.


### PR DESCRIPTION
- Removes the `toggle` option from `CollapseConfig`, `Default`, and `DefaultType`.
- Removes the `this.toggle()` call from the constructor, so a new instance keeps the state that the markup declares.
- Drops `{ toggle: false }` from the two internal `getOrCreateInstance()` calls.
- Removes the `Boolean()` coercion in `_configAfterMerge`.
- Updates the options table, the constructor example, and the type-level API tests.
- Adds a migration note with a before and after example.

Breaking change. Drop `toggle: false` from your config, because it is the behavior you already get. If you relied on the old `toggle: true` default, call `show()` after the constructor.

Closes #34836