### PR TITLE
Add dynamic viewport height and width utilities

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "./dist/css/bootstrap-utilities.css",
-      "maxSize": "18.75 kB"
+      "maxSize": "19.0 kB"
     },
     {
       "path": "./dist/css/bootstrap-utilities.min.css",

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -313,6 +313,16 @@ $utilities: map.merge(
       class: min-vw,
       values: (100: 100vw)
     ),
+    "dynamic-viewport-width": (
+      property: width,
+      class: dvw,
+      values: (100: 100dvw)
+    ),
+    "min-dynamic-viewport-width": (
+      property: min-width,
+      class: min-dvw,
+      values: (100: 100dvw)
+    ),
     // scss-docs-end utils-width
     // scss-docs-start utils-height
     "height": (
@@ -351,6 +361,16 @@ $utilities: map.merge(
       property: min-height,
       class: min-vh,
       values: (100: 100vh)
+    ),
+    "dynamic-viewport-height": (
+      property: height,
+      class: dvh,
+      values: (100: 100dvh)
+    ),
+    "min-dynamic-viewport-height": (
+      property: min-height,
+      class: min-dvh,
+      values: (100: 100dvh)
     ),
     // scss-docs-end utils-height
     // Flex utilities

--- a/site/src/content/docs/guides/migration.mdx
+++ b/site/src/content/docs/guides/migration.mdx
@@ -515,6 +515,7 @@ Bootstrap 6 is a major release with many breaking changes to modernize our codeb
   - Renamed `.mh-*`/`.mw-*` to `.max-h-*`/`.max-w-*`
   - Added `.min-h-*` and `.min-w-*` utilities with two default values, `0` and `100%`
   - Added `auto`, `min-content`, `max-content`, and `fit-content` to `width` and `height` utilities.
+- **New dynamic viewport utilities.** `.dvh-100` and `.min-dvh-100` set `height: 100dvh` and `min-height: 100dvh`. `.dvw-100` and `.min-dvw-100` set `width: 100dvw` and `min-width: 100dvw`. The browser updates a `dv*` unit when it expands or retracts a browser interface. Use `.dvh-100` for full-screen mobile layouts, because the section no longer overflows while a mobile browser shows its URL bar. Note that `dvw` does not fix the `100vw` scrollbar overflow, because CSS sizes every viewport width unit as if the scrollbar does not exist. The v5 `.vh-100`, `.min-vh-100`, `.vw-100`, and `.min-vw-100` utilities are unchanged. Add `svh`, `lvh`, `svw`, and `lvw` utilities yourself with the utilities API — see [Height]([[docsref:/utilities/height]]) and [Width]([[docsref:/utilities/width]]).
 - **Flex & Grid utilities:**
   - Added `.place-items` and `.justify-items` utilities.
   - Added `.grid-cols-*` utilities for `grid-template-columns` (1–4 and 6 column layouts), `.grid-cols-fill` for spanning all columns, `.grid-cols-subgrid` for adopting a parent grid's column tracks, and `.grid-auto-flow` utility.

--- a/site/src/content/docs/utilities/height.mdx
+++ b/site/src/content/docs/utilities/height.mdx
@@ -9,6 +9,8 @@ utility:
   - min-height
   - viewport-height
   - min-viewport-height
+  - dynamic-viewport-height
+  - min-dynamic-viewport-height
 ---
 
 Use height utilities to set the height of elements. Height utilities are generated from the utility API and include support for percentage values, intrinsic sizing keywords, and viewport units.
@@ -62,8 +64,68 @@ Set height relative to the viewport using viewport units.
 ```
 
 <Callout>
-**Full viewport height sections!** Using `vh-100` makes an element take up the entire viewport height, which is useful for hero sections and full-screen layouts.
+**Full viewport height sections!** Using `vh-100` makes an element take up the entire viewport height, which is useful for hero sections and full-screen layouts. On mobile browsers, `vh-100` can be taller than the visible area. See [dynamic viewport height](#dynamic-viewport-height).
 </Callout>
+
+## Dynamic viewport height
+
+On mobile browsers, the URL bar and the toolbars hide and show while the user scrolls. The `vh` unit does not change when this happens. It always measures the viewport with the browser UI hidden. An element with `vh-100` is therefore taller than the visible area while the URL bar shows. The bottom of the element stays off screen.
+
+The `dvh` unit measures the area that the user sees now. The browser updates the value when it hides or shows the browser UI. Use `dvh-100` and `min-dvh-100` to fill the visible area on every device.
+
+```html
+<div class="dvh-100">Height 100dvh</div>
+<div class="min-dvh-100">Min-height 100dvh</div>
+```
+
+<Callout>
+**Which unit do I use?** Use `dvh` for full-screen mobile layouts, such as hero sections and full-height panels. Use `vh` when you need a height that does not change. The browser recalculates `dvh` while the browser UI animates, so the content can move. The browser never recalculates `vh`, but the element can overflow the visible area.
+</Callout>
+
+### Small and large viewport units
+
+CSS gives you two more viewport units:
+
+- `svh` is the small viewport height. It measures the viewport with the browser UI shown.
+- `lvh` is the large viewport height. It measures the viewport with the browser UI hidden. Current browsers give `vh` the same value.
+
+We do not ship utilities for `svh` and `lvh`, because most layouts need `dvh`. Add them with the [utilities API]([[docsref:/utilities/api#add-utilities]]):
+
+```scss
+// my-bootstrap.scss
+@use "bootstrap/scss/bootstrap" with (
+  $utilities: (
+    "small-viewport-height": (
+      property: height,
+      class: svh,
+      values: (100: 100svh)
+    ),
+    "min-small-viewport-height": (
+      property: min-height,
+      class: min-svh,
+      values: (100: 100svh)
+    ),
+    "large-viewport-height": (
+      property: height,
+      class: lvh,
+      values: (100: 100lvh)
+    ),
+    "min-large-viewport-height": (
+      property: min-height,
+      class: min-lvh,
+      values: (100: 100lvh)
+    )
+  )
+);
+```
+
+This adds `.svh-100`, `.min-svh-100`, `.lvh-100`, and `.min-lvh-100`.
+
+<Callout>
+Every browser that Bootstrap 6 supports has `dvh`, `svh`, and `lvh`. Read [Browsers & devices]([[docsref:/getting-started/browsers-devices]]) for the full support policy.
+</Callout>
+
+We ship the same utilities for the width axis, `dvw-100` and `min-dvw-100`. Read [dynamic viewport width]([[docsref:/utilities/width#dynamic-viewport-width]]) to see how the width units differ.
 
 ## CSS
 

--- a/site/src/content/docs/utilities/width.mdx
+++ b/site/src/content/docs/utilities/width.mdx
@@ -9,6 +9,8 @@ utility:
   - min-width
   - viewport-width
   - min-viewport-width
+  - dynamic-viewport-width
+  - min-dynamic-viewport-width
 ---
 
 Use width utilities to set the width of elements. Width utilities are generated from the utility API and include support for a preset scale, percentage values, intrinsic sizing keywords, and viewport units.
@@ -80,7 +82,71 @@ Set width relative to the viewport using viewport units.
 ```
 
 <Callout type="warning">
-**Beware of the viewport width!** Using `vw-100` can cause horizontal scrollbars if the content is wider than the viewport, particularly on smaller screens.
+**Beware of the viewport width!** CSS sizes `vw` as if the scrollbar does not exist. On a desktop browser that shows a classic scrollbar, `vw-100` is wider than the content area. The page then scrolls sideways. Use `w-100` to fill the parent element instead. See [dynamic viewport width](#dynamic-viewport-width).
+</Callout>
+
+## Dynamic viewport width
+
+The `vw` unit measures the large viewport width. The browser calculates that width as if every retractable browser interface is retracted. The value stays the same while the user scrolls.
+
+The `dvw` unit measures the viewport width that the user sees now. The browser updates the value when it expands or retracts a browser interface. Use `dvw-100` and `min-dvw-100` when a browser interface changes the viewport width.
+
+```html
+<div class="dvw-100">Width 100dvw</div>
+<div class="min-dvw-100">Min-width 100dvw</div>
+```
+
+Most browsers put the retractable interface at the top and the bottom of the screen. That interface changes the viewport height, not the viewport width. On these browsers, `dvw` and `vw` give you the same value. The `dvw` unit is therefore less useful than [`dvh`]([[docsref:/utilities/height#dynamic-viewport-height]]). We ship it so that the width utilities match the height utilities.
+
+<Callout type="warning">
+**`dvw` does not fix the scrollbar problem.** CSS sizes every viewport width unit as if the scrollbar does not exist. The `dvw` unit gets the same treatment as the `vw` unit. To make the units respect the scrollbar, set `overflow: scroll` or `scrollbar-gutter: stable` on the root element.
+</Callout>
+
+<Callout>
+**Which unit do I use?** Use `w-100` for a full-width layout. It fills the parent element, so the page does not scroll sideways. Use `dvw` when a browser interface changes the viewport width. Use `vw` when you need a width that does not change while the user scrolls.
+</Callout>
+
+### Small and large viewport units
+
+CSS gives you two more viewport width units:
+
+- `svw` is the small viewport width. The browser calculates it as if every retractable browser interface is expanded.
+- `lvw` is the large viewport width. The browser calculates it as if every retractable browser interface is retracted. Current browsers give `vw` the same value.
+
+We do not ship utilities for `svw` and `lvw`, because most layouts need `w-100` or `dvw`. Add them with the [utilities API]([[docsref:/utilities/api#add-utilities]]):
+
+```scss
+// my-bootstrap.scss
+@use "bootstrap/scss/bootstrap" with (
+  $utilities: (
+    "small-viewport-width": (
+      property: width,
+      class: svw,
+      values: (100: 100svw)
+    ),
+    "min-small-viewport-width": (
+      property: min-width,
+      class: min-svw,
+      values: (100: 100svw)
+    ),
+    "large-viewport-width": (
+      property: width,
+      class: lvw,
+      values: (100: 100lvw)
+    ),
+    "min-large-viewport-width": (
+      property: min-width,
+      class: min-lvw,
+      values: (100: 100lvw)
+    )
+  )
+);
+```
+
+This adds `.svw-100`, `.min-svw-100`, `.lvw-100`, and `.min-lvw-100`.
+
+<Callout>
+Every browser that Bootstrap 6 supports has `dvw`, `svw`, and `lvw`. Read [Browsers & devices]([[docsref:/getting-started/browsers-devices]]) for the full support policy.
 </Callout>
 
 ## CSS


### PR DESCRIPTION
- Adds `.dvh-100` and `.min-dvh-100` for `height: 100dvh` and `min-height: 100dvh`.
- Adds `.dvw-100` and `.min-dvw-100` for `width: 100dvw` and `min-width: 100dvw`.
- A mobile browser changes the viewport when it shows or hides its URL bar, so a `100vh` section overflows. The `dv*` units follow that change.
- Documents the new utilities on the height and width pages, and shows how to add `svh`, `lvh`, `svw`, and `lvw` yourself with the utilities API.
- Leaves the v5 `.vh-100`, `.min-vh-100`, `.vw-100`, and `.min-vw-100` utilities unchanged.
- Adds a migration note.

`dvw` does not fix the `100vw` scrollbar overflow. The spec defines every viewport width unit as if the scrollbar does not exist, so `100dvw` is also wider than the content area when a classic scrollbar is present.

Closes #41055